### PR TITLE
fix(map): resolve critical memory leaks and prototype pollution

### DIFF
--- a/src/lib/components/map/OLMap.svelte
+++ b/src/lib/components/map/OLMap.svelte
@@ -98,13 +98,13 @@
 			// Cleanup function (replaces onDestroy)
 			return () => {
 				if (map) {
-					map.setTarget(undefined);
+					map.dispose();
 					map = null;
 					markerFeature = null;
 				}
 			};
 		}
-		
+
 		// Return undefined if mapElement is not available yet
 		return;
 	});

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -195,6 +195,16 @@
 		// Globale Referenz bereinigen, damit GC die Objekte freigeben kann
 		delete (window as unknown as { mapCountManager?: unknown }).mapCountManager;
 
+		// CountManager-Ressourcen aufräumen (Event-Listener)
+		if (countManager) {
+			countManager.dispose();
+		}
+
+		// Map-Ressourcen aufräumen (Geolocation, Overlay, Event-Listener)
+		if (mapInstance) {
+			mapInstance.dispose();
+		}
+
 		// Reset Manager
 		countManager = null;
 		panelManager = null;

--- a/src/lib/map/countManager.test.ts
+++ b/src/lib/map/countManager.test.ts
@@ -1,6 +1,6 @@
 // SichtungenMap (aus optimizedMapController) braucht echtes OpenLayers.
 // Wir mocken den Import des Controllers vollständig und testen MapCountManager isoliert.
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../logger', () => ({
 	createLogger: () => ({
@@ -106,6 +106,10 @@ describe('MapCountManager', () => {
 			addEventListener: vi.fn(),
 			removeEventListener: vi.fn()
 		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	describe('getCounts() — vor initialize()', () => {

--- a/src/lib/map/countManager.test.ts
+++ b/src/lib/map/countManager.test.ts
@@ -102,7 +102,10 @@ describe('MapCountManager', () => {
 
 	beforeEach(() => {
 		manager = new MapCountManager();
-		vi.stubGlobal('document', { addEventListener: vi.fn() });
+		vi.stubGlobal('document', {
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn()
+		});
 	});
 
 	describe('getCounts() — vor initialize()', () => {
@@ -235,6 +238,38 @@ describe('MapCountManager', () => {
 			manager.updateCounts();
 			// Zähler dürfen nicht akkumulieren
 			expect(manager.getCounts().speciesCounts['0']!.total).toBe(1);
+		});
+	});
+
+	describe('dispose()', () => {
+		it('entfernt den Change-Event-Listener vom Document', () => {
+			const mockMap = createMockMap();
+			manager.initialize(mockMap as any, defaultTranslations as any);
+
+			// Nach initialize() wurde addEventListener aufgerufen
+			expect(document.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+			manager.dispose();
+
+			// Nach dispose() wurde removeEventListener mit demselben Handler aufgerufen
+			expect(document.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+		});
+
+		it('setzt mapInstance und updateCallback auf undefined', () => {
+			const mockMap = createMockMap();
+			const callback = vi.fn();
+			manager.initialize(mockMap as any, defaultTranslations as any);
+			manager.onCountsUpdated(callback);
+
+			manager.dispose();
+
+			// updateCounts() sollte den Callback nicht mehr aufrufen
+			manager.updateCounts();
+			expect(callback).not.toHaveBeenCalled();
+		});
+
+		it('wirft keinen Fehler wenn ohne initialize() aufgerufen', () => {
+			expect(() => manager.dispose()).not.toThrow();
 		});
 	});
 

--- a/src/lib/map/countManager.test.ts
+++ b/src/lib/map/countManager.test.ts
@@ -242,17 +242,35 @@ describe('MapCountManager', () => {
 	});
 
 	describe('dispose()', () => {
-		it('entfernt den Change-Event-Listener vom Document', () => {
+		it('entfernt exakt denselben Change-Event-Listener vom Document', () => {
 			const mockMap = createMockMap();
 			manager.initialize(mockMap as any, defaultTranslations as any);
 
-			// Nach initialize() wurde addEventListener aufgerufen
-			expect(document.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+			// Handler-Referenz aus dem addEventListener-Mock auslesen
+			const addCall = vi
+				.mocked(document.addEventListener)
+				.mock.calls.find(([eventName]) => eventName === 'change');
+			expect(addCall).toBeDefined();
+			const changeHandler = addCall?.[1];
+			expect(changeHandler).toEqual(expect.any(Function));
 
 			manager.dispose();
 
-			// Nach dispose() wurde removeEventListener mit demselben Handler aufgerufen
-			expect(document.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+			// Nach dispose() wurde removeEventListener mit exakt demselben Handler aufgerufen
+			expect(document.removeEventListener).toHaveBeenCalledWith('change', changeHandler);
+		});
+
+		it('setzt Legend-Callback in der Map auf Noop zurück', () => {
+			const mockMap = createMockMap();
+			manager.initialize(mockMap as any, defaultTranslations as any);
+
+			// setLegendUpdateCallback wurde beim initialize() aufgerufen
+			expect(mockMap.setLegendUpdateCallback).toHaveBeenCalledOnce();
+
+			manager.dispose();
+
+			// Beim dispose() wird der Callback auf Noop zurückgesetzt
+			expect(mockMap.setLegendUpdateCallback).toHaveBeenCalledTimes(2);
 		});
 
 		it('setzt mapInstance und updateCallback auf undefined', () => {

--- a/src/lib/map/countManager.ts
+++ b/src/lib/map/countManager.ts
@@ -27,6 +27,7 @@ export class MapCountManager implements CountManager {
 	private speciesCounts: Record<string, { visible: number; total: number }> = {};
 	private colorCounts: Record<string, number> = {};
 	private updateCallback?: (counts: CountData) => void;
+	private changeHandler?: (event: Event) => void;
 
 	private readonly colorGroups = ['ct0', 'ct1', 'ct2', 'ct6', 'ct11', 'ct15'];
 
@@ -152,7 +153,7 @@ export class MapCountManager implements CountManager {
 		if (!this.mapInstance) return;
 
 		// Event-Delegation für dynamisch hinzugefügte Checkboxen
-		document.addEventListener('change', (event) => {
+		this.changeHandler = (event: Event) => {
 			const target = event.target as HTMLInputElement;
 
 			if (target.classList.contains('species-checkbox')) {
@@ -160,7 +161,20 @@ export class MapCountManager implements CountManager {
 			} else if (target.classList.contains('color-checkbox')) {
 				this.mapInstance!.setColorVisibility(target.value, target.checked);
 			}
-		});
+		};
+		document.addEventListener('change', this.changeHandler);
+	}
+
+	/**
+	 * Räumt alle Ressourcen auf. MUSS beim Unmount aufgerufen werden.
+	 */
+	public dispose(): void {
+		if (this.changeHandler) {
+			document.removeEventListener('change', this.changeHandler);
+			delete this.changeHandler;
+		}
+		delete this.mapInstance;
+		delete this.updateCallback;
 	}
 
 	/**

--- a/src/lib/map/countManager.ts
+++ b/src/lib/map/countManager.ts
@@ -22,12 +22,12 @@ export interface CountManager {
 }
 
 export class MapCountManager implements CountManager {
-	private mapInstance?: SichtungenMap;
-	private translations?: MapTranslations;
+	private mapInstance: SichtungenMap | undefined;
+	private translations: MapTranslations | undefined;
 	private speciesCounts: Record<string, { visible: number; total: number }> = {};
 	private colorCounts: Record<string, number> = {};
-	private updateCallback?: (counts: CountData) => void;
-	private changeHandler?: (event: Event) => void;
+	private updateCallback: ((counts: CountData) => void) | undefined;
+	private changeHandler: ((event: Event) => void) | undefined;
 
 	private readonly colorGroups = ['ct0', 'ct1', 'ct2', 'ct6', 'ct11', 'ct15'];
 
@@ -152,6 +152,11 @@ export class MapCountManager implements CountManager {
 	private initializeEventHandlers(): void {
 		if (!this.mapInstance) return;
 
+		// Bestehenden Handler entfernen (idempotent bei Re-Init / HMR)
+		if (this.changeHandler) {
+			document.removeEventListener('change', this.changeHandler);
+		}
+
 		// Event-Delegation für dynamisch hinzugefügte Checkboxen
 		this.changeHandler = (event: Event) => {
 			const target = event.target as HTMLInputElement;
@@ -169,12 +174,18 @@ export class MapCountManager implements CountManager {
 	 * Räumt alle Ressourcen auf. MUSS beim Unmount aufgerufen werden.
 	 */
 	public dispose(): void {
+		// Legend-Callback in der Map zurücksetzen, um Closure-Referenz auf diesen Manager freizugeben
+		if (this.mapInstance) {
+			this.mapInstance.setLegendUpdateCallback(() => {});
+		}
+
 		if (this.changeHandler) {
 			document.removeEventListener('change', this.changeHandler);
-			delete this.changeHandler;
 		}
-		delete this.mapInstance;
-		delete this.updateCallback;
+
+		this.changeHandler = undefined;
+		this.updateCallback = undefined;
+		this.mapInstance = undefined;
 	}
 
 	/**

--- a/src/lib/map/countManager.ts
+++ b/src/lib/map/countManager.ts
@@ -186,6 +186,11 @@ export class MapCountManager implements CountManager {
 		this.changeHandler = undefined;
 		this.updateCallback = undefined;
 		this.mapInstance = undefined;
+		this.translations = undefined;
+
+		// Count-Objekte leeren um Referenzen freizugeben
+		this.speciesCounts = {};
+		this.colorCounts = {};
 	}
 
 	/**

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -730,6 +730,22 @@ export class SichtungenMap {
 		}
 	}
 
+	/**
+	 * Räumt alle Map-Ressourcen auf: Geolocation, Overlay, Event-Listener, Map.
+	 * MUSS beim Unmount der Komponente aufgerufen werden.
+	 */
+	public dispose(): void {
+		// Geolocation stoppen
+		this.geolocation.setTracking(false);
+
+		// Popup entfernen
+		this.popup.setPosition(undefined);
+		this.map.removeOverlay(this.popup);
+
+		// Map disposen (entfernt alle Layer, Controls, Event-Listener)
+		this.map.dispose();
+	}
+
 	public getHidden(): { species: Record<string, boolean>; colors: Record<string, boolean> } {
 		return {
 			species: this.hiddenSpecies,

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -735,8 +735,8 @@ export class SichtungenMap {
 	 * MUSS beim Unmount der Komponente aufgerufen werden.
 	 */
 	public dispose(): void {
-		// Geolocation stoppen
-		this.geolocation.setTracking(false);
+		// Geolocation stoppen und internen Tracking-Status zurücksetzen
+		this.stopTracking();
 
 		// Popup entfernen
 		this.popup.setPosition(undefined);

--- a/src/lib/map/styleUtils.test.ts
+++ b/src/lib/map/styleUtils.test.ts
@@ -36,7 +36,13 @@ vi.mock('ol/style', () => {
 	return { Stroke, Fill, Style, Circle, RegularShape, Text };
 });
 
-import { backgroundColors, getFeatureColorGroup, legendGroups, speciesSymbols } from './styleUtils';
+import {
+	backgroundColors,
+	getFeatureColorGroup,
+	isBetween,
+	legendGroups,
+	speciesSymbols
+} from './styleUtils';
 import type { SightingProperties } from './styleUtils';
 
 describe('styleUtils', () => {
@@ -175,16 +181,21 @@ describe('styleUtils', () => {
 		});
 	});
 
-	describe('Number.prototype.between', () => {
-		it('ist nach Import verfügbar', () => {
-			expect((5 as number).between(1, 10)).toBe(true);
-			expect((0 as number).between(1, 10)).toBe(false);
-			expect((10 as number).between(1, 10)).toBe(true);
+	describe('isBetween', () => {
+		it('gibt true zurück für Wert innerhalb des Bereichs', () => {
+			expect(isBetween(5, 1, 10)).toBe(true);
+			expect(isBetween(1, 1, 10)).toBe(true);
+			expect(isBetween(10, 1, 10)).toBe(true);
 		});
 
-		it('funktioniert auch wenn first > last', () => {
-			expect((5 as number).between(10, 1)).toBe(true);
-			expect((0 as number).between(10, 1)).toBe(false);
+		it('gibt false zurück für Wert außerhalb des Bereichs', () => {
+			expect(isBetween(0, 1, 10)).toBe(false);
+			expect(isBetween(11, 1, 10)).toBe(false);
+		});
+
+		it('funktioniert auch wenn lower > upper', () => {
+			expect(isBetween(5, 10, 1)).toBe(true);
+			expect(isBetween(0, 10, 1)).toBe(false);
 		});
 	});
 });

--- a/src/lib/map/styleUtils.ts
+++ b/src/lib/map/styleUtils.ts
@@ -2,18 +2,12 @@ import { Stroke, Fill, Style, Circle, RegularShape, Text } from 'ol/style';
 import type { Feature } from 'ol';
 import type { Geometry } from 'ol/geom';
 
-// Erweiterung von Number für die between-Methode
-declare global {
-	interface Number {
-		between(this: number, first: number, last: number): boolean;
-	}
-}
-
-// Hilfsfunktion, falls between noch nicht existiert
-if (!Number.prototype.between) {
-	Number.prototype.between = function (this: number, first: number, last: number): boolean {
-		return first < last ? this >= first && this <= last : this >= last && this <= first;
-	};
+/**
+ * Prüft ob ein Wert zwischen zwei Grenzen liegt (inklusiv).
+ * Ersetzt die vorherige Number.prototype.between Prototype-Extension.
+ */
+export function isBetween(value: number, lower: number, upper: number): boolean {
+	return lower < upper ? value >= lower && value <= upper : value >= upper && value <= lower;
 }
 
 /**
@@ -61,67 +55,78 @@ export interface SpeciesSymbol {
  * Mapping von Tierarten zu verbesserten Symbolen
  */
 export const speciesSymbols: Record<string, SpeciesSymbol> = {
-	'0': { // Schweinswal
+	'0': {
+		// Schweinswal
 		symbol: '🐋',
 		baseColor: '#4A90E2', // Blau für Kleinwale
 		size: 1.0,
 		category: 'kleinwal'
 	},
-	'1': { // Kegelrobbe
+	'1': {
+		// Kegelrobbe
 		symbol: '🦭',
 		baseColor: '#8B4513', // Braun für Robben
 		size: 1.1,
 		category: 'robbe'
 	},
-	'2': { // Seehund
+	'2': {
+		// Seehund
 		symbol: '🦭',
 		baseColor: '#CD853F', // Helles Braun für Seehunde
 		size: 1.0,
 		category: 'robbe'
 	},
-	'3': { // Delphin
+	'3': {
+		// Delphin
 		symbol: '🐬',
 		baseColor: '#00CED1', // Türkis für Delphine
 		size: 1.0,
 		category: 'kleinwal'
 	},
-	'4': { // Beluga
+	'4': {
+		// Beluga
 		symbol: '🐋',
 		baseColor: '#F0F8FF', // Weiß für Beluga
 		size: 1.2,
 		category: 'kleinwal'
 	},
-	'5': { // Zwergwal
+	'5': {
+		// Zwergwal
 		symbol: '🐳',
 		baseColor: '#2F4F4F', // Dunkelgrau für Großwale
 		size: 1.3,
 		category: 'grosswal'
 	},
-	'6': { // Finnwal
+	'6': {
+		// Finnwal
 		symbol: '🐋',
 		baseColor: '#1C1C1C', // Schwarz für Finnwal
 		size: 1.5,
 		category: 'grosswal'
 	},
-	'7': { // Buckelwal
+	'7': {
+		// Buckelwal
 		symbol: '🐳',
 		baseColor: '#36454F', // Charcoal für Buckelwal
 		size: 1.4,
 		category: 'grosswal'
 	},
-	'8': { // Unbekannte Walart
+	'8': {
+		// Unbekannte Walart
 		symbol: '❓',
 		baseColor: '#696969', // Grau für unbekannt
 		size: 1.2,
 		category: 'grosswal'
 	},
-	'9': { // Ringelrobbe
+	'9': {
+		// Ringelrobbe
 		symbol: '🦭',
 		baseColor: '#A0522D', // Sienna für Ringelrobbe
 		size: 0.9,
 		category: 'robbe'
 	},
-	'10': { // Unbekannte Robbenart
+	'10': {
+		// Unbekannte Robbenart
 		symbol: '❓',
 		baseColor: '#8B4513', // Braun für unbekannte Robbe
 		size: 1.0,
@@ -133,9 +138,9 @@ export const speciesSymbols: Record<string, SpeciesSymbol> = {
  * Hintergrundfarben für bessere Sichtbarkeit der Symbole
  */
 export const backgroundColors: Record<string, string> = {
-	'kleinwal': '#E6F3FF', // Helles Blau
-	'grosswal': '#F0F0F0', // Hellgrau
-	'robbe': '#F5E6D3' // Beige
+	kleinwal: '#E6F3FF', // Helles Blau
+	grosswal: '#F0F0F0', // Hellgrau
+	robbe: '#F5E6D3' // Beige
 };
 
 /**
@@ -192,10 +197,7 @@ export function getFeatureColorGroup(properties: SightingProperties): string {
 /**
  * Erstellt einen verbesserten Unicode-basierten Style für ein Feature
  */
-function createUnicodeSymbolStyle(
-	speciesId: string,
-	colorGroup: string
-): Style {
+function createUnicodeSymbolStyle(speciesId: string, colorGroup: string): Style {
 	const speciesSymbol = speciesSymbols[speciesId];
 	if (!speciesSymbol) {
 		// Fallback für unbekannte Arten
@@ -204,21 +206,21 @@ function createUnicodeSymbolStyle(
 
 	// Berechne die finale Größe basierend auf der Tierart
 	const fontSize = Math.round(defaultRadius * 2.5 * speciesSymbol.size);
-	
+
 	// Bestimme die Farbe basierend auf der Count-Gruppe
-	const countColor = legendGroups[colorGroup]?.fill.getColor() as string || '#333333';
-	
+	const countColor = (legendGroups[colorGroup]?.fill.getColor() as string) || '#333333';
+
 	// Erstelle Hintergrund-Style für bessere Sichtbarkeit
 	const backgroundColor = backgroundColors[speciesSymbol.category] || '#FFFFFF';
-	
+
 	return new Style({
 		// Hintergrundkreis für bessere Sichtbarkeit
 		image: new Circle({
 			radius: fontSize / 2 + 4,
 			fill: new Fill({ color: backgroundColor + 'CC' }), // 80% Transparenz
-			stroke: new Stroke({ 
+			stroke: new Stroke({
 				color: countColor,
-				width: 2 
+				width: 2
 			})
 		}),
 		// Unicode-Text-Symbol
@@ -240,10 +242,7 @@ function createUnicodeSymbolStyle(
 /**
  * Fallback: Erstellt geometrische Formen für Browser ohne Unicode-Support
  */
-function createFallbackGeometricStyle(
-	speciesId: string,
-	colorGroup: string
-): Style {
+function createFallbackGeometricStyle(speciesId: string, colorGroup: string): Style {
 	// Verwende die ursprüngliche geometrische Form-Logik als Fallback
 	let points = 4;
 	let angle = Math.PI / 4;
@@ -340,7 +339,7 @@ export function createFeatureStyle(
 	if (
 		hiddenSpecies[speciesId] ||
 		hiddenColors[colorGroup] ||
-		!(properties.ts * 1000).between(timeFilter.lower, timeFilter.upper)
+		!isBetween(properties.ts * 1000, timeFilter.lower, timeFilter.upper)
 	) {
 		feature.set('stcVisibility', false);
 		return null;
@@ -359,7 +358,7 @@ export function createFeatureStyle(
 
 	// Versuche zuerst Unicode-Symbole zu verwenden
 	let style: Style;
-	
+
 	try {
 		style = createUnicodeSymbolStyle(speciesId, colorGroup);
 	} catch (error) {
@@ -380,10 +379,10 @@ export function createFeatureStyle(
 export function createClusterStyle(feature: Feature<Geometry>): Style {
 	const features = feature.get('features');
 	const size = features ? features.length : 0;
-	
+
 	// Cache-Key für Cluster-Styles
 	const clusterKey = `cluster_${size}`;
-	
+
 	if (styleCache[clusterKey]) {
 		return styleCache[clusterKey];
 	}
@@ -392,7 +391,7 @@ export function createClusterStyle(feature: Feature<Geometry>): Style {
 	let radius = 15;
 	let fontSize = 12;
 	let color = '#3399CC';
-	
+
 	if (size < 5) {
 		radius = 18;
 		fontSize = 12;

--- a/src/lib/utils/map/openLayersHelpers.ts
+++ b/src/lib/utils/map/openLayersHelpers.ts
@@ -85,7 +85,10 @@ export class FormLocationControl extends Control {
 				}
 			},
 			(error) => {
-				logger.warn({ error: error instanceof Error ? error.message : error }, 'GPS-Positionierung fehlgeschlagen');
+				logger.warn(
+					{ error: error instanceof Error ? error.message : error },
+					'GPS-Positionierung fehlgeschlagen'
+				);
 				this.stopTracking();
 			},
 			{
@@ -109,6 +112,15 @@ export class FormLocationControl extends Control {
 		this.button.style.backgroundColor = 'rgba(0, 60, 136, 0.5)';
 		this.button.style.color = 'white';
 		this.button.title = 'GPS-Position anzeigen';
+	}
+
+	/**
+	 * OpenLayers ruft disposeInternal() auf Controls auf wenn die Map disposed wird.
+	 * Stoppt laufendes GPS-Tracking damit keine verwaisten watchPosition-Callbacks bleiben.
+	 */
+	override disposeInternal() {
+		this.stopTracking();
+		super.disposeInternal();
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `dispose()` method to `SichtungenMap` for proper cleanup of Map, Geolocation, and Overlay resources on component unmount
- Replace `OLMap.svelte` `setTarget(undefined)` with `map.dispose()` for complete resource cleanup
- Replace `Number.prototype.between` global prototype extension with local `isBetween()` utility function to prevent prototype pollution
- Fix `CountManager` event listener leak by storing handler reference and removing it in new `dispose()` method

## Context
OpenLayers Audit identified 4 P0 (critical) issues: the map was never properly disposed on unmount, causing memory leaks; Geolocation tracking continued after component destruction; a global prototype extension polluted `Number.prototype`; and the CountManager registered event listeners without ever removing them.

## Test plan
- [x] All 1220 unit tests pass (`npm run test:unit`)
- [x] ESLint clean (`npm run lint`)
- [x] TypeScript clean (`npm run type-check`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual: Navigate to/from map page repeatedly, verify no memory growth in DevTools
- [ ] Manual: Enable GPS tracking, navigate away, verify tracking stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)