### PR TITLE
test(a11y): add e2e regression test for form field focus indicator

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -116,6 +116,21 @@ Komponenten gegen-patchen:
 Ein `alert-soft` zusätzlich zu setzen ist überflüssig; die Klassen `alert-info`,
 `alert-success`, `alert-warning`, `alert-error` liefern den Soft-Look bereits.
 
+> **Zum Fokus-Override:** DaisyUI setzt für dieselben Felder ein eigenes
+> `outline: 2px solid var(--input-color)` (= `--color-base-content`) innerhalb von
+> `@layer utilities`. Der projekteigene Block in `app.css` steht ungelayert und
+> gewinnt deshalb die Kaskade — unabhängig davon, dass die globale
+> `:focus-visible`-Regel weiter unten in der Datei steht (die ist mit `(0,1,0)`
+> weniger spezifisch als `.input:focus` mit `(0,2,0)`). Abgesichert ist das durch
+> `e2e/form-a11y.spec.ts` → „Accessibility — Fokus-Indikator"; ein reiner Test über
+> die CSS-Quelle würde eine Regression hier nicht bemerken.
+>
+> **Fallstrick beim Nachmessen:** `:focus` greift nur, wenn das Browserfenster den
+> Fokus hat. Ein `getComputedStyle`-Sample aus einem unfokussierten Fenster (z. B.
+> Browser-Automation ohne echten Klick) liefert stattdessen DaisyUIs 2px und
+> `currentColor` (= `--color-base-content`) und sieht fälschlich nach einem Bug aus.
+> Vor dem Messen `document.hasFocus() === true` prüfen.
+
 > **Zum Alert-Override:** DaisyUI 5 kennt `alert-soft` nur als Modifier-Klasse pro
 > Element. Einen offiziellen Weg, den Soft-Look global zum Default zu machen — etwa
 > eine Theme-Variable oder Plugin-Option — gibt es bis einschließlich **5.7.4**

