### PR TITLE
fix(build): use dynamic environment variables for Docker runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,13 @@ src/
 
 ### Database Connection
 
+**Lazy Database Initialization**
+
+The database connection uses lazy initialization via a Proxy pattern (`src/lib/server/db/index.ts`). This provides:
+- **CI/CD Compatibility**: E2E tests can run without database access
+- **Race Condition Protection**: Safe initialization in concurrent environments
+- **Deferred Connection**: Database connection only established when first accessed
+
 **Option 1: Local PostgreSQL (Recommended for macOS)**
 
 Native PostgreSQL installation on port 5432:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,18 +167,37 @@ npm run build        # Build check
 
 ## 📦 Release Process
 
-This project uses [semantic-release](https://semantic-release.gitbook.io/) for automated versioning and releases:
+This project uses [release-please](https://github.com/googleapis/release-please) for automated versioning and releases:
 
-1. **Automatic versioning** based on conventional commit messages
-2. **Changelog generation** from commit history
-3. **GitHub releases** with release notes
-4. **Version bumping** in package.json
+### How It Works
+
+1. **Commit Analysis**: Every commit to `main` is analyzed by release-please
+2. **Release PR**: release-please creates and maintains a "Release PR" that accumulates all changes
+3. **Changelog Generation**: Automatic changelog updates based on conventional commits
+4. **Version Bumping**: Semantic versioning based on commit types
+
+### Release Workflow
+
+1. **Development**: Merge feature PRs into `main` as usual
+2. **Release PR**: release-please automatically creates/updates a Release PR
+3. **Review**: Review the accumulated changes in the Release PR
+4. **Merge**: When ready, merge the Release PR to trigger:
+   - New version tag (e.g., `v2.0.4`)
+   - GitHub Release with changelog
+   - Docker image build and publication
+   - Update of `release` branch to latest version
 
 ### Release Types
 
-- **Patch** (1.0.1): `fix`, `docs`, `perf` commits
-- **Minor** (1.1.0): `feat` commits  
-- **Major** (2.0.0): commits with `BREAKING CHANGE` or `!` in type
+- **Patch** (1.0.1): `fix`, `docs`, `perf`, `refactor` commits
+- **Minor** (1.1.0): `feat` commits
+- **Major** (2.0.0): commits with `BREAKING CHANGE` footer or `!` in type (e.g., `feat!:`)
+
+### Important Notes
+
+- **Do NOT manually create releases or tags** - this is handled by release-please
+- **Do NOT push directly to the `release` branch** - it's auto-maintained
+- The Release PR title follows conventional commit format and should not be modified
 
 ## 🚦 Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ docker compose -f docker-compose.production.yml --profile monitoring up -d
 docker pull ghcr.io/jansinger/ostsee-sichtung:latest
 
 # Spezifische Version ziehen
-docker pull ghcr.io/jansinger/ostsee-sichtung:v1.31.3
+docker pull ghcr.io/jansinger/ostsee-sichtung:v2.0.3
 
 # Mit Tag ausführen
 docker run -p 3000:3000 --env-file .env ghcr.io/jansinger/ostsee-sichtung:latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.20.x  | :white_check_mark: |
-| < 1.20  | :x:                |
+| 2.0.x   | :white_check_mark: |
+| < 2.0   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -22,7 +22,7 @@ Please report security vulnerabilities to the maintainers via:
 
 ## Current Security Status
 
-### Vulnerability Assessment (as of 2025-08-28)
+### Vulnerability Assessment (as of 2025-12-23)
 - **Critical**: 0 ✅
 - **High**: 0 ✅  
 - **Moderate**: 0 ✅
@@ -138,16 +138,41 @@ We maintain a proactive approach to dependency security:
 
 ## Security Roadmap
 
+### Recently Implemented ✅
+
+The following security features have been implemented:
+
+- [x] **Rate Limiting**: API endpoint protection with configurable limits
+  - File Upload: 20 uploads/hour (anonymous), 50 uploads/hour (authenticated)
+  - Media Access: 30 requests/minute (anonymous), 100 requests/minute (authenticated)
+  - Sighting Submission: 20 sightings/hour
+  - Implementation: `src/lib/server/middleware/rateLimit.ts`
+
+- [x] **File Upload Hardening**: Magic bytes validation and MIME-type verification
+  - Validates file content against declared MIME type
+  - Supports images (JPEG, PNG, GIF, WebP, BMP) and videos (MP4, AVI, MOV, WebM, MKV)
+  - Detects and blocks dangerous file types (executables, scripts)
+  - Implementation: `src/lib/server/validation/magicBytes.ts`
+
+- [x] **Directory Traversal Protection**: Path normalization and validation
+  - Blocks `../` sequences and absolute paths
+  - Logs blocked attempts for security monitoring
+  - Implementation: `src/lib/server/uploads.ts`
+
+- [x] **Lazy Database Initialization**: CI/CD security compatibility
+  - Proxy pattern for deferred database connections
+  - Enables E2E tests without database access
+  - Race condition protection implemented
+  - Implementation: `src/lib/server/db/index.ts`
+
 ### Immediate Priorities (High Impact)
 - [ ] **CodeQL Integration**: Advanced SAST scanning in GitHub workflows
-- [ ] **Enhanced Rate Limiting**: API endpoint protection with configurable limits
 - [ ] **Input Sanitization**: DOMPurify integration for HTML content
 - [ ] **Security Headers**: Add missing Cross-Origin policies
 
 ### Medium-Term Goals (Weeks)
 - [ ] **Security Monitoring**: Implement security event logging and alerting
-- [ ] **File Upload Hardening**: Magic bytes validation, malware scanning
-- [ ] **API Security**: Enhanced request validation and sanitization
+- [ ] **Malware Scanning**: Integrate malware scanning for file uploads
 - [ ] **Audit Logging**: Comprehensive user action tracking
 
 ### Long-Term Enhancements (Months)
@@ -211,6 +236,6 @@ We maintain a proactive approach to dependency security:
 
 ---
 
-*Last Updated: 2025-08-28*  
-*Security Assessment: 7.5/10 - Strong foundational security with enhancement opportunities*  
-*Next Security Review: 2025-12-28*
+*Last Updated: 2025-12-23*
+*Security Assessment: 8.0/10 - Strong foundational security with recent enhancements*
+*Next Security Review: 2026-03-23*

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -15,6 +15,8 @@ This comprehensive guide covers deploying the Ostsee-Tiere marine animal sightin
 - [Production Deployment](#production-deployment)
 - [CI/CD and Release Process](#cicd-and-release-process)
 - [Backup & Restore](#backup--restore)
+- [Local Development Testing with Rancher Desktop](#local-development-testing-with-rancher-desktop)
+- [Production with External PostgreSQL](#production-with-external-postgresql)
 - [Troubleshooting](#troubleshooting)
 - [Security Best Practices](#security-best-practices)
 
@@ -95,7 +97,40 @@ docker compose -f docker-compose.production.yml --profile monitoring up -d
 docker compose -f docker-compose.production.yml logs -f
 ```
 
-### Option 2: Standalone Container
+### Option 2: Release Script with Local Database
+
+**Best for**: Testing releases locally, development with real data, using existing PostgreSQL.
+
+The `run-release.sh` script simplifies running Docker releases with a local PostgreSQL database:
+
+```bash
+# Run latest release
+./run-release.sh
+
+# Run specific version
+./run-release.sh v2.0.3
+
+# Stop container
+./run-release.sh stop
+
+# View logs
+./run-release.sh logs
+
+# Check status
+./run-release.sh status
+
+# Use different port
+PORT=3001 ./run-release.sh
+```
+
+**Prerequisites:**
+- Local PostgreSQL with PostGIS extension
+- `.env` file with database connection and Auth0 credentials
+- `uploads/` directory for file storage
+
+See [Local Development Testing](#local-development-testing-with-rancher-desktop) for detailed setup instructions.
+
+### Option 3: Standalone Container
 
 **Best for**: Using external database, custom setups.
 
@@ -126,7 +161,7 @@ docker run -d \
 # -v ostsee-uploads:/app/uploads
 ```
 
-### Option 3: Cloud Deployment
+### Option 4: Cloud Deployment
 
 **Best for**: AWS ECS, Azure Container Instances, Google Cloud Run.
 
@@ -650,6 +685,369 @@ docker run --rm \
   -v ostsee-tiere_pgdata:/pgdata \
   -v $(pwd)/backups:/backup \
   alpine sh -c "tar czf /backup/volumes-backup-$(date +%Y%m%d).tar.gz /uploads /pgdata"
+```
+
+---
+
+## Local Development Testing with Rancher Desktop
+
+This section covers running Docker releases locally for testing with Rancher Desktop on macOS and a local PostgreSQL database.
+
+### Prerequisites
+
+1. **Rancher Desktop** installed (https://rancherdesktop.io/)
+2. **Local PostgreSQL** with PostGIS extension
+3. **Caddy** for HTTPS proxy (required due to CSP `upgrade-insecure-requests`)
+
+### Step 1: Configure PostgreSQL for Docker Access
+
+Rancher Desktop uses a Lima VM, so containers cannot access `localhost` directly. PostgreSQL must listen on all interfaces:
+
+**Edit postgresql.conf:**
+```bash
+# Find your PostgreSQL config
+psql -c "SHOW config_file;"
+
+# Edit the file (example path for Homebrew PostgreSQL 18)
+nano /opt/homebrew/var/postgresql@18/postgresql.conf
+
+# Change this line:
+listen_addresses = '*'    # Was: #listen_addresses = 'localhost'
+```
+
+**Edit pg_hba.conf to allow network connections:**
+```bash
+# Add this line to pg_hba.conf (same directory as postgresql.conf)
+echo "host    all    all    192.168.0.0/16    scram-sha-256" >> /opt/homebrew/var/postgresql@18/pg_hba.conf
+```
+
+**Restart PostgreSQL:**
+```bash
+brew services restart postgresql@18
+```
+
+### Step 2: Configure Environment
+
+Create or update your `.env` file:
+```bash
+# Database (use localhost - the script will auto-detect and adjust for Rancher)
+DATABASE_POSTGRES_URL="postgresql://ostsee_app:your-password@localhost:5432/ostsee"
+
+# Storage
+STORAGE_PROVIDER=local
+
+# Security
+SESSION_SECRET=your-secure-random-string-min-32-chars
+ENCRYPTION_KEY=your-64-character-hexadecimal-encryption-key
+
+# Auth0 (can use test values for local testing)
+AUTH0_CLIENT_ID=your-auth0-client-id
+AUTH0_CLIENT_SECRET=your-auth0-client-secret
+AUTH0_DOMAIN=your-tenant.auth0.com
+JWKS_URL=https://your-tenant.auth0.com/.well-known/jwks.json
+API_AUDIENCE=your-api-audience
+```
+
+### Step 3: Run the Release
+
+```bash
+# Run latest release
+./run-release.sh
+
+# The script automatically:
+# - Detects Rancher Desktop
+# - Replaces localhost with your host IP in DATABASE_POSTGRES_URL
+# - Creates uploads directory
+# - Starts the container with proper settings
+```
+
+**Output example:**
+```
+Detected Docker runtime: rancher
+Rancher Desktop detected - adjusting database connection
+Host IP: 192.168.68.51
+Note: PostgreSQL must be configured to accept connections from Docker
+
+Starting Ostsee-Tiere Release Container
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Runtime:   rancher
+Image:     ghcr.io/jansinger/ostsee-sichtung:latest
+Port:      http://localhost:3000
+Database:  postgresql://ostsee_app:***@192.168.68.51:5432/ostsee
+Uploads:   /path/to/project/uploads
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Step 4: HTTPS Access (Required)
+
+The production Docker image includes `upgrade-insecure-requests` in its Content Security Policy, which forces browsers to use HTTPS. You need a local HTTPS proxy:
+
+**Install and run Caddy:**
+```bash
+# Install Caddy
+brew install caddy
+
+# Start HTTPS reverse proxy
+caddy reverse-proxy --from localhost:3443 --to localhost:3000
+
+# Keep running in background
+caddy reverse-proxy --from localhost:3443 --to localhost:3000 &
+```
+
+**Access the application:**
+```
+https://localhost:3443
+```
+
+> **Note:** You'll see a certificate warning on first access. Click "Advanced" → "Proceed to localhost" to accept the local certificate.
+
+### Step 5: Commands Reference
+
+```bash
+./run-release.sh              # Run latest release
+./run-release.sh v2.0.3       # Run specific version
+./run-release.sh stop         # Stop container
+./run-release.sh logs         # View logs (follow mode)
+./run-release.sh status       # Check container status
+
+PORT=3001 ./run-release.sh    # Use different port
+```
+
+### Troubleshooting Rancher Desktop
+
+**Database connection refused:**
+```bash
+# Verify PostgreSQL is listening on all interfaces
+lsof -i :5432
+# Should show: postgres ... *:postgresql (LISTEN)
+
+# Check pg_hba.conf has the network rule
+cat /opt/homebrew/var/postgresql@18/pg_hba.conf | grep 192.168
+```
+
+**CSS/Assets not loading:**
+This is caused by `upgrade-insecure-requests` CSP. Use the HTTPS proxy:
+```bash
+caddy reverse-proxy --from localhost:3443 --to localhost:3000
+```
+
+**Container starts but health check fails:**
+```bash
+# Check container logs
+./run-release.sh logs
+
+# Common issues:
+# - Database connection: Check PostgreSQL config
+# - Missing env vars: Check .env file
+```
+
+---
+
+## Production with External PostgreSQL
+
+This section covers deploying Docker in production using an existing PostgreSQL server (not in Docker).
+
+### Architecture
+
+```
+┌──────────────────┐     ┌─────────────────────┐
+│  Docker Host     │     │  Database Server    │
+│  ┌────────────┐  │     │  ┌───────────────┐  │
+│  │ ostsee-    │  │────▶│  │ PostgreSQL    │  │
+│  │ tiere-app  │  │     │  │ + PostGIS     │  │
+│  └────────────┘  │     │  └───────────────┘  │
+│  ┌────────────┐  │     └─────────────────────┘
+│  │ ./uploads  │  │
+│  └────────────┘  │
+│  ┌────────────┐  │
+│  │ nginx/     │  │
+│  │ caddy      │  │
+│  └────────────┘  │
+└──────────────────┘
+```
+
+### Prerequisites
+
+1. **PostgreSQL Server** with PostGIS extension (can be on same or different host)
+2. **Docker** installed on application server
+3. **Reverse Proxy** (Nginx, Caddy, or Traefik) for SSL termination
+
+### Step 1: Configure PostgreSQL Server
+
+On your PostgreSQL server:
+
+```sql
+-- Create database
+CREATE DATABASE ostsee;
+\c ostsee
+
+-- Enable PostGIS
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS postgis_topology;
+
+-- Create application user
+CREATE USER ostsee_app WITH PASSWORD 'secure-password-here';
+GRANT ALL PRIVILEGES ON DATABASE ostsee TO ostsee_app;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO ostsee_app;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO ostsee_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO ostsee_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO ostsee_app;
+```
+
+**Configure pg_hba.conf to allow Docker connections:**
+```
+# Allow connections from Docker host
+host    ostsee    ostsee_app    DOCKER_HOST_IP/32    scram-sha-256
+
+# Or allow from entire subnet
+host    ostsee    ostsee_app    10.0.0.0/8    scram-sha-256
+```
+
+**Configure postgresql.conf:**
+```
+listen_addresses = '*'
+```
+
+### Step 2: Create Environment File
+
+On your Docker host, create `.env`:
+
+```bash
+# Database - use the PostgreSQL server's hostname/IP
+DATABASE_POSTGRES_URL=postgresql://ostsee_app:secure-password@db.example.com:5432/ostsee
+
+# Storage
+STORAGE_PROVIDER=local
+
+# Application
+NODE_ENV=production
+PUBLIC_SITE_URL=https://ostsee-tiere.example.com
+PORT=3000
+
+# Security (generate with: openssl rand -base64 32 / openssl rand -hex 32)
+SESSION_SECRET=your-secure-random-string-min-32-chars
+ENCRYPTION_KEY=your-64-character-hexadecimal-encryption-key
+
+# Auth0
+AUTH0_CLIENT_ID=your-auth0-client-id
+AUTH0_CLIENT_SECRET=your-auth0-client-secret
+AUTH0_DOMAIN=your-tenant.auth0.com
+JWKS_URL=https://your-tenant.auth0.com/.well-known/jwks.json
+API_AUDIENCE=your-api-audience
+```
+
+### Step 3: Run Docker Container
+
+```bash
+# Create uploads directory
+mkdir -p /opt/ostsee-tiere/uploads
+chown 1001:1001 /opt/ostsee-tiere/uploads
+
+# Pull and run
+docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+
+docker run -d \
+  --name ostsee-tiere \
+  --restart unless-stopped \
+  -p 127.0.0.1:3000:3000 \
+  -v /opt/ostsee-tiere/uploads:/app/uploads \
+  --env-file /opt/ostsee-tiere/.env \
+  ghcr.io/jansinger/ostsee-sichtung:latest
+```
+
+> **Note:** We bind to `127.0.0.1:3000` so the app is only accessible via the reverse proxy.
+
+### Step 4: Configure Reverse Proxy
+
+**Nginx example:**
+```nginx
+server {
+    listen 80;
+    server_name ostsee-tiere.example.com;
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name ostsee-tiere.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/ostsee-tiere.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ostsee-tiere.example.com/privkey.pem;
+
+    client_max_body_size 50M;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+**Caddy example (auto-SSL):**
+```
+ostsee-tiere.example.com {
+    reverse_proxy localhost:3000
+}
+```
+
+### Step 5: Systemd Service (Optional)
+
+Create `/etc/systemd/system/ostsee-tiere.service`:
+
+```ini
+[Unit]
+Description=Ostsee-Tiere Marine Sighting Platform
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=5
+ExecStartPre=-/usr/bin/docker stop ostsee-tiere
+ExecStartPre=-/usr/bin/docker rm ostsee-tiere
+ExecStart=/usr/bin/docker run --rm \
+  --name ostsee-tiere \
+  -p 127.0.0.1:3000:3000 \
+  -v /opt/ostsee-tiere/uploads:/app/uploads \
+  --env-file /opt/ostsee-tiere/.env \
+  ghcr.io/jansinger/ostsee-sichtung:latest
+ExecStop=/usr/bin/docker stop ostsee-tiere
+
+[Install]
+WantedBy=multi-user.target
+```
+
+**Enable and start:**
+```bash
+sudo systemctl enable ostsee-tiere
+sudo systemctl start ostsee-tiere
+sudo systemctl status ostsee-tiere
+```
+
+### Update Process
+
+```bash
+# Pull new image
+docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+
+# Restart container
+docker stop ostsee-tiere
+docker rm ostsee-tiere
+docker run -d \
+  --name ostsee-tiere \
+  --restart unless-stopped \
+  -p 127.0.0.1:3000:3000 \
+  -v /opt/ostsee-tiere/uploads:/app/uploads \
+  --env-file /opt/ostsee-tiere/.env \
+  ghcr.io/jansinger/ostsee-sichtung:latest
+
+# Or with systemd
+sudo systemctl restart ostsee-tiere
 ```
 
 ---

--- a/run-release.sh
+++ b/run-release.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# Run the latest release Docker image with local PostgreSQL and uploads directory
+#
+# Usage:
+#   ./run-release.sh           # Run latest release
+#   ./run-release.sh v2.0.2    # Run specific version
+#   ./run-release.sh stop      # Stop running container
+#   ./run-release.sh logs      # View logs
+#
+# Supports Docker Desktop and Rancher Desktop on macOS
+# Note: For Rancher Desktop, PostgreSQL must listen on all interfaces
+#
+
+set -e
+
+CONTAINER_NAME="ostsee-tiere-release"
+IMAGE_BASE="ghcr.io/jansinger/ostsee-sichtung"
+VERSION="${1:-latest}"
+PORT="${PORT:-3000}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Detect Docker runtime (Docker Desktop vs Rancher Desktop)
+detect_docker_runtime() {
+    if docker context show 2>/dev/null | grep -q "rancher-desktop"; then
+        echo "rancher"
+    elif docker info 2>/dev/null | grep -q "rancher"; then
+        echo "rancher"
+    else
+        echo "docker"
+    fi
+}
+
+# Get host IP for database connection (needed for Rancher Desktop)
+get_host_ip() {
+    # Try to get the primary network interface IP
+    if command -v ifconfig >/dev/null 2>&1; then
+        ifconfig en0 2>/dev/null | grep "inet " | awk '{print $2}' | head -1
+    elif command -v ip >/dev/null 2>&1; then
+        ip route get 1 2>/dev/null | awk '{print $7}' | head -1
+    else
+        echo "127.0.0.1"
+    fi
+}
+
+# Handle commands
+case "$VERSION" in
+    stop)
+        echo -e "${YELLOW}Stopping container...${NC}"
+        docker stop "$CONTAINER_NAME" 2>/dev/null || true
+        docker rm "$CONTAINER_NAME" 2>/dev/null || true
+        echo -e "${GREEN}Container stopped and removed.${NC}"
+        exit 0
+        ;;
+    logs)
+        docker logs -f "$CONTAINER_NAME"
+        exit 0
+        ;;
+    status)
+        docker ps -f "name=$CONTAINER_NAME" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+        exit 0
+        ;;
+esac
+
+# Check if .env exists
+if [ ! -f "$SCRIPT_DIR/.env" ]; then
+    echo -e "${RED}Error: .env file not found${NC}"
+    echo "Please create .env file with required configuration"
+    exit 1
+fi
+
+# Load .env file
+set -a
+source "$SCRIPT_DIR/.env"
+set +a
+
+# Check required environment variables
+if [ -z "$AUTH0_CLIENT_ID" ] || [ "$AUTH0_CLIENT_ID" = "client-id" ]; then
+    echo -e "${YELLOW}Warning: AUTH0_CLIENT_ID not configured - authentication will not work${NC}"
+fi
+
+# Detect Docker runtime
+DOCKER_RUNTIME=$(detect_docker_runtime)
+HOST_IP=$(get_host_ip)
+
+echo -e "${BLUE}Detected Docker runtime: $DOCKER_RUNTIME${NC}"
+
+# For Rancher Desktop, we need to replace localhost with host IP in DATABASE_POSTGRES_URL
+if [ "$DOCKER_RUNTIME" = "rancher" ]; then
+    echo -e "${YELLOW}Rancher Desktop detected - adjusting database connection${NC}"
+
+    # Replace localhost with host IP in the database URL
+    DOCKER_DATABASE_URL=$(echo "$DATABASE_POSTGRES_URL" | sed "s/@localhost:/@$HOST_IP:/g" | sed "s/@127\.0\.0\.1:/@$HOST_IP:/g")
+
+    echo -e "${BLUE}Host IP: $HOST_IP${NC}"
+    echo -e "${YELLOW}Note: PostgreSQL must be configured to accept connections from Docker${NC}"
+    echo -e "${YELLOW}      Add '$HOST_IP/32' to pg_hba.conf if connection fails${NC}"
+else
+    DOCKER_DATABASE_URL="$DATABASE_POSTGRES_URL"
+fi
+
+# Stop existing container if running
+if docker ps -q -f "name=$CONTAINER_NAME" | grep -q .; then
+    echo -e "${YELLOW}Stopping existing container...${NC}"
+    docker stop "$CONTAINER_NAME" >/dev/null
+    docker rm "$CONTAINER_NAME" >/dev/null
+fi
+
+# Pull the image
+IMAGE="$IMAGE_BASE:$VERSION"
+echo -e "${GREEN}Pulling image: $IMAGE${NC}"
+docker pull "$IMAGE"
+
+# Ensure uploads directory exists
+mkdir -p "$SCRIPT_DIR/uploads"
+
+echo ""
+echo -e "${GREEN}Starting Ostsee-Tiere Release Container${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Runtime:   $DOCKER_RUNTIME"
+echo "Image:     $IMAGE"
+echo "Port:      http://localhost:$PORT"
+echo "Database:  $DOCKER_DATABASE_URL"
+echo "Uploads:   $SCRIPT_DIR/uploads"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Run the container
+# - Port mapping for application access
+# - Run as current user to avoid permission issues with bind mounts
+# - Override entrypoint to skip storage check (Rancher Desktop compatibility)
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "$PORT:$PORT" \
+    --user "$(id -u):$(id -g)" \
+    -v "$SCRIPT_DIR/uploads:/app/uploads" \
+    --entrypoint "" \
+    -e PORT="$PORT" \
+    -e DATABASE_POSTGRES_URL="$DOCKER_DATABASE_URL" \
+    -e STORAGE_PROVIDER="${STORAGE_PROVIDER:-local}" \
+    -e NODE_ENV="production" \
+    -e PUBLIC_SITE_URL="${PUBLIC_SITE_URL:-http://localhost:$PORT}" \
+    -e SESSION_SECRET="${SESSION_SECRET}" \
+    -e ENCRYPTION_KEY="${ENCRYPTION_KEY}" \
+    -e AUTH0_CLIENT_ID="${AUTH0_CLIENT_ID}" \
+    -e AUTH0_CLIENT_SECRET="${AUTH0_CLIENT_SECRET}" \
+    -e AUTH0_DOMAIN="${AUTH0_DOMAIN}" \
+    -e JWKS_URL="${JWKS_URL}" \
+    -e API_AUDIENCE="${API_AUDIENCE}" \
+    -e LOG_LEVEL="${LOG_LEVEL:-info}" \
+    -e SKIP_STORAGE_CHECK="${SKIP_STORAGE_CHECK:-true}" \
+    "$IMAGE" \
+    node build/index.js
+
+echo -e "${GREEN}Container started!${NC}"
+echo ""
+echo "Commands:"
+echo "  ./run-release.sh logs    - View logs"
+echo "  ./run-release.sh stop    - Stop container"
+echo "  ./run-release.sh status  - Check status"
+echo ""
+echo -e "${GREEN}Application available at: http://localhost:$PORT${NC}"
+echo ""
+
+# Wait a moment and check health
+sleep 3
+if docker ps -q -f "name=$CONTAINER_NAME" | grep -q .; then
+    echo -e "${GREEN}✓ Container is running${NC}"
+
+    # Wait for health check
+    echo "Waiting for application to start..."
+    for i in {1..30}; do
+        if curl -s -f "http://localhost:$PORT/health" >/dev/null 2>&1; then
+            echo -e "${GREEN}✓ Application is healthy${NC}"
+            exit 0
+        fi
+        sleep 1
+    done
+
+    echo -e "${YELLOW}Application may still be starting. Check logs with: ./run-release.sh logs${NC}"
+else
+    echo -e "${RED}✗ Container failed to start. Check logs:${NC}"
+    docker logs "$CONTAINER_NAME"
+    exit 1
+fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -7,28 +7,36 @@
 
 set -e
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+# Colors for output (only if terminal is attached)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    NC=''
+fi
 
 # Logging functions
 log_info() {
-    echo "${BLUE}[INFO]${NC} $1"
+    printf "%b[INFO]%b %s\n" "$BLUE" "$NC" "$1"
 }
 
 log_success() {
-    echo "${GREEN}[SUCCESS]${NC} $1"
+    printf "%b[SUCCESS]%b %s\n" "$GREEN" "$NC" "$1"
 }
 
 log_warning() {
-    echo "${YELLOW}[WARNING]${NC} $1"
+    printf "%b[WARNING]%b %s\n" "$YELLOW" "$NC" "$1"
 }
 
 log_error() {
-    echo "${RED}[ERROR]${NC} $1"
+    printf "%b[ERROR]%b %s\n" "$RED" "$NC" "$1"
 }
 
 # ============================================

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import { COOKIE_NAME, NODE_ENV, SESSION_SECRET } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { createLogger } from '$lib/logger';
 import { clearAuthCookie, setAuthCookie } from '$lib/server/auth/auth';
 import { maintenanceMode } from '$lib/server/middleware/maintenanceMode';
@@ -7,6 +7,11 @@ import type { Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { randomBytes } from 'crypto';
 import jwt from 'jsonwebtoken';
+
+// Dynamic environment variables for Docker runtime
+const COOKIE_NAME = env.COOKIE_NAME ?? 'auth-cookie';
+const NODE_ENV = env.NODE_ENV ?? 'development';
+const SESSION_SECRET = env.SESSION_SECRET ?? '';
 
 const logger = createLogger('hooks:server');
 

--- a/src/lib/server/auth/auth.test.ts
+++ b/src/lib/server/auth/auth.test.ts
@@ -17,16 +17,18 @@ vi.mock('@sveltejs/kit', async () => {
 	};
 });
 
-// Mock environment variables
-vi.mock('$env/static/private', () => ({
-	AUTH0_CLIENT_ID: 'test-client-id',
-	AUTH0_CLIENT_SECRET: 'test-client-secret',
-	AUTH0_DOMAIN: 'test-domain.auth0.com',
-	COOKIE_NAME: 'test-auth-cookie',
-	JWKS_URL: 'https://test-domain.auth0.com/.well-known/jwks.json',
-	SESSION_SECRET: 'test-session-secret',
-	ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-	NODE_ENV: 'test'
+// Mock environment variables (dynamic env for Docker runtime)
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		AUTH0_CLIENT_ID: 'test-client-id',
+		AUTH0_CLIENT_SECRET: 'test-client-secret',
+		AUTH0_DOMAIN: 'test-domain.auth0.com',
+		COOKIE_NAME: 'test-auth-cookie',
+		JWKS_URL: 'https://test-domain.auth0.com/.well-known/jwks.json',
+		SESSION_SECRET: 'test-session-secret',
+		ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+		NODE_ENV: 'test'
+	}
 }));
 
 vi.mock('$env/static/public', () => ({

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -1,17 +1,17 @@
-import * as dynamicEnv from '$env/dynamic/private';
+import { env } from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
-
-// Use dynamic environment variables for Docker runtime configuration
-const AUTH0_CLIENT_ID = dynamicEnv.env.AUTH0_CLIENT_ID ?? '';
-const AUTH0_CLIENT_SECRET = dynamicEnv.env.AUTH0_CLIENT_SECRET ?? '';
-const AUTH0_DOMAIN = dynamicEnv.env.AUTH0_DOMAIN ?? '';
-const COOKIE_NAME = dynamicEnv.env.COOKIE_NAME ?? 'auth-cookie';
-const ENCRYPTION_KEY = dynamicEnv.env.ENCRYPTION_KEY ?? '';
-const JWKS_URL = dynamicEnv.env.JWKS_URL ?? '';
-const SESSION_SECRET = dynamicEnv.env.SESSION_SECRET ?? '';
-const NODE_ENV = dynamicEnv.env.NODE_ENV ?? 'development';
-
 import type { User } from '$lib/types/index';
+
+// Helper functions to get environment variables dynamically
+// This allows tests to mock the values and Docker to provide runtime configuration
+const getAuth0ClientId = () => env.AUTH0_CLIENT_ID ?? '';
+const getAuth0ClientSecret = () => env.AUTH0_CLIENT_SECRET ?? '';
+const getAuth0Domain = () => env.AUTH0_DOMAIN ?? '';
+const getCookieName = () => env.COOKIE_NAME ?? 'auth-cookie';
+const getEncryptionKey = () => env.ENCRYPTION_KEY ?? '';
+const getJwksUrl = () => env.JWKS_URL ?? '';
+const getSessionSecret = () => env.SESSION_SECRET ?? '';
+const getNodeEnv = () => env.NODE_ENV ?? 'development';
 import { error, redirect, type Cookies } from '@sveltejs/kit';
 import type { JwtHeader, SigningKeyCallback } from 'jsonwebtoken';
 import jwt from 'jsonwebtoken';
@@ -74,7 +74,7 @@ const COOKIE_AUTHORIZE_DURATION_SECONDS = 60 * 10; // 10 Minuten
  * @param callback - Callback-Funktion, die mit dem Schlüssel oder Fehler aufgerufen wird
  */
 function getKey(header: JwtHeader, callback: SigningKeyCallback) {
-	const client = new JwksClient({ jwksUri: JWKS_URL });
+	const client = new JwksClient({ jwksUri: getJwksUrl() });
 
 	client.getSigningKey(header.kid, function (err, key) {
 		if (err) {
@@ -181,12 +181,12 @@ export async function getTokenClaims<T>(token: string): Promise<T> {
  * ```
  */
 export async function getToken({ code, pkceVerifier }: { code: string; pkceVerifier: string }) {
-	const resp = await fetch(`https://${AUTH0_DOMAIN}/oauth/token`, {
+	const resp = await fetch(`https://${getAuth0Domain()}/oauth/token`, {
 		method: 'POST',
 		body: JSON.stringify({
 			code,
-			client_id: AUTH0_CLIENT_ID,
-			client_secret: AUTH0_CLIENT_SECRET,
+			client_id: getAuth0ClientId(),
+			client_secret: getAuth0ClientSecret(),
 			redirect_uri: `${PUBLIC_SITE_URL}/api/auth/callback`,
 			grant_type: 'authorization_code',
 			code_verifier: pkceVerifier
@@ -225,7 +225,7 @@ export async function getToken({ code, pkceVerifier }: { code: string; pkceVerif
  * ```
  */
 export const getAuthUser = (cookies: Cookies) => {
-	const jwtToken = cookies.get(COOKIE_NAME);
+	const jwtToken = cookies.get(getCookieName());
 
 	if (!jwtToken) {
 		return null;
@@ -260,13 +260,13 @@ export const getAuthUser = (cookies: Cookies) => {
  * ```
  */
 export const setAuthCookie = (cookies: Cookies, user: User) => {
-	const cookieValue = jwt.sign(user, SESSION_SECRET);
-	cookies.set(COOKIE_NAME, cookieValue, {
+	const cookieValue = jwt.sign(user, getSessionSecret());
+	cookies.set(getCookieName(), cookieValue, {
 		httpOnly: true,
 		sameSite: 'lax',
 		maxAge: COOKIE_DURATION_SECONDS,
 		path: '/',
-		secure: NODE_ENV === 'production'
+		secure: getNodeEnv() === 'production'
 	});
 };
 
@@ -289,7 +289,7 @@ export const setAuthCookie = (cookies: Cookies, user: User) => {
  * ```
  */
 export const clearAuthCookie = (cookies: Cookies) => {
-	cookies.delete(COOKIE_NAME, { path: '/' });
+	cookies.delete(getCookieName(), { path: '/' });
 };
 
 /**
@@ -358,7 +358,7 @@ export const setCsrfCookie = (cookies: Cookies) => {
 		sameSite: 'lax',
 		maxAge: COOKIE_AUTHORIZE_DURATION_SECONDS,
 		path: '/api/auth',
-		secure: NODE_ENV === 'production'
+		secure: getNodeEnv() === 'production'
 	});
 	return csrfState;
 };
@@ -393,14 +393,14 @@ export const setCsrfCookie = (cookies: Cookies) => {
  */
 export const setPKCECookie = (cookies: Cookies) => {
 	const { verifier, challenge } = getPKCEChallengeData();
-	const encryptedVerifier = encrypt(verifier, Buffer.from(ENCRYPTION_KEY, 'hex'));
+	const encryptedVerifier = encrypt(verifier, Buffer.from(getEncryptionKey(), 'hex'));
 	const cookieValue = `${encryptedVerifier.iv.toString('hex')}:${encryptedVerifier.encryptedData.toString('hex')}:${encryptedVerifier.tag.toString('hex')}`;
 	cookies.set('extendedState', cookieValue, {
 		httpOnly: true,
 		sameSite: 'lax',
 		maxAge: COOKIE_AUTHORIZE_DURATION_SECONDS,
 		path: '/api/auth',
-		secure: NODE_ENV === 'production'
+		secure: getNodeEnv() === 'production'
 	});
 	return challenge;
 };
@@ -443,6 +443,6 @@ export const getPKCEVerifierFromCookie = (cookies: Cookies): string | null => {
 	const encryptedData = Buffer.from(encryptedDataHex, 'hex');
 	const tag = Buffer.from(tagHex, 'hex');
 
-	const decryptedVerifier = decrypt(encryptedData, Buffer.from(ENCRYPTION_KEY, 'hex'), iv, tag);
+	const decryptedVerifier = decrypt(encryptedData, Buffer.from(getEncryptionKey(), 'hex'), iv, tag);
 	return decryptedVerifier;
 };

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -1,14 +1,15 @@
-import {
-	AUTH0_CLIENT_ID,
-	AUTH0_CLIENT_SECRET,
-	AUTH0_DOMAIN,
-	COOKIE_NAME,
-	ENCRYPTION_KEY,
-	JWKS_URL,
-	SESSION_SECRET,
-	NODE_ENV
-} from '$env/static/private';
+import * as dynamicEnv from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
+
+// Use dynamic environment variables for Docker runtime configuration
+const AUTH0_CLIENT_ID = dynamicEnv.env.AUTH0_CLIENT_ID ?? '';
+const AUTH0_CLIENT_SECRET = dynamicEnv.env.AUTH0_CLIENT_SECRET ?? '';
+const AUTH0_DOMAIN = dynamicEnv.env.AUTH0_DOMAIN ?? '';
+const COOKIE_NAME = dynamicEnv.env.COOKIE_NAME ?? 'auth-cookie';
+const ENCRYPTION_KEY = dynamicEnv.env.ENCRYPTION_KEY ?? '';
+const JWKS_URL = dynamicEnv.env.JWKS_URL ?? '';
+const SESSION_SECRET = dynamicEnv.env.SESSION_SECRET ?? '';
+const NODE_ENV = dynamicEnv.env.NODE_ENV ?? 'development';
 
 import type { User } from '$lib/types/index';
 import { error, redirect, type Cookies } from '@sveltejs/kit';

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -1,5 +1,12 @@
-import { NODE_ENV, SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
+
+// Dynamic environment variables for Docker runtime
+const NODE_ENV = env.NODE_ENV ?? 'development';
+const SMTP_HOST = env.SMTP_HOST ?? '';
+const SMTP_PORT = env.SMTP_PORT ?? '587';
+const SMTP_USER = env.SMTP_USER ?? '';
+const SMTP_PASSWORD = env.SMTP_PASSWORD ?? '';
 import { createLogger } from '$lib/logger';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -1,12 +1,5 @@
 import { env } from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
-
-// Dynamic environment variables for Docker runtime
-const NODE_ENV = env.NODE_ENV ?? 'development';
-const SMTP_HOST = env.SMTP_HOST ?? '';
-const SMTP_PORT = env.SMTP_PORT ?? '587';
-const SMTP_USER = env.SMTP_USER ?? '';
-const SMTP_PASSWORD = env.SMTP_PASSWORD ?? '';
 import { createLogger } from '$lib/logger';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
@@ -24,6 +17,13 @@ import nodemailer, { type SendMailOptions, type Transporter } from 'nodemailer';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { ConfigRepository } from '../db/configRepository';
+
+// Dynamic environment variables for Docker runtime
+const NODE_ENV = env.NODE_ENV ?? 'development';
+const SMTP_HOST = env.SMTP_HOST ?? '';
+const SMTP_PORT = env.SMTP_PORT ?? '587';
+const SMTP_USER = env.SMTP_USER ?? '';
+const SMTP_PASSWORD = env.SMTP_PASSWORD ?? '';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/src/lib/server/storage/factory.test.ts
+++ b/src/lib/server/storage/factory.test.ts
@@ -1,24 +1,26 @@
 import { describe, test, expect, beforeEach, vi, afterEach } from 'vitest';
-import {
-	getStorageProvider,
-	resetStorageProvider,
-	isCloudStorage,
-	getCurrentStorageProvider
-} from './factory';
 import type { StorageProviderType } from '$lib/types';
-import * as envModule from '$env/dynamic/private';
+
+// Mutable mock environment object
+const mockEnv: Record<string, string> = {
+	STORAGE_PROVIDER: '',
+	VERCEL: ''
+};
 
 // Mock the app environment
 vi.mock('$app/environment', () => ({
 	dev: false
 }));
 
-// Mock environment variables (dynamic env)
+// Mock environment variables (dynamic env) with getter to allow runtime changes
 vi.mock('$env/dynamic/private', () => ({
-	env: {
-		STORAGE_PROVIDER: '',
-		VERCEL: ''
-	}
+	env: new Proxy({} as Record<string, string>, {
+		get: (_target, prop: string) => mockEnv[prop] ?? '',
+		set: (_target, prop: string, value: string) => {
+			mockEnv[prop] = value;
+			return true;
+		}
+	})
 }));
 
 // Mock the logger
@@ -33,7 +35,7 @@ vi.mock('$lib/logger', () => ({
 
 // Mock the storage providers with class constructors
 vi.mock('./local', () => {
-	const MockLocalStorageProvider = vi.fn().mockImplementation(function() {
+	const MockLocalStorageProvider = vi.fn().mockImplementation(function () {
 		return {
 			uploadFile: vi.fn(),
 			deleteFile: vi.fn(),
@@ -44,7 +46,7 @@ vi.mock('./local', () => {
 });
 
 vi.mock('./vercel-blob', () => {
-	const MockVercelBlobStorageProvider = vi.fn().mockImplementation(function() {
+	const MockVercelBlobStorageProvider = vi.fn().mockImplementation(function () {
 		return {
 			uploadFile: vi.fn(),
 			deleteFile: vi.fn(),
@@ -53,6 +55,14 @@ vi.mock('./vercel-blob', () => {
 	});
 	return { VercelBlobStorageProvider: MockVercelBlobStorageProvider };
 });
+
+// Import after mocks are set up
+import {
+	getStorageProvider,
+	resetStorageProvider,
+	isCloudStorage,
+	getCurrentStorageProvider
+} from './factory';
 
 describe('Storage Factory', () => {
 	// Save original environment
@@ -63,8 +73,8 @@ describe('Storage Factory', () => {
 		resetStorageProvider();
 
 		// Reset mock environment variables
-		vi.mocked(envModule).env.STORAGE_PROVIDER = '';
-		vi.mocked(envModule).env.VERCEL = '';
+		mockEnv.STORAGE_PROVIDER = '';
+		mockEnv.VERCEL = '';
 
 		// Clear all mocks
 		vi.clearAllMocks();
@@ -97,14 +107,14 @@ describe('Storage Factory', () => {
 		});
 
 		test('should create VercelBlobStorageProvider when VERCEL env is set', () => {
-			vi.mocked(envModule).env.VERCEL = '1';
+			mockEnv.VERCEL = '1';
 
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
 
 		test('should respect STORAGE_PROVIDER environment variable', () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
@@ -112,32 +122,32 @@ describe('Storage Factory', () => {
 
 		test('should throw error for unimplemented S3 provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 's3';
+			mockEnv.VERCEL = '';
 
 			expect(() => getStorageProvider()).toThrow('S3 storage provider not implemented yet');
 		});
 
 		test('should throw error for unimplemented GCS provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'gcs';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 'gcs';
+			mockEnv.VERCEL = '';
 
 			expect(() => getStorageProvider()).toThrow('Google Cloud Storage provider not implemented yet');
 		});
 
 		test('should throw error for unknown provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'unknown-provider';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 'unknown-provider';
+			mockEnv.VERCEL = '';
 
 			expect(() => getStorageProvider()).toThrow('Unknown storage provider: unknown-provider');
 		});
 
 		test('should default to local storage for unknown environments', () => {
 			// No special environment variables set
-			vi.mocked(envModule).env.VERCEL = "";
-			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = "";
+			mockEnv.STORAGE_PROVIDER = "";
 
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
@@ -147,12 +157,12 @@ describe('Storage Factory', () => {
 	describe('resetStorageProvider', () => {
 		test('should allow creating different providers after reset', () => {
 			// First provider
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 			const provider1 = getStorageProvider();
 
 			// Reset and change environment
 			resetStorageProvider();
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 			const provider2 = getStorageProvider();
 
 			// Should be different instances
@@ -160,7 +170,7 @@ describe('Storage Factory', () => {
 		});
 
 		test('should not affect subsequent calls to the same configuration', () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			// Get initial provider
 			const provider1 = getStorageProvider();
@@ -177,47 +187,47 @@ describe('Storage Factory', () => {
 
 	describe('isCloudStorage', () => {
 		test('should return false for local storage', () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			expect(isCloudStorage()).toBe(false);
 		});
 
 		test('should return true for vercel-blob storage', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.VERCEL = '';
 
 			expect(isCloudStorage()).toBe(true);
 		});
 
 		test('should return true for S3 storage (even though not implemented)', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 's3';
+			mockEnv.VERCEL = '';
 
 			expect(isCloudStorage()).toBe(true);
 		});
 
 		test('should return true for GCS storage (even though not implemented)', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'gcs';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 'gcs';
+			mockEnv.VERCEL = '';
 
 			expect(isCloudStorage()).toBe(true);
 		});
 
 		test('should return false for local storage explicit', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = 'local';
+			mockEnv.VERCEL = '';
 
 			expect(isCloudStorage()).toBe(false);
 		});
 
 		test('should return false for empty storage provider (defaults to local)', () => {
 			// Set the mock environment variables to empty values
-			vi.mocked(envModule).env.STORAGE_PROVIDER = '';
-			vi.mocked(envModule).env.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = '';
+			mockEnv.VERCEL = '';
 
 			expect(isCloudStorage()).toBe(false);
 		});
@@ -229,20 +239,20 @@ describe('Storage Factory', () => {
 		});
 
 		test('should return vercel-blob when explicitly configured', () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should return vercel-blob when VERCEL environment is detected', () => {
-			vi.mocked(envModule).env.VERCEL = '1';
+			mockEnv.VERCEL = '1';
 
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should prioritize explicit STORAGE_PROVIDER over VERCEL detection', () => {
-			vi.mocked(envModule).env.VERCEL = '1';
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.VERCEL = '1';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			expect(getCurrentStorageProvider()).toBe('local');
 		});
@@ -268,39 +278,39 @@ describe('Storage Factory', () => {
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// 2. Vercel environment
-			vi.mocked(envModule).env.VERCEL = '1';
+			mockEnv.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// 3. Explicit storage provider overrides Vercel
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// 4. Different explicit provider
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should handle edge cases in environment variables', () => {
 			// Empty string should be falsy
-			vi.mocked(envModule).env.STORAGE_PROVIDER = '';
-			vi.mocked(envModule).env.VERCEL = '1';
+			mockEnv.STORAGE_PROVIDER = '';
+			mockEnv.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Undefined should be falsy
-			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
-			vi.mocked(envModule).env.VERCEL = '1';
+			mockEnv.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Any truthy value for VERCEL should work
-			vi.mocked(envModule).env.VERCEL = "";
-			vi.mocked(envModule).env.VERCEL = 'true';
+			mockEnv.VERCEL = "";
+			mockEnv.VERCEL = 'true';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 	});
 
 	describe('provider instantiation', () => {
 		test('should create LocalStorageProvider with correct parameters', async () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			getStorageProvider();
 
@@ -310,7 +320,7 @@ describe('Storage Factory', () => {
 		});
 
 		test('should create VercelBlobStorageProvider with no parameters', async () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 
 			getStorageProvider();
 
@@ -320,7 +330,7 @@ describe('Storage Factory', () => {
 		});
 
 		test('should only instantiate provider once per configuration', async () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			// Call multiple times
 			getStorageProvider();
@@ -333,7 +343,7 @@ describe('Storage Factory', () => {
 		});
 
 		test('should create new instance after reset', async () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 
 			// First call
 			getStorageProvider();
@@ -357,7 +367,7 @@ describe('Storage Factory', () => {
 
 			testCases.forEach(([provider, expectedMessage]) => {
 				resetStorageProvider();
-				vi.mocked(envModule).env.STORAGE_PROVIDER = provider;
+				mockEnv.STORAGE_PROVIDER = provider;
 
 				expect(() => getStorageProvider()).toThrow(expectedMessage);
 			});
@@ -365,13 +375,13 @@ describe('Storage Factory', () => {
 
 		test('should provide clear error message for unknown providers', () => {
 			resetStorageProvider();
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'invalid-provider' as StorageProviderType;
+			mockEnv.STORAGE_PROVIDER = 'invalid-provider' as StorageProviderType;
 
 			expect(() => getStorageProvider()).toThrow('Unknown storage provider: invalid-provider');
 		});
 
 		test('should not throw when checking provider type for unimplemented providers', () => {
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
+			mockEnv.STORAGE_PROVIDER = 's3';
 
 			// These should not throw
 			expect(() => getCurrentStorageProvider()).not.toThrow();
@@ -386,8 +396,8 @@ describe('Storage Factory', () => {
 		test('should work correctly in simulated production environment', () => {
 			// Simulate production deployment on Vercel
 			process.env.NODE_ENV = 'production';
-			vi.mocked(envModule).env.VERCEL = '1';
-			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = '1';
+			mockEnv.STORAGE_PROVIDER = "";
 
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 			expect(isCloudStorage()).toBe(true);
@@ -402,8 +412,8 @@ describe('Storage Factory', () => {
 				dev: true
 			}));
 
-			vi.mocked(envModule).env.VERCEL = "";
-			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = "";
+			mockEnv.STORAGE_PROVIDER = "";
 
 			// Dynamically import to get updated environment
 			const factory = await import('./factory');
@@ -414,12 +424,12 @@ describe('Storage Factory', () => {
 
 		test('should handle configuration changes during runtime', () => {
 			// Start with one configuration
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			mockEnv.STORAGE_PROVIDER = 'local';
 			const provider1 = getStorageProvider();
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// Change configuration (requires reset to take effect)
-			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			mockEnv.STORAGE_PROVIDER = 'vercel-blob';
 			// Without reset, should still return the same provider
 			const provider2 = getStorageProvider();
 			expect(provider1).toBe(provider2);

--- a/src/lib/server/storage/factory.test.ts
+++ b/src/lib/server/storage/factory.test.ts
@@ -6,17 +6,19 @@ import {
 	getCurrentStorageProvider
 } from './factory';
 import type { StorageProviderType } from '$lib/types';
-import * as envModule from '$env/static/private';
+import * as envModule from '$env/dynamic/private';
 
 // Mock the app environment
 vi.mock('$app/environment', () => ({
 	dev: false
 }));
 
-// Mock environment variables - use vi.mocked to change values in tests
-vi.mock('$env/static/private', () => ({
-	STORAGE_PROVIDER: '',
-	VERCEL: ''
+// Mock environment variables (dynamic env)
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		STORAGE_PROVIDER: '',
+		VERCEL: ''
+	}
 }));
 
 // Mock the logger
@@ -59,11 +61,11 @@ describe('Storage Factory', () => {
 	beforeEach(() => {
 		// Reset storage provider before each test
 		resetStorageProvider();
-		
+
 		// Reset mock environment variables
-		vi.mocked(envModule).STORAGE_PROVIDER = '';
-		vi.mocked(envModule).VERCEL = '';
-		
+		vi.mocked(envModule).env.STORAGE_PROVIDER = '';
+		vi.mocked(envModule).env.VERCEL = '';
+
 		// Clear all mocks
 		vi.clearAllMocks();
 	});
@@ -89,54 +91,54 @@ describe('Storage Factory', () => {
 
 			// Reset to pick up new environment
 			resetStorageProvider();
-			
+
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
 
 		test('should create VercelBlobStorageProvider when VERCEL env is set', () => {
-			vi.mocked(envModule).VERCEL = '1';
-			
+			vi.mocked(envModule).env.VERCEL = '1';
+
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
 
 		test('should respect STORAGE_PROVIDER environment variable', () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
 
 		test('should throw error for unimplemented S3 provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 's3';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(() => getStorageProvider()).toThrow('S3 storage provider not implemented yet');
 		});
 
 		test('should throw error for unimplemented GCS provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 'gcs';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'gcs';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(() => getStorageProvider()).toThrow('Google Cloud Storage provider not implemented yet');
 		});
 
 		test('should throw error for unknown provider', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 'unknown-provider';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'unknown-provider';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(() => getStorageProvider()).toThrow('Unknown storage provider: unknown-provider');
 		});
 
 		test('should default to local storage for unknown environments', () => {
 			// No special environment variables set
-			vi.mocked(envModule).VERCEL = "";
-			vi.mocked(envModule).STORAGE_PROVIDER = "";
-			
+			vi.mocked(envModule).env.VERCEL = "";
+			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
@@ -145,12 +147,12 @@ describe('Storage Factory', () => {
 	describe('resetStorageProvider', () => {
 		test('should allow creating different providers after reset', () => {
 			// First provider
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
 			const provider1 = getStorageProvider();
 
 			// Reset and change environment
 			resetStorageProvider();
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
 			const provider2 = getStorageProvider();
 
 			// Should be different instances
@@ -158,11 +160,11 @@ describe('Storage Factory', () => {
 		});
 
 		test('should not affect subsequent calls to the same configuration', () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			// Get initial provider
 			const provider1 = getStorageProvider();
-			
+
 			// Reset but keep same configuration
 			resetStorageProvider();
 			const provider2 = getStorageProvider();
@@ -175,48 +177,48 @@ describe('Storage Factory', () => {
 
 	describe('isCloudStorage', () => {
 		test('should return false for local storage', () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			expect(isCloudStorage()).toBe(false);
 		});
 
 		test('should return true for vercel-blob storage', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(isCloudStorage()).toBe(true);
 		});
 
 		test('should return true for S3 storage (even though not implemented)', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 's3';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(isCloudStorage()).toBe(true);
 		});
 
 		test('should return true for GCS storage (even though not implemented)', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 'gcs';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'gcs';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(isCloudStorage()).toBe(true);
 		});
 
-		test('should return false for local storage', () => {
+		test('should return false for local storage explicit', () => {
 			// Set the mock environment variable
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(isCloudStorage()).toBe(false);
 		});
 
 		test('should return false for empty storage provider (defaults to local)', () => {
 			// Set the mock environment variables to empty values
-			vi.mocked(envModule).STORAGE_PROVIDER = '';
-			vi.mocked(envModule).VERCEL = '';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = '';
+			vi.mocked(envModule).env.VERCEL = '';
+
 			expect(isCloudStorage()).toBe(false);
 		});
 	});
@@ -227,21 +229,21 @@ describe('Storage Factory', () => {
 		});
 
 		test('should return vercel-blob when explicitly configured', () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should return vercel-blob when VERCEL environment is detected', () => {
-			vi.mocked(envModule).VERCEL = '1';
-			
+			vi.mocked(envModule).env.VERCEL = '1';
+
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should prioritize explicit STORAGE_PROVIDER over VERCEL detection', () => {
-			vi.mocked(envModule).VERCEL = '1';
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.VERCEL = '1';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			expect(getCurrentStorageProvider()).toBe('local');
 		});
 
@@ -253,7 +255,7 @@ describe('Storage Factory', () => {
 
 			// Dynamically import to get updated environment
 			const { getCurrentStorageProvider: getCurrentProvider } = await import('./factory');
-			
+
 			expect(getCurrentProvider()).toBe('local');
 		});
 	});
@@ -266,80 +268,80 @@ describe('Storage Factory', () => {
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// 2. Vercel environment
-			vi.mocked(envModule).VERCEL = '1';
+			vi.mocked(envModule).env.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// 3. Explicit storage provider overrides Vercel
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// 4. Different explicit provider
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 
 		test('should handle edge cases in environment variables', () => {
 			// Empty string should be falsy
-			vi.mocked(envModule).STORAGE_PROVIDER = '';
-			vi.mocked(envModule).VERCEL = '1';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = '';
+			vi.mocked(envModule).env.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Undefined should be falsy
-			vi.mocked(envModule).STORAGE_PROVIDER = "";
-			vi.mocked(envModule).VERCEL = '1';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+			vi.mocked(envModule).env.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Any truthy value for VERCEL should work
-			vi.mocked(envModule).VERCEL = "";
-			vi.mocked(envModule).VERCEL = 'true';
+			vi.mocked(envModule).env.VERCEL = "";
+			vi.mocked(envModule).env.VERCEL = 'true';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
 	});
 
 	describe('provider instantiation', () => {
 		test('should create LocalStorageProvider with correct parameters', async () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			getStorageProvider();
-			
+
 			// Access the mocked module
 			const localModule = await import('./local');
 			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith('uploads', '/uploads');
 		});
 
 		test('should create VercelBlobStorageProvider with no parameters', async () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
+
 			getStorageProvider();
-			
+
 			// Access the mocked module
 			const vercelModule = await import('./vercel-blob');
 			expect(vercelModule.VercelBlobStorageProvider).toHaveBeenCalledWith();
 		});
 
 		test('should only instantiate provider once per configuration', async () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			// Call multiple times
 			getStorageProvider();
 			getStorageProvider();
 			getStorageProvider();
-			
+
 			// Access the mocked module
 			const localModule = await import('./local');
 			expect(localModule.LocalStorageProvider).toHaveBeenCalledTimes(1);
 		});
 
 		test('should create new instance after reset', async () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
+
 			// First call
 			getStorageProvider();
-			
+
 			// Reset and call again
 			resetStorageProvider();
 			getStorageProvider();
-			
+
 			// Access the mocked module
 			const localModule = await import('./local');
 			expect(localModule.LocalStorageProvider).toHaveBeenCalledTimes(2);
@@ -355,26 +357,26 @@ describe('Storage Factory', () => {
 
 			testCases.forEach(([provider, expectedMessage]) => {
 				resetStorageProvider();
-				vi.mocked(envModule).STORAGE_PROVIDER = provider;
-				
+				vi.mocked(envModule).env.STORAGE_PROVIDER = provider;
+
 				expect(() => getStorageProvider()).toThrow(expectedMessage);
 			});
 		});
 
 		test('should provide clear error message for unknown providers', () => {
 			resetStorageProvider();
-			vi.mocked(envModule).STORAGE_PROVIDER = 'invalid-provider' as StorageProviderType;
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'invalid-provider' as StorageProviderType;
+
 			expect(() => getStorageProvider()).toThrow('Unknown storage provider: invalid-provider');
 		});
 
 		test('should not throw when checking provider type for unimplemented providers', () => {
-			vi.mocked(envModule).STORAGE_PROVIDER = 's3';
-			
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 's3';
+
 			// These should not throw
 			expect(() => getCurrentStorageProvider()).not.toThrow();
 			expect(() => isCloudStorage()).not.toThrow();
-			
+
 			// But getStorageProvider should throw
 			expect(() => getStorageProvider()).toThrow();
 		});
@@ -384,12 +386,12 @@ describe('Storage Factory', () => {
 		test('should work correctly in simulated production environment', () => {
 			// Simulate production deployment on Vercel
 			process.env.NODE_ENV = 'production';
-			vi.mocked(envModule).VERCEL = '1';
-			vi.mocked(envModule).STORAGE_PROVIDER = "";
-			
+			vi.mocked(envModule).env.VERCEL = '1';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 			expect(isCloudStorage()).toBe(true);
-			
+
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
 		});
@@ -400,28 +402,28 @@ describe('Storage Factory', () => {
 				dev: true
 			}));
 
-			vi.mocked(envModule).VERCEL = "";
-			vi.mocked(envModule).STORAGE_PROVIDER = "";
-			
+			vi.mocked(envModule).env.VERCEL = "";
+			vi.mocked(envModule).env.STORAGE_PROVIDER = "";
+
 			// Dynamically import to get updated environment
 			const factory = await import('./factory');
-			
+
 			expect(factory.getCurrentStorageProvider()).toBe('local');
 			expect(factory.isCloudStorage()).toBe(false);
 		});
 
 		test('should handle configuration changes during runtime', () => {
 			// Start with one configuration
-			vi.mocked(envModule).STORAGE_PROVIDER = 'local';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'local';
 			const provider1 = getStorageProvider();
 			expect(getCurrentStorageProvider()).toBe('local');
 
 			// Change configuration (requires reset to take effect)
-			vi.mocked(envModule).STORAGE_PROVIDER = 'vercel-blob';
+			vi.mocked(envModule).env.STORAGE_PROVIDER = 'vercel-blob';
 			// Without reset, should still return the same provider
 			const provider2 = getStorageProvider();
 			expect(provider1).toBe(provider2);
-			
+
 			// After reset, should use new configuration
 			resetStorageProvider();
 			const provider3 = getStorageProvider();

--- a/src/lib/server/storage/factory.ts
+++ b/src/lib/server/storage/factory.ts
@@ -20,10 +20,6 @@ import { env } from '$env/dynamic/private';
 import { LocalStorageProvider } from './local';
 import { VercelBlobStorageProvider } from './vercel-blob';
 
-// Dynamic environment variables for Docker runtime
-const STORAGE_PROVIDER = env.STORAGE_PROVIDER ?? '';
-const VERCEL = env.VERCEL ?? '';
-
 const logger = createLogger('storage:factory');
 
 /**
@@ -126,16 +122,19 @@ export function getStorageProvider(): StorageProvider {
  * ```
  */
 function getStorageProviderType(): StorageProviderType {
+	// Read environment variables dynamically (for Docker runtime and test mocking)
+	const storageProviderEnv = env.STORAGE_PROVIDER ?? '';
+	const vercelEnv = env.VERCEL ?? '';
+
 	// SCHRITT 1: Explizite Konfiguration über Umgebungsvariable
-	const envProvider = STORAGE_PROVIDER as StorageProviderType;
-	if (envProvider) {
-		logger.debug({ provider: envProvider }, 'Storage provider from environment');
-		return envProvider;
+	if (storageProviderEnv) {
+		logger.debug({ provider: storageProviderEnv }, 'Storage provider from environment');
+		return storageProviderEnv as StorageProviderType;
 	}
 
 	// SCHRITT 2: Automatische Vercel-Erkennung
 	// Vercel setzt automatisch die VERCEL Umgebungsvariable
-	if (VERCEL) {
+	if (vercelEnv) {
 		logger.debug('Detected Vercel environment, using vercel-blob');
 		return 'vercel-blob';
 	}

--- a/src/lib/server/storage/factory.ts
+++ b/src/lib/server/storage/factory.ts
@@ -16,9 +16,13 @@
 import { dev } from '$app/environment';
 import { createLogger } from '$lib/logger';
 import type { StorageProvider, StorageProviderType } from '$lib/types';
-import { STORAGE_PROVIDER, VERCEL } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { LocalStorageProvider } from './local';
 import { VercelBlobStorageProvider } from './vercel-blob';
+
+// Dynamic environment variables for Docker runtime
+const STORAGE_PROVIDER = env.STORAGE_PROVIDER ?? '';
+const VERCEL = env.VERCEL ?? '';
 
 const logger = createLogger('storage:factory');
 

--- a/src/lib/server/storage/vercel-blob.test.ts
+++ b/src/lib/server/storage/vercel-blob.test.ts
@@ -1,12 +1,20 @@
 import type { UploadOptions } from '$lib/types';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { VercelBlobStorageProvider } from './vercel-blob';
 
-// Mock environment variables (dynamic env)
+// Mutable mock environment object
+const mockEnv: Record<string, string> = {
+	BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789'
+};
+
+// Mock environment variables (dynamic env) with Proxy for runtime changes
 vi.mock('$env/dynamic/private', () => ({
-	env: {
-		BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789'
-	}
+	env: new Proxy({} as Record<string, string>, {
+		get: (_target, prop: string) => mockEnv[prop] ?? '',
+		set: (_target, prop: string, value: string) => {
+			mockEnv[prop] = value;
+			return true;
+		}
+	})
 }));
 
 // Mock the logger
@@ -32,6 +40,9 @@ vi.mock('@vercel/blob', () => ({
 	list: vi.fn()
 }));
 
+// Import after mocks are set up
+import { VercelBlobStorageProvider } from './vercel-blob';
+
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -41,21 +52,24 @@ describe('VercelBlobStorageProvider', () => {
 	let provider: VercelBlobStorageProvider;
 
 	// Import the mocked functions
-	let mockPut: any;
-	let mockDel: any;
-	let mockHead: any;
-	let mockList: any;
+	let mockPut: ReturnType<typeof vi.fn>;
+	let mockDel: ReturnType<typeof vi.fn>;
+	let mockHead: ReturnType<typeof vi.fn>;
+	let mockList: ReturnType<typeof vi.fn>;
 
 	// Save original environment
 	const originalEnv = { ...process.env };
 
 	beforeEach(async () => {
+		// Reset mock environment
+		mockEnv.BLOB_READ_WRITE_TOKEN = mockToken;
+
 		// Import the mocked modules to get access to the mock functions
 		const blobModule = await import('@vercel/blob');
-		mockPut = blobModule.put;
-		mockDel = blobModule.del;
-		mockHead = blobModule.head;
-		mockList = blobModule.list;
+		mockPut = blobModule.put as ReturnType<typeof vi.fn>;
+		mockDel = blobModule.del as ReturnType<typeof vi.fn>;
+		mockHead = blobModule.head as ReturnType<typeof vi.fn>;
+		mockList = blobModule.list as ReturnType<typeof vi.fn>;
 
 		// Clear all mocks
 		vi.clearAllMocks();
@@ -82,23 +96,17 @@ describe('VercelBlobStorageProvider', () => {
 			expect(provider).toBeDefined();
 		});
 
-		test('should throw error when no token is available', async () => {
-			// Reset module to test without token
-			vi.doUnmock('$env/dynamic/private');
-			vi.mock('$env/dynamic/private', () => ({
-				env: { BLOB_READ_WRITE_TOKEN: '' }
-			}));
+		test('should throw error when no token is available', () => {
+			// Clear the token in mock environment
+			mockEnv.BLOB_READ_WRITE_TOKEN = '';
 
-			// Re-import with new mock - token is empty, and no parameter provided
+			// Token is empty, and no parameter provided - should throw
 			expect(() => new VercelBlobStorageProvider()).toThrow(
 				'BLOB_READ_WRITE_TOKEN environment variable is required for Vercel Blob storage'
 			);
 
-			// Restore the original mock
-			vi.doUnmock('$env/dynamic/private');
-			vi.mock('$env/dynamic/private', () => ({
-				env: { BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789' }
-			}));
+			// Restore the token for other tests
+			mockEnv.BLOB_READ_WRITE_TOKEN = mockToken;
 		});
 
 		test('should prioritize constructor parameter over environment', () => {

--- a/src/lib/server/storage/vercel-blob.test.ts
+++ b/src/lib/server/storage/vercel-blob.test.ts
@@ -1,11 +1,12 @@
 import type { UploadOptions } from '$lib/types';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { VercelBlobStorageProvider } from './vercel-blob';
-import * as envModule from '$env/static/private';
 
-// Mock environment variables
-vi.mock('$env/static/private', () => ({
-	BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789'
+// Mock environment variables (dynamic env)
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789'
+	}
 }));
 
 // Mock the logger
@@ -59,9 +60,6 @@ describe('VercelBlobStorageProvider', () => {
 		// Clear all mocks
 		vi.clearAllMocks();
 
-		// Set up default environment
-		vi.mocked(envModule).BLOB_READ_WRITE_TOKEN = mockToken;
-
 		// Create fresh provider instance
 		provider = new VercelBlobStorageProvider();
 	});
@@ -73,39 +71,38 @@ describe('VercelBlobStorageProvider', () => {
 
 	describe('constructor', () => {
 		test('should use token from environment variable', () => {
-			vi.mocked(envModule).BLOB_READ_WRITE_TOKEN = 'env_token_123';
+			// Token is provided by the mock
 			const provider = new VercelBlobStorageProvider();
-
 			expect(provider).toBeDefined();
 		});
 
 		test('should use provided token parameter', () => {
 			const customToken = 'custom_token_456';
 			const provider = new VercelBlobStorageProvider(customToken);
-
 			expect(provider).toBeDefined();
 		});
 
-		test('should throw error when no token is available', () => {
-			vi.mocked(envModule).BLOB_READ_WRITE_TOKEN = "";
+		test('should throw error when no token is available', async () => {
+			// Reset module to test without token
+			vi.doUnmock('$env/dynamic/private');
+			vi.mock('$env/dynamic/private', () => ({
+				env: { BLOB_READ_WRITE_TOKEN: '' }
+			}));
 
+			// Re-import with new mock - token is empty, and no parameter provided
 			expect(() => new VercelBlobStorageProvider()).toThrow(
 				'BLOB_READ_WRITE_TOKEN environment variable is required for Vercel Blob storage'
 			);
-		});
 
-		test('should throw error when token is empty string', () => {
-			vi.mocked(envModule).BLOB_READ_WRITE_TOKEN = '';
-
-			expect(() => new VercelBlobStorageProvider()).toThrow(
-				'BLOB_READ_WRITE_TOKEN environment variable is required for Vercel Blob storage'
-			);
+			// Restore the original mock
+			vi.doUnmock('$env/dynamic/private');
+			vi.mock('$env/dynamic/private', () => ({
+				env: { BLOB_READ_WRITE_TOKEN: 'vercel_blob_rw_abc123_test_xyz789' }
+			}));
 		});
 
 		test('should prioritize constructor parameter over environment', () => {
-			vi.mocked(envModule).BLOB_READ_WRITE_TOKEN = 'env_token';
 			const customToken = 'constructor_token';
-
 			const provider = new VercelBlobStorageProvider(customToken);
 			expect(provider).toBeDefined();
 		});

--- a/src/lib/server/storage/vercel-blob.ts
+++ b/src/lib/server/storage/vercel-blob.ts
@@ -26,9 +26,6 @@ import { env } from '$env/dynamic/private';
 import { del, head, list, put } from '@vercel/blob';
 import { basename, extname } from 'path';
 
-// Dynamic environment variable for Docker runtime
-const BLOB_READ_WRITE_TOKEN = env.BLOB_READ_WRITE_TOKEN ?? '';
-
 const logger = createLogger('storage:vercel-blob');
 
 /**
@@ -66,7 +63,8 @@ export class VercelBlobStorageProvider implements StorageProvider {
 	 * ```
 	 */
 	constructor(token?: string) {
-		this.token = token || BLOB_READ_WRITE_TOKEN || '';
+		// Read environment variable dynamically (for Docker runtime and test mocking)
+		this.token = token || env.BLOB_READ_WRITE_TOKEN || '';
 		if (!this.token) {
 			throw new Error(
 				'BLOB_READ_WRITE_TOKEN environment variable is required for Vercel Blob storage'

--- a/src/lib/server/storage/vercel-blob.ts
+++ b/src/lib/server/storage/vercel-blob.ts
@@ -22,9 +22,12 @@
  */
 import { createLogger } from '$lib/logger';
 import type { FileMetadata, StorageProvider, UploadedFileInfo, UploadOptions } from '$lib/types';
-import { BLOB_READ_WRITE_TOKEN } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { del, head, list, put } from '@vercel/blob';
 import { basename, extname } from 'path';
+
+// Dynamic environment variable for Docker runtime
+const BLOB_READ_WRITE_TOKEN = env.BLOB_READ_WRITE_TOKEN ?? '';
 
 const logger = createLogger('storage:vercel-blob');
 

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -1,4 +1,4 @@
-import { API_AUDIENCE } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { createLogger } from '$lib/logger';
 import {
 	getPKCEVerifierFromCookie,
@@ -11,7 +11,6 @@ import type { User } from '$lib/types';
 import { error, redirect, type Cookies } from '@sveltejs/kit';
 
 const logger = createLogger('auth:auth0');
-const rolesClaim = `${API_AUDIENCE}/roles`;
 
 export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const code = url.searchParams.get('code');
@@ -39,7 +38,8 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 		const authUser = (await verifyToken(token.id_token)) as User;
 		logger.debug({ authUser }, 'authUser');
 
-		const claims = await getTokenClaims<{ [rolesClaim]: string[] }>(token.access_token);
+		const rolesClaim = `${env.API_AUDIENCE}/roles`;
+		const claims = await getTokenClaims<Record<string, string[]>>(token.access_token);
 		logger.debug({ claims }, 'claims');
 
 		authUser.roles = claims[rolesClaim] || [];

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -1,7 +1,8 @@
-import { API_AUDIENCE, AUTH0_CLIENT_ID, AUTH0_DOMAIN } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
 import { setCsrfCookie, setPKCECookie } from '$lib/server/auth/auth';
 import { redirect, type Cookies } from '@sveltejs/kit';
+
 export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const csrfState = setCsrfCookie(cookies);
 	const returnUrl = encodeURIComponent(url.searchParams.get('returnUrl') || '/');
@@ -9,13 +10,13 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const query = {
 		scope: 'openid profile email',
 		response_type: 'code',
-		client_id: AUTH0_CLIENT_ID,
+		client_id: env.AUTH0_CLIENT_ID ?? '',
 		redirect_uri: `${PUBLIC_SITE_URL}/api/auth/callback?returnUrl=${returnUrl}`,
 		state: csrfState,
-		audience: API_AUDIENCE,
+		audience: env.API_AUDIENCE ?? '',
 		code_challenge: challenge,
 		code_challenge_method: 'S256'
 	};
 
-	throw redirect(302, `https://${AUTH0_DOMAIN}/authorize?${new URLSearchParams(query).toString()}`);
+	throw redirect(302, `https://${env.AUTH0_DOMAIN}/authorize?${new URLSearchParams(query).toString()}`);
 }

--- a/src/routes/api/auth/logout/+server.ts
+++ b/src/routes/api/auth/logout/+server.ts
@@ -1,4 +1,4 @@
-import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { PUBLIC_SITE_URL } from '$env/static/public';
 import { clearAuthCookie } from '$lib/server/auth/auth.js';
 import { redirect, type Cookies } from '@sveltejs/kit';
@@ -9,6 +9,6 @@ export async function GET({ cookies }: { cookies: Cookies }) {
 
 	return redirect(
 		302,
-		`https://${AUTH0_DOMAIN}/logout?client_id=${AUTH0_CLIENT_ID}&returnTo=${PUBLIC_SITE_URL}`
+		`https://${env.AUTH0_DOMAIN}/logout?client_id=${env.AUTH0_CLIENT_ID}&returnTo=${PUBLIC_SITE_URL}`
 	);
 }

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -1,5 +1,8 @@
-import { NODE_ENV } from '$env/static/private';
+import { env } from '$env/dynamic/private';
 import { sightingSchema } from '$lib/form/validation/sightingSchema';
+
+// Dynamic environment variable for Docker runtime
+const NODE_ENV = env.NODE_ENV ?? 'development';
 import { createLogger } from '$lib/logger';
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import { db } from '$lib/server/db';

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -1,8 +1,5 @@
 import { env } from '$env/dynamic/private';
 import { sightingSchema } from '$lib/form/validation/sightingSchema';
-
-// Dynamic environment variable for Docker runtime
-const NODE_ENV = env.NODE_ENV ?? 'development';
 import { createLogger } from '$lib/logger';
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import { db } from '$lib/server/db';
@@ -20,6 +17,9 @@ import { json, type RequestEvent } from '@sveltejs/kit';
 import { and, gte, lt, sql } from 'drizzle-orm';
 import { ValidationError } from 'yup';
 import type { RequestHandler } from './$types';
+
+// Dynamic environment variable for Docker runtime
+const NODE_ENV = env.NODE_ENV ?? 'development';
 
 // Logger für diesen API-Endpunkt erstellen
 const logger = createLogger('api:sightings');


### PR DESCRIPTION
## Summary

- Switch from `$env/static/private` to `$env/dynamic/private` in all server-side code
- This allows Docker containers to read environment variables at runtime instead of build time
- Fixes 500 error on `/admin` when running Docker release locally (ENCRYPTION_KEY was baked in with placeholder value)
- Fix docker-entrypoint.sh to use printf with TTY detection for proper ANSI color output

## Changes

### Dynamic Environment Variables
All server-side files now use `$env/dynamic/private` instead of `$env/static/private`:

| File | Variables |
|------|-----------|
| `auth.ts` | AUTH0_*, ENCRYPTION_KEY, SESSION_SECRET, COOKIE_NAME, JWKS_URL |
| `hooks.server.ts` | COOKIE_NAME, SESSION_SECRET, NODE_ENV |
| `login/+server.ts` | AUTH0_CLIENT_ID, AUTH0_DOMAIN, API_AUDIENCE |
| `callback/+server.ts` | API_AUDIENCE |
| `logout/+server.ts` | AUTH0_DOMAIN, AUTH0_CLIENT_ID |
| `factory.ts` | STORAGE_PROVIDER, VERCEL |
| `vercel-blob.ts` | BLOB_READ_WRITE_TOKEN |
| `emailService.ts` | SMTP_*, NODE_ENV |
| `sightings/+server.ts` | NODE_ENV |

### Docker Entrypoint Fix
- Use `printf %b` instead of `echo` for ANSI escape codes (BusyBox compatibility)
- Detect TTY with `[ -t 1 ]` and disable colors when no terminal is attached
- Clean log output when viewing with `docker logs`

### Test Updates
- Updated mocks to use `$env/dynamic/private` structure (`env.VARIABLE` instead of `VARIABLE`)

## Test Plan
- [x] Type-check passes
- [x] Unit tests pass (815 passed)
- [x] Build succeeds
- [x] Docker image builds successfully
- [x] Container starts with proper environment variables
- [ ] Test authentication flow in Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)