### PR TITLE
fix(report): Phantom-Position entfernen und Formular-UX reparieren

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -66,26 +66,27 @@ paths:
 Rules **ohne** `paths` werden immer geladen: `architecture.md`, `testing.md`.
 Beide sind bewusst kurz — neue Inhalte gehören in eine der path-scoped Rules.
 
-| Rule                  | Lädt bei Dateien in …                                                             |
-| --------------------- | --------------------------------------------------------------------------------- |
-| `admin.md`            | `src/routes/admin/`, `src/lib/components/admin/`                                  |
-| `api.md`              | `src/routes/api/`, `rest_sichtungen/`, `sichtungen/`, `health/`                   |
-| `browser-storage.md`  | `src/lib/storage/`                                                                |
-| `daisyui.md`          | `**/*.svelte`, `src/app.css`, `src/css/`                                          |
-| `database.md`         | `src/lib/server/db/`, `drizzle.config.ts`, `src/lib/server/geo/`, `routes/api/`   |
-| `docker.md`           | `Dockerfile`, `docker-compose*.yml`, `.env.docker`, `run-release.sh`              |
-| `email.md`            | `emailService.ts`, `src/lib/server/templates/`, `api/admin/test-email/`           |
-| `export.md`           | `src/lib/server/export/`, `api/sightings/export/`, `ExportModal.svelte`           |
-| `forms.md`            | `src/lib/form/`, `src/lib/report/`, `components/form/`, `routes/+page.svelte`     |
-| `geo.md`              | `src/lib/server/geo/`, `src/lib/utils/geo/`, `api/geo/`                           |
-| `legacy-api.md`       | `routes/rest_sichtungen/`, `routes/sichtungen/`, `src/lib/legacy-api/`            |
-| `maps.md`             | `src/lib/map/`, `components/map/`, `routes/map/`, `api/map/`                      |
-| `middleware.md`       | `src/lib/server/middleware/`, `src/hooks.server.ts`                               |
-| `security.md`         | `src/lib/server/auth/`, `src/lib/server/storage/`, `hooks.server.ts`, `api/auth/` |
-| `svelte-patterns.md`  | `**/*.svelte`, `**/*.svelte.ts`                                                   |
-| `testing-patterns.md` | `**/*.test.ts`, `**/*.svelte.test.ts`, `e2e/`, `vitest*`, `playwright.config.ts`  |
-| `upload.md`           | `src/lib/server/storage/`, `src/lib/server/media/`, `uploads.ts`, `api/files/`    |
-| `weather.md`          | `components/weather/`, `services/weather*.ts`, `utils/weather/`, `api/weather/`   |
+| Rule                  | Lädt bei Dateien in …                                                                 |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `admin.md`            | `src/routes/admin/`, `src/lib/components/admin/`                                      |
+| `api.md`              | `src/routes/api/`, `rest_sichtungen/`, `sichtungen/`, `health/`                       |
+| `browser-storage.md`  | `src/lib/storage/`                                                                    |
+| `daisyui.md`          | `**/*.svelte`, `src/app.css`, `src/css/`                                              |
+| `design-system.md`    | `src/app.css`, `src/lib/components/`, `src/lib/report/components/`, `routes/*.svelte` |
+| `database.md`         | `src/lib/server/db/`, `drizzle.config.ts`, `src/lib/server/geo/`, `routes/api/`       |
+| `docker.md`           | `Dockerfile`, `docker-compose*.yml`, `.env.docker`, `run-release.sh`                  |
+| `email.md`            | `emailService.ts`, `src/lib/server/templates/`, `api/admin/test-email/`               |
+| `export.md`           | `src/lib/server/export/`, `api/sightings/export/`, `ExportModal.svelte`               |
+| `forms.md`            | `src/lib/form/`, `src/lib/report/`, `components/form/`, `routes/+page.svelte`         |
+| `geo.md`              | `src/lib/server/geo/`, `src/lib/utils/geo/`, `api/geo/`                               |
+| `legacy-api.md`       | `routes/rest_sichtungen/`, `routes/sichtungen/`, `src/lib/legacy-api/`                |
+| `maps.md`             | `src/lib/map/`, `components/map/`, `routes/map/`, `api/map/`                          |
+| `middleware.md`       | `src/lib/server/middleware/`, `src/hooks.server.ts`                                   |
+| `security.md`         | `src/lib/server/auth/`, `src/lib/server/storage/`, `hooks.server.ts`, `api/auth/`     |
+| `svelte-patterns.md`  | `**/*.svelte`, `**/*.svelte.ts`                                                       |
+| `testing-patterns.md` | `**/*.test.ts`, `**/*.svelte.test.ts`, `e2e/`, `vitest*`, `playwright.config.ts`      |
+| `upload.md`           | `src/lib/server/storage/`, `src/lib/server/media/`, `uploads.ts`, `api/files/`        |
+| `weather.md`          | `components/weather/`, `services/weather*.ts`, `utils/weather/`, `api/weather/`       |
 
 Die Tabelle ist Doku für Menschen — die Wahrheit steht im Frontmatter der Datei.
 

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -1,0 +1,105 @@
+---
+paths:
+  - 'src/app.css'
+  - 'src/lib/components/**'
+  - 'src/lib/report/components/**'
+  - 'src/routes/**/*.svelte'
+---
+
+# Design System
+
+Verbindliche Regeln für UI-Änderungen: Feld-Pipeline, Button-Hierarchie, Barrierefreiheit.
+
+**Theme, Farbtokens und DaisyUI-Overrides stehen in `daisyui.md`** (lädt bei denselben Dateien) — dort gilt: einzige Farbquelle ist `src/app.css`, keine Hex-Werte oder Tailwind-Graustufen, kein Dark-Theme. Diese Regel ergänzt das um die Punkte, an denen das Projekt in der Praxis gescheitert ist.
+
+Begründung und verifizierter Ist-Zustand: `docs/DESIGN_GUIDE.md`.
+
+---
+
+## Die `*-content`-Regel (WCAG-relevant)
+
+`text-primary-content`, `text-warning-content`, `text-info-content` usw. sind **ausschließlich** für Text auf der jeweiligen **Vollton**-Fläche gedacht.
+
+Im Theme sind fast alle `*-content`-Farben reines Weiß (`oklch(1 0 0)`). Auf einem hellen Tint ergibt das rechnerisch rund **1,3:1** — weit unter den geforderten 4,5:1.
+
+```svelte
+<!-- ❌ FALSCH: weißer Text auf hellgelbem Tint -->
+<div class="bg-warning/10">
+	<h4 class="text-warning-content">Zusätzliche Informationen für Totfund</h4>
+</div>
+
+<!-- ✅ RICHTIG: Tint trägt normalen Body-Text, Akzent nur am Icon -->
+<div class="bg-warning/10 border-warning/20 border">
+	<h4 class="text-base-content">
+		<Icon icon="lucide:triangle-alert" class="text-warning" aria-hidden="true" />
+		Zusätzliche Informationen für Totfund
+	</h4>
+</div>
+```
+
+**Gegenprobe:** `*-content` ist nur dann korrekt, wenn die Elternfläche die volle Farbe ohne Opacity-Suffix trägt — `bg-primary text-primary-content`, `bg-success text-success-content`. Sobald ein `/10`, `/20`, `/5` an der Hintergrundklasse steht, gehört dort `text-base-content` (bzw. `text-base-content/80` für Sekundärtext) hin; die Statusfarbe darf nur Icon, Border oder eine kurze Auszeichnung tragen. Referenz-Implementierung: `src/lib/report/components/sections/DeadAnimal.svelte`.
+
+---
+
+## Alerts
+
+Die Soft-Darstellung der Alerts kommt aus `app.css` (Details in `daisyui.md`). Für diese Regel zählt nur: `<div class="alert alert-warning">` genügt — den Override **nicht** per `bg-warning`/`text-warning-content`/`shadow-*` an der Aufrufstelle aushebeln, sonst entsteht genau der `*-content`-Fehler von oben.
+
+---
+
+## Button-Hierarchie
+
+- **Genau eine Primäraktion pro Bereich** (`btn btn-primary`). Im Formular ist das „Weiter"/„Absenden".
+- Sekundäre Navigation („Zurück") und Nebenaktionen: `btn btn-outline`. Keine Vollton-Sekundärbuttons neben der Primäraktion — sie konkurrieren optisch mit ihr und wirken je nach Fläche wie deaktiviert.
+- Zurückhaltende Aktionen (Toggles in Panels, Aufklapper): `btn btn-ghost`.
+- Destruktive Aktionen (Löschen, Zurücksetzen) einheitlich in **einer** Variante über das ganze Formular — im Sichtungsformular `btn btn-outline btn-error btn-sm min-h-11` (das `min-h-11` hält das 44-px-Touch-Target, das `btn-sm` sonst unterschreitet). Nicht an einer Stelle `btn-warning`, an anderer `btn-ghost text-error`. Destruktives immer mit Bestätigung.
+- Gleiche Aktion = gleiche Variante = gleiches Icon, egal in welcher Komponente sie auftaucht.
+- Ein Button, der nichts bewirkt, gehört entfernt — nicht dekorativ stehen gelassen.
+
+---
+
+## Formularfeld-Muster
+
+Alle Felder laufen über `FormField` → `FieldRenderer` (`src/lib/report/components/form/fields/`). Kein Feld baut Label, Fehleranzeige oder ARIA selbst.
+
+- Label, Hilfetext, Platzhalter, Icon, Optionen und Feldtyp kommen aus dem Yup-Schema (`.label()` / `.meta({...})` in `src/lib/form/validation/sightingSchema.ts`), nicht aus dem Template.
+- Pflicht-Markierung (`*`) und `aria-required` stammen aus **derselben** Variable in `FieldRenderer`. Nie eines von beidem separat setzen — sonst driften optische und semantische Pflicht auseinander.
+- **Konditionale Pflichten** (Yup `when()`) sind aus `describe()` nicht ableitbar. Dafür den `required`-Override an `FormField` setzen — Beispiel `waterway` in `sections/PositionAndTime.svelte`: `<FormField name="waterway" required={waterwayRequired} />`.
+- Neues Feld: im Schema definieren **und** in `formStepsConfig` (`src/lib/report/formConfig.ts`) dem richtigen Schritt zuordnen — sonst greift weder Schritt-Validierung noch Fehler-Navigation.
+- `data-testid="field-<name>"` entsteht automatisch; keine eigenen Test-IDs an Feldern vergeben.
+- Fehler **nie** beim Betreten eines Schritts anzeigen — erst nach einem gescheiterten „Weiter"-Versuch (`StepNavigation.svelte` / `stepNavigationState.ts`).
+
+---
+
+## A11y-Mindestanforderungen (WCAG 2.1 AA)
+
+- Kontrast: **≥ 4,5:1** für Text (WCAG 1.4.3), **≥ 3:1** für grafische Objekte und UI-Begrenzungen (1.4.11).
+- Touch-Targets: Projekt-Mindestmaß **44×44 px** für alles, was im Feld mobil bedient wird (WCAG 2.5.5 ist formal AAA — hier gilt es trotzdem, weil das Formular an Deck ausgefüllt wird). DaisyUI-Default-Größen nicht per `btn-xs`/`input-xs` darunter drücken.
+- Fokus muss sichtbar bleiben: `:focus-visible` und die Input-Fokus-Regel in `app.css` nicht durch `outline-none` überschreiben.
+- Labels statt Platzhaltertexte. Ein `placeholder` ist Beispiel, nie Ersatz für das Label.
+- Dekorative Icons bekommen `aria-hidden="true"`; informationstragende Icons brauchen ein `aria-label` am fokussierbaren Element.
+- Radiogruppen als `fieldset`/`legend`, nicht als `label[for]` auf mehrere Inputs.
+- Fehlermeldungen mit `role="alert"` und `aria-live="polite"`, referenziert über `aria-describedby` — und nur dann referenziert, wenn das Element tatsächlich gerendert ist.
+
+---
+
+## Icons
+
+- UI-Icons ausschließlich über `src/lib/components/Icon.svelte` (unplugin-icons / lucide): `<Icon icon="lucide:map-pin" width="20" />`. Neue Icons dort einmalig importieren, nicht in Einzelkomponenten.
+- Wetter-Icons sind CSS-basiert (`src/css/weather-icons*.css`): `<i class="wi wi-day-sunny"></i>`.
+
+---
+
+## Keine toten Utility-Klassen
+
+Vor der Nutzung einer Utility prüfen, ob sie im Setup überhaupt existiert.
+
+- Es ist **kein** Animations-Plugin installiert (weder `tailwindcss-animate` noch `tw-animate-css`). Klassen wie `animate-in`, `fade-in`, `slide-in-from-top-1` sind wirkungslos — sie sehen im Code nach Design aus und tun nichts.
+- Für Ein-/Ausblendungen `transition:slide` / `transition:fade` aus `svelte/transition` verwenden (so gelöst in `sections/SightingDetails.svelte`).
+- Gleiches gilt für `dark:`-Varianten (kein Dark-Theme, siehe `daisyui.md`) und für Keyframes, die nur in `app.css` definiert, aber an keine Klasse gebunden sind.
+
+---
+
+## Zahlen in Nutzertexten nur mit Quelle
+
+Hilfetexte und Tooltips (`meta.helpText` / `meta.valueText` im Yup-Schema) werden Bürgern als Aussage eines Forschungsmuseums präsentiert. Statistische Behauptungen ohne belegte Quelle gehören dort nicht hinein — im Zweifel die Aussage qualitativ formulieren („Bei ruhiger See sind Tiere leichter zu entdecken") statt eine Zahl zu erfinden.

--- a/.claude/rules/forms.md
+++ b/.claude/rules/forms.md
@@ -89,7 +89,11 @@ export const sightingSchema = yup.object({
 
 ## createForm Pattern (projekteigene Implementierung)
 
-**Hinweis:** Das Projekt nutzt KEINE externe Form-Library. `src/lib/form/createForm.ts` ist eine eigene, schlanke Implementierung auf Basis von Svelte-Stores (`writable`/`derived`) + Yup. `$form`, `$errors`, `$isSubmitting`, `$isValid` sind Svelte-Stores und werden mit `$` abonniert. Es gibt KEIN `touched` und KEIN `validateField` — validiert wird beim Submit (`abortEarly: false`, sammelt alle Fehler); `updateField` löscht den Fehler des geänderten Feldes.
+**Hinweis:** Das Projekt nutzt KEINE externe Form-Library. `src/lib/form/createForm.ts` ist eine eigene, schlanke Implementierung auf Basis von Svelte-Stores (`writable`/`derived`) + Yup. `$form`, `$errors`, `$touched`, `$isSubmitting`, `$isValid` sind Svelte-Stores und werden mit `$` abonniert.
+
+- **`touched`** (`Record<string, boolean>`) wird von `handleChange`/`updateField` gesetzt und von `updateInitialValues` zurückgesetzt. Es steuert ausschließlich die Anzeige (grünes Häkchen nur an Feldern, die der Nutzer wirklich berührt hat) — nicht die Validierung.
+- **Kein `validateField`**: Validiert wird beim Submit (`abortEarly: false`, sammelt alle Fehler) sowie schrittweise über `validateStep` (`src/lib/form/validation/stepValidation.ts`, nutzt `sightingSchema.pick(...)`). `updateField` löscht den Fehler des geänderten Feldes.
+- **Fehler-Timing**: Fehler erscheinen erst nach einem gescheiterten „Weiter"-Versuch, nie beim Betreten eines Schritts (siehe `stepNavigationState.ts`).
 
 API: `{ form, errors, isSubmitting, isValid, handleSubmit, handleChange, updateField, updateInitialValues }`
 
@@ -182,29 +186,27 @@ function prevStep() {
 
 ## Accessibility
 
-### Labels
+### Labels und ARIA kommen aus der Feld-Pipeline
+
+**Kein handgeschriebenes ARIA in Formular-Sections.** Felder laufen über `FormField` → `FieldRenderer`
+(`src/lib/report/components/form/fields/`). Diese Pipeline erzeugt zentral: Label, Pflicht-Sternchen,
+`aria-required`, `aria-describedby` (Hilfetext/Beschreibung/Fehler), `aria-invalid`, `role="alert"` an der
+Fehlermeldung und `data-testid="field-<name>"` für E2E-Tests.
 
 ```svelte
-<fieldset class="fieldset">
-	<label class="label" for="species">
-		Tierart *
-		<span class="text-base-content/70 text-sm font-normal">Wähle die beobachtete Tierart</span>
-	</label>
-	<input
-		id="species"
-		name="species"
-		class="input w-full"
-		aria-describedby={$errors.species && $touched.species ? 'species-error' : undefined}
-		aria-required="true"
-		aria-invalid={!!($errors.species && $touched.species)}
-	/>
-	{#if $errors.species && $touched.species}
-		<p id="species-error" class="label text-error" role="alert" aria-live="polite">
-			{$errors.species}
-		</p>
-	{/if}
-	<!-- Hinweis: aria-describedby nur setzen wenn das referenzierte Element auch existiert -->
-</fieldset>
+<!-- Richtig: Label, Hilfetext, Fehler und ARIA kommen aus dem Schema-`meta` -->
+<FormField name="species" />
+```
+
+Beschriftung, Hilfetext, Platzhalter, Icon und Feldtyp werden im Yup-Schema unter `.meta({...})` gepflegt,
+nicht in der Komponente.
+
+**Konditionale Pflichtfelder:** `FieldRenderer` leitet `required` aus der statischen Schema-Beschreibung ab —
+ein Yup-`when()` ist dort nicht sichtbar. Für Felder, die nur unter Bedingungen Pflicht sind, den
+`required`-Override setzen, damit Sternchen und `aria-required` mit der Validierung übereinstimmen:
+
+```svelte
+<FormField name="waterway" required={$form.hasPosition !== true} />
 ```
 
 ### Keyboard Navigation

--- a/.claude/skills/prepare-pr/SKILL.md
+++ b/.claude/skills/prepare-pr/SKILL.md
@@ -97,14 +97,34 @@ Enthält:
 
 Führe `/simplify` auf den geänderten Dateien aus, um Code-Qualität, Wiederverwendung und Effizienz zu prüfen. Behebe gefundene Probleme bevor du fortfährst.
 
-### Schritt 5: Git Status prüfen
+### Schritt 5: A11y- und Design-System-Prüfung
+
+Verbindliche Regeln: `.claude/rules/design-system.md`. Geänderte `.svelte`-Dateien auf verdächtige Muster durchsuchen:
+
+```bash
+git diff --name-only main...HEAD \
+  | grep '\.svelte$' \
+  | xargs grep -ln 'text-[a-z]*-content\|placeholder=\|onclick\|~icons/\|animate-in\|slide-in-from' 2>/dev/null
+```
+
+Für jeden Treffer prüfen:
+
+1. **Kontrast:** `*-content`-Text auf `bg-*/10`/`/20`-Tint? Im Theme `meeresmuseum` (`src/app.css`) sind `*-content`-Farben fast durchgängig Weiß — auf hellem Tint unlesbar (Praxisfall: gemessen 1,3:1). Messen im Dev-Server: `getComputedStyle` liefert `oklch(...)`-Strings; per Canvas-2D (`ctx.fillStyle = wert`, dann `ctx.getImageData`) nach sRGB konvertieren und die WCAG-Kontrastformel anwenden. Ziel: Text ≥ 4.5:1, große Schrift/Icons ≥ 3:1.
+2. **Formularfelder:** Pflicht-Sternchen und `aria-required` aus derselben Quelle, Fehler mit `role="alert"` + `aria-describedby`, sichtbares Label statt reinem `placeholder`.
+3. **Interaktive Elemente:** echte `<button>`/`<a>` statt klickbarer `<div>`/`<li>`; unvollständige ARIA-Rollen (z.B. `role="tab"` ohne `tabpanel`) sind ein Fail; Tastaturbedienbarkeit und sichtbarer Fokus; Touch-Target ≥ 44px.
+4. **Dekorative Icons:** ohne eigene Bedeutung → `aria-hidden="true"`.
+5. **Tote Utilities:** `animate-in`/`slide-in-from-*` etc. greifen hier nicht (kein Animations-Plugin installiert) — entfernen oder ersetzen.
+
+**Bei eindeutigem Kontrast-Fail oder fehlendem `aria-required`/`role="alert"`:** beheben, bevor fortgefahren wird. Bei Grenzfällen: unter "Testplan" im PR-Body vermerken statt zu blockieren.
+
+### Schritt 6: Git Status prüfen
 
 ```bash
 git status
 git diff --stat
 ```
 
-### Schritt 6: Änderungen analysieren
+### Schritt 7: Änderungen analysieren
 
 Analysiere welche Dateien geändert wurden:
 
@@ -113,7 +133,7 @@ Analysiere welche Dateien geändert wurden:
 - Refactoring?
 - Dokumentation?
 
-### Schritt 7: Commit erstellen
+### Schritt 8: Commit erstellen
 
 Nutze Conventional Commits Format:
 
@@ -143,7 +163,7 @@ EOF
 **Scopes:**
 `deps`, `api`, `ui`, `db`, `auth`, `export`, `admin`, `report`, `map`, `config`, `build`, `ci`, `docs`, `test`, `types`, `style`, `perf`, `security`, `a11y`, `release`, `media`
 
-### Schritt 8: Push und PR erstellen
+### Schritt 9: Push und PR erstellen
 
 ```bash
 # Push (mit Upstream-Tracking)
@@ -193,6 +213,7 @@ Nächste Schritte:
 - [ ] Nicht auf main Branch
 - [ ] Alle Tests bestanden
 - [ ] Keine Linting-Fehler
+- [ ] A11y-/Design-System-Prüfung durchgeführt (Kontrast, Formularfelder, ARIA) — siehe `.claude/rules/design-system.md`
 - [ ] Commit Message folgt Conventional Commits
 - [ ] PR-Beschreibung aussagekräftig
 - [ ] Dokumentation aktualisiert (falls nötig)

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -72,6 +72,67 @@ grep -n '`SELECT.*\${' <file>
 
 **Fix:** Drizzle `sql` Tagged Template oder Repository Pattern verwenden.
 
+#### Accessibility & Design-System (WCAG 2.1 AA)
+
+Verbindliche Regeln: `.claude/rules/design-system.md`. Hier nur die praktikablen Checks für geänderte `.svelte`-Dateien.
+
+**1. Kontrast bei `*-content` auf Tint-Hintergrund**
+
+```bash
+# *-content Text auf bg-*/10, /20 ... ist im Theme "meeresmuseum" (src/app.css)
+# fast immer reines Weiß -> auf hellem Tint unlesbar (Praxisfall: gemessen 1,3:1)
+grep -n 'text-[a-z]*-content' <file>
+```
+
+Bei Treffer: zugehörige `bg-*/NN`-Klasse suchen und Kontrast messen. Richtwerte: Text ≥ 4.5:1, große Schrift (≥ 24px bzw. 19px bold) ≥ 3:1, Icons/grafische Objekte ≥ 3:1.
+
+**Messmethode im laufenden Dev-Server:** Theme-Farben sind in `oklch()` notiert, `getComputedStyle` gibt diese Notation unverändert zurück. In der Browser-Konsole:
+
+```js
+getComputedStyle(el).color; // "oklch(...)"
+getComputedStyle(el.closest('[class*="bg-"]')).backgroundColor;
+```
+
+Zur Umrechnung `oklch → sRGB` einen Canvas-2D-Context nutzen (`ctx.fillStyle = wert`, dann `ctx.getImageData` auslesen) statt manueller Formel, danach WCAG-Kontrastformel auf die RGB-Werte anwenden.
+
+**2. Formularfelder**
+
+- Pflicht-Sternchen und `aria-required` müssen aus derselben Quelle stammen (z.B. `required`-Prop), nicht getrennt gepflegt werden.
+- Fehlermeldung: `role="alert"` + Verknüpfung per `aria-describedby` mit der Feld-ID.
+- Sichtbares `<label>` vorhanden — `placeholder` allein ersetzt kein Label.
+
+```bash
+grep -n 'placeholder=' <file>
+```
+
+**3. Interaktive Elemente**
+
+```bash
+# Klickbare div/li/span statt button/a
+grep -n 'onclick' <file>
+```
+
+- Echte `<button>`/`<a>` statt klickbarer `<div>`/`<li>`/`<span>` verwenden.
+- ARIA-Rollen nur vollständig: `role="tab"` ohne zugehöriges `role="tabpanel"` (+ `aria-controls`/`aria-selected`) ist ein Fail.
+- Tastaturbedienbarkeit und sichtbarer Fokus (`:focus-visible`) prüfen; Touch-Targets ≥ 44×44px.
+
+**4. Dekorative Icons**
+
+```bash
+grep -n "~icons/" <file>
+```
+
+Icon ohne eigene Bedeutung (rein dekorativ, Text daneben vorhanden) → `aria-hidden="true"`.
+
+**5. Tote Utility-Klassen**
+
+```bash
+# Kein Animations-Plugin installiert - diese Klassen greifen nicht
+grep -n 'animate-in\|slide-in-from-top\|slide-in-from-bottom\|fade-in\|zoom-in' <file>
+```
+
+Bei Treffer: prüfen ob die Utility im Setup (`tailwind.config`, installierte Plugins) überhaupt existiert, sonst entfernen oder durch eine funktionierende Animation ersetzen.
+
 ### Schritt 3: /simplify ausführen
 
 Führe `/simplify` auf den geänderten Dateien aus für allgemeine Code-Qualität:
@@ -100,6 +161,9 @@ WARNUNG:
 HINWEIS:
 - [datei:zeile] Globaler $state in .ts Datei
 
+A11Y:
+- [datei:zeile] Kontrast text-warning-content auf bg-warning/10 (gemessen 1,3:1, Ziel ≥ 4.5:1)
+
 /simplify Ergebnis:
 - [Zusammenfassung der Findings]
 ```
@@ -111,4 +175,9 @@ HINWEIS:
 - [ ] Kein `{@html}` ohne Sanitisierung
 - [ ] Kein globaler `$state` in `.ts` Dateien
 - [ ] Keine nicht-parametrisierte SQL
+- [ ] Kontrast `*-content` auf Tint-Hintergrund ≥ 4.5:1 (groß/Icons ≥ 3:1)
+- [ ] Formularfelder: Pflicht-Markierung = `aria-required`, Fehler mit `role="alert"` + `aria-describedby`, sichtbares Label
+- [ ] Echte `<button>`/`<a>` statt klickbarer `<div>`/`<li>`, ARIA-Rollen vollständig, Fokus sichtbar, Touch-Target ≥ 44px
+- [ ] Dekorative Icons mit `aria-hidden="true"`
+- [ ] Keine toten Utility-Klassen (z.B. `animate-in` ohne Plugin)
 - [ ] Code-Qualität durch /simplify geprüft

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,9 @@ Beim Erstellen oder Ändern von `.ts`/`.svelte`-Dateien mit Business-Logik MUSS 
 
 Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) bedienen produktive Mobile Apps und MÜSSEN exakt kompatibel bleiben. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
 
-### Design Guide
+### Design System — PFLICHT bei UI-Änderungen
 
-UX- und Design-Richtlinien: `docs/DESIGN_GUIDE.md`
+Theme-Tokens statt hardcodierter Farben, `*-content` ausschließlich auf Vollton-Flächen (auf Tints wie `bg-warning/10` gehört `text-base-content` — sonst weiß auf hell), WCAG 2.1 AA. Regeln laden automatisch bei UI-Dateien: `.claude/rules/design-system.md` (Feld-Pipeline, Button-Hierarchie, A11y-Minima) und `.claude/rules/daisyui.md` (Theme, DaisyUI-Overrides). Hintergrund und verifizierter Ist-Zustand: `docs/DESIGN_GUIDE.md`
 
 ---
 
@@ -113,7 +113,7 @@ Automatisiert über **release-please**: Commits auf `main` werden analysiert, ei
 | Dokument                           | Inhalt                                   |
 | ---------------------------------- | ---------------------------------------- |
 | `.claude/README.md`                | Aufbau der Claude-Konfiguration          |
-| `docs/DESIGN_GUIDE.md`             | UX/Design-Richtlinien                    |
+| `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen  |
 | `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)   |
 | `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                    |
 | `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung) |

--- a/docs/DESIGN_GUIDE.md
+++ b/docs/DESIGN_GUIDE.md
@@ -1,314 +1,161 @@
-# Modern Long Form Design Guide for Whale Sighting Systems
+# Design Guide — Ostsee-Tiere
 
-Current research reveals that **multi-step forms achieve 86% higher conversion rates** than single-page equivalents, while forms following modern usability guidelines see **78% one-try submission rates versus 42% for non-compliant forms**. For whale sighting reporting systems, this translates to significantly higher data collection success when design principles are properly implemented.
+Dieses Dokument beschreibt die **Design- und UX-Leitlinien** des Projekts und den **tatsächlichen Ist-Zustand** der Umsetzung. Beides ist bewusst getrennt: Leitlinien sagen, was gelten soll; der Ist-Zustand ist am Code überprüfbar und enthält keine Wunschvorstellungen.
 
-## Current Implementation Status
+**Verbindliche Kurzform:** `.claude/rules/design-system.md` — die dort formulierten Regeln sind bei jeder UI-Änderung einzuhalten. Dieses Dokument liefert die Begründung und den Kontext.
 
-**The Ostsee-Tiere application demonstrates exceptional adherence to modern form design principles**, achieving an **A- grade** in implementation quality. The current form successfully implements multi-step architecture, comprehensive accessibility, mobile-first design, and progressive disclosure patterns.
+**Verwandte Dokumente:** `.claude/rules/forms.md` (Form-State-Pattern), `.claude/rules/architecture.md` (Svelte-5-Runes, A11y-Grundsätze), `docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md` (Review-Befunde mit Status).
 
-### Implementation Achievement Summary
+---
 
-- ✅ **Multi-step architecture** with 4-step logical progression
-- ✅ **WCAG 2.2 accessibility compliance** with comprehensive ARIA implementation  
-- ✅ **Mobile-first responsive design** with proper touch targets (48x48 DP)
-- ✅ **Progressive disclosure** with smart conditional logic
-- ✅ **Optimal validation timing** without premature error states
-- ✅ **Advanced state management** with auto-save and persistence
-- ✅ **Comprehensive help systems** with contextual guidance
+## Inhalt
 
-## Multi-step Architecture - Successfully Implemented ✅
+- [Leitprinzipien](#leitprinzipien)
+- [Ist-Zustand (am Code verifiziert)](#ist-zustand-am-code-verifiziert)
+- [Bekannte Einschränkungen / offene Punkte](#bekannte-einschränkungen--offene-punkte)
+- [Checkliste vor einem UI-PR](#checkliste-vor-einem-ui-pr)
 
-**The evidence strongly favors multi-step over single-page approaches** for whale sighting forms. Recent 2024-2025 data shows multi-step forms not only improve completion rates but also enhance data quality through reduced cognitive load and better error handling.
+---
 
-### Current Implementation Structure
+## Leitprinzipien
 
-**Our 4-step structure perfectly aligns with research recommendations:**
-- **Step 1: Position & Time** (location, temporal data) - 4 fields maximum
-- **Step 2: Sighting Details** (species, count, distance) - 5-6 fields  
-- **Step 3: Behavioral Observations** (optional details) - 3-4 fields
-- **Step 4: Contact Information** (observer data) - 3 fields
+### 1. Ein Thema pro Schritt
 
-This approach follows the **GOV.UK "One Thing Per Page" pattern**, endorsed by Nielsen Norman Group. Our implementation includes:
+Das Sichtungsformular ist lang. Statt einer Endlosseite wird es in thematisch geschlossene Schritte zerlegt (GOV.UK-Muster „One Thing Per Page"). Der Nutzen ist konkret und nicht statistisch begründet: Ein Schritt lässt sich für sich validieren, Fehler bleiben lokal, und ein Abbruch verliert weniger Kontext.
 
-```typescript
-// Step validation without premature errors
-const canGoNext = $derived(isStepValid(currentStep, $form));
+**Konsequenz für neuen Code:** Ein neues Feld gehört in genau einen Schritt und muss dort in `formStepsConfig` (`src/lib/report/formConfig.ts`) eingetragen werden — sonst wird es weder von der Schritt-Validierung noch von der Fehler-Navigation gefunden.
 
-// Progressive step navigation with proper state management
-const steps = [
-  { id: 1, name: 'Position & Time', isOptional: false },
-  { id: 2, name: 'Sighting Details', isOptional: false },
-  { id: 3, name: 'Behavioral Observations', isOptional: true },
-  { id: 4, name: 'Contact Information', isOptional: false }
-];
-```
+### 2. Fehler erst nach einem Versuch
 
-**Progressive disclosure techniques** are implemented through conditional rendering. Research shows forms with conditional logic see **14% improvement in conversions** and **42% reduction in completion time** when properly implemented.
+Ein Formularschritt darf beim Betreten **nie** rot sein. Fehler erscheinen erst, wenn der Nutzer aktiv „Weiter"/„Absenden" gedrückt hat und die Validierung fehlschlägt. Begründung: Ein Feld, das der Nutzer noch nicht gesehen hat, kann er nicht falsch ausgefüllt haben; eine Vorab-Fehlermeldung ist reines Rauschen.
 
-### Successful Conditional Logic Implementation
+### 3. Optionale Felder sind sichtbar optional
 
-```svelte
-{#if $form.isDead}
-  <FormField name="deadCondition" label="Zustand des Tieres" />
-  <FormField name="deadSex" label="Geschlecht" />
-  <FormField name="deadSize" label="Größe" />
-{/if}
-```
+Pflichtfelder werden markiert, optionale nicht (Markieren beider Sorten verdoppelt nur das visuelle Rauschen). Ein ganzer Schritt darf optional sein und muss dann überspringbar sein.
 
-## Effective Communication - Enhanced Implementation Needed 🔄
+### 4. Progressive Disclosure statt Dauer-Sichtbarkeit
 
-**The key insight from behavioral research**: users need clear value propositions for optional fields, not just labels. Analysis of successful form optimization shows that **adding explanatory microcopy can triple completion rates**.
+Felder, die nur in einem bestimmten Kontext sinnvoll sind (Bootsantrieb nur bei Boots-Sichtung, Totfund-Details nur bei Totfund), werden erst eingeblendet, wenn der Kontext eintritt. Wird der Kontext zurückgenommen, muss der Formular-State mit aufgeräumt werden — sonst würden unsichtbare Werte mit abgeschickt.
 
-### Current State and Improvement Opportunities
+### 5. Ein Theme, eine Quelle für Farben
 
-**Current Implementation:**
-- Clear field labels with basic help text
-- Comprehensive FormHelp.svelte component with detailed guidance
-- Species identification assistance
-
-**Enhancement Opportunities - Benefit-Focused Messaging:**
-
-**Instead of generic labels, use benefit-focused messaging:**
-- Current: "Schwimmrichtung" 
-- **Recommended**: "Schwimmrichtung (hilft bei Wanderungsanalysen)" 
-- Current: "Verhalten"
-- **Recommended**: "Verhalten (verbessert Schutzforschung)"
-- Current: "Anzahl Tiere"
-- **Recommended**: "Anzahl Tiere (hilft bei Populationsanalysen)"
-
-**Effective tooltip patterns that work:**
-- **Format guidance**: "Gruppengröße: Zähle alle sichtbaren Wale (gib 'ca. 15' ein bei Unsicherheit)"
-- **Value explanation**: "Verhaltensnotizen helfen Forschern bei der Analyse von Futter- und Lebensraumnutzung"
-- **Context setting**: "Fotos erhöhen den Forschungswert deiner Sichtung erheblich"
+Alle Farben, Radien und Border-Stärken kommen aus dem DaisyUI-Theme in `src/app.css`. Hardcodierte Hex-Werte oder Tailwind-Graustufen in Komponenten hebeln das Theme aus und werden bei Theme-Änderungen nicht mitgezogen.
 
-**Language that encourages without overwhelming:**
-- Use conversational tone: "Hilf uns zu verstehen, was du gesehen hast"
-- Provide social proof: "Die meisten Walbeobachter finden diese Informationen einfach bereitzustellen"
-- Explain impact: "Deine Details tragen zu Schutzmaßnahmen bei"
+### 6. Barrierefreiheit ist Teil der Definition of Done
 
-Research shows **marking only required fields** with asterisks is more effective than labeling optional ones. Our current implementation successfully follows this pattern.
-
-## Mobile-first Design Principles - Excellent Implementation ✅
-
-**Critical insight**: **42.95% of form completions happen on mobile devices**, and whale sighting reporting occurs in challenging field conditions requiring specialized mobile optimization.
-
-### Current Mobile Implementation Excellence
-
-Our implementation successfully addresses all essential mobile requirements:
-
-```css
-/* Excellent mobile-first patterns in app.css */
-.form-field input, .form-field select, .form-field textarea {
-  min-height: 48px; /* Meets 48×48 DP requirement */
-  font-size: 16px; /* Prevents iOS zoom */
-}
-
-/* Responsive touch targets */
-@media (max-width: 640px) {
-  .form-navigation button {
-    min-height: 48px;
-    padding: 12px 24px;
-  }
-}
-```
-
-**Successfully implemented features:**
-- ✅ **48×48 DP minimum touch targets** with proper spacing
-- ✅ **Single-column layouts** on mobile with responsive grid adaptations  
-- ✅ **Auto-focus management** with `focusElement()` utility
-- ✅ **Appropriate input types** (tel, email, date, time, number)
-
-### Mobile Enhancement Opportunities
-
-**Currently Missing - Recommended Additions:**
-- Voice-to-text capability for behavioral descriptions
-- Enhanced GPS integration with better offline fallbacks
-- Camera integration with GPS metadata embedding (partially implemented)
-- More robust offline data storage indicators
-
-**Performance benchmarks show** our current implementation successfully avoids problematic patterns like dropdown overuse and premature password requirements.
-
-## Domain-specific Scientific Data Patterns - Well Implemented ✅
-
-**Analysis of successful wildlife reporting platforms** reveals consistent patterns that balance scientific rigor with user accessibility. Our implementation successfully incorporates these patterns.
-
-### Current Scientific Data Implementation
-
-**Successfully implemented patterns:**
-
-**Hierarchical species validation:**
-- ✅ Species options filtered by geographic region (Baltic Sea focus)
-- ✅ "Unknown species" options with photo upload capability
-- ✅ Visual identification guides integrated in FormHelp component
-
-**Data quality assurance layers:**
-- ✅ **Level 1**: Automated validation (GPS coordinates, date/time validation)
-- ✅ **Level 2**: Form validation with comprehensive Yup schema
-- ✅ **Level 3**: Admin review workflow in place
-
-**Current scientific data structure accommodates:**
-```typescript
-// From sightingSchema.ts - excellent comprehensive validation
-export const sightingSchema = yup.object({
-  // Mandatory core fields
-  lat: yup.number().required(),
-  lng: yup.number().required(),
-  date: yup.string().required(),
-  time: yup.string().required(),
-  species: yup.string().required(),
-  count: yup.number().positive().integer().required(),
-  
-  // Contextual details with proper validation
-  behavior: yup.string().nullable(),
-  conditions: yup.string().nullable(),
-  
-  // Evidence and observer metadata
-  images: yup.array().of(yup.string()),
-  observerExperience: yup.string().nullable()
-});
-```
-
-## Modern Technical Implementation - Excellence Achieved ✅
-
-### Current Technical Stack Assessment
-
-**Our current implementation uses an optimal modern stack:**
-- ✅ **SvelteKit 5** with modern runes (`$state`, `$derived`, `$effect`)
-- ✅ **Yup schema validation** for unified client/server validation  
-- ✅ **Progressive web app architecture** capabilities
-- ✅ **WCAG 2.2 compliance** through comprehensive ARIA implementation
-
-### Accessibility Implementation Excellence
-
-**Current accessibility implementation exceeds requirements:**
-
-```svelte
-<!-- Proper labeling for screen readers - current implementation -->
-<label for="species-id">Tierart</label>
-<input 
-  type="text" 
-  id="species-id"
-  name="species"
-  aria-describedby="species-help species-error"
-  aria-required="true"
-  aria-invalid={hasError}
-  bind:value={$form.species}
->
-<div id="species-help">Verwende den deutschen Namen oder wähle "unbekannt"</div>
-{#if hasError}
-  <div id="species-error" role="alert" aria-live="polite">{errorMessage}</div>
-{/if}
-```
-
-### Performance Optimization - Successfully Implemented
-
-**Current performance optimizations:**
-- ✅ **Lazy loading** of form sections with conditional rendering
-- ✅ **Debounced validation** with proper timing (no premature errors)
-- ✅ **Auto-save functionality** with localStorage backup
-- ✅ **Service worker** implementation for offline capability
-
-**Field validation timing based on research:**
-- ✅ Avoids validation on field focus (prevents premature errors)
-- ✅ Validates on step navigation with `isStepValid()`
-- ✅ Error messages positioned adjacent to problematic fields
-- ✅ Constructive language: "Tierart nicht erkannt - verwende deutschen Namen oder wähle aus der Liste"
-
-## Implementation Roadmap - Current Status and Next Steps
-
-### Phase 1 Priorities - COMPLETED ✅
-
-**Successfully implemented based on highest-impact research findings:**
-1. ✅ **Multi-step form structure** with comprehensive progress indicators
-2. ✅ **Mobile-optimized touch interface** with appropriate input types  
-3. ✅ **WCAG 2.2 compliance** for keyboard navigation and screen readers
-4. ✅ **GPS integration** with manual coordinate override
-
-### Phase 2 Enhancements - PARTIALLY IMPLEMENTED 🔄
-
-**Current status and recommendations:**
-1. ✅ **Visual species identification aids** embedded in FormHelp component
-2. 🔄 **Photo upload with GPS metadata** (implemented, could be enhanced)
-3. ✅ **Offline data persistence** with localStorage and service worker
-4. ✅ **Admin review workflow** integrated in backend
-
-### Phase 3 Recommendations - FUTURE ENHANCEMENTS 🚀
-
-**Recommended next improvements:**
-1. **Enhanced benefit-focused messaging** in field help text
-2. **Voice-to-text capability** for mobile behavioral descriptions  
-3. **Social proof integration** in help text and guidance
-4. **Advanced analytics dashboard** for form performance tracking
-
-### Current Performance Metrics
-
-**Excellent metrics to continue tracking:**
-- **View-to-start rate**: Monitor form initiation success
-- **Field-level abandonment**: Current implementation minimizes this
-- **Completion by device type**: Mobile-first design shows strong results
-- **Error recovery rates**: Comprehensive validation shows excellent rates
-- **Time to completion**: Multi-step architecture optimizes this
-
-## Critical Success Factors - Achievement Status
-
-**The research reveals four fundamental principles** for successful long-form design:
-
-### 1. Cognitive Load Reduction - EXCELLENT ✅
-**Successfully implemented** through progressive disclosure and logical grouping. Our 4-step architecture prevents the overwhelming feeling that causes 18% of users to abandon forms immediately.
-
-### 2. Value Communication - GOOD (Enhancement Needed) 🔄
-Current implementation has solid foundations but could benefit from more behavioral psychology principles in help text to further increase completion rates.
-
-### 3. Mobile-First Responsive Design - EXCELLENT ✅
-**Fully achieved** - acknowledges that nearly half of interactions occur on mobile devices, with comprehensive optimization for challenging field conditions.
-
-### 4. Accessibility Integration - EXCELLENT ✅
-**Comprehensively implemented** from the foundation, ensuring forms work for all users while improving usability for everyone through clearer navigation and better error handling.
-
-## Current Performance Assessment
-
-**Modern whale sighting reporting forms succeeding with these principles** see completion rates approaching 65-75% compared to industry averages of 44.96%. 
-
-**Our current implementation status:**
-- ✅ **Multi-step architecture**: Fully implemented
-- ✅ **Mobile optimization**: Exceeds requirements  
-- ✅ **Accessibility compliance**: WCAG 2.2 compliant
-- 🔄 **Value communication**: Good foundation, enhancement opportunities exist
-
-The combination of our excellent technical implementation with minor enhancements to value communication messaging will ensure we achieve the highest possible completion rates while maximizing valuable data collection for marine conservation efforts.
-
-## Technical Implementation Notes
-
-### SvelteKit 5 Patterns
-
-**Current implementation leverages modern SvelteKit 5 features:**
-
-```typescript
-// Reactive state management with runes
-const form = $state(initialFormState);
-const currentStep = $state(1);
-const canGoNext = $derived(isStepValid(currentStep, form));
-
-// Reactive effects for auto-save
-$effect(() => {
-  saveToStorage(form);
-});
-```
-
-### Form Context Pattern
-
-**Successfully implemented centralized form context:**
-```typescript
-// FormContext.svelte - excellent state management
-export const formContext = {
-  form: $state(initialState),
-  errors: $state({}),
-  touched: $state({}),
-  validateStep,
-  isStepValid,
-  goToNextStep,
-  goToPrevStep
-};
-```
-
-This design guide reflects our current high-quality implementation while identifying specific areas for continued enhancement. The foundation is excellent, requiring only refinements to achieve optimal performance.
+Zielniveau ist **WCAG 2.1 AA**. Das ist kein Nachrüst-Thema: Label-Zuordnung, Kontrast, Fokus-Sichtbarkeit und Fehler-Ansage entstehen an derselben Stelle wie das Feld selbst — in der zentralen Feld-Pipeline, nicht in jedem Aufrufer einzeln.
+
+### 7. Keine Utility-Klasse ohne Deckung im Setup
+
+Tailwind-Utilities, die im Projekt-Setup nicht existieren, sehen im Code aus wie Design und sind wirkungslos. Vor der Nutzung einer unbekannten Klasse prüfen, ob das zugehörige Plugin installiert ist (`package.json`).
+
+---
+
+## Ist-Zustand (am Code verifiziert)
+
+Stand: Juli 2026. Jede Aussage ist mit Datei belegt. Code wird bewusst **nicht** dupliziert — die Datei ist die Wahrheit.
+
+### Theme und globale Styles
+
+**`src/app.css`** enthält alles Globale:
+
+| Bereich           | Inhalt                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Theme             | DaisyUI-v5-Theme `meeresmuseum` via `@plugin 'daisyui/theme'`, `color-scheme: light`, `default: true`, `prefersdark: false`                            |
+| Farben            | `--color-primary`/`-secondary`/`-accent`/`-neutral`, `--color-base-100/200/300`, `--color-base-content`, Status: `info`/`success`/`warning`/`error`    |
+| Layout-Tokens     | `--radius-selector`, `--radius-field`, `--radius-box`, `--size-selector`, `--size-field`, `--border`, `--depth`, `--noise`                             |
+| Alert-Override    | `.alert-info/-success/-warning/-error` werden auf ein Soft-Muster gesetzt (Text in Statusfarbe, Hintergrund als 12-%-Mix in `base-100`, kein Schatten) |
+| Fokus             | `.input:focus`/`.select:focus`/`.textarea:focus` → 3px `--color-primary`-Outline plus Ring; global `:focus-visible` → 2px Outline                      |
+| Motion            | `@media (prefers-reduced-motion: reduce)` reduziert Animationen und Transitions global                                                                 |
+| iframe-Modus      | `.iframe-mode` blendet Navbar/Footer aus und setzt Formularfelder auf `font-size: 1rem`                                                                |
+| Weitere Utilities | `.scroll-styled` (Scrollbar), `.panel-transition`/`.panel-shadow`, `.no-print`                                                                         |
+
+Sämtliche `*-content`-Farben des Themes (`--color-primary-content`, `--color-warning-content`, …) sind auf reines Weiß (`oklch(1 0 0)`) gesetzt — mit Ausnahme von `--color-accent-content`. Daraus folgt die `*-content`-Regel in `.claude/rules/design-system.md`.
+
+### Formular-Architektur
+
+| Ebene           | Datei                                                                      |
+| --------------- | -------------------------------------------------------------------------- |
+| Container       | `src/routes/+page.svelte`                                                  |
+| Formular-Root   | `src/lib/report/components/ModernReportForm.svelte`                        |
+| Schritt-Anzeige | `src/lib/report/components/form/FormSteps.svelte`                          |
+| Schritt-Navi    | `src/lib/report/components/form/StepNavigation.svelte`                     |
+| Schritte        | `src/lib/report/components/steps/Step1…Step4*.svelte`                      |
+| Sections        | `src/lib/report/components/sections/` (`SectionCard.svelte` als Rahmen)    |
+| Schritt-Konfig  | `src/lib/report/formConfig.ts` (`formStepsConfig`, `initialFormState`)     |
+| Schema          | `src/lib/form/validation/sightingSchema.ts`                                |
+| Form-State      | `src/lib/form/createForm.ts` (eigene Implementierung, keine Fremd-Library) |
+
+Vier Schritte, `currentStep` ist **0-basiert**: Position & Zeit, Sichtungsdetails, Beobachtungen (`isOptional: true`), Kontaktdaten. Schritt 3 hat einen expliziten Überspringen-Button in `Step3Observations.svelte`.
+
+### Feld-Pipeline
+
+Jedes Formularfeld läuft über `FormField` → `FieldRenderer` (beide in `src/lib/report/components/form/fields/`):
+
+- `FormField` holt den Form-Context (`getFormContext()`), zieht die Feld-Beschreibung aus `sightingSchemaFields` (das ist `sightingSchema.describe().fields`) und reicht Wert, Fehler und `touched` weiter.
+- `FieldRenderer` erzeugt Label, Pflicht-Markierung, Hilfetext, Beschreibung, Statusicon, Fehlerblock und wählt die passende `Base*`-Komponente (Input/Select/Textarea/Radio/Checkbox/Toggle).
+- Label, Hilfetext, Icon, Platzhalter, Optionen und Feldtyp kommen aus dem Yup-Schema (`.label()` und `.meta({...})`) — **nicht** aus dem Aufrufer. Ein neues Feld wird daher im Schema konfiguriert, nicht im Template.
+
+Barrierefreiheits-Details, die dort zentral entstehen:
+
+- `required` ist **eine** Variable und speist sowohl das Sternchen als auch `aria-required` (`requiredOverride ?? fieldConfig.optional === false`).
+- Der `required`-Prop von `FormField` ist der Override für konditionale `when()`-Regeln, die aus `describe()` nicht ableitbar sind.
+- IDs nach festem Muster: `field-<name>`, `-help`, `-error`, `-desc`; `aria-describedby` wird nur aus tatsächlich gerenderten Elementen zusammengesetzt.
+- Fehlerblock mit `role="alert"` und `aria-live="polite"`.
+- Radiogruppen werden als `fieldset`/`legend` gerendert (ein `label[for]` würde ins Leere zeigen), Checkbox/Toggle rendern ihr eigenes Label.
+- Jedes Feld erhält `data-testid="field-<name>"`; der Wrapper trägt `data-field="<name>"`.
+- Dekoratives (Statusicon, Feld-Icons, Dropdown-Chevron) ist `aria-hidden`.
+
+Testabdeckung dieser Pipeline: `src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts`.
+
+### Validierungs-Zeitpunkt
+
+- `StepNavigation.svelte` hält `attemptedStep`. Der Inline-Alert und die Fehlermarkierung erscheinen erst nach einem gescheiterten „Weiter"-Versuch; ein Schrittwechsel setzt den Marker zurück (Logik ausgelagert in `form/stepNavigationState.ts`).
+- Schritt-Validierung: `isStepValid`/`validateStep` in `src/lib/form/validation/stepValidation.ts` validieren per `sightingSchema.pick(...)` nur die Felder des aktuellen Schritts.
+- Vor dem endgültigen Absenden validiert `ModernReportForm.handleFinalSubmit` das **vollständige** Schema, schreibt alle Fehler in den Store und springt via `findStepForErrors` zum frühesten betroffenen Schritt. Ein Submit scheitert damit nie unsichtbar.
+- `createForm` löscht den Fehler eines Feldes, sobald es geändert wird, und markiert es als `touched`. Das grüne Häkchen im Label erscheint nur für berührte, gültige Felder.
+
+### Persistenz
+
+`ModernReportForm` speichert über `$lib/storage/localStorage` (`saveToStorage`/`loadFromStorage`). Formulardaten und aktueller Schritt liegen in `sessionStorage`; Kontaktdaten landen nur bei erteilter Einwilligung (`persistentDataConsent`) in `localStorage`, sonst ebenfalls in `sessionStorage`. Wiederhergestellte Eingaben werden per Toast angekündigt. Details: `.claude/rules/browser-storage.md`.
+
+### Progressive Disclosure im Bestand
+
+- Totfund-Felder: `sections/AnimalInfo.svelte` blendet `DeadAnimal.svelte` bei `$form.isDead` ein.
+- Bootsantrieb: `sections/SightingDetails.svelte` zeigt `boatDrive`/`boatDriveText` nur bei Segelschiff/Motorboot und setzt die Werte beim Wechsel zurück — die Reset-Bedingung ist in `sections/boatDriveReset.ts` isoliert und getestet, damit ein initialer Mount (Admin-Edit) keinen gespeicherten Wert löscht.
+- Ein-/Ausblenden nutzt `transition:slide` aus `svelte/transition`, nicht CSS-Utility-Klassen.
+
+### Icons
+
+- UI-Icons: `src/lib/components/Icon.svelte` als zentraler Wrapper über unplugin-icons (lucide). Aufruf über den String-Namen, z.B. `<Icon icon="lucide:map-pin" width="20" />`.
+- Wetter-Icons: CSS-basiert (`src/css/weather-icons.css`, `weather-icons-wind.css`, in `app.css` importiert), Nutzung als `<i class="wi wi-…">`.
+
+---
+
+## Bekannte Einschränkungen / offene Punkte
+
+Ehrliche Liste. Wer hier etwas behebt, streicht den Punkt.
+
+| Punkt                            | Beschreibung                                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Nur Light-Theme**              | `meeresmuseum` ist mit `color-scheme: light` und `prefersdark: false` definiert. Es gibt kein Dark-Theme; `dark:`-Varianten in Komponenten sind wirkungslos.                                                                                                                                                                                                                                                           |
+| **Kein Service Worker**          | Es existiert keine Service-Worker-Datei und keine PWA-Konfiguration. Offline-Fähigkeit beschränkt sich auf Session-/LocalStorage-Persistenz des Formulars.                                                                                                                                                                                                                                                             |
+| **`boatDrive` ohne „k. A."**     | Die DB-Spalte `bootsantrieb` ist `integer default(0) notNull` und `0` bedeutet „Sonstiger Bootsantrieb". Ein leeres Feld wird dadurch beim Speichern nicht von einer aktiven Auswahl „Sonstiges" unterschieden.                                                                                                                                                                                                        |
+| **Kein Animations-Plugin**       | Weder `tailwindcss-animate` noch `tw-animate-css` sind installiert. Klassen wie `animate-in` oder `slide-in-from-top-*` haben keine Wirkung.                                                                                                                                                                                                                                                                           |
+| **Admin-UI nicht theme-rein**    | Zwei Stellen nutzen noch Tailwind-Graustufen statt Theme-Tokens: der Admin-Bereich (`AdminSightingEditForm.svelte`, `BooleanStatus.svelte`, `routes/admin/[id]/**`) und `src/lib/form/fields/dropzone.ts` (genutzt von `DropzoneBase.svelte`, enthält zusätzlich wirkungslose `dark:`-Klassen und einen Klassen-Typo `bg-bray-800`). Die Step- und Section-Komponenten des Sichtungsformulars sind bereits theme-rein. |
+| **Kontrast nicht automatisiert** | Es gibt keinen automatischen Kontrast-Check in CI. Der `*-content`-Fehler in `DeadAnimal.svelte` wurde manuell im Review gefunden — die Regel dazu steht in `.claude/rules/design-system.md`, die Prüfung bleibt Handarbeit.                                                                                                                                                                                           |
+| **Fokus nach Schrittwechsel**    | `scrollToElement('#form-content')` scrollt unter Badge und Überschrift; der Fokus wird zwar auf den Step-Header gesetzt, die Scroll-Position lässt den Header aber teilweise oberhalb des Viewports.                                                                                                                                                                                                                   |
+| **Sonstige Review-Befunde**      | Offene UX-Punkte werden in `docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md` mit Status geführt, nicht hier dupliziert.                                                                                                                                                                                                                                                                                          |
+
+---
+
+## Checkliste vor einem UI-PR
+
+1. Farben, Radien, Borders ausschließlich über Theme-Tokens / DaisyUI-Utilities.
+2. Kein `*-content` auf Tint-Flächen (`bg-…/10` o.ä.) — siehe Regel.
+3. Neues Feld: im Schema mit `.label()`/`.meta()` konfiguriert **und** in `formStepsConfig` eingetragen.
+4. Konditionale Pflicht? Dann `required`-Override an `FormField` setzen.
+5. Kein neuer Fehlerzustand, der schon beim Betreten eines Schritts sichtbar ist.
+6. Verwendete Utility-Klassen existieren im Setup (kein Animations-Plugin!).
+7. Tastaturbedienung und sichtbarer Fokus geprüft; dekorative Icons `aria-hidden`.
+8. `npm run test:quick` ist grün.

--- a/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
+++ b/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
@@ -1,0 +1,225 @@
+# UX & Design System Review — Sichtungsformular
+
+**Datum:** 2026-07-24
+**Umfang:** Multi-Step-Sichtungsformular (`/`), Design System (DaisyUI-Theme `meeresmuseum`), `.claude`-Rules/Agents/Skills
+**Methodik:** Code-Review aller Formular-Komponenten + Live-Durchgang im Browser (Mobile ~606 px und Desktop 1440 px, alle 4 Schritte)
+
+---
+
+## Gesamteindruck
+
+Das Formular ist strukturell gut: klare 4-Schritt-Architektur, Positionsmethoden-Wahl (Foto/Karte/Beschreibung), Auto-Save, Wetter-Autovorschlag, durchdachte Consent-Trennung. Die Basis ist deutlich besser als der Durchschnitt von Meldeformularen.
+
+**Aber:** Die im `DESIGN_GUIDE.md` behauptete „A-"-Qualität hält der Prüfung nicht stand. Es gibt **drei kritische Datenqualitäts-/A11y-Probleme**, eine Reihe von UX-Inkonsistenzen und ein Dokumentations-/Rules-Set, das an mehreren Stellen nicht mehr zum Code passt.
+
+---
+
+## 🔴 Kritische Befunde
+
+### K1: Default-Koordinaten gaukeln eine echte Position vor (Datenqualität!)
+
+`sightingSchema.ts` setzt als Schema-Defaults:
+
+- `latitude: 54.5` (Zeile 214), `longitude: 13.5` (Zeile 246), `hasPosition: true` (Zeile 178)
+
+Folgen (live verifiziert):
+
+1. Ein **leeres, unberührtes Formular** zeigt bereits „✓ Die Koordinaten liegen innerhalb der Ostsee."
+2. Schritt 1 ist ohne jede Nutzereingabe „gültig" — „Weiter" ist sofort aktiv.
+3. Die Wetter-Sektion lädt **automatisch Wetterdaten für die Phantom-Position** „54° 30′ N 13° 30′ E".
+4. Wer keine Position angibt, meldet unbemerkt eine Sichtung mitten in der Ostsee — wissenschaftlich wertlose bzw. verfälschende Daten.
+
+**Empfehlung:** Defaults auf `undefined`/`null` + `hasPosition: false`; Position (oder explizit „Beschreibung statt GPS") als bewusste Nutzeraktion validieren. VerifyLocation und Wetter-Fetch nur nach echter Eingabe rendern.
+
+### K2: Tierart „Schweinswal" und Anzahl „1" sind vorausgefüllt und grün abgehakt
+
+`species` default `0` (= Schweinswal), `totalCount` default `1`. In Schritt 2 erscheint die Tierart-Auswahl **vorbelegt mit grünem Häkchen**, als hätte der Nutzer sie bestätigt. Wer eine Robbe meldet und das Feld übersieht, meldet einen Schweinswal. Gleiches Muster: grüne Häkchen an allen Feldern mit Default-Wert (Häkchen = „hat Wert", nicht „vom Nutzer bestätigt").
+
+**Empfehlung:** `species` ohne Default („Bitte wählen…"), Validitäts-Häkchen nur für _berührte_ Felder anzeigen (touched-State existiert im eigenen `createForm` nicht — ergänzen oder Häkchen-Logik entfernen).
+
+### K3: WCAG-Kontrastbruch im Totfund-Bereich (weiß auf hellgelb)
+
+`DeadAnimal.svelte` nutzt `text-warning-content` auf `bg-warning/10`. Das Theme definiert `--color-warning-content: oklch(1 0 0)` (weiß). Ergebnis (live gemessen): **weißer Text auf ~90 % hellem Hintergrund, Kontrast ≈ 1,1:1** — praktisch unlesbar, klarer WCAG-2.x-Fail in einem inhaltlich wichtigen Bereich (Verhaltensregeln bei Totfund!).
+
+**Empfehlung:** `text-base-content` bzw. eine `warning`-Textfarbe mit dunklem Ton verwenden (analog zum Alert-Override in `app.css`, der genau dieses Problem für `.alert-warning` bereits löst). Grundsatzfrage: `*-content`-Farben sind für Text _auf_ der Vollton-Farbe gedacht, nicht auf `/10`-Tints — als Regel ins Design-System aufnehmen.
+
+---
+
+## 🟡 UX-Befunde (moderat)
+
+| #   | Befund                                                                                                                                                                                                                                                                                                                                                        | Beleg                                                                                |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| U1  | **Vorzeitige Fehleranzeige:** Beim Betreten von Schritt 2 und 4 erscheint sofort ein Warn-Alert („Bitte geben Sie eine Entfernung an." / „Vorname erforderlich"), obwohl der Nutzer nichts berührt hat. Widerspricht dem eigenen Design Guide („Optimal validation timing without premature error states").                                                   | StepNavigation.svelte:33–35 (`stepErrorMessages` ohne touched-Check)                 |
+| U2  | **Deaktivierter Weiter-Button + Fehler-Whack-a-mole:** „Weiter" ist disabled, solange der Schritt invalide ist; der Alert zeigt nur den **ersten** Fehler. Der aufwendige `showValidationError()`-Flow (Toast, Fehlerzähler, Scroll-zum-Feld) ist **toter Code**, weil der Button bei Invalidität gar nicht klickbar ist.                                     | StepNavigation.svelte:56–59 vs. 169                                                  |
+| U3  | **Bootsantrieb blockiert Land-Melder:** Pflichtfeld ohne Konditionallogik — auch bei „Sichtung von: Land" muss ein Bootsantrieb gewählt werden; es gibt keine Option „Kein Boot". Schema-Kommentar sagt „Optional", Code sagt `.required()` **ohne deutsche Fehlermeldung** → es erscheint der englische Yup-Fallback **„Bootsantrieb is a required field"**. | sightingSchema.ts:889–907                                                            |
+| U4  | **Toter „Abbrechen"-Button:** `handleCancel` macht `goto('/')` — das Formular _ist_ Seite `/`. Der Button tut effektiv nichts. Zudem wirkt er als `btn-ghost` wie einfacher Text.                                                                                                                                                                             | +page.svelte:32–35, FormActions.svelte:80–89                                         |
+| U5  | **Doppelte „Kontaktdaten löschen"-Funktion** mit unterschiedlichen Confirm-Texten und Feedback (Toast vs. Logger) in Step4Contact **und** FormActions; beide mit nativem `confirm()` statt DaisyUI-Modal.                                                                                                                                                     | Step4Contact.svelte:24–37, FormActions.svelte:26–43                                  |
+| U6  | **Stepper ohne Labels:** Nur Kreise „1 2 3 4" — Schritte 3/4 zudem kontrastschwach. Nutzer sehen nicht, was kommt (Design Guide fordert benannte Schritte). A11y: `role="tablist"`/`role="tab"` ohne `tabpanel` ist falsche Semantik; interaktives `<li>` mit `tabindex`/`onclick` statt `<button>`.                                                          | FormSteps.svelte:36–58                                                               |
+| U7  | **Doppelte Labels bei Toggles/Checkboxen:** Label erscheint zweimal („Handelt es sich um einen Totfund?" ×2, „Einverständnis zur Mediennutzung" ×2) — FieldRenderer rendert das Label, BaseToggle/BaseCheckbox wiederholen es.                                                                                                                                | FieldRenderer.svelte:237–272 + 291–293                                               |
+| U8  | **Copy-Fehler / inkonsistente Sprache:** „Handel**tete** es sich um **L**ebende Tiere…" (Tippfehler); „Reaktion auf **Ihr Boot**" auch bei Land-Sichtung; Medien-Sektion bewirbt „Fotos/**Videos**", akzeptiert aber nur Bildformate (JPG/PNG/GIF/WEBP); „max 10MB" vs. 30-MB-Cap im GPS-Upload-Code.                                                         | sightingSchema (isDead helpText), Behavior/Media-Sections, PositionAndTime.svelte:32 |
+| U9  | **Scroll/Fokus nach Schrittwechsel landet unterhalb des Step-Headers** (Badge „Schritt X von 4" und Überschrift werden übersprungen; live mehrfach mitten im Formular gelandet).                                                                                                                                                                              | StepNavigation.svelte:41–51 (`#form-content` beginnt unter dem Header)               |
+| U10 | **Positionsmethode nicht persistiert:** Nach Reload steht die Auswahl wieder auf „Foto mit GPS", auch wenn der Nutzer Karte/Beschreibung gewählt hatte; Methodenwechsel setzt bereits gesetzte Koordinaten nicht zurück.                                                                                                                                      | PositionAndTime.svelte:14, 39–48                                                     |
+| U11 | **Fehlermeldungs-Stil inkonsistent:** teils freundlich-deutsch („Wie viele Tiere haben Sie gesehen?"), teils technisch-englisch (U3), teils Feldname-Präfix („GPS-Position: Breitengrad ist erforderlich").                                                                                                                                                   | sightingSchema.ts passim                                                             |
+
+---
+
+## 🎨 Design-System-Befunde
+
+**Positiv:** Ein echtes Theme (`meeresmuseum`) als DaisyUI-v5-Plugin mit OKLCH-Tokens, dokumentierten Radius-/Border-Variablen, Alert-Soft-Override, Fokus-Indikatoren, `prefers-reduced-motion`-Fallback. Lucide-Icons konsequent über `Icon.svelte`/unplugin-icons. Die Basis-Feldkomponenten (BaseInput/Select/…) nutzen sauber DaisyUI-Klassen.
+
+Schwächen:
+
+| #   | Befund                                                                                                                                                                                                                                                                                                                      | Beleg                                                      |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| D1  | **`animate-in`/`slide-in-from-top-1`/`duration-200` sind tote Klassen** — kein `tailwindcss-animate`/`tw-animate-css` in `package.json`. Die Fehler-„Animation" existiert nicht.                                                                                                                                            | FieldRenderer.svelte:309, SpeciesIdentificationHelp.svelte |
+| D2  | **`*-content`-Farben auf Tints** (K3) — Regel fehlt, wann `text-warning-content` erlaubt ist.                                                                                                                                                                                                                               | DeadAnimal.svelte                                          |
+| D3  | **Button-Hierarchie uneinheitlich:** „Zurück" = `btn-secondary` (Vollton, wirkt fast disabled neben dem grauen Container), „Formular zurücksetzen" = `btn-outline btn-sm`, „Abbrechen" = `btn-ghost`, „Kontaktdaten löschen" = `btn-warning btn-sm` bzw. `btn-ghost btn-xs text-error` — fünf Stile für sekundäre Aktionen. | StepNavigation/FormActions/Step4Contact                    |
+| D4  | **Inline-Styles statt Utilities** (`style="word-wrap: break-word; …"`).                                                                                                                                                                                                                                                     | FieldRenderer.svelte:240                                   |
+| D5  | **Step-4-Markup:** sämtliche Sections sind _im_ zentrierten Step-Header verschachtelt → `text-center` muss überall per `text-left` zurückgedreht werden; Heading-Hierarchie springt (h4 „Erforderliche Zustimmung" ohne h3-Kontext in RequiredConsent).                                                                     | Step4Contact.svelte:42–207                                 |
+| D6  | **Nur Light-Theme** (`prefersdark: false`, kein dunkles Pendant) — bewusste Entscheidung? Für Feldnutzung nachts (Totfund-Meldung) wäre Dark Mode sinnvoll.                                                                                                                                                                 | app.css:26–30                                              |
+| D7  | Section-Icons doppelt vergeben (`lucide:activity` für „Sichtungsdetails" **und** „Weitere Sichtungsdetails").                                                                                                                                                                                                               | SightingDetails/OptionalSightingDetails                    |
+
+---
+
+## 📚 Rules-, Skills- & Doku-Audit
+
+### Veraltet / falsch
+
+| Dokument                             | Problem                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.claude/rules/forms.md`             | Beschreibt **svelte-forms-lib** als Form-Stack inkl. Codebeispiel `import { createForm } from 'svelte-forms-lib'`. Das Paket ist **nicht mehr in `package.json`** — das Projekt hat eine eigene `createForm`-Implementierung (`src/lib/form/createForm.ts`). Ein Agent, der dieser Rule folgt, schreibt falschen Code. Auch das Schema-Beispiel (`lat`, `lng`, `date`, `count`) entspricht nicht den echten Feldnamen (`latitude`, `sightingDate`, `totalCount`, …). |
+| `.claude/rules/architecture.md`      | Tech-Stack-Tabelle: „Forms \| svelte-forms-lib + Yup" — stale.                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `.claude/agents/form-development.md` | „svelte-forms-lib + Yup Integration" als Kernfähigkeit — stale.                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `.claude/README.md`                  | Ebenfalls svelte-forms-lib-Referenz (Zeile 109).                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `CLAUDE.md` (Root)                   | Übernimmt den Stack-Einzeiler mit svelte-forms-lib.                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `docs/DESIGN_GUIDE.md`               | Größtes Problem: liest sich als Erfolgsbilanz („A- grade", lauter ✅), enthält aber **nachweislich falsche Behauptungen**: zitierte CSS-Regeln (`.form-field`, `.form-navigation`) existieren nicht in `app.css`; „Service worker ✅" — es gibt keinen; „keine premature errors ✅" — live widerlegt (U1); Schema-/Code-Snippets entsprechen nicht dem echten Code. Als Referenz für Design-Entscheidungen derzeit irreführend.                                      |
+
+### Lücken (fehlende Skills/Rules für den genutzten Stack)
+
+1. **Eigenes Form-Framework undokumentiert:** `createForm`-API, `FormContext`, `FieldRenderer`/`FormField`-Pattern, Schema-`meta`-Konventionen (`helpText`, `valueText`, `icon`, `type`, options) — nirgends beschrieben. Genau hier halluzinieren Agents sonst svelte-forms-lib. → `forms.md` komplett neu auf die hauseigene API schreiben (höchste Priorität im Doku-Bereich).
+2. **Kein Design-System-Dokument mit Verbindlichkeit:** Es fehlt eine kompakte Rule (`.claude/rules/design-system.md` o.ä.) mit: Theme-Tokens, Button-Hierarchie, Alert-/Tint-Regeln (wann `*-content`), Label/Toggle-Pattern, Icon-Konventionen. `DESIGN_GUIDE.md` ersetzt das nicht (siehe oben). |
+3. **Kein A11y-Check im Workflow:** architecture.md fordert WCAG 2.1 AA, aber weder `/review` noch `/prepare-pr` enthalten einen Kontrast-/ARIA-Check (K3, U6 wären sonst aufgefallen). Plugin-Skills wie `design:accessibility-review` bzw. `ecc:a11y-architect` sind vorhanden, werden aber nirgends referenziert.
+4. **Vorhandene Framework-Abdeckung ist gut:** Svelte-5-Plugin (svelte-file-editor Agent + Autofixer-MCP), Context7, dedizierte Doku-MCPs für DaisyUI, Drizzle, OpenLayers. Hier fehlt nichts Wesentliches — die Lücke liegt bei den **projekteigenen** Patterns, nicht bei den Frameworks.
+
+---
+
+## Was gut funktioniert
+
+- 4-Schritt-Struktur mit optionalem Schritt 3 inkl. prominentem „Schritt überspringen"
+- Positionsmethoden-Auswahl (Foto-GPS bevorzugt) — starke, feldtaugliche Idee
+- Auto-Save (Session) + Consent-basierte Kontaktdaten-Persistenz (GDPR-sauber differenziert)
+- Wetter-Autovorschlag mit Quellenangabe und Forecast/Historie-Unterscheidung
+- Datum default = heute, Zeit optional — richtige Priorisierung
+- Durchgängige Icon-Sprache, ordentliche Fokus-Stile, `prefers-reduced-motion`
+- Klare, zweckgebundene Datenschutz-Kommunikation vor dem Absenden
+
+---
+
+## Priorisierte Empfehlungen
+
+1. **K1/K2 sofort:** Defaults für `latitude`/`longitude`/`hasPosition`/`species` entfernen; „gültig"-Häkchen an touched koppeln. (Kleiner Eingriff, größter Effekt auf Datenqualität.)
+2. **K3 + D1:** Totfund-Kontrast fixen; tote `animate-in`-Klassen entfernen oder Plugin nachrüsten.
+3. **U1/U2:** Fehler-Alert erst nach Interaktionsversuch zeigen; „Weiter" immer klickbar lassen und beim Klick den vorhandenen `showValidationError()`-Flow nutzen (Toast + Scroll zum ersten Fehlerfeld) — der Code existiert bereits.
+4. **U3:** `boatDrive` konditional auf `sightingFrom` (Boot-Typen) machen, deutsche Fehlermeldung ergänzen, Option „Kein Boot" bzw. Feld bei Land ausblenden.
+5. **forms.md & Co. aktualisieren:** svelte-forms-lib-Referenzen in 5 Dateien ersetzen durch die dokumentierte hauseigene `createForm`-API; `DESIGN_GUIDE.md` durch ein ehrliches, kompaktes Design-System-Dokument ersetzen.
+6. **Stepper:** Labels unter die Punkte, `tablist`-Semantik durch Buttons ersetzen (U6).
+7. Kleinigkeiten: Copy-Fixes (U8), doppelte Labels (U7), toten Abbrechen-Button entfernen oder mit Reset zusammenführen (U4/U5).
+
+---
+
+_Review erstellt mit Live-Verifikation; Screenshots der Befunde K1 (grüne Ostsee-Bestätigung auf leerem Formular), K3 (weißer Text auf hellem Grund), U1/U3 (premature Errors, englische Fehlermeldung) wurden im Browser-Durchgang erhoben._
+
+---
+
+## Update nach Rebase auf main (Commit `acce0d2`, Pre-Launch-Review #558)
+
+Neubewertung aller Befunde gegen den aktuellen Stand (Code-Diff + erneuter Browser-Check):
+
+### ✅ Durch #558 behoben
+
+| Befund                                                                        | Status                                                                                                                                                                                                                        |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **U6** Stepper ohne Labels / falsche Semantik                                 | **Behoben.** Sichtbare Schritt-Titel unter den Punkten, echte `<button>` statt klickbarer `<li>`, `role="tablist"` entfernt (live verifiziert). Rest-Punkt: inaktive Kreise weiterhin kontrastschwach.                        |
+| **U7** Doppelte Labels bei Toggles/Checkboxen                                 | **Behoben.** FieldRenderer überspringt das Caption-Label für Checkbox/Toggle (`isSingleControl`); Radio-Gruppen jetzt korrekt mit `fieldset`/`legend`.                                                                        |
+| **U8 (teilweise)** Copy-Fehler                                                | „Handeltete"-Tippfehler und „Junge Tiere" korrigiert; SubmissionSuccess-Texte gefixt. **Offen:** Medien-Sektion bewirbt weiter „Fotos/Videos", akzeptiert aber nur Bildformate; 10 MB vs. 30 MB.                              |
+| **U9 (teilweise)** Fokus nach Schrittwechsel                                  | „Schritt überspringen" setzt jetzt den Fokus auf den Step-Header. **Offen:** regulärer Schrittwechsel scrollt weiterhin zu `#form-content` (unterhalb von Badge/Überschrift).                                                 |
+| **Doku: forms.md / architecture.md / CLAUDE.md / agents/form-development.md** | **Behoben.** forms.md dokumentiert jetzt die hauseigene `createForm`-API (inkl. „kein touched/validateField"-Hinweis), Tech-Stack-Tabellen aktualisiert. **Offen:** `.claude/README.md:109` nennt weiterhin svelte-forms-lib. |
+| Bonus (nicht im Original-Review)                                              | Autocomplete-Attribute auf Kontaktfeldern, Confirm vor „Formular zurücksetzen", Info-Tooltips tastaturerreichbar, Skip-Link/Landmarks.                                                                                        |
+
+### 🔴 Weiterhin offen (kritisch)
+
+| Befund                                                                | Verifiziert im aktuellen Code                                                                                                                      |
+| --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **K1** Default-Koordinaten / Phantom-Position                         | `sightingSchema.ts`: `hasPosition .default(true)` (Z. 178), `latitude .default(54.5)` (Z. 214), `longitude .default(13.5)` (Z. 246) — unverändert. |
+| **K2** Tierart/Anzahl vorbelegt + grüne Haken auf unberührten Feldern | Defaults und `hasValue`-basierte Häkchen unverändert.                                                                                              |
+| **K3** Totfund-Kontrast (weiß auf hellgelb)                           | `DeadAnimal.svelte` nutzt weiter `text-warning-content` auf `bg-warning/10`.                                                                       |
+
+### 🟡 Weiterhin offen (moderat)
+
+- **U1/U2:** Premature-Error-Alert + disabled „Weiter" unverändert (`StepNavigation.svelte:33–35, 169`); `showValidationError()`-Flow bleibt toter Code.
+- **U3:** `boatDrive` weiter unconditional `.required()` ohne deutsche Meldung (englischer Yup-Fallback), Schema-Kommentar sagt „Optional"; keine Konditionallogik auf `sightingFrom`.
+- **U4:** „Abbrechen" → `goto('/')` auf Seite `/` — toter Button.
+- **U5:** Doppelte „Kontaktdaten löschen"-Funktion (Step4Contact + FormActions) mit unterschiedlichen Texten; native `confirm()`.
+- **U10:** Positionsmethode nicht persistiert; Methodenwechsel setzt Koordinaten nicht zurück.
+- **U11:** Fehlermeldungs-Stil weiter inkonsistent.
+- **D1:** `animate-in`-Klassen weiter tot (kein Animations-Plugin in package.json), jetzt `FieldRenderer.svelte:331`.
+- **D3–D7:** Button-Hierarchie, Inline-Styles, Step-4-Verschachtelung, nur Light-Theme, Icon-Duplikate — unverändert.
+- **`docs/DESIGN_GUIDE.md`:** unverändert veraltet (falsche CSS-Zitate, Service-Worker-Behauptung, „keine premature errors").
+- **Fehlende Rules:** Design-System-Rule (Tokens, `*-content`-Regel, Button-Hierarchie) und A11y-Check in `/review`//`prepare-pr` weiterhin offen — forms.md deckt jetzt nur das Form-State-Pattern ab.
+
+### Umsetzung am 2026-07-24 (dieser Branch, uncommitted)
+
+Die Top-Prioritäten wurden test-first umgesetzt und live im Browser verifiziert (alle 1654 Unit-Tests + 29 Browser-Komponententests grün, svelte-check 0 Fehler, Lint 0 Fehler):
+
+- **K1 behoben:** Schema-Defaults `latitude`/`longitude` entfernt, `hasPosition` default `false`; `waterway` ist Pflicht, wenn keine GPS-Position vorliegt (leeres Formular kommt nicht mehr durch Schritt 1); `hasPosition` wird nur noch bei echten Koordinaten (Karte/GPS-Foto) gesetzt; Methodenwechsel zu „Beschreibung" setzt Koordinaten zurück. VerifyLocation/Wetter-Fetch rendern bei leerem Formular nicht mehr.
+- **K2 behoben:** `species` ohne Default („Bitte wählen..."); `createForm` hat jetzt einen `touched`-Store, grüne Häkchen erscheinen nur noch an vom Nutzer berührten Feldern.
+- **K3 behoben:** Totfund-Box nutzt `text-base-content`/`text-warning` statt weißem `text-warning-content`; dasselbe Muster an 5 weiteren Stellen in FormHelp.svelte gefixt.
+- **U1/U2 behoben:** Kein Fehler-Alert mehr beim Betreten eines Schritts; „Weiter" immer klickbar; Klick bei invalidem Schritt zeigt Toast + alle Schrittfehler als Liste + Scroll zum ersten Fehlerfeld (Logik als pure Funktionen in `stepNavigationState.ts`, 12 neue Tests).
+- **U3 behoben:** `boatDrive` nur noch Pflicht bei Segelschiff/Motorboot (deutsche Meldung „Bitte wählen Sie den Bootsantrieb aus."); UI blendet den Block bei Land/Fähre/Sonstiges aus und setzt versteckte Werte zurück (11 neue Schema-Tests).
+- **D1 behoben:** Tote `animate-in`-Klassen entfernt. **U8 (Rest) behoben:** Medien-Copy ohne Video-Versprechen. **Doku:** letzte svelte-forms-lib-Referenz in `.claude/README.md` korrigiert.
+
+Weiterhin offen (bewusst nicht in diesem Schwung): U4/U5 (Abbrechen/doppeltes Kontaktdaten-Löschen), U9-Rest (Scrollziel Schrittwechsel), U10, U11-Rest, D3–D7, DESIGN_GUIDE.md-Ersatz, Design-System-Rule, A11y-Check in `/review`.
+
+### Nachtrag: Review der Umsetzung (2026-07-27)
+
+Ein Code-/UX-Review der obigen Änderungen (inkl. unabhängigem Zweitgutachten und erstmaligem E2E-Lauf) fand vier Regressionen, die anschließend behoben wurden:
+
+| Befund                                                  | Ursache                                                                                                                                                                                                                              | Behebung                                                                                                                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Datenverlust im Admin** (kritisch, nie in Produktion) | Der `$effect` zum Zurücksetzen von `boatDrive` lief auch beim Mount — beim Öffnen einer bestehenden Land-Sichtung wurde der gespeicherte Wert unsichtbar gelöscht und beim Speichern als 0 („Sonstiger Bootsantrieb") überschrieben. | `boatDriveReset.ts`: Reset nur beim echten Übergang Boot → kein Boot; der erste Durchlauf initialisiert nur den Merker.                                          |
+| **E2E-Suite rot** (10/11 in `form-ux`)                  | `fillStep1`/`fillStep2` bauten auf den entfernten Phantom-Defaults bzw. dem immer sichtbaren Bootsantrieb auf.                                                                                                                       | Helper und Specs nachgezogen; komplette Suite läuft: **86 passed, 1 skipped** (DB-gated).                                                                        |
+| **Sackgasse in Schritt 1**                              | `waterway` war Pflicht, aber nur in der Methode „Beschreibung" gerendert — Fehler ohne behebbares Feld.                                                                                                                              | Fahrwasser-Block in allen drei Methoden erreichbar („Kein GPS? Beschreiben Sie das Seegebiet"), dynamisches Pflicht-Sternchen + `aria-required`.                 |
+| **Sichtbare Phantom-Koordinaten**                       | Anzeige-Fallback `?? 54.5/13.5` füllte die Koordinatenfelder, obwohl der State leer war.                                                                                                                                             | `defaultCenter`-Prop in `LocationInput`: Karte startet über der Ostsee, Eingabefelder bleiben leer. Gleiches im Admin-Pfad (`Location.svelte` + `toCoordinate`). |
+| **Stiller Fehlschlag beim Absenden**                    | Immer klickbarer Button + `createForm` schluckt `ValidationError` → Klick ohne jede Reaktion.                                                                                                                                        | `findStepForErrors.ts`: Abbruch vor dem Submit, Fehler in den Store, Sprung zum frühesten betroffenen Schritt, Toast über die bestehende Fehlerbehandlung.       |
+
+Stand nach der Nacharbeit: 1685 Unit-Tests, 74 Browser-Komponententests, 86 E2E-Tests grün; svelte-check 0 Fehler, ESLint 0 Fehler.
+
+### Restliste abgearbeitet (2026-07-27)
+
+| Befund                                       | Umsetzung                                                                                                                                                                                                         |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **U4** toter Abbrechen-Button                | Entfernt (`goto('/')` auf der eigenen Seite war nachweislich wirkungslos, auch im iFrame-Modus).                                                                                                                  |
+| **U5** doppeltes „Kontaktdaten löschen"      | Konsolidiert in `src/lib/report/clearContactData.ts`, nur noch in Schritt 4 (fachlicher Kontext), ein Text, ein Toast.                                                                                            |
+| **U9** Scrollziel beim Schrittwechsel        | `scrollToStepHeader()` in `fieldNavigation.ts` — der Kopf des neuen Schritts (Icon/Überschrift/Badge) ist jetzt sichtbar.                                                                                         |
+| **U10** Positionsmethode nicht persistiert   | `positionMethod.ts`: Methode wird beim Mount aus dem Formularzustand abgeleitet (Koordinaten → Karte, Fahrwasser → Beschreibung, sonst Foto).                                                                     |
+| **U11/U8** erfundene Statistiken in Tooltips | Vier unbelegte Zahlen („73 % der Sichtungen morgens", „5x mehr Tiere", „40 % durch Nordwind", „60 % mit Elektromotor") entfernt und durch nachprüfbare Aussagen ersetzt. Belegte Zahlen können mit Quelle zurück. |
+| **D3** Button-Hierarchie                     | Eine Primäraktion pro Bereich; destruktive Aktionen einheitlich `btn-outline btn-error` mit 44 px Touch-Target; „Zurück" von Vollton auf `btn-outline`.                                                           |
+| **D5** Step-4-Markup                         | Sections liegen nicht mehr im zentrierten Header; alle `text-left`-Gegensteuerungen entfallen.                                                                                                                    |
+| **Stale Position**                           | `exifPositionReset.ts`: Beim Entfernen des GPS-Fotos werden nur die daraus gesetzten Koordinaten zurückgenommen — manuell geänderte Werte bleiben.                                                                |
+| **OpenAPI-Spec**                             | `latitude`/`longitude` nicht mehr als Pflicht deklariert, „Position oder Fahrwasser"-Regel dokumentiert, `hasPosition` ergänzt, `species` `minimum: 0` (0 = Schweinswal).                                         |
+| **Upload-Konfiguration**                     | Client-Fallback versprach Videos/50 MB, Server erlaubt anonym nur Bilder/10 MB — beide ziehen jetzt aus `src/lib/constants/uploadDefaults.ts`.                                                                    |
+| **DESIGN_GUIDE.md**                          | Ersetzt: Leitlinien und verifizierter Ist-Zustand getrennt, alle erfundenen Metriken und falschen Code-Zitate raus, „Bekannte Einschränkungen" ergänzt.                                                           |
+| **Design-System-Rule**                       | Neu: `.claude/rules/design-system.md` (Theme-Tokens, `*-content`-Regel, Alerts, Button-Hierarchie, Feld-Pipeline, A11y-Minima, tote Utilities).                                                                   |
+| **A11y im Workflow**                         | Prüfschritt in `/review` und `/prepare-pr` verankert, inkl. Messmethode für `oklch`-Farben.                                                                                                                       |
+| **forms.md**                                 | Behauptete „Es gibt KEIN `touched`" — seit der Umsetzung falsch; korrigiert, handgeschriebenes ARIA-Beispiel durch Verweis auf die `FormField`-Pipeline ersetzt.                                                  |
+
+Endstand: **1703 Unit-Tests, 80 Browser-Komponententests, 86 E2E-Tests grün**; svelte-check 0 Fehler, ESLint 0 Fehler.
+
+Weiterhin bewusst offen: nur Light-Theme (Produktentscheidung), `boatDrive` kann DB-bedingt (`notNull default 0`) kein „keine Angabe" abbilden, Karten-Neuaufbau bei jeder Koordinatenänderung (vorbestehend).
+
+### Aktualisierte Prioritäten
+
+1. **K1/K2:** Schema-Defaults entfernen (unverändert wichtigster Fix).
+2. **K3 + D1:** Totfund-Kontrast, tote Animationsklassen.
+3. **U1/U2 + U3:** Fehler-Timing & Bootsantrieb-Konditionallogik.
+4. Doku-Rest: `.claude/README.md`-Zeile, `DESIGN_GUIDE.md` ersetzen, Design-System-Rule + A11y-Check ergänzen.

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -55,12 +55,11 @@ test.describe('RequiredConsent — Datenschutz', () => {
 		});
 		await formPage.clickNext();
 
-		// Fill Step 2
+		// Fill Step 2 (sightingFrom = Land → boatDrive bleibt ausgeblendet, keine Pflicht)
 		await formPage.selectSpecies(0);
 		await formPage.fillTotalCount(2);
 		await formPage.selectDistance(1);
 		await formPage.selectSightingFrom(3);
-		await formPage.selectBoatDrive(1);
 		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled({
 			timeout: 3000
 		});
@@ -106,14 +105,19 @@ test.describe('Accessibility — Keyboard Navigation', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		// Navigate to Step 2 — inline error appears automatically for invalid step
+		// Step 1 ist mit fillStep1() valide → Navigation zu Step 2 gelingt ohne Fehler
 		await fillStep1(formPage);
 		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled({
 			timeout: 3000
 		});
 		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
 
-		// Inline validation error is shown above the disabled Next button
+		// Step 2 hat leere Pflichtfelder → erst der Klick auf "Weiter" löst die
+		// Inline-Fehlermeldung aus (kein automatisches Erscheinen beim Betreten)
+		await formPage.clickNext();
+
+		// Inline validation error is shown above the Next button
 		await page.locator('[role="alert"]').first().waitFor({ state: 'visible' });
 
 		// Check role="alert" elements exist

--- a/e2e/form-autosave.spec.ts
+++ b/e2e/form-autosave.spec.ts
@@ -70,9 +70,10 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		// Fill data
+		// Fill data (waterway required, da hasPosition standardmäßig false ist)
 		await formPage.fillDate(today);
 		await formPage.fillTime('14:30');
+		await formPage.fillWaterway('Kieler Bucht');
 
 		// Navigate to Step 2 so we're not on Step 1
 		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled({

--- a/e2e/form-position.spec.ts
+++ b/e2e/form-position.spec.ts
@@ -30,16 +30,23 @@ test.describe('PositionAndTime — Methoden-Switching', () => {
 		await expect(page.locator('[data-testid="field-seaMark"]')).toBeVisible({ timeout: 3000 });
 	});
 
-	test('Methoden-Wechsel versteckt vorherige Eingabefelder', async ({ page }) => {
-		// Switch to manual method
+	// Fahrwasser ist Pflicht solange keine GPS-Position vorliegt und wird deshalb
+	// inzwischen in ALLEN drei Positionsmethoden angezeigt (Foto/Karte: Fallback-
+	// Bereich "Kein GPS? Beschreiben Sie das Seegebiet"; Beschreibung: direkt).
+	// Was sich beim Methoden-Wechsel tatsächlich ändert, ist der Foto-Upload-Bereich.
+	test('Methoden-Wechsel: Foto-Upload erscheint/verschwindet, Fahrwasser bleibt erreichbar', async ({
+		page
+	}) => {
+		// Switch to manual method — Fahrwasser sichtbar, kein Foto-Upload
 		await page.locator('label[for="method-manual"]').click();
 		await expect(page.locator('[data-testid="field-waterway"]')).toBeVisible({ timeout: 3000 });
+		await expect(page.getByText(/Foto per Drag & Drop oder Klick hochladen/i)).not.toBeVisible();
 
-		// Switch back to photo method
+		// Switch back to photo method — Foto-Upload erscheint wieder, Fahrwasser bleibt sichtbar
 		await page.locator('label[for="method-photo"]').click();
-		// Manual fields should be hidden
-		await expect(page.locator('[data-testid="field-waterway"]')).not.toBeVisible({
+		await expect(page.getByText(/Foto per Drag & Drop oder Klick hochladen/i)).toBeVisible({
 			timeout: 3000
 		});
+		await expect(page.locator('[data-testid="field-waterway"]')).toBeVisible();
 	});
 });

--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -94,22 +94,25 @@ test.describe('Sichtung melden — Step-Validierung', () => {
 		await expect(stepButtons.nth(0)).toHaveAttribute('aria-disabled', 'false');
 	});
 
-	test('Validierungsfehler zeigt Inline-Fehlermeldung und deaktiviert Weiter-Button', async ({
+	test('Validierungsfehler auf Step 2 zeigt Inline-Fehlermeldung erst nach Klick auf Weiter', async ({
 		page
 	}) => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		// Step 1 hat Schema-Defaults → ist valid. Navigiere zu Step 2.
+		// Step 1 mit gültigem Fahrwasser (fillStep1) → valid. Navigiere zu Step 2.
 		await fillStep1(formPage);
 		await waitForNextEnabled(page);
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Sichtungsdetails/i);
 
-		// Step 2 hat keine Defaults für Pflichtfelder → Weiter-Button ist deaktiviert
-		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeDisabled();
+		// Step 2 hat keine Defaults für Pflichtfelder, der Weiter-Button bleibt aber
+		// klickbar — er wird nur noch beim Absenden ($isSubmitting) deaktiviert.
+		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled();
 
-		// Inline-Fehlermeldung erscheint direkt über dem Weiter-Button
+		// Erst der Klick auf "Weiter" löst die Validierung aus und zeigt die
+		// Inline-Fehlermeldung über dem Button.
+		await formPage.clickNext();
 		await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 3000 });
 	});
 });

--- a/e2e/form-ux.spec.ts
+++ b/e2e/form-ux.spec.ts
@@ -49,7 +49,7 @@ test.describe('StepNavigation — Error-UX', () => {
 		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).not.toBeVisible();
 	});
 
-	test('Validierungsfehler auf Step 2 zeigt Inline-Fehlermeldung und deaktiviert Weiter-Button', async ({
+	test('Step 2 ohne Eingabe: kein Fehler-Alert beim Betreten, Weiter-Button bleibt klickbar', async ({
 		page
 	}) => {
 		const formPage = new FormPage(page);
@@ -60,14 +60,16 @@ test.describe('StepNavigation — Error-UX', () => {
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Sichtungsdetails/i);
 
-		// Step 2 Pflichtfelder leer → Weiter-Button direkt deaktiviert
-		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeDisabled();
+		// Kein Fehler-Alert direkt beim Betreten des Schritts (keine premature errors)
+		await expect(page.locator('[role="alert"]')).toHaveCount(0);
 
-		// Inline-Fehlermeldung über dem Weiter-Button erscheint automatisch
-		await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 3000 });
+		// Weiter-Button bleibt klickbar, auch wenn der Schritt (noch) invalide ist
+		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled();
 	});
 
-	test('Fehler-Felder zeigen rote Markierungen nach Validierung', async ({ page }) => {
+	test('Validierungsfehler auf Step 2 zeigt Inline-Fehlermeldung erst nach Klick auf Weiter', async ({
+		page
+	}) => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
@@ -76,9 +78,32 @@ test.describe('StepNavigation — Error-UX', () => {
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Sichtungsdetails/i);
 
-		// Inline error appears automatically for invalid step (no click needed)
-		const alerts = page.locator('[role="alert"]');
-		await expect(alerts.first()).toBeVisible({ timeout: 3000 });
+		// Step 2 Pflichtfelder leer → Klick auf "Weiter" löst Validierung aus
+		await formPage.clickNext();
+
+		// Inline-Fehlermeldung über dem Weiter-Button erscheint nach dem fehlgeschlagenen Versuch
+		await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 3000 });
+	});
+
+	test('Inline-Fehlermeldung verschwindet wieder, wenn zurück zu Step 1 navigiert wird', async ({
+		page
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await fillStep1(formPage);
+		await waitForNextEnabled(page);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		// Fehlgeschlagener Weiter-Versuch zeigt den Alert
+		await formPage.clickNext();
+		await expect(page.locator('[role="alert"]').first()).toBeVisible({ timeout: 3000 });
+
+		// Zurück zu Step 1 navigieren → Anzeige-Zustand wird zurückgesetzt
+		await formPage.clickPrevious();
+		await expectCurrentStep(page, /Position/i);
+		await expect(page.locator('[role="alert"]')).toHaveCount(0);
 	});
 });
 

--- a/e2e/helpers/form-helpers.ts
+++ b/e2e/helpers/form-helpers.ts
@@ -3,19 +3,35 @@ import { FormPage } from '../pages/FormPage';
 
 const today = new Date().toISOString().substring(0, 10);
 
-/** Fill Step 1 with valid date and time */
+/**
+ * Fill Step 1 with valid date, time and a waterway description.
+ *
+ * `hasPosition` defaults to `false` and there are no more phantom GPS
+ * defaults, so `waterway` is required (schema: `waterway.when('hasPosition',
+ * { is: (v) => v !== true, then: required })`). Filling it here is the
+ * simplest, most stable way to make Step 1 valid — no need to touch the
+ * map/coordinate fields.
+ */
 export async function fillStep1(formPage: FormPage) {
 	await formPage.fillDate(today);
 	await formPage.fillTime('14:30');
+	await formPage.fillWaterway('Kieler Bucht');
 }
 
-/** Fill Step 2 with valid sighting details */
+/**
+ * Fill Step 2 with valid sighting details.
+ *
+ * `boatDrive` is only rendered/required when `sightingFrom` is Segelschiff
+ * (1) or Motorboot (2) — see `isBoatSightingFrom` in
+ * `src/lib/report/components/sections/boatDriveReset.ts`. With
+ * `sightingFrom` = Land (3) the field is hidden, so selecting it here would
+ * time out; it must not be touched for this combination.
+ */
 export async function fillStep2(formPage: FormPage) {
 	await formPage.selectSpecies(0); // Schweinswal
 	await formPage.fillTotalCount(2);
 	await formPage.selectDistance(1);
-	await formPage.selectSightingFrom(3); // Land
-	await formPage.selectBoatDrive(1); // Motor
+	await formPage.selectSightingFrom(3); // Land — boatDrive stays hidden
 }
 
 /** Fill Step 4 with valid contact data */
@@ -33,7 +49,18 @@ export async function expectCurrentStep(page: Page, pattern: RegExp) {
 	});
 }
 
-/** Wait for the Next button to become enabled */
+/**
+ * Wait for the "Weiter"/"Nächster Schritt" button to be ready for interaction.
+ *
+ * NOTE: The button is now only ever disabled while a submission is in
+ * flight (`$isSubmitting`) — it is no longer a proxy for step validity.
+ * Validation errors surface only AFTER a click (see StepNavigation.svelte),
+ * and an invalid step simply does not advance `currentStep`. This helper
+ * therefore just guards against racing an in-flight submission; it does
+ * NOT prove the step's fields are valid. Callers that need proof of a
+ * successful navigation must assert the resulting step via
+ * `expectCurrentStep()` after `clickNext()`.
+ */
 export async function waitForNextEnabled(page: Page) {
 	await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled({
 		timeout: 3000

--- a/e2e/pages/FormPage.ts
+++ b/e2e/pages/FormPage.ts
@@ -52,6 +52,20 @@ export class FormPage {
 		await this.page.locator('[data-testid="field-sightingTime"]').fill(value);
 	}
 
+	/**
+	 * Fahrwasser/Seegebiet — Pflichtfeld solange keine GPS-Position vorliegt
+	 * (`hasPosition !== true`). Sichtbar in allen drei Positionsmethoden
+	 * (Foto/Karte: Fallback-Bereich "Kein GPS?"; Beschreibung: direkt).
+	 */
+	async fillWaterway(value: string) {
+		await this.page.locator('[data-testid="field-waterway"]').fill(value);
+	}
+
+	/** Wechselt die Positionsmethode über das zugehörige Radio-Label (Radios sind sr-only). */
+	async selectPositionMethod(method: 'photo' | 'map' | 'manual') {
+		await this.page.locator(`label[for="method-${method}"]`).click();
+	}
+
 	// ── Step 2: Sichtungsdetails ─────────────────────────────────────────────
 
 	async selectSpecies(index: number) {

--- a/src/lib/constants/uploadDefaults.ts
+++ b/src/lib/constants/uploadDefaults.ts
@@ -1,0 +1,24 @@
+/**
+ * Öffentliche Upload-Konfiguration (anonyme Melder).
+ *
+ * Einzige Quelle für die Werte, die `/api/config/upload` an nicht
+ * authentifizierte Nutzer ausliefert UND für die Client-Fallbacks in
+ * `$lib/stores/configStore`. Beide Seiten müssen übereinstimmen: Weichen sie
+ * ab, akzeptiert die Dropzone Dateien, die der Server anschließend ablehnt
+ * (oder die UI verspricht Formate, die es gar nicht gibt).
+ *
+ * Authentifizierte Nutzer (Admin) erhalten stattdessen die Laufzeit-Konfiguration
+ * aus dem ConfigService — die kann großzügiger sein.
+ */
+export const PUBLIC_UPLOAD_MAX_FILE_SIZE_MB = 10;
+
+export const PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES = PUBLIC_UPLOAD_MAX_FILE_SIZE_MB * 1024 * 1024;
+
+export const PUBLIC_UPLOAD_ALLOWED_TYPES = [
+	'image/jpeg',
+	'image/png',
+	'image/gif',
+	'image/webp'
+] as const;
+
+export const PUBLIC_UPLOAD_ACCEPT = PUBLIC_UPLOAD_ALLOWED_TYPES.join(',');

--- a/src/lib/form/createForm.test.ts
+++ b/src/lib/form/createForm.test.ts
@@ -37,6 +37,53 @@ describe('createForm — initial state', () => {
 	});
 });
 
+describe('createForm — touched state', () => {
+	it('touched store starts as empty object', () => {
+		const { touched } = createForm({ initialValues: defaultValues, onSubmit: vi.fn() });
+		expect(get(touched)).toEqual({});
+	});
+
+	it('markiert ein Feld als touched bei updateField', () => {
+		const { touched, updateField } = createForm({
+			initialValues: { name: 'Max', count: 1 },
+			onSubmit: vi.fn()
+		});
+		updateField('name', 'Moritz');
+		expect(get(touched)).toEqual({ name: true });
+	});
+
+	it('markiert ein Feld als touched bei handleChange', () => {
+		const { touched, handleChange } = createForm({
+			initialValues: { name: '' },
+			onSubmit: vi.fn()
+		});
+		handleChange({
+			target: { name: 'name', id: '', value: 'Elke', type: 'text', tagName: 'INPUT' }
+		} as unknown as Event);
+		expect(get(touched).name).toBe(true);
+	});
+
+	it('markiert nur berührte Felder, unberührte bleiben ungesetzt', () => {
+		const { touched, updateField } = createForm({
+			initialValues: { name: 'Max', count: 1 },
+			onSubmit: vi.fn()
+		});
+		updateField('name', 'Moritz');
+		expect(get(touched).count).toBeUndefined();
+	});
+
+	it('setzt touched bei updateInitialValues zurück', () => {
+		const { touched, updateField, updateInitialValues } = createForm({
+			initialValues: { name: 'Max', count: 1 },
+			onSubmit: vi.fn()
+		});
+		updateField('name', 'Moritz');
+		expect(get(touched).name).toBe(true);
+		updateInitialValues({ name: 'Neu', count: 2 });
+		expect(get(touched)).toEqual({});
+	});
+});
+
 describe('createForm — updateField', () => {
 	it('updates the specified field without affecting other fields', () => {
 		const { form, updateField } = createForm({

--- a/src/lib/form/createForm.ts
+++ b/src/lib/form/createForm.ts
@@ -15,11 +15,19 @@ export function createForm<T extends Record<string, unknown>>(options: FormProps
 
 	const form = writable<T>({ ...initialValues });
 	const errors = writable<Record<string, string>>({});
+	const touched = writable<Record<string, boolean>>({});
 	const isSubmitting = writable(false);
 	const isValid = derived(errors, ($errors) => Object.keys($errors).length === 0);
 
+	function markTouched(field: keyof T): void {
+		touched.update((current) =>
+			current[field as string] ? current : { ...current, [field as string]: true }
+		);
+	}
+
 	function updateField(field: keyof T, value: unknown): void {
 		form.update((current) => ({ ...current, [field]: value }));
+		markTouched(field);
 		errors.update((current) => {
 			const next = { ...current };
 			delete next[field as string];
@@ -30,6 +38,7 @@ export function createForm<T extends Record<string, unknown>>(options: FormProps
 	function updateInitialValues(values: T): void {
 		form.set({ ...values });
 		errors.set({});
+		touched.set({});
 	}
 
 	function handleChange(event: Event): void {
@@ -91,6 +100,7 @@ export function createForm<T extends Record<string, unknown>>(options: FormProps
 	return {
 		form,
 		errors,
+		touched,
 		isSubmitting,
 		isValid,
 		handleSubmit,

--- a/src/lib/form/fields/dropzone.ts
+++ b/src/lib/form/fields/dropzone.ts
@@ -1,2 +1,9 @@
+/**
+ * Basis-Klassen für die Dropzone.
+ *
+ * Nutzt Theme-Tokens statt Tailwind-Grays: Das Projekt hat genau ein Theme
+ * (`meeresmuseum`, siehe src/app.css) und keinen Dark Mode — `dark:`-Varianten
+ * wären hier wirkungslos. Siehe .claude/rules/design-system.md.
+ */
 export const dropzoneBaseClass =
-	'flex flex-col justify-center items-center w-full h-64 bg-gray-50 rounded-lg border-2 border-gray-300 border-dashed cursor-pointer dark:hover:bg-bray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600';
+	'flex flex-col justify-center items-center w-full h-64 bg-base-200 rounded-lg border-2 border-base-300 border-dashed cursor-pointer hover:bg-base-300 hover:border-primary/50 transition-colors';

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -175,7 +175,7 @@ export const sightingSchemaBase = yup.object().shape({
 			valueText: 'Falls nein, können Sie das Gebiet beschreiben',
 			icon: ToggleLeft
 		})
-		.default(true),
+		.default(false),
 
 	//----------------------------------------------------------------------
 	// Location (Standort)
@@ -210,8 +210,7 @@ export const sightingSchemaBase = yup.object().shape({
 			helpText: 'Nördliche Position (N) - je mehr Nachkommastellen, desto genauer',
 			valueText: 'GPS-Präzision: 6 Nachkommastellen = 11cm Genauigkeit',
 			icon: Navigation
-		})
-		.default(54.5),
+		}),
 
 	/**
 	 * Längengrad der Sichtung (GPS-Koordinate)
@@ -242,12 +241,12 @@ export const sightingSchemaBase = yup.object().shape({
 			helpText: 'Östliche Position (E) - je mehr Nachkommastellen, desto genauer',
 			valueText: 'Ihre GPS-Koordinaten werden mit anderen Sichtungen verglichen',
 			icon: Navigation2
-		})
-		.default(13.5),
+		}),
 
 	/**
 	 * Fahrwasser oder Meeresgebiet, in dem die Sichtung erfolgte
-	 * Alternative zur GPS-Position
+	 * Alternative zur GPS-Position: erforderlich, wenn keine GPS-Position vorliegt
+	 * (hasPosition !== true), damit ein leeres Formular Schritt 1 nicht passieren kann.
 	 */
 	waterway: yup
 		.string()
@@ -260,7 +259,14 @@ export const sightingSchemaBase = yup.object().shape({
 				'Gewässerbezeichnungen helfen bei der regionalen Populationsverteilung - auch ungefähre Angaben sind wissenschaftlich wertvoll',
 			icon: Waves
 		})
-		.notRequired(),
+		.when('hasPosition', {
+			is: (value: unknown) => value !== true,
+			then: (schema) =>
+				schema.required(
+					'Bitte beschreiben Sie das Fahrwasser/Seegebiet oder wählen Sie eine GPS-Position'
+				),
+			otherwise: (schema) => schema.notRequired()
+		}),
 
 	/**
 	 * Seezeichen in der Nähe der Sichtung
@@ -318,7 +324,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'z.B. 14:30 oder 09:15',
 			helpText: 'Zu welchem Zeitpunkt ungefähr? (optional)',
 			valueText:
-				'Uhrzeitangaben decken Tagesrhythmen auf - 73% der Schweinswalsichtungen erfolgen morgens zwischen 6-10 Uhr',
+				'Uhrzeitangaben helfen dabei, Tagesrhythmen der Tiere zu erkennen - auch eine grobe Schätzung ist wertvoll',
 			type: 'time',
 			icon: Clock
 		})
@@ -334,6 +340,7 @@ export const sightingSchemaBase = yup.object().shape({
 	 */
 	species: yup
 		.number()
+		.transform((value) => (isNaN(value) ? undefined : value))
 		.required('Bitte wählen Sie eine Tierart aus')
 		.test('is-valid-species', 'Diese Tierart ist nicht verfügbar', (value) =>
 			isValidSpecies(String(value))
@@ -345,8 +352,7 @@ export const sightingSchemaBase = yup.object().shape({
 			type: 'select',
 			options: getSpeciesOptions(true),
 			icon: Fish
-		})
-		.default(0),
+		}),
 
 	/**
 	 * Gesamtanzahl der gesichteten Tiere
@@ -673,7 +679,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Wie war die Beschaffenheit der Meeresoberfläche?',
 			valueText:
-				'Bei ruhiger See werden 5x mehr Tiere entdeckt - Ihre Seegangsangabe hilft bei der korrekten Populationsschätzung. 89% erfahrener Beobachter geben diese Information an',
+				'Bei ruhiger See sind Tiere deutlich leichter zu entdecken - Ihre Seegangsangabe hilft, Sichtungszahlen richtig einzuordnen',
 			type: 'select',
 			options: getSeaStateOptions(),
 			icon: Waves
@@ -717,7 +723,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Aus welcher Richtung kam der Wind?',
 			valueText:
-				'Windrichtung korreliert mit Walwanderungen - Nordwinde erhöhen Sichtungswahrscheinlichkeit um 40%. Ihre Wetterangaben vervollständigen das ökologische Bild',
+				'Wind beeinflusst Seegang und Sichtbedingungen - Ihre Wetterangaben vervollständigen das ökologische Bild',
 			type: 'select',
 			options: getWindDirectionOptions(),
 			icon: Wind
@@ -886,25 +892,37 @@ export const sightingSchemaBase = yup.object().shape({
 
 	/**
 	 * Art des Bootsantriebs
-	 * Optional, muss einer gültigen Antriebskategorie entsprechen
+	 * Nur erforderlich, wenn die Sichtung von einem Segelschiff oder Motorboot
+	 * aus gemacht wurde (sightingFrom). Bei Land, Fähre, Sonstiges oder nicht
+	 * gesetztem sightingFrom ist das Feld optional/nullable — wer kein Boot hat,
+	 * kann keinen Bootsantrieb angeben.
 	 */
 	boatDrive: yup
 		.number()
+		.nullable()
 		.test(
 			'is-valid-boat-drive',
 			'Bitte wählen Sie einen gültigen Bootsantrieb aus.',
-			(value) => value === undefined || isValidBoatDrive(value)
+			(value) => value === undefined || value === null || isValidBoatDrive(value)
 		)
 		.label('Bootsantrieb')
 		.meta({
 			helpText: 'Welcher Antrieb wurde während der Sichtung verwendet?',
 			valueText:
-				'Motor-Typ bestimmt Unterwasserlärm - Elektromotoren ermöglichen 60% mehr Sichtungen durch geringere Störung',
+				'Die Antriebsart bestimmt den Unterwasserlärm und damit, wie stark Tiere gestört werden',
 			type: 'select',
 			options: getBoatDriveOptions(),
 			icon: Zap
 		})
-		.required(),
+		.when('sightingFrom', {
+			is: (v: unknown) =>
+				v === SightingFromEnum.SAILBOAT ||
+				v === String(SightingFromEnum.SAILBOAT) ||
+				v === SightingFromEnum.MOTORBOAT ||
+				v === String(SightingFromEnum.MOTORBOAT),
+			then: (schema) => schema.required('Bitte wählen Sie den Bootsantrieb aus.'),
+			otherwise: (schema) => schema.notRequired()
+		}),
 
 	/**
 	 * Genauere Beschreibung des Bootsantriebs (optional, auch bei Sonstiges)

--- a/src/lib/form/validation/sightingSchemaBoatDrive.test.ts
+++ b/src/lib/form/validation/sightingSchemaBoatDrive.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Tests für die Bootsantrieb-Validierung (Befund U3)
+ *
+ * Hintergrund: boatDrive war unconditional required, ohne deutsche Fehlermeldung.
+ * Das blockierte Land-Melder ("Sichtung von: Land"), die kein Boot haben.
+ *
+ * Ziel: boatDrive ist nur noch required, wenn sightingFrom Segelschiff (1)
+ * oder Motorboot (2) ist — mit deutscher Fehlermeldung.
+ *
+ * boatDriveText bleibt unabhängig davon generell optional (siehe
+ * sightingSchemaWhen.test.ts) — das gilt auch in Kombination mit den hier
+ * getesteten sightingFrom-Werten.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sightingSchema } from './sightingSchema';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
+
+/**
+ * Validiert ein einzelnes Feld im Schema und gibt den Fehlertext zurück
+ * (oder null, wenn keine Validierung fehlschlägt).
+ */
+async function fieldError(
+	fieldName: string,
+	formData: Record<string, unknown>
+): Promise<string | null> {
+	try {
+		await sightingSchema.validateAt(fieldName, formData, { abortEarly: true });
+		return null;
+	} catch (error) {
+		return error instanceof Error ? error.message : String(error);
+	}
+}
+
+describe('sightingSchema - boatDrive (Befund U3)', () => {
+	it('ist NICHT erforderlich, wenn die Sichtung von Land aus gemacht wurde', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.LAND, // 3
+			boatDrive: undefined
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('ist NICHT erforderlich, wenn die Sichtung von einer Fähre aus gemacht wurde', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.FERRY, // 4
+			boatDrive: undefined
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('ist NICHT erforderlich, wenn sightingFrom "Sonstiges" ist', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.OTHER, // 0
+			boatDrive: undefined
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('ist NICHT erforderlich, wenn sightingFrom (noch) nicht gesetzt ist', async () => {
+		const fehler = await fieldError('boatDrive', {
+			boatDrive: undefined
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('ist erforderlich mit deutscher Fehlermeldung, wenn die Sichtung von einem Motorboot aus gemacht wurde', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.MOTORBOAT, // 2
+			boatDrive: undefined
+		});
+		expect(fehler).toBe('Bitte wählen Sie den Bootsantrieb aus.');
+	});
+
+	it('ist erforderlich mit deutscher Fehlermeldung, wenn die Sichtung von einem Segelschiff aus gemacht wurde', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.SAILBOAT, // 1
+			boatDrive: undefined
+		});
+		expect(fehler).toBe('Bitte wählen Sie den Bootsantrieb aus.');
+	});
+
+	it('ist erforderlich, auch wenn sightingFrom als String "2" (HTML-Select) vorliegt', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: '2',
+			boatDrive: undefined
+		});
+		expect(fehler).toBe('Bitte wählen Sie den Bootsantrieb aus.');
+	});
+
+	it('ist gültig, wenn Motorboot mit gesetztem boatDrive gemeldet wird', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.MOTORBOAT,
+			boatDrive: BoatDriveEnum.MOTOR
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('boatDriveText bleibt optional bei Segelschiff + Sonstiger Antrieb ohne Text', async () => {
+		const fehler = await fieldError('boatDriveText', {
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: BoatDriveEnum.OTHER,
+			boatDriveText: ''
+		});
+		expect(fehler).toBeNull();
+	});
+});
+
+describe('sightingSchema - Schritt-2-Validierung (Zusammenspiel boatDrive/sightingFrom)', () => {
+	it('Schritt 2 ist gültig ohne boatDrive, wenn von Land gemeldet wird', async () => {
+		const pickedSchema = sightingSchema.pick(['sightingFrom', 'boatDrive']);
+		await expect(
+			pickedSchema.validate(
+				{ sightingFrom: SightingFromEnum.LAND, boatDrive: undefined },
+				{ abortEarly: false }
+			)
+		).resolves.toBeDefined();
+	});
+
+	it('Schritt 2 ist ungültig ohne boatDrive, wenn von einem Motorboot gemeldet wird', async () => {
+		const pickedSchema = sightingSchema.pick(['sightingFrom', 'boatDrive']);
+		await expect(
+			pickedSchema.validate(
+				{ sightingFrom: SightingFromEnum.MOTORBOAT, boatDrive: undefined },
+				{ abortEarly: false }
+			)
+		).rejects.toBeDefined();
+	});
+});

--- a/src/lib/form/validation/sightingSchemaDefaults.test.ts
+++ b/src/lib/form/validation/sightingSchemaDefaults.test.ts
@@ -55,7 +55,14 @@ describe('sightingSchema — entfernte Defaults', () => {
 	});
 
 	it('behält einen Default für sightingDate (heute)', () => {
-		expect(defaults.sightingDate).toBe(new Date().toISOString().split('T')[0]);
+		// Der Schema-Default wird beim Modul-Load berechnet, der Vergleichswert erst
+		// zur Testlaufzeit. Läuft der Test über Mitternacht, liegen beide einen Tag
+		// auseinander — deshalb gilt "heute oder gestern" als korrekt.
+		const heute = new Date();
+		const gestern = new Date(heute.getTime() - 24 * 60 * 60 * 1000);
+		const alsDatum = (d: Date) => d.toISOString().split('T')[0];
+
+		expect([alsDatum(heute), alsDatum(gestern)]).toContain(defaults.sightingDate);
 	});
 });
 

--- a/src/lib/form/validation/sightingSchemaDefaults.test.ts
+++ b/src/lib/form/validation/sightingSchemaDefaults.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview Tests für die entfernten Schema-Defaults (Datenqualitäts-Fix K1/K2)
+ *
+ * Hintergrund: Ein leeres Formular darf keine "gültige" Phantom-Position (54.5, 13.5)
+ * und keine vorausgewählte Tierart mehr haben. hasPosition ist genau dann gültig,
+ * wenn echte Koordinaten ODER eine Fahrwasser-Beschreibung vorliegen.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { sightingSchema } from './sightingSchema';
+
+async function validates(formData: Record<string, unknown>): Promise<boolean> {
+	try {
+		await sightingSchema.validate(formData, { abortEarly: false });
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function fieldHasError(
+	fieldName: string,
+	formData: Record<string, unknown>
+): Promise<boolean> {
+	try {
+		await sightingSchema.validateAt(fieldName, formData, { abortEarly: true });
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+describe('sightingSchema — entfernte Defaults', () => {
+	const description = sightingSchema.describe();
+	const defaults = description.default as Record<string, unknown>;
+
+	it('hat keinen numerischen Default für latitude', () => {
+		expect(defaults.latitude).toBeUndefined();
+	});
+
+	it('hat keinen numerischen Default für longitude', () => {
+		expect(defaults.longitude).toBeUndefined();
+	});
+
+	it('setzt hasPosition standardmäßig auf false', () => {
+		expect(defaults.hasPosition).toBe(false);
+	});
+
+	it('hat keinen Default für species (Nutzer muss aktiv wählen)', () => {
+		expect(defaults.species).toBeUndefined();
+	});
+
+	it('behält den Default für totalCount (=1)', () => {
+		expect(defaults.totalCount).toBe(1);
+	});
+
+	it('behält einen Default für sightingDate (heute)', () => {
+		expect(defaults.sightingDate).toBe(new Date().toISOString().split('T')[0]);
+	});
+});
+
+describe('sightingSchema — Position/Fahrwasser-Gating', () => {
+	it('waterway ist erforderlich, wenn keine GPS-Position vorliegt (hasPosition=false)', async () => {
+		expect(await fieldHasError('waterway', { hasPosition: false, waterway: '' })).toBe(true);
+	});
+
+	it('waterway ist erforderlich, wenn hasPosition undefined ist', async () => {
+		expect(await fieldHasError('waterway', { waterway: '' })).toBe(true);
+	});
+
+	it('waterway ist optional, wenn hasPosition=true', async () => {
+		expect(await fieldHasError('waterway', { hasPosition: true, waterway: '' })).toBe(false);
+	});
+
+	it('latitude ist erforderlich, wenn hasPosition=true', async () => {
+		expect(await fieldHasError('latitude', { hasPosition: true })).toBe(true);
+	});
+});
+
+describe('sightingSchema — Vollformular-Validierung', () => {
+	const baseContact = {
+		referenceId: 'test-ref-123',
+		firstName: 'Jane',
+		lastName: 'Doe',
+		email: 'jane@example.com',
+		privacyConsent: true,
+		species: 0,
+		totalCount: 1,
+		distance: 1,
+		sightingFrom: 1,
+		boatDrive: 1,
+		entryChannel: 0,
+		sightingDate: new Date().toISOString().split('T')[0]
+	};
+
+	it('ein leeres Formular ist ungültig (keine Phantom-Position)', async () => {
+		expect(await validates({})).toBe(false);
+	});
+
+	it('gültig mit echten Koordinaten (hasPosition=true)', async () => {
+		expect(
+			await validates({
+				...baseContact,
+				hasPosition: true,
+				latitude: 54.5,
+				longitude: 13.5
+			})
+		).toBe(true);
+	});
+
+	it('gültig mit Fahrwasser-Beschreibung ohne Koordinaten (hasPosition=false)', async () => {
+		expect(
+			await validates({
+				...baseContact,
+				hasPosition: false,
+				waterway: 'Kieler Bucht'
+			})
+		).toBe(true);
+	});
+
+	it('ungültig ohne Koordinaten und ohne Fahrwasser', async () => {
+		expect(
+			await validates({
+				...baseContact,
+				hasPosition: false
+			})
+		).toBe(false);
+	});
+
+	it('lässt fehlende Koordinaten beim Cast aus (bleiben undefined)', async () => {
+		const result = await sightingSchema.validate(
+			{ ...baseContact, hasPosition: false, waterway: 'Kieler Bucht' },
+			{ abortEarly: false }
+		);
+		expect(result.latitude).toBeUndefined();
+		expect(result.longitude).toBeUndefined();
+	});
+});

--- a/src/lib/form/validation/stepNavigation.test.ts
+++ b/src/lib/form/validation/stepNavigation.test.ts
@@ -17,7 +17,7 @@ vi.mock('$lib/report/formConfig', () => ({
 		{
 			id: 'location-time',
 			title: 'Position & Zeit',
-			fields: ['hasPosition', 'latitude', 'longitude', 'sightingDate']
+			fields: ['hasPosition', 'latitude', 'longitude', 'waterway', 'sightingDate']
 		},
 		{
 			id: 'sighting-details',

--- a/src/lib/form/validation/stepValidation.test.ts
+++ b/src/lib/form/validation/stepValidation.test.ts
@@ -19,7 +19,7 @@ vi.mock('$lib/report/formConfig', () => ({
 		{
 			id: 'location-time',
 			title: 'Position & Zeit',
-			fields: ['hasPosition', 'latitude', 'longitude', 'sightingDate']
+			fields: ['hasPosition', 'latitude', 'longitude', 'waterway', 'sightingDate']
 		},
 		{
 			id: 'sighting-details',
@@ -72,16 +72,26 @@ describe('isStepValid', () => {
 			expect(isStepValid(0, validLocationData)).toBe(true);
 		});
 
-		it('returns true when hasPosition is false (position is optional, defaults fill coords)', () => {
-			// latitude/longitude have defaults (54.5 / 13.5) and are only required when hasPosition=true
-			// sightingDate has a default (today)
-			expect(isStepValid(0, { hasPosition: false })).toBe(true);
+		it('returns true when hasPosition is false but a waterway description is provided', () => {
+			// Ohne GPS-Position ist waterway erforderlich (Alternative "Beschreibung")
+			expect(
+				isStepValid(0, { hasPosition: false, waterway: 'Kieler Bucht', sightingDate: today })
+			).toBe(true);
 		});
 
-		it('returns true when hasPosition is true and coords use schema defaults', () => {
-			// Schema defaults: latitude=54.5, longitude=13.5, sightingDate=today
-			// Yup applies defaults during validation, so missing fields get filled
-			expect(isStepValid(0, { hasPosition: true })).toBe(true);
+		it('returns false for an empty form (no coords, no waterway)', () => {
+			// Nach Entfernen der Defaults: hasPosition=false, keine Koordinaten, kein waterway
+			// → waterway ist erforderlich → Schritt 1 blockiert
+			expect(isStepValid(0, {})).toBe(false);
+		});
+
+		it('returns false when hasPosition=false and waterway is missing', () => {
+			expect(isStepValid(0, { hasPosition: false, sightingDate: today })).toBe(false);
+		});
+
+		it('returns false when hasPosition is true but coordinates are missing (no defaults)', () => {
+			// latitude/longitude haben keine Defaults mehr und sind bei hasPosition=true erforderlich
+			expect(isStepValid(0, { hasPosition: true, sightingDate: today })).toBe(false);
 		});
 
 		it('returns false for latitude out of Baltic Sea bounds', () => {
@@ -112,6 +122,7 @@ describe('isStepValid', () => {
 			expect(
 				isStepValid(0, {
 					hasPosition: false,
+					waterway: 'Kieler Bucht',
 					sightingDate: future.toISOString().substring(0, 10)
 				})
 			).toBe(false);
@@ -123,9 +134,9 @@ describe('isStepValid', () => {
 			expect(isStepValid(1, validSightingData)).toBe(true);
 		});
 
-		it('returns true when species is missing (schema default is 0 = Schweinswal)', () => {
-			// species has .default(0) in sightingSchema — omitting it is valid
-			expect(isStepValid(1, { totalCount: 2, distance: 1 })).toBe(true);
+		it('returns false when species is missing (no default — user must actively choose)', () => {
+			// species hat keinen Default mehr → fehlende Tierart blockiert Schritt 2
+			expect(isStepValid(1, { totalCount: 2, distance: 1 })).toBe(false);
 		});
 
 		it('returns false for species value -1 (below valid range)', () => {
@@ -184,11 +195,18 @@ describe('validateStep', () => {
 			expect(result.errors).toEqual({});
 		});
 
-		it('returns isValid=true when hasPosition=true and coords use schema defaults', () => {
-			// Schema defaults fill in latitude, longitude and sightingDate
-			const result = validateStep(0, { hasPosition: true });
-			expect(result.isValid).toBe(true);
-			expect(result.errors).toEqual({});
+		it('returns errors for an empty form (waterway required without coords)', () => {
+			// Kein GPS, kein waterway → waterway-Fehler; sightingDate hat noch einen Default
+			const result = validateStep(0, {});
+			expect(result.isValid).toBe(false);
+			expect(result.errors).toHaveProperty('waterway');
+		});
+
+		it('returns coordinate errors when hasPosition=true but coords are missing', () => {
+			const result = validateStep(0, { hasPosition: true, sightingDate: today });
+			expect(result.isValid).toBe(false);
+			expect(result.errors).toHaveProperty('latitude');
+			expect(result.errors).toHaveProperty('longitude');
 		});
 
 		it('returns errors for both out-of-bounds coordinates', () => {
@@ -208,6 +226,7 @@ describe('validateStep', () => {
 			future.setFullYear(future.getFullYear() + 1);
 			const result = validateStep(0, {
 				hasPosition: false,
+				waterway: 'Kieler Bucht',
 				sightingDate: future.toISOString().substring(0, 10)
 			});
 			expect(result.isValid).toBe(false);

--- a/src/lib/report/clearContactData.test.ts
+++ b/src/lib/report/clearContactData.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { clearUserContactData } = vi.hoisted(() => ({ clearUserContactData: vi.fn() }));
+vi.mock('$lib/storage/localStorage', () => ({ clearUserContactData }));
+
+const { createToast } = vi.hoisted(() => ({ createToast: vi.fn() }));
+vi.mock('$lib/stores/toastState.svelte', () => ({ createToast }));
+
+import { USER_CONTACT_FIELDS } from '$lib/report/formConfig';
+import {
+	CLEAR_CONTACT_DATA_CONFIRM_MESSAGE,
+	CLEAR_CONTACT_DATA_SUCCESS_MESSAGE,
+	confirmAndClearContactData,
+	resetSavedContactData
+} from './clearContactData';
+
+describe('resetSavedContactData', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('löscht die gespeicherten Kontaktdaten im Storage', () => {
+		const updateField = vi.fn();
+
+		resetSavedContactData({}, updateField);
+
+		expect(clearUserContactData).toHaveBeenCalledOnce();
+	});
+
+	it('setzt alle Kontaktfelder auf ihren jeweiligen Default zurück', () => {
+		const updateField = vi.fn();
+		const formValues: Record<string, unknown> = {
+			firstName: 'Max',
+			email: 'max@example.com',
+			nameConsent: true,
+			shipNameConsent: false
+		};
+
+		resetSavedContactData(formValues, updateField);
+
+		expect(updateField).toHaveBeenCalledTimes(USER_CONTACT_FIELDS.length);
+		expect(updateField).toHaveBeenCalledWith('firstName', '');
+		expect(updateField).toHaveBeenCalledWith('email', '');
+		expect(updateField).toHaveBeenCalledWith('nameConsent', false);
+		expect(updateField).toHaveBeenCalledWith('shipNameConsent', false);
+	});
+});
+
+describe('confirmAndClearContactData', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('fragt den Nutzer mit dem einheitlichen Bestätigungstext', () => {
+		const confirmSpy = vi.fn().mockReturnValue(false);
+		vi.stubGlobal('confirm', confirmSpy);
+
+		confirmAndClearContactData({}, vi.fn());
+
+		expect(confirmSpy).toHaveBeenCalledWith(CLEAR_CONTACT_DATA_CONFIRM_MESSAGE);
+		vi.unstubAllGlobals();
+	});
+
+	it('löscht Kontaktdaten und zeigt einen Erfolgs-Toast, wenn der Nutzer bestätigt', () => {
+		vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+		const updateField = vi.fn();
+
+		const result = confirmAndClearContactData({ firstName: 'Max' }, updateField);
+
+		expect(result).toBe(true);
+		expect(clearUserContactData).toHaveBeenCalledOnce();
+		expect(updateField).toHaveBeenCalledWith('firstName', '');
+		expect(createToast).toHaveBeenCalledWith('success', CLEAR_CONTACT_DATA_SUCCESS_MESSAGE);
+
+		vi.unstubAllGlobals();
+	});
+
+	it('tut nichts und gibt false zurück, wenn der Nutzer den Dialog abbricht', () => {
+		vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+		const updateField = vi.fn();
+
+		const result = confirmAndClearContactData({}, updateField);
+
+		expect(result).toBe(false);
+		expect(clearUserContactData).not.toHaveBeenCalled();
+		expect(updateField).not.toHaveBeenCalled();
+		expect(createToast).not.toHaveBeenCalled();
+
+		vi.unstubAllGlobals();
+	});
+});

--- a/src/lib/report/clearContactData.ts
+++ b/src/lib/report/clearContactData.ts
@@ -1,0 +1,70 @@
+/**
+ * Konsolidierte "Kontaktdaten löschen"-Logik.
+ *
+ * Vorher gab es diese Aktion zweimal (FormActions.svelte + Step4Contact.svelte)
+ * mit unterschiedlichem Bestätigungstext und unterschiedlichem Feedback
+ * (Toast vs. nur Logger). Diese Datei bündelt beides zu einer Implementierung
+ * mit einem Text und einem Feedback-Weg (Toast).
+ */
+import { USER_CONTACT_FIELDS } from '$lib/report/formConfig';
+import { clearUserContactData } from '$lib/storage/localStorage';
+import { createToast } from '$lib/stores/toastState.svelte';
+import type { SightingFormData } from '$lib/types/Form';
+
+/**
+ * Signatur von `updateField` aus dem Form-Context (`FormApi<SightingFormData>`).
+ * Bewusst gegen `SightingFormData` getippt (statt generisch), da `updateField`
+ * nur echte Feldnamen des Sichtungsformulars akzeptiert — `formValues` bleibt
+ * dagegen locker typisiert, damit die Funktion auch mit einfachen Test-Objekten
+ * aufgerufen werden kann.
+ */
+type UpdateContactField = (field: keyof SightingFormData, value: unknown) => void;
+
+export const CLEAR_CONTACT_DATA_CONFIRM_MESSAGE =
+	'Möchten Sie wirklich alle gespeicherten Kontaktdaten löschen? Diese müssen dann bei der nächsten Sichtung erneut eingegeben werden.';
+
+export const CLEAR_CONTACT_DATA_SUCCESS_MESSAGE = 'Gespeicherte Kontaktdaten wurden gelöscht';
+
+/**
+ * Setzt die Kontaktfelder im Formular-State auf ihren jeweiligen Default zurück
+ * (leerer String bzw. `false` bei Boolean-Feldern) und löscht die im Local-/
+ * Session-Storage gespeicherten Kontaktdaten.
+ *
+ * Reine Datenoperation ohne Confirm-Dialog oder Toast, damit sie isoliert
+ * testbar ist und unabhängig von `window.confirm` verwendet werden kann.
+ */
+export function resetSavedContactData(
+	formValues: Record<string, unknown>,
+	updateField: UpdateContactField
+): void {
+	clearUserContactData();
+
+	for (const field of USER_CONTACT_FIELDS) {
+		const defaultValue = typeof formValues[field] === 'boolean' ? false : '';
+		updateField(field, defaultValue);
+	}
+}
+
+/**
+ * Fragt den Nutzer über das native `confirm()` und löscht bei Bestätigung die
+ * gespeicherten Kontaktdaten inklusive der zugehörigen Formularfelder. Zeigt
+ * anschließend einen Erfolgs-Toast an.
+ *
+ * Einheitliche Implementierung für alle Aufrufer (aktuell: Step4Contact).
+ *
+ * @returns `true` wenn die Löschung durchgeführt wurde, `false` wenn der
+ * Nutzer den Dialog abgebrochen hat.
+ */
+export function confirmAndClearContactData(
+	formValues: Record<string, unknown>,
+	updateField: UpdateContactField
+): boolean {
+	if (!confirm(CLEAR_CONTACT_DATA_CONFIRM_MESSAGE)) {
+		return false;
+	}
+
+	resetSavedContactData(formValues, updateField);
+	createToast('success', CLEAR_CONTACT_DATA_SUCCESS_MESSAGE);
+
+	return true;
+}

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -146,7 +146,7 @@
 								<li><strong>Tipp:</strong> Auch unscharfe Bilder können nützlich sein</li>
 							</ul>
 							<div class="bg-success/10 mt-2 rounded p-2">
-								<div class="text-success-content/70 text-xs">
+								<div class="text-base-content/70 text-xs">
 									✅ <strong>
 										{#if loading}
 											<span class="loading loading-dots loading-xs"></span>
@@ -189,8 +189,8 @@
 											3x
 										{/if}
 									</div>
-									<div class="text-success-content text-sm font-medium">häufiger zitiert</div>
-									<div class="text-success-content/70 mt-1 text-xs">
+									<div class="text-base-content text-sm font-medium">häufiger zitiert</div>
+									<div class="text-base-content/70 mt-1 text-xs">
 										werden komplette Meldungen in Studien verwendet
 									</div>
 								</div>
@@ -202,8 +202,8 @@
 											{statistics.yearsOfService}
 										{/if}
 									</div>
-									<div class="text-success-content text-sm font-medium">Jahre Treue</div>
-									<div class="text-success-content/70 mt-1 text-xs">
+									<div class="text-base-content text-sm font-medium">Jahre Treue</div>
+									<div class="text-base-content/70 mt-1 text-xs">
 										{#if !loading && statistics.uniqueUsers > 0}
 											{statistics.uniqueUsers} verschiedene Nutzer melden bereits regelmäßig
 										{:else}
@@ -223,8 +223,8 @@
 											)}%
 										{/if}
 									</div>
-									<div class="text-success-content text-sm font-medium">mit Fotos/Videos</div>
-									<div class="text-success-content/70 mt-1 text-xs">
+									<div class="text-base-content text-sm font-medium">mit Fotos/Videos</div>
+									<div class="text-base-content/70 mt-1 text-xs">
 										{#if !loading}
 											{statistics.sightingsWithMedia.toLocaleString('de-DE')} Sichtungen mit Medien dokumentiert
 										{:else}
@@ -257,7 +257,7 @@
 											{statistics.deadAnimalsFound}
 										{/if}
 									</div>
-									<div class="text-warning-content text-xs">
+									<div class="text-base-content text-xs">
 										Totfunde bereits für die Wissenschaft dokumentiert
 									</div>
 								</div>

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -8,6 +8,7 @@
 	import { submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
+	import { findStepForErrors } from '$lib/report/findStepForErrors';
 	import { initialFormState } from '$lib/report/formConfig';
 	import { toast } from '$lib/stores/toastState.svelte';
 	import {
@@ -25,6 +26,7 @@
 	import { combineToDate } from '$lib/utils/format/dateTime';
 	import { createId } from '@paralleldrive/cuid2';
 	import { formStepsConfig } from '$lib/report/formConfig';
+	import { ValidationError } from 'yup';
 	import Form from './form/Form.svelte';
 	import FormSteps from './form/FormSteps.svelte';
 	import FormHelp from './FormHelp.svelte';
@@ -137,26 +139,57 @@
 	async function handleFinalSubmit(e: Event): Promise<void> {
 		logger.info('Final submission:');
 
-		// Pre-submit: validate and log any failing fields so bugs are visible in the console
+		// Pre-submit: validate against the FULL Schema. A step's own
+		// validation only covers ITS OWN fields — a field can become invalid
+		// after its step was already left (e.g. a value depends on another
+		// step). Submitting despite that must never look like "nothing
+		// happened", so on failure we:
+		// 1. write the resulting errors into the errors store (so the
+		//    affected fields render as invalid wherever they are shown),
+		// 2. jump to the earliest affected step,
+		// 3. abort BEFORE calling formContext.handleSubmit — and rethrow so
+		//    StepNavigation's existing submit-catch (toast + showValidationError)
+		//    takes over, exactly like it already does for real submit errors.
 		const formValues = await new Promise<unknown>((resolve) => {
 			const unsub = formContext.form.subscribe((v) => resolve(v));
 			unsub();
 		});
-		await sightingSchema
-			.validate(formValues, { abortEarly: false })
-			.then(() => logger.info('Pre-submit validation: all fields OK'))
-			.catch((yupError) => {
-				const errors: { field: string; error: string }[] = yupError.inner?.map(
-					(e: { path: string; message: string }) => ({
-						field: e.path,
-						error: e.message
-					})
-				) ?? [{ field: 'unknown', error: yupError.message }];
-				logger.error(
-					{ validationErrors: errors },
-					'Pre-submit validation FAILED — submission blocked'
-				);
+
+		try {
+			await sightingSchema.validate(formValues, { abortEarly: false });
+			logger.info('Pre-submit validation: all fields OK');
+		} catch (yupError) {
+			if (!(yupError instanceof ValidationError)) {
+				throw yupError;
+			}
+
+			const validationErrors: Record<string, string> = {};
+			for (const innerError of yupError.inner) {
+				if (innerError.path && innerError.message) {
+					validationErrors[innerError.path] = innerError.message;
+				}
+			}
+
+			logger.error({ validationErrors }, 'Pre-submit validation FAILED — submission blocked');
+
+			// Mark all currently invalid fields, wherever their step is
+			formContext.errors.set(validationErrors);
+
+			// Jump to the earliest step that actually contains an error —
+			// no-op if the errors are already visible on the current step
+			const targetStep = findStepForErrors(
+				Object.keys(validationErrors),
+				formStepsConfig,
+				currentStep
+			);
+			if (targetStep !== null) {
+				currentStep = targetStep;
+			}
+
+			throw new Error('Formularvalidierung fehlgeschlagen. Bitte prüfen Sie Ihre Eingaben.', {
+				cause: yupError
 			});
+		}
 
 		return formContext.handleSubmit(e);
 	}

--- a/src/lib/report/components/form/FormActions.svelte
+++ b/src/lib/report/components/form/FormActions.svelte
@@ -1,27 +1,24 @@
 <script lang="ts">
-	import { USER_CONTACT_FIELDS } from '$lib/report/formConfig';
 	import { getFormContext } from '$lib/report/formContext';
-	import { clearUserContactData, loadUserContactData } from '$lib/storage/localStorage';
-	import { createToast } from '$lib/stores/toastState.svelte';
-	import Icon from '$lib/components/Icon.svelte';
 
+	// `onCancel` bleibt Teil der Props für Abwärtskompatibilität mit
+	// ModernReportForm.svelte, das den Wert weiterreicht. Der bisherige
+	// "Abbrechen"-Button wurde entfernt, da `onCancel` in der einzigen
+	// aktuellen Einbindung (src/routes/+page.svelte) auf dieselbe Seite
+	// navigiert, auf der das Formular bereits liegt — der Button hatte also
+	// keine erkennbare Wirkung. Ein Button ohne Funktion ist schlechter als
+	// gar keiner. Sollte künftig ein Aufrufer eine echte Abbrechen-Semantik
+	// benötigen (z.B. iFrame-Einbindung mit "zurück an Elternseite"), kann
+	// hier wieder ein Button ergänzt werden.
 	let {
-		onCancel = () => {},
-		onReset = () => {}
+		onReset = () => {},
+		onCancel: _onCancel = () => {}
 	}: {
-		onCancel?: () => void;
 		onReset?: () => void;
+		onCancel?: () => void;
 	} = $props();
 
-	const { isSubmitting, form, updateField } = getFormContext();
-
-	// Check if user has saved contact data (reactive $state, updated after clear)
-	let hasSavedContactData = $state(false);
-
-	$effect(() => {
-		const savedData = loadUserContactData();
-		hasSavedContactData = !!(savedData.firstName || savedData.lastName || savedData.email);
-	});
+	const { isSubmitting } = getFormContext();
 
 	function handleReset() {
 		if (
@@ -32,75 +29,16 @@
 			onReset();
 		}
 	}
-
-	function clearContactData() {
-		if (
-			confirm(
-				'Möchten Sie wirklich alle gespeicherten Kontaktdaten löschen? Diese müssen dann bei der nächsten Sichtung erneut eingegeben werden.'
-			)
-		) {
-			clearUserContactData();
-			hasSavedContactData = false;
-
-			// Clear contact fields in form state without page reload
-			for (const field of USER_CONTACT_FIELDS) {
-				const defaultValue = typeof $form[field] === 'boolean' ? false : '';
-				updateField(field, defaultValue);
-			}
-
-			createToast('success', 'Gespeicherte Kontaktdaten wurden gelöscht');
-		}
-	}
 </script>
 
-<!-- Form Actions - 3 Column Layout -->
-<div class="mx-auto mt-8">
-	<div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
-		<!-- Left Column: Reset -->
-		<div class="flex justify-center sm:justify-start">
-			<button
-				type="button"
-				class="btn btn-outline btn-sm w-full sm:w-auto"
-				onclick={handleReset}
-				disabled={$isSubmitting}
-			>
-				Formular zurücksetzen
-			</button>
-		</div>
-
-		<!-- Middle Column: Clear Contact Data or Empty -->
-		<div class="flex justify-center">
-			{#if hasSavedContactData}
-				<button
-					type="button"
-					class="btn btn-warning btn-sm w-full sm:w-auto"
-					onclick={clearContactData}
-					disabled={$isSubmitting}
-					title="Löscht gespeicherte Kontaktdaten permanent"
-				>
-					<Icon icon="lucide:trash-2" class="h-[14px] w-[14px]" /> Kontaktdaten löschen
-				</button>
-			{:else}
-				<!-- Empty space to maintain grid layout -->
-				<div></div>
-			{/if}
-		</div>
-
-		<!-- Right Column: Cancel or Empty -->
-		<div class="flex justify-center sm:justify-end">
-			{#if onCancel}
-				<button
-					type="button"
-					class="btn btn-ghost w-full sm:w-auto"
-					onclick={onCancel}
-					disabled={$isSubmitting}
-				>
-					Abbrechen
-				</button>
-			{:else}
-				<!-- Empty space to maintain grid layout -->
-				<div></div>
-			{/if}
-		</div>
-	</div>
+<!-- Form Actions -->
+<div class="mx-auto mt-8 flex justify-center sm:justify-start">
+	<button
+		type="button"
+		class="btn btn-outline btn-error btn-sm min-h-11 w-full sm:w-auto"
+		onclick={handleReset}
+		disabled={$isSubmitting}
+	>
+		Formular zurücksetzen
+	</button>
 </div>

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -86,9 +86,17 @@
 		emitField('longitude', longitude);
 	}
 
+	/**
+	 * `createForm.handleChange` übernimmt `target.value` unverändert in den
+	 * Formular-State. Ein leerer String würde dort als Koordinate liegen bleiben
+	 * und beim Validieren zu `NaN` casten ("Breitengrad must be a number type"),
+	 * obwohl die Koordinate ohne GPS-Position optional ist. Deshalb wird eine
+	 * fehlende Koordinate als `undefined` und eine vorhandene als `number`
+	 * gemeldet — nie als String.
+	 */
 	function emitField(name: 'latitude' | 'longitude', value: number | undefined) {
 		onchange?.({
-			target: { id: name, name, value: value === undefined ? '' : String(value) }
+			target: { id: name, name, value }
 		} as unknown as Event);
 	}
 
@@ -123,11 +131,18 @@
 		notifyChange();
 	}
 
-	/** Direkte Eingabe in die Dezimalgrad-Felder: leeres Feld ⇒ keine Position. */
-	function onDecimalChange(event: Event) {
+	/**
+	 * Direkte Eingabe in die Dezimalgrad-Felder: leeres Feld ⇒ keine Position.
+	 *
+	 * Meldet bewusst über `notifyChange()` statt das DOM-Event weiterzureichen:
+	 * Das Original-Event trägt nur das gerade bearbeitete Feld und dessen
+	 * String-Wert (leer beim Löschen) — die andere Koordinate bliebe im Formular
+	 * stehen. `notifyChange()` meldet beide normalisiert aus dem Komponenten-State.
+	 */
+	function onDecimalChange() {
 		latitude = ddLatitude ?? undefined;
 		longitude = ddLongitude ?? undefined;
-		onchange?.(event);
+		notifyChange();
 	}
 </script>
 

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -1,71 +1,145 @@
 <script lang="ts">
 	import { ddToDm, ddToDms, dmsToDd, dmToDd } from '$lib/utils/geo/coordinateConversion';
+	import { untrack } from 'svelte';
 
 	import OLMap from '$lib/components/map/OLMap.svelte';
 
+	type DmsParts = { deg: number | null; min: number | null; sec: number | null };
+	type DmParts = { deg: number | null; min: number | null };
+
 	let {
 		mode = 'dd',
-		latitude = $bindable(54.5),
-		longitude = $bindable(13.5),
+		latitude = $bindable(),
+		longitude = $bindable(),
+		defaultCenter = { latitude: 54.5, longitude: 13.5 },
 		onchange = () => {}
 	} = $props<{
 		mode?: 'dms' | 'dm' | 'dd';
-		latitude: number;
-		longitude: number;
+		/** Echter Formularwert — bleibt undefined, solange keine Position gewählt wurde. */
+		latitude?: number | undefined;
+		/** Echter Formularwert — bleibt undefined, solange keine Position gewählt wurde. */
+		longitude?: number | undefined;
+		/** Nur für die Kartenansicht: Startpunkt, solange keine echte Position vorliegt. */
+		defaultCenter?: { latitude: number; longitude: number };
 		onchange?: EventListener | null;
 	}>();
 
-	let dms: {
-		latitude: { deg: number; min: number; sec: number };
-		longitude: { deg: number; min: number; sec: number };
-	} = $state({ latitude: { deg: 0, min: 0, sec: 0 }, longitude: { deg: 0, min: 0, sec: 0 } });
-	let dm: { latitude: { deg: number; min: number }; longitude: { deg: number; min: number } } =
-		$state({ latitude: { deg: 0, min: 0 }, longitude: { deg: 0, min: 0 } });
+	// Kartenansicht ist von den Eingabefeldern getrennt: Die Karte braucht immer
+	// konkrete Zahlen (sonst startet sie im Nullmeridian), die Zahlenfelder bleiben
+	// leer, solange der Nutzer keine Position gewählt hat.
+	let mapLatitude = $state(untrack(() => latitude ?? defaultCenter.latitude));
+	let mapLongitude = $state(untrack(() => longitude ?? defaultCenter.longitude));
 
+	// Echte Position von außen (EXIF-GPS, Formular-Restore) auf die Karte spiegeln.
 	$effect(() => {
-		dms.longitude = ddToDms(longitude);
-		dms.latitude = ddToDms(latitude);
-		dm.longitude = ddToDm(longitude);
-		dm.latitude = ddToDm(latitude);
+		if (latitude === undefined) return;
+		if (untrack(() => mapLatitude) !== latitude) mapLatitude = latitude;
+	});
+	$effect(() => {
+		if (longitude === undefined) return;
+		if (untrack(() => mapLongitude) !== longitude) mapLongitude = longitude;
 	});
 
-	// svelte-ignore non_reactive_update
-	let latitudeInput: HTMLInputElement;
-	// svelte-ignore non_reactive_update
-	let longitudeInput: HTMLInputElement;
+	let dms: { latitude: DmsParts; longitude: DmsParts } = $state({
+		latitude: { deg: null, min: null, sec: null },
+		longitude: { deg: null, min: null, sec: null }
+	});
+	let dm: { latitude: DmParts; longitude: DmParts } = $state({
+		latitude: { deg: null, min: null },
+		longitude: { deg: null, min: null }
+	});
+
+	// Dezimalgrad-Felder: schreibbares $derived, damit ein geleertes Feld (null) nicht
+	// als Koordinate durchgereicht wird und externe Änderungen trotzdem ankommen.
+	let ddLatitude: number | null = $derived(latitude ?? null);
+	let ddLongitude: number | null = $derived(longitude ?? null);
+
+	const EMPTY_DMS: DmsParts = { deg: null, min: null, sec: null };
+	const EMPTY_DM: DmParts = { deg: null, min: null };
+
+	$effect(() => {
+		dms.longitude = longitude === undefined ? { ...EMPTY_DMS } : ddToDms(longitude);
+		dms.latitude = latitude === undefined ? { ...EMPTY_DMS } : ddToDms(latitude);
+		dm.longitude = longitude === undefined ? { ...EMPTY_DM } : ddToDm(longitude);
+		dm.latitude = latitude === undefined ? { ...EMPTY_DM } : ddToDm(latitude);
+	});
+
+	/** Leere Eingabefelder als NaN weiterreichen — die Konverter behandeln NaN bereits als 0. */
+	function part(value: number | null): number {
+		return value ?? Number.NaN;
+	}
+
+	/** Vorzeichen aus dem Grad-Feld; NaN (leeres Feld) bedeutet Nord/Ost. */
+	function signOf(deg: number): 1 | -1 {
+		return isNaN(deg) || deg >= 0 ? 1 : -1;
+	}
+
+	/**
+	 * Meldet eine Koordinatenänderung an das Formular. Bewusst über synthetische
+	 * Events statt über DOM-Referenzen: Die Dezimalgrad-Felder existieren in den
+	 * Modi "dm"/"dms" gar nicht, ein Marker-Verschieben würde dort sonst nie im
+	 * Formular ankommen.
+	 */
+	function notifyChange() {
+		if (!onchange) return;
+		emitField('latitude', latitude);
+		emitField('longitude', longitude);
+	}
+
+	function emitField(name: 'latitude' | 'longitude', value: number | undefined) {
+		onchange?.({
+			target: { id: name, name, value: value === undefined ? '' : String(value) }
+		} as unknown as Event);
+	}
 
 	function updateFromFields() {
 		try {
 			if (mode === 'dms') {
-				// NaN-Guard: NaN >= 0 ist false → würde fälschlicherweise sign = -1 liefern.
-				// Standard-Vorzeichen 1 (Nord/Ost) wenn Grad-Feld noch nicht ausgefüllt.
-				const latSign = isNaN(dms.latitude.deg) ? 1 : dms.latitude.deg >= 0 ? 1 : -1;
-				const lonSign = isNaN(dms.longitude.deg) ? 1 : dms.longitude.deg >= 0 ? 1 : -1;
-				latitude = dmsToDd(dms.latitude.deg, dms.latitude.min, dms.latitude.sec, latSign);
-				longitude = dmsToDd(dms.longitude.deg, dms.longitude.min, dms.longitude.sec, lonSign);
+				const latDeg = part(dms.latitude.deg);
+				const lonDeg = part(dms.longitude.deg);
+				latitude = dmsToDd(latDeg, part(dms.latitude.min), part(dms.latitude.sec), signOf(latDeg));
+				longitude = dmsToDd(
+					lonDeg,
+					part(dms.longitude.min),
+					part(dms.longitude.sec),
+					signOf(lonDeg)
+				);
 			} else if (mode === 'dm') {
-				const latSign = isNaN(dm.latitude.deg) ? 1 : dm.latitude.deg >= 0 ? 1 : -1;
-				const lonSign = isNaN(dm.longitude.deg) ? 1 : dm.longitude.deg >= 0 ? 1 : -1;
-				latitude = dmToDd(dm.latitude.deg, dm.latitude.min, latSign);
-				longitude = dmToDd(dm.longitude.deg, dm.longitude.min, lonSign);
+				const latDeg = part(dm.latitude.deg);
+				const lonDeg = part(dm.longitude.deg);
+				latitude = dmToDd(latDeg, part(dm.latitude.min), signOf(latDeg));
+				longitude = dmToDd(lonDeg, part(dm.longitude.min), signOf(lonDeg));
 			}
 		} catch (error) {
 			console.error('Fehler beim Aktualisieren der Felder:', error);
 		}
-		onMapChange();
+		notifyChange();
 	}
 
+	/** Marker verschoben oder GPS-Button genutzt → Kartenposition wird zur echten Position. */
 	function onMapChange() {
-		setTimeout(() => {
-			longitudeInput?.dispatchEvent(new Event('change', { bubbles: true }));
-			latitudeInput?.dispatchEvent(new Event('change', { bubbles: true }));
-		}, 0);
+		latitude = mapLatitude;
+		longitude = mapLongitude;
+		notifyChange();
+	}
+
+	/** Direkte Eingabe in die Dezimalgrad-Felder: leeres Feld ⇒ keine Position. */
+	function onDecimalChange(event: Event) {
+		latitude = ddLatitude ?? undefined;
+		longitude = ddLongitude ?? undefined;
+		onchange?.(event);
 	}
 </script>
 
 <div class="w-full">
 	<div class="border-base-300 mb-4 overflow-hidden rounded-lg border">
-		<OLMap bind:latitude bind:longitude readonly={false} enableGPS={true} onchange={onMapChange} />
+		<OLMap
+			bind:latitude={mapLatitude}
+			bind:longitude={mapLongitude}
+			readonly={false}
+			enableGPS={true}
+			onchange={onMapChange}
+		/>
 	</div>
 
 	<div class="mb-4 flex items-center justify-between">
@@ -225,9 +299,8 @@
 					max="90"
 					step="0.0001"
 					placeholder="Dezimalgrad"
-					bind:value={latitude}
-					{onchange}
-					bind:this={latitudeInput}
+					bind:value={ddLatitude}
+					onchange={onDecimalChange}
 				/>
 			</div>
 			<div>
@@ -240,9 +313,8 @@
 					max="180"
 					step="0.0001"
 					placeholder="Dezimalgrad"
-					bind:value={longitude}
-					{onchange}
-					bind:this={longitudeInput}
+					bind:value={ddLongitude}
+					onchange={onDecimalChange}
 				/>
 			</div>
 		</div>

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -3,8 +3,17 @@
 	import { createLogger } from '$lib/logger';
 	import { getFormContext } from '$lib/report/formContext';
 	import { toast } from '$lib/stores/toastState.svelte';
-	import { getErrorCount, scrollToElement, scrollToFirstError } from '$lib/utils/fieldNavigation';
+	import {
+		getErrorCount,
+		scrollToFirstError,
+		scrollToStepHeader
+	} from '$lib/utils/fieldNavigation';
 	import { formStepsConfig } from '$lib/report/formConfig';
+	import {
+		getStepAlertMessages,
+		shouldShowStepAlert,
+		type StepAttemptMarker
+	} from './stepNavigationState';
 
 	const logger = createLogger('report:StepNavigation');
 
@@ -29,23 +38,49 @@
 
 	const canGoNext = $derived(stepValidation.isValid);
 
-	// Step error messages for inline display (only when step is invalid)
-	const stepErrorMessages = $derived(
-		canGoNext ? [] : (Object.values(stepValidation.errors).filter(Boolean) as string[])
-	);
+	// Tracks whether the user already attempted "Weiter"/"Absenden" on the
+	// CURRENT step. Errors must never appear just from entering a step —
+	// only after a failed navigation attempt (see stepNavigationState.ts).
+	let attemptedStep = $state<StepAttemptMarker>(null);
+
+	// Reset the attempt marker whenever currentStep changes — this covers
+	// both our own next/previousStep() calls AND external changes via the
+	// stepper in FormSteps.svelte (currentStep is a shared $bindable prop),
+	// so a freshly (re-)entered step never shows a stale alert.
+	$effect(() => {
+		if (attemptedStep !== null && attemptedStep !== currentStep) {
+			attemptedStep = null;
+		}
+	});
+
+	// Whether the inline alert above the navigation should be visible
+	const showStepAlert = $derived(shouldShowStepAlert(attemptedStep, currentStep, canGoNext));
+
+	// All error messages of the current step, for inline display
+	const stepErrorMessages = $derived(getStepAlertMessages(stepValidation.errors));
 
 	const isLastStep = $derived(currentStep >= totalSteps - 1);
 	const isFirstStep = $derived(currentStep <= 0);
 
-	/** Scroll to form and focus the step header for screen reader announcement */
+	/**
+	 * Scrollt zum Kopf des neuen Schritts (Icon/Überschrift/Badge) und fokussiert
+	 * die Überschrift für die Screenreader-Ansage.
+	 *
+	 * U9: `#form-content` bleibt über den Schrittwechsel hinweg dasselbe Element,
+	 * enthält aber auch den bisherigen Schritt-Inhalt — Scrollen direkt dorthin
+	 * kann den Kopf des NEUEN Schritts (Badge/Überschrift) außerhalb des sichtbaren
+	 * Bereichs lassen. `scrollToStepHeader` findet daher gezielt den Kopfbereich
+	 * (Elternelement der `h2`, das laut Step-Konvention Icon+Badge umschließt).
+	 *
+	 * Suche UND Scroll werden verzögert, bis Svelte den neuen Schritt gerendert
+	 * hat — sonst würden wir noch den Kopf des VORHERIGEN Schritts finden.
+	 */
 	function scrollAndFocusStep(): void {
-		scrollToElement(document.getElementById('form-content'));
-		// Defer focus to after Svelte re-renders the new step content
 		requestAnimationFrame(() => {
-			const stepHeader = document.querySelector('#form-content h2');
-			if (stepHeader instanceof HTMLElement) {
-				stepHeader.setAttribute('tabindex', '-1');
-				stepHeader.focus({ preventScroll: true });
+			const stepHeading = scrollToStepHeader('form-content');
+			if (stepHeading) {
+				stepHeading.setAttribute('tabindex', '-1');
+				stepHeading.focus({ preventScroll: true });
 			}
 		});
 	}
@@ -55,6 +90,7 @@
 		try {
 			if (!canGoNext) {
 				logger.warn({ currentStep }, 'Validation failed for current step');
+				attemptedStep = currentStep;
 				await showValidationError();
 				return;
 			}
@@ -141,10 +177,18 @@
 	}
 </script>
 
-<!-- Inline validation error above navigation -->
-{#if stepErrorMessages.length > 0}
+<!-- Inline validation error above navigation — only after a failed "Weiter"-attempt -->
+{#if showStepAlert && stepErrorMessages.length > 0}
 	<div class="alert alert-warning mb-2" role="alert">
-		<span>{stepErrorMessages[0]}</span>
+		{#if stepErrorMessages.length === 1}
+			<span>{stepErrorMessages[0]?.message}</span>
+		{:else}
+			<ul class="list-inside list-disc">
+				{#each stepErrorMessages as { field, message } (field)}
+					<li>{message}</li>
+				{/each}
+			</ul>
+		{/if}
 	</div>
 {/if}
 
@@ -157,7 +201,7 @@
 		type="button"
 		onclick={previousStep}
 		disabled={isFirstStep || $isSubmitting}
-		class="btn btn-secondary"
+		class="btn btn-outline"
 		aria-label="Vorheriger Schritt"
 	>
 		← Zurück
@@ -166,7 +210,7 @@
 	<button
 		type="button"
 		onclick={nextStep}
-		disabled={!canGoNext || $isSubmitting}
+		disabled={$isSubmitting}
 		class="btn btn-primary"
 		aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
 	>

--- a/src/lib/report/components/form/coordinateValue.test.ts
+++ b/src/lib/report/components/form/coordinateValue.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { hasCoordinates, toCoordinate } from './coordinateValue';
+
+describe('toCoordinate', () => {
+	it('gibt undefined für undefined zurück (kein Phantom-Default)', () => {
+		expect(toCoordinate(undefined)).toBeUndefined();
+	});
+
+	it('gibt undefined für null zurück', () => {
+		expect(toCoordinate(null)).toBeUndefined();
+	});
+
+	it('gibt undefined für einen leeren String zurück (geleertes Eingabefeld)', () => {
+		expect(toCoordinate('')).toBeUndefined();
+		expect(toCoordinate('   ')).toBeUndefined();
+	});
+
+	it('gibt undefined für nicht-numerische Strings zurück', () => {
+		expect(toCoordinate('keine Zahl')).toBeUndefined();
+	});
+
+	it('gibt undefined für Booleans zurück', () => {
+		expect(toCoordinate(true)).toBeUndefined();
+		expect(toCoordinate(false)).toBeUndefined();
+	});
+
+	it('übernimmt Zahlen unverändert', () => {
+		expect(toCoordinate(54.5042)).toBe(54.5042);
+	});
+
+	it('akzeptiert die Null als gültige Koordinate', () => {
+		expect(toCoordinate(0)).toBe(0);
+		expect(toCoordinate('0')).toBe(0);
+	});
+
+	it('wandelt EXIF-Strings der Form "54.5000" in Zahlen um', () => {
+		expect(toCoordinate('54.5000')).toBe(54.5);
+		expect(toCoordinate('-13.2500')).toBe(-13.25);
+	});
+
+	it('gibt undefined für NaN und Infinity zurück', () => {
+		expect(toCoordinate(Number.NaN)).toBeUndefined();
+		expect(toCoordinate(Number.POSITIVE_INFINITY)).toBeUndefined();
+	});
+});
+
+describe('hasCoordinates', () => {
+	it('ist true, wenn Breite und Länge echte Zahlen sind', () => {
+		expect(hasCoordinates(54.5, 13.5)).toBe(true);
+		expect(hasCoordinates('54.5000', '13.5000')).toBe(true);
+	});
+
+	it('ist false, wenn eine der beiden Koordinaten fehlt', () => {
+		expect(hasCoordinates(54.5, undefined)).toBe(false);
+		expect(hasCoordinates(undefined, 13.5)).toBe(false);
+		expect(hasCoordinates('', '')).toBe(false);
+	});
+
+	it('ist true für den Nullmeridian/Äquator (0 ist kein "leerer" Wert)', () => {
+		expect(hasCoordinates(0, 0)).toBe(true);
+	});
+});

--- a/src/lib/report/components/form/coordinateValue.test.ts
+++ b/src/lib/report/components/form/coordinateValue.test.ts
@@ -60,3 +60,15 @@ describe('hasCoordinates', () => {
 		expect(hasCoordinates(0, 0)).toBe(true);
 	});
 });
+
+describe('Koordinaten-Emission an das Formular (Regression)', () => {
+	it('leeres Koordinatenfeld darf keinen leeren String im Formular hinterlassen', () => {
+		// Regression: emitField schrieb '' statt undefined. Da createForm.handleChange
+		// target.value unverändert speichert, landete '' im State — yup castet das zu
+		// NaN und meldet "Breitengrad must be a `number` type", obwohl die Koordinate
+		// ohne GPS-Position optional ist.
+		expect(toCoordinate('')).toBeUndefined();
+		expect(toCoordinate(undefined)).toBeUndefined();
+		expect(hasCoordinates('', '')).toBe(false);
+	});
+});

--- a/src/lib/report/components/form/coordinateValue.ts
+++ b/src/lib/report/components/form/coordinateValue.ts
@@ -1,0 +1,35 @@
+/**
+ * Hilfsfunktionen zur Normalisierung von Koordinaten-Formularwerten.
+ *
+ * Die Formularwerte für `latitude`/`longitude` sind zur Laufzeit nicht zwingend
+ * Zahlen: `handleChange` speichert den DOM-String des Eingabefeldes und die
+ * EXIF-Extraktion schreibt `toFixed(4)`-Strings. Nach dem Entfernen der
+ * Phantom-Defaults können sie außerdem `undefined` oder `''` sein.
+ *
+ * Für Kartenanzeige und Pflichtfeld-Logik brauchen wir daraus entweder eine
+ * echte Zahl oder `undefined` — niemals einen erfundenen Ersatzwert.
+ */
+
+/**
+ * Wandelt einen rohen Formularwert in eine echte Koordinate um.
+ *
+ * @returns die Zahl, oder `undefined` wenn kein verwertbarer Wert vorliegt
+ */
+export function toCoordinate(value: unknown): number | undefined {
+	if (value === undefined || value === null || typeof value === 'boolean') {
+		return undefined;
+	}
+	if (typeof value === 'string' && value.trim() === '') {
+		return undefined;
+	}
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * True, wenn Breiten- UND Längengrad als echte Zahlen vorliegen.
+ * Entspricht der Bedingung, unter der `hasPosition` gesetzt werden darf.
+ */
+export function hasCoordinates(latitude: unknown, longitude: unknown): boolean {
+	return toCoordinate(latitude) !== undefined && toCoordinate(longitude) !== undefined;
+}

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -20,7 +20,7 @@
 	import { createLogger } from '$lib/logger';
 	import { getFormContext } from '$lib/report/formContext';
 	import { createToast } from '$lib/stores/toastState.svelte';
-	import type { UploadedFileInfo, ValidationPreset } from '$lib/types';
+	import type { ExifData, UploadedFileInfo, ValidationPreset } from '$lib/types';
 	import { deleteFileDirect } from '$lib/utils';
 	import { formatFileSize } from '$lib/utils/file/fileSize';
 	import { getFileIcon } from '$lib/utils/file/fileType';
@@ -29,11 +29,23 @@
 	import { isInBalticArea } from '$lib/utils/geo/checkBalticSea';
 	import { MediaFile } from '$lib/utils/media/MediaFile';
 	import { deleteMultipleFiles } from '$lib/utils/upload/fileProcessing';
+	import {
+		shouldResetExifPosition,
+		type AppliedExifPosition
+	} from '$lib/report/components/form/fields/exifPositionReset';
+	import { get } from 'svelte/store';
 
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('DropzoneEnhanced');
 	let { form, handleChange, mediaStore } = getFormContext();
+
+	// Merkt sich die zuletzt aus EXIF in den Formularzustand übernommene
+	// Position (siehe `applyExifPosition`). Wird beim Entfernen des Fotos
+	// (`handleClear`/`handleFileRemoved`) genutzt, um `latitude`/`longitude`/
+	// `hasPosition` NUR dann zurückzunehmen, wenn der Nutzer sie seither nicht
+	// manuell überschrieben hat (siehe `exifPositionReset.ts`).
+	let appliedExifPosition = $state<AppliedExifPosition | null>(null);
 
 	// Component Props
 	let {
@@ -121,11 +133,40 @@
 		triggerChange('uploadedFiles', uploadedFiles);
 	}
 
+	/**
+	 * Übernimmt eine aus EXIF gelesene GPS-Position in den Formularzustand und
+	 * merkt sich die geschriebenen Rohwerte in `appliedExifPosition`, damit ein
+	 * späteres Entfernen des Fotos diese (und nur diese) wieder zurücknehmen kann.
+	 */
+	function applyExifPosition(exifData: ExifData): void {
+		const latitude = exifData.latitude!.toFixed(4);
+		const longitude = exifData.longitude!.toFixed(4);
+		triggerChange('latitude', latitude);
+		triggerChange('longitude', longitude);
+		// Echte Koordinaten vorhanden → Position ist gesetzt
+		triggerChange('hasPosition', true);
+		appliedExifPosition = { latitude, longitude };
+	}
+
+	/**
+	 * Nimmt eine zuvor aus EXIF übernommene Position wieder zurück — aber NUR,
+	 * wenn die aktuellen Formular-Koordinaten noch exakt diesem Wert entsprechen
+	 * (siehe `shouldResetExifPosition` in `exifPositionReset.ts`). Hat der Nutzer
+	 * die Position inzwischen manuell überschrieben, bleibt sie erhalten.
+	 */
+	function resetExifPositionIfUnchanged(): void {
+		if (shouldResetExifPosition(get(form), appliedExifPosition)) {
+			triggerChange('latitude', undefined);
+			triggerChange('longitude', undefined);
+			triggerChange('hasPosition', false);
+		}
+		appliedExifPosition = null;
+	}
+
 	$effect(() => {
 		if (positionMediaFile) {
 			if (positionMediaFile.exifData?.latitude && positionMediaFile.exifData?.longitude) {
-				triggerChange('latitude', positionMediaFile.exifData.latitude.toFixed(4));
-				triggerChange('longitude', positionMediaFile.exifData.longitude.toFixed(4));
+				applyExifPosition(positionMediaFile.exifData);
 			}
 			const timestamp = positionMediaFile.timestamp;
 			if (timestamp) {
@@ -193,8 +234,7 @@
 				// runs before EXIF extraction completes (async), and won't re-run afterwards because
 				// positionMediaFile stays the same object reference (plain class property, not $state).
 				if (isPositionStep && mediaFile.hasPosition()) {
-					triggerChange('latitude', mediaFile.exifData!.latitude!.toFixed(4));
-					triggerChange('longitude', mediaFile.exifData!.longitude!.toFixed(4));
+					applyExifPosition(mediaFile.exifData!);
 					if (mediaFile.timestamp) {
 						const { date: sightingDate, time: sightingTime } = splitDateTime(mediaFile.timestamp);
 						logger.info(
@@ -222,7 +262,10 @@
 	 * 1. Löschung vom Server (falls hochgeladen)
 	 * 2. Entfernung aus Upload-Map
 	 * 3. Entfernung aus Media Store
-	 * 4. User-Feedback
+	 * 4. GPS-Formulardaten zurücknehmen — aber NUR, wenn sie noch dem zuletzt
+	 *    aus diesem Foto übernommenen EXIF-Wert entsprechen und der Nutzer sie
+	 *    nicht inzwischen manuell überschrieben hat (siehe `resetExifPositionIfUnchanged`)
+	 * 5. User-Feedback
 	 *
 	 * @param index - Index der zu löschenden Datei im gefilterten Array
 	 */
@@ -250,6 +293,7 @@
 				await deleteFileDirect(fileInfo.filePath);
 				// Aus lokalen Stores entfernen
 				deleteFile(mediaFile.uid);
+				resetExifPositionIfUnchanged();
 				createToast('success', 'Datei erfolgreich gelöscht.');
 			}
 		} catch (error) {
@@ -265,7 +309,9 @@
 	 * 1. Object URLs freigeben (Memory Leaks vermeiden)
 	 * 2. Alle Dateien vom Server löschen
 	 * 3. UI-State komplett zurücksetzen
-	 * 4. GPS-Formulardaten löschen (im GPS-Modus)
+	 * 4. GPS-Formulardaten zurücknehmen — aber NUR, wenn sie noch dem zuletzt aus
+	 *    EXIF übernommenen Wert entsprechen und der Nutzer sie nicht inzwischen
+	 *    manuell überschrieben hat (siehe `resetExifPositionIfUnchanged`)
 	 */
 	function handleClear() {
 		try {
@@ -279,6 +325,7 @@
 
 			// Clear uploaded files
 			uploadedFiles = [];
+			resetExifPositionIfUnchanged();
 
 			triggerChange('uploadedFiles', uploadedFiles);
 			createToast('success', 'Alle Dateien erfolgreich gelöscht.');

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -19,19 +19,29 @@
 		name = '',
 		value = $bindable(),
 		error = undefined,
+		touched = false,
 		disabled = false,
 		size = 'md',
 		variant = 'default',
-		onchange = undefined
+		onchange = undefined,
+		required: requiredOverride = undefined
 	}: {
 		fieldConfig: yup.SchemaDescription;
 		name?: string;
 		value?: string | number | boolean | undefined | null;
 		error?: string | undefined;
+		touched?: boolean;
 		disabled?: boolean;
 		size?: FieldSize;
 		variant?: FieldVariant;
 		onchange?: (event: Event) => void;
+		/**
+		 * Überschreibt die aus dem Yup-Schema abgeleitete Pflichtfeld-Markierung.
+		 * Nötig für konditionale `when()`-Regeln, die in `fieldConfig.optional`
+		 * nicht sichtbar sind (z.B. `waterway` ohne GPS-Position).
+		 * `undefined` = Ableitung aus dem Schema (Default).
+		 */
+		required?: boolean | undefined;
 	} = $props();
 
 	// Bindable values for different component types
@@ -99,7 +109,8 @@
 	}
 
 	// Extract field configuration (reactive to prop changes)
-	let required = $derived(fieldConfig.optional === false);
+	// Einzige Quelle für Sternchen UND aria-required: expliziter Override, sonst Schema.
+	let required = $derived(requiredOverride ?? fieldConfig.optional === false);
 	let metaValues = $derived.by(() => {
 		const meta = fieldConfig.meta || {};
 		return {
@@ -121,7 +132,8 @@
 	// State computations
 	let hasError = $derived(!!error && error.length > 0);
 	let hasValue = $derived(value !== undefined && value !== '' && value !== null);
-	let isValid = $derived(hasValue && !hasError);
+	// Grünes Häkchen nur für vom Nutzer berührte Felder — Default-Werte gelten nicht als bestätigt
+	let isValid = $derived(touched && hasValue && !hasError);
 
 	// Type normalization
 	let normalizedType = $derived(
@@ -245,8 +257,8 @@
 			<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
 		{/if}
 
-		<!-- Status Indicator -->
-		{#if hasValue}
+		<!-- Status Indicator (Häkchen nur bei berührten, gültigen Feldern) -->
+		{#if hasError || isValid}
 			<span class="ml-2 inline-block" aria-hidden="true">
 				{#if hasError}
 					<Icon icon="lucide:x" width="14" class="text-error inline" />
@@ -324,14 +336,9 @@
 		</div>
 	{/if}
 
-	<!-- Error Message with Animation -->
+	<!-- Error Message -->
 	{#if error}
-		<div
-			id={errorId}
-			class="animate-in slide-in-from-top-1 mt-1 text-left duration-200"
-			role="alert"
-			aria-live="polite"
-		>
+		<div id={errorId} class="mt-1 text-left" role="alert" aria-live="polite">
 			<span class="text-error flex items-center gap-1 text-xs font-medium">
 				<Icon icon="lucide:triangle-alert" width="14" class="text-error flex-shrink-0" />
 				{error}

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -130,6 +130,118 @@ describe('FieldRenderer', () => {
 		});
 	});
 
+	describe('Pflichtfeld-Override (konditionale Schema-Regeln)', () => {
+		// waterway ist im Schema `optional`, wird aber über `when('hasPosition')`
+		// zur Pflicht, sobald keine GPS-Position vorliegt.
+		const waterwayFieldConfig = makeFieldConfig({
+			label: 'Fahrwasser/Seegebiet',
+			optional: true,
+			meta: { type: 'text', placeholder: 'z.B. Kieler Bucht' }
+		});
+
+		it('zeigt Stern für ein schema-optionales Feld mit required={true}', async () => {
+			render(FieldRenderer, {
+				fieldConfig: waterwayFieldConfig,
+				name: 'waterway',
+				value: '',
+				required: true
+			});
+
+			await expect.element(page.getByLabelText('Pflichtfeld')).toBeVisible();
+		});
+
+		it('setzt aria-required=true bei required={true} trotz optionalem Schema', async () => {
+			render(FieldRenderer, {
+				fieldConfig: waterwayFieldConfig,
+				name: 'waterway',
+				value: '',
+				required: true
+			});
+
+			await expect
+				.element(page.getByTestId('field-waterway'))
+				.toHaveAttribute('aria-required', 'true');
+		});
+
+		it('entfernt Stern und aria-required bei required={false}', async () => {
+			render(FieldRenderer, {
+				fieldConfig: waterwayFieldConfig,
+				name: 'waterway',
+				value: '',
+				required: false
+			});
+
+			await expect.element(page.getByLabelText('Pflichtfeld')).not.toBeInTheDocument();
+			await expect
+				.element(page.getByTestId('field-waterway'))
+				.not.toHaveAttribute('aria-required', 'true');
+		});
+
+		it('unterdrückt die Schema-Pflicht, wenn required={false} übergeben wird', async () => {
+			render(FieldRenderer, {
+				fieldConfig: emailFieldConfig,
+				name: 'email',
+				value: '',
+				required: false
+			});
+
+			await expect.element(page.getByLabelText('Pflichtfeld')).not.toBeInTheDocument();
+			await expect
+				.element(page.getByTestId('field-email'))
+				.not.toHaveAttribute('aria-required', 'true');
+		});
+
+		it('nutzt ohne Override weiterhin die Schema-Ableitung', async () => {
+			render(FieldRenderer, {
+				fieldConfig: waterwayFieldConfig,
+				name: 'waterway',
+				value: ''
+			});
+
+			await expect.element(page.getByLabelText('Pflichtfeld')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Häkchen nur bei berührten Feldern', () => {
+		it('zeigt KEIN grünes Häkchen für ein Feld mit Wert, das nicht berührt wurde', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: emailFieldConfig,
+				name: 'email',
+				value: 'test@test.de',
+				touched: false
+			});
+
+			// Erfolgs-Icon (lucide:check) darf nicht gerendert sein
+			const check = screen.container.querySelector('.text-success');
+			expect(check).toBeNull();
+		});
+
+		it('zeigt grünes Häkchen für ein berührtes Feld mit Wert und ohne Fehler', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: emailFieldConfig,
+				name: 'email',
+				value: 'test@test.de',
+				touched: true
+			});
+
+			const check = screen.container.querySelector('.text-success');
+			expect(check).not.toBeNull();
+		});
+
+		it('zeigt kein Häkchen für ein berührtes Feld mit Fehler', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: emailFieldConfig,
+				name: 'email',
+				value: 'test@test.de',
+				touched: true,
+				error: 'Fehler'
+			});
+
+			const check = screen.container.querySelector('.text-success');
+			expect(check).toBeNull();
+		});
+	});
+
 	describe('Error-Anzeige', () => {
 		it('zeigt Fehlermeldung mit role="alert"', async () => {
 			render(FieldRenderer, {

--- a/src/lib/report/components/form/fields/FormField.svelte
+++ b/src/lib/report/components/form/fields/FormField.svelte
@@ -17,12 +17,19 @@
 		name,
 		disabled = false,
 		size = 'md',
-		variant = 'default'
+		variant = 'default',
+		required = undefined
 	}: {
 		name: keyof Omit<SightingFormData, 'uploadedFiles'>;
 		disabled?: boolean;
 		size?: 'sm' | 'md' | 'lg';
 		variant?: 'default' | 'compact' | 'full';
+		/**
+		 * Optionaler Override der Pflichtfeld-Markierung für konditionale
+		 * Schema-Regeln (`when()`), die aus `describe()` nicht ableitbar sind.
+		 * Ohne Angabe gilt weiterhin die Ableitung aus dem Yup-Schema.
+		 */
+		required?: boolean | undefined;
 	} = $props();
 
 	const context = getFormContext();
@@ -31,7 +38,7 @@
 		throw new Error('FormField must be used inside a Form component (context not found)');
 	}
 
-	const { form, errors, handleChange } = context;
+	const { form, errors, touched, handleChange } = context;
 
 	let fieldConfig = $derived.by(() => {
 		const config = sightingSchemaFields[name] as yup.SchemaDescription | undefined;
@@ -48,18 +55,22 @@
 	});
 
 	let error = $derived($errors[name]);
+	let fieldTouched = $derived($touched[name] ?? false);
 	// Extract the value and ensure it's a compatible type for FieldRenderer
 	let formValue = $derived($form[name]);
 	let value: string | number | boolean | undefined | null = $derived(
 		// Convert any complex types to their primitive representation
-		typeof formValue === 'object' && formValue !== null ?
-			JSON.stringify(formValue) :
-			formValue as string | number | boolean | undefined | null
+		typeof formValue === 'object' && formValue !== null
+			? JSON.stringify(formValue)
+			: (formValue as string | number | boolean | undefined | null)
 	);
 
 	// Only log during development (untrack to avoid re-running on every form change)
 	$effect(() => {
-		logger.debug({ form: untrack(() => $form), config: untrack(() => fieldConfig) }, `FormField "${name}" rendered`);
+		logger.debug(
+			{ form: untrack(() => $form), config: untrack(() => fieldConfig) },
+			`FormField "${name}" rendered`
+		);
 	});
 </script>
 
@@ -69,9 +80,11 @@
 		{name}
 		bind:value
 		{error}
+		touched={fieldTouched}
 		{disabled}
 		{size}
 		{variant}
+		{required}
 		onchange={handleChange}
 	/>
 </div>

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -350,10 +350,7 @@
 
 	<!-- Expandable Content -->
 	{#if isExpanded}
-		<div
-			id="species-help-content"
-			class="animate-in slide-in-from-top-2 bg-base-100 border-base-300 mt-2 rounded-lg border p-4 duration-200"
-		>
+		<div id="species-help-content" class="bg-base-100 border-base-300 mt-2 rounded-lg border p-4">
 			<div class="mb-4">
 				<h4 class="text-base-content mb-2 text-sm font-semibold">
 					Bestimmungshilfe für Meerestiere

--- a/src/lib/report/components/form/fields/exifPositionReset.test.ts
+++ b/src/lib/report/components/form/fields/exifPositionReset.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { shouldResetExifPosition } from './exifPositionReset';
+
+/**
+ * Regressionstest: `DropzoneEnhanced.svelte` behauptete in einem Doc-Kommentar,
+ * beim Entfernen des GPS-Fotos würden die daraus abgeleiteten Positionsdaten
+ * zurückgesetzt — tatsächlich passierte das nicht (`handleClear`/
+ * `handleFileRemoved` setzten `latitude`/`longitude`/`hasPosition` nie zurück).
+ *
+ * `shouldResetExifPosition` entscheidet, ob ein Reset beim Entfernen des Fotos
+ * sicher ist: nur wenn die aktuellen Formular-Koordinaten noch EXAKT den
+ * zuletzt aus EXIF übernommenen Werten entsprechen. Hat der Nutzer die Position
+ * inzwischen manuell überschrieben (z.B. über die Karte), bleibt sie erhalten.
+ */
+describe('shouldResetExifPosition', () => {
+	it('erlaubt den Reset, wenn die aktuellen Koordinaten noch exakt aus EXIF stammen', () => {
+		const applied = { latitude: '54.5000', longitude: '13.2000' };
+		expect(shouldResetExifPosition({ latitude: '54.5000', longitude: '13.2000' }, applied)).toBe(
+			true
+		);
+	});
+
+	it('verweigert den Reset, wenn der Nutzer die Breite inzwischen manuell geändert hat', () => {
+		const applied = { latitude: '54.5000', longitude: '13.2000' };
+		expect(shouldResetExifPosition({ latitude: '55.0000', longitude: '13.2000' }, applied)).toBe(
+			false
+		);
+	});
+
+	it('verweigert den Reset, wenn der Nutzer die Länge inzwischen manuell geändert hat', () => {
+		const applied = { latitude: '54.5000', longitude: '13.2000' };
+		expect(shouldResetExifPosition({ latitude: '54.5000', longitude: '14.0000' }, applied)).toBe(
+			false
+		);
+	});
+
+	it('verweigert den Reset, wenn noch nie eine EXIF-Position übernommen wurde (null)', () => {
+		expect(shouldResetExifPosition({ latitude: '54.5000', longitude: '13.2000' }, null)).toBe(
+			false
+		);
+	});
+
+	it('verweigert den Reset, wenn die Koordinaten inzwischen gelöscht/leer sind', () => {
+		const applied = { latitude: '54.5000', longitude: '13.2000' };
+		expect(shouldResetExifPosition({ latitude: undefined, longitude: undefined }, applied)).toBe(
+			false
+		);
+	});
+});

--- a/src/lib/report/components/form/fields/exifPositionReset.ts
+++ b/src/lib/report/components/form/fields/exifPositionReset.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure Entscheidungslogik: Darf eine aus EXIF übernommene Position beim
+ * Entfernen des zugehörigen GPS-Fotos zurückgenommen werden?
+ *
+ * Hintergrund: `DropzoneEnhanced.svelte` schreibt beim Auslesen von GPS-EXIF
+ * `latitude`/`longitude`/`hasPosition` in den Formularzustand. Beim Entfernen
+ * des Fotos (`handleClear`, `handleFileRemoved`) darf dieser Zustand NUR dann
+ * zurückgesetzt werden, wenn die aktuellen Formular-Koordinaten noch exakt
+ * dem zuletzt aus EXIF übernommenen Wert entsprechen — hat der Nutzer die
+ * Position seither manuell überschrieben (z.B. über die Karte), muss ihre
+ * Eingabe erhalten bleiben, auch wenn das ursprüngliche Foto entfernt wird.
+ */
+
+/** Die zuletzt aus EXIF in den Formularzustand übernommene Position (Rohwerte, wie `toFixed(4)` sie liefert). */
+export interface AppliedExifPosition {
+	latitude: string;
+	longitude: string;
+}
+
+/** Minimale Teilmenge der Formularwerte, die für die Entscheidung nötig ist. */
+export interface CurrentPositionValues {
+	latitude?: unknown;
+	longitude?: unknown;
+}
+
+/**
+ * True, wenn `applied` gesetzt ist und die aktuellen Formular-Koordinaten
+ * noch exakt den zuletzt aus EXIF übernommenen Werten entsprechen — also
+ * seither nicht manuell verändert wurden und sicher zurückgenommen werden dürfen.
+ */
+export function shouldResetExifPosition(
+	current: CurrentPositionValues,
+	applied: AppliedExifPosition | null
+): boolean {
+	if (!applied) {
+		return false;
+	}
+
+	return (
+		String(current.latitude ?? '') === applied.latitude &&
+		String(current.longitude ?? '') === applied.longitude
+	);
+}

--- a/src/lib/report/components/form/stepNavigationState.test.ts
+++ b/src/lib/report/components/form/stepNavigationState.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getStepAlertMessages, shouldShowStepAlert } from './stepNavigationState';
+
+describe('shouldShowStepAlert', () => {
+	it('zeigt keinen Alert beim ersten Betreten eines Schritts, auch wenn dieser invalide ist', () => {
+		expect(shouldShowStepAlert(null, 1, false)).toBe(false);
+	});
+
+	it('zeigt den Alert nach einem fehlgeschlagenen Weiter-Versuch auf einem invaliden Schritt', () => {
+		expect(shouldShowStepAlert(1, 1, false)).toBe(true);
+	});
+
+	it('zeigt keinen Alert, sobald der Schritt valide ist, obwohl bereits versucht wurde', () => {
+		expect(shouldShowStepAlert(1, 1, true)).toBe(false);
+	});
+
+	it('zeigt keinen Alert, wenn der markierte Versuch zu einem anderen Schritt gehört', () => {
+		expect(shouldShowStepAlert(1, 2, false)).toBe(false);
+	});
+
+	it('zeigt keinen Alert mehr, nachdem der Versuch zurückgesetzt wurde (Schrittwechsel)', () => {
+		expect(shouldShowStepAlert(1, 1, false)).toBe(true);
+		expect(shouldShowStepAlert(null, 1, false)).toBe(false);
+	});
+
+	it('zeigt den Alert wieder, wenn nach einem Reset erneut auf demselben Schritt versucht wird', () => {
+		expect(shouldShowStepAlert(null, 1, false)).toBe(false);
+		expect(shouldShowStepAlert(1, 1, false)).toBe(true);
+	});
+});
+
+describe('getStepAlertMessages', () => {
+	it('gibt ein leeres Array bei keinen Fehlern zurück', () => {
+		expect(getStepAlertMessages({})).toEqual([]);
+	});
+
+	it('gibt alle vorhandenen Fehlermeldungen inkl. Feldname als Array zurück', () => {
+		const errors = { lat: 'Position erforderlich', date: 'Datum erforderlich' };
+		expect(getStepAlertMessages(errors)).toEqual([
+			{ field: 'lat', message: 'Position erforderlich' },
+			{ field: 'date', message: 'Datum erforderlich' }
+		]);
+	});
+
+	it('filtert leere/undefined Fehlermeldungen heraus', () => {
+		const errors = { lat: 'Position erforderlich', date: '' } as Record<string, string>;
+		expect(getStepAlertMessages(errors)).toEqual([
+			{ field: 'lat', message: 'Position erforderlich' }
+		]);
+	});
+
+	it('liefert für zwei Felder mit identischer Meldung zwei eigenständige Einträge (eindeutige Keys)', () => {
+		// Regressionstest: sightingFrom/sightingFromText teilen sich dieselbe Fehlermeldung.
+		// Ein {#each ... (message)} in StepNavigation.svelte würde hier mit
+		// each_key_duplicate kollidieren — deshalb trägt jeder Eintrag seinen Feldnamen.
+		const errors = {
+			sightingFrom: 'Bitte angeben, von wo aus beobachtet wurde',
+			sightingFromText: 'Bitte angeben, von wo aus beobachtet wurde'
+		};
+		const messages = getStepAlertMessages(errors);
+		expect(messages).toHaveLength(2);
+		expect(new Set(messages.map((m) => m.field)).size).toBe(2);
+	});
+});

--- a/src/lib/report/components/form/stepNavigationState.ts
+++ b/src/lib/report/components/form/stepNavigationState.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure Anzeige-Logik für den Validierungs-Alert in StepNavigation.svelte.
+ *
+ * Ziel: Fehler werden NICHT sofort beim Betreten eines Schritts angezeigt
+ * (premature errors), sondern erst nachdem der Nutzer aktiv versucht hat,
+ * mit einem invaliden Schritt fortzufahren ("Weiter"/"Absenden" geklickt).
+ *
+ * `attemptedStep` (Schrittnummer oder `null`) wird als schlichter `$state` in
+ * StepNavigation.svelte selbst verwaltet — die Initialisierung (`null`),
+ * das Markieren (`= currentStep`) und das Zurücksetzen (`= null`) sind triviale
+ * Zuweisungen ohne eigene Logik und werden dort direkt inline vorgenommen.
+ * Hier verbleibt nur die tatsächliche Entscheidungslogik.
+ */
+
+/** Schrittnummer des zuletzt versuchten (aber ggf. gescheiterten) "Weiter", oder `null` */
+export type StepAttemptMarker = number | null;
+
+/**
+ * Entscheidet, ob der Inline-Validierungs-Alert sichtbar sein soll:
+ * Nur wenn der Versuch GENAU zum aktuellen Schritt gehört (kein veralteter
+ * Versuch eines verlassenen Schritts) UND dieser Schritt (weiterhin) invalide ist.
+ */
+export function shouldShowStepAlert(
+	attemptedStep: StepAttemptMarker,
+	currentStep: number,
+	canGoNext: boolean
+): boolean {
+	return attemptedStep === currentStep && !canGoNext;
+}
+
+/** Eine Fehlermeldung eines Schritts, zusammen mit dem auslösenden Feldnamen. */
+export interface StepAlertMessage {
+	field: string;
+	message: string;
+}
+
+/**
+ * Liefert alle nicht-leeren Fehlermeldungen eines Schritts inkl. Feldname.
+ *
+ * Der Feldname bleibt erhalten, damit `{#each}` in StepNavigation.svelte einen
+ * eindeutigen Key hat: Zwei verschiedene Felder können denselben Meldungstext
+ * teilen (z.B. `sightingFrom`/`sightingFromText`), ein Keying nur auf den Text
+ * würde dann mit `each_key_duplicate` kollidieren.
+ */
+export function getStepAlertMessages(errors: Record<string, string>): StepAlertMessage[] {
+	return Object.entries(errors)
+		.filter((entry): entry is [string, string] => Boolean(entry[1]))
+		.map(([field, message]) => ({ field, message }));
+}

--- a/src/lib/report/components/sections/DeadAnimal.svelte
+++ b/src/lib/report/components/sections/DeadAnimal.svelte
@@ -4,11 +4,16 @@
 </script>
 
 <div class="bg-warning/10 border-warning/20 mt-6 rounded-lg border p-4">
-	<h4 class="text-warning-content mb-3 flex items-center gap-2 font-semibold md:whitespace-nowrap">
-		<Icon icon="lucide:triangle-alert" width="16" class="text-warning-content shrink-0" />
+	<h4 class="text-base-content mb-3 flex items-center gap-2 font-semibold md:whitespace-nowrap">
+		<Icon
+			aria-hidden="true"
+			icon="lucide:triangle-alert"
+			width="16"
+			class="text-warning shrink-0"
+		/>
 		<span>Zusätzliche Informationen für Totfund</span>
 	</h4>
-	<div class="text-warning-content/80 mb-4 text-sm">
+	<div class="text-base-content/80 mb-4 text-sm">
 		<p class="mb-2 font-medium">Totfunde sind besonders wertvoll für die Wissenschaft!</p>
 		<ul class="list-inside list-disc space-y-1 text-xs">
 			<li><strong>Todesursachen:</strong> Helfen bei der Identifikation von Bedrohungen</li>

--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -12,8 +12,8 @@
 
 	const { form, handleChange } = getFormContext();
 
-	let latitude: number | null = $derived($form.latitude);
-	let longitude: number | null = $derived($form.longitude);
+	let latitude: number | null | undefined = $derived($form.latitude);
+	let longitude: number | null | undefined = $derived($form.longitude);
 	let sightingDate: string | null = $derived($form.sightingDate);
 	let sightingTime: string | undefined | null = $derived($form.sightingTime);
 

--- a/src/lib/report/components/sections/Location.svelte
+++ b/src/lib/report/components/sections/Location.svelte
@@ -3,12 +3,20 @@
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import LocationInput from '$lib/report/components/form/LocationInput.svelte';
 	import VerifyLocation from '$lib/report/components/form/VerifyLocation.svelte';
+	import { toCoordinate } from '$lib/report/components/form/coordinateValue';
 	import SectionCard from './SectionCard.svelte';
 
 	const { form, handleChange } = getFormContext();
 
 	// Reactive form state using Svelte 5 $derived runes
 	let hasPosition = $derived($form.hasPosition);
+
+	// Rohwerte aus dem Formular (im Admin ggf. Strings aus toFixed) auf echte
+	// Zahlen normalisieren. Fehlt eine Koordinate, bleibt sie undefined —
+	// LocationInput zentriert die Karte dann über defaultCenter, ohne die
+	// Eingabefelder mit Phantom-Werten zu füllen.
+	let latitude = $derived(toCoordinate($form.latitude));
+	let longitude = $derived(toCoordinate($form.longitude));
 </script>
 
 <!-- Location Section -->
@@ -19,13 +27,11 @@
 	<!-- GPS Coordinates (shown when hasPosition = true) -->
 	{#if hasPosition}
 		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
-			<LocationInput
-				latitude={$form.latitude}
-				longitude={$form.longitude}
-				onchange={handleChange}
-			/>
+			<LocationInput {latitude} {longitude} onchange={handleChange} />
 
-			<VerifyLocation longitude={$form.longitude} latitude={$form.latitude} />
+			{#if latitude !== undefined && longitude !== undefined}
+				<VerifyLocation {longitude} {latitude} />
+			{/if}
 		</div>
 	{:else}
 		<!-- Waterway Input (shown when hasPosition = false) -->

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -16,7 +16,7 @@
 
 	// Generate dynamic format description
 	let formatDescription = $derived.by(() => {
-		if (!uploadConfig) return 'JPG, PNG, MP4, MOV, AVI';
+		if (!uploadConfig) return 'JPG, PNG, GIF, WEBP';
 
 		const imageTypes = uploadConfig.allowedTypes.filter((type) => type.startsWith('image/'));
 		const videoTypes = uploadConfig.allowedTypes.filter((type) => type.startsWith('video/'));
@@ -34,7 +34,7 @@
 
 	// Generate file size description
 	let maxSizeDescription = $derived.by(() => {
-		if (!uploadConfig) return 'max 50MB';
+		if (!uploadConfig) return 'max 10MB';
 		const sizeMB = Math.round(uploadConfig.maxFileSize / (1024 * 1024));
 		return `max ${sizeMB}MB`;
 	});
@@ -48,15 +48,14 @@
 </script>
 
 <!-- Media Section -->
-<SectionCard title="Foto- oder Videoaufnahmen" icon="lucide:camera">
+<SectionCard title="Fotoaufnahmen" icon="lucide:camera">
 	<div class="text-base-content/70 mb-4 text-sm">
 		<p class="mb-2 flex items-center gap-2 font-medium">
 			<Icon icon="lucide:camera" width="16" class="text-primary" aria-hidden="true" />
-			Fotos und Videos sind extrem wertvoll für die Forschung!
+			Fotos sind extrem wertvoll für die Forschung!
 		</p>
 		<ul class="list-inside list-disc space-y-1 text-xs">
 			<li><strong>Artbestimmung:</strong> Auch unscharfe Bilder können helfen</li>
-			<li><strong>Verhaltensanalyse:</strong> Videos zeigen wichtige Verhaltensmuster</li>
 			<li><strong>GPS-Daten:</strong> Automatische Positionserkennung aus Bildern</li>
 			<li>
 				<strong>Formatunterstützung:</strong>

--- a/src/lib/report/components/sections/PositionAndTime.svelte
+++ b/src/lib/report/components/sections/PositionAndTime.svelte
@@ -1,23 +1,40 @@
 <script lang="ts">
 	import { getFormContext } from '$lib/report/formContext';
 	import { getUploadConfig } from '$lib/stores/configStore';
+	import { get } from 'svelte/store';
 	import type { ValidationPreset } from '$lib/types';
 	import Icon from '$lib/components/Icon.svelte';
 	import DropzoneEnhanced from '$lib/report/components/form/fields/DropzoneEnhanced.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import LocationInput from '$lib/report/components/form/LocationInput.svelte';
 	import VerifyLocation from '$lib/report/components/form/VerifyLocation.svelte';
+	import { hasCoordinates, toCoordinate } from '$lib/report/components/form/coordinateValue';
+	import { derivePositionMethod } from './positionMethod';
 
 	const { form, handleChange } = getFormContext();
 
 	// Position input method: 'photo', 'map', 'manual'
-	let positionMethod = $state<'photo' | 'map' | 'manual'>('photo');
+	//
+	// U10: Die initiale Methode wird EINMALIG beim Mount aus dem bereits
+	// vorhandenen Formularzustand abgeleitet (z.B. nach Wiederherstellung aus
+	// der Session) — siehe `derivePositionMethod` in `./positionMethod.ts`.
+	// Der Aufruf von `get(form)` hier im $state-Initializer läuft nur einmal
+	// bei der Komponenten-Erstellung, NICHT reaktiv — eine spätere manuelle
+	// Auswahl des Nutzers (siehe `selectMethod`) wird dadurch nie überschrieben.
+	let positionMethod = $state<'photo' | 'map' | 'manual'>(derivePositionMethod(get(form)));
 
 	// Generiere eine einfache referenceId für Upload (temporäre Lösung)
 	const referenceId = $derived($form.referenceId);
 
-	const longitude = $derived($form.longitude);
-	const latitude = $derived($form.latitude);
+	// Echte Koordinaten aus dem Formular — bleiben undefined, solange keine Position
+	// gewählt wurde. Die Karte startet über einen separaten Anzeige-Mittelpunkt
+	// (defaultCenter) über der Ostsee, ohne die Eingabefelder zu füllen.
+	const longitude = $derived(toCoordinate($form.longitude));
+	const latitude = $derived(toCoordinate($form.latitude));
+
+	// Fahrwasser ist laut Schema Pflicht, solange keine GPS-Position vorliegt
+	// (`waterway.when('hasPosition', { is: (v) => v !== true, ... })`).
+	const waterwayRequired = $derived($form.hasPosition !== true);
 
 	// Dynamic GPS photo configuration
 	let gpsPhotoConfig = $state<ValidationPreset | null>(null);
@@ -36,15 +53,31 @@
 		});
 	});
 
+	/** Setzt ein Formularfeld über den synthetischen handleChange-Event-Pfad. */
+	function setField(name: string, value: unknown) {
+		handleChange({ target: { name, value } } as unknown as Event);
+	}
+
 	function selectMethod(method: 'photo' | 'map' | 'manual') {
 		positionMethod = method;
 
-		// Reset position data when switching methods
-		if (method !== 'photo') {
-			handleChange({
-				target: { name: 'hasPosition', value: method !== 'manual' }
-			} as unknown as Event);
+		// Beim Wechsel zur Beschreibung: echte Koordinaten und hasPosition zurücksetzen,
+		// damit keine Phantom-Position (leere/alte GPS-Daten) bestehen bleibt.
+		if (method === 'manual') {
+			setField('latitude', undefined);
+			setField('longitude', undefined);
+			setField('hasPosition', false);
 		}
+	}
+
+	/**
+	 * Koordinaten-Änderung aus der Karte / den GPS-Eingabefeldern.
+	 * hasPosition ist genau dann true, wenn echte Breiten- UND Längengrade gesetzt sind.
+	 */
+	function handleLocationChange(event: Event) {
+		handleChange(event);
+		const values = get(form);
+		setField('hasPosition', hasCoordinates(values.latitude, values.longitude));
 	}
 </script>
 
@@ -186,13 +219,35 @@
 					<Icon aria-hidden="true" icon="lucide:map-pin" width="18" />
 					Position auf Karte wählen
 				</h4>
-				<LocationInput {latitude} {longitude} onchange={handleChange} />
+				<LocationInput {latitude} {longitude} onchange={handleLocationChange} />
 			{/if}
 
 			{#if positionMethod !== 'manual'}
-				{#if $form.latitude && $form.longitude}
+				{#if latitude !== undefined && longitude !== undefined}
 					<VerifyLocation {longitude} {latitude} />
 				{/if}
+
+				<!--
+					Fallback-Bereich: Das Fahrwasser ist ohne GPS-Position Pflicht und muss
+					deshalb in JEDER Methode erreichbar sein — sonst landet der Nutzer beim
+					Klick auf "Weiter" in einer Sackgasse (Fehler ohne zugehöriges Feld).
+				-->
+				<div class="divider text-base-content/60 mt-6 mb-3 text-xs">oder</div>
+
+				<div class="border-base-300 bg-base-200/40 rounded-lg border p-3 sm:p-4">
+					<h5 class="mb-1 flex items-center gap-2 text-sm font-semibold">
+						<Icon aria-hidden="true" icon="lucide:waves" width="16" class="text-primary" />
+						Kein GPS? Beschreiben Sie das Seegebiet
+					</h5>
+					<p class="text-base-content/70 mb-3 text-xs">
+						Viele Fotos enthalten keine GPS-Daten, und nicht jede Position lässt sich auf der Karte
+						wiederfinden — das ist kein Problem. Eine kurze Beschreibung des Fahrwassers genügt uns,
+						auch ungefähre Angaben sind wertvoll.
+					</p>
+
+					<FormField name="waterway" required={waterwayRequired} />
+					<FormField name="seaMark" />
+				</div>
 			{/if}
 
 			<!-- Manual Input Section -->
@@ -202,7 +257,7 @@
 					Beschreibung der Position
 				</h4>
 
-				<FormField name="waterway" />
+				<FormField name="waterway" required={waterwayRequired} />
 				<FormField name="seaMark" />
 			{/if}
 		</div>

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -5,8 +5,43 @@
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
+	import {
+		NOT_YET_TRACKED,
+		isBoatSightingFrom,
+		shouldResetBoatDrive,
+		type TrackedSightingFromValue
+	} from './boatDriveReset';
 
-	const { form } = getFormContext();
+	const { form, updateField } = getFormContext();
+
+	/** Sichtung erfolgte von einem Boot mit Antrieb (Segelschiff/Motorboot) aus. */
+	const showsBoatDrive = $derived(isBoatSightingFrom($form.sightingFrom));
+
+	// Zuletzt gesehener sightingFrom-Wert. Startet mit NOT_YET_TRACKED, damit der
+	// erste Durchlauf (Mount, ggf. mit vorbefüllten Admin-Daten) NIE einen Reset
+	// auslöst - siehe shouldResetBoatDrive.
+	let previousSightingFrom: TrackedSightingFromValue = NOT_YET_TRACKED;
+
+	// Wechselt der NUTZER aktiv von Boot zu Land/Fähre/Sonstiges, verstecken wir
+	// den Bootsantrieb-Block wieder. Dabei müssen boatDrive/boatDriveText im
+	// Formular-State zurückgesetzt werden, damit keine versteckten
+	// Boot-Angaben unbeabsichtigt mit übermittelt werden. Beim initialen Mount
+	// (z.B. Admin-Edit einer bestehenden Land-Sichtung) darf das NICHT passieren,
+	// sonst geht ein gespeicherter boatDrive-Wert unsichtbar verloren.
+	$effect(() => {
+		const currentSightingFrom = $form.sightingFrom;
+
+		if (shouldResetBoatDrive(previousSightingFrom, currentSightingFrom)) {
+			if ($form.boatDrive !== undefined) {
+				updateField('boatDrive', undefined);
+			}
+			if ($form.boatDriveText !== undefined) {
+				updateField('boatDriveText', undefined);
+			}
+		}
+
+		previousSightingFrom = currentSightingFrom;
+	});
 </script>
 
 <!-- Sighting Details Section -->
@@ -19,14 +54,16 @@
 			</div>
 		{/if}
 	</div>
-	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
-		<FormField name="boatDrive" />
-		{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
-			<div transition:slide>
-				<FormField name="boatDriveText" />
-			</div>
-		{/if}
-	</div>
+	{#if showsBoatDrive}
+		<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1" transition:slide>
+			<FormField name="boatDrive" />
+			{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
+				<div transition:slide>
+					<FormField name="boatDriveText" />
+				</div>
+			{/if}
+		</div>
+	{/if}
 
 	<FormField name="distance" />
 </SectionCard>

--- a/src/lib/report/components/sections/boatDriveReset.test.ts
+++ b/src/lib/report/components/sections/boatDriveReset.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { NOT_YET_TRACKED, isBoatSightingFrom, shouldResetBoatDrive } from './boatDriveReset';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+
+/**
+ * Regressionstest für den stillen Datenverlust im Admin-Formular:
+ * Öffnet ein Admin eine bestehende Sichtung mit sightingFrom = Land/Fähre/Sonstiges,
+ * durfte boatDrive NICHT beim initialen Rendern (Mount) gelöscht werden, da das
+ * bestehende `boatDrive` sonst unsichtbar aus dem Formular-State verschwindet und
+ * beim Speichern durch eine falsche 0 ("Sonstiger Bootsantrieb") überschrieben wird.
+ */
+
+describe('isBoatSightingFrom', () => {
+	it('erkennt Segelschiff als Boot mit Antrieb', () => {
+		expect(isBoatSightingFrom(SightingFromEnum.SAILBOAT)).toBe(true);
+	});
+
+	it('erkennt Motorboot als Boot mit Antrieb', () => {
+		expect(isBoatSightingFrom(SightingFromEnum.MOTORBOAT)).toBe(true);
+	});
+
+	it('erkennt Land NICHT als Boot mit Antrieb', () => {
+		expect(isBoatSightingFrom(SightingFromEnum.LAND)).toBe(false);
+	});
+
+	it('ist robust gegenüber String-Werten aus HTML-Selects', () => {
+		expect(isBoatSightingFrom(String(SightingFromEnum.MOTORBOAT))).toBe(true);
+		expect(isBoatSightingFrom('3')).toBe(false);
+	});
+});
+
+describe('shouldResetBoatDrive', () => {
+	it('löst beim ersten Durchlauf (kein vorheriger Wert) mit Land KEINEN Reset aus', () => {
+		// Admin-Fall: Formular wird mit bestehenden Daten (sightingFrom = Land) gemountet.
+		expect(shouldResetBoatDrive(NOT_YET_TRACKED, SightingFromEnum.LAND)).toBe(false);
+	});
+
+	it('löst beim ersten Durchlauf (kein vorheriger Wert) mit Motorboot KEINEN Reset aus', () => {
+		expect(shouldResetBoatDrive(NOT_YET_TRACKED, SightingFromEnum.MOTORBOAT)).toBe(false);
+	});
+
+	it('löst beim Wechsel von Motorboot zu Land einen Reset aus', () => {
+		expect(shouldResetBoatDrive(SightingFromEnum.MOTORBOAT, SightingFromEnum.LAND)).toBe(true);
+	});
+
+	it('löst beim Wechsel von Segelschiff zu Fähre einen Reset aus', () => {
+		expect(shouldResetBoatDrive(SightingFromEnum.SAILBOAT, SightingFromEnum.FERRY)).toBe(true);
+	});
+
+	it('löst beim Wechsel von Land zu Motorboot KEINEN Reset aus (Feld wird sichtbar)', () => {
+		expect(shouldResetBoatDrive(SightingFromEnum.LAND, SightingFromEnum.MOTORBOAT)).toBe(false);
+	});
+
+	it('löst beim Wechsel zwischen zwei Nicht-Boot-Werten (Land -> Fähre) KEINEN erneuten Reset aus', () => {
+		expect(shouldResetBoatDrive(SightingFromEnum.LAND, SightingFromEnum.FERRY)).toBe(false);
+	});
+
+	it('ist robust bei String- vs. Number-Werten aus HTML-Selects (kein falscher Reset bei gleichem Wert)', () => {
+		expect(
+			shouldResetBoatDrive(SightingFromEnum.MOTORBOAT, String(SightingFromEnum.MOTORBOAT))
+		).toBe(false);
+		expect(
+			shouldResetBoatDrive(String(SightingFromEnum.MOTORBOAT), SightingFromEnum.MOTORBOAT)
+		).toBe(false);
+	});
+
+	it('erkennt einen echten Wechsel auch dann, wenn die Werte als String/Number gemischt vorliegen', () => {
+		expect(shouldResetBoatDrive('2', SightingFromEnum.LAND)).toBe(true);
+		expect(shouldResetBoatDrive(SightingFromEnum.SAILBOAT, '3')).toBe(true);
+	});
+});

--- a/src/lib/report/components/sections/boatDriveReset.ts
+++ b/src/lib/report/components/sections/boatDriveReset.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure Entscheidungslogik für den Bootsantrieb-Reset in SightingDetails.svelte.
+ *
+ * Hintergrund (Bugfix): `boatDrive`/`boatDriveText` dürfen nur zurückgesetzt
+ * werden, wenn der NUTZER `sightingFrom` aktiv von einem Boot mit Antrieb
+ * (Segelschiff/Motorboot) auf einen Nicht-Boot-Wert (Land/Fähre/Sonstiges)
+ * ändert. Beim initialen Mount mit bereits vorbefüllten Daten (z.B. im
+ * Admin-Edit-Formular für eine bestehende Land-Sichtung) darf KEIN Reset
+ * passieren, da sonst ein gespeicherter `boatDrive`-Wert unsichtbar aus dem
+ * Formular-State gelöscht und beim Speichern durch 0 ("Sonstiger
+ * Bootsantrieb") überschrieben wird.
+ */
+
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+
+/** Formularwert für "Sichtung erfolgte von" - String (HTML-Select) oder Number (Yup-Schema) */
+export type SightingFromValue = string | number | undefined | null;
+
+/** Sentinel: es wurde noch kein vorheriger `sightingFrom`-Wert beobachtet (initialer Mount). */
+export const NOT_YET_TRACKED = Symbol('sightingFrom:not-yet-tracked');
+
+/** Zustand des "zuletzt gesehenen" `sightingFrom`-Werts, inkl. Initialzustand. */
+export type TrackedSightingFromValue = typeof NOT_YET_TRACKED | SightingFromValue;
+
+/**
+ * Sichtung erfolgte von einem Boot mit Antrieb (Segelschiff/Motorboot) aus.
+ * String-Vergleich, damit sowohl Number- (Yup) als auch String-Werte
+ * (HTML-Select via bind:value) robust erkannt werden.
+ */
+export function isBoatSightingFrom(value: SightingFromValue): boolean {
+	return (
+		String(value) === String(SightingFromEnum.SAILBOAT) ||
+		String(value) === String(SightingFromEnum.MOTORBOAT)
+	);
+}
+
+/**
+ * Entscheidet, ob `boatDrive`/`boatDriveText` zurückgesetzt werden müssen.
+ *
+ * Reset nur beim ECHTEN Übergang "Boot mit Antrieb" -> "kein Boot mit Antrieb":
+ * - `previous` ist bereits bekannt (kein initialer Mount, siehe `NOT_YET_TRACKED`)
+ * - `previous` war ein Boot mit Antrieb
+ * - `next` ist KEIN Boot mit Antrieb (mehr)
+ *
+ * Alle anderen Fälle (initialer Mount, Wechsel zwischen zwei Nicht-Boot-Werten,
+ * Wechsel zu einem Boot-Wert) lösen bewusst KEINEN Reset aus.
+ */
+export function shouldResetBoatDrive(
+	previous: TrackedSightingFromValue,
+	next: SightingFromValue
+): boolean {
+	if (previous === NOT_YET_TRACKED) {
+		return false;
+	}
+
+	return isBoatSightingFrom(previous) && !isBoatSightingFrom(next);
+}

--- a/src/lib/report/components/sections/positionMethod.test.ts
+++ b/src/lib/report/components/sections/positionMethod.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { derivePositionMethod } from './positionMethod';
+
+/**
+ * Regressionstest für U10: Nach einem Reload aus der Session wiederhergestellte
+ * Formulardaten sollen die initiale Positionsmethode bestimmen, statt immer
+ * hart auf "Foto mit GPS" zu starten.
+ */
+describe('derivePositionMethod', () => {
+	it('liefert "photo" für ein komplett leeres Formular', () => {
+		expect(derivePositionMethod({})).toBe('photo');
+	});
+
+	it('liefert "map" wenn Breiten- und Längengrad als Zahlen vorliegen', () => {
+		expect(derivePositionMethod({ latitude: 54.5, longitude: 13.2 })).toBe('map');
+	});
+
+	it('liefert "map" wenn Koordinaten als Strings vorliegen (z.B. aus EXIF/handleChange)', () => {
+		expect(derivePositionMethod({ latitude: '54.5000', longitude: '13.2000' })).toBe('map');
+	});
+
+	it('liefert "manual" wenn kein GPS, aber das Fahrwasser ausgefüllt ist', () => {
+		expect(derivePositionMethod({ waterway: 'Kieler Bucht' })).toBe('manual');
+	});
+
+	it('liefert "manual" wenn kein GPS, aber das Seezeichen ausgefüllt ist', () => {
+		expect(derivePositionMethod({ seaMark: 'Leuchtturm Dahmeshöved' })).toBe('manual');
+	});
+
+	it('ignoriert reine Whitespace-Werte bei Fahrwasser/Seezeichen', () => {
+		expect(derivePositionMethod({ waterway: '   ', seaMark: '\t' })).toBe('photo');
+	});
+
+	it('bevorzugt "map" gegenüber vorhandenem Fahrwasser, wenn beides gesetzt ist', () => {
+		expect(
+			derivePositionMethod({ latitude: 54.5, longitude: 13.2, waterway: 'Kieler Bucht' })
+		).toBe('map');
+	});
+
+	it('liefert "photo" wenn nur eine der beiden Koordinaten vorhanden ist', () => {
+		expect(derivePositionMethod({ latitude: 54.5 })).toBe('photo');
+		expect(derivePositionMethod({ longitude: 13.2 })).toBe('photo');
+	});
+
+	it('ignoriert ungültige (nicht-numerische) Koordinaten-Strings', () => {
+		expect(derivePositionMethod({ latitude: 'abc', longitude: 'def' })).toBe('photo');
+	});
+
+	it('ignoriert nicht-string Werte bei Fahrwasser/Seezeichen', () => {
+		expect(derivePositionMethod({ waterway: undefined, seaMark: null })).toBe('photo');
+	});
+});

--- a/src/lib/report/components/sections/positionMethod.ts
+++ b/src/lib/report/components/sections/positionMethod.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure Ableitung der initialen Positionsmethode aus dem (ggf. aus der Session
+ * wiederhergestellten) Formularzustand.
+ *
+ * Hintergrund (U10): `PositionAndTime.svelte` hielt `positionMethod` bisher als
+ * reinen UI-State, der nach jedem Reload wieder auf "Foto mit GPS" zurückfiel —
+ * unabhängig davon, was der Nutzer zuvor über die Karte oder als Fahrwasser-
+ * Beschreibung eingegeben hatte (der Formularzustand selbst wird ja per
+ * sessionStorage wiederhergestellt, siehe `$lib/storage/localStorage.ts`).
+ *
+ * Diese Funktion wird EINMALIG beim Mount von `PositionAndTime.svelte`
+ * aufgerufen, um die initiale Anzeige aus dem bestehenden Formularzustand
+ * abzuleiten. Eine spätere manuelle Auswahl des Nutzers ruft diese Funktion
+ * nicht erneut auf und wird dadurch nie überschrieben.
+ *
+ * Regeln (in dieser Reihenfolge):
+ * 1. Echte GPS-Koordinaten vorhanden (Breiten- UND Längengrad) → "map" (Karte)
+ * 2. Keine Koordinaten, aber Fahrwasser oder Seezeichen ausgefüllt → "manual" (Beschreibung)
+ * 3. Sonst (leeres Formular) → "photo" (Standard/bevorzugte Methode)
+ */
+import { hasCoordinates } from '$lib/report/components/form/coordinateValue';
+
+export type PositionMethod = 'photo' | 'map' | 'manual';
+
+export interface PositionMethodFormValues {
+	latitude?: unknown;
+	longitude?: unknown;
+	waterway?: unknown;
+	seaMark?: unknown;
+}
+
+/** True, wenn der Wert ein nicht-leerer (getrimmter) String ist. */
+function isFilledText(value: unknown): boolean {
+	return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Leitet die initiale Positionsmethode aus den übergebenen Formularwerten ab.
+ * Reine Funktion ohne Svelte-/Store-Abhängigkeit — daher in Node testbar.
+ */
+export function derivePositionMethod(values: PositionMethodFormValues): PositionMethod {
+	if (hasCoordinates(values.latitude, values.longitude)) {
+		return 'map';
+	}
+
+	if (isFilledText(values.waterway) || isFilledText(values.seaMark)) {
+		return 'manual';
+	}
+
+	return 'photo';
+}

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -4,13 +4,11 @@
 -->
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
-	import { createLogger } from '$lib/logger';
-	import { USER_CONTACT_FIELDS } from '$lib/report/formConfig';
+	import { confirmAndClearContactData } from '$lib/report/clearContactData';
 	import { getFormContext } from '$lib/report/formContext';
-	import { clearUserContactData, loadUserContactData } from '$lib/storage/localStorage';
+	import { loadUserContactData } from '$lib/storage/localStorage';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 
-	const logger = createLogger('report:step4-contact');
 	const { form, updateField } = getFormContext();
 
 	// Check if user has saved contact data
@@ -22,17 +20,8 @@
 	});
 
 	function clearContactData() {
-		if (confirm('Sind Sie sicher, dass Sie alle gespeicherten Kontaktdaten löschen möchten?')) {
-			clearUserContactData();
+		if (confirmAndClearContactData($form, updateField)) {
 			hasSavedContactData = false;
-
-			// Clear contact fields in form state without page reload
-			for (const field of USER_CONTACT_FIELDS) {
-				const defaultValue = typeof $form[field] === 'boolean' ? false : '';
-				updateField(field, defaultValue);
-			}
-
-			logger.info('User contact data cleared by user request');
 		}
 	}
 </script>
@@ -60,148 +49,148 @@
 				Schritt 4 von 4 - Fast geschafft!
 			</div>
 		</div>
+	</div>
 
-		<!-- Personal Contact Information -->
-		<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-			<h3 class="mb-3 flex gap-2 text-left text-base font-semibold sm:text-lg">
-				<Icon icon="lucide:user" width="20" class="text-primary" />
-				Ihre Kontaktdaten
-			</h3>
-			<div class="text-base-content/70 mb-4 text-left text-sm">
-				<p class="mb-1 flex items-center gap-2 text-left font-medium">
-					<Icon icon="lucide:mail" width="16" class="text-primary" />
-					Ihre E-Mail-Adresse ist erforderlich für:
-				</p>
-				<ul class="list-inside list-disc space-y-1 text-left text-xs">
-					<li>Bestätigung Ihrer Sichtungsmeldung</li>
-					<li>Wichtige Rückfragen zur Datenqualität</li>
-					<li>Information über wissenschaftliche Ergebnisse (optional)</li>
-				</ul>
+	<!-- Personal Contact Information -->
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
+		<h3 class="mb-3 flex gap-2 text-base font-semibold sm:text-lg">
+			<Icon icon="lucide:user" width="20" class="text-primary" />
+			Ihre Kontaktdaten
+		</h3>
+		<div class="text-base-content/70 mb-4 text-sm">
+			<p class="mb-1 flex items-center gap-2 font-medium">
+				<Icon icon="lucide:mail" width="16" class="text-primary" />
+				Ihre E-Mail-Adresse ist erforderlich für:
+			</p>
+			<ul class="list-inside list-disc space-y-1 text-xs">
+				<li>Bestätigung Ihrer Sichtungsmeldung</li>
+				<li>Wichtige Rückfragen zur Datenqualität</li>
+				<li>Information über wissenschaftliche Ergebnisse (optional)</li>
+			</ul>
 
-				<div class="alert alert-info mt-4">
-					<div class="text-xs">
-						<p class="mb-2 flex items-center gap-2 font-medium">
-							<Icon icon="lucide:save" width="16" class="text-info" />
-							Automatische Speicherung für Komfort
-						</p>
-						<p>
-							Ihre Kontaktdaten werden nach erfolgreicher Übermittlung lokal gespeichert und bei der
-							nächsten Sichtungsmeldung automatisch ausgefüllt.
-						</p>
+			<div class="alert alert-info mt-4">
+				<div class="text-xs">
+					<p class="mb-2 flex items-center gap-2 font-medium">
+						<Icon icon="lucide:save" width="16" class="text-info" />
+						Automatische Speicherung für Komfort
+					</p>
+					<p>
+						Ihre Kontaktdaten werden nach erfolgreicher Übermittlung lokal gespeichert und bei der
+						nächsten Sichtungsmeldung automatisch ausgefüllt.
+					</p>
 
-						{#if hasSavedContactData}
-							<div class="mt-3 flex items-center justify-between">
-								<span class="text-success font-medium">✓ Gespeicherte Kontaktdaten gefunden</span>
-								<button
-									type="button"
-									class="btn btn-ghost btn-xs text-error hover:bg-error/10"
-									onclick={clearContactData}
-								>
-									<Icon icon="lucide:trash-2" width="14" />
-									Kontaktdaten löschen
-								</button>
-							</div>
-						{/if}
-					</div>
+					{#if hasSavedContactData}
+						<div class="mt-3 flex items-center justify-between">
+							<span class="text-success font-medium">✓ Gespeicherte Kontaktdaten gefunden</span>
+							<button
+								type="button"
+								class="btn btn-outline btn-error btn-sm min-h-11"
+								onclick={clearContactData}
+							>
+								<Icon icon="lucide:trash-2" width="14" />
+								Kontaktdaten löschen
+							</button>
+						</div>
+					{/if}
 				</div>
-			</div>
-
-			<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-				<FormField name="firstName" />
-				<FormField name="lastName" />
-			</div>
-
-			<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-				<FormField name="email" />
-
-				<FormField name="phone" />
-			</div>
-
-			<!-- Address (optional) -->
-			<details class="bg-base-100 collapse mt-4">
-				<summary class="collapse-title min-h-0 py-2 text-sm font-medium">
-					<span class="inline-flex items-center gap-1.5">
-						<Icon icon="lucide:map-pin" width="14" class="text-primary" />
-						Adresse (optional)
-					</span>
-				</summary>
-				<div class="collapse-content space-y-4 pt-4">
-					<FormField name="street" />
-
-					<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-						<FormField name="zipCode" />
-
-						<FormField name="city" />
-					</div>
-				</div>
-			</details>
-		</div>
-
-		<!-- Boat Information Section -->
-		<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-			<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
-				<Icon icon="lucide:anchor" width="20" class="text-primary" />
-				Boot-/Schiffsinformationen
-			</h3>
-
-			<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-				<FormField name="shipName" />
-
-				<FormField name="homePort" />
-			</div>
-
-			<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
-				<FormField name="boatType" />
 			</div>
 		</div>
 
-		<!-- Additional Information Section -->
-		<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-			<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
-				<Icon icon="lucide:message-square" width="20" class="text-primary" />
-				Zusätzliche Informationen
-			</h3>
-
-			<FormField name="notes" />
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+			<FormField name="firstName" />
+			<FormField name="lastName" />
 		</div>
 
-		<!-- Privacy and Consent Section -->
-		<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-			<h3 class="mb-3 flex gap-2 text-base font-semibold sm:text-lg">
-				<Icon icon="lucide:lock" width="20" class="text-primary" />
-				Datenschutz und Einverständnis
-			</h3>
+		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+			<FormField name="email" />
 
-			<!-- Optional Consents für Namensnennung -->
-			<div class="mt-6 space-y-4">
-				<h4 class="flex items-center gap-2 text-left text-base font-semibold">
-					<Icon icon="lucide:pen-line" width="16" class="text-primary" />
-					Optionale Veröffentlichung Ihres Namens
-				</h4>
-				<p class="text-base-content/70 mb-4 text-left text-sm">
-					Diese Einverständniserklärungen sind <strong>optional</strong>. Ihre Sichtung wird auch
-					ohne diese Zustimmungen gespeichert.
-				</p>
+			<FormField name="phone" />
+		</div>
 
-				<div class="space-y-3">
-					<FormField name="nameConsent" />
-					<FormField name="shipNameConsent" />
+		<!-- Address (optional) -->
+		<details class="bg-base-100 collapse mt-4">
+			<summary class="collapse-title min-h-0 py-2 text-sm font-medium">
+				<span class="inline-flex items-center gap-1.5">
+					<Icon icon="lucide:map-pin" width="14" class="text-primary" />
+					Adresse (optional)
+				</span>
+			</summary>
+			<div class="collapse-content space-y-4 pt-4">
+				<FormField name="street" />
+
+				<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<FormField name="zipCode" />
+
+					<FormField name="city" />
 				</div>
 			</div>
+		</details>
+	</div>
 
-			<!-- Persistent Data Storage Consent -->
-			<div class="mt-6 space-y-4">
-				<h4 class="text-left text-base font-semibold">
-					<Icon icon="lucide:save" width="16" class="inline" /> Dauerhafte Speicherung der Kontaktdaten
-				</h4>
-				<p class="text-base-content/70 mb-4 text-left text-sm">
-					Möchten Sie, dass Ihre Kontaktdaten auch nach dem Schließen des Browser-Fensters erhalten
-					bleiben? Dies erspart Ihnen das erneute Eingeben bei zukünftigen Sichtungsmeldungen.
-				</p>
+	<!-- Boat Information Section -->
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
+		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+			<Icon icon="lucide:anchor" width="20" class="text-primary" />
+			Boot-/Schiffsinformationen
+		</h3>
 
-				<div class="space-y-3">
-					<FormField name="persistentDataConsent" />
-				</div>
+		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+			<FormField name="shipName" />
+
+			<FormField name="homePort" />
+		</div>
+
+		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
+			<FormField name="boatType" />
+		</div>
+	</div>
+
+	<!-- Additional Information Section -->
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
+		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+			<Icon icon="lucide:message-square" width="20" class="text-primary" />
+			Zusätzliche Informationen
+		</h3>
+
+		<FormField name="notes" />
+	</div>
+
+	<!-- Privacy and Consent Section -->
+	<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 sm:p-4">
+		<h3 class="mb-3 flex gap-2 text-base font-semibold sm:text-lg">
+			<Icon icon="lucide:lock" width="20" class="text-primary" />
+			Datenschutz und Einverständnis
+		</h3>
+
+		<!-- Optional Consents für Namensnennung -->
+		<div class="mt-6 space-y-4">
+			<h4 class="flex items-center gap-2 text-base font-semibold">
+				<Icon icon="lucide:pen-line" width="16" class="text-primary" />
+				Optionale Veröffentlichung Ihres Namens
+			</h4>
+			<p class="text-base-content/70 mb-4 text-sm">
+				Diese Einverständniserklärungen sind <strong>optional</strong>. Ihre Sichtung wird auch ohne
+				diese Zustimmungen gespeichert.
+			</p>
+
+			<div class="space-y-3">
+				<FormField name="nameConsent" />
+				<FormField name="shipNameConsent" />
+			</div>
+		</div>
+
+		<!-- Persistent Data Storage Consent -->
+		<div class="mt-6 space-y-4">
+			<h4 class="text-base font-semibold">
+				<Icon icon="lucide:save" width="16" class="inline" /> Dauerhafte Speicherung der Kontaktdaten
+			</h4>
+			<p class="text-base-content/70 mb-4 text-sm">
+				Möchten Sie, dass Ihre Kontaktdaten auch nach dem Schließen des Browser-Fensters erhalten
+				bleiben? Dies erspart Ihnen das erneute Eingeben bei zukünftigen Sichtungsmeldungen.
+			</p>
+
+			<div class="space-y-3">
+				<FormField name="persistentDataConsent" />
 			</div>
 		</div>
 	</div>

--- a/src/lib/report/findStepForErrors.test.ts
+++ b/src/lib/report/findStepForErrors.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { findStepForErrors } from './findStepForErrors';
+import type { FormStep } from '$lib/types';
+
+/**
+ * Minimaler, aber realistischer Steps-Aufbau für die Tests — analog zu
+ * formStepsConfig (4 Schritte mit jeweils eigenen Feldern).
+ */
+const steps: FormStep[] = [
+	{
+		id: 'location-time',
+		title: 'Position & Zeit',
+		description: '',
+		fields: ['latitude', 'longitude', 'sightingDate']
+	},
+	{
+		id: 'sighting-details',
+		title: 'Sichtungsdetails',
+		description: '',
+		fields: ['species', 'totalCount']
+	},
+	{
+		id: 'observations',
+		title: 'Beobachtungen',
+		description: '',
+		fields: ['behavior', 'seaState']
+	},
+	{
+		id: 'contact',
+		title: 'Kontaktdaten',
+		description: '',
+		fields: ['firstName', 'lastName', 'email']
+	}
+];
+
+describe('findStepForErrors', () => {
+	it('liefert null, wenn die Fehler nur auf dem aktuellen Schritt liegen (kein Sprung nötig)', () => {
+		const result = findStepForErrors(['species', 'totalCount'], steps, 1);
+		expect(result).toBeNull();
+	});
+
+	it('springt zu Schritt 1 (Index 0), wenn dort ein Fehler liegt, während man auf Schritt 4 (Index 3) ist', () => {
+		const result = findStepForErrors(['latitude'], steps, 3);
+		expect(result).toBe(0);
+	});
+
+	it('wählt bei Fehlern über mehrere Schritte hinweg den frühesten betroffenen Schritt', () => {
+		// Fehler liegen auf Schritt 2 (Index 2) UND Schritt 1 (Index 0) — der frühere gewinnt
+		const result = findStepForErrors(['behavior', 'latitude'], steps, 3);
+		expect(result).toBe(0);
+	});
+
+	it('liefert null (sinnvoller Fallback), wenn nur ein unbekanntes Feld betroffen ist', () => {
+		const result = findStepForErrors(['einUnbekanntesFeld'], steps, 2);
+		expect(result).toBeNull();
+	});
+
+	it('ignoriert unbekannte Felder und springt trotzdem zum frühesten bekannten Schritt', () => {
+		const result = findStepForErrors(['einUnbekanntesFeld', 'species'], steps, 3);
+		expect(result).toBe(1);
+	});
+
+	it('liefert null bei einer leeren Fehlerliste', () => {
+		const result = findStepForErrors([], steps, 2);
+		expect(result).toBeNull();
+	});
+
+	it('liefert null, wenn der früheste betroffene Schritt zufällig der aktuelle ist, obwohl auch spätere Schritte Fehler haben', () => {
+		// Fehler auf Schritt 1 (aktuell) und Schritt 3 — Schritt 1 ist früher, also kein Sprung
+		const result = findStepForErrors(['species', 'firstName'], steps, 1);
+		expect(result).toBeNull();
+	});
+});

--- a/src/lib/report/findStepForErrors.ts
+++ b/src/lib/report/findStepForErrors.ts
@@ -1,0 +1,40 @@
+import type { FormStep } from '$lib/types';
+
+/**
+ * Bestimmt, zu welchem Schritt navigiert werden muss, wenn eine Validierung
+ * gegen das VOLLE Formular-Schema fehlschlägt (z.B. beim Absenden), während
+ * der Nutzer sich gerade auf einem anderen Schritt befindet.
+ *
+ * Liefert den Index des frühesten Schritts, der eines der übergebenen
+ * Fehlerfelder enthält. Liegt der früheste betroffene Schritt bereits auf
+ * `currentStep` (die Fehler sind also schon sichtbar), ist kein Sprung nötig
+ * → `null`. Felder, die keinem Schritt zugeordnet werden können, werden
+ * ignoriert; sind ausschließlich solche unbekannten Felder betroffen, gibt es
+ * kein sinnvolles Sprungziel → ebenfalls `null` (Fallback: auf dem aktuellen
+ * Schritt bleiben).
+ *
+ * Reine Funktion ohne Svelte-/Store-Abhängigkeit — leicht in Node testbar.
+ */
+export function findStepForErrors(
+	errorFields: string[],
+	steps: FormStep[],
+	currentStep: number
+): number | null {
+	let earliestStep: number | null = null;
+
+	for (const field of errorFields) {
+		const stepIndex = steps.findIndex((step) => step.fields.includes(field));
+		if (stepIndex === -1) {
+			continue;
+		}
+		if (earliestStep === null || stepIndex < earliestStep) {
+			earliestStep = stepIndex;
+		}
+	}
+
+	if (earliestStep === null || earliestStep === currentStep) {
+		return null;
+	}
+
+	return earliestStep;
+}

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -1,6 +1,6 @@
 /**
  * Modern whale sighting form configuration
- * Based on form-design.md recommendations for optimal user experience
+ * Richtlinien: docs/DESIGN_GUIDE.md, verbindliche Regeln: .claude/rules/design-system.md
  */
 
 import { sightingSchema } from '$lib/form/validation/sightingSchema';

--- a/src/lib/stores/configStore.test.ts
+++ b/src/lib/stores/configStore.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	PUBLIC_UPLOAD_ALLOWED_TYPES,
+	PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES
+} from '$lib/constants/uploadDefaults';
 
 vi.mock('$lib/logger', () => ({
 	createLogger: () => ({
@@ -78,14 +82,17 @@ describe('configStore', () => {
 			expect(config.accept).toBe('image/jpeg');
 		});
 
-		it('gibt Fallback zurück wenn fetch fehlschlägt', async () => {
+		it('gibt den restriktiven öffentlichen Fallback zurück wenn fetch fehlschlägt', async () => {
 			vi.mocked(fetch).mockRejectedValueOnce(new Error('Network error'));
 
 			const { getUploadConfig } = await import('./configStore');
 			const config = await getUploadConfig();
 
-			expect(config.allowedTypes).toContain('image/jpeg');
-			expect(config.maxFileSize).toBe(50 * 1024 * 1024);
+			// Der Fallback muss der öffentlichen Server-Konfiguration entsprechen,
+			// sonst nimmt die Dropzone Dateien an, die der Server ablehnt.
+			expect(config.allowedTypes).toEqual([...PUBLIC_UPLOAD_ALLOWED_TYPES]);
+			expect(config.maxFileSize).toBe(PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES);
+			expect(config.allowedTypes.some((type) => type.startsWith('video/'))).toBe(false);
 		});
 
 		it('gibt Fallback zurück bei HTTP-Fehler-Status', async () => {

--- a/src/lib/stores/configStore.ts
+++ b/src/lib/stores/configStore.ts
@@ -2,10 +2,29 @@
  * Client-side configuration store for dynamic settings
  */
 import { browser } from '$app/environment';
+import {
+	PUBLIC_UPLOAD_ACCEPT,
+	PUBLIC_UPLOAD_ALLOWED_TYPES,
+	PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES
+} from '$lib/constants/uploadDefaults';
 import { createLogger } from '$lib/logger';
 import type { ValidationPreset } from '$lib/types';
 
 const logger = createLogger('configStore');
+
+/**
+ * Fallback, wenn die Server-Konfiguration (noch) nicht vorliegt — bewusst die
+ * restriktive öffentliche Variante: Lieber clientseitig zu viel ablehnen als
+ * eine Datei annehmen, die der Server anschließend zurückweist.
+ */
+function publicUploadFallback(): ValidationPreset {
+	return {
+		allowedTypes: [...PUBLIC_UPLOAD_ALLOWED_TYPES],
+		maxFileSize: PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES,
+		maxFiles: 20,
+		accept: PUBLIC_UPLOAD_ACCEPT
+	};
+}
 
 // Cache for upload configuration
 let uploadConfigCache: ValidationPreset | null = null;
@@ -22,25 +41,20 @@ export async function getUploadConfig(): Promise<ValidationPreset> {
 	}
 
 	if (!browser) {
-		// Server-side fallback - return default values
-		return {
-			allowedTypes: ['image/jpeg', 'image/png', 'image/webp', 'video/mp4', 'video/quicktime'],
-			maxFileSize: 50 * 1024 * 1024, // 50MB in bytes
-			maxFiles: 20,
-			accept: 'image/*,video/*'
-		};
+		// Server-side rendering: noch kein Fetch möglich
+		return publicUploadFallback();
 	}
 
 	try {
 		logger.debug('Fetching upload configuration from server');
-		
+
 		const response = await fetch('/api/config/upload');
 		if (!response.ok) {
 			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 		}
 
 		const config = await response.json();
-		
+
 		// Transform server response to ValidationPreset format
 		const validationPreset: ValidationPreset = {
 			allowedTypes: config.allowedTypes,
@@ -52,29 +66,20 @@ export async function getUploadConfig(): Promise<ValidationPreset> {
 		// Update cache
 		uploadConfigCache = validationPreset;
 		uploadConfigCacheTimestamp = Date.now();
-		
+
 		logger.debug(
-			{ 
+			{
 				maxFileSizeMB: config.maxFileSize,
 				allowedTypes: config.allowedTypes.length
-			}, 
+			},
 			'Upload configuration loaded successfully'
 		);
-		
-		return validationPreset;
 
+		return validationPreset;
 	} catch (error) {
 		logger.error({ error }, 'Failed to fetch upload configuration, using fallback');
-		
-		// Return fallback configuration
-		const fallback: ValidationPreset = {
-			allowedTypes: ['image/jpeg', 'image/png', 'image/webp', 'video/mp4', 'video/quicktime'],
-			maxFileSize: 50 * 1024 * 1024, // 50MB in bytes
-			maxFiles: 20,
-			accept: 'image/*,video/*'
-		};
-		
-		return fallback;
+
+		return publicUploadFallback();
 	}
 }
 

--- a/src/lib/utils/fieldNavigation.svelte.test.ts
+++ b/src/lib/utils/fieldNavigation.svelte.test.ts
@@ -1,0 +1,105 @@
+/**
+ * `fieldNavigation.ts` ist reine DOM-Logik (kein Svelte-Import), braucht aber
+ * echtes `document`/`window` (siehe vitest.config.ts: von der Node-Coverage
+ * ausgeschlossen als "Browser-only utility"). Der `.svelte.test.ts`-Suffix
+ * routet diese Datei deshalb ins Browser-Test-Projekt (echter Chromium via
+ * Playwright), obwohl keine Svelte-Komponente gerendert wird.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { scrollToElement, scrollToStepHeader } from './fieldNavigation';
+
+/** Baut die für Step-Komponenten typische Struktur nach: Container > Step-Root > Header(Icon, h2, Badge) */
+function buildStepContainer(containerId: string): { header: HTMLElement; heading: HTMLElement } {
+	const container = document.createElement('div');
+	container.id = containerId;
+
+	const stepRoot = document.createElement('div'); // wie <div class="space-y-8"> in Step*.svelte
+	const header = document.createElement('div'); // "Step Header": Icon + h2 + p + Badge
+
+	const icon = document.createElement('div');
+	const heading = document.createElement('h2');
+	heading.textContent = 'Position & Zeit';
+	const badge = document.createElement('div');
+	badge.textContent = 'Schritt 1 von 4';
+
+	header.append(icon, heading, badge);
+	stepRoot.appendChild(header);
+	container.appendChild(stepRoot);
+	document.body.appendChild(container);
+
+	return { header, heading };
+}
+
+describe('scrollToElement', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+		vi.restoreAllMocks();
+	});
+
+	it('scrollt mit dem Default-Offset von -80 (Platz für die sticky Navbar)', () => {
+		const el = document.createElement('div');
+		document.body.appendChild(el);
+		vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ top: 500 } as DOMRect);
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+		scrollToElement(el);
+
+		expect(scrollSpy).toHaveBeenCalledWith({
+			top: 500 + window.scrollY - 80,
+			behavior: 'smooth'
+		});
+	});
+
+	it('erlaubt einen eigenen Offset statt des Defaults', () => {
+		const el = document.createElement('div');
+		document.body.appendChild(el);
+		vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({ top: 500 } as DOMRect);
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+		scrollToElement(el, -20);
+
+		expect(scrollSpy).toHaveBeenCalledWith({
+			top: 500 + window.scrollY - 20,
+			behavior: 'smooth'
+		});
+	});
+
+	it('tut nichts, wenn kein Element übergeben wird', () => {
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		scrollToElement(null);
+		expect(scrollSpy).not.toHaveBeenCalled();
+	});
+});
+
+describe('scrollToStepHeader', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+		vi.restoreAllMocks();
+	});
+
+	it('gibt null zurück und scrollt nicht, wenn der Container nicht existiert', () => {
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+		expect(scrollToStepHeader('does-not-exist')).toBeNull();
+		expect(scrollSpy).not.toHaveBeenCalled();
+	});
+
+	it('scrollt zum Eltern-Element der h2 (Icon+Badge-Block), nicht nur zum Container', () => {
+		const { header } = buildStepContainer('form-content');
+		vi.spyOn(header, 'getBoundingClientRect').mockReturnValue({ top: 300 } as DOMRect);
+		const scrollSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+		scrollToStepHeader('form-content');
+
+		expect(scrollSpy).toHaveBeenCalledWith({
+			top: 300 + window.scrollY - 80,
+			behavior: 'smooth'
+		});
+	});
+
+	it('gibt die h2 zurück, damit der Aufrufer sie fokussieren kann', () => {
+		const { heading } = buildStepContainer('form-content');
+		vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+		expect(scrollToStepHeader('form-content')).toBe(heading);
+	});
+});

--- a/src/lib/utils/fieldNavigation.ts
+++ b/src/lib/utils/fieldNavigation.ts
@@ -78,18 +78,62 @@ function findFieldElement(fieldName: string): HTMLElement | null {
 
 /**
  * Smoothly scrolls to an element with some offset for better UX
+ * @param element - Element to scroll into view, no-op if `null`
+ * @param yOffset - Offset in px added to the scroll target (negative = leave
+ * room above the element, e.g. for a fixed/sticky header). Defaults to -80.
  */
-export function scrollToElement(element: HTMLElement | null): void {
+export function scrollToElement(element: HTMLElement | null, yOffset = -80): void {
 	if (!element) {
 		return;
 	}
-	const yOffset = -80; // Offset to account for fixed headers
 	const elementTop = element.getBoundingClientRect().top + window.pageYOffset + yOffset;
 
 	window.scrollTo({
 		top: elementTop,
 		behavior: 'smooth'
 	});
+}
+
+/**
+ * Findet den "Kopf" eines Formular-Schritts (Icon + Überschrift + Badge)
+ * innerhalb des übergebenen Containers und scrollt gezielt dorthin — statt nur
+ * zum Container selbst.
+ *
+ * Hintergrund (U9): `#form-content` bleibt über einen Schrittwechsel hinweg
+ * dasselbe Element und enthält den kompletten neuen Schritt inklusive seines
+ * Kopfbereichs. Scrollen direkt zum Container ist daher zeitkritisch — läuft
+ * es VOR dem Re-Render des neuen Schritts, landet man mitten im (noch alten
+ * oder frisch angehängten, aber ungünstig hohen) Inhalt, statt am Kopf des
+ * neuen Schritts. Diese Funktion kapselt deshalb Suche UND Scroll in einem
+ * Aufruf, den der Aufrufer sicher NACH dem Re-Render (z.B. in
+ * `requestAnimationFrame`) ausführen kann.
+ *
+ * Sucht die `h2`-Überschrift im Container und nimmt deren Elternelement als
+ * Scrollziel — laut Konvention der Step-Komponenten (`Step1LocationTime.svelte`,
+ * `Step2SightingDetails.svelte`, ...) umschließt dieses Icon, Überschrift UND
+ * Badge gemeinsam. Fällt auf die `h2` selbst zurück, falls keine solche
+ * Eltern-Struktur existiert.
+ *
+ * @returns die gefundene Überschrift (`h2`), damit der Aufrufer sie z.B. für
+ * eine Screenreader-Ansage fokussieren kann, oder `null` wenn der Container
+ * nicht existiert.
+ */
+export function scrollToStepHeader(containerId: string, yOffset = -80): HTMLElement | null {
+	const container = document.getElementById(containerId);
+	if (!container) {
+		return null;
+	}
+
+	const heading = container.querySelector('h2');
+	if (!heading) {
+		scrollToElement(container, yOffset);
+		return null;
+	}
+
+	const headerBlock = (heading.parentElement as HTMLElement | null) ?? heading;
+	scrollToElement(headerBlock, yOffset);
+
+	return heading;
 }
 
 /**
@@ -112,10 +156,7 @@ function focusElement(element: HTMLElement): void {
 /**
  * Gets a user-friendly error message from field errors (internal use only)
  */
-function _getErrorMessage(
-	errors: Record<string, string | string[]>,
-	fieldName: string
-): string {
+function _getErrorMessage(errors: Record<string, string | string[]>, fieldName: string): string {
 	const error = errors[fieldName];
 
 	// Handle array of errors (multiple validation rules failed)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,7 +3,6 @@
   Meldeformular für Meerestier-Sichtungen in der Ostsee
 -->
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { createLogger } from '$lib/logger';
 	import ModernReportForm from '$lib/report/components/ModernReportForm.svelte';
 	import SubmissionSuccess from '$lib/report/components/SubmissionSuccess.svelte';
@@ -24,14 +23,6 @@
 		// Simulate successful submission
 		submissionSuccess = true;
 		submittedData = formData;
-	}
-
-	/**
-	 * Handle form cancellation
-	 */
-	function handleCancel() {
-		logger.info('Form cancelled');
-		goto('/');
 	}
 
 	/**
@@ -81,7 +72,7 @@
 		{#if submissionSuccess && submittedData}
 			<SubmissionSuccess {submittedData} {handleNewReport} />
 		{:else}
-			<ModernReportForm onSubmit={handleSubmit} onCancel={handleCancel} />
+			<ModernReportForm onSubmit={handleSubmit} />
 		{/if}
 	</div>
 </div>

--- a/src/routes/api/config/upload/+server.ts
+++ b/src/routes/api/config/upload/+server.ts
@@ -1,3 +1,9 @@
+import {
+	PUBLIC_UPLOAD_ACCEPT,
+	PUBLIC_UPLOAD_ALLOWED_TYPES,
+	PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES,
+	PUBLIC_UPLOAD_MAX_FILE_SIZE_MB
+} from '$lib/constants/uploadDefaults';
 import { createLogger } from '$lib/logger.server';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { ServerConfigService } from '$lib/services/configService';
@@ -6,12 +12,13 @@ import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:config:upload');
 
-// Public configuration for anonymous users
+// Public configuration for anonymous users — shared with the client fallbacks
+// in $lib/stores/configStore so both sides can never drift apart.
 const PUBLIC_UPLOAD_CONFIG = {
-	maxFileSize: 10, // 10 MB
-	maxFileSizeBytes: 10 * 1024 * 1024,
-	allowedTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
-	accept: 'image/jpeg,image/png,image/gif,image/webp'
+	maxFileSize: PUBLIC_UPLOAD_MAX_FILE_SIZE_MB,
+	maxFileSizeBytes: PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES,
+	allowedTypes: [...PUBLIC_UPLOAD_ALLOWED_TYPES],
+	accept: PUBLIC_UPLOAD_ACCEPT
 };
 
 export const GET: RequestHandler = async ({ setHeaders, locals, request, getClientAddress }) => {

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2280,13 +2280,17 @@ components:
 
     SightingFormData:
       type: object
-      description: Formulardaten für neue oder geänderte Sichtung
+      description: >
+        Formulardaten für neue oder geänderte Sichtung.
+
+
+        Ortsangabe: Entweder GPS-Koordinaten (`latitude` + `longitude`, dann
+        `hasPosition: true`) ODER eine Beschreibung des Seegebiets (`waterway`).
+        Fehlen beide, wird die Sichtung mit VALIDATION_ERROR abgelehnt.
       required:
         - sightingDate
         - species
         - totalCount
-        - latitude
-        - longitude
         - email
       properties:
         sightingDate:
@@ -2296,9 +2300,9 @@ components:
           example: "2024-01-01T14:30:00Z"
         species:
           type: integer
-          description: Tierart
-          minimum: 1
-          example: 1
+          description: "Tierart (0 = Schweinswal, siehe /rest_sichtungen/antworten.json)"
+          minimum: 0
+          example: 0
         totalCount:
           type: integer
           description: Gesamtanzahl der Tiere
@@ -2316,17 +2320,24 @@ components:
           enum: [0, 1]
           default: 0
           example: 0
+        hasPosition:
+          type: boolean
+          description: >
+            Gibt an, ob GPS-Koordinaten vorliegen. Bei `true` sind `latitude`
+            und `longitude` Pflicht, bei `false` stattdessen `waterway`.
+          default: false
+          example: true
         latitude:
           type: number
           format: float
-          description: Breitengrad
+          description: "Breitengrad (Pflicht, wenn hasPosition = true)"
           minimum: -90
           maximum: 90
           example: 54.3233
         longitude:
           type: number
           format: float
-          description: Längengrad
+          description: "Längengrad (Pflicht, wenn hasPosition = true)"
           minimum: -180
           maximum: 180
           example: 13.0814
@@ -2344,7 +2355,7 @@ components:
         waterway:
           type: string
           nullable: true
-          description: Gewässer
+          description: "Gewässer/Seegebiet (Pflicht, wenn keine GPS-Position vorliegt)"
           maxLength: 255
           example: "Greifswalder Bodden"
         firstName:


### PR DESCRIPTION
## Zusammenfassung

- **Datenqualität:** Das Sichtungsformular hatte Schema-Defaults, die eine Position vortäuschten (`latitude: 54.5`, `longitude: 13.5`, `hasPosition: true`). Ein leeres Formular galt damit als gültig, bestätigte „Die Koordinaten liegen innerhalb der Ostsee" und lud Wetterdaten für eine Position, die niemand eingegeben hatte. Wer keine Position angab, meldete unbemerkt eine Sichtung mitten in der Ostsee.
- **Formular-UX:** Fehler erschienen beim Betreten eines Schritts statt nach einem Versuch, der Weiter-Button war deaktiviert (wodurch die vorhandene Fehler-Navigation toter Code war), und ein Absenden mit Schema-Fehler passierte still.
- **Barrierefreiheit:** Weißer Text auf hellem Warn-Tint (gemessen **1,3:1**) mitten in den Verhaltensregeln zu Totfunden.

Grundlage ist ein vollständiger UX- und Design-System-Review: `docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md` (enthält alle Befunde mit Status).

## Änderungen

**Datenqualität**
- [x] `latitude`/`longitude`/`species` ohne Default, `hasPosition` default `false`
- [x] `waterway` ist Pflicht, solange keine GPS-Position vorliegt
- [x] `hasPosition` nur bei echten Koordinaten; Entfernen des GPS-Fotos nimmt ausschließlich die daraus gesetzten Werte zurück
- [x] `boatDrive` nur noch Pflicht bei Segelschiff/Motorboot (deutsche Meldung statt englischem Yup-Fallback); der Reset läuft nicht mehr beim Mount und überschreibt keine Bestandsdaten im Admin

**Formular-UX**
- [x] Fehler erst nach gescheitertem „Weiter"; Button bleibt klickbar und löst Toast + Sprung zum Fehlerfeld aus
- [x] Fehlgeschlagenes Absenden führt zum frühesten betroffenen Schritt statt still zu verpuffen
- [x] Fahrwasser in allen Positionsmethoden erreichbar; Karte startet über der Ostsee, ohne die Koordinatenfelder vorzubefüllen
- [x] Positionsmethode wird beim Mount aus dem Formularzustand abgeleitet
- [x] Grüne Haken nur an vom Nutzer berührten Feldern (`touched`-Store)
- [x] Wirkungsloser Abbrechen-Button entfernt, „Kontaktdaten löschen" konsolidiert, Button-Hierarchie vereinheitlicht, Schritt-4-Markup entschachtelt

**Barrierefreiheit**
- [x] Kontrast im Totfund-Block und in FormHelp: 1,3:1 → **15,1:1**; dekoratives Icon mit `aria-hidden`
- [x] Pflicht-Markierung und `aria-required` aus derselben Quelle, inkl. Override für konditionale Pflichtfelder
- [x] Wirkungslose `animate-in`-Klassen entfernt (kein Animations-Plugin installiert)

**Inhalt, Konfiguration, Doku**
- [x] Vier unbelegte Statistiken aus Feld-Tooltips entfernt (siehe „Offene Frage")
- [x] Upload-Fallback deckt sich mit der öffentlichen Server-Konfiguration (vorher Videos/50 MB versprochen, Server erlaubt anonym Bilder/10 MB)
- [x] OpenAPI: `latitude`/`longitude` nicht mehr pauschal Pflicht, „Position oder Fahrwasser" dokumentiert, `species: minimum 0`
- [x] `docs/DESIGN_GUIDE.md` ersetzt (enthielt erfundene Metriken, nicht existierende CSS-Regeln und einen behaupteten Service Worker), neue verbindliche `.claude/rules/design-system.md`, A11y-Prüfschritt in `/review` und `/prepare-pr`

## Testplan

- [x] `npm run test:quick` — ESLint, Type-Check, Svelte-Check, Unit-Tests
- [x] **1703 Unit-Tests** grün (100 Dateien)
- [x] **80 Browser-Komponententests** grün
- [x] **86 E2E-Tests** grün, 1 übersprungen (DB-gebundener Submit-Test, `test.skip` ohne `DATABASE_POSTGRES_URL`)
- [x] `svelte-check`: 0 Fehler / 0 Warnungen, ESLint: 0 Fehler
- [x] Manuell im Browser geprüft: leeres Formular kommt nicht mehr durch Schritt 1, Fahrwasser-Fallback in allen Methoden, leere Koordinatenfelder in der Kartenmethode, Bootsantrieb bei „Land" ausgeblendet, Kontrast im Totfund-Block nachgerechnet
- [ ] Review der geänderten Nutzertexte (siehe unten)

**Hinweis für Reviewer:** Die E2E-Helper (`e2e/helpers/form-helpers.ts`) kodierten die alten Defaults und waren nach der Schema-Änderung rot — sie wurden an das neue Verhalten angepasst, nicht aufgeweicht. Bei künftigen Änderungen an Formular-Schema oder Validierung bitte die Playwright-Suite als Abnahme mitlaufen lassen; Unit-Tests allein decken das nicht ab.

## Offene Frage an das Fachteam

In den Feld-Tooltips standen vier Zahlen ohne Quelle: „73 % der Schweinswalsichtungen erfolgen morgens zwischen 6–10 Uhr", „bei ruhiger See werden 5x mehr Tiere entdeckt … 89 % erfahrener Beobachter geben diese Information an", „Nordwinde erhöhen die Sichtungswahrscheinlichkeit um 40 %", „Elektromotoren ermöglichen 60 % mehr Sichtungen". Das ist dieselbe Familie wie das in #558 entfernte „wird mit 2.847 anderen Sichtungen verglichen". Die Zahlen sind entfernt und durch nachprüfbare Aussagen ersetzt — **falls belegte Werte existieren, gehören sie mit Quelle zurück.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)