### PR TITLE
Pre-Launch-Review: Security-, UX-, Produktions- und Doku-Fixes

### DIFF
--- a/.claude/agents/form-development.md
+++ b/.claude/agents/form-development.md
@@ -15,7 +15,7 @@ model: inherit
 ## Fähigkeiten
 
 - Multi-Step Formular-Architektur
-- svelte-forms-lib + Yup Integration
+- Projekteigene `createForm`-Implementierung (`src/lib/form/createForm.ts`) + Yup Integration
 - Conditional Logic / Progressive Disclosure
 - Accessibility (WCAG 2.1 AA)
 - Mobile-First Form Design
@@ -60,7 +60,7 @@ export const sightingSchema = yup.object({
 });
 ```
 
-2. **FormState erweitern** (`formState.ts`):
+2. **FormState erweitern** (`src/lib/report/formConfig.ts`):
 
 ```typescript
 export const initialFormState = {
@@ -110,7 +110,7 @@ neuesFeld: yup.string().when('bedingung', {
 
 ### Schritt 3: FormState erweitern
 
-- `formState.ts` mit Initialwerten
+- `initialFormState` in `src/lib/report/formConfig.ts` mit Initialwerten
 - Type-Definition aktualisieren
 
 ### Schritt 4: UI implementieren
@@ -135,7 +135,7 @@ neuesFeld: yup.string().when('bedingung', {
 ## Erfolgs-Kriterien
 
 - [ ] Schema in `sightingSchema.ts` erweitert
-- [ ] FormState in `formState.ts` aktualisiert
+- [ ] FormState in `src/lib/report/formConfig.ts` aktualisiert
 - [ ] UI-Komponente erstellt/erweitert
 - [ ] Deutsche Fehlermeldungen
 - [ ] Accessibility-Labels vorhanden

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -6,16 +6,16 @@ Diese Regeln gelten für **jede** Code-Änderung im Projekt.
 
 ## Technology Stack
 
-| Bereich   | Technologie                                   |
-| --------- | --------------------------------------------- |
-| Framework | SvelteKit 5 mit TypeScript                    |
-| Datenbank | PostgreSQL + PostGIS                          |
-| ORM       | Drizzle (type-safe)                           |
-| Styling   | TailwindCSS + DaisyUI (Theme: `meeresmuseum`) |
-| Karten    | OpenLayers                                    |
-| Forms     | svelte-forms-lib + Yup                        |
-| Logging   | Pino                                          |
-| Icons     | unplugin-icons (lucide)                       |
+| Bereich   | Technologie                                                    |
+| --------- | -------------------------------------------------------------- |
+| Framework | SvelteKit 5 mit TypeScript                                     |
+| Datenbank | PostgreSQL + PostGIS                                           |
+| ORM       | Drizzle (type-safe)                                            |
+| Styling   | TailwindCSS + DaisyUI (Theme: `meeresmuseum`)                  |
+| Karten    | OpenLayers                                                     |
+| Forms     | Eigene `createForm`-Impl. (`src/lib/form/createForm.ts`) + Yup |
+| Logging   | Pino                                                           |
+| Icons     | unplugin-icons (lucide)                                        |
 
 ---
 
@@ -25,32 +25,56 @@ Diese Regeln gelten für **jede** Code-Änderung im Projekt.
 src/
 ├── lib/
 │   ├── components/          # Wiederverwendbare UI-Komponenten
-│   │   └── map/             # Karten-Komponenten (OLMap.svelte etc.)
+│   │   ├── admin/           # Admin-UI-Komponenten
+│   │   ├── docs/            # API-Doku-Komponenten
+│   │   ├── form/            # Generische Form-Komponenten
+│   │   ├── map/             # Karten-Komponenten (OLMap.svelte etc.)
+│   │   ├── media/           # Medien-Anzeige (Galerie etc.)
+│   │   ├── ui/              # Basis-UI (Dialog, Toast etc.)
+│   │   └── weather/         # Wetter-Anzeige
 │   ├── constants/           # Enums, Konstanten
-│   ├── form/validation/     # Yup Validation Schema
+│   ├── form/                # createForm.ts + validation/ (Yup Schema)
 │   ├── legacy-api/          # Legacy API Utilities (Field Mapping, Validation)
+│   ├── logger/              # Pino Logger (Server + Client)
 │   ├── map/                 # OpenLayers Controller & Utilities
 │   ├── report/              # Sichtungsmeldung
 │   │   ├── components/      # Form Steps, Sections, Fields
 │   │   └── formOptions/     # Enum/Option Definitionen (16 Dateien)
 │   ├── server/
+│   │   ├── audit/           # Audit-Logging
 │   │   ├── auth/            # JWT/Auth0 Authentication
+│   │   ├── config/          # ConfigService, Access Control
+│   │   ├── datetime/        # Server-Datums-Utilities
 │   │   ├── db/              # Schema, Repository Layer
 │   │   ├── export/          # CSV, JSON, KML, XML Export
 │   │   ├── geo/             # Baltic Sea Validation
-│   │   ├── middleware/       # Security Headers, Rate Limit, Maintenance
+│   │   ├── media/           # Medien-Verarbeitung
+│   │   ├── middleware/      # Security Headers, Rate Limit, Maintenance, DB-Check
 │   │   ├── services/        # Email, Weather Services
-│   │   └── storage/         # File Storage (Local, Vercel Blob)
+│   │   ├── spam/            # Spam-Erkennung
+│   │   ├── storage/         # File Storage (Local, Vercel Blob)
+│   │   ├── templates/       # Email-Templates (Handlebars)
+│   │   ├── utils/           # Server-Utilities (z.B. getClientIp)
+│   │   └── validation/      # Request-Validierung, Magic Bytes
+│   ├── services/            # Client-Services (configService, weatherService)
 │   ├── storage/             # Browser Storage (GDPR-aware)
-│   └── types/               # TypeScript Definitionen
+│   ├── stores/              # Svelte Stores (Toast, Config)
+│   ├── types/               # TypeScript Definitionen
+│   └── utils/               # Client/Shared Utilities (date, geo, media, upload, ...)
 ├── routes/
+│   ├── about/               # Über-Seite
 │   ├── admin/               # Admin-Interface
 │   ├── api/                 # Backend API Endpoints
+│   ├── docs/                # API-Dokumentation (Scalar)
+│   ├── health/              # Health-Check-Endpoint
+│   ├── maintenance/         # Wartungsmodus-Seite
 │   ├── map/                 # Karten-Visualisierung
 │   ├── rest_sichtungen/     # Legacy REST API
-│   └── sichtungen/          # Legacy Sichtungs-API
+│   ├── sichtungen/          # Legacy Sichtungs-API
+│   └── uploads/             # Ausgelieferte Uploads (Local Storage)
 └── hooks.server.ts          # Middleware Chain (sequence)
 e2e/                         # E2E Tests (Root-Level)
+monitoring/                  # Prometheus + Grafana Konfiguration
 ```
 
 ---
@@ -288,7 +312,7 @@ Immer `$lib` mit vollständigen Pfaden verwenden:
 ```typescript
 // Korrekt
 import { formatDate } from '$lib/utils/date';
-import { sightingSchema } from '$lib/sightingSchema';
+import { sightingSchema } from '$lib/form/validation/sightingSchema';
 
 // Falsch
 import { formatDate } from '../../../lib/utils/date';

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -17,6 +17,7 @@ Regeln für PostgreSQL, PostGIS und Drizzle ORM.
 npm run db:start   # PostgreSQL starten (Docker, Port 5433)
 npm run db:stop    # Datenbank stoppen
 npm run db:push    # Schema direkt auf DB pushen (kein drizzle/-Verzeichnis nötig)
+npm run db:migrate # drizzle-kit migrate — läuft mangels drizzle/-Verzeichnis derzeit ins Leere
 npm run db:studio  # Drizzle Studio öffnen
 ```
 

--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -66,22 +66,18 @@ CMD ["node", "build"]
 
 ---
 
-## adapter-node Konfiguration
+## Adapter-Konfiguration (Dual: Vercel / Node)
 
-```javascript
-// svelte.config.js
-import adapter from '@sveltejs/adapter-node';
+`svelte.config.js` wählt den Adapter **dynamisch**: Default ist `@sveltejs/adapter-vercel`; nur wenn `USE_NODE_ADAPTER=true` gesetzt ist, wird `@sveltejs/adapter-node` verwendet.
 
-export default {
-	kit: {
-		adapter: adapter({
-			out: 'build',
-			precompress: true,
-			envPrefix: ''
-		})
-	}
-};
+Für Docker-Builds wird deshalb das Script `npm run build:docker` genutzt:
+
+```bash
+# package.json
+"build:docker": "USE_NODE_ADAPTER=true svelte-kit sync && vite build"
 ```
+
+Der Node-Adapter erzeugt `build/index.js` (Server startet via `node build`, siehe Dockerfile-`runtime`-Stage). Ohne `USE_NODE_ADAPTER=true` würde stattdessen für Vercel gebaut — im Docker-Kontext also immer `build:docker` verwenden.
 
 ---
 

--- a/.claude/rules/forms.md
+++ b/.claude/rules/forms.md
@@ -8,17 +8,17 @@ paths:
 
 # Multi-Step Forms
 
-Regeln für Formular-Entwicklung mit svelte-forms-lib und Yup.
+Regeln für Formular-Entwicklung mit der projekteigenen `createForm`-Implementierung und Yup.
 
 ---
 
 ## Tech Stack
 
-| Bibliothek       | Zweck                 |
-| ---------------- | --------------------- |
-| svelte-forms-lib | Form State Management |
-| Yup              | Schema Validation     |
-| DaisyUI          | Form Components       |
+| Bibliothek                                  | Zweck                                      |
+| ------------------------------------------- | ------------------------------------------ |
+| `createForm` (`src/lib/form/createForm.ts`) | Form State Management (svelte/store + Yup) |
+| Yup                                         | Schema Validation                          |
+| DaisyUI                                     | Form Components                            |
 
 ---
 
@@ -87,16 +87,18 @@ export const sightingSchema = yup.object({
 
 ---
 
-## svelte-forms-lib Pattern
+## createForm Pattern (projekteigene Implementierung)
 
-**Hinweis:** `svelte-forms-lib` basiert auf Svelte 4 Stores (`writable`). In Svelte 5 funktioniert es über den Legacy-Kompatibilitätsmodus — `$form`, `$errors`, `$touched` sind Svelte-Stores, die mit `$` abonniert werden. Das ist korrekt und funktioniert stabil.
+**Hinweis:** Das Projekt nutzt KEINE externe Form-Library. `src/lib/form/createForm.ts` ist eine eigene, schlanke Implementierung auf Basis von Svelte-Stores (`writable`/`derived`) + Yup. `$form`, `$errors`, `$isSubmitting`, `$isValid` sind Svelte-Stores und werden mit `$` abonniert. Es gibt KEIN `touched` und KEIN `validateField` — validiert wird beim Submit (`abortEarly: false`, sammelt alle Fehler); `updateField` löscht den Fehler des geänderten Feldes.
+
+API: `{ form, errors, isSubmitting, isValid, handleSubmit, handleChange, updateField, updateInitialValues }`
 
 ```svelte
 <script lang="ts">
-	import { createForm } from 'svelte-forms-lib';
+	import { createForm } from '$lib/form/createForm';
 	import * as yup from 'yup';
 
-	const { form, errors, touched, handleSubmit, validateField } = createForm({
+	const { form, errors, isSubmitting, handleSubmit, updateField } = createForm({
 		initialValues: {
 			species: '',
 			count: 1,
@@ -120,14 +122,14 @@ export const sightingSchema = yup.object({
 			id="species"
 			name="species"
 			bind:value={$form.species}
-			onblur={() => validateField('species')}
 			class="input w-full"
-			class:input-error={$errors.species && $touched.species}
+			class:input-error={$errors.species}
 		/>
-		{#if $errors.species && $touched.species}
+		{#if $errors.species}
 			<p class="label text-error">{$errors.species}</p>
 		{/if}
 	</fieldset>
+	<button class="btn btn-primary" disabled={$isSubmitting}>Absenden</button>
 </form>
 ```
 

--- a/.claude/rules/maps.md
+++ b/.claude/rules/maps.md
@@ -30,10 +30,14 @@ src/lib/
 ├── map/                              # Map Utilities & Controller
 │   ├── optimizedMapController.ts     # Performance-optimierter Controller
 │   ├── styleUtils.ts                 # Style-Definitionen & Legenden
-│   ├── dataLoader.ts                 # Daten-Laden
-│   ├── countManager.ts              # Species/Color Count Management
-│   ├── timeSliderManager.ts         # Zeitfilterung
-│   └── mapUtils.ts                   # GeoJSON-Konvertierung & Typen
+│   ├── countManager.ts               # Species/Color Count Management
+│   ├── timeSliderManager.ts          # Zeitfilterung
+│   ├── mapUtils.ts                   # GeoJSON-Konvertierung & Typen
+│   ├── mapContext.ts                 # Svelte Context für Map-Instanz
+│   ├── panelManager.ts               # Panel-Zustand (Filter/Legende)
+│   ├── dateUtils.ts                  # Datums-Hilfen für Zeitfilter
+│   ├── mapStyles.css                 # Karten-CSS
+│   └── controls/                     # Custom OL-Controls (LocationControl, ZoomAllControl)
 └── components/map/
     ├── OLMap.svelte                  # Haupt-Karten-Komponente
     ├── SightingsMapView.svelte       # Sichtungs-Kartenansicht

--- a/.claude/rules/middleware.md
+++ b/.claude/rules/middleware.md
@@ -54,6 +54,12 @@ In-Memory Rate Limiting mit automatischem Cleanup (10min).
 **Identifier:** `user:{sub}` oder `ip:{clientIp}`
 **Headers:** `X-RateLimit-{Limit,Remaining,Reset,Window}`
 
+**Deployment-Kontext:** Der Zähler liegt im Prozess-Speicher. Das ist für das
+**Single-Container-Docker-Deployment** (Prod) korrekt und wirksam. Voraussetzung: Der
+adapter-node muss hinter dem Reverse Proxy die echte Client-IP kennen — dafür sind
+`ADDRESS_HEADER`/`XFF_DEPTH` gesetzt (siehe docs/ENVIRONMENT.md). Bei horizontaler Skalierung
+(mehrere Replicas) wäre ein gemeinsamer Store (Redis/Postgres) nötig — aktuell nicht der Fall.
+
 ---
 
 ## securityHeaders.ts

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -113,14 +113,14 @@ await db.execute(`SELECT * FROM sichtungen WHERE id = ${id}`);
 {@html userInput}
 <!-- GEFÄHRLICH -->
 
-<!-- Korrekt: DOMPurify verwenden -->
+<!-- Korrekt: sanitizeHtml verwenden -->
 {@html sanitizeHtml(userInput)}
 <!-- Erlaubt nur sichere Tags -->
 ```
 
-### DOMPurify Sanitization
+### HTML-Sanitization mit sanitize-html
 
-`isomorphic-dompurify` wird für HTML-Sanitization verwendet (SSR + Client):
+`sanitize-html` wird für HTML-Sanitization verwendet (Wrapper in `src/lib/utils/sanitize.ts`):
 
 ```typescript
 import { sanitizeHtml, sanitizeText } from '$lib/utils/sanitize';
@@ -263,35 +263,37 @@ CSP wird separat in `svelte.config.js` konfiguriert.
 
 ## SAST Scanning
 
-**CodeQL** läuft automatisch via `.github/workflows/codeql.yml`:
-
-- Push/PR auf `main` + wöchentlich (Sonntag 03:00 UTC)
-- Query Suite: `security-extended`
-- Ergebnisse unter GitHub Security → Code scanning alerts
+Kein dediziertes CodeQL-Workflow. Container-Image-Scan mit SARIF-Upload läuft in `.github/workflows/docker-publish.yml` (Ergebnisse unter GitHub Security → Code scanning alerts).
 
 ---
 
 ## Rate Limiting
 
+Implementierung: `src/lib/server/middleware/rateLimit.ts` (In-Memory, mit automatischem Cleanup).
+
 ```typescript
-import { rateLimit } from '$lib/server/rateLimit';
+import {
+	RATE_LIMITS,
+	checkRateLimit,
+	createRateLimitIdentifier,
+	enforceRateLimit,
+	buildRateLimitHeaders
+} from '$lib/server/middleware/rateLimit';
 
-export async function POST({ request, getClientAddress }) {
-	const ip = getClientAddress();
+export async function POST({ locals, getClientAddress }) {
+	// Identifier: `user:{sub}` (authentifiziert) oder `ip:{clientIp}`
+	const identifier = createRateLimitIdentifier(locals.user?.sub, getClientAddress(), !!locals.user);
 
-	// 10 Anfragen pro Minute
-	const allowed = await rateLimit(ip, {
-		limit: 10,
-		window: 60
-	});
+	// wirft SvelteKit error(429) bei Überschreitung
+	const result = enforceRateLimit(identifier, RATE_LIMITS.SIGHTING_SUBMISSION, 'sightings');
 
-	if (!allowed) {
-		return new Response('Zu viele Anfragen', { status: 429 });
-	}
-
+	// Response-Headers: X-RateLimit-{Limit,Remaining,Reset,Window}
+	const headers = buildRateLimitHeaders(RATE_LIMITS.SIGHTING_SUBMISSION, result);
 	// ...
 }
 ```
+
+Vordefinierte Limits in `RATE_LIMITS`: File Upload 20/h (anonym) bzw. 50/h (auth), Media Access 30/min bzw. 100/min, Sighting Submission 20/h.
 
 ---
 

--- a/.env.docker
+++ b/.env.docker
@@ -46,6 +46,14 @@ PORT="3000"
 HOST="0.0.0.0"
 BODY_SIZE_LIMIT="52428800"
 
+# Reverse-Proxy / Client-IP-Auflösung (adapter-node hinter Nginx/Caddy).
+# Nötig, damit die echte Client-IP erkannt wird und IP-Rate-Limiting pro Client
+# greift. XFF_DEPTH = Anzahl vertrauenswürdiger Proxies (bei einem Proxy: 1).
+ADDRESS_HEADER="x-forwarded-for"
+XFF_DEPTH="1"
+PROTOCOL_HEADER="x-forwarded-proto"
+HOST_HEADER="x-forwarded-host"
+
 # ============================================
 # Security Settings (CHANGE THESE IN PRODUCTION!)
 # ============================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ npm run test:quick        # Schnell-Test (lint + types + check + unit)
 
 ### Tech Stack
 
-SvelteKit 5 + TypeScript, PostgreSQL/PostGIS, Drizzle ORM, TailwindCSS/DaisyUI, OpenLayers, svelte-forms-lib + Yup. Details: .claude/rules/architecture.md
+SvelteKit 5 + TypeScript, PostgreSQL/PostGIS, Drizzle ORM, TailwindCSS/DaisyUI, OpenLayers, eigene `createForm`-Implementierung (`src/lib/form/createForm.ts`) + Yup. Details: .claude/rules/architecture.md
 
 ### Projektstruktur
 

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -53,6 +53,17 @@ services:
       PUBLIC_SITE_URL: ${PUBLIC_SITE_URL:-http://localhost:3000}
       BODY_SIZE_LIMIT: ${BODY_SIZE_LIMIT:-52428800}
 
+      # Reverse-Proxy / Client-IP-Auflösung (adapter-node)
+      # WICHTIG: Die App läuft hinter einem Reverse Proxy (Nginx/Caddy). Damit
+      # getClientAddress() die echte Client-IP liefert (statt der Proxy-IP) und
+      # das IP-basierte Rate-Limiting pro Client greift, MUSS der adapter-node
+      # die Forwarded-Header auswerten. XFF_DEPTH = Anzahl vertrauenswürdiger
+      # Proxies vor der App (bei genau einem Reverse Proxy: 1).
+      ADDRESS_HEADER: ${ADDRESS_HEADER:-x-forwarded-for}
+      XFF_DEPTH: ${XFF_DEPTH:-1}
+      PROTOCOL_HEADER: ${PROTOCOL_HEADER:-x-forwarded-proto}
+      HOST_HEADER: ${HOST_HEADER:-x-forwarded-host}
+
       # Security Settings
       SESSION_SECRET: ${SESSION_SECRET}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -671,6 +671,49 @@ Before deploying, verify:
 
 ---
 
+## Reverse Proxy & Client IP (Production / Docker)
+
+Die Produktion läuft als **adapter-node im Docker-Container hinter einem Reverse Proxy**
+(Nginx/Caddy). Damit `getClientAddress()` die echte Client-IP liefert (statt der internen
+Proxy-IP) — Voraussetzung dafür, dass das **IP-basierte Rate-Limiting pro Client** greift —
+müssen die Forwarded-Header ausgewertet werden. Diese Variablen sind in
+`docker-compose.production.yml` / `.env.docker` bereits gesetzt:
+
+| Variable          | Empfohlen           | Beschreibung                                                    |
+| ----------------- | ------------------- | --------------------------------------------------------------- |
+| `ADDRESS_HEADER`  | `x-forwarded-for`   | Header, aus dem der adapter-node die Client-IP liest            |
+| `XFF_DEPTH`       | `1`                 | Anzahl vertrauenswürdiger Proxies vor der App (bei 1 Proxy = 1) |
+| `PROTOCOL_HEADER` | `x-forwarded-proto` | Header für das Original-Protokoll (http/https)                  |
+| `HOST_HEADER`     | `x-forwarded-host`  | Header für den Original-Host                                    |
+
+> **Sicherheitshinweis:** `ADDRESS_HEADER` darf nur gesetzt sein, wenn tatsächlich ein
+> vertrauenswürdiger Reverse Proxy davorsteht, der `X-Forwarded-For` **überschreibt** (nicht
+> nur anhängt). Der Nginx-/Caddy-Beispiel-Config in DOCKER_DEPLOYMENT.md setzt
+> `X-Forwarded-For $proxy_add_x_forwarded_for`. Ohne echten Proxy davor wäre der Header
+> client-spoofbar (Rate-Limit-Bypass). `XFF_DEPTH` muss exakt zur Proxy-Anzahl passen.
+
+### Rate-Limiting-Hinweis
+
+Das Rate-Limiting (`src/lib/server/middleware/rateLimit.ts`) hält seinen Zähler **im
+Prozess-Speicher**. Das ist für das dokumentierte **Single-Container-Deployment korrekt und
+wirksam**. Bei einer künftigen **horizontalen Skalierung** (mehrere App-Container/Replicas
+hinter einem Load Balancer) würde jeder Container getrennt zählen — dann ist ein **gemeinsamer
+Store** (Redis/Postgres) erforderlich.
+
+---
+
+## `SKIP_DB_CHECK`
+
+- **Type**: Boolean (`"true"` / unset)
+- **Required**: No
+- **Default**: unset (DB-Check aktiv)
+
+Überspringt die DB-Verfügbarkeitsprüfung der `databaseCheck`-Middleware
+(`src/lib/server/middleware/databaseCheck.ts`). **Nur für CI/Tests** gedacht — in Produktion
+niemals setzen, sonst laufen Requests bei DB-Ausfall in Fehler statt in einen sauberen 503.
+
+---
+
 ## Support
 
 For questions about environment configuration:

--- a/docs/LAUNCH_REVIEW_2026-07-24.md
+++ b/docs/LAUNCH_REVIEW_2026-07-24.md
@@ -1,0 +1,209 @@
+# Launch-Review Ostsee-Tiere — 2026-07-24
+
+Umfassender Pre-Launch-Review: Security, UX/Design-System, Produktionsreife, Dependencies,
+Doku-Abgleich. Grundlage: statische Code-Analyse durch spezialisierte Review-Agenten +
+`npm audit`, `npm run test:quick`. Keine Laufzeit-/Penetrationstests.
+
+**Gesamturteil:** Solide, überdurchschnittlich sorgfältig gebaute App (starke ARIA-Verdrahtung,
+konsequente Admin-Autorisierung, parametrisierte Queries, GDPR-Feldfilterung). Vor dem Launch
+sind einige klar umrissene Punkte zu beheben — v. a. 3 Security-HIGH und 4 UX-HIGH. Keine
+CRITICAL-Findings.
+
+---
+
+## 0. Test-/Build-Status
+
+- `npm run lint`: 0 Fehler, 2 `any`-Warnings (nur in Test-Helper `src/tests/contract/helpers/createEvent.ts`).
+- `type-check`, `svelte-check`: grün (nach `svelte-kit sync`).
+- Unit-Tests: **1577 / 1578 grün**. Der eine Fehlschlag ist ein flakiger Performance-Test
+  (`checkBalticSeaFile.comprehensive.test.ts:444`, erwartet <20 ms, unter Last 43 ms) — kein
+  Funktionsdefekt. Empfehlung: Schwelle anheben oder Assertion entfernen, damit CI nicht flaky ist.
+
+---
+
+## 1. Security
+
+**Gut abgesichert (geprüft):** Admin-/`/api/admin`-Routen erzwingen durchgängig `requireUserRole`;
+JWT/Session via `jose` (httpOnly/secure/sameSite=lax, PKCE+state, AES-256-GCM-Verifier);
+durchgängig parametrisierte Drizzle-Queries (kein `sql.raw`); mehrstufiger Path-Traversal-Schutz;
+GDPR-Feldfilterung in `showreports.json`/`api/map/sightings` (Name/Schiff nur mit Consent, nie
+E-Mail/Telefon/Adresse); beide `{@html}` nutzen `sanitizeHtml()`; Handlebars-Autoescape; keine
+Secrets im Repo; **Produktions-Dependencies: 0 Vulnerabilities**.
+
+### HIGH (vor Launch beheben)
+
+1. **Open Redirect im OAuth-Callback.** `returnUrl` wird ungeprüft aus dem Query-String
+   übernommen und in `redirect(302, returnUrl)` verwendet.
+   `src/routes/api/auth/callback/+server.ts:19,60` (+ Weiterschleifen in `login/+server.ts:8,15`).
+   → Post-Login-Phishing auf beliebige externe Domain. **Fix:** `returnUrl` auf relative
+   Same-Origin-Pfade beschränken (`startsWith('/') && !startsWith('//')`), sonst `/`.
+
+2. **Öffentliche Datei-Auslieferung ohne Freigabe-Prüfung.** `/uploads/[...path]` liefert jede
+   Datei ohne DB-/Freigabe-/Auth-Check und mit `Access-Control-Allow-Origin: *` aus — parallel zur
+   korrekt abgesicherten Route `/api/media/[...path]` (prüft `approvedAt` + Admin).
+   `src/routes/uploads/[...path]/+server.ts`. Aktiv genutzt via `LocalStorageProvider.getUrl()`
+   (`storage/local.ts:168`), `MediaFile.ts:80`, `MediaGallery.svelte`. → Medien nicht freigegebener
+   Sichtungen (Totfunde, GPS-EXIF) öffentlich abrufbar. **Fix:** Route auf denselben DB-Freigabe-Check
+   umstellen oder entfernen und alle Links auf `/api/media/...` umziehen.
+
+3. **In-Memory Rate Limiting — Deployment-abhängig.** `rateLimitStore = new Map()`
+   (`middleware/rateLimit.ts:26`). **Auflösung (2026-07-24):** Produktion läuft als
+   **Single-Container-Docker** (adapter-node), nicht Vercel — dort ist der In-Memory-Zähler
+   **korrekt und wirksam**, kein Code-Fix nötig. Erforderlich war jedoch die Client-IP-Auflösung
+   hinter dem Reverse Proxy: `ADDRESS_HEADER`/`XFF_DEPTH`/`PROTOCOL_HEADER`/`HOST_HEADER` sind jetzt
+   in `docker-compose.production.yml` und `.env.docker` gesetzt und in `docs/ENVIRONMENT.md`
+   dokumentiert. Ohne diese hätte `getClientAddress()` allen Requests die Proxy-IP zugewiesen und
+   das IP-Rate-Limiting global statt pro Client greifen lassen. Hinweis für die Zukunft: Bei
+   horizontaler Skalierung (mehrere Replicas) ist ein gemeinsamer Store (Redis/Postgres) nötig.
+
+### MEDIUM
+
+4. `application/pdf` ohne Magic-Bytes-Signatur → Upload-Whitelist für PDF faktisch unwirksam
+   (`validation/magicBytes.ts`). Fix: `%PDF-`-Signatur ergänzen.
+5. `ENCRYPTION_KEY` ohne Fail-Fast-Guard; `.env.example` liefert gültigen Default-Key. Analog zum
+   vorhandenen `SESSION_SECRET`-Guard (`hooks.server.ts:21`) prüfen, dass ≠ Platzhalter in Prod.
+6. CSP global `script-src 'unsafe-inline'` (für Scalar-Doku, aber app-weit); generierter
+   `cspNonce` (`hooks.server.ts:44`) wird nirgends verwendet (toter Code). Fix: auf `/docs/api/scalar`
+   beschränken oder echtes Nonce-Scripting.
+7. `/api/csp-report` unauthentifiziert, ohne Rate-Limit, loggt `fullReport` ungefiltert bei
+   50 MB Body-Limit → Log-Flooding. Fix: Rate-Limit + Feldbegrenzung.
+8. `securityHeaders.ts:36` schreibt global alle `SameSite=Strict`-Cookies auf `None` um (Footgun
+   für künftige Cookies). Fix: nur den benötigten Cookie-Namen gezielt behandeln.
+9. `/api/files/delete` ohne Rate-Limit und ohne Ownership-Prüfung für anonyme Uploads
+   (`sightingId === null`). Fix: Rate-Limit + `uid`/Session-Abgleich.
+
+### LOW
+
+10. `error.message` an Client (`api/map/sightings/+server.ts:89`, `rest_sichtungen:153`).
+11. Legacy-`search`-Parameter ist ein Email-Oracle (spec-bedingt, kein Fix ohne Spec-Bruch — Monitoring).
+12. Keine Rate-Limits auf `/api/geo/inBaltic`, `/api/weather/historical`.
+13. `getClientIp` XFF-Fallback in Prod spoofbar, falls Adapter nicht korrekt konfiguriert.
+    **Behoben (2026-07-24):** `ADDRESS_HEADER`/`XFF_DEPTH` in Prod-Config gesetzt + in
+    `docs/ENVIRONMENT.md` dokumentiert (inkl. Sicherheitshinweis zur Proxy-Anzahl).
+
+---
+
+## 2. UX & Design-System
+
+**Positiv:** Theme `meeresmuseum` (oklch + WCAG-Kommentare, reduced-motion, globale Fokus-Indikatoren)
+vorbildlich; Fokus-Management beim Schrittwechsel; ARIA-Grundgerüst (`aria-describedby/-invalid/-required`,
+`role="alert"`); Reload-Wiederherstellung mit Toast + GDPR-Consent; Ladezustände; Karten-Tastaturkürzel.
+
+### HIGH (vor Launch)
+
+1. **Platzhalter-Support-Adresse** `mailto:support@example.com` auf der Fehlerseite
+   (`+error.svelte:188`). Echte Adresse einsetzen.
+2. **Lösch-Dialog visuell defekt + nicht barrierefrei.** `bg-opacity-50` existiert in Tailwind 4
+   nicht mehr → Backdrop deckend schwarz; kein `<dialog>`/`aria-modal`/Fokus-Trap/ESC
+   (`ui/Dialog/DeleteDialog.svelte:19`). Auf natives `<dialog>`-Muster (wie Spam-Check-Modal) +
+   `bg-black/50` umstellen. Tote `bg-opacity-*`/`*-focus`-Utilities auch in `PublicNavbar.svelte:62`,
+   `SightingsMapView.svelte:331,409`.
+3. **"Formular zurücksetzen" ohne Bestätigung** (`FormActions.svelte:51`) löscht sofort alle
+   Eingaben + Storage. Bestätigungsdialog ergänzen.
+4. **Admin-Aktionen scheitern stumm** — Löschen/Verifizieren-Fehler nur im Logger, kein UI-Feedback
+   (`admin/+page.svelte:242,323`). `toast.error(...)` ergänzen.
+
+### MEDIUM (Auswahl)
+
+5. Validierungs-Timing: Fehler erscheinen sofort bei Betreten eines unberührten Schritts
+   (`StepNavigation.svelte`), widerspricht Design Guide; "Weiter"-Button `disabled` macht die
+   gebaute Fehlernavigation zu totem Code. "Weiter" aktiv lassen + Fehlernavigation triggern.
+6. Stepper ohne sichtbare Schritt-Namen, `role="tablist/tab"` falsch, klickbare `<li>` statt Buttons
+   (`FormSteps.svelte:36`).
+7. Fehlende `autocomplete`-Attribute auf Kontaktfeldern (WCAG 1.3.5).
+8. Radiogruppen ohne `fieldset`/`legend`, Label-`for` zeigt ins Leere (`FieldRenderer.svelte:237`).
+9. Tooltip-Inhalte per Tastatur unerreichbar (`tabindex="-1"`).
+10. Hardcodierte Farben (`text-gray-*` etc.) auf Rand-Seiten (`about`, `docs`, `admin/settings`, Karten-UI).
+11. Karte nicht per Tastatur wählbar (`OLMap.svelte` ohne `tabindex`) — abgemildert durch manuelle
+    Koordinatenfelder, dort aber Label-Mismatch `for="dd-latitude"` vs. `id="latitude"`.
+12. Admin-Tabellen-Sortierung nicht barrierefrei (`<th onclick>` ohne Button/`aria-sort`).
+13. Drei parallele Dialog-Systeme + native `confirm()`/`alert()` — konsolidieren.
+14. Erfolgsseite: Tierart hart auf 0/1/2 gemappt statt `getSpeciesLabel()`; Tippfehler "gehen"→"geben";
+    Text "Upload per E-Mail" widerspricht Direkt-Upload (`SubmissionSuccess.svelte`).
+15. Landmarks/Skip-Link fehlen; `admin/+layout.svelte` verschachtelt `<main>` in `<main>`.
+
+### LOW
+
+17. Sprachfehler in Yup-Messages ("Handeltete", "Lebende"/"Junge" groß) — `sightingSchema.ts:385,400`.
+18. Erfundene Social-Proof-Zahl "2.847 Sichtungen" (`sightingSchema.ts:220`).
+19. Vertauschte lat/lng-Defaults in `LocationInput.svelte:8`.
+20. Fehlerseiten-Titel "Sichtungen WebApp" statt "Ostsee-Tiere"; undefinierter `pulse`-Keyframe.
+
+---
+
+## 3. Produktionsreife
+
+**Positiv:** Middleware-Reihenfolge korrekt + fail-open bei Config-Fehlern; Fail-fast für
+`SESSION_SECRET`; Dockerfile (non-root, multi-stage, dumb-init, Healthcheck, Log-Rotation);
+Legacy-Routen mit durchgängigem try/catch + Ergebnis-Limit 1000; CI deckt Lint/Types/Tests/E2E ab.
+
+### HIGH
+
+1. **Health-Check prüft keine DB.** Der DB-Block in `src/routes/health/+server.ts:29` ist
+   auskommentiert → `/health` liefert immer 200, auch bei DB-Ausfall → Docker/Compose-Healthcheck
+   markiert Container nie als unhealthy, kein Auto-Restart. Fix: DB-Check aktivieren, ggf.
+   Liveness (`/health`) von Readiness (`/health/ready`) trennen.
+
+### MEDIUM
+
+2. `saveSighting()` nicht transaktional — Insert + Media-Verknüpfung getrennt
+   (`sightingRepository.ts:82` + `sightingFilesRepository.ts:49`) → verwaiste Medien bei Fehler
+   dazwischen. In `db.transaction()` kapseln.
+3. E-Mail-Versand blockiert synchron die API-Response (`await` vor Response in
+   `rest_sichtungen:181`, `api/sightings:220`); nodemailer + Open-Meteo-`fetch` ohne Timeout →
+   Response hängt bis zu Minuten bei SMTP-Ausfall. Fire-and-forget oder kurze explizite Timeouts.
+4. Kein globales Pino-`redact` — `sightingRepository.ts:70,78` loggt komplettes Objekt inkl. E-Mail
+   im Klartext. Zentrales `redact: { paths: [...], remove: true }` in `serverLogger.ts`.
+5. Kein `handleError`-Hook → unerwartete Fehler nicht strukturiert geloggt.
+6. Postgres ohne explizite Pool-/Timeout-Config (`db/index.ts:42`) → Connection-Exhaustion-Risiko
+   auf Serverless. `postgres(url, { max, idle_timeout, connect_timeout })`.
+7. Kein Graceful-Shutdown (SIGTERM) → abrupter Abbruch laufender Requests bei Deploy.
+8. OpenLayers statisch in die Startseite gebundelt (`LocationInput.svelte` → `OLMap`) → großes
+   Initial-Bundle. Lazy `import()`.
+
+### LOW
+
+- In-Memory-Rate-Limit nicht Multi-Instanz-fähig (siehe Security #3).
+- Kein Index auf `sightings.verified` trotz häufigem Filter.
+- `RUN_MIGRATIONS`/`drizzle-kit migrate` im Entrypoint läuft mangels Migrationsverzeichnis ins Leere.
+- `SKIP_DB_CHECK` nicht in `docs/ENVIRONMENT.md`.
+
+---
+
+## 4. Dependencies
+
+- **Produktion: 0 Vulnerabilities.** Alle Kern-Libs aktuell (Svelte 5.56, SvelteKit 2.70,
+  Drizzle 0.45, OpenLayers 10.9, jose 6.2, pino 10.3, nodemailer 9, handlebars 4.7.9, sanitize-html 2.17).
+- 13 Audit-Findings (5 high) ausschließlich in **Dev-Tooling**: `commitizen`
+  (lodash/tmp/inquirer), `drizzle-kit` (altes esbuild), `eslint-plugin-svelte` (yaml 1.x),
+  `@cyclonedx/cyclonedx-npm` (fast-uri), `vitest-openapi` (axios). Kein Runtime-Risiko.
+- Verfügbare Major-Updates (alle Dev, optional): commitlint 21, cyclonedx-npm 6,
+  prettier-plugin-svelte 4, vitest-browser-svelte 3, @types/node 26. Prod nur `html-to-text` 9→10.
+- Empfehlung: `npm audit fix` (non-breaking) für die Dev-Deps nach Launch; nicht launch-blockierend.
+
+---
+
+## 5. Doku-Abgleich (.claude) — bereits korrigiert
+
+Im Zuge dieses Reviews aktualisiert:
+
+- `svelte-forms-lib` → projekteigene `createForm`-Implementierung (`CLAUDE.md`, `architecture.md`,
+  `forms.md`, `agents/form-development.md`).
+- `security.md`: `isomorphic-dompurify` → `sanitize-html`; `rateLimit`-Pfad/API korrigiert;
+  CodeQL-Behauptung → tatsächlicher SARIF-Upload in `docker-publish.yml`.
+- `form-development.md`: `formState.ts` → `src/lib/report/formConfig.ts`.
+- `maps.md`: `dataLoader.ts` entfernt, reale Dateien ergänzt.
+- `architecture.md`: Strukturdiagramm auf reale Verzeichnisse aktualisiert; Beispiel-Importpfad.
+- `docker.md`: Dual-Adapter (Vercel/Node via `USE_NODE_ADAPTER` + `build:docker`).
+- `database.md`: `db:migrate`-Hinweis.
+
+Noch offen (Bonus, nicht in .claude): `src/lib/report/README.md` verweist auf `$lib/constants/…`
+statt `$lib/report/formOptions/…`.
+
+---
+
+## Empfohlene Launch-Reihenfolge
+
+**Blocker (vor Go-Live):** Security HIGH 1–3, UX HIGH 1–4, Produktion HIGH 1, Tailwind-4-Altlasten
+(`bg-opacity-*`, `*-focus`). **Kurz danach:** Security MEDIUM 4–9, Produktion MEDIUM 2–7,
+UX MEDIUM 5–8. **Backlog:** restliche MEDIUM/LOW + Dev-Dependency-Updates.

--- a/e2e/form-autosave.spec.ts
+++ b/e2e/form-autosave.spec.ts
@@ -81,9 +81,10 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Sichtungsdetails/i);
 
-		// Click reset button
+		// Click reset button — a confirm() dialog now guards the reset, accept it
 		const resetBtn = page.getByRole('button', { name: /zurücksetzen/i });
 		await expect(resetBtn).toBeVisible();
+		page.once('dialog', (dialog) => dialog.accept());
 		await resetBtn.click();
 
 		// After reset, should be back on Step 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1554,16 +1554,16 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -1743,6 +1743,28 @@
 				"@antfu/install-pkg": "^1.1.0",
 				"@iconify/types": "^2.0.0",
 				"mlly": "^1.8.0"
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+			"integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@isaacs/cliui": {
@@ -4678,9 +4700,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4804,9 +4826,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4885,9 +4907,9 @@
 			}
 		},
 		"node_modules/cacache/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -4962,9 +4984,9 @@
 			}
 		},
 		"node_modules/cachedir": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
-			"integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+			"integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5023,9 +5045,9 @@
 			}
 		},
 		"node_modules/chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+			"integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5177,13 +5199,13 @@
 			}
 		},
 		"node_modules/commitizen": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.1.tgz",
-			"integrity": "sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.2.tgz",
+			"integrity": "sha512-1Zs37z9JPvAcuTSSricZZwBhOPVNNxJouuY4yDEt+eD70EoxT2TU9kViG8CuB/PmVg2G4XsAGQiK4YCst97aDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cachedir": "2.3.0",
+				"cachedir": "2.4.0",
 				"cz-conventional-changelog": "3.3.0",
 				"dedent": "0.7.0",
 				"detect-indent": "6.1.0",
@@ -5191,10 +5213,10 @@
 				"find-root": "1.1.0",
 				"fs-extra": "9.1.0",
 				"glob": "7.2.3",
-				"inquirer": "8.2.5",
+				"inquirer": "8.2.7",
 				"is-utf8": "^0.2.1",
-				"lodash": "4.17.21",
-				"minimist": "1.2.7",
+				"lodash": "4.18.1",
+				"minimist": "1.2.8",
 				"strip-bom": "4.0.0",
 				"strip-json-comments": "3.1.1"
 			},
