### PR TITLE
fix(api): remove phantom sighting creation from weather cache

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -608,7 +608,7 @@ SOFTWARE.</pre>
 					</p>
 				</div>
 
-				<div class="stats bg-base-100/50 mb-8 shadow-xl">
+				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-xl">
 					<div class="stat">
 						<div class="stat-title">Bereits erfasst</div>
 						<div class="stat-value text-primary">1.800+</div>

--- a/src/routes/api/weather/historical/+server.ts
+++ b/src/routes/api/weather/historical/+server.ts
@@ -4,11 +4,8 @@ import {
 	getWeatherDescription
 } from '$lib/constants/weather';
 import { createLogger } from '$lib/logger';
-import { db } from '$lib/server/db';
-import { sightings } from '$lib/server/db/schema';
 import { getCachedWeatherForSighting } from '$lib/server/db/sightingRepository';
 import {
-	convertToStoredWeatherData,
 	mapWeatherToFormFields,
 	type OpenMeteoRawData,
 	type WeatherData
@@ -427,60 +424,9 @@ export const GET: RequestHandler = async ({ url }) => {
 				weatherResult = await fetchHistoricalData(latitude, longitude, date, time);
 			}
 
-			// Store weather data in database for caching
-			if (weatherResult) {
-				try {
-					const storedWeatherData = convertToStoredWeatherData(
-						weatherResult.weatherData,
-						weatherResult.rawData,
-						weatherResult.dataType,
-						latitude,
-						longitude
-					);
-
-					// Create a temporary sighting entry to store weather data
-					await db.insert(sightings).values({
-						sightingDate: new Date(date + 'T' + (time || '12:00:00') + ':00'),
-						latitude: String(latitude),
-						longitude: String(longitude),
-						species: 0, // 0 = temp-weather-cache
-						totalCount: 0,
-						juvenileCount: 0,
-						distribution: 0,
-						seaState: 0,
-						visibility: 0,
-						mediaUpload: 0,
-						behavior: 0,
-						boatDrive: 0,
-						nameConsent: 0,
-						shipNameConsent: 0,
-						entryChannel: 0,
-						verified: 0,
-						inBalticSeaGeo: 0,
-						isDead: 0,
-						deadCondition: 0,
-						deadSex: 0,
-						deadPhoneContact: 0,
-						privacyConsent: 0,
-						created: new Date(),
-						weatherData: storedWeatherData,
-						weatherFetchedAt: new Date(),
-						weatherProvider: 'open-meteo',
-						weatherApiVersion: 'v1',
-						weatherDataType: weatherResult.dataType
-					});
-
-					logger.info(
-						{ latitude, longitude, date, dataType: weatherResult.dataType },
-						'Weather data stored in database for caching'
-					);
-				} catch (error) {
-					logger.error(
-						{ error, latitude, longitude, date },
-						'Failed to store weather data for caching'
-					);
-				}
-			}
+			// Note: Weather data is NOT cached separately in the database.
+			// It will be stored with the actual sighting when the form is submitted.
+			// This prevents creating phantom sighting entries just for weather caching.
 		}
 
 		if (!weatherResult) {


### PR DESCRIPTION
## Summary

- Removes code that created fake sighting entries when fetching weather data
- Weather data is already stored with the actual sighting on form submission
- Prevents phantom database entries with missing data

## Problem

The `/api/weather/historical` endpoint was inserting "temporary" sighting records into the `sichtungen` table to cache weather data. This caused:

1. **Phantom entries** - Sightings with no `referenz_id`, no personal data, and `species: 0`
2. **Duplicate records** - When a user fetched weather, changed the time, then submitted, two entries appeared
3. **Data inconsistency** - The cached entry had a different timestamp than the actual submission

Example of the bug: User fills form with time 10:40, weather is fetched → phantom entry created. User changes time to 08:40, submits → real entry created. Result: Two database rows for one sighting.

## Solution

Remove the weather caching code entirely. The weather data is already properly stored with the actual sighting when the form is submitted via `saveSighting()`.

## Test plan

- [x] TypeScript compiles without errors
- [x] All 843 unit tests pass
- [ ] Manual test: Fill sighting form, verify only one database entry is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)