### PR TITLE
docs: add v2.0.8 release highlights to production deployment guide

### DIFF
--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -4,6 +4,8 @@ Schnellanleitung für das Deployment von Ostsee-Tiere in einer Produktionsumgebu
 
 > **Hinweis:** Diese Anleitung ist für erfahrene Administratoren gedacht, die Docker und Linux-Server verwalten. Für detaillierte Hintergrundinformationen siehe [DOCKER_DEPLOYMENT.md](./DOCKER_DEPLOYMENT.md).
 
+> **Neu in v2.0.8:** PostgreSQL 18 mit PostGIS 3.6 Support, Security Hardening (no-new-privileges, Logging-Limits), verbesserte Dokumentation.
+
 ---
 
 ## Inhaltsverzeichnis


### PR DESCRIPTION
## Summary

Adds a prominent note to the Production Deployment Guide highlighting the key improvements in v2.0.8:

- PostgreSQL 18 with PostGIS 3.6 support
- Security hardening (no-new-privileges, logging limits)
- Improved documentation

## Why?

The previous Docker hardening PR (#294) used `chore(build):` prefix which doesn't appear in the release changelog. This `docs:` commit ensures the improvements are visible to users in the v2.0.8 release notes.

## Test plan

- [x] Documentation builds correctly
- [x] Note is visible at the top of the guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)