### PR TITLE
fix(report): form review fixes — yup conditions, a11y, performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 test-results
 node_modules
+.worktrees
 
 # Output
 .output

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -533,7 +533,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.string()
 		.max(255, 'Die Angabe darf nicht länger als 255 Zeichen sein.')
 		.when('sightingFrom', {
-			is: String(SightingFromEnum.OTHER) || SightingFromEnum.OTHER,
+			is: (v: unknown) => v === SightingFromEnum.OTHER || v === String(SightingFromEnum.OTHER),
 			then: (schema) => schema.required('Bitte geben Sie an, von wo die Sichtung erfolgte.'),
 			otherwise: (schema) => schema.notRequired()
 		})
@@ -597,7 +597,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
 		.when('distribution', {
-			is: String(DistributionEnum.OTHER) || DistributionEnum.OTHER,
+			is: (v: unknown) => v === DistributionEnum.OTHER || v === String(DistributionEnum.OTHER),
 			then: (schema) => schema.required('Bitte beschreiben Sie die Verteilung.'),
 			otherwise: (schema) => schema.notRequired()
 		})
@@ -641,7 +641,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
 		.when('behavior', {
-			is: String(AnimalBehaviorEnum.OTHER) || AnimalBehaviorEnum.OTHER,
+			is: (v: unknown) => v === AnimalBehaviorEnum.OTHER || v === String(AnimalBehaviorEnum.OTHER),
 			then: (schema) => schema.required('Bitte beschreiben Sie das Verhalten.'),
 			otherwise: (schema) => schema.notRequired()
 		})
@@ -931,7 +931,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
 		.when('boatDrive', {
-			is: String(BoatDriveEnum.OTHER) || BoatDriveEnum.OTHER,
+			is: (v: unknown) => v === BoatDriveEnum.OTHER || v === String(BoatDriveEnum.OTHER),
 			then: (schema) => schema.required('Bitte beschreiben Sie den Bootsantrieb.'),
 			otherwise: (schema) => schema.notRequired()
 		})

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -1,0 +1,253 @@
+/**
+ * @fileoverview Tests für die bedingten `.when()`-Validierungen im sightingSchema
+ *
+ * Vier Felder werden getestet, die required werden wenn ihr Elternfeld den
+ * OTHER-Wert (0) hat:
+ *   - sightingFromText  (wenn sightingFrom  === 0)
+ *   - distributionText  (wenn distribution  === 0)
+ *   - behaviorText      (wenn behavior      === 0)
+ *   - boatDriveText     (wenn boatDrive     === 0)
+ *
+ * Besonderes Augenmerk liegt auf dem HTML-<select>-Fall, bei dem der Browser
+ * immer Strings zurückgibt (z.B. "0" statt 0).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { sightingSchema } from './sightingSchema';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+import { DistributionEnum } from '$lib/report/formOptions/distribution';
+import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
+import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
+
+// Logger-Mock um Test-Output sauber zu halten
+vi.mock('$lib/logger', () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+// formConfig-Mock um Abhängigkeit von Laufzeit-Konfiguration zu entkoppeln
+vi.mock('$lib/report/formConfig', () => ({
+	formStepsConfig: [
+		{
+			id: 'location-time',
+			title: 'Position & Zeit',
+			fields: ['hasPosition', 'latitude', 'longitude', 'sightingDate']
+		},
+		{
+			id: 'sighting-details',
+			title: 'Sichtungsdetails',
+			fields: ['species', 'totalCount', 'distance']
+		},
+		{
+			id: 'observations',
+			title: 'Beobachtungen',
+			fields: ['behavior'],
+			isOptional: true
+		},
+		{
+			id: 'contact',
+			title: 'Kontaktdaten',
+			fields: ['firstName', 'lastName', 'email', 'privacyConsent']
+		}
+	]
+}));
+
+// ── Hilfsfunktion ─────────────────────────────────────────────────────────────
+
+/**
+ * Validiert ein einzelnes Feld im Schema und gibt an ob ein Fehler auftrat.
+ * Gibt true zurück wenn die Validierung wirft (Fehler), false wenn sie besteht.
+ */
+async function fieldHasError(
+	fieldName: string,
+	formData: Record<string, unknown>
+): Promise<boolean> {
+	try {
+		await sightingSchema.validateAt(fieldName, formData, { abortEarly: true });
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+// ── sightingFromText ──────────────────────────────────────────────────────────
+
+describe('sightingSchema - bedingte when()-Validierung', () => {
+	describe('sightingFromText', () => {
+		it('ist required wenn sightingFrom die Zahl 0 (OTHER) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('sightingFromText', {
+				sightingFrom: SightingFromEnum.OTHER, // 0 als Zahl
+				sightingFromText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist required wenn sightingFrom der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('sightingFromText', {
+				sightingFrom: '0', // "0" als String (HTML <select>-Verhalten)
+				sightingFromText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist NOT required wenn sightingFrom ein anderer Wert ist (z.B. 1 = Segelschiff)', async () => {
+			const hatFehler = await fieldHasError('sightingFromText', {
+				sightingFrom: SightingFromEnum.SAILBOAT, // 1
+				sightingFromText: ''
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn sightingFrom OTHER ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('sightingFromText', {
+				sightingFrom: SightingFromEnum.OTHER, // 0
+				sightingFromText: 'Von der Hafenmole aus'
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn sightingFrom OTHER als String ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('sightingFromText', {
+				sightingFrom: '0',
+				sightingFromText: 'Von der Hafenmole aus'
+			});
+			expect(hatFehler).toBe(false);
+		});
+	});
+
+	// ── distributionText ───────────────────────────────────────────────────────
+
+	describe('distributionText', () => {
+		it('ist required wenn distribution die Zahl 0 (OTHER) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: DistributionEnum.OTHER, // 0 als Zahl
+				distributionText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist required wenn distribution der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: '0', // "0" als String (HTML <select>-Verhalten)
+				distributionText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist NOT required wenn distribution ein anderer Wert ist (z.B. 1 = Einzeln)', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: DistributionEnum.SINGLE, // 1
+				distributionText: ''
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn distribution OTHER ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: DistributionEnum.OTHER, // 0
+				distributionText: 'V-Formation entlang der Küste'
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn distribution OTHER als String ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: '0',
+				distributionText: 'V-Formation entlang der Küste'
+			});
+			expect(hatFehler).toBe(false);
+		});
+	});
+
+	// ── behaviorText ───────────────────────────────────────────────────────────
+
+	describe('behaviorText', () => {
+		it('ist required wenn behavior die Zahl 0 (OTHER) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: AnimalBehaviorEnum.OTHER, // 0 als Zahl
+				behaviorText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist required wenn behavior der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: '0', // "0" als String (HTML <select>-Verhalten)
+				behaviorText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist NOT required wenn behavior ein anderer Wert ist (z.B. 1 = Konstanter Kurs)', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: AnimalBehaviorEnum.CONSTANT_COURSE, // 1
+				behaviorText: ''
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn behavior OTHER ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: AnimalBehaviorEnum.OTHER, // 0
+				behaviorText: 'Spielverhalten mit einem anderen Tier'
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn behavior OTHER als String ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: '0',
+				behaviorText: 'Spielverhalten mit einem anderen Tier'
+			});
+			expect(hatFehler).toBe(false);
+		});
+	});
+
+	// ── boatDriveText ──────────────────────────────────────────────────────────
+
+	describe('boatDriveText', () => {
+		it('ist required wenn boatDrive die Zahl 0 (OTHER) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: BoatDriveEnum.OTHER, // 0 als Zahl
+				boatDriveText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist required wenn boatDrive der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: '0', // "0" als String (HTML <select>-Verhalten)
+				boatDriveText: ''
+			});
+			expect(hatFehler).toBe(true);
+		});
+
+		it('ist NOT required wenn boatDrive ein anderer Wert ist (z.B. 1 = Motor)', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: BoatDriveEnum.MOTOR, // 1
+				boatDriveText: ''
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn boatDrive OTHER ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: BoatDriveEnum.OTHER, // 0
+				boatDriveText: 'Hybridantrieb Solar-Elektrisch'
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('ist valid wenn boatDrive OTHER als String ist und Text einen Wert hat', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: '0',
+				boatDriveText: 'Hybridantrieb Solar-Elektrisch'
+			});
+			expect(hatFehler).toBe(false);
+		});
+	});
+});

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -12,49 +12,14 @@
  * immer Strings zurückgibt (z.B. "0" statt 0).
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { sightingSchema } from './sightingSchema';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 import { DistributionEnum } from '$lib/report/formOptions/distribution';
 import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
 