@@ -5204,7 +5226,7 @@
 				"git-cz": "bin/git-cz"
 			},
 			"engines": {
-				"node": ">= 12"
+				"node": ">= 18"
 			}
 		},
 		"node_modules/commitizen/node_modules/glob": {
@@ -5227,16 +5249,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/commitizen/node_modules/minimist": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/commondir": {
@@ -6853,16 +6865,16 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
@@ -7120,21 +7132,6 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7157,9 +7154,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -7629,16 +7626,16 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/glob/node_modules/minimatch": {
@@ -7962,16 +7959,20 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/ieee754": {
@@ -8083,17 +8084,17 @@
 			}
 		},
 		"node_modules/inquirer": {
-			"version": "8.2.5",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-			"integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+			"version": "8.2.7",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+			"integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@inquirer/external-editor": "^1.0.0",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.1.1",
 				"cli-cursor": "^3.1.0",
 				"cli-width": "^3.0.0",
-				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
 				"lodash": "^4.17.21",
 				"mute-stream": "0.0.8",
@@ -8103,10 +8104,25 @@
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0",
 				"through": "^2.3.6",
-				"wrap-ansi": "^7.0.0"
+				"wrap-ansi": "^6.0.1"
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/inquirer/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ip-address": {
@@ -9076,9 +9092,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10460,9 +10476,9 @@
 			}
 		},
 		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -12294,19 +12310,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
-			"engines": {
-				"node": ">=0.6.0"
 			}
 		},
 		"node_modules/to-regex-range": {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -36,7 +36,7 @@ declare module 'yup' {
 		step?: number;
 		selectPlaceholder?: string;
 		rows?: number;
-		description?: string;
+		autocomplete?: AutoFill;
 		icon?: string | IconSource;
 	}
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,19 +1,24 @@
 import { env } from '$env/dynamic/private';
 import { createLogger } from '$lib/logger.server';
 import { clearAuthCookie, setAuthCookie } from '$lib/server/auth/auth';
+import { closeDb } from '$lib/server/db';
 import { databaseCheck } from '$lib/server/middleware/databaseCheck';
 import { maintenanceMode } from '$lib/server/middleware/maintenanceMode';
 import { createSecurityHeadersHandler } from '$lib/server/middleware/securityHeaders';
 import type { User } from '$lib/types/index';
-import type { Handle } from '@sveltejs/kit';
+import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
-import { randomBytes } from 'crypto';
+import { randomUUID } from 'crypto';
 import { jwtVerify } from 'jose';
 
 // Dynamic environment variables for Docker runtime
 const COOKIE_NAME = env.COOKIE_NAME ?? 'auth-cookie';
 const NODE_ENV = env.NODE_ENV ?? 'development';
 const SESSION_SECRET = env.SESSION_SECRET ?? '';
+const ENCRYPTION_KEY = env.ENCRYPTION_KEY ?? '';
+
+// Platzhalter-Wert aus der Beispiel-Konfiguration (64x "0") — NIE in Produktion nutzen
+const PLACEHOLDER_ENCRYPTION_KEY = '0'.repeat(64);
 
 const logger = createLogger('hooks:server');
 
@@ -22,6 +27,20 @@ if (NODE_ENV === 'production' && !SESSION_SECRET) {
 	throw new Error(
 		'SESSION_SECRET environment variable is required in production. ' +
 			'Set it to a strong random secret before starting the server.'
+	);
+}
+
+// Guard: fail fast if ENCRYPTION_KEY is missing or still the default placeholder in production.
+// ENCRYPTION_KEY schützt den PKCE-Verifier im Auth-Flow (AES-256-GCM); ein Platzhalter
+// würde die Verschlüsselung wirkungslos machen.
+if (
+	NODE_ENV === 'production' &&
+	(!ENCRYPTION_KEY || ENCRYPTION_KEY === PLACEHOLDER_ENCRYPTION_KEY)
+) {
+	throw new Error(
+		'ENCRYPTION_KEY environment variable is required in production and must not be the ' +
+			'default placeholder value. Set it to a strong random 32-byte hex secret (64 hex chars) ' +
+			'before starting the server.'
 	);
 }
 
@@ -40,9 +59,10 @@ const authentication: Handle = async ({ event, resolve }) => {
 		// SvelteKit's CSRF protection can be bypassed by handling in the route itself
 	}
 
-	// Generate CSP nonce
-	const nonce = randomBytes(16).toString('base64');
-	event.locals.cspNonce = nonce;
+	// Hinweis: Es wird bewusst KEIN CSP-Nonce erzeugt. Das CSP in svelte.config.js
+	// nutzt 'unsafe-inline' (für die Scalar-API-Doku), daher hätte ein Nonce keine
+	// Schutzwirkung. Um keine falsche Sicherheit vorzutäuschen, wurde der frühere
+	// (nirgends verwendete) Nonce-Code entfernt.
 
 	// Authentication
 	const cookie = event.cookies.get(COOKIE_NAME);
@@ -84,3 +104,64 @@ export const handle: Handle = sequence(
 	authentication, // Third: Handle authentication
 	setAdditionalHeaders // Fourth: Set security headers
 );
+
+/**
+ * Zentraler Error-Hook für unerwartete (nicht abgefangene) Server-Fehler.
+ *
+ * Loggt den Fehler strukturiert über Pino (inkl. Stack, Pfad, Status und einer
+ * korrelierbaren errorId) und gibt dem Client nur eine generische Meldung zurück,
+ * damit keine internen Details (Stacktraces, DB-Fehler) nach außen gelangen.
+ */
+export const handleError: HandleServerError = ({ error, event, status, message }) => {
+	const errorId = randomUUID();
+
+	logger.error(
+		{
+			event: 'unhandled_error',
+			errorId,
+			status,
+			message,
+			pathname: event.url.pathname,
+			error: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined
+		},
+		'Unerwarteter Serverfehler'
+	);
+
+	return {
+		message: 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.',
+		errorId
+	};
+};
+
+/**
+ * Graceful Shutdown: schließt die DB-Verbindung sauber bei SIGTERM/SIGINT
+ * (z.B. `docker stop`). Idempotent — ein bereits laufender Shutdown wird nicht
+ * doppelt ausgeführt. Das Dockerfile nutzt `dumb-init`, daher kommen die Signale
+ * korrekt am Node-Prozess an.
+ */
+let shuttingDown = false;
+
+async function gracefulShutdown(signal: string): Promise<void> {
+	if (shuttingDown) return;
+	shuttingDown = true;
+
+	logger.info({ signal }, 'Graceful shutdown initiiert');
+
+	try {
+		await closeDb();
+		logger.info({ signal }, 'Datenbankverbindung geschlossen');
+	} catch (error) {
+		logger.error(
+			{ signal, error: error instanceof Error ? error.message : String(error) },
+			'Fehler beim Schließen der Datenbankverbindung'
+		);
+	} finally {
+		process.exit(0);
+	}
+}
+
+if (typeof process !== 'undefined' && NODE_ENV !== 'test') {
+	process.once('SIGTERM', () => void gracefulShutdown('SIGTERM'));
+	process.once('SIGINT', () => void gracefulShutdown('SIGINT'));
+}

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -59,7 +59,7 @@
 
 {#if isNotIFrame}
 	<!-- Fixed Navbar -->
-	<header class="bg-base-200 bg-opacity-95 sticky top-0 z-50 shadow-md backdrop-blur-lg">
+	<header class="bg-base-200/95 sticky top-0 z-50 shadow-md backdrop-blur-lg">
 		<div class="container mx-auto">
 			<div class="navbar">
 				<div class="navbar-start">

--- a/src/lib/components/admin/weather/WeatherDataDisplay.svelte
+++ b/src/lib/components/admin/weather/WeatherDataDisplay.svelte
@@ -4,6 +4,7 @@
 	import type { StoredWeatherData } from '$lib/services/weatherService';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
+	import { toast } from '$lib/stores/toastState.svelte';
 
 	interface Props {
 		weatherData: StoredWeatherData | null;
@@ -55,7 +56,7 @@
 
 	async function refreshWeatherData() {
 		if (!latitude || !longitude) {
-			alert('Keine GPS-Koordinaten für Wetter-Update verfügbar');
+			toast.warning('Keine GPS-Koordinaten für Wetter-Update verfügbar');
 			return;
 		}
 
@@ -76,10 +77,10 @@
 				}
 			} else {
 				const error = await response.json();
-				alert(`Fehler beim Aktualisieren der Wetterdaten: ${error.error}`);
+				toast.error(`Fehler beim Aktualisieren der Wetterdaten: ${error.error}`);
 			}
 		} catch (error) {
-			alert(`Netzwerkfehler: ${error}`);
+			toast.error(`Netzwerkfehler: ${error}`);
 		} finally {
 			isRefreshing = false;
 		}
@@ -135,7 +136,7 @@
 					</div>
 					{#if weatherData.location.elevation}
 						<div class="flex items-center gap-2">
-							<Icon icon="lucide:mountain" width="12" class="text-gray-600" />
+							<Icon icon="lucide:mountain" width="12" class="text-base-content/70" />
 							<span>{weatherData.location.elevation}m ü.NN</span>
 						</div>
 					{/if}
@@ -152,13 +153,13 @@
 			<div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
 				{#if weatherData.processed.humidity}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:cloud" width="14" class="text-blue-400" />
+						<Icon icon="lucide:cloud" width="14" class="text-info" />
 						<span>Luftfeuchtigkeit: {weatherData.processed.humidity}%</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.precipitation}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:cloud-rain" width="14" class="text-blue-500" />
+						<Icon icon="lucide:cloud-rain" width="14" class="text-info" />
 						<span>Niederschlag: {weatherData.raw_data.precipitation}mm</span>
 					</div>
 				{/if}
@@ -170,25 +171,25 @@
 				{/if}
 				{#if weatherData.raw_data.wave_height}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:waves" width="14" class="text-blue-600" />
+						<Icon icon="lucide:waves" width="14" class="text-info" />
 						<span>Wellenhöhe: {weatherData.raw_data.wave_height.toFixed(2)}m</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.wave_direction}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:wind" width="14" class="text-blue-600" />
+						<Icon icon="lucide:wind" width="14" class="text-info" />
 						<span>Wellenrichtung: {Math.round(weatherData.raw_data.wave_direction)}°</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.wave_period}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:gem" width="14" class="text-cyan-600" />
+						<Icon icon="lucide:gem" width="14" class="text-info" />
 						<span>Wellenperiode: {weatherData.raw_data.wave_period.toFixed(1)}s</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.sea_surface_temperature}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:thermometer" width="14" class="text-blue-500" />
+						<Icon icon="lucide:thermometer" width="14" class="text-info" />
 						<span>Wassertemp: {weatherData.raw_data.sea_surface_temperature}°C</span>
 					</div>
 				{/if}
@@ -203,7 +204,7 @@
 			</button>
 
 			{#if isExpanded}
-				<div class="expanded-weather-data bg-base-50 mt-3 rounded border p-3">
+				<div class="expanded-weather-data bg-base-200 mt-3 rounded border p-3">
 					<h6 class="text-base-content/70 mb-2 text-xs font-medium">QUALITÄTS- UND QUELLINFO</h6>
 					<div class="text-base-content/60 grid grid-cols-1 gap-2 text-xs md:grid-cols-2">
 						<div>Abgerufen: {formatLocalDateTime(weatherData.fetched_at, 'datetime')}</div>

--- a/src/lib/components/docs/ApiDocumentation.svelte
+++ b/src/lib/components/docs/ApiDocumentation.svelte
@@ -52,8 +52,8 @@
 <div class={containerClass}>
 	<!-- Header Section -->
 	<div class="mb-8 text-center">
-		<h1 class="mb-4 text-4xl font-bold text-gray-900">{title}</h1>
-		<p class="mx-auto max-w-3xl text-lg text-gray-600">
+		<h1 class="mb-4 text-4xl font-bold text-base-content">{title}</h1>
+		<p class="mx-auto max-w-3xl text-lg text-base-content/70">
 			{description}
 		</p>
 
@@ -81,35 +81,35 @@
 			<div class="grid gap-6 md:grid-cols-2">
 				<div>
 					<h3 class="mb-2 text-lg font-medium">Öffentliche Endpunkte</h3>
-					<p class="mb-3 text-sm text-gray-600">
+					<p class="mb-3 text-sm text-base-content/70">
 						Einige Endpunkte sind öffentlich verfügbar und benötigen keine Authentifizierung:
 					</p>
 					<ul class="space-y-1 text-sm">
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /api/sightings</code> - Öffentliche Sichtungen
+							• <code class="rounded bg-base-200 px-1">GET /api/sightings</code> - Öffentliche Sichtungen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">POST /api/sightings</code> - Neue Sichtung melden
+							• <code class="rounded bg-base-200 px-1">POST /api/sightings</code> - Neue Sichtung melden
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /api/geo/inBaltic</code> - Koordinaten prüfen
+							• <code class="rounded bg-base-200 px-1">GET /api/geo/inBaltic</code> - Koordinaten prüfen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">POST /api/files/upload</code> - Dateien hochladen
+							• <code class="rounded bg-base-200 px-1">POST /api/files/upload</code> - Dateien hochladen
 						</li>
 						<li>
-							• <code class="rounded bg-gray-100 px-1">GET /api/media/{'{path}'}</code> - Sichere Medien
+							• <code class="rounded bg-base-200 px-1">GET /api/media/{'{path}'}</code> - Sichere Medien
 							abrufen
 						</li>
 					</ul>
 				</div>
 				<div>
 					<h3 id="authentication" class="mb-2 text-lg font-medium">🔐 Admin-Authentifizierung</h3>
-					<p class="mb-3 text-sm text-gray-600">
+					<p class="mb-3 text-sm text-base-content/70">
 						Für Admin-Funktionen ist eine Anmeldung erforderlich:
 					</p>
 					<ol class="space-y-1 text-sm">
-						<li>1. <code class="rounded bg-gray-100 px-1">GET /api/auth/login</code> aufrufen</li>
+						<li>1. <code class="rounded bg-base-200 px-1">GET /api/auth/login</code> aufrufen</li>
 						<li>2. Auth0-Login-Flow durchlaufen</li>
 						<li>3. Session-Cookie wird automatisch gesetzt</li>
 						<li>4. Admin-Endpunkte sind nun verfügbar</li>
@@ -121,7 +121,7 @@
 
 	<!-- API Reference Container -->
 	{#if isLoading}
-		<div class="py-8 text-center text-gray-500">
+		<div class="py-8 text-center text-base-content/60">
 			<div class="loading loading-spinner loading-lg"></div>
 			<p class="mt-4">API-Dokumentation wird geladen...</p>
 			<p class="mt-2 text-sm">
@@ -165,7 +165,7 @@
 
 		<!-- Fallback notice -->
 		<div class="mt-4 text-center">
-			<p class="text-sm text-gray-500">
+			<p class="text-sm text-base-content/60">
 				Falls die interaktive Dokumentation nicht funktioniert, nutzen Sie die
 				<a href="/docs/api/fallback" class="link link-primary">Fallback-Dokumentation</a>
 				oder laden Sie die

--- a/src/lib/components/map/LazyMapWrapper.svelte
+++ b/src/lib/components/map/LazyMapWrapper.svelte
@@ -9,7 +9,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-black text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;

--- a/src/lib/components/map/OLMap.svelte
+++ b/src/lib/components/map/OLMap.svelte
@@ -118,7 +118,17 @@
 	});
 </script>
 
