### PR TITLE
feat(map): improve map UX and production readiness

### DIFF
--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -41,6 +41,13 @@
 		}, 800);
 	}
 
+	// Cleanup bei Unmount
+	$effect(() => {
+		return () => {
+			if (filterFeedbackTimeout) clearTimeout(filterFeedbackTimeout);
+		};
+	});
+
 	function handleYearChange(e: Event) {
 		const year = parseInt((e.target as HTMLSelectElement).value, 10);
 		if (!isNaN(year)) userSelectedYear = year;

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -30,18 +30,20 @@
 		isOpen = false;
 	}
 
-	// Funktion für Filter-Anwendung mit visueller Rückmeldung
+	// Kurze visuelle Rückmeldung bei Filter-Änderung
+	let filterFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
 	function handleFilterApply() {
 		isApplyingFilter = true;
-
-		// Simuliere Filterzeit (wird durch den echten Filter-Prozess ersetzt)
-		setTimeout(() => {
+		if (filterFeedbackTimeout) clearTimeout(filterFeedbackTimeout);
+		filterFeedbackTimeout = setTimeout(() => {
 			isApplyingFilter = false;
-		}, 1500);
+			filterFeedbackTimeout = null;
+		}, 800);
 	}
 
 	function handleYearChange(e: Event) {
-		userSelectedYear = parseInt((e.target as HTMLSelectElement).value);
+		const year = parseInt((e.target as HTMLSelectElement).value, 10);
+		if (!isNaN(year)) userSelectedYear = year;
 		handleFilterApply();
 	}
 </script>

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -83,6 +83,21 @@
 	// Aktuell angezeigtes Jahr für den Titel
 	let currentDisplayedYear = $state(defaultYear);
 
+	// Feature-Anzahl direkt vom Map-Controller abfragen (robuster als counts-basiert)
+	let featureCount = $state(0);
+	let totalFeatures = $derived(
+		Object.values(counts.speciesCounts).reduce((sum, c) => sum + c.total, 0)
+	);
+	let visibleFeatures = $derived(
+		Object.values(counts.speciesCounts).reduce((sum, c) => sum + c.visible, 0)
+	);
+	let showNoResults = $derived(
+		!isInitialLoading && !isLoadingData && featureCount === 0 && totalFeatures === 0
+	);
+	let showNoVisibleResults = $derived(
+		!isInitialLoading && !isLoadingData && featureCount > 0 && visibleFeatures === 0
+	);
+
 	// Event Handler für Cleanup
 	let keyboardHandler: ((event: KeyboardEvent) => void) | null = null;
 	let unhandledRejectionHandler: ((event: PromiseRejectionEvent) => void) | null = null;
@@ -119,8 +134,10 @@
 
 			// Initialisiere Count Manager und setze Callback
 			countManager.initialize(mapInstance, translations);
+			const countMapInstance = mapInstance;
 			countManager.onCountsUpdated((newCounts) => {
 				counts = newCounts;
+				featureCount = countMapInstance.getFeatures().length;
 			});
 
 			// Initialisiere andere Manager
@@ -350,6 +367,33 @@
 			isVisible={isInitialLoading || isLoadingData}
 			type={isInitialLoading ? 'initial' : loadingType}
 		/>
