### PR TITLE
chore(ci): add severity filter to Trivy security scanner

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -285,6 +285,7 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
           format: 'sarif'
           output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
@@ -298,6 +299,7 @@ jobs:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
           format: 'json'
           output: 'trivy-results.json'
+          severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results as artifact
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- Add severity filter (`CRITICAL,HIGH`) to Trivy security scanner
- Reduces noise from ~22 low-severity Alpine package CVEs to focus on actionable security issues

## Background

The project has two security scanning systems:

| System | Status | What it does |
|--------|--------|--------------|
| **GitHub CodeQL Default Setup** | Unchanged | JS/TS/Actions analysis (wöchentlich + PRs) |
| **Trivy Scanner** | **Filtered** | Docker image CVE scanning |

Most of the 22 current alerts are LOW/MEDIUM severity CVEs in Alpine base packages that cannot be easily fixed without breaking changes. By filtering to CRITICAL/HIGH, we focus on vulnerabilities that require immediate attention.

## Changes

- `.github/workflows/docker-publish.yml`: Added `severity: 'CRITICAL,HIGH'` to both Trivy scan steps

## Note

The empty `codeql-custom-queries-javascript/` directory was already not tracked by Git (Git doesn't track empty directories), so no removal was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)