-// Logger-Mock um Test-Output sauber zu halten
-vi.mock('$lib/logger', () => ({
-	createLogger: () => ({
-		debug: vi.fn(),
-		info: vi.fn(),
-		warn: vi.fn(),
-		error: vi.fn()
-	})
-}));
-
-// formConfig-Mock um Abhängigkeit von Laufzeit-Konfiguration zu entkoppeln
-vi.mock('$lib/report/formConfig', () => ({
-	formStepsConfig: [
-		{
-			id: 'location-time',
-			title: 'Position & Zeit',
-			fields: ['hasPosition', 'latitude', 'longitude', 'sightingDate']
-		},
-		{
-			id: 'sighting-details',
-			title: 'Sichtungsdetails',
-			fields: ['species', 'totalCount', 'distance']
-		},
-		{
-			id: 'observations',
-			title: 'Beobachtungen',
-			fields: ['behavior'],
-			isOptional: true
-		},
-		{
-			id: 'contact',
-			title: 'Kontaktdaten',
-			fields: ['firstName', 'lastName', 'email', 'privacyConsent']
-		}
-	]
-}));
+// Kein Mock nötig — sightingSchema importiert weder $lib/logger noch $lib/report/formConfig
 
 // ── Hilfsfunktion ─────────────────────────────────────────────────────────────
 

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -121,7 +121,7 @@
 				currentStep = 0;
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);
 				submissionError = null;
-				return onSubmit(submitValues);
+				return await onSubmit(submitValues);
 			} catch (error: unknown) {
 				submissionError = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
 				logger.error(error, submissionError);

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -116,12 +116,13 @@
 					);
 				}
 
+				submissionError = null;
+				const submitResult = await onSubmit(submitValues);
+				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten)
 				clearFormDataOnly(); // Clears only form data, keeps currentStep and user contact data
