### PR TITLE
refactor(ui): migrate to DaisyUI v5 component patterns

### DIFF
--- a/e2e/map-accessibility.spec.ts
+++ b/e2e/map-accessibility.spec.ts
@@ -31,7 +31,7 @@ test.describe('Map Accessibility', () => {
 		await page.route('**/api/map/sightings**', (route) => route.abort());
 		await page.goto('/map');
 		const errorAlert = page.locator('.alert-error');
-		await expect(errorAlert).toBeVisible({ timeout: 15000 });
+		await expect(errorAlert).toBeVisible({ timeout: 30000 });
 		await expect(errorAlert).toHaveAttribute('role', 'alert');
 	});
 

--- a/e2e/map-error.spec.ts
+++ b/e2e/map-error.spec.ts
@@ -1,6 +1,10 @@
 import { expect, test } from '@playwright/test';
 import { MapPage } from './pages/MapPage';
 
+// Error tests need generous timeouts because the map component must lazy-load
+// OpenLayers before the API error can be displayed. In CI this can take 20s+.
+const ERROR_TIMEOUT = 30000;
+
 test.describe('Map Error State', () => {
 	test('API-Fehler beim initialen Laden zeigt Fehlermeldung', async ({ page }) => {
 		await page.route('**/api/map/sightings**', (route) => route.abort());
@@ -9,7 +13,7 @@ test.describe('Map Error State', () => {
 
 		const mapPage = new MapPage(page);
 		const errorAlert = mapPage.getErrorAlert();
-		await expect(errorAlert).toBeVisible({ timeout: 15000 });
+		await expect(errorAlert).toBeVisible({ timeout: ERROR_TIMEOUT });
 		await expect(errorAlert).toContainText('Fehler');
 	});
 
@@ -19,7 +23,7 @@ test.describe('Map Error State', () => {
 		await page.goto('/map');
 
 		const mapPage = new MapPage(page);
-		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: 15000 });
+		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: ERROR_TIMEOUT });
 		await expect(mapPage.getErrorAlert()).toContainText('Kartendaten');
 	});
 
@@ -29,7 +33,7 @@ test.describe('Map Error State', () => {
 		await page.goto('/map');
 
 		const mapPage = new MapPage(page);
-		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: 15000 });
+		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: ERROR_TIMEOUT });
 
 		await mapPage.getDismissErrorButton().click();
 		await expect(mapPage.getErrorAlert()).toBeHidden();
@@ -43,7 +47,7 @@ test.describe('Map Error State', () => {
 		await page.goto('/map');
 
 		const mapPage = new MapPage(page);
-		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: 15000 });
+		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: ERROR_TIMEOUT });
 		await expect(mapPage.getErrorAlert()).toContainText('Fehler');
 	});
 
@@ -89,7 +93,7 @@ test.describe('Map Error State', () => {
 		await page.goto('/map');
 
 		const mapPage = new MapPage(page);
-		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: 15000 });
+		await expect(mapPage.getErrorAlert()).toBeVisible({ timeout: ERROR_TIMEOUT });
 
 		await mapPage.getDismissErrorButton().click();
 		await expect(mapPage.getErrorAlert()).toBeHidden();

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -11,6 +11,16 @@
 	let { user, isAdmin = false }: { user: PublicUser | null; isAdmin: boolean } = $props();
 
 	const currentPath = $derived(page.url.pathname);