-<div bind:this={mapElement} class="ol-map-container z-10 h-full w-full overflow-hidden"></div>
+<!-- Karte ist ein interaktives Application-Widget (OpenLayers-Tastatursteuerung); tabindex bewusst gesetzt -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+	bind:this={mapElement}
+	class="ol-map-container z-10 h-full w-full overflow-hidden"
+	role="application"
+	aria-label={readonly
+		? 'Interaktive Karte der Sichtungen'
+		: 'Interaktive Karte zur Positionsauswahl. Pfeiltasten zum Verschieben, Plus/Minus zum Zoomen.'}
+	tabindex="0"
+></div>
 
 {#if !readonly}
 	<div class="alert mt-2 mb-0">

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -124,7 +124,7 @@
 									{symbol.symbol}
 								</span>
 							{:else}
-								<div class="h-4 w-4 rounded-full bg-gray-400"></div>
+								<div class="h-4 w-4 rounded-full bg-base-content/40"></div>
 							{/if}
 						</div>
 

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -20,7 +20,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-black text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;
@@ -323,12 +323,12 @@
 		></div>
 		<div
 			id="info"
-			class="pointer-events-none absolute z-10 hidden max-w-sm rounded border border-gray-300 bg-white p-2 shadow-lg"
+			class="border-base-300 bg-base-100 pointer-events-none absolute z-10 hidden max-w-sm rounded border p-2 shadow-lg"
 		></div>
 		<!-- Bestehender Load-Overlay -->
 		<div
 			id="overlay-load"
-			class="bg-opacity-70 absolute top-0 left-0 z-20 flex hidden h-full w-full items-center justify-center bg-white"
+			class="bg-base-100/70 absolute top-0 left-0 z-20 flex hidden h-full w-full items-center justify-center"
 		>
 			<div class="loading loading-lg loading-spinner"></div>
 		</div>
@@ -406,7 +406,7 @@
 	<!-- Tastatur-Hilfe Button -->
 	<button
 		onclick={() => (showKeyboardHelp = true)}
-		class="bg-info text-info-content hover:bg-info-focus fixed bottom-4 left-4 z-30 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full shadow-lg transition-colors duration-300"
+		class="bg-info text-info-content hover:bg-info/80 fixed bottom-4 left-4 z-30 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full shadow-lg transition-colors duration-300"
 		aria-label="Tastatur-Hilfe anzeigen"
 		title="Tastaturkürzel anzeigen (H oder ?)"
 	>

--- a/src/lib/components/media/MediaGallery.svelte
+++ b/src/lib/components/media/MediaGallery.svelte
@@ -111,7 +111,7 @@
 								</p>
 							</div>
 							<a
-								href={`/uploads/${file.filePath}`}
+								href={`/api/media/${file.filePath}`}
 								download={file.originalName}
 								class="btn btn-ghost btn-sm"
 								aria-label="Datei herunterladen"

--- a/src/lib/components/ui/Dialog/DeleteDialog.svelte
+++ b/src/lib/components/ui/Dialog/DeleteDialog.svelte
@@ -1,33 +1,67 @@
 <script lang="ts">
-	let { show = $bindable(false), onConfirm, onCancel } = $props<{
+	let {
+		show = $bindable(false),
+		onConfirm,
+		onCancel
+	} = $props<{
 		show?: boolean;
 		onConfirm?: () => void;
 		onCancel?: () => void;
 	}>();
 
+	let dialogElement = $state<HTMLDialogElement | null>(null);
+	let confirmed = false;
+
+	// Native <dialog> mit showModal()/close() für Fokus-Trap und ESC-Handling
+	$effect(() => {
+		if (!dialogElement) return;
+		if (show && !dialogElement.open) {
+			confirmed = false;
+			dialogElement.showModal();
+		} else if (!show && dialogElement.open) {
+			dialogElement.close();
+		}
+	});
+
 	function confirm() {
+		confirmed = true;
 		onConfirm?.();
 		show = false;
 	}
 
 	function cancel() {
-		onCancel?.();
+		show = false;
+	}
+
+	// Wird bei ESC, Backdrop-Klick und close() ausgelöst
+	function handleClose() {
+		if (!confirmed) {
+			onCancel?.();
+		}
 		show = false;
 	}
 </script>
 
-{#if show}
-	<div class="bg-opacity-50 fixed inset-0 z-50 flex items-center justify-center bg-black">
-		<div class="bg-base-100 w-96 rounded-lg p-6">
-			<h3 class="mb-4 text-lg font-bold">Sichtung löschen</h3>
-			<p class="mb-4">
-				Sind Sie sicher, dass Sie diese Sichtung löschen möchten? Diese Aktion kann nicht rückgängig
-				gemacht werden.
-			</p>
-			<div class="flex justify-end gap-2">
-				<button class="btn" onclick={cancel}>Abbrechen</button>
-				<button class="btn btn-error" onclick={confirm}>Löschen</button>
-			</div>
+<dialog
+	bind:this={dialogElement}
+	class="modal"
+	aria-labelledby="delete-dialog-title"
+	onclose={handleClose}
+>
+	<div class="modal-box w-96">
+		<h3 id="delete-dialog-title" class="mb-4 text-lg font-bold">Sichtung löschen</h3>
+		<p class="mb-4">
+			Sind Sie sicher, dass Sie diese Sichtung löschen möchten? Diese Aktion kann nicht rückgängig
+			gemacht werden.
+		</p>
+		<div class="modal-action">
+			<button class="btn" onclick={cancel}>Abbrechen</button>
+			<button class="btn btn-error" onclick={confirm}>Löschen</button>
 		</div>
 	</div>
-{/if}
+	<form method="dialog" class="modal-backdrop bg-black/50">
+		<button aria-label="Dialog schließen" onclick={cancel}>
+			<span class="sr-only">Dialog schließen</span>
+		</button>
+	</form>
+</dialog>

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -240,7 +240,7 @@ export const sightingSchemaBase = yup.object().shape({
 			type: 'number',
 			placeholder: 'z.B. 13.456789',
 			helpText: 'Östliche Position (E) - je mehr Nachkommastellen, desto genauer',
-			valueText: 'Ihre GPS-Koordinaten werden mit 2.847 anderen Sichtungen verglichen',
+			valueText: 'Ihre GPS-Koordinaten werden mit anderen Sichtungen verglichen',
 			icon: Navigation2
 		})
 		.default(13.5),
@@ -382,7 +382,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.label('Davon Jungtiere')
 		.meta({
 			placeholder: '0',
-			helpText: 'Waren Junge Tiere dabei? Bitte geben Sie die Anzahl ein.',
+			helpText: 'Waren junge Tiere dabei? Bitte geben Sie die Anzahl ein.',
 			valueText: 'Nachwuchsrate zeigt Gesundheit der Population',
 			icon: Baby
 		})
@@ -397,7 +397,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.boolean()
 		.label('Handelt es sich um einen Totfund?')
 		.meta({
-			helpText: 'Handeltete es sich um Lebende Tiere oder einen Totfund?',
+			helpText: 'Handelte es sich um lebende Tiere oder einen Totfund?',
 			valueText: 'Totfunde liefern wichtige Informationen über Todesursachen',
 			icon: Skull
 		})
@@ -955,6 +955,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'Max',
 			helpText: 'Wie dürfen wir Sie ansprechen?',
 			valueText: 'Für die persönliche Kontaktaufnahme',
+			autocomplete: 'given-name',
 			icon: User
 		}),
 
@@ -971,6 +972,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'Mustermann',
 			helpText: 'Ihr Familienname',
 			valueText: 'Zur eindeutigen Zuordnung der Meldung',
+			autocomplete: 'family-name',
 			icon: User
 		}),
 
@@ -989,6 +991,7 @@ export const sightingSchemaBase = yup.object().shape({
 			helpText: 'Wie können wir Sie erreichen?',
 			valueText: 'Für Rückfragen und zur Bestätigung der Sichtung',
 			type: 'email',
+			autocomplete: 'email',
 			icon: Mail
 		}),
 
@@ -1005,6 +1008,7 @@ export const sightingSchemaBase = yup.object().shape({
 			helpText: 'Falls wir Sie anrufen dürfen (optional)',
 			valueText: 'Für schnelle Klärung bei unklaren Angaben',
 			type: 'tel',
+			autocomplete: 'tel',
 			icon: Phone
 		})
 		.notRequired(),
@@ -1021,6 +1025,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'Musterstraße 123',
 			helpText: 'Ihre Adresse (optional)',
 			valueText: 'Ermöglicht lokale Zuordnung der Beobachter',
+			autocomplete: 'street-address',
 			icon: AddressIcon
 		})
 		.notRequired(),
@@ -1037,6 +1042,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: '12345',
 			helpText: 'Ihre PLZ (optional)',
 			valueText: 'Geografische Zuordnung der Beobachter',
+			autocomplete: 'postal-code',
 			icon: Hash
 		})
 		.notRequired(),
@@ -1053,6 +1059,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'Musterstadt',
 			helpText: 'Ihr Wohnort (optional)',
 			valueText: 'Regionale Verteilung der Beobachter',
+			autocomplete: 'address-level2',
 			icon: MapPin
 		})
 		.notRequired(),

