### PR TITLE
Fix: Legacy API showreports.json compatibility with original schweinswalsichtung.de

### DIFF
--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -18,6 +18,7 @@ import { sightings } from '$lib/server/db/schema';
 import { and, between, gte, lt, sql } from 'drizzle-orm';
 import { json, type RequestEvent } from '@sveltejs/kit';
 import { formatDateDDMMYY, formatTimeHHMI, toUnixTimestamp } from '$lib/legacy-api/date-utils.js';
+import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 
 const logger = createLogger('api:legacy:showreports:pdf-compliant');
 
@@ -34,6 +35,8 @@ interface PDFCompliantSightingResponse {
 	lon: string;       // Longitude as STRING (not number!)
 	ct: number;        // Total count
 	yo: number;        // Young count
+	ta?: string;       // Tierart (species name as string)
+	tf?: number;       // Totfund (death finding): 0=false, 1=true
 	sh?: string;       // Ship name (only if consent)
 	na?: string;       // Name (first + last, only if consent)
 	ar?: string;       // Area/waterway
@@ -248,7 +251,9 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				waterway: sightings.waterway,
 				shipName: sightings.shipName,
 				shipNameConsent: sightings.shipNameConsent,
-				approvedAt: sightings.approvedAt
+				approvedAt: sightings.approvedAt,
+				species: sightings.species,
+				isDead: sightings.isDead
 			})
 			.from(sightings)
 			.where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
@@ -277,6 +282,14 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				yo: sighting.juvenileCount || 0 // Young count
 			};
 
+			// Add species name (ta) - convert from enum to German label
+			if (sighting.species !== null && sighting.species !== undefined) {
+				response.ta = getSpeciesLabel(sighting.species);
+			}
+
+			// Add death finding flag (tf) - convert boolean to 0/1
+			response.tf = sighting.isDead ? 1 : 0;
+
 			// Conditional fields based on consent (as per PDF specification)
 			if (sighting.shipNameConsent && sighting.shipName) {
 				response.sh = sighting.shipName;
@@ -296,6 +309,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			return response;
 		});
 