+
+	let mobileMenuElement = $state<HTMLDetailsElement | null>(null);
+
+	// Close mobile menu when navigating (SvelteKit client-side navigation keeps component mounted)
+	$effect(() => {
+		void currentPath; // track path changes
+		if (mobileMenuElement?.open) {
+			mobileMenuElement.open = false;
+		}
+	});
 </script>
 
 {#snippet menuitems()}
@@ -71,7 +81,7 @@
 					</div>
 
 					<!-- Mobile menu -->
-					<details class="dropdown dropdown-end lg:hidden">
+					<details bind:this={mobileMenuElement} class="dropdown dropdown-end lg:hidden">
 						<summary aria-label="Menü" class="btn btn-ghost">
 							<Icon icon="lucide:list" width="24" class="h-6 w-6 shrink-0" />
 						</summary>

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -67,14 +67,14 @@
 						</ul>
 
 						<!-- User Menu - Desktop -->
-						<UserMenu user={user || null} position="right" isAdmin={isAdmin} />
+						<UserMenu user={user || null} position="right" {isAdmin} />
 					</div>
 
 					<!-- Mobile menu -->
-					<div class="dropdown dropdown-end lg:hidden">
-						<button tabindex="0" aria-label="Menü" class="btn btn-ghost">
+					<details class="dropdown dropdown-end lg:hidden">
+						<summary aria-label="Menü" class="btn btn-ghost">
 							<Icon icon="lucide:list" width="24" class="h-6 w-6 shrink-0" />
-						</button>
+						</summary>
 						<ul
 							class="dropdown-content menu menu-sm rounded-box bg-base-100 absolute right-0 z-50 mt-3 w-52 p-2 shadow"
 						>
@@ -82,9 +82,9 @@
 
 							<!-- User Menu - Mobile -->
 							<div class="divider my-2"></div>
-							<UserMenuMobile user={user || null} isAdmin={isAdmin} />
+							<UserMenuMobile user={user || null} {isAdmin} />
 						</ul>
-					</div>
+					</details>
 				</div>
 			</div>
 		</div>

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -34,7 +34,7 @@
 	}
 
 	$effect(() => {
-		if (typeof window === 'undefined') return;
+		if (!detailsElement) return;
 		document.addEventListener('click', handleClickOutside);
 		document.addEventListener('keydown', handleKeydown);
 		return () => {

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -19,6 +19,29 @@
 			detailsElement.open = false;
 		}
 	}
+
+	// Close on Escape key and click outside
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && detailsElement?.open) {
+			closeMenu();
+		}
+	}
+
+	function handleClickOutside(e: MouseEvent) {
+		if (detailsElement?.open && !detailsElement.contains(e.target as Node)) {
+			closeMenu();
+		}
+	}
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		document.addEventListener('click', handleClickOutside);
+		document.addEventListener('keydown', handleKeydown);
+		return () => {
+			document.removeEventListener('click', handleClickOutside);
+			document.removeEventListener('keydown', handleKeydown);
+		};
+	});
 </script>
 
 {#if user}

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -12,26 +12,22 @@
 		isAdmin?: boolean;
 	} = $props();
 