--- a/src/lib/logger/serverLogger.ts
+++ b/src/lib/logger/serverLogger.ts
@@ -13,6 +13,24 @@ function resolveLogLevel(value: string | undefined): pino.Level {
 export const createServerLogger = (context: string) => {
 	return pino({
 		level: resolveLogLevel(env.LOG_LEVEL),
-		base: { pid: process.pid, context }
+		base: { pid: process.pid, context },
+		// Globale Redaction: personenbezogene/geheime Felder werden aus allen Logs
+		// entfernt (Defense-in-Depth gegen versehentliches Loggen von PII/Secrets).
+		// `*.email` deckt eine Verschachtelungsebene ab (z.B. { data: { email } }).
+		redact: {
+			paths: [
+				'email',
+				'*.email',
+				'phone',
+				'*.phone',
+				'telefon',
+				'*.telefon',
+				'password',
+				'*.password',
+				'*.token',
+				'token'
+			],
+			remove: true
+		}
 	});
 };

--- a/src/lib/logger/serverLogger.ts
+++ b/src/lib/logger/serverLogger.ts
@@ -16,7 +16,10 @@ export const createServerLogger = (context: string) => {
 		base: { pid: process.pid, context },
 		// Globale Redaction: personenbezogene/geheime Felder werden aus allen Logs
 		// entfernt (Defense-in-Depth gegen versehentliches Loggen von PII/Secrets).
-		// `*.email` deckt eine Verschachtelungsebene ab (z.B. { data: { email } }).
+		// `*.<feld>` deckt jeweils eine Verschachtelungsebene ab (z.B. { data: { email } }).
+		// Die PII-Felder (name, vorname, strasse, plz, ort, ...) stammen aus der
+		// Legacy-API-Spezifikation (docs/LEGACY_API_SPECIFICATION.md) und dürfen niemals
+		// in Logs erscheinen.
 		redact: {
 			paths: [
 				'email',
@@ -27,8 +30,26 @@ export const createServerLogger = (context: string) => {
 				'*.telefon',
 				'password',
 				'*.password',
+				'token',
 				'*.token',
-				'token'
+				// Personenbezogene Namensfelder (Legacy-API + moderne Form)
+				'name',
+				'*.name',
+				'vorname',
+				'*.vorname',
+				'firstName',
+				'*.firstName',
+				'lastName',
+				'*.lastName',
+				// Anschrift
+				'strasse',
+				'*.strasse',
+				'plz',
+				'*.plz',
+				'ort',
+				'*.ort',
+				'address',
+				'*.address'
 			],
 			remove: true
 		}

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import type { SightingFormValues } from '$lib/types/Form';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
@@ -75,7 +76,8 @@
 							<div>
 								<h3 class="font-semibold">Medien-Upload</h3>
 								<p class="text-base-content/70 text-sm">
-									Sie erhalten Anweisungen zum Upload Ihrer Fotos/Videos per E-Mail
+									Ihre hochgeladenen Fotos und Videos wurden übermittelt und werden gemeinsam mit
+									Ihrer Sichtung geprüft
 								</p>
 							</div>
 						</div>
@@ -118,20 +120,14 @@
 							{submittedData.referenceId}
 						</div>
 						<span class="text-base-content/70 text-xs">
-							(Bitte gehen Sie die ID bei Rückfragen an unser Team an. Die ID hilft bei der
+							(Bitte geben Sie die ID bei Rückfragen an unser Team an. Die ID hilft bei der
 							Zuordnung Ihrer Sichtung)
 						</span>
 					</div>
 					<div class="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
 						<div>
 							<span class="font-medium">Tierart:</span>
-							{submittedData.species === 0
-								? 'Schweinswal'
-								: submittedData.species === 1
-									? 'Kegelrobbe'
-									: submittedData.species === 2
-										? 'Seehund'
-										: 'Andere Art'}
+							{getSpeciesLabel(submittedData.species)}
 						</div>
 						<div>
 							<span class="font-medium">Anzahl:</span>

--- a/src/lib/report/components/form/FormActions.svelte
+++ b/src/lib/report/components/form/FormActions.svelte
@@ -23,6 +23,16 @@
 		hasSavedContactData = !!(savedData.firstName || savedData.lastName || savedData.email);
 	});
 
+	function handleReset() {
+		if (
+			confirm(
+				'Möchten Sie das Formular wirklich zurücksetzen? Alle bisher eingegebenen Daten gehen verloren.'
+			)
+		) {
+			onReset();
+		}
+	}
+
 	function clearContactData() {
 		if (
 			confirm(
@@ -51,7 +61,7 @@
 			<button
 				type="button"
 				class="btn btn-outline btn-sm w-full sm:w-auto"
-				onclick={onReset}
+				onclick={handleReset}
 				disabled={$isSubmitting}
 			>
 				Formular zurücksetzen

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -43,7 +43,8 @@
 				<button
 					type="button"
 					class="step-button px-1 text-xs sm:text-sm"
-					disabled={!navigable}
+					class:cursor-not-allowed={!navigable}
+					aria-disabled={!navigable ? 'true' : 'false'}
 					aria-label={step.title}
 					aria-current={currentStep === index ? 'step' : undefined}
 					title={navigable

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -39,12 +39,13 @@
 			<li
 				class="step {currentStep >= index ? 'step-primary' : ''}"
 				class:opacity-50={!navigable && index > currentStep}
-				aria-current={currentStep === index ? 'step' : undefined}
 			>
 				<button
 					type="button"
 					class="step-button px-1 text-xs sm:text-sm"
 					disabled={!navigable}
+					aria-label={step.title}
+					aria-current={currentStep === index ? 'step' : undefined}
 					title={navigable
 						? step.description
 						: 'Bitte füllen Sie zuerst die vorherigen Schritte aus'}

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -28,34 +28,31 @@
 
 <!--
   DaisyUI steps component styles the <li> directly via .step class.
-  We can't nest a <button> inside without breaking the grid layout.
-  Using role="navigation" + aria-label on the wrapper, and keeping
-  the <li> interactive via tabindex/onclick with aria-current="step"
-  for the active step indicator (WAI stepper pattern).
+  The step title is rendered as visible <li> content (shown below the
+  circle). Navigation is a real <button> for proper keyboard/AT support;
+  aria-current marks the active step (WAI stepper pattern).
 -->
 <nav class="mb-8" aria-label="Formular-Schritte">
-	<ul class="steps steps-horizontal w-full" role="tablist">
+	<ul class="steps steps-horizontal w-full">
 		{#each steps as step, index (step.id)}
 			{@const navigable = canNavigateTo(index)}
 			<li
-				role="tab"
-				class="step step-button {currentStep >= index ? 'step-primary' : ''}"
-				class:cursor-pointer={navigable}
-				class:cursor-not-allowed={!navigable}
+				class="step {currentStep >= index ? 'step-primary' : ''}"
 				class:opacity-50={!navigable && index > currentStep}
-				tabindex={navigable ? 0 : -1}
-				aria-disabled={!navigable}
 				aria-current={currentStep === index ? 'step' : undefined}
-				aria-label={step.title}
-				title={navigable ? step.description : 'Bitte füllen Sie zuerst die vorherigen Schritte aus'}
-				onclick={() => handleStepClick(index)}
-				onkeydown={(e) => {
-					if (e.key === 'Enter' || e.key === ' ') {
-						e.preventDefault();
-						handleStepClick(index);
-					}
-				}}
-			></li>
+			>
+				<button
+					type="button"
+					class="step-button px-1 text-xs sm:text-sm"
+					disabled={!navigable}
+					title={navigable
+						? step.description
+						: 'Bitte füllen Sie zuerst die vorherigen Schritte aus'}
+					onclick={() => handleStepClick(index)}
+				>
+					{step.title}
+				</button>
+			</li>
 		{/each}
 	</ul>
 </nav>

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -5,8 +5,8 @@
 
 	let {
 		mode = 'dd',
-		latitude = $bindable(13.5),
-		longitude = $bindable(54.5),
+		latitude = $bindable(54.5),
+		longitude = $bindable(13.5),
 		onchange = () => {}
 	} = $props<{
 		mode?: 'dms' | 'dm' | 'dd';
@@ -100,6 +100,7 @@
 						min="0"
 						max="59"
 						placeholder="Min"
+						aria-label="Breite Minuten"
 						bind:value={dms.latitude.min}
 						onchange={updateFromFields}
 					/>
@@ -109,6 +110,7 @@
 						min="0"
 						max="59"
 						placeholder="Sek"
+						aria-label="Breite Sekunden"
 						bind:value={dms.latitude.sec}
 						onchange={updateFromFields}
 					/>
@@ -135,6 +137,7 @@
 						min="0"
 						max="59"
 						placeholder="Min"
+						aria-label="Länge Minuten"
 						bind:value={dms.longitude.min}
 						onchange={updateFromFields}
 					/>
@@ -144,6 +147,7 @@
 						min="0"
 						max="59"
 						placeholder="Sek"
+						aria-label="Länge Sekunden"
 						bind:value={dms.longitude.sec}
 						onchange={updateFromFields}
 					/>
@@ -174,6 +178,7 @@
 						max="59.9999"
 						step="0.01"
 						placeholder="Dezimalmin"
+						aria-label="Breite Dezimalminuten"
 						bind:value={dm.latitude.min}
 						onchange={updateFromFields}
 					/>
@@ -201,6 +206,7 @@
 						max="59.9999"
 						step="0.01"
 						placeholder="Dezimalmin"
+						aria-label="Länge Dezimalminuten"
 						bind:value={dm.longitude.min}
 						onchange={updateFromFields}
 					/>
@@ -210,7 +216,7 @@
 	{:else}
 		<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 			<div>
-				<label class="label" for="dd-latitude">Breite (N)</label>
+				<label class="label" for="latitude">Breite (N)</label>
 				<input
 					id="latitude"
 					class="input w-full"

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -29,10 +29,17 @@
 
 	const canGoNext = $derived(stepValidation.isValid);
 
+	// Inline-Warnung erst nach erstem "Weiter"-Versuch auf einem ungültigen Schritt zeigen.
+	// Speichert den Schritt-Index des letzten Versuchs; bei Schrittwechsel greift die Warnung
+	// nicht mehr (unberührter Schritt = keine Warnung).
+	let attemptedStep = $state<number | null>(null);
+
 	// Step error messages for inline display (only when step is invalid)
 	const stepErrorMessages = $derived(
 		canGoNext ? [] : (Object.values(stepValidation.errors).filter(Boolean) as string[])
 	);
+
+	const showInlineError = $derived(attemptedStep === currentStep && stepErrorMessages.length > 0);
 
 	const isLastStep = $derived(currentStep >= totalSteps - 1);
 	const isFirstStep = $derived(currentStep <= 0);
@@ -55,6 +62,7 @@
 		try {
 			if (!canGoNext) {
 				logger.warn({ currentStep }, 'Validation failed for current step');
+				attemptedStep = currentStep;
 				await showValidationError();
 				return;
 			}
@@ -141,8 +149,8 @@
 	}
 </script>
 
-<!-- Inline validation error above navigation -->
-{#if stepErrorMessages.length > 0}
+<!-- Inline validation error above navigation (erst nach erstem Versuch) -->
+{#if showInlineError}
 	<div class="alert alert-warning mb-2" role="alert">
 		<span>{stepErrorMessages[0]}</span>
 	</div>
@@ -166,7 +174,7 @@
 	<button
 		type="button"
 		onclick={nextStep}
-		disabled={!canGoNext || $isSubmitting}
+		disabled={$isSubmitting}
 		class="btn btn-primary"
 		aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
 	>

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -29,17 +29,10 @@
 
 	const canGoNext = $derived(stepValidation.isValid);
 
-	// Inline-Warnung erst nach erstem "Weiter"-Versuch auf einem ungültigen Schritt zeigen.
-	// Speichert den Schritt-Index des letzten Versuchs; bei Schrittwechsel greift die Warnung
-	// nicht mehr (unberührter Schritt = keine Warnung).
-	let attemptedStep = $state<number | null>(null);
-
 	// Step error messages for inline display (only when step is invalid)
 	const stepErrorMessages = $derived(
 		canGoNext ? [] : (Object.values(stepValidation.errors).filter(Boolean) as string[])
 	);
-
-	const showInlineError = $derived(attemptedStep === currentStep && stepErrorMessages.length > 0);
 
 	const isLastStep = $derived(currentStep >= totalSteps - 1);
 	const isFirstStep = $derived(currentStep <= 0);
@@ -62,7 +55,6 @@
 		try {
 			if (!canGoNext) {
 				logger.warn({ currentStep }, 'Validation failed for current step');
-				attemptedStep = currentStep;
 				await showValidationError();
 				return;
 			}
@@ -149,8 +141,8 @@
 	}
 </script>
 
-<!-- Inline validation error above navigation (erst nach erstem Versuch) -->
-{#if showInlineError}
+<!-- Inline validation error above navigation -->
+{#if stepErrorMessages.length > 0}
 	<div class="alert alert-warning mb-2" role="alert">
 		<span>{stepErrorMessages[0]}</span>
 	</div>
@@ -174,7 +166,7 @@
 	<button
 		type="button"
 		onclick={nextStep}
-		disabled={$isSubmitting}
+		disabled={!canGoNext || $isSubmitting}
 		class="btn btn-primary"
 		aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
 	>

--- a/src/lib/report/components/form/fields/BaseCheckbox.svelte
+++ b/src/lib/report/components/form/fields/BaseCheckbox.svelte
@@ -11,6 +11,7 @@
 		label?: string;
 		size?: FieldSize;
 		icon?: string;
+		valueText?: string;
 		onchange?: (event: Event) => void;
 		// Common input attributes
 		id?: string;
@@ -29,6 +30,7 @@
 		label = '',
 		size = 'md',
 		icon = undefined,
+		valueText = undefined,
 		onchange = undefined,
 		id,
 		name,
@@ -49,7 +51,7 @@
 	});
 </script>
 
-<div class="w-full items-start">
+<div class="flex w-full items-start justify-between gap-2">
 	<label class="flex w-full cursor-pointer justify-start gap-3 py-2">
 		{#if icon !== undefined}
 			<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
@@ -74,6 +76,22 @@
 			style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
 		>
 			{label}
+			{#if required}
+				<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
+			{/if}
 		</span>
 	</label>
+
+	<!-- Value Information Tooltip (fokussierbar für Tastatur/Touch), außerhalb des Labels -->
+	{#if valueText}
+		<span class="tooltip tooltip-left flex-shrink-0" data-tip={valueText}>
+			<button
+				type="button"
+				class="btn btn-ghost btn-xs btn-circle"
+				aria-label={`Hinweis: ${valueText}`}
+			>
+				<Icon icon="lucide:info" width="14" class="text-base-content/60" />
+			</button>
+		</span>
+	{/if}
 </div>

--- a/src/lib/report/components/form/fields/BaseToggle.svelte
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte
@@ -11,6 +11,7 @@
 		label?: string;
 		size?: FieldSize;
 		icon?: string;
+		valueText?: string;
 		onchange?: (event: Event) => void;
 		// Common input attributes
 		id?: string;
@@ -29,6 +30,7 @@
 		label = '',
 		size = 'md',
 		icon = undefined,
+		valueText = undefined,
 		onchange = undefined,
 		id,
 		name,
@@ -49,7 +51,7 @@
 	});
 </script>
 
-<div class="w-full items-start">
+<div class="flex w-full items-start justify-between gap-2">
 	<label class="flex w-full cursor-pointer justify-start gap-3 py-2">
 		{#if icon !== undefined}
 			<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
@@ -74,6 +76,22 @@
 			style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
 		>
 			{label}
+			{#if required}
+				<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
+			{/if}
 		</span>
 	</label>
+
+	<!-- Value Information Tooltip (fokussierbar für Tastatur/Touch), außerhalb des Labels -->
+	{#if valueText}
+		<span class="tooltip tooltip-left flex-shrink-0" data-tip={valueText}>
+			<button
+				type="button"
+				class="btn btn-ghost btn-xs btn-circle"
+				aria-label={`Hinweis: ${valueText}`}
+			>
+				<Icon icon="lucide:info" width="14" class="text-base-content/60" />
+			</button>
+		</span>
+	{/if}
 </div>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -111,7 +111,8 @@
 			rows: meta.rows,
 			placeholder: meta.placeholder,
 			selectPlaceholder: meta.selectPlaceholder,
-			description: meta.description
+			description: meta.description,
+			autocomplete: meta.autocomplete
 		};
 	});
 	let hasOptions = $derived(metaValues.options && metaValues.options.length > 0);
@@ -130,6 +131,11 @@
 				? 'toggle'
 				: metaValues.type
 	);
+
+	// Gruppenfelder: Radio hat mehrere Inputs (kein einzelnes label-Ziel) → fieldset/legend.
+	// Checkbox/Toggle rendern ihr eigenes <label> mit dem Control → kein doppeltes Caption-Label.
+	let isRadioGroup = $derived(normalizedType === 'radio' && hasOptions);
+	let isSingleControl = $derived(normalizedType === 'checkbox' || normalizedType === 'toggle');
 
 	// Dynamic CSS classes
 	let containerClasses = $derived.by(() => {
@@ -175,16 +181,10 @@
 		const props = {
 			...commonFieldProps,
 			type: normalizedType as
-				| 'text'
-				| 'email'
-				| 'tel'
-				| 'number'
-				| 'url'
-				| 'password'
-				| 'date'
-				| 'time',
+				'text' | 'email' | 'tel' | 'number' | 'url' | 'password' | 'date' | 'time',
 			placeholder: metaValues.placeholder || '',
-			options: metaValues.options ?? []
+			options: metaValues.options ?? [],
+			...(metaValues.autocomplete && { autocomplete: metaValues.autocomplete })
 		};
 		return props;
 	});
@@ -232,53 +232,54 @@
 	});
 </script>
 
-<div class={containerClasses}>
-	<!-- Enhanced Label with Status Indicators -->
-	<label for={fieldId} class="label w-full overflow-hidden pb-1">
-		<span
-			class="text-base-content block font-medium"
-			style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
-		>
-			{label}
-			{#if required}
-				<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
-			{/if}
+<!-- Caption-Inhalt (Label-Text, Pflichtfeld-Markierung, Status, Info-Tooltip) -->
+{#snippet caption()}
+	<span
+		class="text-base-content block font-medium"
+		style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
+	>
+		{label}
+		{#if required}
+			<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
+		{/if}
 
-			<!-- Status Indicator -->
-			{#if hasValue}
-				<span class="ml-2 inline-block" aria-hidden="true">
-					{#if hasError}
-						<Icon icon="lucide:x" width="14" class="text-error inline" />
-					{:else if isValid}
-						<Icon icon="lucide:check" width="14" class="text-success inline" />
-					{/if}
-				</span>
-			{/if}
+		<!-- Status Indicator -->
+		{#if hasValue}
+			<span class="ml-2 inline-block" aria-hidden="true">
+				{#if hasError}
+					<Icon icon="lucide:x" width="14" class="text-error inline" />
+				{:else if isValid}
+					<Icon icon="lucide:check" width="14" class="text-success inline" />
+				{/if}
+			</span>
+		{/if}
 
-			<!-- Value Information Tooltip -->
-			{#if metaValues.valueText}
-				<span class="tooltip tooltip-left ml-2 inline-block" data-tip={metaValues.valueText}>
-					<button
-						type="button"
-						class="btn btn-ghost btn-xs btn-circle"
-						aria-label="Warum ist diese Information wichtig?"
-						tabindex="-1"
-					>
-						<Icon icon="lucide:info" width="14" class="text-base-content/60" />
-					</button>
-				</span>
-			{/if}
-		</span>
-	</label>
+		<!-- Value Information Tooltip (fokussierbar für Tastatur/Touch) -->
+		{#if metaValues.valueText}
+			<span class="tooltip tooltip-left ml-2 inline-block" data-tip={metaValues.valueText}>
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-circle"
+					aria-label={`Hinweis: ${metaValues.valueText}`}
+				>
+					<Icon icon="lucide:info" width="14" class="text-base-content/60" />
+				</button>
+			</span>
+		{/if}
+	</span>
+{/snippet}
 
-	<!-- Field Description (if different from help text) -->
+<!-- Field-Description (falls abweichend vom Hilfetext) -->
+{#snippet description()}
 	{#if metaValues.description && metaValues.description !== metaValues.helpText}
 		<div id={descriptionId} class="text-base-content/70 mb-2 text-left text-sm">
 			{metaValues.description}
 		</div>
 	{/if}
+{/snippet}
 
-	<!-- Field Components -->
+<!-- Field-Component-Auswahl -->
+{#snippet fieldControl()}
 	{#if ['text', 'email', 'tel', 'number', 'url', 'password', 'date', 'time'].includes(normalizedType)}
 		<BaseInput {...inputProps} bind:value={numberValue} onchange={handleNumberChange} />
 	{:else if normalizedType === 'textarea'}
@@ -291,6 +292,25 @@
 		<BaseCheckbox {...checkboxProps} bind:checked={booleanValue} onchange={handleBooleanChange} />
 	{:else if normalizedType === 'toggle'}
 		<BaseToggle {...toggleProps} bind:checked={booleanValue} onchange={handleBooleanChange} />
+	{/if}
+{/snippet}
+
+<div class={containerClasses}>
+	{#if isRadioGroup}
+		<!-- Radiogruppe: fieldset+legend statt label[for], das ins Leere zeigen würde -->
+		<fieldset class="w-full">
+			<legend class="label w-full overflow-hidden pb-1">{@render caption()}</legend>
+			{@render description()}
+			{@render fieldControl()}
+		</fieldset>
+	{:else if isSingleControl}
+		<!-- Checkbox/Toggle rendern eigenes Label mit dem Control → kein doppeltes Caption-Label -->
+		{@render description()}
+		{@render fieldControl()}
+	{:else}
+		<label for={fieldId} class="label w-full overflow-hidden pb-1">{@render caption()}</label>
+		{@render description()}
+		{@render fieldControl()}
 	{/if}
 
 	<!-- Help Text -->

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -218,7 +218,8 @@
 	let checkboxProps = $derived.by(() => {
 		const props = {
 			...commonFieldProps,
-			label: label || ''
+			label: label || '',
+			...(metaValues.valueText && { valueText: metaValues.valueText })
 		};
 		return props;
 	});
@@ -226,7 +227,8 @@
 	let toggleProps = $derived.by(() => {
 		const props = {
 			...commonFieldProps,
-			label: label || ''
+			label: label || '',
+			...(metaValues.valueText && { valueText: metaValues.valueText })
 		};
 		return props;
 	});

--- a/src/lib/report/components/steps/Step3Observations.svelte
+++ b/src/lib/report/components/steps/Step3Observations.svelte
@@ -24,6 +24,14 @@
 		try {
 			currentStep += 1;
 			scrollToElement(document.getElementById('form-content'));
+			// Fokus auf den Header des neuen Schritts setzen (Screenreader-Ansage), analog StepNavigation
+			requestAnimationFrame(() => {
+				const stepHeader = document.querySelector('#form-content h2');
+				if (stepHeader instanceof HTMLElement) {
+					stepHeader.setAttribute('tabindex', '-1');
+					stepHeader.focus({ preventScroll: true });
+				}
+			});
 			logger.info('Step 3 skipped by user');
 		} catch (error) {
 			logger.error({ error }, 'Error skipping step 3');

--- a/src/lib/server/auth/auth.test.ts
+++ b/src/lib/server/auth/auth.test.ts
@@ -322,12 +322,13 @@ describe('auth.ts', () => {
 			await setAuthCookie(mockCookies, testUser);
 
 			expect(SignJWT).toHaveBeenCalledWith({ ...testUser });
+			// Session-Cookie muss SameSite=None; Secure sein (iframe-Einbettung meeresmuseum.de)
 			expect(mockCookies.set).toHaveBeenCalledWith('test-auth-cookie', 'signed-jwt-token', {
 				httpOnly: true,
-				sameSite: 'lax',
+				sameSite: 'none',
+				secure: true,
 				maxAge: 60 * 60 * 24 * 1, // 1 Tag
-				path: '/',
-				secure: process.env.NODE_ENV === 'production'
+				path: '/'
 			});
 		});
 	});
@@ -336,7 +337,13 @@ describe('auth.ts', () => {
 		it('should delete auth cookie', () => {
 			clearAuthCookie(mockCookies);
 
-			expect(mockCookies.delete).toHaveBeenCalledWith('test-auth-cookie', { path: '/' });
+			// Attribute müssen mit setAuthCookie übereinstimmen, sonst wird der Cookie nicht gelöscht
+			expect(mockCookies.delete).toHaveBeenCalledWith('test-auth-cookie', {
+				path: '/',
+				httpOnly: true,
+				sameSite: 'none',
+				secure: true
+			});
 		});
 	});
 

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -244,8 +244,9 @@ export const getAuthUser = async (cookies: Cookies) => {
  *
  * Sicherheitsmerkmale:
  * - httpOnly: Verhindert JavaScript-Zugriff (XSS-Schutz)
- * - sameSite: 'lax' - CSRF-Schutz
- * - secure: HTTPS-only in Produktion
+ * - sameSite: 'none' - Der Cookie muss im iframe-Kontext (meeresmuseum.de)
+ *   cross-site mitgeschickt werden. SameSite=None erfordert zwingend Secure=true.
+ * - secure: immer true (Prod und Dev laufen über HTTPS) — Browser-Pflicht bei SameSite=None
  * - Signiert mit eigenem Secret (nicht Auth0's)
  *
  * @param cookies - SvelteKit's Cookies-Objekt
@@ -264,10 +265,12 @@ export const setAuthCookie = async (cookies: Cookies, user: User) => {
 	const token = await new SignJWT({ ...user }).setProtectedHeader({ alg: 'HS256' }).sign(secret);
 	cookies.set(getCookieName(), token, {
 		httpOnly: true,
-		sameSite: 'lax',
+		// SameSite=None + Secure: Session-Cookie muss im cross-site iframe
+		// (meeresmuseum.de) mitgesendet werden. Secure ist bei None Browser-Pflicht.
+		sameSite: 'none',
+		secure: true,
 		maxAge: COOKIE_DURATION_SECONDS,
-		path: '/',
-		secure: getNodeEnv() === 'production'
+		path: '/'
 	});
 };
 
@@ -290,7 +293,14 @@ export const setAuthCookie = async (cookies: Cookies, user: User) => {
  * ```
  */
 export const clearAuthCookie = (cookies: Cookies) => {
-	cookies.delete(getCookieName(), { path: '/' });
+	// Attribute müssen mit setAuthCookie übereinstimmen (SameSite=None; Secure),
+	// sonst wird der Cookie vom Browser nicht korrekt überschrieben/gelöscht.
+	cookies.delete(getCookieName(), {
+		path: '/',
+		httpOnly: true,
+		sameSite: 'none',
+		secure: true
+	});
 };
 
 /**

--- a/src/lib/server/auth/returnUrl.ts
+++ b/src/lib/server/auth/returnUrl.ts
@@ -1,0 +1,29 @@
+/**
+ * Validiert eine returnUrl gegen Open-Redirect-Angriffe.
+ *
+ * Erlaubt ausschließlich relative Same-Origin-Pfade, die mit genau einem `/`
+ * beginnen. Externe URLs (`https://evil.com`), protokoll-relative Pfade
+ * (`//evil.com`) und Backslash-Tricks (`/\evil.com`) werden auf `/` normalisiert.
+ *
+ * Liegt in einem eigenen Modul (nicht in `+server.ts`), weil SvelteKit aus
+ * `+server.ts` nur bestimmte Exports erlaubt.
+ */
+export function sanitizeReturnUrl(returnUrl: string | null | undefined): string {
+	if (typeof returnUrl !== 'string' || returnUrl.length === 0) {
+		return '/';
+	}
+	// Whitespace-Zeichen ablehnen. Der WHATWG-URL-Parser entfernt
+	// Tab/CR/LF VOR der Auflösung, sodass z.B. '/\t/evil.com' zu
+	// 'http://evil.com/' würde und die startsWith-Prüfung unten umginge.
+	// Legitime relative Pfade enthalten keine rohen Whitespace-Zeichen
+	// (Leerzeichen wären %20-kodiert).
+	if (/\s/.test(returnUrl)) {
+		return '/';
+	}
+	// Muss mit genau einem '/' beginnen — keine protokoll-relativen ('//')
+	// und keine Backslash-Pfade ('/\'), die Browser als externe URL interpretieren.
+	if (!returnUrl.startsWith('/') || returnUrl.startsWith('//') || returnUrl.startsWith('/\\')) {
+		return '/';
+	}
+	return returnUrl;
+}

--- a/src/lib/server/auth/uploadOwnership.ts
+++ b/src/lib/server/auth/uploadOwnership.ts
@@ -1,0 +1,49 @@
+import { createId } from '@paralleldrive/cuid2';
+import type { Cookies } from '@sveltejs/kit';
+
+/**
+ * Name des langlebigen Cookies, das anonyme Uploads an den hochladenden Client bindet.
+ * Ziel: Nur DER Client, der eine (noch nicht zugeordnete) Datei hochgeladen hat, darf
+ * sie wieder löschen — nicht jeder, der den Datei-Pfad kennt.
+ */
+export const UPLOAD_UID_COOKIE = 'upload-uid';
+
+/** Lebensdauer des Upload-Owner-Cookies: 1 Jahr (in Sekunden). */
+const UPLOAD_UID_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Liest den vorhandenen Upload-Owner-UID aus dem Cookie oder erzeugt einen neuen,
+ * serverseitig generierten, nicht-erratbaren Wert (cuid2) und setzt ihn als Cookie.
+ *
+ * Der zurückgegebene Wert wird mit der Datei in der DB gespeichert und dient beim
+ * Löschen als Ownership-Nachweis.
+ *
+ * Cookie-Attribute:
+ * - httpOnly: kein JS-Zugriff (XSS-Schutz)
+ * - secure: nur über HTTPS (Prod und Dev laufen über HTTPS)
+ * - sameSite 'lax': ausreichend, da Upload/Delete same-site erfolgen
+ */
+export function getOrCreateUploadUid(cookies: Cookies): string {
+	const existing = cookies.get(UPLOAD_UID_COOKIE);
+	if (existing) {
+		return existing;
+	}
+
+	const uid = createId();
+	cookies.set(UPLOAD_UID_COOKIE, uid, {
+		httpOnly: true,
+		secure: true,
+		sameSite: 'lax',
+		path: '/',
+		maxAge: UPLOAD_UID_MAX_AGE_SECONDS
+	});
+	return uid;
+}
+
+/**
+ * Liest den Upload-Owner-UID aus dem Cookie (ohne ihn zu erzeugen).
+ * Gibt `undefined` zurück, wenn kein Cookie vorhanden ist.
+ */
+export function getUploadUid(cookies: Cookies): string | undefined {
+	return cookies.get(UPLOAD_UID_COOKIE);
+}

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -9,6 +9,7 @@ const DB_NOT_CONFIGURED_ERROR =
 
 // Track database connection state
 let _realDb: PostgresJsDatabase<typeof schema> | null = null;
+let _client: ReturnType<typeof postgres> | null = null;
 let _initError: string | null = null;
 
 /**
@@ -39,7 +40,16 @@ function initializeDb(): void {
 		}
 
 		// postgres() returns immediately - actual connection is lazy
-		const client = postgres(databaseUrl);
+		// Pool-/Timeout-Optionen für den Single-Container-Docker-Betrieb:
+		// - max: Verbindungspool-Obergrenze (eine Instanz, kein Fan-out nötig)
+		// - idle_timeout: Leerlaufverbindungen nach 20s schließen
+		// - connect_timeout: Verbindungsaufbau nach 10s abbrechen
+		const client = postgres(databaseUrl, {
+			max: 10,
+			idle_timeout: 20,
+			connect_timeout: 10
+		});
+		_client = client;
 		_realDb = drizzle(client, { schema });
 	} catch (error) {
 		_initError = error instanceof Error ? error.message : String(error);
@@ -142,4 +152,25 @@ export async function testDatabaseConnection(): Promise<boolean> {
  */
 export function resetConnectionTestCache(): void {
 	_lastConnectionTest = null;
+}
+
+/**
+ * Schließt die postgres.js-Verbindung sauber (für Graceful Shutdown).
+ *
+ * Idempotent: mehrfache Aufrufe sind unschädlich. Wird beim Empfang von
+ * SIGTERM/SIGINT (z.B. `docker stop`) aufgerufen, damit offene Verbindungen
+ * kontrolliert beendet werden statt hart abzubrechen.
+ */
+export async function closeDb(): Promise<void> {
+	if (!_client) {
+		return;
+	}
+
+	const client = _client;
+	// Referenzen sofort zurücksetzen, damit parallele Aufrufe nicht doppelt schließen
+	_client = null;
+	_realDb = null;
+	_lastConnectionTest = null;
+
+	await client.end({ timeout: 5 });
 }

--- a/src/lib/server/db/sightingFilesRepository.ts
+++ b/src/lib/server/db/sightingFilesRepository.ts
@@ -1,10 +1,19 @@
 import { createLogger } from '$lib/logger.server';
 import type { UploadedFileInfo } from '$lib/types';
 import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { db } from '.';
 import { sightingFiles } from './schema';
+import type * as schema from './schema';
 
 const logger = createLogger('repository:sightingFiles');
+
+/**
+ * Ausführungskontext für DB-Operationen: entweder die reguläre `db`-Instanz
+ * oder eine Transaktion (`tx`). Beide teilen die verwendete `update`-API,
+ * sodass Aufrufer optional innerhalb einer Transaktion arbeiten können.
+ */
+type DbExecutor = Pick<PostgresJsDatabase<typeof schema>, 'update'>;
 
 export async function saveUploadedFile(
 	uploadedFile: UploadedFileInfo,
@@ -43,10 +52,14 @@ export async function deleteFileByPath(filePath: string) {
 	logger.info({ filePath, count: result.length }, 'Mediendatei erfolgreich gelöscht');
 }
 
-export async function setSightingIdForReferenceId(referenceId: string, sightingId: number) {
+export async function setSightingIdForReferenceId(
+	referenceId: string,
+	sightingId: number,
+	executor: DbExecutor = db
+) {
 	logger.info({ referenceId, sightingId }, 'Aktualisiere Mediendatein');
 
-	const result = await db
+	const result = await executor
 		.update(sightingFiles)
 		.set({ sightingId })
 		.where(eq(sightingFiles.referenceId, referenceId))

--- a/src/lib/server/db/sightingRepository.test.ts
+++ b/src/lib/server/db/sightingRepository.test.ts
@@ -272,6 +272,57 @@ describe('sightingRepository', () => {
 			// Drizzle ORM sollte parametrisierte Queries verwenden
 			expect(mockDb.insert).toHaveBeenCalled();
 		});
+
+		/**
+		 * Test: Insert + Datei-Verknüpfung laufen in einer Transaktion
+		 */
+		it('sollte Insert und Datei-Verknüpfung in einer Transaktion kapseln', async () => {
+			// Arrange
+			const mockDb = db as any;
+			mockDb.insert.mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					returning: vi.fn().mockResolvedValue([{ id: 77 }])
+				})
+			});
+			mockDb.update.mockReturnValue({
+				set: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						returning: vi.fn().mockResolvedValue([{ uid: 'file-1' }])
+					})
+				})
+			});
+
+			// Act
+			const result = await saveSighting(mockFormData);
+
+			// Assert
+			expect(result).toEqual({ id: 77 });
+			expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+		});
+
+		/**
+		 * Test: Fehler bei der Datei-Verknüpfung propagiert (Rollback-Semantik)
+		 */
+		it('sollte Fehler propagieren wenn die Datei-Verknüpfung fehlschlägt', async () => {
+			// Arrange
+			const mockDb = db as any;
+			mockDb.insert.mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					returning: vi.fn().mockResolvedValue([{ id: 88 }])
+				})
+			});
+			// Die Datei-Verknüpfung (update) wirft -> gesamte Transaktion muss scheitern
+			mockDb.update.mockReturnValue({
+				set: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						returning: vi.fn().mockRejectedValue(new Error('Update failed'))
+					})
+				})
+			});
+
+			// Act & Assert
+			await expect(saveSighting(mockFormData)).rejects.toThrow('Update failed');
+		});
 	});
 
 	describe('updateSighting', () => {

--- a/src/lib/server/db/sightingRepository.ts
+++ b/src/lib/server/db/sightingRepository.ts
@@ -78,19 +78,28 @@ export const saveSighting = async (
 		logger.info({ sightingData }, 'Speichere neue Sichtung ohne Wetterdaten');
 	}
 
-	// Führe Hauptinsert-Operation mit automatischer ID-Generierung aus
-	const [result] = await db.insert(sightings).values(sightingData).returning({ id: sightings.id });
+	// Insert der Sichtung UND das Verknüpfen der Mediendateien laufen in einer
+	// Transaktion: Schlägt einer der Schritte fehl, wird nichts gespeichert und
+	// es bleiben keine verwaisten Datei-Referenzen zurück.
+	const sightingId = await db.transaction(async (tx) => {
+		const [result] = await tx
+			.insert(sightings)
+			.values(sightingData)
+			.returning({ id: sightings.id });
 
-	const sightingId = result?.id;
+		const id = result?.id;
 
-	if (!sightingId) {
-		logger.error({ sightingData }, 'Fehler beim Speichern der Sichtung');
-		throw new Error('Fehler beim Speichern der Sichtung');
-	} else {
-		// Update referenced media files
-		await setSightingIdForReferenceId(formData.referenceId, sightingId);
-		logger.info({ sightingId, hasWeatherData: !!weatherData }, 'Sichtung erfolgreich gespeichert');
-	}
+		if (!id) {
+			logger.error({ sightingData }, 'Fehler beim Speichern der Sichtung');
+			throw new Error('Fehler beim Speichern der Sichtung');
+		}
+
+		// Update referenced media files innerhalb derselben Transaktion
+		await setSightingIdForReferenceId(formData.referenceId, id, tx);
+		return id;
+	});
+
+	logger.info({ sightingId, hasWeatherData: !!weatherData }, 'Sichtung erfolgreich gespeichert');
 
 	return { id: sightingId };
 };

--- a/src/lib/server/geo/checkBalticSeaFile.comprehensive.test.ts
+++ b/src/lib/server/geo/checkBalticSeaFile.comprehensive.test.ts
@@ -435,12 +435,16 @@ describe('checkBalticSeaFile', () => {
 
 	describe('Performance and Reliability', () => {
 		it('should execute quickly for valid coordinates', () => {
+			// Warmup: first call lazily initialises the ~32MB RBush singleton index,
+			// which must not be measured as query time (caused CI flakiness).
+			checkBalticSeaFile(10.1367, 54.3233);
+
 			const start = performance.now();
 			const result = checkBalticSeaFile(10.1367, 54.3233);
 			const duration = performance.now() - start;
 
 			expect(result).toBeDefined();
-			// Should complete within reasonable time (20ms allows for CI variability)
+			// Warm query should be well under 20ms (per-query cost is ~0.5-2ms).
 			expect(duration).toBeLessThan(20);
 		});
 

--- a/src/lib/server/middleware/securityHeaders.test.ts
+++ b/src/lib/server/middleware/securityHeaders.test.ts
@@ -102,30 +102,14 @@ describe('securityHeaders', () => {
 		expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
 	});
 
-	it('rewrites SameSite=Strict to SameSite=None; Secure for the session cookie', async () => {
+	it('leaves Set-Cookie headers unveraendert (kein SameSite-Rewrite mehr)', async () => {
+		// Der Session-Cookie wird jetzt direkt in auth.ts mit SameSite=None; Secure gesetzt.
+		// Die Middleware darf Set-Cookie-Header nicht mehr umschreiben.
 		const response = await runHandler(
 			'production',
 			{},
-			{ 'Set-Cookie': 'auth-cookie=abc; SameSite=Strict' }
+			{ 'Set-Cookie': 'auth-cookie=abc; SameSite=None; Secure' }
 		);
 		expect(response.headers.get('Set-Cookie')).toBe('auth-cookie=abc; SameSite=None; Secure');
-	});
-
-	it('does not modify the session cookie without SameSite=Strict', async () => {
-		const response = await runHandler(
-			'production',
-			{},
-			{ 'Set-Cookie': 'auth-cookie=abc; SameSite=Lax' }
-		);
-		expect(response.headers.get('Set-Cookie')).toBe('auth-cookie=abc; SameSite=Lax');
-	});
-
-	it('does NOT rewrite SameSite=Strict for non-session cookies', async () => {
-		const response = await runHandler(
-			'production',
-			{},
-			{ 'Set-Cookie': 'other=abc; SameSite=Strict' }
-		);
-		expect(response.headers.get('Set-Cookie')).toBe('other=abc; SameSite=Strict');
 	});
 });

--- a/src/lib/server/middleware/securityHeaders.test.ts
+++ b/src/lib/server/middleware/securityHeaders.test.ts
@@ -60,9 +60,7 @@ describe('securityHeaders', () => {
 
 	it('sets Cross-Origin-Opener-Policy to same-origin-allow-popups', async () => {
 		const response = await runHandler('production');
-		expect(response.headers.get('Cross-Origin-Opener-Policy')).toBe(
-			'same-origin-allow-popups'
-		);
+		expect(response.headers.get('Cross-Origin-Opener-Policy')).toBe('same-origin-allow-popups');
 	});
 
 	it('sets Cross-Origin-Resource-Policy to cross-origin', async () => {
@@ -104,13 +102,30 @@ describe('securityHeaders', () => {
 		expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
 	});
 
-	it('rewrites SameSite=Strict to SameSite=None; Secure', async () => {
-		const response = await runHandler('production', {}, { 'Set-Cookie': 'session=abc; SameSite=Strict' });
-		expect(response.headers.get('Set-Cookie')).toBe('session=abc; SameSite=None; Secure');
+	it('rewrites SameSite=Strict to SameSite=None; Secure for the session cookie', async () => {
+		const response = await runHandler(
+			'production',
+			{},
+			{ 'Set-Cookie': 'auth-cookie=abc; SameSite=Strict' }
+		);
+		expect(response.headers.get('Set-Cookie')).toBe('auth-cookie=abc; SameSite=None; Secure');
 	});
 
-	it('does not modify cookies without SameSite=Strict', async () => {
-		const response = await runHandler('production', {}, { 'Set-Cookie': 'session=abc; SameSite=Lax' });
-		expect(response.headers.get('Set-Cookie')).toBe('session=abc; SameSite=Lax');
+	it('does not modify the session cookie without SameSite=Strict', async () => {
+		const response = await runHandler(
+			'production',
+			{},
+			{ 'Set-Cookie': 'auth-cookie=abc; SameSite=Lax' }
+		);
+		expect(response.headers.get('Set-Cookie')).toBe('auth-cookie=abc; SameSite=Lax');
+	});
+
+	it('does NOT rewrite SameSite=Strict for non-session cookies', async () => {
+		const response = await runHandler(
+			'production',
+			{},
+			{ 'Set-Cookie': 'other=abc; SameSite=Strict' }
+		);
+		expect(response.headers.get('Set-Cookie')).toBe('other=abc; SameSite=Strict');
 	});
 });

--- a/src/lib/server/middleware/securityHeaders.ts
+++ b/src/lib/server/middleware/securityHeaders.ts
@@ -1,9 +1,4 @@
-import { env } from '$env/dynamic/private';
 import type { Handle } from '@sveltejs/kit';
-
-// Name des Session-Cookies (identisch zu auth.ts / hooks.server.ts).
-// Nur dieser Cookie wird für die iframe-Einbettung auf SameSite=None umgeschrieben.
-const COOKIE_NAME = env.COOKIE_NAME ?? 'auth-cookie';
 
 export function createSecurityHeadersHandler(nodeEnv: string): Handle {
 	return async ({ event, resolve }) => {
@@ -32,25 +27,9 @@ export function createSecurityHeadersHandler(nodeEnv: string): Handle {
 			response.headers.set('Access-Control-Allow-Credentials', 'true');
 		}
 
-		// Cookie security for iframe context:
-		// Nur der Session-Cookie (COOKIE_NAME) wird für die meeresmuseum.de-iframe-
-		// Einbettung von SameSite=Strict auf SameSite=None; Secure umgeschrieben.
-		// Ein globaler Rewrite über ALLE Set-Cookie-Header wäre zu breit und würde
-		// auch fremde/kurzlebige Cookies unnötig cross-site freigeben.
-		const setCookies = response.headers.getSetCookie?.() ?? [];
-		if (setCookies.length > 0) {
-			response.headers.delete('Set-Cookie');
-			for (const cookie of setCookies) {
-				if (cookie.startsWith(`${COOKIE_NAME}=`)) {
-					response.headers.append(
-						'Set-Cookie',
-						cookie.replace(/SameSite=Strict/g, 'SameSite=None; Secure')
-					);
-				} else {
-					response.headers.append('Set-Cookie', cookie);
-				}
-			}
-		}
+		// Hinweis: Der Session-Cookie wird direkt in auth.ts mit SameSite=None; Secure
+		// gesetzt (nötig für die iframe-Einbettung auf meeresmuseum.de). Ein nachträglicher
+		// Header-Rewrite ist daher nicht mehr erforderlich.
 
 		return response;
 	};

--- a/src/lib/server/middleware/securityHeaders.ts
+++ b/src/lib/server/middleware/securityHeaders.ts
@@ -1,4 +1,9 @@
+import { env } from '$env/dynamic/private';
 import type { Handle } from '@sveltejs/kit';
+
+// Name des Session-Cookies (identisch zu auth.ts / hooks.server.ts).
+// Nur dieser Cookie wird für die iframe-Einbettung auf SameSite=None umgeschrieben.
+const COOKIE_NAME = env.COOKIE_NAME ?? 'auth-cookie';
 
 export function createSecurityHeadersHandler(nodeEnv: string): Handle {
 	return async ({ event, resolve }) => {
@@ -16,32 +21,35 @@ export function createSecurityHeadersHandler(nodeEnv: string): Handle {
 
 		// HSTS for production (HTTPS only)
 		if (event.url.protocol === 'https:') {
-			response.headers.set(
-				'Strict-Transport-Security',
-				'max-age=31536000; includeSubDomains'
-			);
+			response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 		}
 
 		// Development-specific CORS headers
 		if (nodeEnv === 'development') {
 			response.headers.set('Access-Control-Allow-Origin', '*');
-			response.headers.set(
-				'Access-Control-Allow-Methods',
-				'GET, POST, PUT, DELETE, OPTIONS'
-			);
+			response.headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
 			response.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 			response.headers.set('Access-Control-Allow-Credentials', 'true');
 		}
 
-		// Cookie security for iframe context
-		const existingCookies = response.headers.get('Set-Cookie');
-		if (existingCookies) {
-			// SameSite=None for iframe functionality (only with Secure)
-			const iframeFriendlyCookies = existingCookies.replace(
-				/SameSite=Strict/g,
-				'SameSite=None; Secure'
-			);
-			response.headers.set('Set-Cookie', iframeFriendlyCookies);
+		// Cookie security for iframe context:
+		// Nur der Session-Cookie (COOKIE_NAME) wird für die meeresmuseum.de-iframe-
+		// Einbettung von SameSite=Strict auf SameSite=None; Secure umgeschrieben.
+		// Ein globaler Rewrite über ALLE Set-Cookie-Header wäre zu breit und würde
+		// auch fremde/kurzlebige Cookies unnötig cross-site freigeben.
+		const setCookies = response.headers.getSetCookie?.() ?? [];
+		if (setCookies.length > 0) {
+			response.headers.delete('Set-Cookie');
+			for (const cookie of setCookies) {
+				if (cookie.startsWith(`${COOKIE_NAME}=`)) {
+					response.headers.append(
+						'Set-Cookie',
+						cookie.replace(/SameSite=Strict/g, 'SameSite=None; Secure')
+					);
+				} else {
+					response.headers.append('Set-Cookie', cookie);
+				}
+			}
 		}
 
 		return response;

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -98,7 +98,8 @@ export class EmailService {
 				return;
 			}
 
-			// Create transporter
+			// Create transporter mit expliziten Timeouts, damit ein hängender SMTP-Server
+			// den Request/Prozess nicht blockiert (Single-Container-Docker-Betrieb).
 			this.transporter = nodemailer.createTransport({
 				host: smtpHost,
 				port: smtpPort,
@@ -106,7 +107,10 @@ export class EmailService {
 				auth: {
 					user: smtpUser,
 					pass: smtpPassword
-				}
+				},
+				connectionTimeout: 5000, // max. 5s für den Verbindungsaufbau
+				greetingTimeout: 5000, // max. 5s auf das SMTP-Greeting warten
+				socketTimeout: 10000 // max. 10s Inaktivität auf dem Socket
 			});
 
 			// Verify connection

--- a/src/lib/server/services/weatherRefreshService.ts
+++ b/src/lib/server/services/weatherRefreshService.ts
@@ -1,6 +1,14 @@
 import { createLogger } from '$lib/logger.server';
-import { convertToStoredWeatherData, type StoredWeatherData, type WeatherData } from '$lib/services/weatherService';
-import { degreesToCardinal, getWeatherDescription, calculateSeaState } from '$lib/constants/weather';
+import {
+	convertToStoredWeatherData,
+	type StoredWeatherData,
+	type WeatherData
+} from '$lib/services/weatherService';
+import {
+	degreesToCardinal,
+	getWeatherDescription,
+	calculateSeaState
+} from '$lib/constants/weather';
 
 const logger = createLogger('service:weather-refresh');
 
@@ -35,7 +43,6 @@ interface MarineResponse {
 	};
 }
 
-
 /**
  * Fetch weather data directly from Open-Meteo API
  */
@@ -51,56 +58,65 @@ export async function fetchWeatherData(
 	// Prüfe ob das Datum heute oder in der Zukunft ist
 	const today = new Date().toISOString().split('T')[0] || '';
 	const isToday = date >= today;
-	
+
 	// Build Open-Meteo API URL - verwende Forecast API für heutige/zukünftige Daten
 	const params = new URLSearchParams({
 		latitude: latitude.toString(),
 		longitude: longitude.toString(),
 		timezone: 'Europe/Berlin'
 	});
-	
+
 	let url: string;
 	if (isToday) {
 		// Aktuelle/zukünftige Daten: Forecast API
-		params.append('hourly', [
-			'temperature_2m',
-			'wind_speed_10m', 
-			'wind_direction_10m',
-			'weather_code',
-			'visibility',
-			'relative_humidity_2m',
-			'surface_pressure',
-			'precipitation',
-			'cloud_cover'
-		].join(','));
+		params.append(
+			'hourly',
+			[
+				'temperature_2m',
+				'wind_speed_10m',
+				'wind_direction_10m',
+				'weather_code',
+				'visibility',
+				'relative_humidity_2m',
+				'surface_pressure',
+				'precipitation',
+				'cloud_cover'
+			].join(',')
+		);
 		url = `https://api.open-meteo.com/v1/forecast?${params}`;
-		logger.debug({ date, isToday, apiType: 'forecast' }, 'Using Forecast API for current/future date');
+		logger.debug(
+			{ date, isToday, apiType: 'forecast' },
+			'Using Forecast API for current/future date'
+		);
 	} else {
 		// Historische Daten: Archive API
 		params.append('start_date', startDate);
 		params.append('end_date', endDate);
-		params.append('hourly', [
-			'temperature_2m',
-			'wind_speed_10m', 
-			'wind_direction_10m',
-			'weather_code',
-			'visibility',
-			'relative_humidity_2m',
-			'surface_pressure',
-			'precipitation',
-			'cloud_cover'
-		].join(','));
+		params.append(
+			'hourly',
+			[
+				'temperature_2m',
+				'wind_speed_10m',
+				'wind_direction_10m',
+				'weather_code',
+				'visibility',
+				'relative_humidity_2m',
+				'surface_pressure',
+				'precipitation',
+				'cloud_cover'
+			].join(',')
+		);
 		url = `https://archive-api.open-meteo.com/v1/archive?${params}`;
 		logger.debug({ date, isToday, apiType: 'archive' }, 'Using Archive API for historical date');
 	}
-	
+
 	// Build Marine API URL for wave data
 	const marineParams = new URLSearchParams({
 		latitude: latitude.toString(),
 		longitude: longitude.toString(),
 		timezone: 'Europe/Berlin'
 	});
-	
+
 	let marineUrl: string;
 	if (isToday) {
 		marineParams.append('hourly', 'wave_height,wave_direction,wave_period');
@@ -112,61 +128,81 @@ export async function fetchWeatherData(
 		marineParams.append('hourly', 'wave_height,wave_direction,wave_period');
 		marineUrl = `https://marine-api.open-meteo.com/v1/marine?${marineParams}`;
 	}
-	
-	logger.info({ url, marineUrl, latitude, longitude, date, time }, 'Fetching weather and marine data from Open-Meteo');
+
+	logger.info(
+		{ url, marineUrl, latitude, longitude, date, time },
+		'Fetching weather and marine data from Open-Meteo'
+	);
 
 	try {
-		// Fetch both weather and marine data in parallel
+		// Fetch both weather and marine data in parallel.
+		// Timeout von 5s pro Request, damit ein langsames/hängendes Open-Meteo den
+		// Aufruf (und damit den Sichtungs-Speichervorgang) nicht unbegrenzt blockiert.
 		const [weatherResponse, marineResponse] = await Promise.allSettled([
-			fetch(url),
-			fetch(marineUrl)
+			fetch(url, { signal: AbortSignal.timeout(5000) }),
+			fetch(marineUrl, { signal: AbortSignal.timeout(5000) })
 		]);
-		
+
 		if (weatherResponse.status === 'rejected') {
 			throw new Error(`Open-Meteo Weather API error: ${weatherResponse.reason}`);
 		}
-		
+
 		if (!weatherResponse.value.ok) {
-			throw new Error(`Open-Meteo Weather API error: ${weatherResponse.value.status} ${weatherResponse.value.statusText}`);
+			throw new Error(
+				`Open-Meteo Weather API error: ${weatherResponse.value.status} ${weatherResponse.value.statusText}`
+			);
 		}
 
 		const data: OpenMeteoResponse = await weatherResponse.value.json();
-		
+
 		// Try to get marine data, but don't fail if it's not available
 		let marineData: MarineResponse | null = null;
 		if (marineResponse.status === 'fulfilled' && marineResponse.value.ok) {
 			try {
 				marineData = await marineResponse.value.json();
-				logger.info({ hasMarineData: true, marineDataKeys: marineData ? Object.keys(marineData) : [] }, 'Marine data successfully fetched');
+				logger.info(
+					{ hasMarineData: true, marineDataKeys: marineData ? Object.keys(marineData) : [] },
+					'Marine data successfully fetched'
+				);
 			} catch (error) {
 				logger.error({ error }, 'Failed to parse marine data response');
 			}
 		} else {
-			logger.error({ 
-				status: marineResponse.status,
-				statusText: marineResponse.status === 'fulfilled' ? marineResponse.value.statusText : 'rejected',
-				statusCode: marineResponse.status === 'fulfilled' ? marineResponse.value.status : 'N/A'
-			}, 'Marine API request failed or rejected');
+			logger.error(
+				{
+					status: marineResponse.status,
+					statusText:
+						marineResponse.status === 'fulfilled' ? marineResponse.value.statusText : 'rejected',
+					statusCode: marineResponse.status === 'fulfilled' ? marineResponse.value.status : 'N/A'
+				},
+				'Marine API request failed or rejected'
+			);
 		}
 
 		if (!data.hourly?.time || data.hourly.time.length === 0) {
-			logger.error({ latitude, longitude, date, time, apiResponse: data }, 'No weather data available from Open-Meteo API');
+			logger.error(
+				{ latitude, longitude, date, time, apiResponse: data },
+				'No weather data available from Open-Meteo API'
+			);
 			throw new Error('No weather data available for the specified date and location');
 		}
-		
-		logger.debug({ 
-			availableTimes: data.hourly.time.slice(0, 5),
-			totalTimeSlots: data.hourly.time.length,
-			requestedDate: date,
-			requestedTime: time 
-		}, 'Available weather data slots from Open-Meteo');
+
+		logger.debug(
+			{
+				availableTimes: data.hourly.time.slice(0, 5),
+				totalTimeSlots: data.hourly.time.length,
+				requestedDate: date,
+				requestedTime: time
+			},
+			'Available weather data slots from Open-Meteo'
+		);
 
 		// Find the closest time match
 		let bestIndex = 0;
 		if (time) {
 			const targetTime = `${date}T${time}:00`;
 			let minDiff = Infinity;
-			
+
 			data.hourly.time.forEach((t, i) => {
 				const diff = Math.abs(new Date(t).getTime() - new Date(targetTime).getTime());
 				if (diff < minDiff) {
@@ -179,27 +215,33 @@ export async function fetchWeatherData(
 		// Extract weather data for the best matching time
 		const hourly = data.hourly;
 		const observationTime = hourly.time[bestIndex];
-		
+
 		// Debug logging für den bestIndex
-		logger.debug({ 
-			bestIndex, 
-			observationTime, 
-			totalSlots: hourly.time.length,
-			timeSlotAtIndex: hourly.time[bestIndex],
-			temperatureAtIndex: hourly.temperature_2m[bestIndex]
-		}, 'Selected weather data slot');
-		
+		logger.debug(
+			{
+				bestIndex,
+				observationTime,
+				totalSlots: hourly.time.length,
+				timeSlotAtIndex: hourly.time[bestIndex],
+				temperatureAtIndex: hourly.temperature_2m[bestIndex]
+			},
+			'Selected weather data slot'
+		);
+
 		if (!observationTime) {
-			logger.error({ bestIndex, totalSlots: hourly.time.length }, 'Invalid bestIndex - no observation time found');
+			logger.error(
+				{ bestIndex, totalSlots: hourly.time.length },
+				'Invalid bestIndex - no observation time found'
+			);
 			throw new Error('Invalid time index selected for weather data');
 		}
-		
+
 		const temperature = hourly.temperature_2m[bestIndex] ?? 0;
 		const windSpeed = hourly.wind_speed_10m[bestIndex] ?? 0;
 		const windDirection = hourly.wind_direction_10m[bestIndex] ?? 0;
 		const weatherCode = hourly.weather_code[bestIndex] ?? 0;
 		const visibility = hourly.visibility[bestIndex] ?? 10000;
-		
+
 		const weatherData: WeatherData = {
 			time: observationTime,
 			temperature,
@@ -259,25 +301,32 @@ export async function fetchWeatherData(
 			longitude
 		);
 
-		logger.info({ 
-			latitude, 
-			longitude, 
-			date, 
-			time, 
-			observationTime,
-			temperature: weatherData.temperature,
-			weatherCode: weatherData.weatherCode,
-			hasMarineData: !!marineData,
-			marineDataSample: marineData?.hourly ? {
-				waveHeightCount: marineData.hourly.wave_height?.length || 0,
-				firstWaveHeight: marineData.hourly.wave_height?.[bestIndex]
-			} : null
-		}, 'Weather data successfully fetched from Open-Meteo');
+		logger.info(
+			{
+				latitude,
+				longitude,
+				date,
+				time,
+				observationTime,
+				temperature: weatherData.temperature,
+				weatherCode: weatherData.weatherCode,
+				hasMarineData: !!marineData,
+				marineDataSample: marineData?.hourly
+					? {
+							waveHeightCount: marineData.hourly.wave_height?.length || 0,
+							firstWaveHeight: marineData.hourly.wave_height?.[bestIndex]
+						}
+					: null
+			},
+			'Weather data successfully fetched from Open-Meteo'
+		);
 
 		return storedWeatherData;
-
 	} catch (error) {
-		logger.error({ error: error instanceof Error ? error.message : error, latitude, longitude, date, time }, 'Failed to fetch weather data');
+		logger.error(
+			{ error: error instanceof Error ? error.message : error, latitude, longitude, date, time },
+			'Failed to fetch weather data'
+		);
 		throw error;
 	}
 }

--- a/src/lib/server/validation/magicBytes.test.ts
+++ b/src/lib/server/validation/magicBytes.test.ts
@@ -502,6 +502,30 @@ describe('magicBytes validation', () => {
 			});
 		});
 
+		describe('PDF files', () => {
+			it('should accept a valid PDF with %PDF- prefix', () => {
+				const pdfBuffer = Buffer.concat([
+					Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34]), // %PDF-1.4
+					Buffer.from('\nrest of pdf content', 'utf8')
+				]);
+
+				const result = validateMagicBytes(pdfBuffer, 'application/pdf');
+
+				expect(result.isValid).toBe(true);
+			});
+
+			it('should reject a fake PDF with wrong prefix', () => {
+				const fakePdf = Buffer.from('NOT-A-PDF file content', 'utf8');
+
+				const result = validateMagicBytes(fakePdf, 'application/pdf');
+
+				expect(result.isValid).toBe(false);
+				expect(result.message).toContain(
+					'Dateiinhalt stimmt nicht mit dem angegebenen Typ überein'
+				);
+			});
+		});
+
 		describe('Edge cases', () => {
 			it('should handle empty buffers', () => {
 				const emptyBuffer = Buffer.alloc(0);

--- a/src/lib/server/validation/magicBytes.ts
+++ b/src/lib/server/validation/magicBytes.ts
@@ -42,6 +42,11 @@ const MAGIC_BYTES: Record<string, Array<Array<{ bytes: number[]; offset: number 
 		[{ bytes: [0x42, 0x4d], offset: 0 }] // BM
 	],
 
+	// Document formats
+	'application/pdf': [
+		[{ bytes: [0x25, 0x50, 0x44, 0x46, 0x2d], offset: 0 }] // %PDF-
+	],
+
 	// Video formats
 	'video/mp4': [
 		[{ bytes: [0x66, 0x74, 0x79, 0x70], offset: 4 }], // ftyp

--- a/src/lib/utils/media/MediaFile.ts
+++ b/src/lib/utils/media/MediaFile.ts
@@ -77,7 +77,8 @@ export class MediaFile {
 		mediaFile.file = mockFile;
 		mediaFile.size = fileInfo.size;
 		mediaFile.exifData = fileInfo.exifData as ExifData | null | undefined;
-		mediaFile.thumbnail = `/uploads/${fileInfo.filePath}`;
+		// Abgesicherte Media-Route statt direktem /uploads-Zugriff (Freigabe-/Admin-Prüfung)
+		mediaFile.thumbnail = `/api/media/${fileInfo.filePath}`;
 		mediaFile.timestamp = mediaFile.exifData?.dateTimeOriginal
 			? new Date(mediaFile.exifData.dateTimeOriginal)
 			: null;

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -93,7 +93,7 @@
 </script>
 
 <svelte:head>
-	<title>Fehler {status} - Sichtungen WebApp</title>
+	<title>Fehler {status} - Ostsee-Tiere</title>
 	<meta name="description" content="Ein Fehler ist aufgetreten - {errorMessage.title}" />
 </svelte:head>
 
@@ -180,18 +180,15 @@
 						<li>Versuchen Sie es in ein paar Minuten erneut</li>
 						<li>Leeren Sie den Browser-Cache</li>
 					</ul>
+					<p>Andernfalls versuchen Sie es später erneut oder kehren Sie zur Startseite zurück.</p>
 				</div>
 
-				<!-- Kontakt-Info (optional) -->
+				<!-- Zur Startseite -->
 				<div class="card-actions mt-4 justify-end">
-					<a
-						href="mailto:support@example.com"
-						class="btn btn-sm btn-ghost"
-						aria-label="Support kontaktieren"
-					>
-						<Icon icon="lucide:mail" class="mr-1 h-4 w-4" />
-						Support
-					</a>
+					<button class="btn btn-sm btn-ghost" onclick={goHome} aria-label="Zur Startseite">
+						<Icon icon="lucide:home" class="mr-1 h-4 w-4" />
+						Zur Startseite
+					</button>
 				</div>
 			</div>
 		</div>
@@ -213,9 +210,5 @@
 			opacity: 1;
 			transform: translateY(0);
 		}
-	}
-
-	.avatar.placeholder {
-		animation: pulse 2s infinite;
 	}
 </style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,19 +10,26 @@
 </script>
 
 <div class:iframe-mode={!isNotIFrame}>
+	<!-- Skip-Link: erster fokussierbarer Inhalt vor der Navigation -->
+	<a
+		href="#main-content"
+		class="btn btn-primary sr-only z-[100] focus:not-sr-only focus:absolute focus:top-2 focus:left-2"
+	>
+		Zum Hauptinhalt springen
+	</a>
+
 	<PublicNavbar user={data.user} isAdmin={data.showAdminMenu} />
 
 	<!-- Maintenance Mode Banner for Admins -->
 	{#if data.maintenanceConfig?.enabled && data.showAdminMenu && isNotIFrame}
 		<div class="container mx-auto px-4 py-2">
-			<MaintenanceBanner 
-				isAdmin={true} 
-				maintenanceMessage={data.maintenanceConfig.message} 
-			/>
+			<MaintenanceBanner isAdmin={true} maintenanceMessage={data.maintenanceConfig.message} />
 		</div>
 	{/if}
 
-	{@render children()}
+	<main id="main-content">
+		{@render children()}
+	</main>
 
 	<PublicFooter />
 

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -220,7 +220,7 @@
 						<Icon icon="lucide:shield-check" width="30" class="text-success" />
 						<h3 class="card-title">Datenschutz</h3>
 					</div>
-					<p class="mb-4 text-sm text-gray-700">
+					<p class="mb-4 text-sm text-base-content/80">
 						Ihre Daten sind bei uns sicher. Wir verarbeiten alle personenbezogenen Daten gemäß der
 						EU-Datenschutz-Grundverordnung (DSGVO) und dem Bundesdatenschutzgesetz (BDSG).
 					</p>
@@ -262,7 +262,7 @@
 						<Icon icon="lucide:lock" width="30" class="text-info" />
 						<h3 class="card-title">Technische Sicherheit</h3>
 					</div>
-					<p class="mb-4 text-sm text-gray-700">
+					<p class="mb-4 text-sm text-base-content/80">
 						Wir nutzen modernste Sicherheitstechnologien, um Ihre Daten und unsere Plattform zu
 						schützen.
 					</p>
@@ -310,7 +310,7 @@
 				<Icon icon="lucide:file-text" width="24" class="text-success" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">DSGVO-Konformität</h4>
-					<p class="mb-3 text-sm text-gray-700">
+					<p class="mb-3 text-sm text-base-content/80">
 						Als öffentliche Einrichtung nehmen wir den Datenschutz besonders ernst. Unsere Plattform
 						erfüllt alle Anforderungen der europäischen Datenschutz-Grundverordnung:
 					</p>
@@ -339,7 +339,7 @@
 		<!-- Contact for Data Protection -->
 		<div class="bg-base-200 mt-8 rounded-lg p-6 text-center">
 			<h4 class="mb-3 font-semibold">Fragen zum Datenschutz?</h4>
-			<p class="mb-4 text-sm text-gray-700">
+			<p class="mb-4 text-sm text-base-content/80">
 				Bei Fragen zum Datenschutz oder zur Verarbeitung Ihrer Daten können Sie sich jederzeit an
 				uns wenden:
 			</p>
@@ -370,26 +370,26 @@
 			</h2>
 			<div class="badge badge-neutral badge-lg font-mono">Version {data.version}</div>
 		</div>
-		<p class="mx-auto mb-8 max-w-3xl text-center text-gray-700">
+		<p class="mx-auto mb-8 max-w-3xl text-center text-base-content/80">
 			Unsere Plattform nutzt moderne Web-Technologien für eine optimale Benutzererfahrung und
 			zuverlässige Datenverarbeitung.
 		</p>
 		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
 			<div class="text-center">
 				<div class="badge badge-primary badge-lg">SvelteKit</div>
-				<p class="mt-2 text-xs text-gray-600">Modern Web Framework</p>
+				<p class="mt-2 text-xs text-base-content/70">Modern Web Framework</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-secondary badge-lg">PostGIS</div>
-				<p class="mt-2 text-xs text-gray-600">Geografische Datenbank</p>
+				<p class="mt-2 text-xs text-base-content/70">Geografische Datenbank</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-accent badge-lg">OpenAPI</div>
-				<p class="mt-2 text-xs text-gray-600">Standardisierte API</p>
+				<p class="mt-2 text-xs text-base-content/70">Standardisierte API</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-info badge-lg">OpenLayers</div>
-				<p class="mt-2 text-xs text-gray-600">Interaktive Karten</p>
+				<p class="mt-2 text-xs text-base-content/70">Interaktive Karten</p>
 			</div>
 		</div>
 	</div>
@@ -409,16 +409,16 @@
 						<Icon icon="lucide:file-text" width="32" height="32" class="text-primary" />
 						<h3 class="card-title">Projekt-Lizenz</h3>
 					</div>
-					<p class="mb-4 text-sm text-gray-700">
+					<p class="mb-4 text-sm text-base-content/80">
 						Die Ostsee-Tiere Plattform ist Open Source Software und steht unter der MIT-Lizenz. Dies
 						bedeutet, dass der Quellcode frei verfügbar ist und für eigene Projekte genutzt werden
 						kann.
 					</p>
-					<div class="rounded-lg bg-gray-50 p-4">
+					<div class="rounded-lg bg-base-200 p-4">
 						<div class="mb-2 font-mono text-xs font-semibold">MIT License</div>
-						<div class="max-h-48 overflow-y-auto rounded border border-gray-200 bg-white p-3">
+						<div class="max-h-48 overflow-y-auto rounded border border-base-300 bg-white p-3">
 							<pre
-								class="font-mono text-xs whitespace-pre-wrap text-gray-600">Copyright (c) 2025-2026 Ostsee-Tiere WebApp Contributors
+								class="font-mono text-xs whitespace-pre-wrap text-base-content/70">Copyright (c) 2025-2026 Ostsee-Tiere WebApp Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -464,36 +464,36 @@ SOFTWARE.</pre>
 						<Icon icon="lucide:archive" width="32" height="32" class="text-primary" />
 						<h3 class="card-title">Verwendete Technologien</h3>
 					</div>
-					<p class="mb-4 text-sm text-gray-700">
+					<p class="mb-4 text-sm text-base-content/80">
 						Diese Plattform baut auf bewährten Open Source Technologien auf:
 					</p>
 					<div class="space-y-2 text-xs">
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">SvelteKit</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">TailwindCSS</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">DaisyUI</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">OpenLayers</span>
 							<span class="badge badge-sm">BSD-2</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">PostgreSQL</span>
 							<span class="badge badge-sm">PostgreSQL</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-gray-50 p-2">
+						<div class="flex items-center justify-between rounded bg-base-200 p-2">
 							<span class="font-medium">Drizzle ORM</span>
 							<span class="badge badge-sm">Apache-2.0</span>
 						</div>
 					</div>
-					<p class="mt-3 text-xs text-gray-500">
+					<p class="mt-3 text-xs text-base-content/60">
 						Alle verwendeten Bibliotheken sind sorgfältig ausgewählt und lizenzkonform eingesetzt.
 					</p>
 				</div>
@@ -508,7 +508,7 @@ SOFTWARE.</pre>
 				<Icon icon="lucide:circle-alert" width="32" height="32" class="text-warning mt-1" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">Fehler gefunden oder Verbesserungsvorschlag?</h4>
-					<p class="mb-3 text-sm text-gray-700">
+					<p class="mb-3 text-sm text-base-content/80">
 						Wir freuen uns über Ihr Feedback! Die Ostsee-Tiere Plattform wird kontinuierlich
 						weiterentwickelt. Ihre Hinweise helfen uns dabei, die Plattform zu verbessern.
 					</p>
@@ -548,7 +548,7 @@ SOFTWARE.</pre>
 				<Icon icon="lucide:heart" width="20" height="20" class="text-primary" />
 				Danksagung
 			</h4>
-			<p class="mb-4 text-sm text-gray-700">
+			<p class="mb-4 text-sm text-base-content/80">
 				Wir danken allen Entwicklern und Organisationen, die durch ihre Open Source Projekte diese
 				Plattform ermöglichen. Besonderer Dank gilt:
 			</p>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -2,11 +2,12 @@
 	let { children }: { children: import('svelte').Snippet } = $props();
 </script>
 
-<main class="w-full">
+<!-- Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit -->
+<div class="w-full">
 	<div class="flex min-h-screen flex-col">
 		<!-- Page content with top padding for fixed navbar -->
-		<main class="w-full">
+		<div class="w-full">
 			{@render children()}
-		</main>
+		</div>
 	</div>
-</main>
+</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -63,7 +63,7 @@
 		{ key: 'referenceId', label: 'Referenz-ID', sortKey: null },
 		{ key: 'sightingDate', label: 'Sichtungsdatum', sortKey: 'sightingDate' },
 		{ key: 'created', label: 'Meldedatum', sortKey: 'created' },
-		{ key: 'email', label: 'Email', sortKey: 'email' },
+		{ key: 'email', label: 'E-Mail', sortKey: 'email' },
 		{ key: 'species', label: 'Tierart', sortKey: 'species' },
 		{ key: 'distance', label: 'Entfernung', sortKey: 'distance' },
 		{ key: 'totalCount', label: 'Anzahl', sortKey: 'totalCount' },
@@ -237,14 +237,23 @@
 			if (response.ok) {
 				const result = await response.json();
 				logger.info({ id, result }, 'Sichtung erfolgreich gelöscht');
+				toast.success('Sichtung wurde gelöscht', { duration: 5000 });
 				// Reload data via SvelteKit's invalidation instead of full page reload
 				await invalidateAll();
 			} else {
 				const error = await response.json();
 				logger.error({ id, error }, 'Fehler beim Löschen der Sichtung');
+				toast.error(error.error || 'Sichtung konnte nicht gelöscht werden', {
+					title: 'Fehler',
+					dismissible: true
+				});
 			}
 		} catch (error) {
 			logger.error({ id, error }, 'Netzwerkfehler beim Löschen');
+			toast.error('Netzwerkfehler beim Löschen der Sichtung', {
+				title: 'Verbindungsfehler',
+				dismissible: true
+			});
 		}
 	}
 
@@ -323,9 +332,20 @@
 			} else {
 				const error = await response.json();
 				logger.error({ id, error }, 'Fehler beim Ändern des Verifizierungsstatus');
+				toast.error(error.error || 'Verifizierungsstatus konnte nicht geändert werden', {
+					title: 'Fehler',
+					dismissible: true
+				});
+				// Toggle springt zurück: Daten neu laden, damit UI den echten Serverzustand zeigt
+				await invalidateAll();
 			}
 		} catch (error) {
 			logger.error({ id, error }, 'Netzwerkfehler beim Ändern des Verifizierungsstatus');
+			toast.error('Netzwerkfehler beim Ändern des Verifizierungsstatus', {
+				title: 'Verbindungsfehler',
+				dismissible: true
+			});
+			await invalidateAll();
 		}
 	}
 </script>
@@ -678,6 +698,24 @@
 		{/each}
 	</div>
 
+	<!-- Sortierbarer Spaltenkopf: <button> im <th> mit aria-sort für Screenreader -->
+	{#snippet sortableTh(label: string, key: string)}
+		{@const isActive = page.url.searchParams.get('sort') === key}
+		{@const isDesc = page.url.searchParams.get('order') === 'desc'}
+		<th class="p-0" aria-sort={isActive ? (isDesc ? 'descending' : 'ascending') : 'none'}>
+			<button
+				type="button"
+				class="hover:bg-base-300 flex w-full items-center gap-1 px-4 py-3 text-left font-semibold"
+				onclick={() => updateSort(key)}
+			>
+				{label}
+				{#if isActive}
+					<span aria-hidden="true">{isDesc ? '↓' : '↑'}</span>
+				{/if}
+			</button>
+		</th>
+	{/snippet}
+
 	<!-- Desktop Table Layout -->
 	<div class="hidden px-2 sm:px-4 md:block">
 		<div class="border-base-300 bg-base-100 w-full overflow-x-auto rounded-lg border shadow-sm">
@@ -688,133 +726,40 @@
 							<th class="hover:bg-base-300">Referenz-ID</th>
 						{/if}
 						{#if columnVisibility.sightingDate}
-							<th
-								class="hover:bg-base-300 cursor-pointer"
-								onclick={() => updateSort('sightingDate')}
-							>
-								Sichtungsdatum
-								{#if page.url.searchParams.get('sort') === 'sightingDate'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Sichtungsdatum', 'sightingDate')}
 						{/if}
 						{#if columnVisibility.created}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('created')}>
-								Meldedatum
-								{#if page.url.searchParams.get('sort') === 'created'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Meldedatum', 'created')}
 						{/if}
 						{#if columnVisibility.email}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('email')}>
-								Email
-								{#if page.url.searchParams.get('sort') === 'email'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('E-Mail', 'email')}
 						{/if}
 						{#if columnVisibility.species}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('species')}>
-								Tierart
-								{#if page.url.searchParams.get('sort') === 'species'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Tierart', 'species')}
 						{/if}
 						{#if columnVisibility.distance}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('distance')}>
-								Entfernung
-								{#if page.url.searchParams.get('sort') === 'distance'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Entfernung', 'distance')}
 						{/if}
 						{#if columnVisibility.totalCount}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('totalCount')}>
-								Anzahl
-								{#if page.url.searchParams.get('sort') === 'totalCount'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Anzahl', 'totalCount')}
 						{/if}
 						{#if columnVisibility.juvenileCount}
-							<th
-								class="hover:bg-base-300 cursor-pointer"
-								onclick={() => updateSort('juvenileCount')}
-							>
-								Jung
-								{#if page.url.searchParams.get('sort') === 'juvenileCount'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Jung', 'juvenileCount')}
 						{/if}
 						{#if columnVisibility.distribution}
-							<th
-								class="hover:bg-base-300 cursor-pointer"
-								onclick={() => updateSort('distribution')}
-							>
-								Verteilung
-								{#if page.url.searchParams.get('sort') === 'distribution'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Verteilung', 'distribution')}
 						{/if}
 						{#if columnVisibility.behavior}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('behavior')}>
-								Verhalten
-								{#if page.url.searchParams.get('sort') === 'behavior'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Verhalten', 'behavior')}
 						{/if}
 						{#if columnVisibility.seaState}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('seaState')}>
-								Seegang
-								{#if page.url.searchParams.get('sort') === 'seaState'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Seegang', 'seaState')}
 						{/if}
 						{#if columnVisibility.wind}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('wind')}>
-								Wind
-								{#if page.url.searchParams.get('sort') === 'wind'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Wind', 'wind')}
 						{/if}
 						{#if columnVisibility.visibility}
-							<th class="hover:bg-base-300 cursor-pointer" onclick={() => updateSort('visibility')}>
-								Sichtweite
-								{#if page.url.searchParams.get('sort') === 'visibility'}
-									<span class="ml-1"
-										>{page.url.searchParams.get('order') === 'desc' ? '↓' : '↑'}</span
-									>
-								{/if}
-							</th>
+							{@render sortableTh('Sichtweite', 'visibility')}
 						{/if}
 						{#if columnVisibility.mediaUpload}
 							<th class="hover:bg-base-300">Aufnahme</th>

--- a/src/routes/admin/docs/+page.svelte
+++ b/src/routes/admin/docs/+page.svelte
@@ -50,42 +50,42 @@
 		<div class="grid gap-6 md:grid-cols-2">
 			<div>
 				<h3 class="mb-2 text-lg font-medium">Erweiterte Funktionen</h3>
-				<p class="mb-3 text-sm text-gray-600">
+				<p class="mb-3 text-sm text-base-content/70">
 					Als angemeldeter Administrator haben Sie Zugriff auf zusätzliche Endpunkte:
 				</p>
 				<ul class="space-y-1 text-sm">
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings</code> - Alle Sichtungen abrufen
+						• <code class="rounded bg-base-200 px-1">GET /api/sightings</code> - Alle Sichtungen abrufen
 						(mit Filtern)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">PUT /api/sightings/{'{id}'}</code> - Sichtung bearbeiten
+						• <code class="rounded bg-base-200 px-1">PUT /api/sightings/{'{id}'}</code> - Sichtung bearbeiten
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">DELETE /api/sightings/{'{id}'}</code> - Sichtung
+						• <code class="rounded bg-base-200 px-1">DELETE /api/sightings/{'{id}'}</code> - Sichtung
 						löschen
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">PATCH /api/sightings/{'{id}'}/approve</code> - Sichtung
+						• <code class="rounded bg-base-200 px-1">PATCH /api/sightings/{'{id}'}/approve</code> - Sichtung
 						genehmigen
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export</code> - Datenexport (JSON)
+						• <code class="rounded bg-base-200 px-1">GET /api/sightings/export</code> - Datenexport (JSON)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/csv</code> - Datenexport
+						• <code class="rounded bg-base-200 px-1">GET /api/sightings/export/csv</code> - Datenexport
 						(CSV)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/kml</code> - Datenexport
+						• <code class="rounded bg-base-200 px-1">GET /api/sightings/export/kml</code> - Datenexport
 						(KML)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/sightings/export/xml</code> - Datenexport
+						• <code class="rounded bg-base-200 px-1">GET /api/sightings/export/xml</code> - Datenexport
 						(XML)
 					</li>
 					<li>
-						• <code class="rounded bg-gray-100 px-1">GET /api/statistics</code> - Detaillierte Statistiken
+						• <code class="rounded bg-base-200 px-1">GET /api/statistics</code> - Detaillierte Statistiken
 					</li>
 				</ul>
 			</div>
@@ -124,21 +124,21 @@
 					📊<br />
 					<span class="text-sm">Dashboard</span>
 				</a>
-				<p class="mt-2 text-xs text-gray-500">Übersicht und Statistiken</p>
+				<p class="mt-2 text-xs text-base-content/60">Übersicht und Statistiken</p>
 			</div>
 			<div class="text-center">
 				<a href="/map" class="btn btn-secondary btn-wide">
 					🗺️<br />
 					<span class="text-sm">Sichtungs-Karte</span>
 				</a>
-				<p class="mt-2 text-xs text-gray-500">Alle Sichtungen auf der Karte</p>
+				<p class="mt-2 text-xs text-base-content/60">Alle Sichtungen auf der Karte</p>
 			</div>
 			<div class="text-center">
 				<a href="/docs/api" class="btn btn-outline btn-wide">
 					📖<br />
 					<span class="text-sm">Öffentliche Docs</span>
 				</a>
-				<p class="mt-2 text-xs text-gray-500">Für Entwickler</p>
+				<p class="mt-2 text-xs text-base-content/60">Für Entwickler</p>
 			</div>
 		</div>
 	</div>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -313,11 +313,11 @@
 	<!-- Header -->
 	<div class="mb-8 flex items-center justify-between">
 		<div>
-			<h1 class="flex items-center gap-3 text-3xl font-bold text-gray-900">
+			<h1 class="flex items-center gap-3 text-3xl font-bold text-base-content">
 				<Icon icon="lucide:settings" width="32" height="32" class="text-primary" />
 				Anwendungseinstellungen
 			</h1>
-			<p class="mt-2 text-gray-600">
+			<p class="mt-2 text-base-content/70">
 				Konfigurieren Sie alle Aspekte der Ostsee-Tiere Anwendung über diese zentrale Oberfläche.
 			</p>
 		</div>
@@ -438,13 +438,13 @@
 									? 'border-warning bg-warning/5'
 									: activeConfigKeys.has(config.key)
 										? 'border-base-300'
-										: 'border-gray-200 bg-gray-50'}"
+										: 'border-base-300 bg-base-200'}"
 							>
 								<!-- Config Header -->
 								<div class="mb-3 flex items-start justify-between">
 									<div class="flex-1">
 										<div class="flex items-center gap-2">
-											<div class="text-sm font-semibold text-gray-900">
+											<div class="text-sm font-semibold text-base-content">
 												{config.key}
 											</div>
 											{#if changedConfigs.has(config.key)}
@@ -456,7 +456,7 @@
 											{/if}
 										</div>
 										{#if config.description}
-											<p class="mt-1 text-sm text-gray-600">{config.description}</p>
+											<p class="mt-1 text-sm text-base-content/70">{config.description}</p>
 										{/if}
 									</div>
 

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -13,6 +13,25 @@ import { error, redirect, type Cookies } from '@sveltejs/kit';
 
 const logger = createLogger('auth:auth0');
 
+/**
+ * Validiert eine returnUrl gegen Open-Redirect-Angriffe.
+ *
+ * Erlaubt ausschließlich relative Same-Origin-Pfade, die mit genau einem `/`
+ * beginnen. Externe URLs (`https://evil.com`), protokoll-relative Pfade
+ * (`//evil.com`) und Backslash-Tricks (`/\evil.com`) werden auf `/` normalisiert.
+ */
+export function sanitizeReturnUrl(returnUrl: string | null | undefined): string {
+	if (typeof returnUrl !== 'string' || returnUrl.length === 0) {
+		return '/';
+	}
+	// Muss mit genau einem '/' beginnen — keine protokoll-relativen ('//')
+	// und keine Backslash-Pfade ('/\'), die Browser als externe URL interpretieren.
+	if (!returnUrl.startsWith('/') || returnUrl.startsWith('//') || returnUrl.startsWith('/\\')) {
+		return '/';
+	}
+	return returnUrl;
+}
+
 export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const code = url.searchParams.get('code');
 	const state = url.searchParams.get('state');
@@ -57,7 +76,8 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 			userEmail: authUser.email
 		});
 		cookies.delete('csrfState', { path: '/' });
-		redirect(302, returnUrl);
+		// Open-Redirect-Schutz: nur relative Same-Origin-Pfade zulassen
+		redirect(302, sanitizeReturnUrl(returnUrl));
 	} catch (err) {
 		// SvelteKit redirect() throws internally — re-throw without treating as error
 		if (err instanceof Response || (err as { status?: number })?.status === 302) {

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -8,37 +8,11 @@ import {
 	setAuthCookie,
 	verifyToken
 } from '$lib/server/auth/auth.js';
+import { sanitizeReturnUrl } from '$lib/server/auth/returnUrl';
 import type { User } from '$lib/types';
 import { error, redirect, type Cookies } from '@sveltejs/kit';
 
 const logger = createLogger('auth:auth0');
-
-/**
- * Validiert eine returnUrl gegen Open-Redirect-Angriffe.
- *
- * Erlaubt ausschließlich relative Same-Origin-Pfade, die mit genau einem `/`
- * beginnen. Externe URLs (`https://evil.com`), protokoll-relative Pfade
- * (`//evil.com`) und Backslash-Tricks (`/\evil.com`) werden auf `/` normalisiert.
- */
-export function sanitizeReturnUrl(returnUrl: string | null | undefined): string {
-	if (typeof returnUrl !== 'string' || returnUrl.length === 0) {
-		return '/';
-	}
-	// Whitespace-Zeichen ablehnen. Der WHATWG-URL-Parser entfernt
-	// Tab/CR/LF VOR der Auflösung, sodass z.B. '/\t/evil.com' zu
-	// 'http://evil.com/' würde und die startsWith-Prüfung unten umginge.
-	// Legitime relative Pfade enthalten keine rohen Whitespace/Control-Zeichen
-	// (Leerzeichen wären %20-kodiert).
-	if (/\s/.test(returnUrl)) {
-		return '/';
-	}
-	// Muss mit genau einem '/' beginnen — keine protokoll-relativen ('//')
-	// und keine Backslash-Pfade ('/\'), die Browser als externe URL interpretieren.
-	if (!returnUrl.startsWith('/') || returnUrl.startsWith('//') || returnUrl.startsWith('/\\')) {
-		return '/';
-	}
-	return returnUrl;
-}
 
 export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const code = url.searchParams.get('code');

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -24,6 +24,14 @@ export function sanitizeReturnUrl(returnUrl: string | null | undefined): string 
 	if (typeof returnUrl !== 'string' || returnUrl.length === 0) {
 		return '/';
 	}
+	// Whitespace-Zeichen ablehnen. Der WHATWG-URL-Parser entfernt
+	// Tab/CR/LF VOR der Auflösung, sodass z.B. '/\t/evil.com' zu
+	// 'http://evil.com/' würde und die startsWith-Prüfung unten umginge.
+	// Legitime relative Pfade enthalten keine rohen Whitespace/Control-Zeichen
+	// (Leerzeichen wären %20-kodiert).
+	if (/\s/.test(returnUrl)) {
+		return '/';
+	}
 	// Muss mit genau einem '/' beginnen — keine protokoll-relativen ('//')
 	// und keine Backslash-Pfade ('/\'), die Browser als externe URL interpretieren.
 	if (!returnUrl.startsWith('/') || returnUrl.startsWith('//') || returnUrl.startsWith('/\\')) {

--- a/src/routes/api/auth/callback/callback.test.ts
+++ b/src/routes/api/auth/callback/callback.test.ts
@@ -42,7 +42,8 @@ vi.mock('$lib/server/auth/auth.js', () => ({
 	setAuthCookie: mockSetAuthCookie
 }));
 
-import { GET, sanitizeReturnUrl } from './+server';
+import { GET } from './+server';
+import { sanitizeReturnUrl } from '$lib/server/auth/returnUrl';
 
 function makeCookies() {
 	return {

--- a/src/routes/api/auth/callback/callback.test.ts
+++ b/src/routes/api/auth/callback/callback.test.ts
@@ -178,6 +178,15 @@ describe('sanitizeReturnUrl', () => {
 		expect(sanitizeReturnUrl('http://evil.com/pfad')).toBe('/');
 	});
 
+	it('blockt Whitespace-Bypässe (Tab/CR/LF werden vom URL-Parser gestrippt)', () => {
+		// '/\t/evil.com' würde sonst zu 'http://evil.com/' auflösen
+		expect(sanitizeReturnUrl('/\t/evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('/\tevil.com')).toBe('/');
+		expect(sanitizeReturnUrl('/\n/evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('/\r/evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('/ /evil.com')).toBe('/');
+	});
+
 	it('normalisiert leere/ungültige Werte auf /', () => {
 		expect(sanitizeReturnUrl(null)).toBe('/');
 		expect(sanitizeReturnUrl(undefined)).toBe('/');

--- a/src/routes/api/auth/callback/callback.test.ts
+++ b/src/routes/api/auth/callback/callback.test.ts
@@ -42,7 +42,7 @@ vi.mock('$lib/server/auth/auth.js', () => ({
 	setAuthCookie: mockSetAuthCookie
 }));
 
-import { GET } from './+server';
+import { GET, sanitizeReturnUrl } from './+server';
 
 function makeCookies() {
 	return {
@@ -112,6 +112,43 @@ describe('GET /api/auth/callback — Audit Logging', () => {
 		expect(loginFailureCalls).toHaveLength(0);
 	});
 
+	it('normalisiert eine externe returnUrl auf / (Open-Redirect-Schutz)', async () => {
+		mockGetToken.mockResolvedValue({ id_token: 'id-tok', access_token: 'access-tok' });
+		mockVerifyToken.mockResolvedValue({ email: 'user@test.com', sub: 'auth0|123' });
+		mockGetTokenClaims.mockResolvedValue({ 'https://api.test/roles': ['admin'] });
+
+		let thrown: unknown;
+		await GET({
+			url: new URL(
+				'http://localhost/api/auth/callback?code=auth-code&state=valid-csrf&returnUrl=https://evil.com'
+			),
+			cookies: makeCookies()
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		expect((thrown as { status?: number; location?: string })?.status).toBe(302);
+		expect((thrown as { location?: string })?.location).toBe('/');
+	});
+
+	it('lässt einen legitimen relativen Pfad durch (/admin)', async () => {
+		mockGetToken.mockResolvedValue({ id_token: 'id-tok', access_token: 'access-tok' });
+		mockVerifyToken.mockResolvedValue({ email: 'user@test.com', sub: 'auth0|123' });
+		mockGetTokenClaims.mockResolvedValue({ 'https://api.test/roles': ['admin'] });
+
+		let thrown: unknown;
+		await GET({
+			url: new URL(
+				'http://localhost/api/auth/callback?code=auth-code&state=valid-csrf&returnUrl=/admin'
+			),
+			cookies: makeCookies()
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		expect((thrown as { location?: string })?.location).toBe('/admin');
+	});
+
 	it('loggt security.csrf_mismatch warn bei ungültigem State', async () => {
 		const cookiesWithMismatch = {
 			get: vi.fn().mockImplementation((name: string) => {
@@ -130,5 +167,28 @@ describe('GET /api/auth/callback — Audit Logging', () => {
 			expect.objectContaining({ event: 'security.csrf_mismatch' }),
 			expect.any(String)
 		);
+	});
+});
+
+describe('sanitizeReturnUrl', () => {
+	it('normalisiert externe und protokoll-relative URLs auf /', () => {
+		expect(sanitizeReturnUrl('https://evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('//evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('/\\evil.com')).toBe('/');
+		expect(sanitizeReturnUrl('http://evil.com/pfad')).toBe('/');
+	});
+
+	it('normalisiert leere/ungültige Werte auf /', () => {
+		expect(sanitizeReturnUrl(null)).toBe('/');
+		expect(sanitizeReturnUrl(undefined)).toBe('/');
+		expect(sanitizeReturnUrl('')).toBe('/');
+		expect(sanitizeReturnUrl('admin')).toBe('/');
+	});
+
+	it('lässt legitime relative Pfade durch', () => {
+		expect(sanitizeReturnUrl('/admin')).toBe('/admin');
+		expect(sanitizeReturnUrl('/map')).toBe('/map');
+		expect(sanitizeReturnUrl('/')).toBe('/');
+		expect(sanitizeReturnUrl('/admin/sightings?year=2024')).toBe('/admin/sightings?year=2024');
 	});
 });

--- a/src/routes/api/csp-report/+server.ts
+++ b/src/routes/api/csp-report/+server.ts
@@ -1,31 +1,66 @@
 import { json } from '@sveltejs/kit';
 import type { RequestEvent } from '@sveltejs/kit';
 import { createLogger } from '$lib/logger.server';
+import { enforceRateLimit, createRateLimitIdentifier } from '$lib/server/middleware/rateLimit';
 
 const logger = createLogger('csp-report');
 
+/** Rate-Limit für CSP-Reports: 60 Reports pro Minute und IP */
+const CSP_REPORT_RATE_LIMIT = { windowMs: 60 * 1000, maxRequests: 60 };
+
+/** Maximale akzeptierte Body-Größe eines CSP-Reports (8 KB) */
+const MAX_CSP_REPORT_BYTES = 8 * 1024;
+
+/** Bekannte, unbedenkliche CSP-Report-Felder, die geloggt werden dürfen */
+type CspReportPayload = Record<string, unknown>;
+
+function extractKnownFields(cspReport: CspReportPayload) {
+	return {
+		blockedUri: cspReport['blocked-uri'],
+		violatedDirective: cspReport['violated-directive'],
+		documentUri: cspReport['document-uri'],
+		sourceFile: cspReport['source-file'],
+		lineNumber: cspReport['line-number']
+	};
+}
+
 /**
  * POST-Handler für /api/csp-report
- * Empfängt und verarbeitet CSP-Verstoßberichte, die vom Browser gesendet werden
+ * Empfängt und verarbeitet CSP-Verstoßberichte, die vom Browser gesendet werden.
  *
- * @param request - Die eingehende Anfrage mit dem CSP-Verstoßbericht
- * @returns Eine leere JSON-Antwort mit 204 Status (No Content)
+ * Sicherheit:
+ * - Rate-Limit gegen Log-Flooding (unauthentifizierter Endpunkt)
+ * - Übergroße Payloads werden verworfen (kein Ressourcen-/Log-Missbrauch)
+ * - Es werden ausschließlich bekannte CSP-Felder geloggt (kein ungefilterter `fullReport`)
  */
-export async function POST({ request }: RequestEvent) {
+export async function POST({ request, getClientAddress }: RequestEvent) {
+	// Rate Limiting (immer anonym — CSP-Reports tragen keine Auth)
+	const clientIp = getClientAddress?.() ?? 'unknown';
+	const identifier = createRateLimitIdentifier(undefined, clientIp, false);
+	enforceRateLimit(identifier, CSP_REPORT_RATE_LIMIT, 'csp_report');
+
+	// Übergroße Payloads ignorieren
+	const contentLength = Number(request.headers.get('content-length') ?? '0');
+	if (Number.isFinite(contentLength) && contentLength > MAX_CSP_REPORT_BYTES) {
+		logger.warn({ contentLength }, 'CSP-Report verworfen — Payload zu groß');
+		return new Response(null, { status: 204 });
+	}
+
 	try {
 		// CSP-Verstoß aus dem Request-Body extrahieren
-		const report = await request.json();
+		const report = (await request.json()) as CspReportPayload;
 
-		// CSP-Verstoß loggen
-		logger.warn('CSP-Verstoß erkannt', {
-			// Bei neueren Browsern ist der Report im 'csp-report' Feld
-			...report['csp-report'],
-			// Bei älteren Browsern kann der Report direkt im Objekt sein
-			fullReport: report,
-			timestamp: new Date().toISOString()
-		});
+		// Bei neueren Browsern ist der Report im 'csp-report' Feld, sonst direkt im Objekt
+		const cspReport = (report['csp-report'] as CspReportPayload) ?? report ?? {};
 
-		// Optional: Hier könntest du den Verstoß in eine Datenbank oder einen externen Logging-Dienst schreiben
+		// Nur bekannte Felder loggen — kein ungefilterter fullReport
+		logger.warn(
+			{
+				...extractKnownFields(cspReport),
+				timestamp: new Date().toISOString()
+			},
+			'CSP-Verstoß erkannt'
+		);
 
 		// 204 No Content zurückgeben, da keine Antwort erforderlich ist
 		return new Response(null, { status: 204 });

--- a/src/routes/api/csp-report/+server.ts
+++ b/src/routes/api/csp-report/+server.ts
@@ -39,16 +39,32 @@ export async function POST({ request, getClientAddress }: RequestEvent) {
 	const identifier = createRateLimitIdentifier(undefined, clientIp, false);
 	enforceRateLimit(identifier, CSP_REPORT_RATE_LIMIT, 'csp_report');
 
-	// Übergroße Payloads ignorieren
+	// Schnelle Vorabprüfung anhand des content-length-Headers (kann fehlen/gefälscht sein).
 	const contentLength = Number(request.headers.get('content-length') ?? '0');
 	if (Number.isFinite(contentLength) && contentLength > MAX_CSP_REPORT_BYTES) {
-		logger.warn({ contentLength }, 'CSP-Report verworfen — Payload zu groß');
+		logger.warn({ contentLength }, 'CSP-Report verworfen — Payload zu groß (Header)');
+		return new Response(null, { status: 204 });
+	}
+
+	// Tatsächliche Body-Größe begrenzen: Body als Text lesen und VOR dem Parsen prüfen.
+	// So greift das Limit auch bei chunked Transfer oder fehlendem content-length-Header,
+	// bevor die (globale) BODY_SIZE_LIMIT-Grenze relevant würde.
+	let bodyText: string;
+	try {
+		bodyText = await request.text();
+	} catch (error) {
+		logger.error({ error }, 'Fehler beim Lesen des CSP-Report-Bodys');
+		return json({ success: false, error: 'Ungültiges CSP-Verstoßformat' }, { status: 400 });
+	}
+
+	if (bodyText.length > MAX_CSP_REPORT_BYTES) {
+		logger.warn({ byteLength: bodyText.length }, 'CSP-Report verworfen — Payload zu groß');
 		return new Response(null, { status: 204 });
 	}
 
 	try {
-		// CSP-Verstoß aus dem Request-Body extrahieren
-		const report = (await request.json()) as CspReportPayload;
+		// CSP-Verstoß aus dem bereits gelesenen Body-Text parsen
+		const report = JSON.parse(bodyText) as CspReportPayload;
 
 		// Bei neueren Browsern ist der Report im 'csp-report' Feld, sonst direkt im Objekt
 		const cspReport = (report['csp-report'] as CspReportPayload) ?? report ?? {};

--- a/src/routes/api/csp-report/+server.ts
+++ b/src/routes/api/csp-report/+server.ts
@@ -57,8 +57,11 @@ export async function POST({ request, getClientAddress }: RequestEvent) {
 		return json({ success: false, error: 'Ungültiges CSP-Verstoßformat' }, { status: 400 });
 	}
 
-	if (bodyText.length > MAX_CSP_REPORT_BYTES) {
-		logger.warn({ byteLength: bodyText.length }, 'CSP-Report verworfen — Payload zu groß');
+	// Echte UTF-8-Bytelänge prüfen (nicht String-Länge/UTF-16-Code-Units),
+	// damit das Limit bei Nicht-ASCII-Payloads korrekt greift.
+	const byteLength = Buffer.byteLength(bodyText, 'utf8');
+	if (byteLength > MAX_CSP_REPORT_BYTES) {
+		logger.warn({ byteLength }, 'CSP-Report verworfen — Payload zu groß');
 		return new Response(null, { status: 204 });
 	}
 

--- a/src/routes/api/csp-report/cspReport.test.ts
+++ b/src/routes/api/csp-report/cspReport.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLoggerWarn, mockEnforceRateLimit } = vi.hoisted(() => ({
+	mockLoggerWarn: vi.fn(),
+	mockEnforceRateLimit: vi.fn().mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 })
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: mockLoggerWarn, error: vi.fn() })
+}));
+
+vi.mock('$lib/server/middleware/rateLimit', () => ({
+	enforceRateLimit: mockEnforceRateLimit,
+	createRateLimitIdentifier: vi.fn().mockReturnValue('ip:10.0.0.1')
+}));
+
+import { POST } from './+server';
+
+function makeEvent(body: unknown, headers: Record<string, string> = {}) {
+	const payload = JSON.stringify(body);
+	return {
+		request: new Request('http://localhost/api/csp-report', {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', ...headers },
+			body: payload
+		}),
+		getClientAddress: () => '10.0.0.1'
+	};
+}
+
+describe('POST /api/csp-report', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockEnforceRateLimit.mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 });
+	});
+
+	it('erzwingt Rate-Limiting', async () => {
+		await POST(makeEvent({ 'csp-report': {} }) as never);
+		expect(mockEnforceRateLimit).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.any(Object),
+			'csp_report'
+		);
+	});
+
+	it('loggt nur bekannte CSP-Felder, keinen fullReport', async () => {
+		const report = {
+			'csp-report': {
+				'blocked-uri': 'https://evil.example/script.js',
+				'violated-directive': 'script-src',
+				'document-uri': 'https://app.example/page',
+				'source-file': 'https://app.example/inline',
+				'line-number': 42,
+				'secret-field': 'sollte-nicht-geloggt-werden'
+			}
+		};
+
+		const res = await POST(makeEvent(report) as never);
+		expect(res.status).toBe(204);
+
+		expect(mockLoggerWarn).toHaveBeenCalledOnce();
+		const [logged] = mockLoggerWarn.mock.calls[0] as [Record<string, unknown>, string];
+		expect(logged).toMatchObject({
+			blockedUri: 'https://evil.example/script.js',
+			violatedDirective: 'script-src',
+			documentUri: 'https://app.example/page',
+			sourceFile: 'https://app.example/inline',
+			lineNumber: 42
+		});
+		expect(logged).not.toHaveProperty('fullReport');
+		expect(logged).not.toHaveProperty('secret-field');
+	});
+
+	it('verwirft übergroße Payloads mit 204 ohne zu loggen', async () => {
+		const res = await POST(
+			makeEvent({ 'csp-report': {} }, { 'content-length': String(9 * 1024) }) as never
+		);
+		expect(res.status).toBe(204);
+		// Nur die "zu groß"-Warnung, kein CSP-Verstoß-Log mit Feldern
+		const cspViolationLogs = mockLoggerWarn.mock.calls.filter(
+			(call) => call[1] === 'CSP-Verstoß erkannt'
+		);
+		expect(cspViolationLogs).toHaveLength(0);
+	});
+
+	it('gibt 429 zurück, wenn das Rate-Limit greift', async () => {
+		const { error } = await import('@sveltejs/kit');
+		mockEnforceRateLimit.mockImplementation(() => {
+			throw error(429, 'Rate limit exceeded');
+		});
+
+		await expect(POST(makeEvent({ 'csp-report': {} }) as never)).rejects.toMatchObject({
+			status: 429
+		});
+	});
+});

--- a/src/routes/api/csp-report/cspReport.test.ts
+++ b/src/routes/api/csp-report/cspReport.test.ts
@@ -71,7 +71,7 @@ describe('POST /api/csp-report', () => {
 		expect(logged).not.toHaveProperty('secret-field');
 	});
 
-	it('verwirft übergroße Payloads mit 204 ohne zu loggen', async () => {
+	it('verwirft übergroße Payloads mit 204 ohne zu loggen (content-length-Header)', async () => {
 		const res = await POST(
 			makeEvent({ 'csp-report': {} }, { 'content-length': String(9 * 1024) }) as never
 		);
@@ -81,6 +81,32 @@ describe('POST /api/csp-report', () => {
 			(call) => call[1] === 'CSP-Verstoß erkannt'
 		);
 		expect(cspViolationLogs).toHaveLength(0);
+	});
+
+	it('verwirft übergroßen Body trotz kleinem/gefälschtem content-length-Header', async () => {
+		// Tatsächlicher Body > 8 KB, aber content-length-Header gibt fälschlich 10 Bytes an.
+		// Der Header-Check greift NICHT — die tatsächliche Body-Größe muss die Grenze setzen.
+		const hugeReport = { 'csp-report': { 'blocked-uri': 'x'.repeat(9 * 1024) } };
+		const res = await POST(makeEvent(hugeReport, { 'content-length': '10' }) as never);
+
+		expect(res.status).toBe(204);
+		const cspViolationLogs = mockLoggerWarn.mock.calls.filter(
+			(call) => call[1] === 'CSP-Verstoß erkannt'
+		);
+		expect(cspViolationLogs).toHaveLength(0);
+	});
+
+	it('gibt 400 bei ungültigem JSON zurück', async () => {
+		const event = {
+			request: new Request('http://localhost/api/csp-report', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: '{ not valid json'
+			}),
+			getClientAddress: () => '10.0.0.1'
+		};
+		const res = await POST(event as never);
+		expect(res.status).toBe(400);
 	});
 
 	it('gibt 429 zurück, wenn das Rate-Limit greift', async () => {

--- a/src/routes/api/files/delete/+server.ts
+++ b/src/routes/api/files/delete/+server.ts
@@ -4,6 +4,7 @@ import { sightingFiles } from '$lib/server/db/schema';
 import { deleteFileByPath } from '$lib/server/db/sightingFilesRepository';
 import { getStorageProvider } from '$lib/server/storage/factory';
 import { isAdminUser } from '$lib/server/auth/auth';
+import { getUploadUid } from '$lib/server/auth/uploadOwnership';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import {
@@ -17,7 +18,7 @@ import type { RequestHandler } from './$types';
 
 const logger = createLogger('FileDeleteAPI');
 
-export const DELETE: RequestHandler = async ({ request, locals, getClientAddress }) => {
+export const DELETE: RequestHandler = async ({ request, locals, getClientAddress, cookies }) => {
 	const userIdentifier = locals.user?.sub || 'anonymous';
 	const isAuthenticated = !!locals.user;
 	const clientIp = getClientIp(getClientAddress, request);
@@ -59,7 +60,11 @@ export const DELETE: RequestHandler = async ({ request, locals, getClientAddress
 		if (!isAdmin) {
 			// For non-admin users, check if file exists and has no sightingId assigned
 			const fileRecord = await db
-				.select({ id: sightingFiles.id, sightingId: sightingFiles.sightingId })
+				.select({
+					id: sightingFiles.id,
+					sightingId: sightingFiles.sightingId,
+					uid: sightingFiles.uid
+				})
 				.from(sightingFiles)
 				.where(eq(sightingFiles.filePath, filePath))
 				.limit(1);
@@ -87,6 +92,26 @@ export const DELETE: RequestHandler = async ({ request, locals, getClientAddress
 					403,
 					'Datei kann nicht gelöscht werden - sie ist bereits einer Sichtung zugeordnet'
 				);
+			}
+
+			// Ownership-Binding: Anonyme, noch nicht zugeordnete Uploads dürfen nur von DEM
+			// Client gelöscht werden, der sie hochgeladen hat. Der beim Upload gesetzte,
+			// cookie-gebundene Owner-UID muss mit dem gespeicherten uid der Datei übereinstimmen.
+			const requesterUid = getUploadUid(cookies);
+			if (!requesterUid || requesterUid !== file.uid) {
+				logger.warn(
+					{
+						action: 'file_delete_blocked',
+						reason: 'upload_uid_mismatch',
+						filePath,
+						user: userIdentifier,
+						authenticated: isAuthenticated,
+						hasCookie: !!requesterUid,
+						clientIp
+					},
+					'Non-admin user attempted to delete file without matching upload-uid cookie'
+				);
+				throw error(403, 'Datei kann nicht gelöscht werden - keine Berechtigung');
 			}
 
 			logger.info(

--- a/src/routes/api/files/delete/+server.ts
+++ b/src/routes/api/files/delete/+server.ts
@@ -6,6 +6,11 @@ import { getStorageProvider } from '$lib/server/storage/factory';
 import { isAdminUser } from '$lib/server/auth/auth';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { getClientIp } from '$lib/server/utils/getClientIp';
+import {
+	RATE_LIMITS,
+	enforceRateLimit,
+	createRateLimitIdentifier
+} from '$lib/server/middleware/rateLimit';
 import { error, isHttpError, json } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
@@ -18,6 +23,17 @@ export const DELETE: RequestHandler = async ({ request, locals, getClientAddress
 	const clientIp = getClientIp(getClientAddress, request);
 
 	try {
+		// Rate Limiting (analog zum Upload) — verhindert massenhaftes anonymes Löschen
+		const rateLimitConfig = isAuthenticated
+			? RATE_LIMITS.FILE_UPLOAD_AUTHENTICATED
+			: RATE_LIMITS.FILE_UPLOAD_ANONYMOUS;
+		const rateLimitIdentifier = createRateLimitIdentifier(
+			locals.user?.sub,
+			clientIp ?? 'unknown',
+			isAuthenticated
+		);
+		enforceRateLimit(rateLimitIdentifier, rateLimitConfig, 'file_delete');
+
 		const { filePath } = await request.json();
 
 		if (!filePath) {

--- a/src/routes/api/files/delete/fileDelete.test.ts
+++ b/src/routes/api/files/delete/fileDelete.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockLogAuditEvent, mockIsAdminUser, mockSelect, mockStorage } = vi.hoisted(() => ({
-	mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
-	mockIsAdminUser: vi.fn().mockReturnValue(true),
-	mockSelect: vi.fn(),
-	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) }
+const { mockLogAuditEvent, mockIsAdminUser, mockSelect, mockStorage, mockEnforceRateLimit } =
+	vi.hoisted(() => ({
+		mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
+		mockIsAdminUser: vi.fn().mockReturnValue(true),
+		mockSelect: vi.fn(),
+		mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
+		mockEnforceRateLimit: vi.fn().mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 })
+	}));
+
+vi.mock('$lib/server/middleware/rateLimit', () => ({
+	RATE_LIMITS: {
+		FILE_UPLOAD_ANONYMOUS: { windowMs: 3600000, maxRequests: 20 },
+		FILE_UPLOAD_AUTHENTICATED: { windowMs: 3600000, maxRequests: 50 }
+	},
+	enforceRateLimit: mockEnforceRateLimit,
+	createRateLimitIdentifier: vi.fn().mockReturnValue('ip:10.0.0.1')
 }));
 
 vi.mock('$lib/server/audit/auditService', () => ({
@@ -65,6 +76,30 @@ describe('DELETE /api/files/delete — Audit Logging', () => {
 		vi.clearAllMocks();
 		mockStorage.delete.mockResolvedValue(undefined);
 		mockIsAdminUser.mockReturnValue(true);
+		mockEnforceRateLimit.mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 });
+	});
+
+	it('erzwingt Rate-Limiting vor dem Löschen', async () => {
+		const event = makeEvent('uploads/test-image.jpg');
+		await DELETE(event as never);
+
+		expect(mockEnforceRateLimit).toHaveBeenCalledOnce();
+		expect(mockEnforceRateLimit).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({ maxRequests: 50 }),
+			'file_delete'
+		);
+	});
+
+	it('bricht mit 429 ab, wenn das Rate-Limit überschritten ist', async () => {
+		const { error } = await import('@sveltejs/kit');
+		mockEnforceRateLimit.mockImplementation(() => {
+			throw error(429, 'Rate limit exceeded');
+		});
+
+		const event = makeEvent('uploads/test-image.jpg');
+		await expect(DELETE(event as never)).rejects.toMatchObject({ status: 429 });
+		expect(mockStorage.delete).not.toHaveBeenCalled();
 	});
 
 	it('loggt file.delete für Admin-Löschungen', async () => {

--- a/src/routes/api/files/delete/fileDelete.test.ts
+++ b/src/routes/api/files/delete/fileDelete.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockLogAuditEvent, mockIsAdminUser, mockSelect, mockStorage, mockEnforceRateLimit } =
-	vi.hoisted(() => ({
-		mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
-		mockIsAdminUser: vi.fn().mockReturnValue(true),
-		mockSelect: vi.fn(),
-		mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
-		mockEnforceRateLimit: vi.fn().mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 })
-	}));
+const {
+	mockLogAuditEvent,
+	mockIsAdminUser,
+	mockSelect,
+	mockStorage,
+	mockEnforceRateLimit,
+	mockGetUploadUid
+} = vi.hoisted(() => ({
+	mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
+	mockIsAdminUser: vi.fn().mockReturnValue(true),
+	mockSelect: vi.fn(),
+	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
+	mockEnforceRateLimit: vi.fn().mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 }),
+	mockGetUploadUid: vi.fn().mockReturnValue('owner-uid-match')
+}));
 
 vi.mock('$lib/server/middleware/rateLimit', () => ({
 	RATE_LIMITS: {
@@ -24,6 +31,10 @@ vi.mock('$lib/server/audit/auditService', () => ({
 
 vi.mock('$lib/server/auth/auth', () => ({
 	isAdminUser: mockIsAdminUser
+}));
+
+vi.mock('$lib/server/auth/uploadOwnership', () => ({
+	getUploadUid: mockGetUploadUid
 }));
 
 vi.mock('$lib/logger.server', () => ({
@@ -56,7 +67,12 @@ vi.mock('drizzle-orm', () => ({
 
 import { DELETE } from './+server';
 
-function makeEvent(filePath: string) {
+function makeEvent(
+	filePath: string,
+	locals: Record<string, unknown> = {
+		user: { email: 'admin@test.com', sub: 'auth0|admin', roles: ['admin'] }
+	}
+) {
 	return {
 		request: new Request('http://localhost/api/files/delete', {
 			method: 'DELETE',
@@ -66,10 +82,15 @@ function makeEvent(filePath: string) {
 			},
 			body: JSON.stringify({ filePath })
 		}),
-		locals: { user: { email: 'admin@test.com', sub: 'auth0|admin', roles: ['admin'] } },
-		getClientAddress: () => '10.0.0.1'
+		locals,
+		getClientAddress: () => '10.0.0.1',
+		// Cookies werden im Handler nur an das (gemockte) getUploadUid übergeben.
+		cookies: { get: vi.fn() }
 	};
 }
+
+/** Locals eines anonymen (nicht angemeldeten) Nutzers. */
+const ANON_LOCALS = { user: null };
 
 describe('DELETE /api/files/delete — Audit Logging', () => {
 	beforeEach(() => {
@@ -77,7 +98,16 @@ describe('DELETE /api/files/delete — Audit Logging', () => {
 		mockStorage.delete.mockResolvedValue(undefined);
 		mockIsAdminUser.mockReturnValue(true);
 		mockEnforceRateLimit.mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 });
+		mockGetUploadUid.mockReturnValue('owner-uid-match');
 	});
+
+	/** Setzt den Select-Mock so, dass eine nicht zugeordnete Datei mit gegebenem uid gefunden wird. */
+	function mockFileRecord(uid: string | null, sightingId: number | null = null) {
+		const mockLimit = vi.fn().mockResolvedValue([{ id: 1, sightingId, uid }]);
+		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+		mockSelect.mockReturnValue({ from: mockFrom });
+	}
 
 	it('erzwingt Rate-Limiting vor dem Löschen', async () => {
 		const event = makeEvent('uploads/test-image.jpg');
@@ -118,15 +148,56 @@ describe('DELETE /api/files/delete — Audit Logging', () => {
 
 	it('loggt KEIN file.delete für nicht-Admin-Löschungen', async () => {
 		mockIsAdminUser.mockReturnValue(false);
+		mockFileRecord('owner-uid-match');
+		mockGetUploadUid.mockReturnValue('owner-uid-match');
 
-		const mockLimit = vi.fn().mockResolvedValue([{ id: 1, sightingId: null }]);
-		const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-		const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-		mockSelect.mockReturnValue({ from: mockFrom });
-
-		const event = makeEvent('uploads/unassigned.jpg');
+		const event = makeEvent('uploads/unassigned.jpg', ANON_LOCALS);
 		await DELETE(event as never);
 
 		expect(mockLogAuditEvent).not.toHaveBeenCalled();
+	});
+
+	it('erlaubt Löschen einer nicht zugeordneten Datei mit passendem upload-uid-Cookie', async () => {
+		mockIsAdminUser.mockReturnValue(false);
+		mockFileRecord('owner-uid-match');
+		mockGetUploadUid.mockReturnValue('owner-uid-match');
+
+		const event = makeEvent('uploads/unassigned.jpg', ANON_LOCALS);
+		const res = await DELETE(event as never);
+
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/unassigned.jpg');
+		expect((res as Response).status).toBe(200);
+	});
+
+	it('blockiert Löschen mit fremdem upload-uid-Cookie (403)', async () => {
+		mockIsAdminUser.mockReturnValue(false);
+		mockFileRecord('owner-uid-match');
+		mockGetUploadUid.mockReturnValue('someone-else');
+
+		const event = makeEvent('uploads/unassigned.jpg', ANON_LOCALS);
+		await expect(DELETE(event as never)).rejects.toMatchObject({ status: 403 });
+		expect(mockStorage.delete).not.toHaveBeenCalled();
+	});
+
+	it('blockiert Löschen ohne upload-uid-Cookie (403)', async () => {
+		mockIsAdminUser.mockReturnValue(false);
+		mockFileRecord('owner-uid-match');
+		mockGetUploadUid.mockReturnValue(undefined);
+
+		const event = makeEvent('uploads/unassigned.jpg', ANON_LOCALS);
+		await expect(DELETE(event as never)).rejects.toMatchObject({ status: 403 });
+		expect(mockStorage.delete).not.toHaveBeenCalled();
+	});
+
+	it('erlaubt Admin das Löschen unabhängig vom upload-uid-Cookie', async () => {
+		mockIsAdminUser.mockReturnValue(true);
+		mockGetUploadUid.mockReturnValue(undefined); // Admin braucht keinen Cookie
+
+		const event = makeEvent('uploads/admin-delete.jpg');
+		const res = await DELETE(event as never);
+
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/admin-delete.jpg');
+		expect((res as Response).status).toBe(200);
+		expect(mockLogAuditEvent).toHaveBeenCalledOnce();
 	});
 });

--- a/src/routes/api/files/upload/+server.ts
+++ b/src/routes/api/files/upload/+server.ts
@@ -2,6 +2,7 @@ import { FILE_VALIDATION_PRESETS } from '$lib/constants/upload';
 import { createLogger } from '$lib/logger.server';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { saveUploadedFile } from '$lib/server/db/sightingFilesRepository';
+import { getOrCreateUploadUid } from '$lib/server/auth/uploadOwnership';
 import { readImageExifData } from '$lib/server/media/exifUtils';
 import { getStorageProvider } from '$lib/server/storage/factory';
 import { isDangerousFileType, validateMagicBytes } from '$lib/server/validation/magicBytes';
@@ -22,7 +23,7 @@ const logger = createLogger('FileUploadAPI');
 // Get storage provider and upload file
 const storage = getStorageProvider();
 
-export const POST: RequestHandler = async ({ request, locals, getClientAddress }) => {
+export const POST: RequestHandler = async ({ request, locals, getClientAddress, cookies }) => {
 	// Security: Track authentication status
 	const isAuthenticated = !!locals.user;
 	const userIdentifier = locals.user?.sub || 'anonymous';
@@ -197,8 +198,13 @@ export const POST: RequestHandler = async ({ request, locals, getClientAddress }
 
 		uploadedFile.exifData = metadata;
 
-		// Speichere die hochgeladene Datei in der Datenbank
-		await saveUploadedFile(uploadedFile, referenceId);
+		// Ownership-Binding: Serverseitig generierter, cookie-gebundener Owner-UID.
+		// Wird MIT der Datei gespeichert (überschreibt den nicht vertrauenswürdigen
+		// client-gelieferten FormData-uid in der DB) und beim Löschen als Nachweis geprüft.
+		// Wichtig: Dateiname auf der Platte und die JSON-Response behalten den per-Datei-uid
+		// (Frontend-Key); nur der DB-Datensatz erhält den Owner-UID.
+		const ownerUid = getOrCreateUploadUid(cookies);
+		await saveUploadedFile({ ...uploadedFile, uid: ownerUid }, referenceId);
 
 		// Add rate limit headers from the already-computed result (no second counter increment)
 		return json(uploadedFile, {

--- a/src/routes/api/map/sightings/+server.ts
+++ b/src/routes/api/map/sightings/+server.ts
@@ -82,13 +82,8 @@ export const GET: RequestHandler = async ({ url }) => {
 			'Fehler beim Abrufen der Sichtungen für die Karte'
 		);
 
-		// Fehlerantwort zurückgeben
-		return json(
-			{
-				error: 'Fehler beim Abrufen der Sichtungen',
-				details: error instanceof Error ? error.message : 'Unbekannter Fehler'
-			},
-			{ status: 500 }
-		);
+		// Fehlerantwort zurückgeben — keine internen Fehlerdetails an den Client leaken
+		// (der konkrete Fehler wurde oben serverseitig geloggt).
+		return json({ error: 'Fehler beim Abrufen der Sichtungen' }, { status: 500 });
 	}
 };

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -211,18 +211,26 @@ export const POST: RequestHandler = async ({ request, locals, getClientAddress }
 
 		logger.info({ id, referenceId }, 'Sichtung erfolgreich gespeichert');
 
-		// Send email notification if enabled
+		// Send email notification if enabled — fire-and-forget, damit der SMTP-Versand
+		// die HTTP-Response nicht blockiert. Fehler werden geloggt, nicht geworfen.
 		try {
 			const emailConfig = await ServerConfigService.getEmailConfig();
 			if (emailConfig.enabled && emailConfig.recipient && id) {
 				// Use new ID-based email service that reads from database
 				// This ensures correct Baltic Sea validation data is used
-				await EmailService.sendNewSightingNotification(id);
-
-				logger.info({ id, referenceId }, 'Email notification sent successfully');
+				void EmailService.sendNewSightingNotification(id)
+					.then(() => {
+						logger.info({ id, referenceId }, 'Email notification sent successfully');
+					})
+					.catch((emailError) => {
+						logger.error(
+							{ emailError, id },
+							'Failed to send email notification, but sighting was saved'
+						);
+					});
 			}
 		} catch (emailError) {
-			// Don't fail the request if email sending fails
+			// Don't fail the request if the email config lookup fails
 			logger.error({ emailError, id }, 'Failed to send email notification, but sighting was saved');
 		}
 

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -7,6 +7,6 @@
 	<meta name="description" content="API-Dokumentation für die Ostsee-Tiere Plattform" />
 </svelte:head>
 
-<main class="container mx-auto p-4">
+<div class="container mx-auto p-4">
 	<slot />
-</main>
+</div>

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -37,7 +37,7 @@
 			<Icon icon="lucide:book-open" width="40" height="40" class="text-primary" />
 			Dokumentation
 		</h1>
-		<p class="text-lg text-gray-600">Willkommen zur Dokumentation der Ostsee-Tiere Plattform</p>
+		<p class="text-lg text-base-content/70">Willkommen zur Dokumentation der Ostsee-Tiere Plattform</p>
 	</div>
 
 	<div class="grid gap-6 md:grid-cols-2">
@@ -49,13 +49,13 @@
 					API-Dokumentation
 					<div class="badge badge-primary">Interactive</div>
 				</h2>
-				<p class="text-sm text-gray-600">
+				<p class="text-sm text-base-content/70">
 					Umfassende OpenAPI-Dokumentation mit interaktiver Schnittstelle. Testen Sie alle Endpunkte
 					direkt im Browser.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Verfügbare APIs:</h3>
-					<ul class="space-y-1 text-xs text-gray-600">
+					<ul class="space-y-1 text-xs text-base-content/70">
 						<li>• Sichtungen verwalten</li>
 						<li>• Dateien hochladen</li>
 						<li>• Datenexport (CSV, JSON, XML, KML)</li>
@@ -78,21 +78,21 @@
 					Erste Schritte
 					<div class="badge badge-secondary">Guide</div>
 				</h2>
-				<p class="text-sm text-gray-600">Schnelleinstieg für Entwickler und API-Nutzer.</p>
+				<p class="text-sm text-base-content/70">Schnelleinstieg für Entwickler und API-Nutzer.</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Öffentliche Endpunkte:</h3>
 					<div class="space-y-2">
-						<div class="rounded bg-gray-50 p-2 text-xs">
-							<code class="text-blue-600">GET /api/sightings</code>
-							<span class="ml-2 text-gray-500">Öffentliche Sichtungen</span>
+						<div class="rounded bg-base-200 p-2 text-xs">
+							<code class="text-info">GET /api/sightings</code>
+							<span class="ml-2 text-base-content/60">Öffentliche Sichtungen</span>
 						</div>
-						<div class="rounded bg-gray-50 p-2 text-xs">
-							<code class="text-blue-600">POST /api/sightings</code>
-							<span class="ml-2 text-gray-500">Neue Sichtung melden</span>
+						<div class="rounded bg-base-200 p-2 text-xs">
+							<code class="text-info">POST /api/sightings</code>
+							<span class="ml-2 text-base-content/60">Neue Sichtung melden</span>
 						</div>
-						<div class="rounded bg-gray-50 p-2 text-xs">
-							<code class="text-blue-600">POST /api/files/upload</code>
-							<span class="ml-2 text-gray-500">Dateien hochladen</span>
+						<div class="rounded bg-base-200 p-2 text-xs">
+							<code class="text-info">POST /api/files/upload</code>
+							<span class="ml-2 text-base-content/60">Dateien hochladen</span>
 						</div>
 					</div>
 				</div>
@@ -110,13 +110,13 @@
 					OpenAPI Spezifikation
 					<div class="badge badge-accent">Download</div>
 				</h2>
-				<p class="text-sm text-gray-600">
+				<p class="text-sm text-base-content/70">
 					Laden Sie die vollständige OpenAPI-Spezifikation herunter für die Verwendung in Tools wie
 					Postman, Insomnia oder zur Code-Generierung.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Formate:</h3>
-					<ul class="space-y-1 text-xs text-gray-600">
+					<ul class="space-y-1 text-xs text-base-content/70">
 						<li>• YAML (empfohlen)</li>
 						<li>• JSON (über API)</li>
 						<li>• Code-Generierung unterstützt</li>
@@ -138,12 +138,12 @@
 					Authentifizierung
 					<div class="badge badge-warning">Admin</div>
 				</h2>
-				<p class="text-sm text-gray-600">
+				<p class="text-sm text-base-content/70">
 					Für Admin-Funktionen ist eine Authentifizierung über Auth0 erforderlich.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Authentifizierungs-Flow:</h3>
-					<ol class="list-inside list-decimal space-y-1 text-xs text-gray-600">
+					<ol class="list-inside list-decimal space-y-1 text-xs text-base-content/70">
 						<li>Login-Endpunkt aufrufen</li>
 						<li>Auth0-Flow durchlaufen</li>
 						<li>Session-Cookie wird gesetzt</li>
@@ -188,7 +188,7 @@
 	</div>
 
 	<!-- Project Information -->
-	<div class="mt-8 text-center text-sm text-gray-500">
+	<div class="mt-8 text-center text-sm text-base-content/60">
 		<p>
 			Die Ostsee-Tiere Plattform ermöglicht es Bürgern, Forschern und Naturbeobachtern, ihre
 			Sichtungen von Walen, Robben und anderen Meerestieren zu melden.

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -59,7 +59,7 @@
 <div class="mx-auto max-w-6xl p-4">
 	<div class="mb-8">
 		<h1 class="mb-4 text-3xl font-bold">📄 API-Dokumentation (Fallback)</h1>
-		<p class="mb-4 text-gray-600">
+		<p class="mb-4 text-base-content/70">
 			Diese vereinfachte Ansicht zeigt die OpenAPI-Spezifikation an, falls die interaktive
 			Scalar-Dokumentation nicht geladen werden kann.
 		</p>
@@ -89,16 +89,16 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔍 Sichtungen</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-green-600">GET</code> /sightings - Öffentliche Sichtungen</div>
-						<div><code class="text-blue-600">POST</code> /sightings - Neue Sichtung</div>
+						<div><code class="text-success">GET</code> /sightings - Öffentliche Sichtungen</div>
+						<div><code class="text-info">POST</code> /sightings - Neue Sichtung</div>
 						<div>
-							<code class="text-green-600">GET</code> /sightings/{'{id}'} - Einzelne Sichtung
+							<code class="text-success">GET</code> /sightings/{'{id}'} - Einzelne Sichtung
 						</div>
 						<div>
 							<code class="text-orange-600">PUT</code> /sightings/{'{id}'} - Sichtung ändern
 						</div>
 						<div>
-							<code class="text-red-600">DELETE</code> /sightings/{'{id}'} - Sichtung löschen
+							<code class="text-error">DELETE</code> /sightings/{'{id}'} - Sichtung löschen
 						</div>
 					</div>
 				</div>
@@ -108,9 +108,9 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔐 Authentifizierung</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-green-600">GET</code> /auth/login - Login starten</div>
-						<div><code class="text-green-600">GET</code> /auth/logout - Logout</div>
-						<div><code class="text-green-600">GET</code> /auth/callback - Auth0 Callback</div>
+						<div><code class="text-success">GET</code> /auth/login - Login starten</div>
+						<div><code class="text-success">GET</code> /auth/logout - Logout</div>
+						<div><code class="text-success">GET</code> /auth/callback - Auth0 Callback</div>
 					</div>
 				</div>
 			</div>
@@ -119,8 +119,8 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">📁 Dateien</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-blue-600">POST</code> /files/upload - Datei hochladen</div>
-						<div><code class="text-red-600">DELETE</code> /files/delete - Datei löschen</div>
+						<div><code class="text-info">POST</code> /files/upload - Datei hochladen</div>
+						<div><code class="text-error">DELETE</code> /files/delete - Datei löschen</div>
 					</div>
 				</div>
 			</div>
@@ -129,10 +129,10 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">📊 Export</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-green-600">GET</code> /sightings/export/json - JSON Export</div>
-						<div><code class="text-green-600">GET</code> /sightings/export/csv - CSV Export</div>
-						<div><code class="text-green-600">GET</code> /sightings/export/xml - XML Export</div>
-						<div><code class="text-green-600">GET</code> /sightings/export/kml - KML Export</div>
+						<div><code class="text-success">GET</code> /sightings/export/json - JSON Export</div>
+						<div><code class="text-success">GET</code> /sightings/export/csv - CSV Export</div>
+						<div><code class="text-success">GET</code> /sightings/export/xml - XML Export</div>
+						<div><code class="text-success">GET</code> /sightings/export/kml - KML Export</div>
 					</div>
 				</div>
 			</div>
@@ -142,10 +142,10 @@
 					<h2 class="card-title text-lg">⚙️ Admin</h2>
 					<div class="space-y-1 text-sm">
 						<div>
-							<code class="text-blue-600">POST</code> /sightings/{'{id}'}/approve - Genehmigen
+							<code class="text-info">POST</code> /sightings/{'{id}'}/approve - Genehmigen
 						</div>
 						<div>
-							<code class="text-blue-600">POST</code> /sightings/{'{id}'}/verify - Verifizieren
+							<code class="text-info">POST</code> /sightings/{'{id}'}/verify - Verifizieren
 						</div>
 					</div>
 				</div>
@@ -155,15 +155,15 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🌍 Geo</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-green-600">GET</code> /geo/inBaltic - Ostsee-Prüfung</div>
-						<div><code class="text-green-600">GET</code> /map/sightings - Kartendaten</div>
+						<div><code class="text-success">GET</code> /geo/inBaltic - Ostsee-Prüfung</div>
+						<div><code class="text-success">GET</code> /map/sightings - Kartendaten</div>
 					</div>
 				</div>
 			</div>
 		</div>
 
 		<!-- Authentication Info -->
-		<div class="mb-8 rounded-lg border border-yellow-200 bg-yellow-50 p-6">
+		<div class="mb-8 rounded-lg border border-warning/30 bg-warning/10 p-6">
 			<h2 class="mb-4 text-xl font-semibold">🔐 Authentifizierung</h2>
 			<div class="grid gap-6 md:grid-cols-2">
 				<div>
@@ -195,7 +195,7 @@
 					YAML-Inhalt anzeigen
 				</summary>
 				<div class="collapse-content">
-					<pre class="max-h-96 overflow-auto rounded border bg-gray-50 p-4 text-xs"><code
+					<pre class="max-h-96 overflow-auto rounded border bg-base-200 p-4 text-xs"><code
 							>{openApiSpec}</code
 						></pre>
 				</div>
@@ -203,23 +203,23 @@
 		</div>
 
 		<!-- Alternative Tools -->
-		<div class="rounded-lg border border-blue-200 bg-blue-50 p-6">
+		<div class="rounded-lg border border-info/30 bg-info/10 p-6">
 			<h2 class="mb-4 text-xl font-semibold">🔧 Alternative Tools</h2>
-			<p class="mb-4 text-sm text-gray-600">
+			<p class="mb-4 text-sm text-base-content/70">
 				Sie können die OpenAPI-Spezifikation in diesen Tools verwenden:
 			</p>
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Postman</h3>
-					<p class="text-xs text-gray-600">Importieren Sie die YAML-Datei für API-Tests</p>
+					<p class="text-xs text-base-content/70">Importieren Sie die YAML-Datei für API-Tests</p>
 				</div>
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Insomnia</h3>
-					<p class="text-xs text-gray-600">Laden Sie die Spezifikation für REST-Tests</p>
+					<p class="text-xs text-base-content/70">Laden Sie die Spezifikation für REST-Tests</p>
 				</div>
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Swagger Editor</h3>
-					<p class="text-xs text-gray-600">Online-Editor für OpenAPI-Specs</p>
+					<p class="text-xs text-base-content/70">Online-Editor für OpenAPI-Specs</p>
 				</div>
 			</div>
 		</div>

--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -10,14 +10,20 @@
  */
 
 import { env } from '$env/dynamic/private';
+import { testDatabaseConnection } from '$lib/server/db';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
+
+const NO_CACHE_HEADERS = {
+	'Cache-Control': 'no-cache, no-store, must-revalidate',
+	'Content-Type': 'application/json'
+} as const;
 
 export const GET: RequestHandler = async () => {
 	const startTime = Date.now();
 
-	// Basic health status
-	const health = {
+	// Basis-Status
+	const health: Record<string, unknown> = {
 		status: 'healthy',
 		timestamp: new Date().toISOString(),
 		uptime: process.uptime(),
@@ -25,42 +31,34 @@ export const GET: RequestHandler = async () => {
 		version: env.npm_package_version ?? process.env.npm_package_version ?? 'unknown'
 	};
 
-	// Optional: Check database connectivity
-	// Uncomment if you want database health checks
-	/*
+	// Readiness: echte DB-Konnektivität prüfen. Docker/compose fragt nur `/health`
+	// ab, daher prüft dieser Endpoint die Datenbank und liefert 503 bei Ausfall.
+	// testDatabaseConnection() fängt Fehler bereits intern ab und cached das
+	// Ergebnis kurz, um die DB nicht zu überlasten.
+	let databaseHealthy = false;
 	try {
-		const { db } = await import('$lib/server/db');
-		const { sql } = await import('drizzle-orm');
+		databaseHealthy = await testDatabaseConnection();
+	} catch {
+		databaseHealthy = false;
+	}
 
-		await db.execute(sql`SELECT 1`);
-		health.database = 'connected';
-	} catch (error) {
+	if (!databaseHealthy) {
 		health.status = 'unhealthy';
 		health.database = 'disconnected';
-		health.error = error instanceof Error ? error.message : 'Unknown database error';
 
 		const responseTime = Date.now() - startTime;
 		return json(
 			{ ...health, responseTime: `${responseTime}ms` },
-			{ status: 503 }
+			{ status: 503, headers: NO_CACHE_HEADERS }
 		);
 	}
-	*/
 
+	health.database = 'connected';
 	const responseTime = Date.now() - startTime;
 
 	return json(
-		{
-			...health,
-			responseTime: `${responseTime}ms`
-		},
-		{
-			status: 200,
-			headers: {
-				'Cache-Control': 'no-cache, no-store, must-revalidate',
-				'Content-Type': 'application/json'
-			}
-		}
+		{ ...health, responseTime: `${responseTime}ms` },
+		{ status: 200, headers: NO_CACHE_HEADERS }
 	);
 };
 

--- a/src/routes/health/health.test.ts
+++ b/src/routes/health/health.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit-Tests für den /health-Endpoint.
+ *
+ * Prüft die Readiness-Semantik: DB erreichbar → 200 healthy,
+ * DB nicht erreichbar oder Fehler → 503 unhealthy.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testDatabaseConnection = vi.fn();
+
+vi.mock('$env/dynamic/private', () => ({
+	env: { NODE_ENV: 'test', npm_package_version: '0.0.0' }
+}));
+
+vi.mock('$lib/server/db', () => ({
+	testDatabaseConnection: (...args: unknown[]) => testDatabaseConnection(...args)
+}));
+
+import { GET } from './+server';
+
+// Minimales RequestEvent-Mock (GET nutzt keine Event-Argumente)
+const event = {} as Parameters<typeof GET>[0];
+
+describe('GET /health', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('liefert 200 und status "healthy" wenn die DB erreichbar ist', async () => {
+		testDatabaseConnection.mockResolvedValue(true);
+
+		const res = await GET(event);
+		const body = await res.json();
+
+		expect(res.status).toBe(200);
+		expect(body.status).toBe('healthy');
+		expect(body.database).toBe('connected');
+	});
+
+	it('liefert 503 und status "unhealthy" wenn die DB nicht erreichbar ist', async () => {
+		testDatabaseConnection.mockResolvedValue(false);
+
+		const res = await GET(event);
+		const body = await res.json();
+
+		expect(res.status).toBe(503);
+		expect(body.status).toBe('unhealthy');
+		expect(body.database).toBe('disconnected');
+	});
+
+	it('liefert 503 wenn der DB-Check eine Exception wirft', async () => {
+		testDatabaseConnection.mockRejectedValue(new Error('connection refused'));
+
+		const res = await GET(event);
+		const body = await res.json();
+
+		expect(res.status).toBe(503);
+		expect(body.status).toBe('unhealthy');
+	});
+
+	it('setzt no-cache Header auch im Fehlerfall', async () => {
+		testDatabaseConnection.mockResolvedValue(false);
+
+		const res = await GET(event);
+
+		expect(res.headers.get('cache-control')).toContain('no-cache');
+	});
+});

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -172,21 +172,30 @@ export async function POST(event: RequestEvent): Promise<Response> {
 				'Legacy sighting created successfully (PDF compliant)'
 			);
 
-			// Send email notification if enabled
+			// Send email notification if enabled — fire-and-forget, damit der SMTP-Versand
+			// die HTTP-Response nicht blockiert. Fehler werden geloggt, nicht geworfen.
 			try {
 				const emailConfig = await ServerConfigService.getEmailConfig();
 				if (emailConfig.enabled && emailConfig.recipient && savedSighting.id) {
 					// Use new ID-based email service that reads from database
 					// This ensures correct Baltic Sea validation data is used
-					await EmailService.sendNewSightingNotification(savedSighting.id);
-
-					logger.info(
-						{ sightingId: savedSighting.id, referenceId: transformedData.referenceId },
-						'Legacy API email notification sent successfully'
-					);
+					const emailSightingId = savedSighting.id;
+					void EmailService.sendNewSightingNotification(emailSightingId)
+						.then(() => {
+							logger.info(
+								{ sightingId: emailSightingId, referenceId: transformedData.referenceId },
+								'Legacy API email notification sent successfully'
+							);
+						})
+						.catch((emailError) => {
+							logger.warn(
+								{ sightingId: emailSightingId, emailError },
+								'Failed to send email notification for legacy sighting'
+							);
+						});
 				}
 			} catch (emailError) {
-				// Don't fail the request if email fails
+				// Don't fail the request if the email config lookup fails
 				logger.warn(
 					{ sightingId: savedSighting.id, emailError },
 					'Failed to send email notification for legacy sighting'

--- a/src/routes/uploads/[...path]/+server.ts
+++ b/src/routes/uploads/[...path]/+server.ts
@@ -3,25 +3,105 @@ import { getFileInfo, getUploadPath, isValidUploadPath } from '$lib/server/uploa
 import { error } from '@sveltejs/kit';
 import { createReadStream } from 'fs';
 import { getStorageProvider, isCloudStorage } from '$lib/server/storage/factory';
+import { isAdminUser } from '$lib/server/auth/auth';
+import { db } from '$lib/server/db';
+import { sightingFiles, sightings } from '$lib/server/db/schema';
+import { getClientIp } from '$lib/server/utils/getClientIp';
+import {
+	RATE_LIMITS,
+	enforceRateLimit,
+	createRateLimitIdentifier
+} from '$lib/server/middleware/rateLimit';
+import { eq } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:uploads');
 
-export const GET: RequestHandler = async ({ params }) => {
+/**
+ * Prüft anhand der Datenbank, ob der Zugriff auf eine Datei erlaubt ist.
+ *
+ * Regeln (analog zu /api/media):
+ * - Öffentlicher Zugriff nur für freigegebene Sichtungen (`approvedAt` gesetzt).
+ * - Unfreigegebene Medien nur für Admins.
+ * - Unbekannte Dateien werden als 404 behandelt (Existenz wird nicht verraten).
+ */
+async function assertFileAccessAllowed(
+	filePath: string,
+	locals: App.Locals,
+	clientIp: string
+): Promise<void> {
+	const fileRecord = await db
+		.select({
+			sightingId: sightingFiles.sightingId,
+			approvedAt: sightings.approvedAt
+		})
+		.from(sightingFiles)
+		.innerJoin(sightings, eq(sightingFiles.sightingId, sightings.id))
+		.where(eq(sightingFiles.filePath, filePath))
+		.limit(1);
+
+	const file = fileRecord[0];
+	if (!file) {
+		logger.warn({ filePath, clientIp }, 'Datei nicht in Datenbank gefunden');
+		throw error(404, 'Datei nicht gefunden');
+	}
+
+	const isApproved = !!file.approvedAt;
+	if (!isApproved) {
+		const user = locals.user;
+		if (!isAdminUser(user)) {
+			logger.warn(
+				{
+					action: 'upload_access_unauthorized',
+					filePath,
+					sightingId: file.sightingId,
+					hasUser: !!user,
+					clientIp
+				},
+				'Nicht autorisierter Zugriff auf unfreigegebene Datei'
+			);
+			// Existenz nicht verraten
+			throw error(404, 'Datei nicht gefunden');
+		}
+
+		logger.info(
+			{ filePath, sightingId: file.sightingId, userId: user?.sub },
+			'Admin greift auf unfreigegebene Datei zu'
+		);
+	}
+}
+
+export const GET: RequestHandler = async ({ params, request, locals, getClientAddress }) => {
 	const filePath = params.path;
-	
+	const clientIp = getClientIp(getClientAddress, request) ?? 'unknown';
+
 	// Pfad-Validierung
 	if (!filePath || !isValidUploadPath(filePath)) {
 		logger.warn({ filePath }, 'Ungültiger Dateipfad angefordert');
 		throw error(400, 'Ungültiger Dateipfad');
 	}
 
+	// Rate Limiting basierend auf Authentifizierungsstatus
+	const isAuthenticated = !!locals.user;
+	const rateLimitConfig = isAuthenticated
+		? RATE_LIMITS.MEDIA_ACCESS_AUTHENTICATED
+		: RATE_LIMITS.MEDIA_ACCESS_ANONYMOUS;
+	const rateLimitIdentifier = createRateLimitIdentifier(
+		locals.user?.sub,
+		clientIp,
+		isAuthenticated
+	);
+	enforceRateLimit(rateLimitIdentifier, rateLimitConfig, 'upload_access');
+
+	// Freigabe-/Admin-Prüfung (analog zu /api/media)
+	await assertFileAccessAllowed(filePath, locals, clientIp);
+
 	// For cloud storage, redirect to the actual URL
 	if (isCloudStorage()) {
 		try {
 			const storage = getStorageProvider();
 			const url = storage.getUrl(filePath);
-			
+
 			// For Vercel Blob and other cloud providers, redirect to their URL
 			return new Response(null, {
 				status: 302,
@@ -38,10 +118,10 @@ export const GET: RequestHandler = async ({ params }) => {
 
 	// Local storage - serve directly
 	const fullPath = getUploadPath(filePath);
-	
+
 	// Datei-Informationen abrufen
 	const fileInfo = getFileInfo(fullPath);
-	
+
 	if (!fileInfo) {
 		logger.info({ filePath }, 'Datei nicht gefunden');
 		throw error(404, 'Datei nicht gefunden');
@@ -53,11 +133,14 @@ export const GET: RequestHandler = async ({ params }) => {
 		throw error(403, 'Dateityp nicht erlaubt');
 	}
 
-	logger.debug({ filePath, size: fileInfo.size, mimeType: fileInfo.mimeType }, 'Upload-Datei serviert');
+	logger.debug(
+		{ filePath, size: fileInfo.size, mimeType: fileInfo.mimeType },
+		'Upload-Datei serviert'
+	);
 
 	// Datei-Stream erstellen
 	const stream = createReadStream(fullPath);
-	
+
 	// Node.js ReadStream in Web ReadableStream konvertieren
 	const readableStream = new ReadableStream({
 		start(controller) {
@@ -72,7 +155,7 @@ export const GET: RequestHandler = async ({ params }) => {
 			stream.on('error', (err) => controller.error(err));
 		}
 	});
-	
+
 	// Response mit Security-Headers
 	return new Response(readableStream, {
 		status: 200,
@@ -84,11 +167,7 @@ export const GET: RequestHandler = async ({ params }) => {
 			// Security Headers
 			'X-Content-Type-Options': 'nosniff',
 			'Content-Security-Policy': "default-src 'none'",
-			'X-Frame-Options': 'DENY',
-			// CORS für lokale Entwicklung
-			'Access-Control-Allow-Origin': '*',
-			'Access-Control-Allow-Methods': 'GET',
-			'Access-Control-Allow-Headers': 'Content-Type'
+			'X-Frame-Options': 'DENY'
 		}
 	});
 };

--- a/src/routes/uploads/[...path]/uploads.test.ts
+++ b/src/routes/uploads/[...path]/uploads.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+	mockIsAdminUser,
+	mockSelect,
+	mockIsCloudStorage,
+	mockGetStorageProvider,
+	mockEnforceRateLimit,
+	mockIsValidUploadPath
+} = vi.hoisted(() => ({
+	mockIsAdminUser: vi.fn().mockReturnValue(false),
+	mockSelect: vi.fn(),
+	mockIsCloudStorage: vi.fn().mockReturnValue(true),
+	mockGetStorageProvider: vi.fn().mockReturnValue({
+		getUrl: vi.fn().mockReturnValue('https://cdn.example/blob/file.jpg')
+	}),
+	mockEnforceRateLimit: vi.fn().mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 }),
+	mockIsValidUploadPath: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/server/uploads', () => ({
+	isValidUploadPath: mockIsValidUploadPath,
+	getUploadPath: vi.fn().mockReturnValue('/abs/uploads/file.jpg'),
+	getFileInfo: vi.fn()
+}));
+
+vi.mock('$lib/server/storage/factory', () => ({
+	getStorageProvider: mockGetStorageProvider,
+	isCloudStorage: mockIsCloudStorage
+}));
+
+vi.mock('$lib/server/auth/auth', () => ({
+	isAdminUser: mockIsAdminUser
+}));
+
+vi.mock('$lib/server/db', () => ({
+	db: { select: mockSelect }
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightingFiles: { sightingId: {}, filePath: {}, id: {} },
+	sightings: { id: {}, approvedAt: {} }
+}));
+
+vi.mock('drizzle-orm', () => ({
+	eq: vi.fn()
+}));
+
+vi.mock('$lib/server/middleware/rateLimit', () => ({
+	RATE_LIMITS: {
+		MEDIA_ACCESS_ANONYMOUS: { windowMs: 60000, maxRequests: 30 },
+		MEDIA_ACCESS_AUTHENTICATED: { windowMs: 60000, maxRequests: 100 }
+	},
+	enforceRateLimit: mockEnforceRateLimit,
+	createRateLimitIdentifier: vi.fn().mockReturnValue('ip:10.0.0.1')
+}));
+
+vi.mock('$lib/server/utils/getClientIp', () => ({
+	getClientIp: vi.fn().mockReturnValue('10.0.0.1')
+}));
+
+import { GET } from './+server';
+
+function mockDbResult(rows: Array<{ sightingId: number | null; approvedAt: Date | null }>) {
+	const limit = vi.fn().mockResolvedValue(rows);
+	const where = vi.fn().mockReturnValue({ limit });
+	const innerJoin = vi.fn().mockReturnValue({ where });
+	const from = vi.fn().mockReturnValue({ innerJoin });
+	mockSelect.mockReturnValue({ from });
+}
+
+function makeEvent(path: string, user: unknown = null) {
+	return {
+		params: { path },
+		request: new Request(`http://localhost/uploads/${path}`),
+		locals: { user },
+		getClientAddress: () => '10.0.0.1'
+	};
+}
+
+describe('GET /uploads/[...path] — Zugriffskontrolle', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockIsAdminUser.mockReturnValue(false);
+		mockIsCloudStorage.mockReturnValue(true);
+		mockIsValidUploadPath.mockReturnValue(true);
+		mockEnforceRateLimit.mockReturnValue({ remaining: 10, resetTime: Date.now() + 1000 });
+	});
+
+	it('verweigert anonymen Zugriff auf unfreigegebene Dateien mit 404', async () => {
+		mockDbResult([{ sightingId: 5, approvedAt: null }]);
+
+		await expect(GET(makeEvent('ref/unapproved.jpg') as never)).rejects.toMatchObject({
+			status: 404
+		});
+	});
+
+	it('liefert freigegebene Dateien aus (Cloud-Redirect)', async () => {
+		mockDbResult([{ sightingId: 5, approvedAt: new Date() }]);
+
+		const res = await GET(makeEvent('ref/approved.jpg') as never);
+		expect(res.status).toBe(302);
+		expect(res.headers.get('Location')).toBe('https://cdn.example/blob/file.jpg');
+	});
+
+	it('setzt keinen Access-Control-Allow-Origin: * Header', async () => {
+		mockDbResult([{ sightingId: 5, approvedAt: new Date() }]);
+
+		const res = await GET(makeEvent('ref/approved.jpg') as never);
+		expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull();
+	});
+
+	it('erlaubt Admins den Zugriff auf unfreigegebene Dateien', async () => {
+		mockIsAdminUser.mockReturnValue(true);
+		mockDbResult([{ sightingId: 5, approvedAt: null }]);
+
+		const res = await GET(
+			makeEvent('ref/unapproved.jpg', { sub: 'auth0|admin', roles: ['admin'] }) as never
+		);
+		expect(res.status).toBe(302);
+	});
+
+	it('gibt 404 für unbekannte Dateien zurück', async () => {
+		mockDbResult([]);
+
+		await expect(GET(makeEvent('ref/missing.jpg') as never)).rejects.toMatchObject({
+			status: 404
+		});
+	});
+});

--- a/src/tests/contract/csp-report.contract.test.ts
+++ b/src/tests/contract/csp-report.contract.test.ts
@@ -33,6 +33,7 @@ describe('Contract: POST /api/csp-report', () => {
 		const event = {
 			...createEvent('/api/csp-report', { method: 'POST' }),
 			request: {
+				headers: new Headers({ 'content-type': 'application/json' }),
 				json: async () => {
 					throw new SyntaxError('Unexpected token');
 				}

--- a/src/tests/contract/health.contract.test.ts
+++ b/src/tests/contract/health.contract.test.ts
@@ -15,6 +15,11 @@ vi.mock('$env/dynamic/private', () => ({
 	env: { NODE_ENV: 'test', npm_package_version: '0.0.0' }
 }));
 
+// DB-Konnektivität mocken: gesund (true), damit der Contract-Test 200 erhält
+vi.mock('$lib/server/db', () => ({
+	testDatabaseConnection: vi.fn().mockResolvedValue(true)
+}));
+
 describe('Contract: GET /health', () => {
 	it('returns 200 and satisfies the OpenAPI spec', async () => {
 		const event = createEvent('/health');

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1394,7 +1394,11 @@ paths:
       tags:
         - files
       summary: Datei löschen
-      description: Löscht eine hochgeladene Datei
+      description: |
+        Löscht eine hochgeladene Datei.
+
+        Rate-Limiting je nach Authentifizierungsstatus (anonym / authentifiziert)
+        verhindert massenhaftes anonymes Löschen.
       requestBody:
         required: true
         content:
@@ -1421,6 +1425,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -1540,7 +1546,22 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: >-
+            Interner Serverfehler. Es wird ausschließlich eine generische
+            Fehlermeldung zurückgegeben; interne Fehlerdetails (`details`,
+            Exception-Message) werden aus Sicherheitsgründen NICHT an den Client
+            geleakt (der konkrete Fehler wird nur serverseitig geloggt).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Generische Fehlermeldung ohne interne Details
+                    example: "Fehler beim Abrufen der Sichtungen"
+              example:
+                error: "Fehler beim Abrufen der Sichtungen"
 
   /rest_sichtungen:
     post:
@@ -1834,9 +1855,14 @@ paths:
       description: |
         Stellt hochgeladene Dateien bereit. Für lokalen Storage werden Dateien direkt ausgeliefert,
         für Cloud Storage erfolgt eine Weiterleitung zur Cloud-URL.
-        
+
         **Zugriffskontrolle:**
         - Validierung des Dateipfads
+        - Öffentlicher Zugriff nur für freigegebene Sichtungen; nicht freigegebene
+          Medien sind ausschließlich für Admins zugänglich.
+        - Für nicht gefundene ODER nicht freigegebene Dateien wird 404 zurückgegeben
+          (die Existenz wird nicht preisgegeben).
+        - Rate-Limiting je nach Authentifizierungsstatus (anonym / authentifiziert).
         - Cache-Optimierung für statische Inhalte
         - Support für lokalen und Cloud-Storage
       parameters:
@@ -1905,14 +1931,26 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 message: "Ungültiger Dateipfad"
-        '404':
-          description: Datei nicht gefunden
+        '403':
+          description: Dateityp nicht erlaubt
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
               example:
-                message: "File not found"
+                message: "Dateityp nicht erlaubt"
+        '404':
+          description: >-
+            Datei nicht gefunden oder nicht freigegeben (nicht freigegebene Dateien
+            liefern für nicht-Admins 404, um die Existenz nicht preiszugeben).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                message: "Datei nicht gefunden"
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -1921,7 +1959,15 @@ paths:
       tags:
         - security
       summary: CSP Violation Report
-      description: Endpunkt für Content Security Policy Violation Reports
+      description: |
+        Endpunkt für Content Security Policy Violation Reports.
+
+        **Sicherheit:**
+        - Rate-Limiting gegen Log-Flooding (unauthentifizierter Endpunkt): 60 Reports
+          pro Minute und IP.
+        - Übergroße Payloads (Content-Length > 8 KB) werden verworfen und mit
+          204 No Content beantwortet (kein Ressourcen-/Log-Missbrauch).
+        - Es werden ausschließlich bekannte CSP-Felder geloggt.
       requestBody:
         required: true
         content:
@@ -1934,9 +1980,13 @@ paths:
                   description: CSP Violation Report Objekt
       responses:
         '204':
-          description: Report erfolgreich empfangen
+          description: >-
+            Report erfolgreich empfangen. Wird auch zurückgegeben, wenn die Payload
+            die maximale Größe (8 KB) überschreitet und verworfen wird.
         '400':
           $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/RateLimitExceeded'
 
 components:
   securitySchemes:
@@ -2915,6 +2965,13 @@ components:
           enum: [healthy, unhealthy]
           description: Systemstatus
           example: "healthy"
+        database:
+          type: string
+          enum: [connected, disconnected]
+          description: >-
+            Status der Datenbankverbindung. `connected` bei erfolgreicher
+            Konnektivitätsprüfung (HTTP 200), `disconnected` bei Ausfall (HTTP 503).
+          example: "connected"
         timestamp:
           type: string
           format: date-time

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1399,6 +1399,12 @@ paths:
 
         Rate-Limiting je nach Authentifizierungsstatus (anonym / authentifiziert)
         verhindert massenhaftes anonymes Löschen.
+
+        Ownership: Anonyme Nutzer können nur noch nicht zugeordnete Dateien
+        (ohne Sichtungs-Zuordnung) löschen, die sie selbst hochgeladen haben
+        (Nachweis über ein serverseitig gesetztes `upload-uid`-Cookie). Fehlt
+        das Cookie oder gehört die Datei einem anderen Uploader, wird 403
+        zurückgegeben. Admins dürfen jede Datei löschen.
       requestBody:
         required: true
         content:

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -47,7 +47,11 @@ const config = {
 				'script-src': [
 					"'self'",
 					"'wasm-unsafe-eval'",
-					"'unsafe-inline'", // Required for Scalar API documentation
+					// 'unsafe-inline' ist für die Scalar-API-Dokumentation (/docs/api/scalar)
+					// nötig, die Inline-Scripts injiziert. Ein Nonce-basiertes CSP ist damit
+					// nicht umsetzbar (Nonces und 'unsafe-inline' schließen sich für script-src
+					// gegenseitig aus), daher wird auch KEIN cspNonce in hooks.server.ts erzeugt.
+					"'unsafe-inline'",
 					...(process.env.NODE_ENV === 'development' ? ["'unsafe-eval'"] : [])
 				],
 				'style-src': ["'self'", "'unsafe-inline'", 'https://openlayers.org'],


### PR DESCRIPTION
## Überblick

Umfassender Pre-Launch-Review (Security, UX/Design-System, Produktionsreife, Dependencies, Doku) mit Umsetzung aller bestätigten Befunde. Anschließend ein adversariales Code-Review über die eigenen Änderungen, dessen Funde ebenfalls behoben wurden. **Produktionsziel: Single-Container-Docker (adapter-node), nicht Vercel.**

Voller Bericht: `docs/LAUNCH_REVIEW_2026-07-24.md`.

## Security

- **Open Redirect** im OAuth-Callback geschlossen: `returnUrl` wird auf relative Same-Origin-Pfade validiert. Der Erst-Fix war per Whitespace umgehbar (`/⇥/evil.com` → `http://evil.com/`, da der URL-Parser Tab/CR/LF strippt) — im Review gefunden und mit Whitespace-Ablehnung + Regressionstests geschlossen.
- **`/uploads/[...path]`** liefert Medien jetzt nur mit DB-Freigabe-/Admin-Check (wie `/api/media`) + Rate-Limit; `Access-Control-Allow-Origin: *` entfernt.
- **`/api/files/delete`**: Rate-Limit **und** Ownership-Binding — anonyme, nicht zugeordnete Uploads sind an ein server-gesetztes `upload-uid`-Cookie gebunden; Nicht-Admins löschen nur eigene Dateien (sonst 403).
- **`/api/csp-report`**: Rate-Limit, Feld-Whitelist beim Logging, echtes Body-Größenlimit (nicht nur `Content-Length`).
- PDF-Magic-Bytes ergänzt, `ENCRYPTION_KEY`-Fail-Fast, `error.message`-Leak entfernt, Pino-Redaction für PII (E-Mail/Telefon/Name/Adresse).
- **Auth-Cookie `SameSite=None; Secure`** für die iframe-Einbettung in meeresmuseum.de (ersetzt einen wirkungslosen Header-Rewrite).

## Produktionsreife

- Health-Check prüft jetzt echt die DB (503 bei Ausfall).
- `saveSighting` transaktional (Sichtung + Datei-Verknüpfung).
- Email-Versand fire-and-forget + SMTP/Fetch-Timeouts (blockiert die API-Response nicht mehr).
- `handleError`-Hook, Postgres-Pool-Config, Graceful Shutdown via SIGTERM.
- Reverse-Proxy-Client-IP-Header (`ADDRESS_HEADER`/`XFF_DEPTH`/…) in der Docker-Prod-Config, damit In-Memory-Rate-Limiting hinter dem Proxy pro Client greift.

## UX & Design-System

- Fehlerseite (Platzhalter-Support-Mail entfernt), Delete-Dialog auf natives `<dialog>` (Fokus-Trap/ESC, `bg-black/50`), Reset mit Bestätigung, Admin-Fehler-Toasts.
- Alle Tailwind-4-Altlasten (`bg-opacity-*`, `*-focus`) bereinigt; Theme-Farben statt Hardcodes.
- Stepper mit sichtbaren Titeln + echten Buttons, `autocomplete` auf Kontaktfeldern, Radio/Checkbox-Gruppen mit `fieldset`/`legend`, keyboard-erreichbare Tooltips, Landmarks/Skip-Link.
- GDPR-Pflichtfeld `privacyConsent` zeigt Pflicht-`*` + Info-Tooltip wieder (Regression aus dem `fieldset`-Umbau behoben).

## Dependencies & Doku

- `npm audit fix` (non-breaking); **Prod-Dependencies: 0 Vulnerabilities**. Verbleibende 4 moderate liegen nur im Dev-Tooling (esbuild via drizzle-kit).
- `.claude`-Regeln/CLAUDE.md an den Code angeglichen (u. a. eigene `createForm`-Impl. statt `svelte-forms-lib`, `sanitize-html`, Dual-Adapter, Struktur).
- OpenAPI-Spec für geänderte Endpunkte aktualisiert.

## Verifikation

- **1608 Server-Tests + 66 Browser-Tests grün**, Lint/Type-Check/svelte-check sauber, OpenAPI validiert.
- Flaky Performance-Test entschärft (RBush-Index-Warmup).

## Hinweise für Reviewer

- Auth-Login funktioniert durch `SameSite=None; Secure` nur noch über **HTTPS** (Dev via basicSSL + Prod gedeckt).
- Bewusst offen (LOW-Backlog, keine Launch-Blocker): echtes Request-Draining beim Shutdown, `/health` 10s-DB-Cache, Radio-`aria-required`-Durchreichung (Vorbestand), `aria-current`-Platzierung, Timeout-Test für den Wetter-Service, Konsolidierung verbliebener nativer `confirm()`-Dialoge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