+		// Convert array to object with string keys (as per original API format)
+		const responseObject: Record<string, PDFCompliantSightingResponse> = {};
+		pdfCompliantSightings.forEach((sighting, index) => {
+			responseObject[index.toString()] = sighting;
+		});
+
 		logger.info({ 
 			totalResults: pdfCompliantSightings.length,
 			filtersApplied: {
@@ -308,7 +327,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			ip: clientIp 
 		}, 'PDF-compliant legacy sightings retrieval completed');
 
-		return json(pdfCompliantSightings, {
+		return json(responseObject, {
 			headers: {
 				'Cache-Control': 'public, max-age=300', // Cache for 5 minutes
 				'Content-Type': 'application/json'

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -27,7 +27,9 @@ const mockSightingData = [
 		waterway: 'Kieler Förde',
 		shipName: 'Fährschiff "Deutschland"',
 		shipNameConsent: true,
-		approvedAt: new Date('2012-01-26T10:00:00.000Z')
+		approvedAt: new Date('2012-01-26T10:00:00.000Z'),
+		species: 0, // Schweinswal
+		isDead: 0   // Not a death finding
 	},
 	{
 		id: 826,
@@ -42,7 +44,9 @@ const mockSightingData = [
 		waterway: null,
 		shipName: null,
 		shipNameConsent: false,
-		approvedAt: new Date('2012-03-31T09:00:00.000Z')
+		approvedAt: new Date('2012-03-31T09:00:00.000Z'),
+		species: 1, // Kegelrobbe
+		isDead: 0   // Not a death finding
 	},
 	{
 		id: 827,
@@ -57,7 +61,9 @@ const mockSightingData = [
 		waterway: 'Fehmarnbelt',
 		shipName: 'Private Yacht',
 		shipNameConsent: false, // No consent - should not show ship name
-		approvedAt: new Date('2012-04-16T08:00:00.000Z')
+		approvedAt: new Date('2012-04-16T08:00:00.000Z'),
+		species: 2, // Seehund
+		isDead: 1   // Death finding
 	}
 ];
 
@@ -113,11 +119,13 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			expect(response.status).toBe(200);
 
 			const responseData = await response.json();
-			expect(Array.isArray(responseData)).toBe(true);
-			expect(responseData.length).toBe(3);
+			// Should be an object with string keys, not an array
+			expect(typeof responseData).toBe('object');
+			expect(Array.isArray(responseData)).toBe(false);
+			expect(Object.keys(responseData)).toEqual(['0', '1', '2']);
 
 			// Verify EXACT PDF field names (abbreviated)
-			const firstSighting = responseData[0];
+			const firstSighting = responseData['0'];
 			expect(firstSighting).toHaveProperty('ts'); // Unix Timestamp
 			expect(firstSighting).toHaveProperty('id'); // Report ID
 			expect(firstSighting).toHaveProperty('dt'); // Date DD.MM.YY
@@ -126,6 +134,8 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			expect(firstSighting).toHaveProperty('lon'); // Longitude as STRING
 			expect(firstSighting).toHaveProperty('ct'); // Total count
 			expect(firstSighting).toHaveProperty('yo'); // Young count
+			expect(firstSighting).toHaveProperty('ta'); // Tierart (species)
+			expect(firstSighting).toHaveProperty('tf'); // Totfund (death finding)
 			
 			// Optional fields (consent-dependent)
 			expect(firstSighting).toHaveProperty('sh'); // Ship name
@@ -141,6 +151,8 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			expect(typeof firstSighting.lon).toBe('string'); // CRITICAL: Must be string
 			expect(typeof firstSighting.ct).toBe('number');
 			expect(typeof firstSighting.yo).toBe('number');
+			expect(typeof firstSighting.ta).toBe('string'); // Species name
+			expect(typeof firstSighting.tf).toBe('number'); // Death finding flag (0/1)
 		});
 
 		it('should format dates exactly as PDF specification (DD.MM.YY)', async () => {
@@ -148,7 +160,7 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const response = await GET(event);
 			const responseData = await response.json();
 
-			const firstSighting = responseData[0];
+			const firstSighting = responseData['0'];
 			
 			// PDF format: DD.MM.YY (2-digit year!)
 			expect(firstSighting.dt).toBe('25.01.12');
@@ -163,7 +175,7 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const response = await GET(event);
 			const responseData = await response.json();
 
-			const firstSighting = responseData[0];
+			const firstSighting = responseData['0'];
 			
 			// PDF requirement: Coordinates must be strings, not numbers
 			expect(firstSighting.lat).toBe('54.646667');
@@ -176,10 +188,10 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const responseData = await response.json();
 
 			// First sighting: has name consent
-			expect(responseData[0].na).toBe('Jörg Schneider');
+			expect(responseData['0'].na).toBe('Jörg Schneider');
 			
 			// Third sighting: no name consent (nameConsent: false)
-			expect(responseData[2].na).toBeUndefined();
+			expect(responseData['2'].na).toBeUndefined();
 		});
 
 		it('should respect ship name consent settings as per PDF', async () => {
@@ -188,13 +200,13 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const responseData = await response.json();
 
 			// First sighting: has ship name consent
-			expect(responseData[0].sh).toBe('Fährschiff "Deutschland"');
+			expect(responseData['0'].sh).toBe('Fährschiff "Deutschland"');
 			
 			// Second sighting: no ship name consent
-			expect(responseData[1].sh).toBeUndefined();
+			expect(responseData['1'].sh).toBeUndefined();
 			
 			// Third sighting: no ship name consent
-			expect(responseData[2].sh).toBeUndefined();
+			expect(responseData['2'].sh).toBeUndefined();
 		});
 
 		it('should include area/waterway information', async () => {
@@ -203,13 +215,13 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const responseData = await response.json();
 
 			// First sighting: has waterway
-			expect(responseData[0].ar).toBe('Kieler Förde');
+			expect(responseData['0'].ar).toBe('Kieler Förde');
 			
 			// Second sighting: no waterway (null in database)
-			expect(responseData[1].ar).toBeUndefined();
+			expect(responseData['1'].ar).toBeUndefined();
 			
 			// Third sighting: has waterway
-			expect(responseData[2].ar).toBe('Fehmarnbelt');
+			expect(responseData['2'].ar).toBe('Fehmarnbelt');
 		});
 
 		it('should not include admin-only fields (bm, va) in public response', async () => {
@@ -217,11 +229,29 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const response = await GET(event);
 			const responseData = await response.json();
 
-			responseData.forEach((sighting: any) => {
+			Object.values(responseData).forEach((sighting: any) => {
 				// PDF: "wird nur bei angemeldetem Admin geliefert"
 				expect(sighting).not.toHaveProperty('bm'); // Baltic marker
 				expect(sighting).not.toHaveProperty('va'); // Validated
 			});
+		});
+
+		it('should include species (ta) and death finding (tf) fields', async () => {
+			const event = createMockRequestEvent();
+			const response = await GET(event);
+			const responseData = await response.json();
+
+			// First sighting: Schweinswal, not dead
+			expect(responseData['0'].ta).toBe('Schweinswal');
+			expect(responseData['0'].tf).toBe(0);
+
+			// Second sighting: Kegelrobbe, not dead
+			expect(responseData['1'].ta).toBe('Kegelrobbe');
+			expect(responseData['1'].tf).toBe(0);
+
+			// Third sighting: Seehund, dead
+			expect(responseData['2'].ta).toBe('Seehund');
+			expect(responseData['2'].tf).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
## 🐛 Problem
The `/sichtungen/showreports.json` endpoint had critical incompatibilities with the original schweinswalsichtung.de API that could break the mobile app. After comparing both APIs, I found significant structural differences.

Fixes #44

## 🔍 Issues Found
1. **Wrong Response Structure**: Our API returned an array, but the original returns an object with string keys
2. **Missing Fields**: Two critical fields were missing:
   - `ta` (tierart/species): Shows animal species in German ("Schweinswal", "Kegelrobbe", "Seehund")
   - `tf` (totfund/death finding): Boolean as 0/1 indicating death findings

## ✅ Changes Made

### Response Structure Fixed
```diff
- [{"ts": 123, "id": 1, ...}, {"ts": 456, "id": 2, ...}]
+ {"0": {"ts": 123, "id": 1, ...}, "1": {"ts": 456, "id": 2, ...}}
```

### Added Missing Fields
- **ta**: Species name in German (e.g., "Schweinswal", "Kegelrobbe", "Seehund")
- **tf**: Death finding flag (0 = alive sighting, 1 = death finding)

### Updated Tests
- Modified all tests to expect object structure instead of array
- Added test data for `species` and `isDead` fields
- Added specific test case for new `ta` and `tf` fields
- All 24 tests passing ✅

## 🧪 Testing
- ✅ All unit tests pass (362 total)
- ✅ Lint and type-check clean
- ✅ Response format matches original API exactly

## 📊 API Compatibility
Now **100% compatible** with original schweinswalsichtung.de API:

| Field | Type | Description | Status |
|-------|------|-------------|---------|
| ts | number | Unix timestamp | ✅ |
| id | number | Report ID | ✅ |
| dt | string | Date (DD.MM.YY) | ✅ |
| ti | string | Time (HH:MI) | ✅ |
| lat | string | Latitude | ✅ |
| lon | string | Longitude | ✅ |
| ct | number | Total count | ✅ |
| yo | number | Young count | ✅ |
| **ta** | **string** | **Species name** | ✅ **NEW** |
| **tf** | **number** | **Death finding (0/1)** | ✅ **NEW** |
| sh | string | Ship name (consent) | ✅ |
| na | string | Observer name (consent) | ✅ |
| ar | string | Area/waterway | ✅ |

## 🎯 Impact
This ensures the existing mobile app will continue to work seamlessly with our new backend, maintaining the required 100% compatibility as specified in the PDF documentation.