### PR TITLE
chore(ci): include dependency updates in release changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -21,6 +21,7 @@
     { "type": "docs", "section": "Documentation" },
     { "type": "refactor", "section": "Code Refactoring" },
     { "type": "build", "section": "Build System" },
+    { "type": "chore(deps)", "section": "Dependencies" },
     { "type": "chore", "section": "Miscellaneous", "hidden": true },
     { "type": "ci", "section": "CI/CD", "hidden": true },
     { "type": "test", "section": "Tests", "hidden": true },


### PR DESCRIPTION
## Summary

Configures release-please to include `chore(deps)` commits in the changelog and trigger patch releases.

### Changes:
- Add `chore(deps)` as a visible changelog section named "Dependencies"
- Position it before the hidden `chore` section so it matches first

### Why:
Previously, Dependabot updates used `chore(deps):` prefix which was hidden and didn't trigger releases. This meant:
- Security fixes in dependencies weren't released automatically
- Users couldn't see dependency updates in the changelog
- Docker images didn't get updated after dependency merges

### After this change:
- Dependabot PRs will trigger patch releases when merged
- Dependency updates appear in the "Dependencies" section of the changelog
- Docker images are automatically rebuilt with updated dependencies

### Example changelog output:
```markdown
## [2.0.2] - 2025-12-24

### Dependencies

* bump tailwindcss from 4.1.17 to 4.1.18 (#264)
* bump the production-dependencies group with 8 updates (#260)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)