### PR TITLE
fix(api,ui): safe getClientAddress, optional other-text fields, lightbox fixes

### DIFF
--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -581,12 +581,12 @@ export const sightingSchemaBase = yup.object().shape({
 		.notRequired(),
 
 	/**
-	 * Genauere Beschreibung der Verteilung
-	 * Erforderlich, wenn distribution = 3 (Sonstiges)
+	 * Genauere Beschreibung der Verteilung (optional, auch bei Sonstiges)
 	 */
 	distributionText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
+		.nullable()
 		.notRequired()
 		.label('Sonstige Verteilung')
 		.meta({
@@ -621,12 +621,12 @@ export const sightingSchemaBase = yup.object().shape({
 		.notRequired(),
 
 	/**
-	 * Genauere Beschreibung des Verhaltens
-	 * Erforderlich, wenn behavior = 3 (Sonstiges)
+	 * Genauere Beschreibung des Verhaltens (optional, auch bei Sonstiges)
 	 */
 	behaviorText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
+		.nullable()
 		.notRequired()
 		.label('Sonstiges Verhalten')
 		.meta({
@@ -907,12 +907,12 @@ export const sightingSchemaBase = yup.object().shape({
 		.required(),
 
 	/**
-	 * Genauere Beschreibung des Bootsantriebs
-	 * Erforderlich, wenn boatDrive = 4 (Sonstiges)
+	 * Genauere Beschreibung des Bootsantriebs (optional, auch bei Sonstiges)
 	 */
 	boatDriveText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
+		.nullable()
 		.notRequired()
 		.label('Sonstiger Antrieb')
 		.meta({

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -14,7 +14,6 @@
  */
 
 import {
-	AnimalBehaviorEnum,
 	getAnimalBehaviorOptions,
 	isValidAnimalBehavior
 } from '$lib/report/formOptions/animalBehavior';
@@ -22,17 +21,9 @@ import {
 	getAnimalConditionOptions,
 	isValidAnimalCondition
 } from '$lib/report/formOptions/animalCondition';
-import {
-	BoatDriveEnum,
-	getBoatDriveOptions,
-	isValidBoatDrive
-} from '$lib/report/formOptions/boatDrive';
+import { getBoatDriveOptions, isValidBoatDrive } from '$lib/report/formOptions/boatDrive';
 import { getDistanceOptions, isValidDistance } from '$lib/report/formOptions/distance';
-import {
-	DistributionEnum,
-	getDistributionOptions,
-	isValidDistribution
-} from '$lib/report/formOptions/distribution';
+import { getDistributionOptions, isValidDistribution } from '$lib/report/formOptions/distribution';
 import { getEntryChannelOptions, isValidEntryChannel } from '$lib/report/formOptions/entryChannel';
 import { getSeaStateOptions, isValidSeaState } from '$lib/report/formOptions/seaState';
 import { getSexOptions, isValidSex } from '$lib/report/formOptions/sex';
@@ -596,11 +587,7 @@ export const sightingSchemaBase = yup.object().shape({
 	distributionText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
-		.when('distribution', {
-			is: (v: unknown) => v === DistributionEnum.OTHER || v === String(DistributionEnum.OTHER),
-			then: (schema) => schema.required('Bitte beschreiben Sie die Verteilung.'),
-			otherwise: (schema) => schema.notRequired()
-		})
+		.notRequired()
 		.label('Sonstige Verteilung')
 		.meta({
 			placeholder: 'z.B. V-Formation, kreisförmig, entlang der Küstenlinie',
@@ -640,11 +627,7 @@ export const sightingSchemaBase = yup.object().shape({
 	behaviorText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
-		.when('behavior', {
-			is: (v: unknown) => v === AnimalBehaviorEnum.OTHER || v === String(AnimalBehaviorEnum.OTHER),
-			then: (schema) => schema.required('Bitte beschreiben Sie das Verhalten.'),
-			otherwise: (schema) => schema.notRequired()
-		})
+		.notRequired()
 		.label('Sonstiges Verhalten')
 		.meta({
 			placeholder: 'z.B. Spielverhalten, Jagd, Paarung, Interaktion mit Booten',
@@ -930,11 +913,7 @@ export const sightingSchemaBase = yup.object().shape({
 	boatDriveText: yup
 		.string()
 		.max(255, 'Die Beschreibung darf nicht länger als 255 Zeichen sein.')
-		.when('boatDrive', {
-			is: (v: unknown) => v === BoatDriveEnum.OTHER || v === String(BoatDriveEnum.OTHER),
-			then: (schema) => schema.required('Bitte beschreiben Sie den Bootsantrieb.'),
-			otherwise: (schema) => schema.notRequired()
-		})
+		.notRequired()
 		.label('Sonstiger Antrieb')
 		.meta({
 			placeholder: 'z.B. Hybridantrieb, Wasserstoff, Solar-Elektro',

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -1,11 +1,10 @@
 /**
- * @fileoverview Tests für die bedingten `.when()`-Validierungen im sightingSchema
+ * @fileoverview Tests für die Validierungen von "Sonstiges"-Textfeldern im sightingSchema
  *
- * Ein Feld wird getestet, das required wird wenn sein Elternfeld den OTHER-Wert (0) hat:
- *   - sightingFromText  (wenn sightingFrom === 0)
+ * sightingFromText: required wenn sightingFrom === 0 (OTHER)
  *
- * Die Felder distributionText, behaviorText und boatDriveText sind generell optional
- * (kein required, auch bei OTHER-Selektion), da Altdaten keinen Text enthalten können.
+ * distributionText, behaviorText, boatDriveText: generell optional (auch bei OTHER),
+ * akzeptieren null und leeren String — Altdaten aus der DB können NULL enthalten.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -122,6 +121,14 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 			});
 			expect(hatFehler).toBe(false);
 		});
+
+		it('akzeptiert null (Legacy-DB-Wert)', async () => {
+			const hatFehler = await fieldHasError('distributionText', {
+				distribution: DistributionEnum.OTHER,
+				distributionText: null
+			});
+			expect(hatFehler).toBe(false);
+		});
 	});
 
 	// ── behaviorText ───────────────────────────────────────────────────────────
@@ -166,6 +173,14 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 			});
 			expect(hatFehler).toBe(false);
 		});
+
+		it('akzeptiert null (Legacy-DB-Wert)', async () => {
+			const hatFehler = await fieldHasError('behaviorText', {
+				behavior: AnimalBehaviorEnum.OTHER,
+				behaviorText: null
+			});
+			expect(hatFehler).toBe(false);
+		});
 	});
 
 	// ── boatDriveText ──────────────────────────────────────────────────────────
@@ -207,6 +222,14 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 			const hatFehler = await fieldHasError('boatDriveText', {
 				boatDrive: '0',
 				boatDriveText: 'Hybridantrieb Solar-Elektrisch'
+			});
+			expect(hatFehler).toBe(false);
+		});
+
+		it('akzeptiert null (Legacy-DB-Wert)', async () => {
+			const hatFehler = await fieldHasError('boatDriveText', {
+				boatDrive: BoatDriveEnum.OTHER,
+				boatDriveText: null
 			});
 			expect(hatFehler).toBe(false);
 		});

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -36,7 +36,7 @@ async function fieldHasError(
 
 // ── sightingFromText ──────────────────────────────────────────────────────────
 
-describe('sightingSchema - bedingte when()-Validierung', () => {
+describe('sightingSchema - Sonstiges-Textfeld-Validierung', () => {
 	describe('sightingFromText', () => {
 		it('ist required wenn sightingFrom die Zahl 0 (OTHER) ist und Text leer', async () => {
 			const hatFehler = await fieldHasError('sightingFromText', {

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -1,15 +1,11 @@
 /**
  * @fileoverview Tests für die bedingten `.when()`-Validierungen im sightingSchema
  *
- * Vier Felder werden getestet, die required werden wenn ihr Elternfeld den
- * OTHER-Wert (0) hat:
- *   - sightingFromText  (wenn sightingFrom  === 0)
- *   - distributionText  (wenn distribution  === 0)
- *   - behaviorText      (wenn behavior      === 0)
- *   - boatDriveText     (wenn boatDrive     === 0)
+ * Ein Feld wird getestet, das required wird wenn sein Elternfeld den OTHER-Wert (0) hat:
+ *   - sightingFromText  (wenn sightingFrom === 0)
  *
- * Besonderes Augenmerk liegt auf dem HTML-<select>-Fall, bei dem der Browser
- * immer Strings zurückgibt (z.B. "0" statt 0).
+ * Die Felder distributionText, behaviorText und boatDriveText sind generell optional
+ * (kein required, auch bei OTHER-Selektion), da Altdaten keinen Text enthalten können.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -87,20 +83,20 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 	// ── distributionText ───────────────────────────────────────────────────────
 
 	describe('distributionText', () => {
-		it('ist required wenn distribution die Zahl 0 (OTHER) ist und Text leer', async () => {
+		it('ist optional wenn distribution die Zahl 0 (OTHER) ist und Text leer (Altdaten)', async () => {
 			const hatFehler = await fieldHasError('distributionText', {
 				distribution: DistributionEnum.OTHER, // 0 als Zahl
 				distributionText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
-		it('ist required wenn distribution der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+		it('ist optional wenn distribution der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
 			const hatFehler = await fieldHasError('distributionText', {
 				distribution: '0', // "0" als String (HTML <select>-Verhalten)
 				distributionText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
 		it('ist NOT required wenn distribution ein anderer Wert ist (z.B. 1 = Einzeln)', async () => {
@@ -131,20 +127,20 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 	// ── behaviorText ───────────────────────────────────────────────────────────
 
 	describe('behaviorText', () => {
-		it('ist required wenn behavior die Zahl 0 (OTHER) ist und Text leer', async () => {
+		it('ist optional wenn behavior die Zahl 0 (OTHER) ist und Text leer (Altdaten)', async () => {
 			const hatFehler = await fieldHasError('behaviorText', {
 				behavior: AnimalBehaviorEnum.OTHER, // 0 als Zahl
 				behaviorText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
-		it('ist required wenn behavior der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+		it('ist optional wenn behavior der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
 			const hatFehler = await fieldHasError('behaviorText', {
 				behavior: '0', // "0" als String (HTML <select>-Verhalten)
 				behaviorText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
 		it('ist NOT required wenn behavior ein anderer Wert ist (z.B. 1 = Konstanter Kurs)', async () => {
@@ -175,20 +171,20 @@ describe('sightingSchema - bedingte when()-Validierung', () => {
 	// ── boatDriveText ──────────────────────────────────────────────────────────
 
 	describe('boatDriveText', () => {
-		it('ist required wenn boatDrive die Zahl 0 (OTHER) ist und Text leer', async () => {
+		it('ist optional wenn boatDrive die Zahl 0 (OTHER) ist und Text leer (Altdaten)', async () => {
 			const hatFehler = await fieldHasError('boatDriveText', {
 				boatDrive: BoatDriveEnum.OTHER, // 0 als Zahl
 				boatDriveText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
-		it('ist required wenn boatDrive der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
+		it('ist optional wenn boatDrive der String "0" (OTHER aus HTML-Select) ist und Text leer', async () => {
 			const hatFehler = await fieldHasError('boatDriveText', {
 				boatDrive: '0', // "0" als String (HTML <select>-Verhalten)
 				boatDriveText: ''
 			});
-			expect(hatFehler).toBe(true);
+			expect(hatFehler).toBe(false);
 		});
 
 		it('ist NOT required wenn boatDrive ein anderer Wert ist (z.B. 1 = Motor)', async () => {

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -28,6 +28,10 @@
 	}
 
 	function openImageModal(src: string, alt: string, copyright: string | null = null) {
+		if (modalCloseTimer !== null) {
+			clearTimeout(modalCloseTimer);
+			modalCloseTimer = null;
+		}
 		modalImageSrc = src;
 		modalImageAlt = alt;
 		modalImageCopyright = copyright;

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -14,6 +14,14 @@
 	let modalImageSrc = $state<string | null>(null);
 	let modalImageAlt = $state<string>('');
 	let modalImageCopyright = $state<string | null>(null);
+	let modalElement = $state<HTMLDialogElement | null>(null);
+	let modalCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+	$effect(() => {
+		return () => {
+			if (modalCloseTimer !== null) clearTimeout(modalCloseTimer);
+		};
+	});
 
 	function toggleExpanded() {
 		isExpanded = !isExpanded;
@@ -23,21 +31,20 @@
 		modalImageSrc = src;
 		modalImageAlt = alt;
 		modalImageCopyright = copyright;
-		// Show DaisyUI modal
-		const modal = document.getElementById('species-image-modal') as HTMLDialogElement;
-		if (modal) {
-			modal.showModal();
-		}
+		modalElement?.showModal();
 	}
 
 	function closeImageModal() {
-		modalImageSrc = null;
-		modalImageAlt = '';
-		modalImageCopyright = null;
-		const modal = document.getElementById('species-image-modal') as HTMLDialogElement;
-		if (modal) {
-			modal.close();
-		}
+		modalElement?.close();
+		// Clear content after DaisyUI close animation to avoid flicker
+		// (close event fires synchronously, state must be deferred)
+		if (modalCloseTimer !== null) clearTimeout(modalCloseTimer);
+		modalCloseTimer = setTimeout(() => {
+			modalImageSrc = null;
+			modalImageAlt = '';
+			modalImageCopyright = null;
+			modalCloseTimer = null;
+		}, 250);
 	}
 
 	// Identifikationsdaten für jede Tierart
@@ -537,7 +544,7 @@
 </div>
 
 <!-- Image Modal für Vollbildansicht -->
-<dialog id="species-image-modal" class="modal">
+<dialog bind:this={modalElement} class="modal">
 	<div class="modal-box w-11/12 max-w-5xl p-0">
 		{#if modalImageSrc}
 			<div class="relative">
@@ -572,7 +579,8 @@
 					<!-- Copyright unter dem vergrößerten Bild -->
 					{#if modalImageCopyright}
 						<p class="text-base-content/60 mt-3 text-sm">
-							{modalImageCopyright}
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+							{@html sanitizeHtml(modalImageCopyright)}
 						</p>
 					{/if}
 				</div>

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -40,8 +40,13 @@
 
 	function closeImageModal() {
 		modalElement?.close();
-		// Clear content after DaisyUI close animation to avoid flicker
-		// (close event fires synchronously, state must be deferred)
+		// deferred state reset is handled by handleDialogClose (onclose event)
+	}
+
+	function handleDialogClose() {
+		// Fires for ALL close paths: button, backdrop click, and native Escape key.
+		// State is cleared after the DaisyUI animation completes to avoid flicker
+		// (the close event fires synchronously, before the animation ends).
 		if (modalCloseTimer !== null) clearTimeout(modalCloseTimer);
 		modalCloseTimer = setTimeout(() => {
 			modalImageSrc = null;
@@ -548,7 +553,7 @@
 </div>
 
 <!-- Image Modal für Vollbildansicht -->
-<dialog bind:this={modalElement} class="modal">
+<dialog bind:this={modalElement} class="modal" onclose={handleDialogClose}>
 	<div class="modal-box w-11/12 max-w-5xl p-0">
 		{#if modalImageSrc}
 			<div class="relative">

--- a/src/lib/server/utils/getClientIp.test.ts
+++ b/src/lib/server/utils/getClientIp.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { getClientIp } from './getClientIp';
+
+describe('getClientIp', () => {
+	it('returns the result of getClientAddress when it does not throw', () => {
+		const result = getClientIp(() => '1.2.3.4');
+		expect(result).toBe('1.2.3.4');
+	});
+
+	it('returns first X-Forwarded-For entry when getClientAddress throws and header is present', () => {
+		const request = new Request('https://example.com', {
+			headers: { 'x-forwarded-for': '10.0.0.1, 10.0.0.2, 10.0.0.3' }
+		});
+		const result = getClientIp(() => {
+			throw new Error('Could not determine clientAddress');
+		}, request);
+		expect(result).toBe('10.0.0.1');
+	});
+
+	it('trims whitespace from X-Forwarded-For entries', () => {
+		const request = new Request('https://example.com', {
+			headers: { 'x-forwarded-for': '  10.0.0.1  , 10.0.0.2' }
+		});
+		const result = getClientIp(() => {
+			throw new Error();
+		}, request);
+		expect(result).toBe('10.0.0.1');
+	});
+
+	it('returns unknown when getClientAddress throws and no request is provided', () => {
+		const result = getClientIp(() => {
+			throw new Error('Could not determine clientAddress');
+		});
+		expect(result).toBe('unknown');
+	});
+
+	it('returns unknown when getClientAddress throws and X-Forwarded-For header is absent', () => {
+		const request = new Request('https://example.com');
+		const result = getClientIp(() => {
+			throw new Error();
+		}, request);
+		expect(result).toBe('unknown');
+	});
+});

--- a/src/lib/server/utils/getClientIp.ts
+++ b/src/lib/server/utils/getClientIp.ts
@@ -1,0 +1,12 @@
+/**
+ * Safely retrieves the client IP address from a SvelteKit request event.
+ * Falls back to 'unknown' when the adapter does not support client address
+ * resolution (e.g. dev mode, certain proxy setups).
+ */
+export function getClientIp(getClientAddress: () => string): string {
+	try {
+		return getClientAddress();
+	} catch {
+		return 'unknown';
+	}
+}

--- a/src/lib/server/utils/getClientIp.ts
+++ b/src/lib/server/utils/getClientIp.ts
@@ -1,12 +1,22 @@
 /**
  * Safely retrieves the client IP address from a SvelteKit request event.
- * Falls back to 'unknown' when the adapter does not support client address
- * resolution (e.g. dev mode, certain proxy setups).
+ * Falls back to the first entry of the X-Forwarded-For header when the adapter
+ * does not support client address resolution (e.g. dev mode, certain proxy setups).
+ * Falls back to 'unknown' if no header is available either.
+ *
+ * Note: X-Forwarded-For can be spoofed by clients not behind a trusted proxy.
+ * This fallback is only reached when the adapter itself cannot determine the address,
+ * which in practice means development mode — not production.
  */
-export function getClientIp(getClientAddress: () => string): string {
+export function getClientIp(getClientAddress: () => string, request?: Request): string {
 	try {
 		return getClientAddress();
 	} catch {
+		const xff = request?.headers.get('x-forwarded-for');
+		if (xff) {
+			const first = xff.split(',').at(0)?.trim();
+			if (first) return first;
+		}
 		return 'unknown';
 	}
 }

--- a/src/routes/api/geo/inBaltic/+server.ts
+++ b/src/routes/api/geo/inBaltic/+server.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '$lib/logger';
 import { checkBalticSeaFile } from '$lib/server/geo/checkBalticSeaFile';
 import { getClientIp } from '$lib/server/utils/getClientIp';
-import { error, json } from '@sveltejs/kit';
+import { error, json, type RequestEvent } from '@sveltejs/kit';
 
 const logger = createLogger('api:geo:inBaltic');
 
@@ -17,12 +17,12 @@ const logger = createLogger('api:geo:inBaltic');
  * - inBaltic: Boolean, ob der Punkt in der Ostsee liegt
  * - inChartArea: Boolean, ob der Punkt im Chart-Bereich liegt
  */
-export async function GET({ url, getClientAddress }: { url: URL; getClientAddress: () => string }) {
-	const clientIp = getClientIp(getClientAddress);
+export async function GET(event: RequestEvent) {
+	const clientIp = getClientIp(() => event.getClientAddress());
 
 	// Parameter aus der URL extrahieren
-	const longitudeParam = url.searchParams.get('longitude');
-	const latitudeParam = url.searchParams.get('latitude');
+	const longitudeParam = event.url.searchParams.get('longitude');
+	const latitudeParam = event.url.searchParams.get('latitude');
 
 	logger.debug(
 		{

--- a/src/routes/api/geo/inBaltic/+server.ts
+++ b/src/routes/api/geo/inBaltic/+server.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '$lib/logger';
 import { checkBalticSeaFile } from '$lib/server/geo/checkBalticSeaFile';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { error, json } from '@sveltejs/kit';
 
 const logger = createLogger('api:geo:inBaltic');
@@ -17,7 +18,7 @@ const logger = createLogger('api:geo:inBaltic');
  * - inChartArea: Boolean, ob der Punkt im Chart-Bereich liegt
  */
 export async function GET({ url, getClientAddress }: { url: URL; getClientAddress: () => string }) {
-	const clientIp = getClientAddress();
+	const clientIp = getClientIp(getClientAddress);
 
 	// Parameter aus der URL extrahieren
 	const longitudeParam = url.searchParams.get('longitude');

--- a/src/routes/api/geo/inBaltic/+server.ts
+++ b/src/routes/api/geo/inBaltic/+server.ts
@@ -18,7 +18,7 @@ const logger = createLogger('api:geo:inBaltic');
  * - inChartArea: Boolean, ob der Punkt im Chart-Bereich liegt
  */
 export async function GET(event: RequestEvent) {
-	const clientIp = getClientIp(() => event.getClientAddress());
+	const clientIp = getClientIp(() => event.getClientAddress(), event.request);
 
 	// Parameter aus der URL extrahieren
 	const longitudeParam = event.url.searchParams.get('longitude');

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -36,7 +36,7 @@ const logger = createLogger('api:legacy:rest_sichtungen:pdf-compliant');
  * POST handler - PDF specification compliant endpoint
  */
 export async function POST(event: RequestEvent): Promise<Response> {
-	const clientIp = getClientIp(event.getClientAddress);
+	const clientIp = getClientIp(() => event.getClientAddress());
 
 	// Rate limiting: 20 submissions per hour per IP (legacy endpoint has no auth)
 	enforceRateLimit(

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -36,7 +36,7 @@ const logger = createLogger('api:legacy:rest_sichtungen:pdf-compliant');
  * POST handler - PDF specification compliant endpoint
  */
 export async function POST(event: RequestEvent): Promise<Response> {
-	const clientIp = getClientIp(() => event.getClientAddress());
+	const clientIp = getClientIp(() => event.getClientAddress(), event.request);
 
 	// Rate limiting: 20 submissions per hour per IP (legacy endpoint has no auth)
 	enforceRateLimit(

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -27,6 +27,7 @@ import { saveSighting } from '$lib/server/db/sightingRepository';
 import { EmailService } from '$lib/server/services/emailService';
 import { ServerConfigService } from '$lib/services/configService';
 import { json, isHttpError, type RequestEvent } from '@sveltejs/kit';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { enforceRateLimit, RATE_LIMITS } from '$lib/server/middleware/rateLimit';
 
 const logger = createLogger('api:legacy:rest_sichtungen:pdf-compliant');
@@ -35,10 +36,14 @@ const logger = createLogger('api:legacy:rest_sichtungen:pdf-compliant');
  * POST handler - PDF specification compliant endpoint
  */
 export async function POST(event: RequestEvent): Promise<Response> {
-	const clientIp = event.getClientAddress();
+	const clientIp = getClientIp(event.getClientAddress);
 
 	// Rate limiting: 20 submissions per hour per IP (legacy endpoint has no auth)
-	enforceRateLimit(`ip:${clientIp}`, RATE_LIMITS.SIGHTING_SUBMISSION, 'legacy:rest_sichtungen:post');
+	enforceRateLimit(
+		`ip:${clientIp}`,
+		RATE_LIMITS.SIGHTING_SUBMISSION,
+		'legacy:rest_sichtungen:post'
+	);
 
 	try {
 		// Handle different request types for mobile app compatibility
@@ -174,12 +179,18 @@ export async function POST(event: RequestEvent): Promise<Response> {
 					// Use new ID-based email service that reads from database
 					// This ensures correct Baltic Sea validation data is used
 					await EmailService.sendNewSightingNotification(savedSighting.id);
-					
-					logger.info({ sightingId: savedSighting.id, referenceId: transformedData.referenceId }, 'Legacy API email notification sent successfully');
+
+					logger.info(
+						{ sightingId: savedSighting.id, referenceId: transformedData.referenceId },
+						'Legacy API email notification sent successfully'
+					);
 				}
 			} catch (emailError) {
 				// Don't fail the request if email fails
-				logger.warn({ sightingId: savedSighting.id, emailError }, 'Failed to send email notification for legacy sighting');
+				logger.warn(
+					{ sightingId: savedSighting.id, emailError },
+					'Failed to send email notification for legacy sighting'
+				);
 			}
 		} catch (saveError: unknown) {
 			const isError = saveError instanceof Error;

--- a/src/routes/rest_sichtungen/antworten.json/+server.ts
+++ b/src/routes/rest_sichtungen/antworten.json/+server.ts
@@ -1,18 +1,21 @@
 /**
  * @fileoverview Legacy REST API endpoint - PDF specification compliance
- * 
+ *
  * GET /rest_sichtungen/antworten.json
- * 
+ *
  * Returns dropdown options in EXACT legacy format from PDF specification.
  * This endpoint MUST maintain 100% compatibility with original schweinswalsichtung.de API.
- * 
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
 
 import { createLogger } from '$lib/logger';
 import { AnimalBehaviorEnum, animalBehaviorLabels } from '$lib/report/formOptions/animalBehavior';
-import { AnimalConditionEnum, animalConditionLabels } from '$lib/report/formOptions/animalCondition';
+import {
+	AnimalConditionEnum,
+	animalConditionLabels
+} from '$lib/report/formOptions/animalCondition';
 import { BoatDriveEnum, boatDriveLabels } from '$lib/report/formOptions/boatDrive';
 import { DistanceEnum, distanceLabels } from '$lib/report/formOptions/distance';
 import { DistributionEnum, distributionLabels } from '$lib/report/formOptions/distribution';
@@ -24,19 +27,20 @@ import { SpeciesEnum, speciesLabels } from '$lib/report/formOptions/species';
 import { VisibilityEnum, visibilityLabels } from '$lib/report/formOptions/visibility';
 import { WindDirectionEnum, windDirectionLabels } from '$lib/report/formOptions/windDirection';
 import { WindStrengthEnum, windStrengthLabels } from '$lib/report/formOptions/windStrength';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { json, type RequestEvent } from '@sveltejs/kit';
 
 const logger = createLogger('api:legacy:antworten:pdf-compliant');
 
 /**
  * GET handler for PDF-compliant response options
- * 
+ *
  * Returns options in the EXACT format specified in the PDF documentation.
  * Format: { "fieldname": { "value": "label" } } NOT array format!
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = event.getClientAddress();
-	
+	const clientIp = getClientIp(event.getClientAddress);
+
 	logger.debug({ ip: clientIp }, 'PDF-compliant legacy response options requested');
 
 	try {
@@ -45,132 +49,171 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			// Species mapping (tierart) - Note: PDF shows 0-10 range
 			tierart: Object.entries(SpeciesEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = speciesLabels[value as SpeciesEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = speciesLabels[value as SpeciesEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Observation location mapping (vonwo) - Note: PDF uses "vonwo" not "beobachtungsort"
 			vonwo: Object.entries(SightingFromEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = sightingFromLabels[value as SightingFromEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = sightingFromLabels[value as SightingFromEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Distance mapping (entfernung) - Note: PDF shows 1-5 range
 			entfernung: Object.entries(DistanceEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = distanceLabels[value as DistanceEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = distanceLabels[value as DistanceEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Distribution mapping (verteilung) - Note: PDF shows 0-3 range
 			verteilung: Object.entries(DistributionEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = distributionLabels[value as DistributionEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = distributionLabels[value as DistributionEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Animal behavior mapping (verhalten) - Note: PDF shows 0-3 range
 			verhalten: Object.entries(AnimalBehaviorEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = animalBehaviorLabels[value as AnimalBehaviorEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = animalBehaviorLabels[value as AnimalBehaviorEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Sea state mapping (seegang) - Note: PDF shows 0-5 range
 			seegang: Object.entries(SeaStateEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = seaStateLabels[value as SeaStateEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = seaStateLabels[value as SeaStateEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Wind direction mapping (windrichtung) - Note: PDF specifies exact values including 'SO'
 			windrichtung: (() => {
 				const validDirections = ['', 'N', 'NW', 'W', 'SW', 'S', 'SO', 'O', 'NO'];
 				const result: Record<string, string> = {};
-				
-				validDirections.forEach(dir => {
+
+				validDirections.forEach((dir) => {
 					if (Object.values(WindDirectionEnum).includes(dir as WindDirectionEnum)) {
 						result[dir] = windDirectionLabels[dir as WindDirectionEnum];
 					}
 				});
-				
+
 				return result;
 			})(),
 
 			// Wind strength mapping (windstaerke) - Note: PDF shows 1-12 range as strings
 			windstaerke: Object.entries(WindStrengthEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = windStrengthLabels[value as WindStrengthEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = windStrengthLabels[value as WindStrengthEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Visibility mapping (sichtweite) - Note: PDF shows 1-4 range
 			sichtweite: Object.entries(VisibilityEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = visibilityLabels[value as VisibilityEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = visibilityLabels[value as VisibilityEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Boat drive mapping (bootsantrieb) - Note: PDF shows 0-4 range
 			bootsantrieb: Object.entries(BoatDriveEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = boatDriveLabels[value as BoatDriveEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = boatDriveLabels[value as BoatDriveEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Entry channel mapping (eingangskanal) - Note: PDF shows 0-5 range
 			eingangskanal: Object.entries(EntryChannelEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = entryChannelLabels[value as EntryChannelEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = entryChannelLabels[value as EntryChannelEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Dead animal condition mapping (totfund_zustand) - Note: PDF shows 0-5 range
 			totfund_zustand: Object.entries(AnimalConditionEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = animalConditionLabels[value as AnimalConditionEnum];
-					return acc;
-				}, {} as Record<string, string>),
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = animalConditionLabels[value as AnimalConditionEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				),
 
 			// Dead animal sex mapping (totfund_geschlecht) - Note: PDF shows 0-2 range
 			totfund_geschlecht: Object.entries(SexEnum)
 				.filter(([_key, value]) => typeof value === 'number')
-				.reduce((acc, [_key, value]) => {
-					acc[value.toString()] = sexLabels[value as SexEnum];
-					return acc;
-				}, {} as Record<string, string>)
+				.reduce(
+					(acc, [_key, value]) => {
+						acc[value.toString()] = sexLabels[value as SexEnum];
+						return acc;
+					},
+					{} as Record<string, string>
+				)
 		};
 
-		logger.info({ 
-			optionCounts: {
-				tierart: Object.keys(responseOptions.tierart).length,
-				vonwo: Object.keys(responseOptions.vonwo).length,
-				entfernung: Object.keys(responseOptions.entfernung).length,
-				verteilung: Object.keys(responseOptions.verteilung).length,
-				verhalten: Object.keys(responseOptions.verhalten).length,
-				seegang: Object.keys(responseOptions.seegang).length,
-				windrichtung: Object.keys(responseOptions.windrichtung).length,
-				windstaerke: Object.keys(responseOptions.windstaerke).length,
-				sichtweite: Object.keys(responseOptions.sichtweite).length,
-				bootsantrieb: Object.keys(responseOptions.bootsantrieb).length,
-				eingangskanal: Object.keys(responseOptions.eingangskanal).length,
-				totfund_zustand: Object.keys(responseOptions.totfund_zustand).length,
-				totfund_geschlecht: Object.keys(responseOptions.totfund_geschlecht).length
+		logger.info(
+			{
+				optionCounts: {
+					tierart: Object.keys(responseOptions.tierart).length,
+					vonwo: Object.keys(responseOptions.vonwo).length,
+					entfernung: Object.keys(responseOptions.entfernung).length,
+					verteilung: Object.keys(responseOptions.verteilung).length,
+					verhalten: Object.keys(responseOptions.verhalten).length,
+					seegang: Object.keys(responseOptions.seegang).length,
+					windrichtung: Object.keys(responseOptions.windrichtung).length,
+					windstaerke: Object.keys(responseOptions.windstaerke).length,
+					sichtweite: Object.keys(responseOptions.sichtweite).length,
+					bootsantrieb: Object.keys(responseOptions.bootsantrieb).length,
+					eingangskanal: Object.keys(responseOptions.eingangskanal).length,
+					totfund_zustand: Object.keys(responseOptions.totfund_zustand).length,
+					totfund_geschlecht: Object.keys(responseOptions.totfund_geschlecht).length
+				},
+				ip: clientIp
 			},
-			ip: clientIp 
-		}, 'PDF-compliant legacy response options generated successfully');
+			'PDF-compliant legacy response options generated successfully'
+		);
 
 		return json(responseOptions, {
 			headers: {
@@ -178,14 +221,16 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				'Content-Type': 'application/json'
 			}
 		});
-
 	} catch (error: unknown) {
 		const isError = error instanceof Error;
-		logger.error({ 
-			error: isError ? error.message : 'Unknown error',
-			stack: isError ? error.stack : undefined,
-			ip: clientIp 
-		}, 'Failed to generate PDF-compliant legacy response options');
+		logger.error(
+			{
+				error: isError ? error.message : 'Unknown error',
+				stack: isError ? error.stack : undefined,
+				ip: clientIp
+			},
+			'Failed to generate PDF-compliant legacy response options'
+		);
 
 		const errorResponse = {
 			error: 'InternalServerError',
@@ -200,22 +245,31 @@ export async function GET(event: RequestEvent): Promise<Response> {
  * Handle unsupported HTTP methods
  */
 export async function POST() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }
 
 export async function PUT() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }
 
 export async function DELETE() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }

--- a/src/routes/rest_sichtungen/antworten.json/+server.ts
+++ b/src/routes/rest_sichtungen/antworten.json/+server.ts
@@ -39,7 +39,7 @@ const logger = createLogger('api:legacy:antworten:pdf-compliant');
  * Format: { "fieldname": { "value": "label" } } NOT array format!
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = getClientIp(event.getClientAddress);
+	const clientIp = getClientIp(() => event.getClientAddress());
 
 	logger.debug({ ip: clientIp }, 'PDF-compliant legacy response options requested');
 

--- a/src/routes/rest_sichtungen/inBaltic.json/+server.ts
+++ b/src/routes/rest_sichtungen/inBaltic.json/+server.ts
@@ -1,130 +1,164 @@
 /**
  * @fileoverview Legacy REST API endpoint - PDF specification compliance
- * 
+ *
  * GET /rest_sichtungen/inBaltic.json
- * 
+ *
  * Checks if coordinates are in Baltic Sea using EXACT legacy format from PDF specification.
  * This endpoint MUST maintain 100% compatibility with original schweinswalsichtung.de API.
- * 
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
 
 import { createLogger } from '$lib/logger';
 import { checkBalticSeaFile } from '$lib/server/geo/checkBalticSeaFile';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { json, type RequestEvent } from '@sveltejs/kit';
 
 const logger = createLogger('api:legacy:inBaltic:pdf-compliant');
 
 /**
  * GET handler for PDF-compliant Baltic Sea position check
- * 
+ *
  * Expected URL format: /rest_sichtungen/inBaltic.json?location=latitude,longitude
  * Response format exactly as specified in PDF: { "inbaltic": boolean, "inchartarea": boolean }
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = event.getClientAddress();
+	const clientIp = getClientIp(event.getClientAddress);
 	const locationParam = event.url.searchParams.get('location');
-	
+
 	try {
 		// Validate required location parameter
 		if (!locationParam) {
 			logger.warn({ ip: clientIp }, 'Missing location parameter in PDF-compliant inBaltic check');
-			
-			return json({ 
-				error: 'MissingParameter',
-				message: 'Parameter "location" is required in format "latitude,longitude"' 
-			}, { status: 400 });
+
+			return json(
+				{
+					error: 'MissingParameter',
+					message: 'Parameter "location" is required in format "latitude,longitude"'
+				},
+				{ status: 400 }
+			);
 		}
 
 		// Parse coordinates (latitude,longitude format)
 		const coords = locationParam.split(',');
 		if (coords.length !== 2) {
-			logger.warn({ 
-				location: locationParam,
-				ip: clientIp 
-			}, 'Invalid location format in PDF-compliant inBaltic check');
-			
-			return json({ 
-				error: 'InvalidFormat',
-				message: 'Parameter "location" must be in format "latitude,longitude"' 
-			}, { status: 400 });
+			logger.warn(
+				{
+					location: locationParam,
+					ip: clientIp
+				},
+				'Invalid location format in PDF-compliant inBaltic check'
+			);
+
+			return json(
+				{
+					error: 'InvalidFormat',
+					message: 'Parameter "location" must be in format "latitude,longitude"'
+				},
+				{ status: 400 }
+			);
 		}
 
 		const latStr = coords[0]!.trim();
 		const lonStr = coords[1]!.trim();
-		
+
 		const latitude = parseFloat(latStr);
 		const longitude = parseFloat(lonStr);
 
 		// Validate coordinates are numeric
 		if (isNaN(latitude) || isNaN(longitude)) {
-			logger.warn({ 
-				location: locationParam,
-				latitude: latStr,
-				longitude: lonStr,
-				ip: clientIp 
-			}, 'Non-numeric coordinates in PDF-compliant inBaltic check');
-			
-			return json({ 
-				error: 'InvalidCoordinates',
-				message: 'Coordinates must be valid numbers' 
-			}, { status: 400 });
+			logger.warn(
+				{
+					location: locationParam,
+					latitude: latStr,
+					longitude: lonStr,
+					ip: clientIp
+				},
+				'Non-numeric coordinates in PDF-compliant inBaltic check'
+			);
+
+			return json(
+				{
+					error: 'InvalidCoordinates',
+					message: 'Coordinates must be valid numbers'
+				},
+				{ status: 400 }
+			);
 		}
 
 		// Validate coordinate ranges
 		if (latitude < -90 || latitude > 90) {
-			logger.warn({ 
-				location: locationParam,
-				latitude,
-				ip: clientIp 
-			}, 'Latitude out of range in PDF-compliant inBaltic check');
-			
-			return json({ 
-				error: 'InvalidLatitude',
-				message: 'Latitude must be between -90 and 90' 
-			}, { status: 400 });
+			logger.warn(
+				{
+					location: locationParam,
+					latitude,
+					ip: clientIp
+				},
+				'Latitude out of range in PDF-compliant inBaltic check'
+			);
+
+			return json(
+				{
+					error: 'InvalidLatitude',
+					message: 'Latitude must be between -90 and 90'
+				},
+				{ status: 400 }
+			);
 		}
 
 		if (longitude < -180 || longitude > 180) {
-			logger.warn({ 
-				location: locationParam,
-				longitude,
-				ip: clientIp 
-			}, 'Longitude out of range in PDF-compliant inBaltic check');
-			
-			return json({ 
-				error: 'InvalidLongitude',
-				message: 'Longitude must be between -180 and 180' 
-			}, { status: 400 });
+			logger.warn(
+				{
+					location: locationParam,
+					longitude,
+					ip: clientIp
+				},
+				'Longitude out of range in PDF-compliant inBaltic check'
+			);
+
+			return json(
+				{
+					error: 'InvalidLongitude',
+					message: 'Longitude must be between -180 and 180'
+				},
+				{ status: 400 }
+			);
 		}
 
 		// Normalize coordinates to 6 decimal places for consistency
 		const normalizedLat = Math.round(latitude * 1000000) / 1000000;
 		const normalizedLon = Math.round(longitude * 1000000) / 1000000;
 
-		logger.debug({ 
-			originalLocation: locationParam,
-			normalizedLat,
-			normalizedLon,
-			ip: clientIp 
-		}, 'Processing PDF-compliant Baltic Sea location check');
+		logger.debug(
+			{
+				originalLocation: locationParam,
+				normalizedLat,
+				normalizedLon,
+				ip: clientIp
+			},
+			'Processing PDF-compliant Baltic Sea location check'
+		);
 
 		// Perform geo validation using existing utility
 		const geoResult = checkBalticSeaFile(normalizedLon, normalizedLat);
 
 		// Create PDF-compliant response format (lowercase field names!)
 		const response = {
-			inbaltic: geoResult.inBaltic,      // Note: lowercase 'b' as per PDF spec
+			inbaltic: geoResult.inBaltic, // Note: lowercase 'b' as per PDF spec
 			inchartarea: geoResult.inChartArea // Note: lowercase as per PDF spec
 		};
 
-		logger.info({ 
-			location: locationParam,
-			normalizedCoords: { lat: normalizedLat, lon: normalizedLon },
-			result: response,
-			ip: clientIp 
-		}, 'PDF-compliant Baltic Sea location check completed');
+		logger.info(
+			{
+				location: locationParam,
+				normalizedCoords: { lat: normalizedLat, lon: normalizedLon },
+				result: response,
+				ip: clientIp
+			},
+			'PDF-compliant Baltic Sea location check completed'
+		);
 
 		return json(response, {
 			headers: {
@@ -132,15 +166,17 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				'Content-Type': 'application/json'
 			}
 		});
-
 	} catch (geoError) {
 		const error = geoError instanceof Error ? geoError : new Error('Unknown geo validation error');
-		logger.error({ 
-			error: error.message,
-			stack: error.stack,
-			location: locationParam,
-			ip: clientIp 
-		}, 'Error in PDF-compliant Baltic Sea location validation');
+		logger.error(
+			{
+				error: error.message,
+				stack: error.stack,
+				location: locationParam,
+				ip: clientIp
+			},
+			'Error in PDF-compliant Baltic Sea location validation'
+		);
 
 		const errorResponse = {
 			error: 'GeoValidationError',
@@ -155,22 +191,31 @@ export async function GET(event: RequestEvent): Promise<Response> {
  * Handle unsupported HTTP methods
  */
 export async function POST() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }
 
 export async function PUT() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }
 
 export async function DELETE() {
-	return json({ 
-		error: 'MethodNotAllowed',
-		message: 'Only GET method is supported for this endpoint' 
-	}, { status: 405 });
+	return json(
+		{
+			error: 'MethodNotAllowed',
+			message: 'Only GET method is supported for this endpoint'
+		},
+		{ status: 405 }
+	);
 }

--- a/src/routes/rest_sichtungen/inBaltic.json/+server.ts
+++ b/src/routes/rest_sichtungen/inBaltic.json/+server.ts
@@ -24,7 +24,7 @@ const logger = createLogger('api:legacy:inBaltic:pdf-compliant');
  * Response format exactly as specified in PDF: { "inbaltic": boolean, "inchartarea": boolean }
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = getClientIp(event.getClientAddress);
+	const clientIp = getClientIp(() => event.getClientAddress());
 	const locationParam = event.url.searchParams.get('location');
 
 	try {

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -17,6 +17,7 @@ import { createLogger } from '$lib/logger';
 import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { json, type RequestEvent } from '@sveltejs/kit';
 import { and, between, sql } from 'drizzle-orm';
 
@@ -50,7 +51,7 @@ interface PDFCompliantSightingResponse {
  * Returns sightings in EXACT PDF format with abbreviated field names
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = event.getClientAddress();
+	const clientIp = getClientIp(event.getClientAddress);
 
 	try {
 		// Parse query parameters exactly as specified in PDF

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -51,7 +51,7 @@ interface PDFCompliantSightingResponse {
  * Returns sightings in EXACT PDF format with abbreviated field names
  */
 export async function GET(event: RequestEvent): Promise<Response> {
-	const clientIp = getClientIp(event.getClientAddress);
+	const clientIp = getClientIp(() => event.getClientAddress());
 
 	try {
 		// Parse query parameters exactly as specified in PDF


### PR DESCRIPTION
## Zusammenfassung

- **500-Fehler `GET /api/geo/inBaltic`**: `getClientAddress()` wirft in Dev-Mode/bestimmten Proxy-Setups — neue `getClientIp()` Hilfsfunktion fängt das ab, alle 5 betroffenen Routen umgestellt
- **Admin-Edit Legacy-Sichtungen**: `distributionText`, `behaviorText`, `boatDriveText` sind jetzt generell optional — Altdaten ohne Text konnten nicht gespeichert werden (entspricht auch der Legacy-API-Spec)
- **Lightbox Copyright**: Wurde als Plaintext gerendert statt als HTML — nutzt jetzt `{@html sanitizeHtml()}` wie die Thumbnail-Ansicht
- **Lightbox Flicker beim Schließen**: State-Reset wird nach DaisyUI-Animation verzögert; `document.getElementById` durch `bind:this` ersetzt; $effect-Cleanup für den Timer

## Änderungen

- `src/lib/server/utils/getClientIp.ts` (neu) — safe wrapper für `getClientAddress()`
- `src/routes/api/geo/inBaltic/+server.ts` + 4 weitere Routen — `getClientIp()` verwenden
- `src/lib/form/validation/sightingSchema.ts` — bedingte `required()`-Validierung für 3 Felder entfernt
- `src/lib/form/validation/sightingSchemaWhen.test.ts` — Tests an neue Spezifikation angepasst
- `src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte` — Copyright-Rendering + Modal-Close-Flicker-Fix

## Testplan

- [x] `npm run test:quick` — 75/75 Test Files, 1472 Tests grün
- [ ] `GET /api/geo/inBaltic?longitude=10.1&latitude=54.3` → 200 statt 500
- [ ] Admin: Legacy-Sichtung mit leerem `bootsantrieb_text`/`verteilung_text` speichern
- [ ] Spezies-Lightbox: Copyright korrekt gerendert (Links klickbar)
- [ ] Spezies-Lightbox: Kein Flackern beim Schließen

🤖 Generated with [Claude Code](https://claude.com/claude-code)