### PR TITLE
fix(admin,ui): correct outdated docs and about page content

### DIFF
--- a/src/lib/components/docs/ApiDocumentation.svelte
+++ b/src/lib/components/docs/ApiDocumentation.svelte
@@ -86,19 +86,20 @@
 					</p>
 					<ul class="space-y-1 text-sm">
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /sightings</code> - Öffentliche Sichtungen
+							• <code class="rounded bg-gray-100 px-1">GET /api/sightings</code> - Öffentliche Sichtungen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">POST /sightings</code> - Neue Sichtung melden
+							• <code class="rounded bg-gray-100 px-1">POST /api/sightings</code> - Neue Sichtung melden
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /geo/inBaltic</code> - Koordinaten prüfen
+							• <code class="rounded bg-gray-100 px-1">GET /api/geo/inBaltic</code> - Koordinaten prüfen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">POST /files/upload</code> - Dateien hochladen
+							• <code class="rounded bg-gray-100 px-1">POST /api/files/upload</code> - Dateien hochladen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /media/{'{path}'}</code> - Sichere Medien abrufen
+							• <code class="rounded bg-gray-100 px-1">GET /api/media/{'{path}'}</code> - Sichere Medien
+							abrufen
 						</li>
 					</ul>
 				</div>
@@ -108,7 +109,7 @@
 						Für Admin-Funktionen ist eine Anmeldung erforderlich:
 					</p>
 					<ol class="space-y-1 text-sm">
-						<li>1. <code class="rounded bg-gray-100 px-1">GET /auth/login</code> aufrufen</li>
+						<li>1. <code class="rounded bg-gray-100 px-1">GET /api/auth/login</code> aufrufen</li>
 						<li>2. Auth0-Login-Flow durchlaufen</li>
 						<li>3. Session-Cookie wird automatisch gesetzt</li>
 						<li>4. Admin-Endpunkte sind nun verfügbar</li>

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,8 +1,11 @@
 import { version } from '../../../package.json';
