### PR TITLE
fix: repair GitHub Actions workflow syntax for dependabot PR parsing

### DIFF
--- a/.github/workflows/dependabot-combined-optimized.yml
+++ b/.github/workflows/dependabot-combined-optimized.yml
@@ -109,10 +109,11 @@ jobs:
           
       - name: Merge Dependabot branches
         if: steps.get-prs.outputs.count != '0'
+        env:
+          PRS_JSON: ${{ steps.get-prs.outputs.prs }}
         run: |
           # Parse PR details
-          PRS='${{ steps.get-prs.outputs.prs }}'
-          echo "$PRS" | jq -r '.[] | "\(.branch) \(.title)"' | while IFS=' ' read -r branch title; do
+          echo "$PRS_JSON" | jq -r '.[] | "\(.branch) \(.title)"' | while IFS=' ' read -r branch title; do
             echo "Merging $branch: $title"
             
             # Merge den Dependabot branch
@@ -124,9 +125,11 @@ jobs:
         if: steps.get-prs.outputs.count != '0'
         id: commit-message
         uses: actions/github-script@v7
+        env:
+          PRS_JSON: ${{ steps.get-prs.outputs.prs }}
         with:
           script: |
-            const prs = JSON.parse('${{ steps.get-prs.outputs.prs }}');
+            const prs = JSON.parse(process.env.PRS_JSON);
             
             // Gruppiere Updates nach Typ
             const updates = {
@@ -241,11 +244,15 @@ jobs:
         if: steps.get-prs.outputs.count != '0'
         id: create-pr
         uses: actions/github-script@v7
+        env:
+          COMMIT_MESSAGE: ${{ steps.commit-message.outputs.commit-message }}
+          PR_BODY: ${{ steps.commit-message.outputs.pr-body }}
+          HAS_MAJOR: ${{ steps.commit-message.outputs.has-major }}
         with:
           script: |
-            const commitMessage = '${{ steps.commit-message.outputs.commit-message }}';
-            const prBody = `${{ steps.commit-message.outputs.pr-body }}`;
-            const hasMajor = ${{ steps.commit-message.outputs.has-major }};
+            const commitMessage = process.env.COMMIT_MESSAGE;
+            const prBody = process.env.PR_BODY;
+            const hasMajor = process.env.HAS_MAJOR === 'true';
             
             let title = commitMessage;
             let labels = ['dependencies', 'pre-validated'];
@@ -281,11 +288,15 @@ jobs:
       - name: Close individual Dependabot PRs
         if: steps.get-prs.outputs.count != '0'
         uses: actions/github-script@v7
+        env:
+          PRS_JSON: ${{ steps.get-prs.outputs.prs }}
+          COMBINED_PR_NUMBER: ${{ steps.create-pr.outputs.pr-number }}
+          COMBINED_PR_URL: ${{ steps.create-pr.outputs.pr-url }}
         with:
           script: |
-            const prs = JSON.parse('${{ steps.get-prs.outputs.prs }}');
-            const combinedPrNumber = ${{ steps.create-pr.outputs.pr-number }};
-            const combinedPrUrl = '${{ steps.create-pr.outputs.pr-url }}';
+            const prs = JSON.parse(process.env.PRS_JSON);
+            const combinedPrNumber = process.env.COMBINED_PR_NUMBER;
+            const combinedPrUrl = process.env.COMBINED_PR_URL;
             
             for (const pr of prs) {
               console.log(`Closing PR #${pr.number}: ${pr.title}`);


### PR DESCRIPTION
## Problem
Die GitHub Actions workflows für PRs 41 und 39 schlugen fehl mit dem Fehler:
```
syntax error near unexpected token '<'
```

## Ursache
Das Problem lag an der direkten Verwendung von JSON-Strings in Bash-Skripten ohne korrektes Escaping. Die GitHub Actions Syntax `${{ steps.get-prs.outputs.prs }}` führte zu Parsing-Fehlern, wenn komplexe JSON-Strukturen direkt in Bash verwendet wurden.

## Lösung
- **Verwendung von Environment Variables**: Statt direkter JSON-Interpolation werden die Werte über Environment Variables übergeben
- **Sichere JSON-Verarbeitung**: `process.env` statt String-Interpolation in GitHub Actions Scripts
- **Verbesserte Fehlerresistenz**: Schutz vor speziellen Zeichen in JSON-Daten

## Geänderte Abschnitte
- `Merge Dependabot branches`: JSON über ENV-Variable
- `Generate conventional commit message`: Sichere JSON-Verarbeitung  
- `Create combined PR`: Environment Variables für alle Outputs
- `Close individual Dependabot PRs`: Saubere JSON-Übergabe

## Test
Der Workflow sollte jetzt ohne Syntax-Fehler laufen und korrekt JSON-Daten verarbeiten.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>