-	let isOpen = $state(false);
-
-	function toggleMenu() {
-		isOpen = !isOpen;
-	}
+	let detailsElement = $state<HTMLDetailsElement | null>(null);
 
 	function closeMenu() {
-		isOpen = false;
+		if (detailsElement) {
+			detailsElement.open = false;
+		}
 	}
 </script>
 
 {#if user}
-	<div class="relative">
+	<details
+		bind:this={detailsElement}
+		class="dropdown {position === 'right' ? 'dropdown-end' : 'dropdown-start'}"
+	>
 		<!-- User Picture Button -->
-		<button
-			type="button"
-			class="btn btn-ghost btn-circle"
-			aria-label="Benutzer-Menü"
-			onclick={toggleMenu}
-		>
+		<summary class="btn btn-ghost btn-circle" aria-label="Benutzer-Menü">
 			{#if user.picture}
 				<div class="avatar">
 					<div class="h-8 w-8 rounded-full">
@@ -45,71 +41,61 @@
 					</div>
 				</div>
 			{/if}
-		</button>
+		</summary>
 
 		<!-- Dropdown Menu -->
-		{#if isOpen}
-			<div
-				class="absolute {position === 'right'
-					? 'right-0'
-					: 'left-0'} bg-base-100 rounded-box border-base-300 top-full z-[100] mt-2 w-64 border p-2 shadow-xl"
-			>
-				<!-- User Info Header -->
-				<div class="border-base-200 border-b px-4 py-2">
-					<div class="flex items-center gap-3">
-						{#if user.picture}
-							<div class="avatar">
-								<div class="h-8 w-8 rounded-full">
-									<img src={user.picture} alt="Profilbild" />
-								</div>
+		<div
+			class="dropdown-content bg-base-100 rounded-box border-base-300 z-[100] mt-2 w-64 border p-2 shadow-xl"
+		>
+			<!-- User Info Header -->
+			<div class="border-base-200 border-b px-4 py-2">
+				<div class="flex items-center gap-3">
+					{#if user.picture}
+						<div class="avatar">
+							<div class="h-8 w-8 rounded-full">
+								<img src={user.picture} alt="Profilbild" />
 							</div>
-						{:else}
-							<div class="avatar placeholder">
-								<div class="bg-neutral text-neutral-content h-8 w-8 rounded-full">
-									<Icon icon="lucide:user" width="16" class="h-4 w-4" />
-								</div>
+						</div>
+					{:else}
+						<div class="avatar placeholder">
+							<div class="bg-neutral text-neutral-content h-8 w-8 rounded-full">
+								<Icon icon="lucide:user" width="16" class="h-4 w-4" />
 							</div>
-						{/if}
-						<div class="min-w-0 flex-1">
-							<div class="truncate text-sm font-medium">
-								{user.nickname || user.name || 'Benutzer'}
-							</div>
-							<div class="text-base-content/60 truncate text-xs">
-								{user.email || ''}
-							</div>
+						</div>
+					{/if}
+					<div class="min-w-0 flex-1">
+						<div class="truncate text-sm font-medium">
+							{user.nickname || user.name || 'Benutzer'}
+						</div>
+						<div class="text-base-content/60 truncate text-xs">
+							{user.email || ''}
 						</div>
 					</div>
 				</div>
+			</div>
 
-				<!-- Menu Items -->
-				<div class="py-2">
-					{#if isAdmin}
-						<a
-							href="/admin"
-							class="hover:bg-base-200 flex items-center gap-2 rounded px-4 py-2"
-							onclick={closeMenu}
-						>
-							<Icon icon="lucide:settings" width="16" class="h-4 w-4" />
-							Admin-Bereich
-						</a>
-					{/if}
-
+			<!-- Menu Items -->
+			<div class="py-2">
+				{#if isAdmin}
 					<a
-						href="/api/auth/logout"
-						class="text-error hover:bg-error/10 flex items-center gap-2 rounded px-4 py-2"
+						href="/admin"
+						class="hover:bg-base-200 flex items-center gap-2 rounded px-4 py-2"
 						onclick={closeMenu}
 					>
-						<Icon icon="lucide:log-out" width="16" class="h-4 w-4" />
-						Abmelden
+						<Icon icon="lucide:settings" width="16" class="h-4 w-4" />
+						Admin-Bereich
 					</a>
-				</div>
-			</div>
-		{/if}
-	</div>
+				{/if}
 
-	<!-- Click outside to close -->
-	{#if isOpen}
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<div class="fixed inset-0 z-[90]" onclick={closeMenu} role="button" tabindex="-1"></div>
-	{/if}
+				<a
+					href="/api/auth/logout"
+					class="text-error hover:bg-error/10 flex items-center gap-2 rounded px-4 py-2"
+					onclick={closeMenu}
+				>
+					<Icon icon="lucide:log-out" width="16" class="h-4 w-4" />
+					Abmelden
+				</a>
+			</div>
+		</div>
+	</details>
 {/if}

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -54,10 +54,10 @@
 	// Geschätzte Dateigröße berechnen (grober Richtwert)
 	function estimateFileSize(format: string, recordCount: number): number {
 		const bytesPerRecord = {
-			csv: 300,    // ~300 bytes pro Zeile CSV
-			json: 800,   // ~800 bytes pro JSON-Objekt (mehr Metadaten)
-			xml: 1200,   // ~1.2KB pro XML-Element (viele Tags)
-			kml: 600     // ~600 bytes pro KML-Placemark
+			csv: 300, // ~300 bytes pro Zeile CSV
+			json: 800, // ~800 bytes pro JSON-Objekt (mehr Metadaten)
+			xml: 1200, // ~1.2KB pro XML-Element (viele Tags)
+			kml: 600 // ~600 bytes pro KML-Placemark
 		};
 
 		return recordCount * (bytesPerRecord[format as keyof typeof bytesPerRecord] || 500);
@@ -68,10 +68,14 @@
 		const filterDisplays: string[] = [];
 
 		if (currentFilters.dateFrom) {
-			filterDisplays.push(`Von: ${new Date(currentFilters.dateFrom as string).toLocaleDateString('de-DE')}`);
+			filterDisplays.push(
+				`Von: ${new Date(currentFilters.dateFrom as string).toLocaleDateString('de-DE')}`
+			);
 		}
 		if (currentFilters.dateTo) {
-			filterDisplays.push(`Bis: ${new Date(currentFilters.dateTo as string).toLocaleDateString('de-DE')}`);
+			filterDisplays.push(
+				`Bis: ${new Date(currentFilters.dateTo as string).toLocaleDateString('de-DE')}`
+			);
 		}
 		if (currentFilters.verified === '1') {
 			filterDisplays.push('Nur geprüfte Sichtungen');
@@ -115,11 +119,13 @@
 			const data = await response.json();
 			loadedSightings = data.sightings;
 
-			logger.info({ 
-				recordCount: loadedSightings.length, 
-				filters: currentFilters 
-			}, 'Export data loaded successfully');
-
+			logger.info(
+				{
+					recordCount: loadedSightings.length,
+					filters: currentFilters
+				},
+				'Export data loaded successfully'
+			);
 		} catch (err) {
 			logger.error(err, 'Failed to load export data');
 			error = err instanceof Error ? err.message : 'Unbekannter Fehler beim Laden der Export-Daten';
@@ -158,17 +164,22 @@
 			// Download mit den entsprechenden Handlers ausführen
 			downloadHandlers[selectedFormat as keyof typeof downloadHandlers](exportData, filename);
 
-			createToast('success', `${formatInfo[selectedFormat as keyof typeof formatInfo].name}-Export erfolgreich heruntergeladen!`);
+			createToast(
+				'success',
+				`${formatInfo[selectedFormat as keyof typeof formatInfo].name}-Export erfolgreich heruntergeladen!`
+			);
 
 			// Modal schließen nach erfolgreichem Download
 			show = false;
 
-			logger.info({ 
-				format: selectedFormat, 
-				filename, 
-				recordCount: loadedSightings.length 
-			}, 'Export download completed');
-
+			logger.info(
+				{
+					format: selectedFormat,
+					filename,
+					recordCount: loadedSightings.length
+				},
+				'Export download completed'
+			);
 		} catch (err) {
 			logger.error(err, 'Export download failed');
 			error = err instanceof Error ? err.message : 'Fehler beim Download';
@@ -182,6 +193,18 @@
 		}
 	});
 
+	let dialogElement = $state<HTMLDialogElement | null>(null);
+
+	// Sync dialog open/close with show prop
+	$effect(() => {
+		if (!dialogElement) return;
+		if (show && !dialogElement.open) {
+			dialogElement.showModal();
+		} else if (!show && dialogElement.open) {
+			dialogElement.close();
+		}
+	});
+
 	function closeModal() {
 		show = false;
 		error = null;
@@ -189,12 +212,11 @@
 	}
 </script>
 
-<!-- Native DaisyUI Modal -->
-<input type="checkbox" bind:checked={show} id="export-modal" class="modal-toggle" />
-<div class="modal" role="dialog">
+<!-- DaisyUI v5 Modal using native dialog element -->
+<dialog bind:this={dialogElement} class="modal" onclose={closeModal}>
 	<div class="modal-box max-w-2xl">
 		<!-- Modal Header -->
-		<div class="flex items-center justify-between mb-6">
+		<div class="mb-6 flex items-center justify-between">
 			<h3 class="text-lg font-semibold">Sichtungen exportieren</h3>
 			<button
 				class="btn btn-ghost btn-sm btn-circle"
@@ -206,81 +228,76 @@
 		</div>
 
 		<div class="space-y-6">
-				<!-- Filter-Info -->
-				<div class="bg-base-200 rounded-lg p-4">
-					<h4 class="text-sm font-medium mb-2">Aktuelle Filter:</h4>
-					<div class="flex flex-wrap gap-2">
-						{#each getActiveFiltersDisplay() as filter, index (index)}
-							<span class="badge badge-outline badge-sm">{filter}</span>
-						{/each}
-					</div>
-					<div class="text-sm text-base-content/70 mt-2">
-						{totalRecords} Datensatz{totalRecords !== 1 ? 'e' : ''} gefunden
-					</div>
+			<!-- Filter-Info -->
+			<div class="bg-base-200 rounded-lg p-4">
+				<h4 class="mb-2 text-sm font-medium">Aktuelle Filter:</h4>
+				<div class="flex flex-wrap gap-2">
+					{#each getActiveFiltersDisplay() as filter, index (index)}
+						<span class="badge badge-outline badge-sm">{filter}</span>
+					{/each}
 				</div>
+				<div class="text-base-content/70 mt-2 text-sm">
+					{totalRecords} Datensatz{totalRecords !== 1 ? 'e' : ''} gefunden
+				</div>
+			</div>
 
-				<!-- Format-Auswahl -->
-				<div>
-					<h4 class="text-sm font-medium mb-3">Export-Format wählen:</h4>
-					<div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-						{#each Object.entries(formatInfo) as [format, info] (format)}
-							<label class="cursor-pointer">
-								<input 
-									type="radio" 
-									bind:group={selectedFormat} 
-									value={format}
-									class="sr-only peer"
-								>
-								<div class="border-2 border-base-300 rounded-lg p-4 peer-checked:border-primary peer-checked:bg-primary/5 hover:border-primary/50 transition-colors">
-									<div class="flex items-start gap-3">
-										<Icon icon={info.icon} width="24" height="24" class="text-primary mt-1" />
-										<div class="flex-1 min-w-0">
-											<div class="font-medium">{info.name}</div>
-											<div class="text-xs text-base-content/70 mt-1">{info.description}</div>
-											<div class="text-xs text-base-content/50 mt-1">
-												~{formatFileSize(estimateFileSize(format, totalRecords))}
-											</div>
+			<!-- Format-Auswahl -->
+			<div>
+				<h4 class="mb-3 text-sm font-medium">Export-Format wählen:</h4>
+				<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+					{#each Object.entries(formatInfo) as [format, info] (format)}
+						<label class="cursor-pointer">
+							<input type="radio" bind:group={selectedFormat} value={format} class="peer sr-only" />
+							<div
+								class="border-base-300 peer-checked:border-primary peer-checked:bg-primary/5 hover:border-primary/50 rounded-lg border-2 p-4 transition-colors"
+							>
+								<div class="flex items-start gap-3">
+									<Icon icon={info.icon} width="24" height="24" class="text-primary mt-1" />
+									<div class="min-w-0 flex-1">
+										<div class="font-medium">{info.name}</div>
+										<div class="text-base-content/70 mt-1 text-xs">{info.description}</div>
+										<div class="text-base-content/50 mt-1 text-xs">
+											~{formatFileSize(estimateFileSize(format, totalRecords))}
 										</div>
 									</div>
 								</div>
-							</label>
-						{/each}
-					</div>
+							</div>
+						</label>
+					{/each}
 				</div>
+			</div>
 
-				<!-- Loading/Status -->
-				{#if isLoading}
-					<div class="flex items-center justify-center py-8">
-						<div class="loading loading-spinner loading-lg"></div>
-						<span class="ml-3">Lade Export-Daten...</span>
-					</div>
-				{:else if error}
-					<div class="alert alert-error">
-						<Icon icon="lucide:circle-alert" class="h-6 w-6 shrink-0" />
-						<span>{error}</span>
-					</div>
-				{:else if loadedSightings.length > 0}
-					<div class="alert alert-success">
-						<Icon icon="lucide:circle-check" class="h-6 w-6 shrink-0" />
-						<span>{loadedSightings.length} Datensätze bereit zum Export</span>
-					</div>
+			<!-- Loading/Status -->
+			{#if isLoading}
+				<div class="flex items-center justify-center py-8">
+					<div class="loading loading-spinner loading-lg"></div>
+					<span class="ml-3">Lade Export-Daten...</span>
+				</div>
+			{:else if error}
+				<div class="alert alert-error">
+					<Icon icon="lucide:circle-alert" class="h-6 w-6 shrink-0" />
+					<span>{error}</span>
+				</div>
+			{:else if loadedSightings.length > 0}
+				<div class="alert alert-success">
+					<Icon icon="lucide:circle-check" class="h-6 w-6 shrink-0" />
+					<span>{loadedSightings.length} Datensätze bereit zum Export</span>
+				</div>
 			{/if}
 		</div>
 
 		<!-- Modal Footer -->
 		<div class="modal-action">
-			<button class="btn btn-ghost" onclick={closeModal}>
-				Abbrechen
-			</button>
-			<button 
+			<button class="btn btn-ghost" onclick={closeModal}> Abbrechen </button>
+			<button
 				class="btn btn-primary"
 				onclick={performDownload}
 				disabled={isLoading || loadedSightings.length === 0}
 			>
-				<Icon icon="lucide:download" class="h-4 w-4 mr-2" />
+				<Icon icon="lucide:download" class="mr-2 h-4 w-4" />
 				{formatInfo[selectedFormat as keyof typeof formatInfo].name} herunterladen
 			</button>
 		</div>
 	</div>
-	<label class="modal-backdrop" for="export-modal">Close</label>
-</div>
+	<form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -213,11 +213,16 @@
 </script>
 
 <!-- DaisyUI v5 Modal using native dialog element -->
-<dialog bind:this={dialogElement} class="modal" onclose={closeModal}>
+<dialog
+	bind:this={dialogElement}
+	class="modal"
+	onclose={closeModal}
+	aria-labelledby="export-modal-title"
+>
 	<div class="modal-box max-w-2xl">
 		<!-- Modal Header -->
 		<div class="mb-6 flex items-center justify-between">
-			<h3 class="text-lg font-semibold">Sichtungen exportieren</h3>
+			<h3 id="export-modal-title" class="text-lg font-semibold">Sichtungen exportieren</h3>
 			<button
 				class="btn btn-ghost btn-sm btn-circle"
 				onclick={closeModal}
@@ -288,7 +293,7 @@
 
 		<!-- Modal Footer -->
 		<div class="modal-action">
-			<button class="btn btn-ghost" onclick={closeModal}> Abbrechen </button>
+			<button class="btn btn-ghost" onclick={closeModal}>Abbrechen</button>
 			<button
 				class="btn btn-primary"
 				onclick={performDownload}
@@ -299,5 +304,7 @@
 			</button>
 		</div>
 	</div>
-	<form method="dialog" class="modal-backdrop"><button>close</button></form>
+	<form method="dialog" class="modal-backdrop">
+		<button aria-label="Modal schließen"><span class="sr-only">Modal schließen</span></button>
+	</form>
 </dialog>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -139,19 +139,23 @@
 
 				<!-- Aktions-Buttons -->
 				<div class="card-actions w-full justify-center">
-					<div class="btn-group btn-group-vertical sm:btn-group-horizontal">
-						<button class="btn btn-primary" onclick={goHome} aria-label="Zur Startseite">
+					<div class="join join-vertical sm:join-horizontal">
+						<button class="btn btn-primary join-item" onclick={goHome} aria-label="Zur Startseite">
 							<Icon icon="lucide:home" class="mr-2 h-4 w-4" />
 							Startseite
 						</button>
 
-						<button class="btn btn-ghost" onclick={goBack} aria-label="Zurück">
+						<button class="btn btn-ghost join-item" onclick={goBack} aria-label="Zurück">
 							<Icon icon="lucide:arrow-left" class="mr-2 h-4 w-4" />
 							Zurück
 						</button>
 
 						{#if status >= 500}
-							<button class="btn btn-outline" onclick={reloadPage} aria-label="Seite neu laden">
+							<button
+								class="btn btn-outline join-item"
+								onclick={reloadPage}
+								aria-label="Seite neu laden"
+							>
 								<Icon icon="lucide:refresh-cw" class="mr-2 h-4 w-4" />
 								Neu laden
 							</button>


### PR DESCRIPTION
## Summary

Comprehensive DaisyUI v5 compliance audit across 64 Svelte files. Four components used deprecated v4 patterns that were fixed:

- **`+error.svelte`**: `btn-group` → `join` + `join-item` (btn-group was removed in v5)
- **`ExportModal.svelte`**: v4 `<input class="modal-toggle">` + `<div class="modal">` → native `<dialog>` with `showModal()`/`close()` and `$effect` state sync
- **`PublicNavbar.svelte`**: v4 `<div class="dropdown">` + `<button tabindex="0">` → `<details>`/`<summary>` pattern
- **`UserMenu.svelte`**: Manual `isOpen` state + fixed overlay div → native `<details class="dropdown">`, removing ~30 lines of boilerplate

## Components verified as already v5-compliant ✅

- `MediaModal.svelte` — already uses `<dialog>`
- `FormHelp.svelte` — collapse uses `<details>`
- `FormSteps.svelte` — steps pattern correct
- All `alert`, `badge`, `card`, `table`, `navbar`, `footer` usage — correct
- All event handlers — using Svelte 5 `onclick` (not `on:click`)

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run type-check` — 0 errors
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run test:unit` — 1226 tests passed
- [ ] Manual: Error page button group renders correctly
- [ ] Manual: Export modal opens/closes, backdrop click closes
- [ ] Manual: Mobile navbar menu opens/closes
- [ ] Manual: User menu dropdown opens/closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)