### PR TITLE
fix(db): lazy initialize database connection to prevent CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run SvelteKit sync
+        run: npx svelte-kit sync
+
       - name: Get Playwright version
         id: playwright-version
         run: |

--- a/src/lib/server/db/configRepository.ts
+++ b/src/lib/server/db/configRepository.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '$lib/logger';
 import { eq } from 'drizzle-orm';
-import { db } from './index';
+import { db, getDb, isDatabaseAvailable } from './index';
 import { appConfig } from './schema';
 
 const logger = createLogger('configRepository');
@@ -27,6 +27,12 @@ export class ConfigRepository {
 	 * Get a configuration value by key
 	 */
 	static async get(key: string): Promise<ConfigValue | null> {
+		// If database is not configured, return null (caller should use defaults)
+		if (!isDatabaseAvailable()) {
+			logger.debug({ key }, 'Database not configured, returning null for config key');
+			return null;
+		}
+
 		try {
 			// Check cache first
 			const cached = configCache.get(key);
@@ -47,10 +53,10 @@ export class ConfigRepository {
 			}
 
 			const value = result[0]?.value as ConfigValue;
-			
+
 			// Update cache
 			configCache.set(key, { value, timestamp: Date.now() });
-			
+
 			return value;
 		} catch (error) {
 			logger.error({ error, key }, 'Failed to get configuration');
@@ -62,8 +68,9 @@ export class ConfigRepository {
 	 * Get multiple configuration values by category
 	 */
 	static async getByCategory(category: ConfigCategory): Promise<ConfigItem[]> {
+		const database = getDb();
 		try {
-			const result = await db
+			const result = await database
 				.select({
 					id: appConfig.id,
 					key: appConfig.key,
@@ -76,7 +83,7 @@ export class ConfigRepository {
 				.from(appConfig)
 				.where(eq(appConfig.category, category));
 
-			return result.map(row => ({
+			return result.map((row) => ({
 				...row,
 				value: row.value as ConfigValue
 			}));
@@ -90,8 +97,9 @@ export class ConfigRepository {
 	 * Get all configuration values
 	 */
 	static async getAll(): Promise<ConfigItem[]> {
+		const database = getDb();
 		try {
-			const result = await db
+			const result = await database
 				.select({
 					id: appConfig.id,
 					key: appConfig.key,
@@ -104,7 +112,7 @@ export class ConfigRepository {
 				.from(appConfig)
 				.orderBy(appConfig.category, appConfig.key);
 
-			return result.map(row => ({
+			return result.map((row) => ({
 				...row,
 				value: row.value as ConfigValue
 			}));
@@ -118,8 +126,9 @@ export class ConfigRepository {
 	 * Set a configuration value
 	 */
 	static async set(key: string, value: ConfigValue, userId?: string): Promise<void> {
+		const database = getDb();
 		try {
-			const existing = await db
+			const existing = await database
 				.select({ id: appConfig.id })
 				.from(appConfig)
 				.where(eq(appConfig.key, key))
@@ -127,7 +136,7 @@ export class ConfigRepository {
 
 			if (existing.length > 0) {
 				// Update existing
-				await db
+				await database
 					.update(appConfig)
 					.set({
 						value: JSON.parse(JSON.stringify(value)) as unknown,
@@ -137,12 +146,14 @@ export class ConfigRepository {
 					.where(eq(appConfig.key, key));
 			} else {
 				// Insert new - requires category
-				throw new Error(`Configuration key '${key}' does not exist. Use upsert() to create new configurations.`);
+				throw new Error(
+					`Configuration key '${key}' does not exist. Use upsert() to create new configurations.`
+				);
 			}
 
 			// Clear cache
 			configCache.delete(key);
-			
+
 			logger.info({ key, userId }, 'Configuration updated');
 		} catch (error) {
 			logger.error({ error, key }, 'Failed to set configuration');
@@ -154,9 +165,9 @@ export class ConfigRepository {
 	 * Upsert a configuration value (insert or update)
 	 */
 	static async upsert(item: ConfigItem, userId?: string): Promise<void> {
+		const database = getDb();
 		try {
-
-			const existing = await db
+			const existing = await database
 				.select({ id: appConfig.id })
 				.from(appConfig)
 				.where(eq(appConfig.key, item.key))
@@ -164,7 +175,7 @@ export class ConfigRepository {
 
 			if (existing.length > 0) {
 				// Update existing
-				await db
+				await database
 					.update(appConfig)
 					.set({
 						value: JSON.parse(JSON.stringify(item.value)) as unknown,
@@ -176,7 +187,7 @@ export class ConfigRepository {
 					.where(eq(appConfig.key, item.key));
 			} else {
 				// Insert new
-				await db.insert(appConfig).values({
+				await database.insert(appConfig).values({
 					key: item.key,
 					value: JSON.parse(JSON.stringify(item.value)) as unknown,
 					description: item.description,
@@ -188,7 +199,7 @@ export class ConfigRepository {
 
 			// Clear cache
 			configCache.delete(item.key);
-			
+
 			logger.info({ key: item.key, userId }, 'Configuration upserted');
 		} catch (error) {
 			logger.error({ error, item }, 'Failed to upsert configuration');
@@ -200,12 +211,13 @@ export class ConfigRepository {
 	 * Delete a configuration
 	 */
 	static async delete(key: string): Promise<void> {
+		const database = getDb();
 		try {
-			await db.delete(appConfig).where(eq(appConfig.key, key));
-			
+			await database.delete(appConfig).where(eq(appConfig.key, key));
+
 			// Clear cache
 			configCache.delete(key);
-			
+
 			logger.info({ key }, 'Configuration deleted');
 		} catch (error) {
 			logger.error({ error, key }, 'Failed to delete configuration');

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,35 +1,76 @@
-import { env } from '$env/dynamic/private';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 
-// Check if database is configured - don't throw immediately to allow app startup
-const DATABASE_URL = env.DATABASE_POSTGRES_URL;
+// Error message constant for consistency
+const DB_NOT_CONFIGURED_ERROR =
+	'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.';
 
-// Track if we have a real database connection
+// Track database connection state
 let _realDb: PostgresJsDatabase<typeof schema> | null = null;
 let _initError: string | null = null;
 
-// Initialize database if URL is available
-if (DATABASE_URL) {
+/**
+ * Gets the database URL from environment variables.
+ * Uses process.env directly to avoid SvelteKit's $env module-level evaluation issues.
+ * This is safe because this module is server-only.
+ */
+function getDatabaseUrl(): string | undefined {
+	return process.env.DATABASE_POSTGRES_URL;
+}
+
+/**
+ * Lazy initialization of database connection.
+ * Since postgres.js creates connections lazily, this function completes synchronously.
+ * The actual database connection will be established when the first query is executed.
+ */
+function initializeDb(): void {
+	// If already initialized (success or failure), return immediately
+	if (_realDb !== null || _initError !== null) {
+		return;
+	}
+
 	try {
-		const client = postgres(DATABASE_URL);
+		const databaseUrl = getDatabaseUrl();
+		if (!databaseUrl) {
+			_initError = DB_NOT_CONFIGURED_ERROR;
+			return;
+		}
+
+		// postgres() returns immediately - actual connection is lazy
+		const client = postgres(databaseUrl);
 		_realDb = drizzle(client, { schema });
 	} catch (error) {
 		_initError = error instanceof Error ? error.message : String(error);
 	}
 }
 
-// Create a proxy that provides the database or throws a clear error
+/**
+ * Ensures database is initialized before use.
+ * Called by all public APIs that need database access.
+ */
+function ensureInitialized(): void {
+	if (_realDb === null && _initError === null) {
+		initializeDb();
+	}
+}
+
+// Create a proxy that lazily initializes the database connection on first access
 // This allows TypeScript to treat db as non-null while still handling missing DB gracefully
 export const db = new Proxy({} as PostgresJsDatabase<typeof schema>, {
 	get(_target, prop) {
+		// Initialize database on first access if not already done
+		ensureInitialized();
+
+		// Check if initialization succeeded
 		if (!_realDb) {
 			const errorMsg = _initError
 				? `Database connection failed: ${_initError}`
-				: 'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.';
+				: DB_NOT_CONFIGURED_ERROR;
 			throw new Error(errorMsg);
 		}
+
+		// Return the actual property/method from the initialized database
 		const value = _realDb[prop as keyof typeof _realDb];
 		if (typeof value === 'function') {
 			return value.bind(_realDb);
@@ -40,15 +81,18 @@ export const db = new Proxy({} as PostgresJsDatabase<typeof schema>, {
 
 // Helper function to check if database is available (for graceful degradation)
 export function isDatabaseAvailable(): boolean {
+	ensureInitialized();
 	return _realDb !== null;
 }
 
 // Helper function to get db with proper error if not available
 export function getDb(): PostgresJsDatabase<typeof schema> {
+	ensureInitialized();
+
 	if (!_realDb) {
 		const errorMsg = _initError
 			? `Database connection failed: ${_initError}`
-			: 'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.';
+			: DB_NOT_CONFIGURED_ERROR;
 		throw new Error(errorMsg);
 	}
 	return _realDb;

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,10 +1,55 @@
 import { env } from '$env/dynamic/private';
-import { drizzle } from 'drizzle-orm/postgres-js';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 
-if (!env.DATABASE_POSTGRES_URL) throw new Error('DATABASE_URL is not set');
+// Check if database is configured - don't throw immediately to allow app startup
+const DATABASE_URL = env.DATABASE_POSTGRES_URL;
 
-const client = postgres(env.DATABASE_POSTGRES_URL);
+// Track if we have a real database connection
+let _realDb: PostgresJsDatabase<typeof schema> | null = null;
+let _initError: string | null = null;
 
-export const db = drizzle(client, { schema });
+// Initialize database if URL is available
+if (DATABASE_URL) {
+	try {
+		const client = postgres(DATABASE_URL);
+		_realDb = drizzle(client, { schema });
+	} catch (error) {
+		_initError = error instanceof Error ? error.message : String(error);
+	}
+}
+
+// Create a proxy that provides the database or throws a clear error
+// This allows TypeScript to treat db as non-null while still handling missing DB gracefully
+export const db = new Proxy({} as PostgresJsDatabase<typeof schema>, {
+	get(_target, prop) {
+		if (!_realDb) {
+			const errorMsg = _initError
+				? `Database connection failed: ${_initError}`
+				: 'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.';
+			throw new Error(errorMsg);
+		}
+		const value = _realDb[prop as keyof typeof _realDb];
+		if (typeof value === 'function') {
+			return value.bind(_realDb);
+		}
+		return value;
+	}
+});
+
+// Helper function to check if database is available (for graceful degradation)
+export function isDatabaseAvailable(): boolean {
+	return _realDb !== null;
+}
+
+// Helper function to get db with proper error if not available
+export function getDb(): PostgresJsDatabase<typeof schema> {
+	if (!_realDb) {
+		const errorMsg = _initError
+			? `Database connection failed: ${_initError}`
+			: 'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.';
+		throw new Error(errorMsg);
+	}
+	return _realDb;
+}

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -1,16 +1,35 @@
-import { ServerConfigService } from '$lib/services/configService';
+import { createLogger } from '$lib/logger';
+import { ServerConfigService, DEFAULT_VALUES } from '$lib/services/configService';
 import type { PageServerLoad } from './$types';
 
+const logger = createLogger('map-page');
+
+// Default map configuration fallback
+const defaultMapConfig = {
+	center: DEFAULT_VALUES['display.defaultMapCenter'],
+	zoom: DEFAULT_VALUES['display.defaultMapZoom'],
+	tileProvider: DEFAULT_VALUES['integration.mapTileProvider'],
+	showUnapprovedSightings: DEFAULT_VALUES['display.showUnapprovedOnMap']
+};
+
 export const load: PageServerLoad = async () => {
-	// Load map configuration for server-side rendering
-	const mapConfig = await ServerConfigService.getMapConfig();
-	
-	return {
-		mapConfig: {
-			center: mapConfig.center,
-			zoom: mapConfig.zoom,
-			tileProvider: mapConfig.tileProvider,
-			showUnapprovedSightings: mapConfig.showUnapprovedSightings
-		}
-	};
+	try {
+		// Load map configuration for server-side rendering
+		const mapConfig = await ServerConfigService.getMapConfig();
+
+		return {
+			mapConfig: {
+				center: mapConfig.center,
+				zoom: mapConfig.zoom,
+				tileProvider: mapConfig.tileProvider,
+				showUnapprovedSightings: mapConfig.showUnapprovedSightings
+			}
+		};
+	} catch (error) {
+		// Log the error but return default config to allow page to render
+		logger.warn({ error }, 'Failed to load map configuration from database, using defaults');
+		return {
+			mapConfig: defaultMapConfig
+		};
+	}
 };


### PR DESCRIPTION
## Summary

- Make database connection lazy-initialized using a Proxy pattern to allow imports to succeed even when DB is not available
- Add graceful error handling in map page server load with fallback to default configuration values
- Fixes E2E tests failing in CI environment without database access

## Problem

The E2E tests were failing in CI because the map page's server-side load function was trying to access the database, which is not available in the CI test environment. The error manifested as the map page not loading correctly, causing navigation to fall back to the main page.

## Solution

1. **Lazy database initialization**: Changed `src/lib/server/db/index.ts` to use a Proxy pattern that delays database connection until the first actual query. This allows module imports to succeed even when the database URL is not configured or the database is unreachable.

2. **Graceful error handling**: Updated `src/routes/map/+page.server.ts` to catch database errors in the load function and return default configuration values, allowing the page to render even without database access.

## Test plan

- [x] Run `npm run test:quick` - all 839 unit tests pass
- [x] Run `npm run test:e2e` in CI mode - all 15 E2E tests pass
- [x] Specifically verified map page tests that were previously failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)