+import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
-import { count, countDistinct, isNotNull } from 'drizzle-orm';
+import { and, count, countDistinct, isNotNull, ne } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
+
+const logger = createLogger('about:page');
 
 export const load: PageServerLoad = async () => {
 	try {
@@ -14,14 +17,17 @@ export const load: PageServerLoad = async () => {
 		const [observersResult] = await db
 			.select({ count: countDistinct(sightings.email) })
 			.from(sightings)
-			.where(isNotNull(sightings.email));
+			.where(
+				and(isNotNull(sightings.approvedAt), isNotNull(sightings.email), ne(sightings.email, ''))
+			);
 
 		return {
 			version,
 			totalSightings: totalResult?.count ?? null,
 			totalObservers: observersResult?.count ?? null
 		};
-	} catch {
+	} catch (err) {
+		logger.error({ err }, 'Fehler beim Laden der About-Statistiken');
 		return {
 			version,
 			totalSightings: null,

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -23,8 +23,8 @@ export const load: PageServerLoad = async () => {
 
 		return {
 			version,
-			totalSightings: totalResult?.count ?? null,
-			totalObservers: observersResult?.count ?? null
+			totalSightings: totalResult?.count != null ? Number(totalResult.count) : null,
+			totalObservers: observersResult?.count != null ? Number(observersResult.count) : null
 		};
 	} catch (err) {
 		logger.error({ err }, 'Fehler beim Laden der About-Statistiken');

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,8 +1,31 @@
 import { version } from '../../../package.json';
+import { db } from '$lib/server/db';
+import { sightings } from '$lib/server/db/schema';
+import { count, countDistinct, isNotNull } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	return {
-		version
-	};
+	try {
+		const [totalResult] = await db
+			.select({ count: count() })
+			.from(sightings)
+			.where(isNotNull(sightings.approvedAt));
+
+		const [observersResult] = await db
+			.select({ count: countDistinct(sightings.email) })
+			.from(sightings)
+			.where(isNotNull(sightings.email));
+
+		return {
+			version,
+			totalSightings: totalResult?.count ?? null,
+			totalObservers: observersResult?.count ?? null
+		};
+	} catch {
+		return {
+			version,
+			totalSightings: null,
+			totalObservers: null
+		};
+	}
 };

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -179,7 +179,7 @@
 			/>
 			<p class="text-primary-content mx-auto mb-4 max-w-2xl leading-relaxed">
 				Diese Plattform wird vom Deutschen Meeresmuseum in Stralsund betrieben, einem der führenden
-				Zentren für Meeresforschung und -bildung in Deutschland. Seit über 50 Jahren widmen wir uns
+				Zentren für Meeresforschung und -bildung in Deutschland. Seit über 70 Jahren widmen wir uns
 				der Erforschung und dem Schutz der marinen Lebensräume.
 			</p>
 			<div class="flex justify-center gap-4">
@@ -617,12 +617,20 @@ SOFTWARE.</pre>
 				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-xl">
 					<div class="stat">
 						<div class="stat-title">Bereits erfasst</div>
-						<div class="stat-value text-primary">1.800+</div>
+						<div class="stat-value text-primary">
+							{data.totalSightings != null
+								? new Intl.NumberFormat('de-DE').format(data.totalSightings)
+								: '1.800+'}
+						</div>
 						<div class="stat-desc">Sichtungen</div>
 					</div>
 					<div class="stat">
 						<div class="stat-title">Aktive</div>
-						<div class="stat-value text-secondary">500+</div>
+						<div class="stat-value text-secondary">
+							{data.totalObservers != null
+								? new Intl.NumberFormat('de-DE').format(data.totalObservers)
+								: '500+'}
+						</div>
 						<div class="stat-desc">Beobachter</div>
 					</div>
 					<div class="stat">

--- a/src/routes/admin/docs/+page.svelte
+++ b/src/routes/admin/docs/+page.svelte
@@ -55,22 +55,22 @@
 				</p>
 				<ul class="space-y-1 text-sm">
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /admin/sightings</code> - Alle Sichtungen verwalten
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings</code> - Alle Sichtungen abrufen
+						(mit Filtern)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">PUT /admin/sightings/{'{id}'}</code> - Sichtungen
-						bearbeiten
+						• <code class="rounded bg-gray-100 px-1">PUT /api/sightings/{'{id}'}</code> - Sichtung bearbeiten
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">DELETE /admin/sightings/{'{id}'}</code> - Sichtungen
-						löschen
+						• <code class="rounded bg-gray-100 px-1">POST /api/sightings/{'{id}'}/approve</code> - Sichtung
+						genehmigen
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /admin/export</code> - Datenexport (CSV, XML,
-						KML)
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export</code> - Datenexport (CSV,
+						JSON, KML, XML)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /admin/statistics</code> - Detaillierte Statistiken
+						• <code class="rounded bg-gray-100 px-1">GET /api/statistics</code> - Detaillierte Statistiken
 					</li>
 				</ul>
 			</div>
@@ -112,11 +112,11 @@
 				<p class="mt-2 text-xs text-gray-500">Übersicht und Statistiken</p>
 			</div>
 			<div class="text-center">
-				<a href="/admin/map" class="btn btn-secondary btn-wide">
+				<a href="/map" class="btn btn-secondary btn-wide">
 					🗺️<br />
-					<span class="text-sm">Admin-Karte</span>
+					<span class="text-sm">Sichtungs-Karte</span>
 				</a>
-				<p class="mt-2 text-xs text-gray-500">Geografische Verwaltung</p>
+				<p class="mt-2 text-xs text-gray-500">Alle Sichtungen auf der Karte</p>
 			</div>
 			<div class="text-center">
 				<a href="/docs/api" class="btn btn-outline btn-wide">

--- a/src/routes/admin/docs/+page.svelte
+++ b/src/routes/admin/docs/+page.svelte
@@ -62,12 +62,27 @@
 						• <code class="rounded bg-gray-100 px-1">PUT /api/sightings/{'{id}'}</code> - Sichtung bearbeiten
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">POST /api/sightings/{'{id}'}/approve</code> - Sichtung
+						• <code class="rounded bg-gray-100 px-1">DELETE /api/sightings/{'{id}'}</code> - Sichtung
+						löschen
+					</li>
+					<li>
+						• <code class="rounded bg-gray-100 px-1">PATCH /api/sightings/{'{id}'}/approve</code> - Sichtung
 						genehmigen
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export</code> - Datenexport (CSV,
-						JSON, KML, XML)
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export</code> - Datenexport (JSON)
+					</li>
+					<li>
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/csv</code> - Datenexport
+						(CSV)
+					</li>
+					<li>
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/kml</code> - Datenexport
+						(KML)
+					</li>
+					<li>
+						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/xml</code> - Datenexport
+						(XML)
 					</li>
 					<li>
 						• <code class="rounded bg-gray-100 px-1">GET /api/statistics</code> - Detaillierte Statistiken


### PR DESCRIPTION
## Zusammenfassung

- Toter Link \`/admin/map\` in Admin-Docs auf \`/map\` korrigiert (Route existierte nie)
- Falsche API-Endpunkt-Pfade (\`/admin/*\`) durch korrekte \`/api/*\`-Pfade ersetzt; \`POST\` für approve auf \`PATCH\` korrigiert; \`DELETE /api/sightings/{id}\` wieder aufgeführt (Endpunkt existiert)
- Alle Export-Subpfade einzeln dokumentiert (\`/csv\`, \`/json\`, \`/kml\`, \`/xml\`)
- Sichtungs-/Beobachterzahlen auf der About-Seite werden dynamisch aus der DB geladen statt hardcoded; Counts via \`Number()\` gegen bigint-Serialisierungsfehler abgesichert
- Altersangabe des Deutschen Meeresmuseums von "über 50" auf "über 70 Jahre" korrigiert (gegründet 1951)

## Änderungen

- \`src/routes/admin/docs/+page.svelte\` — Link-Fix + korrekte API-Pfade (GET, PUT, DELETE, PATCH .../approve, Export-Subpfade, GET /api/statistics)
- \`src/lib/components/docs/ApiDocumentation.svelte\` — Quick-Start-Pfade mit \`/api/\`-Prefix
- \`src/routes/about/+page.svelte\` — Dynamische Statistiken + Museumsalter
- \`src/routes/about/+page.server.ts\` — DB-Queries für Sichtungs- und Beobachteranzahl; Observer-Filter auf approved + nicht-leere E-Mails; Fehler-Logging; Number()-Cast

## Testplan

- [x] \`npm run test:quick\` — 1522 Tests bestanden
- [ ] \`/admin/docs\` aufrufen → "Sichtungs-Karte" Button → führt auf \`/map\`
- [ ] API-Endpunkte im Admin-Docs stimmen mit tatsächlichen Routes überein (inkl. PATCH für approve, DELETE)
- [ ] \`/about\` → dynamische Sichtungszahl aus DB sichtbar, Fallback bei DB-Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)