+
+		<!-- Keine Sichtungen für das gewählte Jahr -->
+		{#if showNoResults}
+			<div
+				role="status"
+				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+			>
+				<p class="text-base-content text-sm font-medium">
+					Keine Sichtungen für {currentDisplayedYear} vorhanden.
+				</p>
+			</div>
+		{/if}
+
+		<!-- Alle Sichtungen durch Filter ausgeblendet -->
+		{#if showNoVisibleResults}
+			<div
+				role="status"
+				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+			>
+				<p class="text-base-content text-sm font-medium">
+					Keine Sichtungen für den aktuellen Filter sichtbar.
+				</p>
+				<p class="text-base-content/60 mt-1 text-xs">
+					Passen Sie den Zeitraum oder die Tierart-Filter an.
+				</p>
+			</div>
+		{/if}
 
 		<!-- Error-Toast -->
 		{#if errorMessage}

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -92,10 +92,18 @@
 		Object.values(counts.speciesCounts).reduce((sum, c) => sum + c.visible, 0)
 	);
 	let showNoResults = $derived(
-		!isInitialLoading && !isLoadingData && featureCount === 0 && totalFeatures === 0
+		!isInitialLoading &&
+			!isLoadingData &&
+			!errorMessage &&
+			featureCount === 0 &&
+			totalFeatures === 0
 	);
 	let showNoVisibleResults = $derived(
-		!isInitialLoading && !isLoadingData && featureCount > 0 && visibleFeatures === 0
+		!isInitialLoading &&
+			!isLoadingData &&
+			!errorMessage &&
+			featureCount > 0 &&
+			visibleFeatures === 0
 	);
 
 	// Event Handler für Cleanup

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -269,7 +269,12 @@
 	function setupKeyboardNavigation() {
 		keyboardHandler = (event) => {
 			// Nur aktiv wenn kein Input-Element fokussiert ist
-			if (event.target instanceof HTMLInputElement || event.target instanceof HTMLSelectElement) {
+			if (
+				event.target instanceof HTMLInputElement ||
+				event.target instanceof HTMLSelectElement ||
+				event.target instanceof HTMLTextAreaElement ||
+				(event.target instanceof HTMLElement && event.target.isContentEditable)
+			) {
 				return;
 			}
 

--- a/src/lib/map/mapUtils.test.ts
+++ b/src/lib/map/mapUtils.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck - Test file with mock data that may not match exact types
 import { describe, it, expect } from 'vitest';
-import { sightingsToGeoJSON } from './mapUtils';
+import { areExtentsColocated, sightingsToGeoJSON } from './mapUtils';
 import type { DBSighting } from './mapUtils';
 
 describe('mapUtils', () => {
@@ -28,7 +28,7 @@ describe('mapUtils', () => {
 
 			expect(result.type).toBe('FeatureCollection');
 			expect(result.features).toHaveLength(1);
-			
+
 			const feature = result.features[0]!;
 			expect(feature.type).toBe('Feature');
 			expect(feature.id).toBe(123);
@@ -277,5 +277,67 @@ describe('mapUtils', () => {
 				expect(timestamp).toBeGreaterThan(0);
 			});
 		});
+	});
+});
+
+describe('areExtentsColocated', () => {
+	it('gibt false zurück bei weniger als 2 Extents', () => {
+		expect(areExtentsColocated([])).toBe(false);
+		expect(areExtentsColocated([[0, 0, 0, 0]])).toBe(false);
+	});
+
+	it('erkennt identische Koordinaten als colocated', () => {
+		const extent: [number, number, number, number] = [1000, 2000, 1000, 2000];
+		expect(areExtentsColocated([extent, extent, extent])).toBe(true);
+	});
+
+	it('erkennt nahe Koordinaten innerhalb des Thresholds als colocated', () => {
+		const extents: [number, number, number, number][] = [
+			[1000, 2000, 1000, 2000],
+			[1050, 2050, 1050, 2050],
+			[1099, 2099, 1099, 2099]
+		];
+		expect(areExtentsColocated(extents, 100)).toBe(true);
+	});
+
+	it('erkennt entfernte Koordinaten als nicht colocated', () => {
+		const extents: [number, number, number, number][] = [
+			[1000, 2000, 1000, 2000],
+			[1200, 2000, 1200, 2000]
+		];
+		expect(areExtentsColocated(extents, 100)).toBe(false);
+	});
+
+	it('erkennt Abweichung nur in Y-Achse als nicht colocated', () => {
+		const extents: [number, number, number, number][] = [
+			[1000, 2000, 1000, 2000],
+			[1000, 2150, 1000, 2150]
+		];
+		expect(areExtentsColocated(extents, 100)).toBe(false);
+	});
+
+	it('verwendet Standard-Threshold von 100', () => {
+		expect(
+			areExtentsColocated([
+				[1000, 2000, 1000, 2000],
+				[1099, 2099, 1099, 2099]
+			])
+		).toBe(true);
+
+		expect(
+			areExtentsColocated([
+				[1000, 2000, 1000, 2000],
+				[1101, 2000, 1101, 2000]
+			])
+		).toBe(false);
+	});
+
+	it('erkennt gemischte Entfernungen korrekt (ein Outlier reicht)', () => {
+		const extents: [number, number, number, number][] = [
+			[1000, 2000, 1000, 2000],
+			[1010, 2010, 1010, 2010],
+			[5000, 6000, 5000, 6000]
+		];
+		expect(areExtentsColocated(extents, 100)).toBe(false);
 	});
 });

--- a/src/lib/map/mapUtils.ts
+++ b/src/lib/map/mapUtils.ts
@@ -1,126 +1,126 @@
 /**
  * @fileoverview Kartendarstellung und GeoJSON-Konvertierung für OpenLayers
- * 
+ *
  * Dieses Modul enthält Funktionen und Typen für die Darstellung von
  * Meeressäuger-Sichtungen auf der interaktiven Karte. Es konvertiert
  * Datenbank-Sichtungen in GeoJSON-Features für OpenLayers und definiert
  * die Schnittstelle für Kartenübersetzungen.
- * 
+ *
  * Die GeoJSON-Struktur folgt der RFC 7946 Spezifikation und ist
  * optimiert für die Anzeige in OpenLayers mit Performance-Optimierungen
  * für große Datenmengen.
- * 
+ *
  * @author Ostsee-Tiere Team
  * @since 1.0.0
  */
 
 /**
  * Übersetzungsschnittstelle für Kartenbeschriftungen
- * 
+ *
  * Definiert alle benötigten Übersetzungsschlüssel für die
  * mehrsprachige Darstellung der interaktiven Karte.
  */
 export interface MapTranslations {
-	overview: string;           // "Übersicht" - Kartenübersicht
-	zoom_title: string;         // Tooltip für Zoom-Kontrolle
-	zoom: string;              // "Zoom" - Zoom-Label
-	report_date: string;       // "Meldedatum" - Datum der Sichtung
-	language: string;          // "Sprache" - Sprachauswahl
-	species: string;           // "Tierart" - Spezies-Label
-	species_legend: string;    // Legende für Tierarten
-	position: string;          // "Position" - Koordinaten
-	count: string;             // "Anzahl" - Tierzahl
-	young: string;             // "Jungtiere" - Kälber/Jungtiere
-	ship: string;              // "Schiff" - Fahrzeug
-	name: string;              // "Name" - Beobachter
-	area: string;              // "Gebiet" - Seegebiet
-	latitude: string;          // "Breitengrad" - Lat-Koordinate
-	longitude: string;         // "Längengrad" - Lon-Koordinate
-	found_dead: string;        // "Totfund" - Tote Tiere
+	overview: string; // "Übersicht" - Kartenübersicht
+	zoom_title: string; // Tooltip für Zoom-Kontrolle
+	zoom: string; // "Zoom" - Zoom-Label
+	report_date: string; // "Meldedatum" - Datum der Sichtung
+	language: string; // "Sprache" - Sprachauswahl
+	species: string; // "Tierart" - Spezies-Label
+	species_legend: string; // Legende für Tierarten
+	position: string; // "Position" - Koordinaten
+	count: string; // "Anzahl" - Tierzahl
+	young: string; // "Jungtiere" - Kälber/Jungtiere
+	ship: string; // "Schiff" - Fahrzeug
+	name: string; // "Name" - Beobachter
+	area: string; // "Gebiet" - Seegebiet
+	latitude: string; // "Breitengrad" - Lat-Koordinate
+	longitude: string; // "Längengrad" - Lon-Koordinate
+	found_dead: string; // "Totfund" - Tote Tiere
 	speciesMap: Record<string, string>; // Mapping von Spezies-IDs zu Namen
 }
 
 /**
  * GeoJSON-Feature für eine einzelne Sichtung
- * 
+ *
  * Entspricht der GeoJSON-Spezifikation für Punkt-Features
  * mit Sichtung-spezifischen Eigenschaften für die Kartendarstellung.
  */
 export interface SightingFeature {
-	type: 'Feature';           // GeoJSON-Typ (immer "Feature")
-	id: number;                // Eindeutige Sichtungs-ID
+	type: 'Feature'; // GeoJSON-Typ (immer "Feature")
+	id: number; // Eindeutige Sichtungs-ID
 	geometry: {
-		type: 'Point';         // Geometrie-Typ (immer "Point" für Sichtungen)
+		type: 'Point'; // Geometrie-Typ (immer "Point" für Sichtungen)
 		coordinates: [number, number]; // [Längengrad, Breitengrad] - WICHTIG: Reihenfolge!
 	};
 	properties: {
-		id: number;            // Sichtungs-ID (doppelt für Kompatibilität)
-		ts: number;            // Unix-Zeitstempel in Sekunden
-		ta: number;            // Tierart (Species-Enum-Wert)
-		ct: number;            // Gesamtanzahl der Tiere
-		jt: number;            // Anzahl Jungtiere/Kälber
-		tf: boolean;           // Totfund ja/nein
+		id: number; // Sichtungs-ID (doppelt für Kompatibilität)
+		ts: number; // Unix-Zeitstempel in Sekunden
+		ta: number; // Tierart (Species-Enum-Wert)
+		ct: number; // Gesamtanzahl der Tiere
+		jt: number; // Anzahl Jungtiere/Kälber
+		tf: boolean; // Totfund ja/nein
 		// Optionale Eigenschaften (nur bei Einwilligung/Verfügbarkeit)
-		name?: string | undefined;      // Nachname des Beobachters
+		name?: string | undefined; // Nachname des Beobachters
 		firstname?: string | undefined; // Vorname des Beobachters
-		shipname?: string | undefined;  // Name des Beobachtungsschiffs
-		waterway?: string | undefined;  // Gewässername
-		seaMark?: string | undefined;   // Seezeichen als Referenz
+		shipname?: string | undefined; // Name des Beobachtungsschiffs
+		waterway?: string | undefined; // Gewässername
+		seaMark?: string | undefined; // Seezeichen als Referenz
 	};
 }
 
 /**
  * GeoJSON-FeatureCollection für alle Sichtungen
- * 
+ *
  * Standard-GeoJSON-Container für eine Sammlung von Sichtungs-Features,
  * optimiert für die Darstellung in OpenLayers.
  */
 export interface GeoJSONResponse {
-	type: 'FeatureCollection';  // GeoJSON-Typ (immer "FeatureCollection")
+	type: 'FeatureCollection'; // GeoJSON-Typ (immer "FeatureCollection")
 	features: SightingFeature[]; // Array aller Sichtungs-Features
 }
 
 /**
  * Datenbank-Sichtung wie sie aus der DB kommt
- * 
+ *
  * Repräsentiert eine Sichtung in dem Format, wie sie aus der
  * Drizzle-Datenbank gelesen wird, bevor sie zu GeoJSON konvertiert wird.
  */
 export interface DBSighting {
-	id: number;                        // Primärschlüssel
-	sightingDate: string;              // ISO-Datum-String
-	longitude: number | string;        // Längengrad (kann String sein bei Legacy-Daten)
-	latitude: number | string;         // Breitengrad (kann String sein bei Legacy-Daten)
-	species: number;                   // Species-Enum-Wert
-	totalCount: number;                // Gesamtanzahl Tiere
-	juvenileCount: number;             // Anzahl Jungtiere
-	isDead: boolean;                   // Totfund-Flag
-	firstName?: string;                // Vorname (optional)
-	lastName?: string;                 // Nachname (optional)
-	nameConsent: boolean;              // Einwilligung zur Namensnennung
-	shipName?: string;                 // Schiffsname (optional)
-	shipNameConsent: boolean;          // Einwilligung zur Schiffsnamen-Nennung
-	waterway?: string;                 // Gewässername (optional)
-	seaMark?: string;                  // Seezeichen (optional)
-	[key: string]: unknown;            // Weitere Felder für Flexibilität
+	id: number; // Primärschlüssel
+	sightingDate: string; // ISO-Datum-String
+	longitude: number | string; // Längengrad (kann String sein bei Legacy-Daten)
+	latitude: number | string; // Breitengrad (kann String sein bei Legacy-Daten)
+	species: number; // Species-Enum-Wert
+	totalCount: number; // Gesamtanzahl Tiere
+	juvenileCount: number; // Anzahl Jungtiere
+	isDead: boolean; // Totfund-Flag
+	firstName?: string; // Vorname (optional)
+	lastName?: string; // Nachname (optional)
+	nameConsent: boolean; // Einwilligung zur Namensnennung
+	shipName?: string; // Schiffsname (optional)
+	shipNameConsent: boolean; // Einwilligung zur Schiffsnamen-Nennung
+	waterway?: string; // Gewässername (optional)
+	seaMark?: string; // Seezeichen (optional)
+	[key: string]: unknown; // Weitere Felder für Flexibilität
 }
 
 /**
  * Konvertiert Datenbank-Sichtungen in GeoJSON-Format für OpenLayers-Darstellung
- * 
+ *
  * Diese Funktion transformiert Sichtungen aus dem Datenbankformat in eine
  * standardkonforme GeoJSON-FeatureCollection, die direkt in OpenLayers
  * geladen werden kann. Dabei werden Datenschutz-Einstellungen respektiert
  * und Legacy-Datenformate unterstützt.
- * 
+ *
  * @param sightingsFromDB Array von Sichtungen aus der Datenbank
  * @returns GeoJSON-FeatureCollection mit allen Sichtungen als Punkt-Features
- * 
+ *
  * @example
  * const geoJson = sightingsToGeoJSON(databaseSightings);
  * map.addLayer(new VectorLayer({ source: new VectorSource({ features: geoJson }) }));
- * 
- * @note 
+ *
+ * @note
  * - Koordinaten-Reihenfolge: [Längengrad, Breitengrad] (GeoJSON-Standard)
  * - Zeitstempel werden in Unix-Sekunden konvertiert für JavaScript-Kompatibilität
  * - Personenbezogene Daten nur bei expliziter Einwilligung
@@ -134,13 +134,15 @@ export function sightingsToGeoJSON(sightingsFromDB: DBSighting[]): GeoJSONRespon
 
 		// Koordinaten-Normalisierung: String -> Number (Legacy-Daten-Support)
 		// WICHTIG: Fallback auf 0 für ungültige Koordinaten
-		const longitude = typeof dbSighting.longitude === 'string'
-			? parseFloat(dbSighting.longitude) || 0  // parseFloat kann NaN zurückgeben
-			: dbSighting.longitude || 0;
+		const longitude =
+			typeof dbSighting.longitude === 'string'
+				? parseFloat(dbSighting.longitude) || 0 // parseFloat kann NaN zurückgeben
+				: dbSighting.longitude || 0;
 
-		const latitude = typeof dbSighting.latitude === 'string'
-			? parseFloat(dbSighting.latitude) || 0   // parseFloat kann NaN zurückgeben
-			: dbSighting.latitude || 0;
+		const latitude =
+			typeof dbSighting.latitude === 'string'
+				? parseFloat(dbSighting.latitude) || 0 // parseFloat kann NaN zurückgeben
+				: dbSighting.latitude || 0;
 
 		// GeoJSON-Feature-Objekt nach RFC 7946 Standard erstellen
 		return {
@@ -152,20 +154,20 @@ export function sightingsToGeoJSON(sightingsFromDB: DBSighting[]): GeoJSONRespon
 				coordinates: [longitude, latitude]
 			},
 			properties: {
-				id: dbSighting.id,                    // Feature-ID
-				ts: timestamp,                        // Zeitstempel (Unix-Sekunden)
-				ta: dbSighting.species,               // Tierart (Species-Enum)
-				ct: dbSighting.totalCount,            // Anzahl Tiere
-				jt: dbSighting.juvenileCount,         // Anzahl Jungtiere
-				tf: dbSighting.isDead,                // Totfund-Flag
+				id: dbSighting.id, // Feature-ID
+				ts: timestamp, // Zeitstempel (Unix-Sekunden)
+				ta: dbSighting.species, // Tierart (Species-Enum)
+				ct: dbSighting.totalCount, // Anzahl Tiere
+				jt: dbSighting.juvenileCount, // Anzahl Jungtiere
+				tf: dbSighting.isDead, // Totfund-Flag
 				// Datenschutz-konforme Namensanzeige
 				name: dbSighting.nameConsent ? dbSighting.lastName : undefined,
 				firstname: dbSighting.nameConsent ? dbSighting.firstName : undefined,
 				// Datenschutz-konforme Schiffsnamenanzeige
 				shipname: dbSighting.shipNameConsent ? dbSighting.shipName : undefined,
 				// Geografische Referenzen (immer verfügbar)
-				waterway: dbSighting.waterway,        // Gewässername
-				seaMark: dbSighting.seaMark           // Seezeichen
+				waterway: dbSighting.waterway, // Gewässername
+				seaMark: dbSighting.seaMark // Seezeichen
 			}
 		};
 	});
@@ -175,4 +177,25 @@ export function sightingsToGeoJSON(sightingsFromDB: DBSighting[]): GeoJSONRespon
 		type: 'FeatureCollection',
 		features
 	};
+}
+
+/**
+ * Prüft ob alle Koordinatenpaare nahe beieinander liegen.
+ * Wird verwendet um zu erkennen, ob Cluster-Features an derselben Position sind
+ * (in dem Fall hilft Zoomen nicht weiter).
+ *
+ * @param extents Array von [minX, minY, maxX, maxY] Extents (EPSG:3857)
+ * @param threshold Maximaler Abstand in Projektion-Einheiten (~Metern bei EPSG:3857)
+ * @returns true wenn alle Extents innerhalb des Thresholds des ersten liegen
+ */
+export function areExtentsColocated(
+	extents: [number, number, number, number][],
+	threshold: number = 100
+): boolean {
+	if (extents.length <= 1) return false;
+	const first = extents[0];
+	if (!first) return false;
+	return extents.every((ext) => {
+		return Math.abs(ext[0] - first[0]) < threshold && Math.abs(ext[1] - first[1]) < threshold;
+	});
 }

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -16,7 +16,7 @@ import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
 import { LocationControl } from './controls/LocationControl.js';
 import { ZoomAllControl } from './controls/ZoomAllControl.js';
 import { getDefaultSightingYear } from '$lib/utils/date/defaultYear';
-import type { MapTranslations } from './mapUtils';
+import { areExtentsColocated, type MapTranslations } from './mapUtils';
 import { createFeatureStyle, getFeatureColorGroup } from './styleUtils';
 import { sanitizeText } from '$lib/utils/sanitize';
 
@@ -500,22 +500,10 @@ export class SichtungenMap {
 	 * In dem Fall hilft Zoomen nicht weiter.
 	 */
 	private hasColocatedFeatures(features: Feature<Geometry>[]): boolean {
-		if (features.length <= 1) return false;
-		const firstFeature = features[0];
-		if (!firstFeature) return false;
-		const firstGeom = firstFeature.getGeometry();
-		if (!firstGeom) return false;
-		const firstExtent = firstGeom.getExtent() as [number, number, number, number];
-		const threshold = 100; // ~100m in EPSG:3857
-		return features.every((f) => {
-			const geom = f.getGeometry();
-			if (!geom) return true;
-			const ext = geom.getExtent() as [number, number, number, number];
-			return (
-				Math.abs(ext[0] - firstExtent[0]) < threshold &&
-				Math.abs(ext[1] - firstExtent[1]) < threshold
-			);
-		});
+		const extents = features
+			.map((f) => f.getGeometry()?.getExtent() as [number, number, number, number] | undefined)
+			.filter((ext): ext is [number, number, number, number] => ext !== undefined);
+		return areExtentsColocated(extents);
 	}
 
 	/**
@@ -544,25 +532,27 @@ export class SichtungenMap {
 				: '';
 
 			items += `
-				<button
-					type="button"
-					data-cluster-index="${index}"
-					class="cluster-list-item"
-					aria-label="${speciesName}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
-				>
-					<span style="flex: 1; font-weight: 500;">${speciesName}${deadBadge}</span>
-					<span style="color: #6b7280; white-space: nowrap;">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
-					<span style="color: #9ca3af; font-size: 11px; white-space: nowrap;">${date}</span>
-				</button>
+				<li>
+					<button
+						type="button"
+						data-cluster-index="${index}"
+						class="cluster-list-item"
+						aria-label="${speciesName}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
+					>
+						<span style="flex: 1; font-weight: 500;">${speciesName}${deadBadge}</span>
+						<span style="color: #6b7280; white-space: nowrap;">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
+						<span style="color: #9ca3af; font-size: 11px; white-space: nowrap;">${date}</span>
+					</button>
+				</li>
 			`;
 		});
 
 		return `
-			<div class="cluster-popup" role="list" aria-label="${count} Sichtungen an diesem Ort">
+			<div class="cluster-popup">
 				<h3 style="margin: 0 0 8px 0; color: #333; font-size: 14px;">${count} Sichtungen an diesem Ort</h3>
-				<div style="max-height: 240px; overflow-y: auto; padding-right: 4px;">
+				<ul aria-label="${count} Sichtungen" style="list-style: none; margin: 0; padding: 0; max-height: 240px; overflow-y: auto; padding-right: 4px;">
 					${items}
-				</div>
+				</ul>
 			</div>
 		`;
 	}
@@ -718,9 +708,8 @@ export class SichtungenMap {
 		this.reportsSource.clear();
 		this.reportsSource.addFeatures(features);
 
-		if (this.legendUpdateCallback) {
-			this.legendUpdateCallback();
-		}
+		// Kein legendUpdateCallback hier — Caller (setYear, applyFilter) sind dafür zuständig,
+		// damit Counts erst nach korrektem timeFilter-Update berechnet werden.
 
 		// Aktiven Controller aufräumen
 		if (this.activeAbortController === abortController) {

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -170,10 +170,6 @@ export class SichtungenMap {
 		const defaultLat = 54.5;
 		const defaultLon = 12.0;
 		const defaultZoom = 7;
-		const balticExtent = olExtent.boundingExtent([
-			fromLonLat([9.4, 53.0]),
-			fromLonLat([30.2, 66.0])
-		]);
 
 		// Initialize the timeFilter with sensible defaults (zeige das ganze Jahr)
 		this.displayedYear = getDefaultSightingYear();
@@ -232,8 +228,7 @@ export class SichtungenMap {
 				center: fromLonLat([defaultLon, defaultLat]),
 				zoom: defaultZoom,
 				projection: 'EPSG:3857',
-				extent: balticExtent,
-				minZoom: 5,
+				minZoom: 2,
 				maxZoom: 18
 			}),
 			controls: defaultControls({ rotate: false }).extend(this.createCustomControls())
@@ -318,6 +313,13 @@ export class SichtungenMap {
 		if (!isTouchDevice) {
 			this.map.on('pointermove', (event) => {
 				const infoElement = document.getElementById('info');
+
+				// Hover ausblenden wenn ein Popup offen ist
+				if (this.popup.getPosition()) {
+					if (infoElement) infoElement.style.display = 'none';
+					return;
+				}
+
 				const feature = this.map.forEachFeatureAtPixel(event.pixel, (feature) => feature);
 
 				if (feature && infoElement) {
@@ -368,15 +370,19 @@ export class SichtungenMap {
 		this.map.on('click', (event) => {
 			const feature = this.map.forEachFeatureAtPixel(event.pixel, (feature) => feature);
 
+			// Hover sofort ausblenden bei Klick
+			const infoElement = document.getElementById('info');
+			if (infoElement) infoElement.style.display = 'none';
+
 			if (feature) {
 				const features = feature.get('features');
 				const zoom = this.map.getView().getZoom() || 7;
 
-				if (features && features.length > 1 && zoom < 12) {
-					// Zoom zu Cluster bei niedrigem Zoom
+				if (features && features.length > 1 && zoom < 12 && !this.hasColocatedFeatures(features)) {
+					// Zoom zu Cluster bei niedrigem Zoom (nur wenn Features an verschiedenen Positionen)
 					this.zoomToCluster(features);
 				} else {
-					// Zeige Popup
+					// Zeige Popup (Einzelfeature oder Liste bei co-located Features)
 					this.showPopup(event.coordinate, feature as Feature<Geometry>);
 				}
 			} else {
@@ -395,8 +401,9 @@ export class SichtungenMap {
 		const features = feature.get('features');
 
 		if (features && features.length > 1) {
-			// Cluster
-			contentDiv.innerHTML = this.createClusterPopupContent(features);
+			// Cluster - zeige Liste aller Sichtungen
+			contentDiv.innerHTML = this.createClusterListContent(features);
+			this.attachClusterListHandlers(contentDiv, features, coordinate);
 		} else {
 			// Einzelfeature
 			const singleFeature = features ? features[0] : feature;
@@ -476,38 +483,123 @@ export class SichtungenMap {
 		return content;
 	}
 
-	private createClusterPopupContent(features: Feature<Geometry>[]): string {
-		const count = features.length;
-		const speciesCount: Record<string, number> = {};
+	/**
+	 * Prüft ob alle Features im Cluster identische oder sehr nahe Koordinaten haben.
+	 * In dem Fall hilft Zoomen nicht weiter.
+	 */
+	private hasColocatedFeatures(features: Feature<Geometry>[]): boolean {
+		if (features.length <= 1) return false;
+		const firstFeature = features[0];
+		if (!firstFeature) return false;
+		const firstGeom = firstFeature.getGeometry();
+		if (!firstGeom) return false;
+		const firstExtent = firstGeom.getExtent() as [number, number, number, number];
+		const threshold = 100; // ~100m in EPSG:3857
+		return features.every((f) => {
+			const geom = f.getGeometry();
+			if (!geom) return true;
+			const ext = geom.getExtent() as [number, number, number, number];
+			return (
+				Math.abs(ext[0] - firstExtent[0]) < threshold &&
+				Math.abs(ext[1] - firstExtent[1]) < threshold
+			);
+		});
+	}
 
-		features.forEach((feature) => {
-			const props = feature.getProperties() as SightingProperties;
-			const species = props.ta.toString();
-			speciesCount[species] = (speciesCount[species] || 0) + 1;
+	/**
+	 * Erstellt eine scrollbare Liste aller Sichtungen im Cluster.
+	 * Jeder Eintrag ist klickbar und zeigt dann die Detailansicht.
+	 */
+	private createClusterListContent(features: Feature<Geometry>[]): string {
+		const count = features.length;
+
+		// Sortiere nach Datum (neueste zuerst)
+		const sorted = [...features].sort((a, b) => {
+			const tsA = (a.getProperties() as SightingProperties).ts || 0;
+			const tsB = (b.getProperties() as SightingProperties).ts || 0;
+			return tsB - tsA;
 		});
 
-		let content = `
-			<div class="cluster-popup">
-				<h3 style="margin: 0 0 10px 0; color: #333;">${count} Sichtungen</h3>
-		`;
+		let items = '';
+		sorted.forEach((feature, index) => {
+			const props = feature.getProperties() as SightingProperties;
+			const speciesName = sanitizeText(
+				this.translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`
+			);
+			const date = props.ts ? new Date(props.ts * 1000).toLocaleDateString('de-DE') : 'Unbekannt';
+			const deadBadge = props.tf
+				? '<span style="color: #dc2626; font-weight: 600; margin-left: 4px;">&#x2020;</span>'
+				: '';
 
-		Object.entries(speciesCount).forEach(([species, count]) => {
-			const speciesName = sanitizeText(this.translations.speciesMap[species] || `Art ${species}`);
-			content += `
-				<div style="margin-bottom: 4px;">
-					${speciesName}: ${count}
-				</div>
+			items += `
+				<button
+					type="button"
+					data-cluster-index="${index}"
+					style="display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px; margin-bottom: 4px; border: 1px solid #e5e7eb; border-radius: 6px; background: #f9fafb; cursor: pointer; text-align: left; font-size: 13px; transition: background 0.15s;"
+					onmouseover="this.style.background='#e0f2fe'"
+					onmouseout="this.style.background='#f9fafb'"
+				>
+					<span style="flex: 1; font-weight: 500;">${speciesName}${deadBadge}</span>
+					<span style="color: #6b7280; white-space: nowrap;">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
+					<span style="color: #9ca3af; font-size: 11px; white-space: nowrap;">${date}</span>
+				</button>
 			`;
 		});
 
-		content += `
-				<div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid #eee; font-size: 12px; color: #666;">
-					Zoomen Sie hinein für Details
+		return `
+			<div class="cluster-popup">
+				<h3 style="margin: 0 0 8px 0; color: #333; font-size: 14px;">${count} Sichtungen an diesem Ort</h3>
+				<div style="max-height: 240px; overflow-y: auto; padding-right: 4px;">
+					${items}
 				</div>
 			</div>
 		`;
+	}
 
-		return content;
+	/**
+	 * Fügt Click-Handler für die Cluster-Listeneinträge hinzu.
+	 * Klick auf einen Eintrag zeigt die Detail-Popup-Ansicht mit Zurück-Button.
+	 */
+	private attachClusterListHandlers(
+		contentDiv: HTMLDivElement,
+		features: Feature<Geometry>[],
+		coordinate: number[]
+	): void {
+		const sorted = [...features].sort((a, b) => {
+			const tsA = (a.getProperties() as SightingProperties).ts || 0;
+			const tsB = (b.getProperties() as SightingProperties).ts || 0;
+			return tsB - tsA;
+		});
+
+		contentDiv.querySelectorAll<HTMLButtonElement>('[data-cluster-index]').forEach((btn) => {
+			btn.addEventListener('click', (e) => {
+				e.stopPropagation();
+				const index = parseInt(btn.dataset.clusterIndex || '0');
+				const feature = sorted[index];
+				if (!feature) return;
+				const props = feature.getProperties() as SightingProperties;
+
+				// Zeige Detail-Ansicht mit Zurück-Button
+				contentDiv.innerHTML = `
+					<div>
+						<button type="button" class="cluster-back-btn" style="display: inline-flex; align-items: center; gap: 4px; border: none; background: none; cursor: pointer; color: #2563eb; font-size: 12px; padding: 0 0 8px 0; font-weight: 500;">
+							&#8592; Alle ${features.length} Sichtungen
+						</button>
+						${this.createSightingPopupContent(props)}
+					</div>
+				`;
+				this.popup.setPosition(coordinate);
+
+				// Zurück-Button Handler
+				const backBtn = contentDiv.querySelector('.cluster-back-btn');
+				backBtn?.addEventListener('click', (e) => {
+					e.stopPropagation();
+					contentDiv.innerHTML = this.createClusterListContent(features);
+					this.attachClusterListHandlers(contentDiv, features, coordinate);
+					this.popup.setPosition(coordinate);
+				});
+			});
+		});
 	}
 
 	private zoomToCluster(features: Feature<Geometry>[]): void {
@@ -573,6 +665,8 @@ export class SichtungenMap {
 			// Redraw und Zeitraum-Anzeige aktualisieren nachdem timeFilter gesetzt wurde
 			this.reportsLayer.changed();
 			this.updateTimeRange();
+			// Counts mit korrektem timeFilter neu berechnen (loadSightings hat sie mit dem alten berechnet)
+			this.legendUpdateCallback?.();
 			this.loadingCallback?.(false);
 		} catch (error) {
 			// Abgebrochene Requests nicht als Fehler behandeln — ein neuerer Request übernimmt

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -275,7 +275,7 @@ export class SichtungenMap {
 				}
 			</style>
 			<div class="ol-popup-content">
-				<button class="ol-popup-closer" type="button">×</button>
+				<button class="ol-popup-closer" type="button" aria-label="Popup schließen">×</button>
 				<div class="popup-body"></div>
 			</div>
 		`;
@@ -329,6 +329,7 @@ export class SichtungenMap {
 				// Hover ausblenden wenn ein Popup offen ist
 				if (this.popup.getPosition()) {
 					if (infoElement) infoElement.style.display = 'none';
+					this.map.getTargetElement().style.cursor = '';
 					return;
 				}
 
@@ -408,14 +409,23 @@ export class SichtungenMap {
 		});
 	}
 
+	private sortFeaturesByDate(features: Feature<Geometry>[]): Feature<Geometry>[] {
+		return [...features].sort((a, b) => {
+			const tsA = (a.getProperties() as SightingProperties).ts || 0;
+			const tsB = (b.getProperties() as SightingProperties).ts || 0;
+			return tsB - tsA;
+		});
+	}
+
 	private showPopup(coordinate: number[], feature: Feature<Geometry>): void {
 		const contentDiv = this.popupElement.querySelector('.popup-body') as HTMLDivElement;
 		const features = feature.get('features');
 
 		if (features && features.length > 1) {
 			// Cluster - zeige Liste aller Sichtungen
-			contentDiv.innerHTML = this.createClusterListContent(features);
-			this.attachClusterListHandlers(contentDiv, features, coordinate);
+			const sorted = this.sortFeaturesByDate(features);
+			contentDiv.innerHTML = this.createClusterListContent(sorted);
+			this.attachClusterListHandlers(contentDiv, sorted, coordinate);
 		} else {
 			// Einzelfeature
 			const singleFeature = features ? features[0] : feature;
@@ -508,20 +518,13 @@ export class SichtungenMap {
 
 	/**
 	 * Erstellt eine scrollbare Liste aller Sichtungen im Cluster.
-	 * Jeder Eintrag ist klickbar und zeigt dann die Detailansicht.
+	 * Erwartet bereits sortierte Features (via sortFeaturesByDate).
 	 */
 	private createClusterListContent(features: Feature<Geometry>[]): string {
 		const count = features.length;
 
-		// Sortiere nach Datum (neueste zuerst)
-		const sorted = [...features].sort((a, b) => {
-			const tsA = (a.getProperties() as SightingProperties).ts || 0;
-			const tsB = (b.getProperties() as SightingProperties).ts || 0;
-			return tsB - tsA;
-		});
-
 		let items = '';
-		sorted.forEach((feature, index) => {
+		features.forEach((feature, index) => {
 			const props = feature.getProperties() as SightingProperties;
 			const speciesName = sanitizeText(
 				this.translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`
@@ -559,24 +562,18 @@ export class SichtungenMap {
 
 	/**
 	 * Fügt Click-Handler für die Cluster-Listeneinträge hinzu.
-	 * Klick auf einen Eintrag zeigt die Detail-Popup-Ansicht mit Zurück-Button.
+	 * Erwartet bereits sortierte Features (via sortFeaturesByDate).
 	 */
 	private attachClusterListHandlers(
 		contentDiv: HTMLDivElement,
-		features: Feature<Geometry>[],
+		sortedFeatures: Feature<Geometry>[],
 		coordinate: number[]
 	): void {
-		const sorted = [...features].sort((a, b) => {
-			const tsA = (a.getProperties() as SightingProperties).ts || 0;
-			const tsB = (b.getProperties() as SightingProperties).ts || 0;
-			return tsB - tsA;
-		});
-
 		contentDiv.querySelectorAll<HTMLButtonElement>('[data-cluster-index]').forEach((btn) => {
 			btn.addEventListener('click', (e) => {
 				e.stopPropagation();
 				const index = parseInt(btn.dataset.clusterIndex || '0', 10);
-				const feature = sorted[index];
+				const feature = sortedFeatures[index];
 				if (!feature) return;
 				const props = feature.getProperties() as SightingProperties;
 
@@ -584,7 +581,7 @@ export class SichtungenMap {
 				contentDiv.innerHTML = `
 					<div>
 						<button type="button" class="cluster-back-btn" style="display: inline-flex; align-items: center; gap: 4px; border: none; background: none; cursor: pointer; color: #2563eb; font-size: 12px; padding: 0 0 8px 0; font-weight: 500;">
-							&#8592; Alle ${features.length} Sichtungen
+							&#8592; Alle ${sortedFeatures.length} Sichtungen
 						</button>
 						${this.createSightingPopupContent(props)}
 					</div>
@@ -595,8 +592,8 @@ export class SichtungenMap {
 				const backBtn = contentDiv.querySelector('.cluster-back-btn');
 				backBtn?.addEventListener('click', (e) => {
 					e.stopPropagation();
-					contentDiv.innerHTML = this.createClusterListContent(features);
-					this.attachClusterListHandlers(contentDiv, features, coordinate);
+					contentDiv.innerHTML = this.createClusterListContent(sortedFeatures);
+					this.attachClusterListHandlers(contentDiv, sortedFeatures, coordinate);
 					this.popup.setPosition(coordinate);
 				});
 			});

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -80,6 +80,7 @@ export class SichtungenMap {
 	private yearChangeCallback?: (year: number) => void;
 	private loadingCallback?: (isLoading: boolean) => void;
 	private activeAbortController: AbortController | null = null;
+	private filterDebounceTimeout: number | null = null;
 	private clusterDistance: number = 40; // Reduziert für bessere Performance
 
 	// Popup-related
@@ -262,6 +263,17 @@ export class SichtungenMap {
 		this.popupElement = document.createElement('div');
 		this.popupElement.className = 'ol-popup';
 		this.popupElement.innerHTML = `
+			<style>
+				.cluster-list-item {
+					display: flex; align-items: center; gap: 8px; width: 100%;
+					padding: 8px; margin-bottom: 4px; border: 1px solid #e5e7eb;
+					border-radius: 6px; background: #f9fafb; cursor: pointer;
+					text-align: left; font-size: 13px; transition: background 0.15s;
+				}
+				.cluster-list-item:hover, .cluster-list-item:focus-visible {
+					background: #e0f2fe; outline: 2px solid #2563eb; outline-offset: -2px;
+				}
+			</style>
 			<div class="ol-popup-content">
 				<button class="ol-popup-closer" type="button">×</button>
 				<div class="popup-body"></div>
@@ -535,9 +547,8 @@ export class SichtungenMap {
 				<button
 					type="button"
 					data-cluster-index="${index}"
-					style="display: flex; align-items: center; gap: 8px; width: 100%; padding: 8px; margin-bottom: 4px; border: 1px solid #e5e7eb; border-radius: 6px; background: #f9fafb; cursor: pointer; text-align: left; font-size: 13px; transition: background 0.15s;"
-					onmouseover="this.style.background='#e0f2fe'"
-					onmouseout="this.style.background='#f9fafb'"
+					class="cluster-list-item"
+					aria-label="${speciesName}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
 				>
 					<span style="flex: 1; font-weight: 500;">${speciesName}${deadBadge}</span>
 					<span style="color: #6b7280; white-space: nowrap;">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
@@ -547,7 +558,7 @@ export class SichtungenMap {
 		});
 
 		return `
-			<div class="cluster-popup">
+			<div class="cluster-popup" role="list" aria-label="${count} Sichtungen an diesem Ort">
 				<h3 style="margin: 0 0 8px 0; color: #333; font-size: 14px;">${count} Sichtungen an diesem Ort</h3>
 				<div style="max-height: 240px; overflow-y: auto; padding-right: 4px;">
 					${items}
@@ -574,7 +585,7 @@ export class SichtungenMap {
 		contentDiv.querySelectorAll<HTMLButtonElement>('[data-cluster-index]').forEach((btn) => {
 			btn.addEventListener('click', (e) => {
 				e.stopPropagation();
-				const index = parseInt(btn.dataset.clusterIndex || '0');
+				const index = parseInt(btn.dataset.clusterIndex || '0', 10);
 				const feature = sorted[index];
 				if (!feature) return;
 				const props = feature.getProperties() as SightingProperties;
@@ -752,7 +763,8 @@ export class SichtungenMap {
 
 				yearSelect.addEventListener('change', (event) => {
 					const target = event.target as HTMLSelectElement;
-					this.setYear(parseInt(target.value));
+					const year = parseInt(target.value, 10);
+					if (!isNaN(year)) this.setYear(year);
 				});
 			}
 		}
@@ -761,10 +773,10 @@ export class SichtungenMap {
 		if (options.filterInputId) {
 			const filterInput = document.getElementById(options.filterInputId) as HTMLInputElement;
 			if (filterInput) {
-				let timeout: number;
 				filterInput.addEventListener('input', () => {
-					clearTimeout(timeout);
-					timeout = window.setTimeout(() => {
+					if (this.filterDebounceTimeout !== null) clearTimeout(this.filterDebounceTimeout);
+					this.filterDebounceTimeout = window.setTimeout(() => {
+						this.filterDebounceTimeout = null;
 						this.applyFilter(filterInput.value);
 					}, 300);
 				});
@@ -808,10 +820,10 @@ export class SichtungenMap {
 	private applyFilter(searchTerm: string): void {
 		this.searchTerm = searchTerm;
 		this.loadingCallback?.(true);
-		// fire-and-forget: unhandled rejection propagiert als window.unhandledrejection
-		// und wird vom Error-Handler in SightingsMapView aufgefangen
 		void this.loadSightings(this.displayedYear, searchTerm)
 			.then(() => {
+				this.reportsLayer.changed();
+				this.legendUpdateCallback?.();
 				this.loadingCallback?.(false);
 			})
 			.catch((error) => {
@@ -883,6 +895,12 @@ export class SichtungenMap {
 	 * MUSS beim Unmount der Komponente aufgerufen werden.
 	 */
 	public dispose(): void {
+		// Ausstehenden Filter-Debounce abbrechen
+		if (this.filterDebounceTimeout !== null) {
+			clearTimeout(this.filterDebounceTimeout);
+			this.filterDebounceTimeout = null;
+		}
+
 		// Laufende Requests abbrechen
 		if (this.activeAbortController) {
 			this.activeAbortController.abort();
@@ -1058,7 +1076,7 @@ export class SichtungenMap {
 			// Convert ta to number for getFeatureColorGroup
 			const colorGroupProperties = {
 				...properties,
-				ta: typeof properties.ta === 'string' ? parseInt(properties.ta) : properties.ta || 0,
+				ta: typeof properties.ta === 'string' ? parseInt(properties.ta, 10) : properties.ta || 0,
 				tf: properties.tf || false, // Provide default value for required tf property
 				ts: properties.ts || 0 // Provide default value for required ts property
 			};

--- a/src/lib/map/timeSliderManager.ts
+++ b/src/lib/map/timeSliderManager.ts
@@ -24,8 +24,8 @@ export class MapTimeSliderManager implements TimeSliderManager {
 
 		// Event-Handler für Start-Slider
 		startSlider.addEventListener('input', () => {
-			const startValue = parseInt(startSlider.value);
-			const endValue = parseInt(endSlider.value);
+			const startValue = parseInt(startSlider.value, 10);
+			const endValue = parseInt(endSlider.value, 10);
 
 			// Stelle sicher, dass Start nicht größer als End ist
 			if (startValue >= endValue) {
@@ -37,8 +37,8 @@ export class MapTimeSliderManager implements TimeSliderManager {
 
 		// Event-Handler für End-Slider
 		endSlider.addEventListener('input', () => {
-			const startValue = parseInt(startSlider.value);
-			const endValue = parseInt(endSlider.value);
+			const startValue = parseInt(startSlider.value, 10);
+			const endValue = parseInt(endSlider.value, 10);
 
 			// Stelle sicher, dass End nicht kleiner als Start ist
 			if (endValue <= startValue) {
@@ -58,8 +58,8 @@ export class MapTimeSliderManager implements TimeSliderManager {
 		const currentYear = new Date().getFullYear();
 		const yearToUse = this.mapInstance.getDisplayedYear() || currentYear;
 
-		const startDay = parseInt(startSlider.value);
-		const endDay = parseInt(endSlider.value);
+		const startDay = parseInt(startSlider.value, 10);
+		const endDay = parseInt(endSlider.value, 10);
 
 		// Berechne Timestamps für Start und Ende
 		const startDate = new Date(yearToUse, 0, 1);


### PR DESCRIPTION
## Summary

- **Global view**: Remove Baltic Sea extent constraint and lower minZoom to 2, allowing users to zoom out to world level
- **Co-located cluster list**: Show scrollable sighting list with detail navigation for features at the same coordinates, replacing the unhelpful "zoom in" message
- **No-results hints**: Display contextual messages when no sightings exist for the selected year or when all sightings are hidden by filters
- **Hover/popup overlap fix**: Hide hover tooltip when popup is open and on click
- **Production-readiness fixes**: CSP-safe CSS hover, ARIA labels, parseInt validation, timer cleanup on dispose, keyboard handler edge cases

## Test plan

- [ ] Verify map can zoom out to world level and back
- [ ] Switch to a year with no data (e.g. 2010) — confirm "Keine Sichtungen" hint appears
- [ ] Use time slider to filter out all sightings — confirm filter hint appears
- [ ] Click a cluster with multiple sightings at the same location — confirm scrollable list appears
- [ ] Click a list entry — confirm detail view with back button works
- [ ] Hover over marker, then click it — confirm hover disappears and popup shows cleanly
- [ ] Tab through cluster list items — confirm focus-visible styling
- [ ] Run `npm run test:quick` — all checks pass (1219 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)