### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foss-compliance.yml
+++ b/.github/workflows/foss-compliance.yml
@@ -1,5 +1,8 @@
 name: FOSS Compliance Check
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:
@@ -16,6 +19,9 @@ jobs:
   foss-compliance:
     name: FOSS License Compliance
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/jansinger/ostsee-sichtung/security/code-scanning/1](https://github.com/jansinger/ostsee-sichtung/security/code-scanning/1)

To address the problem, add a `permissions:` block explicitly specifying the minimum required token permissions. The ideal fix is to set `permissions: contents: read` at the workflow root—before `jobs:`—so all jobs default to read-only repo content access. If any job or step (such as posting a PR comment) requires additional permissions, use a more permissive `permissions:` block at the job level (or only for the relevant job).

In this workflow, only the "Comment on PR (if applicable)" step (which runs only for pull_request events) needs to write PR comments. For best practice:
- At the workflow root, add:
  ```yaml
  permissions:
    contents: read
  ```
- Optionally, add a more permissive block to the `foss-compliance` job. Since the comment is posted via `actions/github-script`, this requires `pull-requests: write` to comment on PRs (or `issues: write`—either is acceptable as PRs are issues), so at `jobs.foss-compliance` add:
  ```yaml
  permissions:
    contents: read
    pull-requests: write
  ```
  Or, use `issues: write` instead if you prefer.

Since there is only one job, it's simplest to add the `permissions:` block at the workflow root granting `contents: read` and add a job-level `permissions:` granting `contents: read` and `pull-requests: write`.

**Required changes:**  
- At the workflow root (insert after `name:`): add `permissions: contents: read`.
- Inside the `foss-compliance` job (insert after `runs-on: ubuntu-latest`): add a job-level `permissions:` block with `contents: read` and `pull-requests: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
