### PR TITLE
fix(ci): use conventional commit format for merge commits

### DIFF
--- a/.github/workflows/dependabot-combine.yml
+++ b/.github/workflows/dependabot-combine.yml
@@ -97,8 +97,8 @@ jobs:
             echo "Fetching and merging $branch..."
             git fetch origin "$branch"
 
-            # Use merge with squash-like behavior to keep history clean
-            if git merge "origin/$branch" --no-ff --no-edit -m "merge: dependabot/$branch"; then
+            # Use merge with conventional commit format
+            if git merge "origin/$branch" --no-ff --no-edit -m "chore(deps): merge $branch"; then
               echo "✓ Successfully merged $branch"
             else
               echo "✗ Failed to merge $branch - this may require manual intervention"


### PR DESCRIPTION
## Problem

Die PR Validation schlägt fehl für Combined Dependabot PRs wegen nicht-konformer Commit Messages:

```
✖ type must be one of [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]
```

## Root Cause

Der `dependabot-combine` Workflow verwendet den Commit-Typ `merge:` für Merge-Commits:

```bash
git merge origin/$branch -m "merge: dependabot/$branch"
```

Der Typ `merge` ist **nicht in den erlaubten Conventional Commit Typen** enthalten.

## Fix

Ändere den Commit-Typ zu `chore(deps):`:

```bash
git merge origin/$branch -m "chore(deps): merge $branch"
```

## Vorher/Nachher

**Vorher (❌ schlägt fehl):**
```
merge: dependabot/dependabot/npm_and_yarn/typescript-eslint-8.46.0
```

**Nachher (✅ validiert):**
```
chore(deps): merge dependabot/npm_and_yarn/typescript-eslint-8.46.0
```

## Testing

Nach dem Merge wird der nächste Combined PR alle Commit-Message-Validierungen bestehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)