--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -122,7 +122,7 @@ Ein `alert-soft` zusätzlich zu setzen ist überflüssig; die Klassen `alert-inf
 > gewinnt deshalb die Kaskade — unabhängig davon, dass die globale
 > `:focus-visible`-Regel weiter unten in der Datei steht (die ist mit `(0,1,0)`
 > weniger spezifisch als `.input:focus` mit `(0,2,0)`). Abgesichert ist das durch
-> `e2e/form-a11y.spec.ts` → „Accessibility — Fokus-Indikator"; ein reiner Test über
+> `e2e/form-a11y.spec.ts` → „Accessibility — Fokus-Indikator“; ein reiner Test über
 > die CSS-Quelle würde eine Regression hier nicht bemerken.
 >
 > **Fallstrick beim Nachmessen:** `:focus` greift nur, wenn das Browserfenster den

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -159,9 +159,12 @@ async function readFocusIndicator(field: Locator) {
 	return field.evaluate((el) => {
 		// `--color-primary` über ein Probe-Element auflösen, damit Soll- und
 		// Ist-Farbe durch dieselbe Browser-Serialisierung laufen (oklch(...)).
+		// Das Element hängt an `document.body` (die Variable kommt vom Theme-Root)
+		// und ist layout-neutral — es darf das Formular-DOM nicht beeinflussen.
 		const probe = document.createElement('span');
-		probe.style.color = 'var(--color-primary)';
-		(el.parentElement ?? document.body).appendChild(probe);
+		probe.style.cssText =
+			'position:fixed;top:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;color:var(--color-primary)';
+		document.body.appendChild(probe);
 		const primary = getComputedStyle(probe).color;
 		probe.remove();
 

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Locator } from '@playwright/test';
 import { FormPage } from './pages/FormPage';
-import { fillStep1, expectCurrentStep } from './helpers/form-helpers';
+import { fillStep1, fillStep2, expectCurrentStep } from './helpers/form-helpers';
 
 // ── Phase 5A: FormSteps Indicator ──────────────────────────────────────────
 
@@ -135,5 +135,131 @@ test.describe('Accessibility — Keyboard Navigation', () => {
 		// Buttons should have aria-labels
 		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeVisible();
 		await expect(page.getByRole('button', { name: /Vorheriger Schritt/i })).toBeVisible();
+	});
+});
+
+// ── Phase 5D: Fokus-Indikator auf Formularfeldern ──────────────────────────
+
+/**
+ * Schützt den Override `.input/.select/.textarea:focus` aus `src/app.css`
+ * (3px-Outline in `--color-primary`, siehe `.claude/rules/daisyui.md`).
+ *
+ * Der Test muss im echten Browser laufen: DaisyUI setzt für dieselben Felder
+ * ein eigenes `outline: 2px solid var(--input-color)` (= `--color-base-content`)
+ * innerhalb von `@layer utilities`. Dass der projekteigene, ungelayerte Override
+ * gewinnt, ergibt sich erst aus der vollständigen Kaskade des gebauten CSS —
+ * ein Unit-Test über die CSS-Quelle würde eine Regression hier nicht bemerken.
+ *
+ * Achtung bei manueller Nachprüfung: `:focus` greift nur, wenn das Browser-
+ * fenster den Fokus hat. Ein `getComputedStyle`-Sample aus einem unfokussierten
+ * Fenster liefert stattdessen DaisyUIs 2px und `currentColor`
+ * (= `--color-base-content`) und sieht fälschlich nach einem Bug aus.
+ */
+async function readFocusIndicator(field: Locator) {
+	return field.evaluate((el) => {
+		// `--color-primary` über ein Probe-Element auflösen, damit Soll- und
+		// Ist-Farbe durch dieselbe Browser-Serialisierung laufen (oklch(...)).
+		const probe = document.createElement('span');
+		probe.style.color = 'var(--color-primary)';
+		(el.parentElement ?? document.body).appendChild(probe);
+		const primary = getComputedStyle(probe).color;
+		probe.remove();
+
+		const style = getComputedStyle(el);
+		return {
+			width: style.outlineWidth,
+			style: style.outlineStyle,
+			color: style.outlineColor,
+			offset: style.outlineOffset,
+			boxShadow: style.boxShadow,
+			primary,
+			focusVisible: el.matches(':focus-visible')
+		};
+	});
+}
+
+/**
+ * Gepollt, weil `BaseSelect` und `BaseTextarea` `transition-all duration-200`
+ * setzen: `outline-offset` wird dadurch mit-animiert und ist unmittelbar nach
+ * dem Fokussieren noch `0px`. Ein einmaliges `getComputedStyle` würde je nach
+ * Timing den Zwischenwert sehen.
+ */
+async function expectPrimaryFocusRing(field: Locator) {
+	await expect
+		.poll(async () => {
+			const indicator = await readFocusIndicator(field);
+			return {
+				style: indicator.style,
+				width: indicator.width,
+				offset: indicator.offset,
+				// Farbe muss `--color-primary` sein — nicht DaisyUIs `--color-base-content`
+				colorIsPrimary: indicator.color === indicator.primary,
+				// Zusätzlicher 4px-Ring aus demselben Regelblock; DaisyUIs
+				// Fokus-Regel setzt an dieser Stelle einen 1px-Inset-Schatten.
+				hasOuterRing: indicator.boxShadow.includes('0px 0px 0px 4px')
+			};
+		})
+		.toEqual({
+			style: 'solid',
+			width: '3px',
+			offset: '2px',
+			colorIsPrimary: true,
+			hasOuterRing: true
+		});
+}
+
+test.describe('Accessibility — Fokus-Indikator', () => {
+	test('Text-Input zeigt bei Tastatur-Fokus den 3px-Primary-Ring', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		const field = page.locator('[data-testid="field-waterway"]');
+		// Shift+Tab und zurück → echter Tastatur-Fokus (setzt :focus-visible),
+		// ohne die Tab-Stopps ab Seitenanfang abzählen zu müssen.
+		await field.focus();
+		await page.keyboard.press('Shift+Tab');
+		await page.keyboard.press('Tab');
+		await expect(field).toBeFocused();
+
+		expect((await readFocusIndicator(field)).focusVisible).toBe(true);
+		await expectPrimaryFocusRing(field);
+	});
+
+	test('Select zeigt denselben Fokus-Ring', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		const field = page.locator('[data-testid="field-species"]');
+		await field.focus();
+		await expect(field).toBeFocused();
+
+		await expectPrimaryFocusRing(field);
+	});
+
+	test('Textarea zeigt denselben Fokus-Ring', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// `notes` steht auf Schritt 4 (Kontaktdaten), nicht auf "Beobachtungen".
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Beobachtungen/i);
+
+		await formPage.skipStep();
+		await expectCurrentStep(page, /Kontaktdaten/i);
+
+		const field = page.locator('[data-testid="field-notes"]');
+		await field.focus();
+		await expect(field).toBeFocused();
+
+		await expectPrimaryFocusRing(field);
 	});
 });


### PR DESCRIPTION
Follow-up to the focus-indicator investigation raised alongside #566. **No behaviour change** — the 3px primary focus indicator was verified to work correctly; the original report turned out to be a measurement artifact. This PR adds the regression test that was missing.

## Why an E2E test

The indicator is a project override in `src/app.css`:

```css
.input:focus, .select:focus, .textarea:focus {
	outline: 3px solid var(--color-primary);
	outline-offset: 2px;
	box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-primary) 20%, transparent);
}
```

daisyUI 5 sets a competing `outline: 2px solid var(--input-color)` (= `--color-base-content`) for the same elements inside `@layer utilities`. Our rule wins **only** because it is emitted unlayered, which beats every layered rule. That is a property of the fully built CSS cascade, so a test over the CSS source would not notice a regression — hence a real browser.

## What is asserted

For `.input` (step 1), `.select` (step 2) and `.textarea` (step 4): outline width, style, colour and offset, plus the accompanying 4px ring. The colour is compared against `--color-primary` resolved through a probe element, so both sides go through the same browser serialisation instead of hard-coding an `oklch()` string.

## Verified to have teeth

With the `app.css` block removed, all three tests fail — the indicator falls back to 2px with no ring:

```
- "hasOuterRing": true      + "hasOuterRing": false
- "width": "3px"            + "width": "2px"
```

## Notes

- Assertions are polled: `BaseSelect` and `BaseTextarea` carry `transition-all duration-200`, which animates `outline-offset`, so an immediate `getComputedStyle` catches `0px` mid-transition.
- `.claude/rules/daisyui.md` gains the cascade rationale and a warning that `:focus` must never be sampled from an unfocused browser window — that is exactly what produced the original false alarm (an unfocused window reports daisyUI's 2px and `currentColor`, i.e. `--color-base-content`).
- Theme colour values are untouched.

`e2e/form-a11y.spec.ts`: 11/11 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)