### PR TITLE
chore(config): add pg-aiguide mcp server for postgis docs

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -129,10 +129,11 @@ Subagents in `agents/` werden über ihre `description` automatisch delegiert.
 Projekt-Server stehen in [`../.mcp.json`](../.mcp.json) und werden **mitcommittet**,
 damit das Team und neue Worktrees sie automatisch erben.
 
-| Server        | Zweck                     | Credentials        |
-| ------------- | ------------------------- | ------------------ |
-| `drizzle-orm` | Drizzle ORM Docs (GitMCP) | keine              |
-| `github`      | PR-/Issue-Management      | `GITHUB_MCP_TOKEN` |
+| Server        | Zweck                                     | Credentials        |
+| ------------- | ----------------------------------------- | ------------------ |
+| `pg-aiguide`  | PostgreSQL-/PostGIS-Doku + Spatial-Skills | keine              |
+| `drizzle-orm` | Drizzle ORM Docs (GitMCP)                 | keine              |
+| `github`      | PR-/Issue-Management                      | `GITHUB_MCP_TOKEN` |
 
 **Secrets gehören nicht in `.mcp.json`.** Der GitHub-Server liest sein Token aus der
 Umgebungsvariablen `GITHUB_MCP_TOKEN`; wer sie nicht gesetzt hat, verliert nur diesen
@@ -156,23 +157,22 @@ aus `docs/*.md` und `llms.txt` im Repo. Die Abdeckung ist allerdings schmal
 (Custom Types, Joins, Table-Introspect); die Haupt-Doku liegt auf orm.drizzle.team.
 Für breitere Fragen bleibt Context7 die bessere Quelle.
 
-### Kandidat: PostgreSQL / PostGIS
+### PostgreSQL / PostGIS
 
-Aktuell ist **kein** Postgres-MCP konfiguriert, obwohl PostGIS Kerntechnologie ist.
-Geprüfte Option: [`pg-aiguide`](https://github.com/timescale/pg-aiguide) von TigerData —
-semantische Suche über PostgreSQL- **und PostGIS**-Doku, bringt eine
-`design-postgis-tables`-Skill mit (SRID, GiST-Indizes, `ST_DWithin`,
-GEOMETRY-vs-GEOGRAPHY). Verbindet sich **nie** mit einer Datenbank, braucht keine
-Credentials:
+`pg-aiguide` von TigerData deckt PostgreSQL- **und PostGIS**-Doku per semantischer
+Suche ab und bringt eine `design-postgis-tables`-Skill mit (SRID, GiST-Indizes,
+`ST_DWithin`, GEOMETRY-vs-GEOGRAPHY) — relevant, weil PostGIS hier Kerntechnologie ist.
 
-```bash
-claude mcp add --transport http --scope project pg-aiguide https://mcp.tigerdata.com/docs
-```
+Er verbindet sich **nie** mit einer Datenbank und braucht keine Credentials. Genau
+deshalb steht er in der committeten `.mcp.json` und nicht user-scoped.
 
-Für Query-Tuning gegen die lokale DB gäbe es zusätzlich `crystaldba/postgres-mcp`
-(EXPLAIN, hypothetische Indizes) — der braucht aber volle DB-Credentials und müsste
-für PostGIS-Queries im `unrestricted`-Modus laufen (Schreibrechte). Nur mit
-`--scope local` und ausschließlich gegen die Dev-DB sinnvoll.
+**Nicht konfiguriert:** Für Query-Tuning gegen die lokale DB gäbe es zusätzlich
+[`crystaldba/postgres-mcp`](https://github.com/crystaldba/postgres-mcp) (EXPLAIN,
+hypothetische Indizes). Der braucht aber volle DB-Credentials und müsste für
+PostGIS-Queries im `unrestricted`-Modus laufen, also mit Schreib- und DDL-Rechten —
+seine Query-Allowlist enthält keine einzige `ST_*`-Funktion. Bei den GDPR-relevanten
+Melderdaten nur mit `claude mcp add --scope local` und ausschließlich gegen die
+Dev-DB vertretbar.
 
 ---
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,9 @@
 {
 	"mcpServers": {
+		"pg-aiguide": {
+			"type": "http",
+			"url": "https://mcp.tigerdata.com/docs"
+		},
 		"drizzle-orm": {
 			"type": "http",
 			"url": "https://gitmcp.io/drizzle-team/drizzle-orm"


### PR DESCRIPTION
## Zusammenfassung

Ergänzt **`pg-aiguide`** in der committeten `.mcp.json`. PostGIS ist Kerntechnologie dieses Projekts, es war aber bisher kein Postgres-MCP konfiguriert.

Der Server wurde im Rahmen von #564 recherchiert und verifiziert: [`timescale/pg-aiguide`](https://github.com/timescale/pg-aiguide) (TigerData, Apache-2.0, aktiv gepflegt). Er indexiert die PostgreSQL- **und PostGIS**-Doku semantisch und liefert eine `design-postgis-tables`-Skill mit — SRID/4326, GiST- vs. BRIN-Indizes, `ST_DWithin`, GEOMETRY-vs-GEOGRAPHY.

**Er verbindet sich nie mit einer Datenbank und nimmt keine Credentials entgegen.** Genau deshalb gehört er in die committete Projektdatei und nicht in user-scoped Config: das ganze Team bekommt ihn, ohne Secret-Handling.

## Warum jetzt

Der Server war lokal bereits per `claude mcp add --scope project` hinzugefügt worden, lag dort aber als **untracked** `.mcp.json` — was nach dem Merge von #564 den `git pull` blockierte, weil Git eine untracked Datei nicht durch eine eingehende getrackte überschreibt. Dieser PR führt beide Stände zusammen; die lokale Datei kann danach ersatzlos gelöscht werden.

## Änderungen

- `.mcp.json`: `pg-aiguide` ergänzt (jetzt drei Server: `pg-aiguide`, `drizzle-orm`, `github`)
- `.claude/README.md`: Der Abschnitt behauptete noch, es sei *kein* Postgres-MCP konfiguriert. Umgeschrieben, Server-Tabelle ergänzt.

## Bewusst nicht enthalten

`crystaldba/postgres-mcp` (EXPLAIN, hypothetische Indizes) wäre für Query-Tuning interessant, ist aber **nicht** aufgenommen — die Begründung steht jetzt in der README, damit sie nicht verloren geht:

- braucht volle DB-Credentials
- seine Query-Allowlist enthält **keine einzige `ST_*`-Funktion**, für PostGIS-Queries müsste er also im `unrestricted`-Modus laufen, d. h. mit Schreib- und DDL-Rechten
- bei den GDPR-relevanten Melderdaten nur mit `--scope local` und ausschließlich gegen die Dev-DB vertretbar

## Testplan

- [x] `.mcp.json` ist valides JSON, Schema entspricht der Doku (`mcpServers`, `type: http`)
- [x] Prettier über beide Dateien
- [x] Server-Endpunkt bereits in #564 live geprüft (`serverInfo: pg-aiguide`, kein Auth nötig)
- [ ] Kein Test: reine Konfigurations- und Dokumentationsänderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)