-				// Nach erfolgreichem Submit auf ersten Schritt zurücksetzen
 				currentStep = 0;
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);
-				submissionError = null;
-				return await onSubmit(submitValues);
+				return submitResult;
 			} catch (error: unknown) {
 				submissionError = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
 				logger.error(error, submissionError);

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -120,6 +120,7 @@
 				// Nach erfolgreichem Submit auf ersten Schritt zurücksetzen
 				currentStep = 0;
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);
+				submissionError = null;
 				return onSubmit(submitValues);
 			} catch (error: unknown) {
 				submissionError = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import FormField from './fields/FormField.svelte';
+	import { formStepsConfig } from '$lib/report/formConfig';
 
 	let { currentStep } = $props<{
 		currentStep: number;
 	}>();
 
-	// Only show on the last step (step 3, 0-indexed)
-	const isLastStep = $derived(currentStep === 3);
+	// Only show on the last step (0-indexed)
+	const isLastStep = $derived(currentStep === formStepsConfig.length - 1);
 </script>
 
 {#if isLastStep}

--- a/src/lib/report/components/form/fields/BaseCheckbox.svelte
+++ b/src/lib/report/components/form/fields/BaseCheckbox.svelte
@@ -52,7 +52,7 @@
 <div class="w-full items-start">
 	<label class="flex w-full cursor-pointer justify-start gap-3 py-2">
 		{#if icon !== undefined}
-			<Icon {icon} width="16" class="text-base-content/60 flex-shrink-0" />
+			<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
 		{/if}
 		<input
 			type="checkbox"

--- a/src/lib/report/components/form/fields/BaseInput.svelte
+++ b/src/lib/report/components/form/fields/BaseInput.svelte
@@ -74,6 +74,7 @@
 	<!-- Icon (if available) -->
 	{#if icon !== undefined}
 		<div
+			aria-hidden="true"
 			class="pointer-events-none absolute inset-y-0 left-0 z-10 flex w-10 items-center justify-center"
 		>
 			<Icon {icon} width="16" class="text-base-content/60" />
@@ -91,7 +92,10 @@
 
 	{#if hasOptions}
 		<!-- Dropdown icon -->
-		<div class="pointer-events-none absolute inset-y-0 right-3 flex items-center">
+		<div
+			aria-hidden="true"
+			class="pointer-events-none absolute inset-y-0 right-3 flex items-center"
+		>
 			<Icon icon="lucide:chevron-down" width="16" class="text-base-content/60" />
 		</div>
 

--- a/src/lib/report/components/form/fields/BaseRadio.svelte
+++ b/src/lib/report/components/form/fields/BaseRadio.svelte
@@ -52,7 +52,7 @@
 				class="hover:bg-base-200/50 flex cursor-pointer justify-start gap-3 rounded-lg py-2 transition-colors"
 			>
 				{#if icon !== undefined}
-					<Icon {icon} width="16" class="text-base-content/60 flex-shrink-0" />
+					<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
 				{/if}
 				<input
 					type="radio"

--- a/src/lib/report/components/form/fields/BaseSelect.svelte
+++ b/src/lib/report/components/form/fields/BaseSelect.svelte
@@ -59,6 +59,7 @@
 	<!-- Icon (if available) -->
 	{#if icon !== undefined}
 		<div
+			aria-hidden="true"
 			class="pointer-events-none absolute inset-y-0 left-0 z-10 flex w-10 items-center justify-center"
 		>
 			<Icon {icon} width="16" class="text-base-content/60" />

--- a/src/lib/report/components/form/fields/BaseToggle.svelte
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte
@@ -52,7 +52,7 @@
 <div class="w-full items-start">
 	<label class="flex w-full cursor-pointer justify-start gap-3 py-2">
 		{#if icon !== undefined}
-			<Icon {icon} width="16" class="text-base-content/60 flex-shrink-0" />
+			<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
 		{/if}
 		<input
 			type="checkbox"

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -337,4 +337,102 @@ describe('FieldRenderer', () => {
 			await expect.element(page.getByText('Totfund bestätigt').first()).toBeVisible();
 		});
 	});
+
+	describe('value synchronisation — incoming prop → internal state', () => {
+		const numberFieldConfig = makeFieldConfig({
+			label: 'Anzahl',
+			optional: true,
+			meta: { type: 'number', placeholder: '' }
+		});
+
+		it('zeigt numerischen Wert 42 korrekt im Number-Input', async () => {
+			render(FieldRenderer, {
+				fieldConfig: numberFieldConfig,
+				name: 'count',
+				value: 42
+			});
+
+			const input = page.getByTestId('field-count');
+			// toHaveValue on <input type="number"> returns a number, not a string
+			await expect.element(input).toHaveValue(42);
+		});
+
+		it('zeigt String-Wert "5" korrekt im Number-Input ohne Verfälschung', async () => {
+			render(FieldRenderer, {
+				fieldConfig: numberFieldConfig,
+				name: 'count',
+				value: '5'
+			});
+
+			const input = page.getByTestId('field-count');
+			// toHaveValue on <input type="number"> returns a number, not a string
+			await expect.element(input).toHaveValue(5);
+		});
+
+		it('zeigt Datums-String "2024-01-15" korrekt im Date-Input (kein NaN)', async () => {
+			render(FieldRenderer, {
+				fieldConfig: dateFieldConfig,
+				name: 'sightingDate',
+				value: '2024-01-15'
+			});
+
+			const input = page.getByTestId('field-sightingDate');
+			await expect.element(input).toHaveValue('2024-01-15');
+		});
+
+		it('setzt Checkbox als aktiviert wenn value=true', async () => {
+			render(FieldRenderer, {
+				fieldConfig: deadConfirmedFieldConfig,
+				name: 'deadConfirmed',
+				value: true
+			});
+
+			await expect.element(page.getByRole('checkbox')).toBeChecked();
+		});
+
+		it('setzt Checkbox als deaktiviert wenn value=false', async () => {
+			render(FieldRenderer, {
+				fieldConfig: deadConfirmedFieldConfig,
+				name: 'deadConfirmed',
+				value: false
+			});
+
+			await expect.element(page.getByRole('checkbox')).not.toBeChecked();
+		});
+
+		it('zeigt Textarea-Inhalt "Hallo Welt" korrekt', async () => {
+			render(FieldRenderer, {
+				fieldConfig: otherObsFieldConfig,
+				name: 'otherObservations',
+				value: 'Hallo Welt'
+			});
+
+			const textarea = page.getByTestId('field-otherObservations');
+			await expect.element(textarea).toHaveValue('Hallo Welt');
+		});
+
+		it('selektiert Option mit Wert 0 im Select korrekt', async () => {
+			const selectWithZero = makeFieldConfig({
+				label: 'Bootsantrieb',
+				optional: true,
+				meta: {
+					type: 'select',
+					selectPlaceholder: 'Bitte wählen...',
+					options: [
+						{ value: 0, label: 'Sonstiges' },
+						{ value: 1, label: 'Motor' }
+					]
+				}
+			});
+
+			render(FieldRenderer, {
+				fieldConfig: selectWithZero,
+				name: 'boatDrive',
+				value: 0
+			});
+
+			const select = page.getByTestId('field-boatDrive');
+			await expect.element(select).toHaveValue('0');
+		});
+	});
 });

--- a/src/lib/report/components/sections/Administrative.svelte
+++ b/src/lib/report/components/sections/Administrative.svelte
@@ -1,32 +1,13 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 </script>
 
 <!-- Administrative Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:settings" width="20" class="text-primary" />
-			Administratives
-		</h3>
+<SectionCard title="Administratives" icon="lucide:settings">
+	<FormField name="verified" />
 
-		<FormField name="verified" />
+	<FormField name="entryChannel" />
 
-		<FormField name="entryChannel" />
-
-		<FormField name="internalComment" />
-	</div>
-</div>
-
-<style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+	<FormField name="internalComment" />
+</SectionCard>

--- a/src/lib/report/components/sections/AnimalInfo.svelte
+++ b/src/lib/report/components/sections/AnimalInfo.svelte
@@ -2,37 +2,30 @@
 	import DeadAnimal from './DeadAnimal.svelte';
 
 	import { getFormContext } from '$lib/report/formContext';
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 
 	const { form } = getFormContext();
 </script>
 
 <!-- Animal Information Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:eye" class="text-primary h-5 w-5" />
-			Tierinformationen
-		</h3>
+<SectionCard title="Tierinformationen" icon="lucide:eye">
+	<!-- Species Selection -->
+	<FormField name="species" />
 
-		<!-- Species Selection -->
-		<FormField name="species" />
-
-		<!-- Animal Count -->
-		<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-2">
-			<FormField name="totalCount" />
-			<FormField name="juvenileCount" />
-		</div>
-
-		<!-- Dead/Alive Status -->
-		<div class="mt-4">
-			<FormField name="isDead" />
-		</div>
-
-		<!-- Dead Animal Additional Fields -->
-		{#if $form.isDead}
-			<DeadAnimal></DeadAnimal>
-		{/if}
+	<!-- Animal Count -->
+	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-2">
+		<FormField name="totalCount" />
+		<FormField name="juvenileCount" />
 	</div>
-</div>
+
+	<!-- Dead/Alive Status -->
+	<div class="mt-4">
+		<FormField name="isDead" />
+	</div>
+
+	<!-- Dead Animal Additional Fields -->
+	{#if $form.isDead}
+		<DeadAnimal></DeadAnimal>
+	{/if}
+</SectionCard>

--- a/src/lib/report/components/sections/Behavior.svelte
+++ b/src/lib/report/components/sections/Behavior.svelte
@@ -1,49 +1,31 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import { getFormContext } from '$lib/report/formContext';
 	import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 
 	const { form } = getFormContext();
 </script>
 
 <!-- Animal Behavior Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:waves" width="20" height="20" class="text-primary" />
-			Verhalten der Tiere
-		</h3>
-		<p class="text-base-content/70 mb-4 text-sm">
-			Verhaltensinformationen helfen Wissenschaftlern, die Ökologie und das Wohlbefinden der Tiere
-			zu verstehen
-		</p>
+<SectionCard title="Verhalten der Tiere" icon="lucide:waves">
+	<p class="text-base-content/70 mb-4 text-sm">
+		Verhaltensinformationen helfen Wissenschaftlern, die Ökologie und das Wohlbefinden der Tiere zu
+		verstehen
+	</p>
 
-		<!-- Behavior with select -->
-		<FormField name="behavior" />
+	<!-- Behavior with select -->
+	<FormField name="behavior" />
 
-		{#if String($form.behavior) === String(AnimalBehaviorEnum.OTHER)}
-			<!-- Additional field for custom behavior -->
-			<div transition:slide>
-				<FormField name="behaviorText" />
-			</div>
-		{/if}
+	{#if String($form.behavior) === String(AnimalBehaviorEnum.OTHER)}
+		<!-- Additional field for custom behavior -->
+		<div transition:slide>
+			<FormField name="behaviorText" />
+		</div>
+	{/if}
 
-		<FormField name="reaction" />
+	<FormField name="reaction" />
 
-		<FormField name="otherObservations" />
-	</div>
-</div>
-
-<style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+	<FormField name="otherObservations" />
+</SectionCard>

--- a/src/lib/report/components/sections/DateTime.svelte
+++ b/src/lib/report/components/sections/DateTime.svelte
@@ -1,31 +1,12 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 </script>
 
 <!-- Date & Time Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:calendar" width="20" class="text-primary" />
-			Zeitpunkt der Sichtung
-		</h3>
-
-		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-			<FormField name="sightingDate" />
-			<FormField name="sightingTime" />
-		</div>
+<SectionCard title="Zeitpunkt der Sichtung" icon="lucide:calendar">
+	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+		<FormField name="sightingDate" />
+		<FormField name="sightingTime" />
 	</div>
-</div>
-
-<style>
-	/* Card hover effects for better interactivity */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+</SectionCard>

--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -7,8 +7,8 @@
 		OpenMeteoRawData
 	} from '$lib/services/weatherService';
 	import { convertToStoredWeatherData } from '$lib/services/weatherService';
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 
 	const { form, handleChange } = getFormContext();
 
@@ -51,63 +51,45 @@
 </script>
 
 <!-- Environmental Conditions Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:waves" width="20" class="text-primary" />
-			Umweltbedingungen
-		</h3>
-		<p class="text-base-content/70 mb-4 text-sm">
-			Wetter- und Seebedingungen beeinflussen sowohl die Sichtbarkeit als auch das Tierverhalten
-		</p>
+<SectionCard title="Umweltbedingungen" icon="lucide:waves">
+	<p class="text-base-content/70 mb-4 text-sm">
+		Wetter- und Seebedingungen beeinflussen sowohl die Sichtbarkeit als auch das Tierverhalten
+	</p>
 
-		<!-- Optionaler Hinweis für User Experience -->
-		<p class="text-base-content/60 mb-2 text-xs">
-			Sobald Position und Datum gesetzt sind, werden Wetterdaten automatisch vorgeschlagen.
-		</p>
+	<!-- Optionaler Hinweis für User Experience -->
+	<p class="text-base-content/60 mb-2 text-xs">
+		Sobald Position und Datum gesetzt sind, werden Wetterdaten automatisch vorgeschlagen.
+	</p>
 
-		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-			<!-- Sea State -->
-			<FormField name="seaState" />
+	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+		<!-- Sea State -->
+		<FormField name="seaState" />
 
-			<!-- Visibility -->
-			<FormField name="visibility" />
-		</div>
-
-		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-			<!-- Wind Direction -->
-			<FormField name="windDirection" />
-
-			<!-- Wind Force -->
-			<FormField name="windForce" />
-		</div>
-
-		<!-- Weather Data Fetcher - Auto-fetch when environment section is visible -->
-		{#if latitude && longitude && sightingDate}
-			<div class="border-base-300 mt-6 border-t pt-4">
-				<WeatherDataFetcher
-					{latitude}
-					{longitude}
-					date={sightingDate}
-					time={sightingTime ?? null}
-					onWeatherFetched={handleWeatherData}
-					onWeatherDataFetched={handleFullWeatherData}
-					autoFetch={true}
-					showInCard={false}
-				/>
-			</div>
-		{/if}
+		<!-- Visibility -->
+		<FormField name="visibility" />
 	</div>
-</div>
 
-<style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
+	<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+		<!-- Wind Direction -->
+		<FormField name="windDirection" />
 
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+		<!-- Wind Force -->
+		<FormField name="windForce" />
+	</div>
+
+	<!-- Weather Data Fetcher - Auto-fetch when environment section is visible -->
+	{#if latitude && longitude && sightingDate}
+		<div class="border-base-300 mt-6 border-t pt-4">
+			<WeatherDataFetcher
+				{latitude}
+				{longitude}
+				date={sightingDate}
+				time={sightingTime ?? null}
+				onWeatherFetched={handleWeatherData}
+				onWeatherDataFetched={handleFullWeatherData}
+				autoFetch={true}
+				showInCard={false}
+			/>
+		</div>
+	{/if}
+</SectionCard>

--- a/src/lib/report/components/sections/Location.svelte
+++ b/src/lib/report/components/sections/Location.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import { getFormContext } from '$lib/report/formContext';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import LocationInput from '$lib/report/components/form/LocationInput.svelte';
 	import VerifyLocation from '$lib/report/components/form/VerifyLocation.svelte';
+	import SectionCard from './SectionCard.svelte';
 
 	const { form, handleChange } = getFormContext();
 
@@ -12,44 +12,25 @@
 </script>
 
 <!-- Location Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:map-pin" width="20" class="text-primary" />
-			Standort der Sichtung
-		</h3>
+<SectionCard title="Standort der Sichtung" icon="lucide:map-pin">
+	<!-- Position Type Selection -->
+	<FormField name="hasPosition" />
 
-		<!-- Position Type Selection -->
-		<FormField name="hasPosition" />
+	<!-- GPS Coordinates (shown when hasPosition = true) -->
+	{#if hasPosition}
+		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
+			<LocationInput
+				latitude={$form.latitude}
+				longitude={$form.longitude}
+				onchange={handleChange}
+			/>
 
-		<!-- GPS Coordinates (shown when hasPosition = true) -->
-		{#if hasPosition}
-			<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
-				<LocationInput
-					latitude={$form.latitude}
-					longitude={$form.longitude}
-					onchange={handleChange}
-				/>
-
-				<VerifyLocation longitude={$form.longitude} latitude={$form.latitude} />
-			</div>
-		{:else}
-			<!-- Waterway Input (shown when hasPosition = false) -->
-			<FormField name="waterway" />
-			<!-- Sea Mark (always optional) -->
-			<FormField name="seaMark" />
-		{/if}
-	</div>
-</div>
-
-<style>
-	/* Card hover effects for better interactivity */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+			<VerifyLocation longitude={$form.longitude} latitude={$form.latitude} />
+		</div>
+	{:else}
+		<!-- Waterway Input (shown when hasPosition = false) -->
+		<FormField name="waterway" />
+		<!-- Sea Mark (always optional) -->
+		<FormField name="seaMark" />
+	{/if}
+</SectionCard>

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -51,7 +51,7 @@
 <SectionCard title="Foto- oder Videoaufnahmen" icon="lucide:camera">
 	<div class="text-base-content/70 mb-4 text-sm">
 		<p class="mb-2 flex items-center gap-2 font-medium">
-			<Icon icon="lucide:camera" width="16" class="text-primary" />
+			<Icon icon="lucide:camera" width="16" class="text-primary" aria-hidden="true" />
 			Fotos und Videos sind extrem wertvoll für die Forschung!
 		</p>
 		<ul class="list-inside list-disc space-y-1 text-xs">
@@ -76,7 +76,7 @@
 		<div class="skeleton h-32 w-full"></div>
 	{/if}
 	<div class="alert alert-info mt-4">
-		<Icon icon="lucide:camera" width="20" />
+		<Icon icon="lucide:camera" width="20" aria-hidden="true" />
 		<span class="text-sm">
 			Falls Sie uns Ihre Medien auf einem anderen Weg zukommen lassen möchten, erhalten Sie
 			Instruktionen nach dem Absenden des Formulars.

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -5,6 +5,7 @@
 	import DropzoneEnhanced from '$lib/report/components/form/fields/DropzoneEnhanced.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import type { ValidationPreset } from '$lib/types';
+	import SectionCard from './SectionCard.svelte';
 
 	// Generiere eine einfache referenceId für Upload (temporäre Lösung)
 	const { form } = getFormContext();
@@ -14,7 +15,7 @@
 	let uploadConfig = $state<ValidationPreset | null>(null);
 
 	// Generate dynamic format description
-	let formatDescription = $derived(() => {
+	let formatDescription = $derived.by(() => {
 		if (!uploadConfig) return 'JPG, PNG, MP4, MOV, AVI';
 
 		const imageTypes = uploadConfig.allowedTypes.filter((type) => type.startsWith('image/'));
@@ -32,7 +33,7 @@
 	});
 
 	// Generate file size description
-	let maxSizeDescription = $derived(() => {
+	let maxSizeDescription = $derived.by(() => {
 		if (!uploadConfig) return 'max 50MB';
 		const sizeMB = Math.round(uploadConfig.maxFileSize / (1024 * 1024));
 		return `max ${sizeMB}MB`;
@@ -47,56 +48,38 @@
 </script>
 
 <!-- Media Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:camera" width="20" class="text-primary" />
-			Foto- oder Videoaufnahmen
-		</h3>
-		<div class="text-base-content/70 mb-4 text-sm">
-			<p class="mb-2 flex items-center gap-2 font-medium">
-				<Icon icon="lucide:camera" width="16" class="text-primary" />
-				Fotos und Videos sind extrem wertvoll für die Forschung!
-			</p>
-			<ul class="list-inside list-disc space-y-1 text-xs">
-				<li><strong>Artbestimmung:</strong> Auch unscharfe Bilder können helfen</li>
-				<li><strong>Verhaltensanalyse:</strong> Videos zeigen wichtige Verhaltensmuster</li>
-				<li><strong>GPS-Daten:</strong> Automatische Positionserkennung aus Bildern</li>
-				<li>
-					<strong>Formatunterstützung:</strong>
-					{formatDescription()} ({maxSizeDescription()})
-				</li>
-			</ul>
-		</div>
-		<FormField name="mediaConsent" />
-		{#if uploadConfig}
-			<DropzoneEnhanced
-				{referenceId}
-				maxFiles={10}
-				config={uploadConfig}
-				enableGPSExtraction={false}
-			/>
-		{:else}
-			<div class="skeleton h-32 w-full"></div>
-		{/if}
-		<div class="alert alert-info mt-4">
-			<Icon icon="lucide:camera" width="20" />
-			<span class="text-sm">
-				Falls Sie uns Ihre Medien auf einem anderen Weg zukommen lassen möchten, erhalten Sie
-				Instruktionen nach dem Absenden des Formulars.
-			</span>
-		</div>
+<SectionCard title="Foto- oder Videoaufnahmen" icon="lucide:camera">
+	<div class="text-base-content/70 mb-4 text-sm">
+		<p class="mb-2 flex items-center gap-2 font-medium">
+			<Icon icon="lucide:camera" width="16" class="text-primary" />
+			Fotos und Videos sind extrem wertvoll für die Forschung!
+		</p>
+		<ul class="list-inside list-disc space-y-1 text-xs">
+			<li><strong>Artbestimmung:</strong> Auch unscharfe Bilder können helfen</li>
+			<li><strong>Verhaltensanalyse:</strong> Videos zeigen wichtige Verhaltensmuster</li>
+			<li><strong>GPS-Daten:</strong> Automatische Positionserkennung aus Bildern</li>
+			<li>
+				<strong>Formatunterstützung:</strong>
+				{formatDescription} ({maxSizeDescription})
+			</li>
+		</ul>
 	</div>
-</div>
-
-<style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+	<FormField name="mediaConsent" />
+	{#if uploadConfig}
+		<DropzoneEnhanced
+			{referenceId}
+			maxFiles={10}
+			config={uploadConfig}
+			enableGPSExtraction={false}
+		/>
+	{:else}
+		<div class="skeleton h-32 w-full"></div>
+	{/if}
+	<div class="alert alert-info mt-4">
+		<Icon icon="lucide:camera" width="20" />
+		<span class="text-sm">
+			Falls Sie uns Ihre Medien auf einem anderen Weg zukommen lassen möchten, erhalten Sie
+			Instruktionen nach dem Absenden des Formulars.
+		</span>
+	</div>
+</SectionCard>

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte
@@ -1,31 +1,12 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 </script>
 
 <!-- Sighting Details Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:activity" width="20" class="text-primary" />
-			Weitere Sichtungsdetails
-		</h3>
+<SectionCard title="Weitere Sichtungsdetails" icon="lucide:activity">
+	<!-- Distribution -->
+	<FormField name="distribution" />
 
-		<!-- Distribution -->
-		<FormField name="distribution" />
-
-		<FormField name="shipCount" />
-	</div>
-</div>
-
-<style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+	<FormField name="shipCount" />
+</SectionCard>

--- a/src/lib/report/components/sections/PositionAndTime.svelte
+++ b/src/lib/report/components/sections/PositionAndTime.svelte
@@ -53,110 +53,116 @@
 	<!-- Position Input Method Selection -->
 	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
 		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
-			<Icon icon="lucide:map-pin" width="20" class="text-primary" />
+			<Icon aria-hidden="true" icon="lucide:map-pin" width="20" class="text-primary" />
 			Positionsangabe
 		</h3>
 		<p class="text-base-content/70 mb-6 text-sm">
 			Wählen Sie die für Sie einfachste Methode zur Positionsangabe
 		</p>
 
-		<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
-			<!-- Photo Method -->
-			<div class="relative">
-				<input
-					type="radio"
-					id="method-photo"
-					name="position-method"
-					value="photo"
-					bind:group={positionMethod}
-					onchange={() => selectMethod('photo')}
-					class="sr-only"
-				/>
-				<label
-					for="method-photo"
-					class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
-						{positionMethod === 'photo'
-						? 'border-primary bg-primary/10'
-						: 'border-base-300 hover:border-primary/50'}"
-				>
-					<div class="flex flex-col items-center text-center">
-						<Icon
-							icon="lucide:camera"
-							width="24"
-							class="mb-2 {positionMethod === 'photo' ? 'text-primary' : 'text-base-content/60'}"
-						/>
-						<h4 class="text-sm font-semibold">Foto mit GPS</h4>
-						<p class="text-base-content/60 mt-1 text-xs">Bevorzugt - GPS und Datum automatisch</p>
-					</div>
-				</label>
-			</div>
+		<fieldset>
+			<legend class="sr-only">Wie möchten Sie den Standort angeben?</legend>
+			<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
+				<!-- Photo Method -->
+				<div class="relative">
+					<input
+						type="radio"
+						id="method-photo"
+						name="position-method"
+						value="photo"
+						bind:group={positionMethod}
+						onchange={() => selectMethod('photo')}
+						class="sr-only"
+					/>
+					<label
+						for="method-photo"
+						class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
+							{positionMethod === 'photo'
+							? 'border-primary bg-primary/10'
+							: 'border-base-300 hover:border-primary/50'}"
+					>
+						<div class="flex flex-col items-center text-center">
+							<Icon
+								aria-hidden="true"
+								icon="lucide:camera"
+								width="24"
+								class="mb-2 {positionMethod === 'photo' ? 'text-primary' : 'text-base-content/60'}"
+							/>
+							<h4 class="text-sm font-semibold">Foto mit GPS</h4>
+							<p class="text-base-content/60 mt-1 text-xs">Bevorzugt - GPS und Datum automatisch</p>
+						</div>
+					</label>
+				</div>
 
-			<!-- Map Method -->
-			<div class="relative">
-				<input
-					type="radio"
-					id="method-map"
-					name="position-method"
-					value="map"
-					bind:group={positionMethod}
-					onchange={() => selectMethod('map')}
-					class="sr-only"
-				/>
-				<label
-					for="method-map"
-					class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
-						{positionMethod === 'map'
-						? 'border-primary bg-primary/10'
-						: 'border-base-300 hover:border-primary/50'}"
-				>
-					<div class="flex flex-col items-center text-center">
-						<Icon
-							icon="lucide:map-pin"
-							width="24"
-							class="mb-2 {positionMethod === 'map' ? 'text-primary' : 'text-base-content/60'}"
-						/>
-						<h4 class="text-sm font-semibold">Karte / GPS Position</h4>
-						<p class="text-base-content/60 mt-1 text-xs">Position auf Karte wählen</p>
-					</div>
-				</label>
-			</div>
+				<!-- Map Method -->
+				<div class="relative">
+					<input
+						type="radio"
+						id="method-map"
+						name="position-method"
+						value="map"
+						bind:group={positionMethod}
+						onchange={() => selectMethod('map')}
+						class="sr-only"
+					/>
+					<label
+						for="method-map"
+						class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
+							{positionMethod === 'map'
+							? 'border-primary bg-primary/10'
+							: 'border-base-300 hover:border-primary/50'}"
+					>
+						<div class="flex flex-col items-center text-center">
+							<Icon
+								aria-hidden="true"
+								icon="lucide:map-pin"
+								width="24"
+								class="mb-2 {positionMethod === 'map' ? 'text-primary' : 'text-base-content/60'}"
+							/>
+							<h4 class="text-sm font-semibold">Karte / GPS Position</h4>
+							<p class="text-base-content/60 mt-1 text-xs">Position auf Karte wählen</p>
+						</div>
+					</label>
+				</div>
 
-			<!-- Manual Method -->
-			<div class="relative">
-				<input
-					type="radio"
-					id="method-manual"
-					name="position-method"
-					value="manual"
-					bind:group={positionMethod}
-					onchange={() => selectMethod('manual')}
-					class="sr-only"
-				/>
-				<label
-					for="method-manual"
-					class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
-						{positionMethod === 'manual'
-						? 'border-primary bg-primary/10'
-						: 'border-base-300 hover:border-primary/50'}"
-				>
-					<div class="flex flex-col items-center text-center">
-						<Icon
-							icon="lucide:square-pen"
-							width="24"
-							class="mb-2 {positionMethod === 'manual' ? 'text-primary' : 'text-base-content/60'}"
-						/>
-						<h4 class="text-sm font-semibold">Beschreibung</h4>
-						<p class="text-base-content/60 mt-1 text-xs">Beschreibung der Position</p>
-					</div>
-				</label>
+				<!-- Manual Method -->
+				<div class="relative">
+					<input
+						type="radio"
+						id="method-manual"
+						name="position-method"
+						value="manual"
+						bind:group={positionMethod}
+						onchange={() => selectMethod('manual')}
+						class="sr-only"
+					/>
+					<label
+						for="method-manual"
+						class="block cursor-pointer rounded-lg border-2 p-4 transition-all md:h-28
+							{positionMethod === 'manual'
+							? 'border-primary bg-primary/10'
+							: 'border-base-300 hover:border-primary/50'}"
+					>
+						<div class="flex flex-col items-center text-center">
+							<Icon
+								aria-hidden="true"
+								icon="lucide:square-pen"
+								width="24"
+								class="mb-2 {positionMethod === 'manual' ? 'text-primary' : 'text-base-content/60'}"
+							/>
+							<h4 class="text-sm font-semibold">Beschreibung</h4>
+							<p class="text-base-content/60 mt-1 text-xs">Beschreibung der Position</p>
+						</div>
+					</label>
+				</div>
 			</div>
-		</div>
+		</fieldset>
 
 		<div class="bg-base-100 mt-4 rounded-lg p-4">
 			<!-- Photo Upload Section -->
 			{#if positionMethod === 'photo'}
 				<h4 class="mb-3 flex items-center gap-2 font-semibold">
-					<Icon icon="lucide:camera" width="18" />
+					<Icon aria-hidden="true" icon="lucide:camera" width="18" />
 					Foto mit GPS-Daten hochladen
 				</h4>
 
@@ -177,7 +183,7 @@
 			<!-- Map/GPS Input Section -->
 			{#if positionMethod === 'map'}
 				<h4 class="mb-3 flex items-center gap-2 font-semibold">
-					<Icon icon="lucide:map-pin" width="18" />
+					<Icon aria-hidden="true" icon="lucide:map-pin" width="18" />
 					Position auf Karte wählen
 				</h4>
 				<LocationInput {latitude} {longitude} onchange={handleChange} />
@@ -192,7 +198,7 @@
 			<!-- Manual Input Section -->
 			{#if positionMethod === 'manual'}
 				<h4 class="mb-3 flex items-center gap-2 font-semibold">
-					<Icon icon="lucide:square-pen" width="18" />
+					<Icon aria-hidden="true" icon="lucide:square-pen" width="18" />
 					Beschreibung der Position
 				</h4>
 
@@ -205,7 +211,7 @@
 	<!-- Date and Time Section (always visible) -->
 	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
 		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
-			<Icon icon="lucide:calendar" width="20" class="text-primary" />
+			<Icon aria-hidden="true" icon="lucide:calendar" width="20" class="text-primary" />
 			Datum und Uhrzeit
 		</h3>
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/src/lib/report/components/sections/PositionAndTime.svelte
+++ b/src/lib/report/components/sections/PositionAndTime.svelte
@@ -60,7 +60,7 @@
 			Wählen Sie die für Sie einfachste Methode zur Positionsangabe
 		</p>
 
-		<fieldset>
+		<fieldset class="fieldset m-0 min-w-0 border-0 p-0">
 			<legend class="sr-only">Wie möchten Sie den Standort angeben?</legend>
 			<div class="grid grid-cols-1 gap-4 md:grid-cols-3">
 				<!-- Photo Method -->

--- a/src/lib/report/components/sections/SectionCard.svelte
+++ b/src/lib/report/components/sections/SectionCard.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Icon from '$lib/components/Icon.svelte';
+
+	interface Props {
+		title: string;
+		icon: string;
+		children: Snippet;
+	}
+
+	let { title, icon, children }: Props = $props();
+</script>
+
+<div class="card bg-base-200 shadow-sm">
+	<div class="card-body">
+		<h3 class="card-title flex items-center gap-2 text-lg">
+			<Icon {icon} width="20" class="text-primary" aria-hidden="true" />
+			{title}
+		</h3>
+		{@render children()}
+	</div>
+</div>
+
+<style>
+	.card {
+		transition: all 0.2s ease;
+	}
+	.card:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 8px 25px -8px var(--color-base-300);
+	}
+</style>

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -2,38 +2,31 @@
 	import { getFormContext } from '$lib/report/formContext';
 	import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
 	import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
-	import Icon from '$lib/components/Icon.svelte';
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+	import SectionCard from './SectionCard.svelte';
 
 	const { form } = getFormContext();
 </script>
 
 <!-- Sighting Details Section -->
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
-			<Icon icon="lucide:activity" width="20" class="text-primary" />
-			Sichtungsdetails
-		</h3>
-
-		<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
-			<FormField name="sightingFrom" />
-			{#if String($form.sightingFrom) === String(SightingFromEnum.OTHER)}
-				<div transition:slide>
-					<FormField name="sightingFromText" />
-				</div>
-			{/if}
-		</div>
-		<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
-			<FormField name="boatDrive" />
-			{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
-				<div transition:slide>
-					<FormField name="boatDriveText" />
-				</div>
-			{/if}
-		</div>
-
-		<FormField name="distance" />
+<SectionCard title="Sichtungsdetails" icon="lucide:activity">
+	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
+		<FormField name="sightingFrom" />
+		{#if String($form.sightingFrom) === String(SightingFromEnum.OTHER)}
+			<div transition:slide>
+				<FormField name="sightingFromText" />
+			</div>
+		{/if}
 	</div>
-</div>
+	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
+		<FormField name="boatDrive" />
+		{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
+			<div transition:slide>
+				<FormField name="boatDriveText" />
+			</div>
+		{/if}
+	</div>
+
+	<FormField name="distance" />
+</SectionCard>

--- a/src/lib/report/formOptions/animalBehavior.ts
+++ b/src/lib/report/formOptions/animalBehavior.ts
@@ -27,12 +27,11 @@ export type AnimalBehavior = AnimalBehaviorEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getAnimalBehaviorOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(animalBehaviorLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const animalBehaviorOptions: Array<{ value: number; label: string }> = Object.entries(
+	animalBehaviorLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getAnimalBehaviorOptions = (): Array<{ value: number; label: string }> =>
+	animalBehaviorOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/animalCondition.ts
+++ b/src/lib/report/formOptions/animalCondition.ts
@@ -29,12 +29,11 @@ export type AnimalCondition = AnimalConditionEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getAnimalConditionOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(animalConditionLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const animalConditionOptions: Array<{ value: number; label: string }> = Object.entries(
+	animalConditionLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getAnimalConditionOptions = (): Array<{ value: number; label: string }> =>
+	animalConditionOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/boatDrive.ts
+++ b/src/lib/report/formOptions/boatDrive.ts
@@ -27,12 +27,10 @@ export type BoatDrive = BoatDriveEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getBoatDriveOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(boatDriveLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const boatDriveOptions: Array<{ value: number; label: string }> = Object.entries(
+	boatDriveLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getBoatDriveOptions = (): Array<{ value: number; label: string }> => boatDriveOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/boatType.ts
+++ b/src/lib/report/formOptions/boatType.ts
@@ -39,12 +39,10 @@ export type BoatType = BoatTypeEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getBoatTypeOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(boatTypeLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const boatTypeOptions: Array<{ value: number; label: string }> = Object.entries(boatTypeLabels).map(
+	([value, label]) => ({ value: Number(value), label })
+);
+export const getBoatTypeOptions = (): Array<{ value: number; label: string }> => boatTypeOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/distance.ts
+++ b/src/lib/report/formOptions/distance.ts
@@ -27,12 +27,10 @@ export type Distance = DistanceEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getDistanceOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(distanceLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const distanceOptions: Array<{ value: number; label: string }> = Object.entries(distanceLabels).map(
+	([value, label]) => ({ value: Number(value), label })
+);
+export const getDistanceOptions = (): Array<{ value: number; label: string }> => distanceOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/distribution.ts
+++ b/src/lib/report/formOptions/distribution.ts
@@ -25,12 +25,11 @@ export type Distribution = DistributionEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getDistributionOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(distributionLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const distributionOptions: Array<{ value: number; label: string }> = Object.entries(
+	distributionLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getDistributionOptions = (): Array<{ value: number; label: string }> =>
+	distributionOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/entryChannel.ts
+++ b/src/lib/report/formOptions/entryChannel.ts
@@ -29,12 +29,11 @@ export type EntryChannel = EntryChannelEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getEntryChannelOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(entryChannelLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const entryChannelOptions: Array<{ value: number; label: string }> = Object.entries(
+	entryChannelLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getEntryChannelOptions = (): Array<{ value: number; label: string }> =>
+	entryChannelOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/mediaType.ts
+++ b/src/lib/report/formOptions/mediaType.ts
@@ -33,12 +33,10 @@ export type MediaType = MediaTypeEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getMediaTypeOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(mediaTypeLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const mediaTypeOptions: Array<{ value: number; label: string }> = Object.entries(
+	mediaTypeLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getMediaTypeOptions = (): Array<{ value: number; label: string }> => mediaTypeOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/reactionToBoat.ts
+++ b/src/lib/report/formOptions/reactionToBoat.ts
@@ -31,12 +31,11 @@ export type ReactionToBoat = ReactionToBoatEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getReactionToBoatOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(reactionToBoatLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const reactionToBoatOptions: Array<{ value: number; label: string }> = Object.entries(
+	reactionToBoatLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getReactionToBoatOptions = (): Array<{ value: number; label: string }> =>
+	reactionToBoatOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/seaState.ts
+++ b/src/lib/report/formOptions/seaState.ts
@@ -29,12 +29,10 @@ export type SeaState = SeaStateEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getSeaStateOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(seaStateLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const seaStateOptions: Array<{ value: number; label: string }> = Object.entries(seaStateLabels).map(
+	([value, label]) => ({ value: Number(value), label })
+);
+export const getSeaStateOptions = (): Array<{ value: number; label: string }> => seaStateOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/sex.ts
+++ b/src/lib/report/formOptions/sex.ts
@@ -23,12 +23,10 @@ export type Sex = SexEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getSexOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(sexLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const sexOptions: Array<{ value: number; label: string }> = Object.entries(sexLabels).map(
+	([value, label]) => ({ value: Number(value), label })
+);
+export const getSexOptions = (): Array<{ value: number; label: string }> => sexOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/sightingFrom.ts
+++ b/src/lib/report/formOptions/sightingFrom.ts
@@ -27,12 +27,11 @@ export type SightingFrom = SightingFromEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getSightingFromOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(sightingFromLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const sightingFromOptions: Array<{ value: number; label: string }> = Object.entries(
+	sightingFromLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getSightingFromOptions = (): Array<{ value: number; label: string }> =>
+	sightingFromOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/species.ts
+++ b/src/lib/report/formOptions/species.ts
@@ -64,27 +64,21 @@ export type Species = SpeciesEnum;
  * @param grouped - Ob die Optionen nach Gruppen gruppiert werden sollen
  * @returns Array von Objekten mit value und label (und optional group)
  */
-export function getSpeciesOptions(grouped = false): Array<{
-	value: string;
-	label: string;
-	group?: string;
-}> {
-	if (!grouped) {
-		return Object.entries(speciesLabels).map(([value, label]) => ({
-			value: String(value),
-			label
-		}));
-	}
-
-	// Gruppierte Optionen zurückgeben
-	return Object.entries(speciesGroups).flatMap(([groupName, species]) =>
+const speciesOptions: Array<{ value: string; label: string }> = Object.entries(speciesLabels).map(
+	([value, label]) => ({ value: String(value), label })
+);
+const speciesOptionsGrouped: Array<{ value: string; label: string; group?: string }> =
+	Object.entries(speciesGroups).flatMap(([groupName, species]) =>
 		species.map((speciesValue) => ({
 			value: String(speciesValue),
 			label: speciesLabels[speciesValue],
 			group: groupName
 		}))
 	);
-}
+export const getSpeciesOptions = (
+	grouped = false
+): Array<{ value: string; label: string; group?: string }> =>
+	grouped ? speciesOptionsGrouped : speciesOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/visibility.ts
+++ b/src/lib/report/formOptions/visibility.ts
@@ -27,12 +27,11 @@ export type Visibility = VisibilityEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getVisibilityOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(visibilityLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const visibilityOptions: Array<{ value: number; label: string }> = Object.entries(
+	visibilityLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getVisibilityOptions = (): Array<{ value: number; label: string }> =>
+	visibilityOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/windDirection.ts
+++ b/src/lib/report/formOptions/windDirection.ts
@@ -35,12 +35,11 @@ export type WindDirection = WindDirectionEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getWindDirectionOptions(): Array<{ value: string; label: string }> {
-	return Object.entries(windDirectionLabels).map(([value, label]) => ({
-		value,
-		label
-	}));
-}
+const windDirectionOptions: Array<{ value: string; label: string }> = Object.entries(
+	windDirectionLabels
+).map(([value, label]) => ({ value, label }));
+export const getWindDirectionOptions = (): Array<{ value: string; label: string }> =>
+	windDirectionOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/lib/report/formOptions/windStrength.ts
+++ b/src/lib/report/formOptions/windStrength.ts
@@ -43,12 +43,11 @@ export type WindStrength = WindStrengthEnum;
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-export function getWindStrengthOptions(): Array<{ value: number; label: string }> {
-	return Object.entries(windStrengthLabels).map(([value, label]) => ({
-		value: Number(value),
-		label
-	}));
-}
+const windStrengthOptions: Array<{ value: number; label: string }> = Object.entries(
+	windStrengthLabels
+).map(([value, label]) => ({ value: Number(value), label }));
+export const getWindStrengthOptions = (): Array<{ value: number; label: string }> =>
+	windStrengthOptions;
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert


### PR DESCRIPTION
## Summary

- Fix broken Yup `.when()` conditions: the OR-pattern `String(Enum.OTHER) || Enum.OTHER` always evaluated to a string, causing required validation on `*Text` fields to silently fail when form values were numbers — now uses an explicit function predicate accepting both `number` and `string`
- Clear `submissionError` state after successful form submission (was never reset)
- Memoize `get*Options()` in all 16 `formOptions/*.ts` files — computed once at module load instead of on every call
- Replace hardcoded step index `3` in `RequiredConsent.svelte` with `formStepsConfig.length - 1`
- Add `aria-hidden="true"` to decorative icons in `BaseInput`, `BaseSelect`, `BaseCheckbox`, `BaseRadio`, `BaseToggle`, `PositionAndTime`
- Wrap position method radio group in `<fieldset>`/`<legend>` for screen readers
- Extract `SectionCard.svelte` — centralises card/header/hover boilerplate shared by 9 section components; removes ~100 lines of duplicated markup and CSS
- Fix two pre-existing bugs in `Media.svelte`: `$derived(() =>)` → `$derived.by(() =>)` for `formatDescription` and `maxSizeDescription`
- Add 7 browser tests for `FieldRenderer` value→state synchronisation (number, date no-NaN, checkbox boolean, textarea, select)

## Test plan

- [ ] `npm run test:quick` — lint + type-check + unit tests (1304 tests)
- [ ] `npm run test:unit:client` — browser component tests incl. new FieldRenderer tests
- [ ] Verify "Sonstiger Ort" / "Sonstige Verteilung" / "Sonstiges Verhalten" / "Sonstiger Antrieb" fields show as required when OTHER option is selected
- [ ] Submit form successfully and confirm no stale error message appears on a second submission
- [ ] All 4 form steps: cards render visually identical (title, icon, hover effect)
- [ ] Screen reader / accessibility tool: confirm radio group label is announced

🤖 Generated with [Claude Code](https://claude.com/claude-code)