### PR TITLE
test: refactor playwright tests to follow best practices

### DIFF
--- a/e2e/basic.test.ts
+++ b/e2e/basic.test.ts
@@ -1,31 +1,37 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Basic Tests', () => {
-	test('server is running', async ({ page }) => {
-		// Use baseURL from config
+test.describe('Basic Application Tests', () => {
+	test('server responds with 200', async ({ page }) => {
 		const response = await page.goto('/');
 		expect(response?.status()).toBe(200);
 	});
 
-	test('page has title', async ({ page }) => {
+	test('page has correct title', async ({ page }) => {
 		await page.goto('/');
 		await expect(page).toHaveTitle(/Ostsee/);
 	});
 
-	test('page loads basic elements', async ({ page }) => {
+	test('page has visible content', async ({ page }) => {
 		await page.goto('/');
-		
-		// Wait for page to be interactive
-		await page.waitForLoadState('networkidle');
-		
-		// Check if page has some content
-		const body = page.locator('body');
-		await expect(body).toBeVisible();
-		
-		// Check for main content container
-		const main = page.locator('main, [role="main"], .container, #app, .app').first();
-		if (await main.count() > 0) {
-			await expect(main).toBeVisible();
-		}
+
+		// Body should be visible
+		await expect(page.locator('body')).toBeVisible();
+
+		// Should have at least one interactive element
+		const buttons = page.getByRole('button');
+		await expect(buttons.first()).toBeVisible();
+	});
+
+	test('form is accessible', async ({ page }) => {
+		await page.goto('/');
+
+		// Main form should be present
+		const form = page.locator('form').first();
+		await expect(form).toBeVisible();
+
+		// Form should have labeled inputs
+		const inputs = page.getByRole('textbox').or(page.getByRole('combobox'));
+		const inputCount = await inputs.count();
+		expect(inputCount).toBeGreaterThan(0);
 	});
 });

--- a/e2e/demo.test.ts
+++ b/e2e/demo.test.ts
@@ -1,33 +1,18 @@
 import { expect, test } from '@playwright/test';
 
-test('home page has expected content', async ({ page }) => {
+test('home page loads successfully', async ({ page }) => {
 	await page.goto('/');
-	
-	// Warte darauf, dass die Seite vollständig geladen ist
-	await page.waitForLoadState('networkidle');
-	
-	// Universeller Test: Prüfe dass die Seite korrekt funktioniert
-	// indem wir nach den charakteristischen Inhalten suchen
-	
-	// Option 1: Das Haupt-h1 ist sichtbar (nicht-iframe Modus)
-	const mainHeading = page.locator('h1').filter({ hasText: /Meerestier.*Sichtung.*melden/i });
-	const mainHeadingCount = await mainHeading.count();
-	
-	// Option 2: Form-Inhalte sind sichtbar (iframe oder nicht-iframe Modus)
-	const formContent = page.locator('h2').filter({ hasText: /Position.*Zeit/i });
-	const formContentCount = await formContent.count();
-	
-	// Einer der beiden sollte sichtbar sein
-	if (mainHeadingCount > 0) {
-		await expect(mainHeading).toBeVisible({ timeout: 10000 });
-	} else if (formContentCount > 0) {
-		await expect(formContent).toBeVisible({ timeout: 10000 });
-	} else {
-		// Fallback: Mindestens ein funktionelles Element sollte da sein
-		const functionalElement = page.locator('form, button, input, select').first();
-		await expect(functionalElement).toBeVisible({ timeout: 10000 });
-	}
-	
-	// Zusätzliche Prüfung: Page-Title sollte korrekt sein
+
+	// Page should have correct title
 	await expect(page).toHaveTitle(/Ostsee-Tiere/i);
+
+	// Main form should be visible
+	await expect(page.locator('form').first()).toBeVisible();
+
+	// Should have interactive form elements
+	const formElements = page
+		.getByRole('button')
+		.or(page.getByRole('textbox'))
+		.or(page.getByRole('combobox'));
+	await expect(formElements.first()).toBeVisible();
 });

--- a/e2e/homepage.test.ts
+++ b/e2e/homepage.test.ts
@@ -1,157 +1,97 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Homepage', () => {
-	test('should load the homepage', async ({ page }) => {
+	test('should load the homepage with main form', async ({ page }) => {
 		await page.goto('/');
 
-		// Warte darauf, dass die Seite vollständig geladen ist
-		await page.waitForLoadState('networkidle');
+		// Wait for page to be fully loaded
+		await expect(page).toHaveTitle(/Ostsee-Tiere/);
 
-		// Prüfe iframe vs nicht-iframe Modus durch Überprüfung des h1
-		const mainHeading = page.locator('h1').first();
-		const mainHeadingCount = await mainHeading.count();
+		// Main form should be visible
+		const mainForm = page.locator('form').first();
+		await expect(mainForm).toBeVisible();
 
-		if (mainHeadingCount > 0) {
-			// Nicht-iframe Modus: Das Haupt-h1 sollte sichtbar sein
-			await expect(mainHeading).toBeVisible({ timeout: 10000 });
-			await expect(mainHeading).toContainText(/Meerestier.*Sichtung.*melden/i);
-		} else {
-			// iframe Modus: Prüfe dass Form-Inhalte korrekt geladen sind
-			const formContent = page.locator('h2, .step, [data-testid]').first();
-			await expect(formContent).toBeVisible({ timeout: 10000 });
-		}
-
-		// Check for the presence of the main form (not modal forms) - funktioniert in beiden Modi
-		const mainForm = page.locator('form:not(.modal-backdrop)').first();
-		await expect(mainForm).toBeVisible({ timeout: 10000 });
+		// Form should have interactive elements
+		await expect(
+			page.getByRole('button').or(page.getByRole('textbox')).or(page.getByRole('combobox')).first()
+		).toBeVisible();
 	});
 
 	test('should have proper meta tags', async ({ page }) => {
 		await page.goto('/');
 
-		// Warte darauf, dass die Seite vollständig geladen ist
-		await page.waitForLoadState('domcontentloaded');
-
 		// Check title
-		await expect(page).toHaveTitle(/Ostsee-Tiere/, { timeout: 10000 });
+		await expect(page).toHaveTitle(/Ostsee-Tiere/);
 
-		// Check meta description (use first match to avoid duplicates)
+		// Check meta description exists and has relevant content about marine animals
 		const metaDescription = page.locator('meta[name="description"]').first();
-		await expect(metaDescription).toHaveAttribute('content', /Ostsee.*[MmTt]ier|[MmTt]eerestier/, {
-			timeout: 5000
-		});
+		await expect(metaDescription).toHaveAttribute('content', /Ostsee.*(Wal|Robben|Meerestier|Sichtung)/i);
 	});
 
 	test('should render page content properly', async ({ page }) => {
 		await page.goto('/');
 
-		// Warte auf das vollständige Laden
-		await page.waitForLoadState('networkidle');
+		// Body should be visible
+		await expect(page.locator('body')).toBeVisible();
 
-		// Prüfe grundlegende Seitenstruktur
-		const body = page.locator('body');
-		await expect(body).toBeVisible();
+		// Should have interactive elements (form is functional)
+		const interactiveElements = page.getByRole('button').or(page.getByRole('textbox'));
+		await expect(interactiveElements.first()).toBeVisible();
 
-		// Prüfe ob die Seite interaktiv ist (keine Ladescreen mehr)
-		const loadingIndicators = page.locator('.loading, [data-loading], .spinner');
-		const loadingCount = await loadingIndicators.count();
-
-		// Falls Loading-Indikatoren vorhanden sind, warte darauf dass sie verschwinden
-		if (loadingCount > 0) {
-			await expect(loadingIndicators.first()).not.toBeVisible({ timeout: 15000 });
-		}
-
-		// Prüfe ob grundlegende interaktive Elemente da sind
-		const interactiveElements = page.locator(
-			'button, input, select, textarea, a[href], [role="button"]'
-		);
-		const interactiveCount = await interactiveElements.count();
-		expect(interactiveCount).toBeGreaterThan(0);
-
-		// Prüfe dass die App funktional ist - unabhängig vom iframe-Modus
-		const appContent = page.locator('form, .form-container, main, [data-app]');
-		await expect(appContent.first()).toBeVisible();
-	});
-
-	test('should navigate to map view', async ({ page }) => {
-		await page.goto('/map');
-
-		// Look for map link/button and click it - könnte in Navigation sein
-		const mapLink = page.locator('a[href="/map"]').first();
-		const mapLinkCount = await mapLink.count();
-
-		if (mapLinkCount > 0) {
-			await mapLink.click();
-			await expect(page).toHaveURL('/map');
-			// Prüfe ob die Karte geladen wurde
-			await expect(page.locator('#map, .map-container, [data-testid="map"]').first()).toBeVisible({
-				timeout: 10000
-			});
-		} else {
-			// Skip the test if no map link is found - this avoids HTTPS/routing issues
-			console.log('No map link found in navigation - skipping direct navigation test');
-		}
+		// Form container should be visible
+		await expect(page.locator('form').first()).toBeVisible();
 	});
 });
 
 test.describe('Form Navigation', () => {
-	test('should show form steps', async ({ page }) => {
+	test('should show form step indicators', async ({ page }) => {
 		await page.goto('/');
 
-		// Warte darauf, dass die Seite vollständig geladen ist
-		await page.waitForLoadState('networkidle');
+		// All step buttons should be accessible via aria-label
+		const positionButton = page.getByRole('button', { name: /Position & Zeit/i });
+		await expect(positionButton).toBeVisible();
 
-		// Check if step indicators are present - looking for steps container
-		const stepsContainer = page
-			.locator('.steps, [role="navigation"], .step-container, [data-testid*="step"]')
-			.first();
-		await expect(stepsContainer).toBeVisible({ timeout: 10000 });
-
-		// Check for individual step items
-		const steps = page.locator('.step, li[class*="step"], [data-testid*="step"]');
-		const stepCount = await steps.count();
-		expect(stepCount).toBeGreaterThan(0);
-	});
-
-	test('should show logo', async ({ page }) => {
-		await page.goto('/');
-
-		// Warte darauf, dass die Seite vollständig geladen ist
-		await page.waitForLoadState('networkidle');
-
-		// Prüfe iframe vs nicht-iframe Modus
-		const mainHeading = page.locator('h1').first();
-		const mainHeadingCount = await mainHeading.count();
-
-		if (mainHeadingCount > 0) {
-			// Nicht-iframe Modus: Logo sollte sichtbar sein
-			const logo = page
-				.locator('img[alt*="Ostsee-Tiere"], img[src*="ostsee-tiere"], img[alt*="Logo"]')
-				.first();
-			await expect(logo).toBeVisible({ timeout: 10000 });
-		} else {
-			// iframe Modus: Logo ist erwartungsgemäß nicht sichtbar, aber Seite sollte funktional sein
-			const pageContent = page.locator('form, h2, main, [role="main"]').first();
-			await expect(pageContent).toBeVisible({ timeout: 10000 });
-		}
+		// Current step should have aria-current="step" attribute
+		const currentStepButton = page.locator('button[aria-current="step"]');
+		await expect(currentStepButton).toBeVisible();
 	});
 
 	test('should have working form elements', async ({ page }) => {
 		await page.goto('/');
 
-		// Warte darauf, dass die Seite vollständig geladen ist
-		await page.waitForLoadState('networkidle');
+		// Wait for form to be visible
+		await expect(page.locator('form').first()).toBeVisible();
 
-		// Warte auf das Hauptformular (nicht Modal-Forms)
-		await page.waitForSelector('form:not(.modal-backdrop)', { timeout: 15000 });
+		// Form should contain input fields (textbox, combobox, or other inputs)
+		const formInputs = page
+			.getByRole('textbox')
+			.or(page.getByRole('combobox'))
+			.or(page.getByRole('spinbutton'));
+		await expect(formInputs.first()).toBeVisible();
+	});
 
-		// Prüfe ob Formularfelder vorhanden sind (ohne Honeypot und versteckte Felder)
-		// Erweiterte Selektor-Logik für bessere Kompatibilität
-		const formFields = page
-			.locator(
-				'input:not([name="_honeypot"]):not([aria-hidden="true"]):not([type="hidden"]), select:not([aria-hidden="true"]), textarea:not([aria-hidden="true"])'
-			)
-			.first();
-		await expect(formFields).toBeVisible({ timeout: 10000 });
+	test('should have clickable step buttons', async ({ page }) => {
+		await page.goto('/');
+
+		// Wait for form to be fully loaded
+		await expect(page.locator('form').first()).toBeVisible();
+
+		// Get step buttons by their aria-labels (semantic approach)
+		const stepButtons = [
+			page.getByRole('button', { name: /Position & Zeit/i }),
+			page.getByRole('button', { name: /Sichtungsdetails/i }),
+			page.getByRole('button', { name: /Beobachtungen/i }),
+			page.getByRole('button', { name: /Kontaktdaten/i })
+		];
+
+		// Each step button should be visible and clickable
+		for (const button of stepButtons) {
+			await expect(button).toBeVisible();
+			await expect(button).toBeEnabled();
+		}
+
+		// Step buttons should have proper accessibility attributes with meaningful labels
+		const firstStepButton = stepButtons[0];
+		await expect(firstStepButton).toHaveAttribute('aria-label', /Position & Zeit/i);
 	});
 });

--- a/e2e/map-lazy-loading.spec.ts
+++ b/e2e/map-lazy-loading.spec.ts
@@ -1,127 +1,107 @@
 import { test, expect } from '@playwright/test';
 
-// Increase timeout for map loading tests
-test.setTimeout(30000);
+test.describe('Map Page', () => {
+	test('loads map page and shows content', async ({ page }) => {
+		await page.goto('/map');
 
-test.describe('LazyMapWrapper', () => {
-    test('zeigt Lade-Overlay und lädt die Karte korrekt', async ({ page }) => {
-        await page.goto('/map');
+		// Page should have correct title
+		await expect(page).toHaveTitle(/Sichtungskarte.*Ostsee-Tiere/);
 
-        // Warte kurz, dann prüfe ob das Loading Overlay sichtbar ist oder bereits verschwunden ist
-        // In schnellen Umgebungen könnte das Loading bereits vorbei sein
-        const dialogLocator = page.getByRole('dialog');
+		// Wait for loading overlay to disappear (if it appears)
+		const loadingDialog = page.getByRole('dialog');
+		if (await loadingDialog.isVisible().catch(() => false)) {
+			await expect(loadingDialog).toBeHidden({ timeout: 15000 });
+		}
 
-        // Prüfe ob Dialog initial sichtbar ist (könnte bereits verschwunden sein wenn Laden schnell war)
-        const isDialogInitiallyVisible = await dialogLocator.isVisible().catch(() => false);
+		// After loading, either map title or error alert should be visible
+		const mapTitle = page.getByRole('heading', { name: /Sichtungskarte/i });
+		const errorAlert = page.getByRole('alert');
 
-        if (isDialogInitiallyVisible) {
-            // Wenn Dialog sichtbar ist, prüfe den Inhalt
-            await expect(page.locator('#loading-title')).toContainText(/wird geladen|wird initialisiert/i);
-            // Nach dem Laden sollte das Overlay verschwinden
-            await expect(dialogLocator).toBeHidden({ timeout: 15000 });
-        } else {
-            // Dialog war nie sichtbar oder bereits verschwunden - das ist OK wenn die Seite schnell lädt
-            // Prüfe stattdessen, dass die Seite korrekt geladen wurde
-            await expect(page.locator('html')).toBeVisible();
-        }
+		// Use Promise.race to wait for either condition
+		await expect(mapTitle.or(errorAlert).first()).toBeVisible({ timeout: 10000 });
+	});
 
-        // In CI ist es ok wenn die Karte nicht lädt - hauptsache das Overlay verschwindet
-        if (!process.env.CI) {
-            await expect(page.locator('h1').filter({ hasText: /Sichtungskarte/i })).toBeVisible({ timeout: 10000 });
-        } else {
-            // CI fallback: Prüfe dass zumindest die Seite responsive ist
-            await expect(page.locator('html')).toBeVisible();
-            // Prüfe dass die Seite Content hat
-            const hasContent = await page.evaluate(() => document.body && document.body.innerHTML.length > 0);
-            expect(hasContent).toBe(true);
-        }
-    });
+	test('shows loading state with accessible dialog', async ({ page }) => {
+		// Only slow down the map component import, not all requests
+		await page.route('**/SightingsMapView*.js', async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 1000));
+			await route.continue();
+		});
 
-    test('zeigt Map-Titel nach erfolgreichem Laden', async ({ page }) => {
-        await page.goto('/map');
+		await page.goto('/map');
 
-        // Warte bis Loading verschwindet (falls es überhaupt angezeigt wurde)
-        const dialogLocator = page.getByRole('dialog');
-        const isDialogVisible = await dialogLocator.isVisible().catch(() => false);
+		// Loading dialog should appear and have proper accessibility attributes
+		const loadingDialog = page.getByRole('dialog');
 
-        if (isDialogVisible) {
-            await expect(dialogLocator).toBeHidden({ timeout: 15000 });
-        }
-        
-        // In CI: Vereinfachter Check - nur prüfen dass die Seite geladen ist
-        if (process.env.CI) {
-            // Prüfe dass die Seite grundsätzlich geladen ist
-            await expect(page.locator('html')).toBeVisible();
-            // Prüfe dass kein JavaScript Fehler die Seite komplett blockiert
-            const hasContent = await page.evaluate(() => document.body && document.body.innerHTML.length > 0);
-            expect(hasContent).toBe(true);
-            return;
-        }
-        
-        // Lokale Tests: Vollständige Validierung
-        const mapTitle = page.locator('h1').filter({ hasText: /Sichtungskarte/i });
-        const errorAlert = page.getByRole('alert');
-        
-        let hasValidContent = false;
-        try {
-            await expect(mapTitle).toBeVisible({ timeout: 5000 });
-            hasValidContent = true;
-        } catch {
-            try {
-                // Falls die Karte nicht lädt, prüfe ob Fehlermeldung da ist
-                await expect(errorAlert).toBeVisible({ timeout: 2000 });
-                await expect(page.getByRole('button', { name: /neu laden/i })).toBeVisible();
-                hasValidContent = true;
-            } catch {
-                throw new Error('Weder Karte noch Fehlermeldung ist sichtbar');
-            }
-        }
-        
-        expect(hasValidContent).toBe(true);
-    });
+		// Dialog may or may not be visible depending on load speed
+		const isDialogVisible = await loadingDialog.isVisible().catch(() => false);
 
-    test('Filter-Panel kann geöffnet werden', async ({ page }) => {
-        await page.goto('/map');
+		if (isDialogVisible) {
+			// Dialog should have proper accessibility attributes
+			await expect(loadingDialog).toHaveAttribute('aria-modal', 'true');
+			await expect(loadingDialog).toHaveAttribute('aria-labelledby', 'loading-title');
 
-        // Warten bis Loading verschwindet (falls es überhaupt angezeigt wurde)
-        const dialogLocator = page.getByRole('dialog');
-        const isDialogVisible = await dialogLocator.isVisible().catch(() => false);
+			// Loading message should be visible
+			await expect(page.locator('#loading-title')).toContainText(/wird/i);
 
-        if (isDialogVisible) {
-            await expect(dialogLocator).toBeHidden({ timeout: 15000 });
-        }
-        
-        // In CI: Vereinfachter Test - skip wenn Filter-Button nicht vorhanden
-        if (process.env.CI) {
-            // Prüfe ob die Seite grundsätzlich funktioniert
-            await expect(page.locator('html')).toBeVisible();
-            
-            // Prüfe ob Filter-Button existiert, aber fail nicht wenn nicht
-            const filterButtonExists = await page.getByRole('button', { name: /filter/i }).first().isVisible().catch(() => false);
-            
-            if (!filterButtonExists) {
-                // In CI ist es OK wenn der Filter-Button nicht lädt - skip den Test
-                console.log('Filter button not found in CI, skipping filter panel test');
-                return;
-            }
-        } else {
-            // Lokale Tests: Vollständige Validierung
-            await expect(page.locator('h1').filter({ hasText: /Sichtungskarte/i })).toBeVisible({ timeout: 10000 });
-        }
+			// Wait for loading to complete
+			await expect(loadingDialog).toBeHidden({ timeout: 15000 });
+		}
 
-        // Prüfe ob Filter-Button existiert
-        const filterButton = page.getByRole('button', { name: /filter/i }).first();
-        await expect(filterButton).toBeVisible({ timeout: 5000 });
-        
-        // Versuche Filter-Panel zu öffnen
-        await filterButton.click();
+		// Page should have content after loading
+		await expect(page.locator('body')).toBeVisible();
+	});
 
-        // Filter-Panel sollte sichtbar sein
-        await expect(page.locator('#year-select')).toBeVisible({ timeout: 5000 });
-        await expect(page.locator('#filter-input')).toBeVisible({ timeout: 5000 });
-        
-        // Jahr-Dropdown sollte Optionen haben
-        const yearOptions = page.locator('#year-select option');
-        expect(await yearOptions.count()).toBeGreaterThan(1);
-    });
+	test('shows error state with retry button on load failure', async ({ page }) => {
+		// Intercept the map component import and make it fail
+		// In dev mode: SightingsMapView.svelte, in prod: chunk with SightingsMapView
+		await page.route('**/SightingsMapView*', (route) => route.abort('failed'));
+
+		await page.goto('/map');
+
+		// Wait for loading to complete
+		const loadingDialog = page.getByRole('dialog');
+		if (await loadingDialog.isVisible().catch(() => false)) {
+			await expect(loadingDialog).toBeHidden({ timeout: 15000 });
+		}
+
+		// Error state should be shown
+		const errorAlert = page.getByRole('alert');
+		await expect(errorAlert).toBeVisible({ timeout: 10000 });
+		await expect(errorAlert).toContainText(/konnte nicht geladen werden/i);
+
+		// Error should have retry button
+		const retryButton = page.getByRole('button', { name: /neu laden/i });
+		await expect(retryButton).toBeVisible();
+		await expect(retryButton).toBeEnabled();
+	});
+
+	test('filter panel can be opened when map loads successfully', async ({ page }) => {
+		await page.goto('/map');
+
+		// Wait for loading to complete
+		const loadingDialog = page.getByRole('dialog');
+		if (await loadingDialog.isVisible().catch(() => false)) {
+			await expect(loadingDialog).toBeHidden({ timeout: 15000 });
+		}
+
+		// Check if map loaded successfully (not error state)
+		const errorAlert = page.getByRole('alert');
+		const isError = await errorAlert.isVisible().catch(() => false);
+
+		if (!isError) {
+			// Find and click filter button - must exist when map loads successfully
+			const filterButton = page.getByRole('button', { name: /filter/i }).first();
+			await expect(filterButton).toBeVisible({ timeout: 10000 });
+			await filterButton.click();
+
+			// Filter panel elements should be visible
+			await expect(page.locator('#year-select')).toBeVisible({ timeout: 5000 });
+			await expect(page.locator('#filter-input')).toBeVisible({ timeout: 5000 });
+
+			// Year dropdown should have options
+			const yearOptions = page.locator('#year-select option');
+			expect(await yearOptions.count()).toBeGreaterThan(1);
+		}
+	});
 });


### PR DESCRIPTION
## Summary

- Refactor E2E tests to use semantic locators (`getByRole`, `getByText`) instead of CSS selectors
- Remove CI-specific fallbacks and workarounds - tests now run identically in CI and local
- Better accessibility validation through semantic queries
- Simplified test structure with clearer assertions

### Changes per file

| File | Changes |
|------|---------|
| `e2e/basic.test.ts` | Simplified, semantic locators |
| `e2e/demo.test.ts` | Compact, essential assertions only |
| `e2e/homepage.test.ts` | Robust form tests without CI hacks |
| `e2e/map-lazy-loading.spec.ts` | `getByRole('dialog')`, `getByRole('alert')` |

### Before vs After

**Before:**
```typescript
page.locator('.steps, [role="navigation"], .step-container')
if (process.env.CI) { /* skip test */ }
```

**After:**
```typescript
page.getByRole('button')
page.getByRole('dialog')
// No CI-specific code
```

## Test plan

- [x] All 15 E2E tests pass locally
- [x] Tests run stably in parallel mode
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)