### PR TITLE
fix(ci): add missing svelte-kit sync step to dependabot-combine workflow

### DIFF
--- a/.github/workflows/dependabot-combine.yml
+++ b/.github/workflows/dependabot-combine.yml
@@ -127,6 +127,10 @@ jobs:
         if: steps.find-prs.outputs.has-prs == 'true'
         run: npm ci
 
+      - name: Ensure Svelte Kit is in sync
+        if: steps.find-prs.outputs.has-prs == 'true'
+        run: npx svelte-kit sync
+
       - name: Run validation tests
         if: steps.find-prs.outputs.has-prs == 'true'
         run: |


### PR DESCRIPTION
## Issue

The dependabot-combine workflow is failing with TypeScript error:
```
error TS5083: Cannot read file '.svelte-kit/tsconfig.json'
```

## Root Cause

The `npx svelte-kit sync` step was accidentally omitted from the merged PR #186. This step is required to generate the `.svelte-kit/tsconfig.json` file before running TypeScript validation.

## Fix

Add the "Ensure Svelte Kit is in sync" step after `npm ci` and before validation tests, matching the pattern used in `pr-validation.yml`.

## Changes

```yaml
- name: Install dependencies
  run: npm ci

- name: Ensure Svelte Kit is in sync  # ← ADDED
  run: npx svelte-kit sync             # ← ADDED

- name: Run validation tests
  run: |
    npm run lint
    npm run type-check
    # ...
```

## Testing

This fix will allow the workflow to:
1. Generate required SvelteKit config files
2. Pass TypeScript validation
3. Successfully create combined Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)