### PR TITLE
fix(ci): enable PR validation for combined Dependabot PR

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.pull_request.draft == false &&
       (
         github.actor != 'dependabot[bot]' ||
-        github.head_ref == 'dependabot-combined'
+        github.event.pull_request.head.ref == 'dependabot-combined'
       )
 
     permissions:


### PR DESCRIPTION
## Problem

Die PR Validation läuft nicht für den Combined Dependabot PR. Individual Dependabot PRs werden korrekt übersprungen, aber der Combined PR sollte validiert werden.

## Root Cause

Die Workflow-Bedingung verwendete `github.head_ref`, welche **nicht verfügbar ist** in `pull_request` Events.

**Falsch:**
```yaml
github.head_ref == 'dependabot-combined'  # ❌ Nicht verfügbar im pull_request event
```

## Fix

Verwende die korrekte Variable für pull_request Events:

```yaml
github.event.pull_request.head.ref == 'dependabot-combined'  # ✅ Korrekt
```

## Validierungs-Verhalten nach dem Fix

- ❌ **Individual Dependabot PRs**: Validation übersprungen
- ✅ **Combined PR** (`dependabot-combined` branch): Validation läuft
- ✅ **Alle anderen PRs**: Validation läuft normal

## Testing

Nach dem Merge wird die PR Validation automatisch für den nächsten Combined PR laufen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)