### PR TITLE
fix(ci): add --ignore-scripts flag to package-lock sync step

### DIFF
--- a/.github/workflows/dependabot-combine.yml
+++ b/.github/workflows/dependabot-combine.yml
@@ -186,7 +186,9 @@ jobs:
           # Use npm install to regenerate package-lock.json
           # This is necessary because merging multiple Dependabot PRs can cause
           # the lock file to become out of sync with package.json
-          npm install --package-lock-only
+          # Use --ignore-scripts to avoid running the prepare script (husky)
+          # which fails because dependencies are not yet installed
+          npm install --package-lock-only --ignore-scripts
 
           # Check if package-lock.json changed
           if git diff --quiet package-lock.json; then


### PR DESCRIPTION
## Summary

Fixes the failing Dependabot combine workflow that fails with:

```
sh: 1: husky: not found
npm error code 127
npm error command failed
npm error command sh -c husky
```

## Problem

The `npm install --package-lock-only` command runs the `prepare` script from package.json which tries to execute `husky`. But at this point in the workflow, dependencies are not yet installed, so husky is not available.

## Solution

Add `--ignore-scripts` flag to prevent running the prepare script during the package-lock regeneration step. The full `npm ci` step that follows will properly install all dependencies including husky.

## Test plan

- [ ] Verify the Dependabot combine workflow runs successfully
- [ ] Confirm package-lock.json is still regenerated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)