### PR TITLE
fix(report): erfundene Statistiken aus Bürgertexten entfernen

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -103,3 +103,28 @@ Vor der Nutzung einer Utility prüfen, ob sie im Setup überhaupt existiert.
 ## Zahlen in Nutzertexten nur mit Quelle
 
 Hilfetexte und Tooltips (`meta.helpText` / `meta.valueText` im Yup-Schema) werden Bürgern als Aussage eines Forschungsmuseums präsentiert. Statistische Behauptungen ohne belegte Quelle gehören dort nicht hinein — im Zweifel die Aussage qualitativ formulieren („Bei ruhiger See sind Tiere leichter zu entdecken") statt eine Zahl zu erfinden.
+
+**Durchgesetzt durch `src/lib/form/validation/sightingSchemaClaims.test.ts`.** Der Test schlägt fehl, sobald ein `valueText` eine Zahl enthält, die nicht in `REVIEWED_NUMERIC_TEXTS` mit Quelle hinterlegt ist. Eine neue Zahl einzubauen erzwingt also, die Herkunft zu dokumentieren.
+
+### Was konkret nicht geht
+
+| Muster              | Beispiel (entfernt)                                 | Problem                                         |
+| ------------------- | --------------------------------------------------- | ----------------------------------------------- |
+| Erfundene Statistik | „73% der Sichtungen erfolgen morgens"               | Eigene DB sagt 10,6 % — widerlegt               |
+| Erfundene Stückzahl | „47 neue Verhaltensweisen dokumentiert"             | Nicht belegbar                                  |
+| Fremde Institution  | „für den IPCC-Meeresspiegel-Report verwendet"       | Frei erfunden, beschädigt fremden Ruf mit       |
+| Verwertungszusage   | „Ihre Fotos werden in Publikationen verwendet"      | Kann die Plattform nicht garantieren → „können" |
+| Superlativ          | „die präziseste Methode für Populationsschätzungen" | Nicht belegbar                                  |
+
+### Wenn eine Zahl belegt ist
+
+Quelle im Text erkennbar machen, nicht als nackte Prozentzahl:
+
+```ts
+// gut — Herkunft steht im Satz, Eintrag in REVIEWED_NUMERIC_TEXTS begründet ihn
+valueText: 'einzelne Schiffe melden laut unserer Sichtungsdatenbank seit über 20 Jahren immer wieder Sichtungen';
+```
+
+### Grenze der eigenen Datenbasis
+
+Die Tabelle `sichtungen` enthält **nur positive Meldungen, keinen Beobachtungsaufwand und keine Nullbeobachtungen**. Aussagen der Form „bei Bedingung X werden N-mal mehr Tiere entdeckt" lassen sich daraus grundsätzlich nicht ableiten — dafür wäre bekannter Suchaufwand nötig. Auch die zeitliche Verteilung der Meldungen bildet primär den Rhythmus der Beobachtenden ab (Mittagsgipfel 11–14 Uhr), nicht den der Tiere.

--- a/docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md
+++ b/docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md
@@ -1,0 +1,163 @@
+# Faktencheck Formulartexte — 2026-07-27
+
+Prüfung aller Zahlen- und Institutionsangaben, die Bürger:innen im Sichtungsformular
+angezeigt werden. Anlass: In PR #558 und #567 wurden erfundene Statistiken entfernt;
+zu klären war, ob es für die Aussagen belegte Zahlen gibt und ob weitere Fälle existieren.
+
+**Ergebnis in einem Satz:** Keine der beanstandeten Zahlen ist belegbar — eine ist durch
+die eigene Datenbank sogar widerlegt — und die Ursache der ganzen Serie wurde gefunden:
+hartkodierte Platzhalter-Statistiken in `FormHelp.svelte`.
+
+---
+
+## 1. Prüfung gegen die eigene Datenbank
+
+| Aussage                                 | Behauptet | Tatsächlich (DB, 19.877 Sichtungen)       | Ergebnis                   |
+| --------------------------------------- | --------- | ----------------------------------------- | -------------------------- |
+| Schweinswalsichtungen morgens 6–10 Uhr  | 73 %      | **10,6 %**                                | **widerlegt**              |
+| Schiffe melden seit … Jahren regelmäßig | 15 Jahre  | **22,8 Jahre** (PENNY LANE, 95 Meldungen) | **belegt, war zu niedrig** |
+
+Die tatsächliche Verteilung der Schweinswalsichtungen hat ihren Gipfel **mittags**
+(11–14 Uhr ≈ 44 %), nicht morgens:
+
+| Stunde | 11     | 12     | 13     | 14     | 15    |
+| ------ | ------ | ------ | ------ | ------ | ----- |
+| Anteil | 11,1 % | 11,4 % | 11,2 % | 10,4 % | 8,8 % |
+
+Das bildet den Rhythmus der **Beobachtenden** ab, nicht den der Tiere.
+
+### Methodische Grenze — wichtig für künftige Aussagen
+
+Die Tabelle `sichtungen` enthält **nur positive Meldungen**. Es gibt keine Tabelle für
+Beobachtungsaufwand und keine Nullbeobachtungen (geprüft: nur `sichtungen`,
+`sichtungen_dateien`, `app_config`, `audit_logs`).
+
+Daraus folgt: Aussagen der Form „bei Bedingung X werden N-mal mehr Tiere entdeckt"
+lassen sich aus dieser Datenbasis **grundsätzlich nicht** ableiten — dafür müsste bekannt
+sein, wie oft unter Bedingung X _vergeblich_ geschaut wurde. Alle vier ursprünglich
+beanstandeten Aussagen sind von dieser Art.
+
+---
+
+## 2. Prüfung gegen die Literatur
+
+| #   | Aussage                                     | Ergebnis                                                                                             |
+| --- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1   | 73 % morgens                                | **Keine Quelle, Muster gegenteilig** — Schweinswale sind akustisch v. a. nachtaktiv                  |
+| 2   | 5× mehr Tiere bei ruhiger See               | Effekt **qualitativ gut belegt**, Faktor 5 nicht                                                     |
+| 3   | Nordwind +40 %                              | **Keine Quelle.** Windrichtung taucht in Habitatmodellen nicht als Prädiktor auf                     |
+| 4   | Elektromotoren +60 % Sichtungen             | **Keine Quelle — und fachlich fragwürdig** (s. u.)                                                   |
+| 5   | Boot 3× bessere Entdeckungsrate als Land    | **Keine Quelle**, Literatur zeigt Gegenbeispiele in beide Richtungen                                 |
+| 6   | Wale tauchen bei Wind länger/seltener auf   | **Keine Quelle** für Verhaltensänderung; belegt ist nur schlechtere Sichtbarkeit                     |
+| 7   | Distance Sampling = „präziseste Methode"    | **Überzogen**, korrekt: etabliertes Standardverfahren                                                |
+| 8   | IPCC-Meeresspiegel-Report                   | **Frei erfunden.** Einen solchen Report gibt es nicht; der IPCC verarbeitet keine Sichtungsmeldungen |
+| 9   | Daten fließen in EU-Meeresschutzrichtlinien | **Qualitativ belegt**, aber differenziert (s. u.)                                                    |
+
+**Zu 2 (Seegang):** Belegbar über Teilmann (2003), _J. Cetacean Res. Manage._ 5(1),
+DOI 10.47536/jcrm.v5i1.830 — signifikanter Effekt bereits zwischen Seastate 0–3. Konkrete
+Zahlen bei Gilles et al. (2023), SCANS-IV, Tab. 5: effektive Suchbreite 167 m (gute
+Bedingungen) vs. 114 m (mäßig), g(0) 0,415 vs. 0,298.
+
+**Zu 4 (Antrieb):** Smith et al. (2026), _JASA_ 159(3), 2388–2397 — Elektroantriebe sind
+breitbandig leiser, erzeugen aber hochfrequente tonale Komponenten **genau im besten
+Hörbereich des Schweinswals**. „Elektro = mehr Sichtungen" wäre also nicht nur unbelegt,
+sondern potenziell irreführend. Belegt ist dagegen die Störwirkung von Bootslärm generell:
+Wisniewska et al. (2018), _Proc. R. Soc. B_ 285:20172314; Dyndo et al. (2015), _Sci. Rep._ 5:11083.
+
+**Zu 9 (EU):** Belegt ist, dass **standardisierte Bestandserfassungen** (SCANS, SAMBAH) in
+MSRL-, FFH-, HELCOM- und ASCOBANS-Bewertungen einfließen (Gilles et al. 2023, S. 30 f.).
+Opportunistische Bürgermeldungen sind eine **ergänzende** Quelle für Verbreitung und
+Präsenz — sie liefern keine Abundanzschätzung. Die bisherige Formulierung („fließen direkt
+ein", „Sie beeinflussen maritime Politik!") war deshalb zu stark.
+
+---
+
+## 3. Ursache der Serie — hartkodierte Platzhalter
+
+Der Ursprung aller beanstandeten Zahlen stand in `src/lib/report/components/FormHelp.svelte`
+als Fallback-Werte der Statistik-Anzeige:
+
+```ts
+// vorher
+let statistics = $state<SightingStatistics>({
+	totalSightings: 2847, // ← die in PR #558 entfernte „2.847 andere Sichtungen"
+	completionRate: 89, // ← die „89 % erfahrener Beobachter" aus Aussage 2
+	yearsOfService: 15, // ← die „seit 15 Jahren" aus dem Schiffsnamen-Text
+	uniqueUsers: 150,
+	sightingsWithMedia: 1200,
+	deadAnimalsFound: 25
+});
+```
+
+Jemand hat plausibel aussehende Platzhalter gesetzt und später Marketing-Texte
+**auf diese Platzhalter hin** geschrieben. PR #558 und #567 haben die Texte entfernt,
+die Platzhalter blieben.
+
+Sie waren nicht bloß totes Beiwerk: Nur der erste Statistik-Block prüfte `fetchFailed`.
+Bei einem Ausfall von `/api/statistics` bekamen Bürger:innen die erfundenen Zahlen als
+Tatsachen angezeigt:
+
+| Anzeige         | Platzhalter | Echt (API) |
+| --------------- | ----------- | ---------- |
+| Jahre           | 15          | **24**     |
+| mit Fotos       | 42 %        | **4 %**    |
+| Totfunde        | 25          | **1.830**  |
+| Sichtungen ges. | 2.847       | **19.877** |
+
+Zusätzlich stand dort eine fest verdrahtete Kachel **„3× häufiger zitiert"** — mit
+Lade-Spinner, also optisch als geladene Statistik getarnt — sowie ein Alert mit
+**„IPCC-Klimabericht"**, dem Badge **„IPCC Report"** und dem Satz
+„Windpark-Planungen werden anhand Ihrer Koordinaten angepasst".
+
+---
+
+## 4. Was geändert wurde
+
+**`sightingSchema.ts`** — neun Texte überarbeitet: `sightingFrom`, `distance`, `visibility`,
+`windForce`, `mediaFile`, `mediaConsent`, `shipName`, `shipCount`, `behaviorText`, `notes`,
+`otherObservations`.
+
+Der einzige Fall, in dem eine Zahl **bleibt**, ist der durch die eigene DB belegte:
+
+```ts
+valueText: 'Schiffsnamen ermöglichen Langzeitauswertungen - einzelne Schiffe melden laut
+            unserer Sichtungsdatenbank seit über 20 Jahren immer wieder Sichtungen';
+```
+
+**`FormHelp.svelte`** — Platzhalter durch `null` ersetzt (keine erfundene Zahl kann mehr
+angezeigt werden), fehlerhafter `response.ok`-Zweig korrigiert, `3×`-Kachel und
+IPCC-Alert entfernt, EU-Aussage auf die belegbare Formulierung reduziert.
+
+**`sightingSchemaClaims.test.ts`** (neu) — macht die Regel durchsetzbar statt nur
+dokumentiert. Der Test schlägt fehl, sobald ein `valueText` eine Zahl ohne Quelleneintrag
+enthält oder eine fremde Institution vereinnahmt. Verifiziert durch Mutationstest.
+
+**`.claude/rules/design-system.md`** — Regel „Zahlen in Nutzertexten nur mit Quelle" um
+Negativbeispiele, Format für belegte Zahlen und die methodische Grenze der Datenbasis ergänzt.
+
+---
+
+## 5. Offene Punkte für das Fachteam
+
+Diese Fragen kann nur das Haus selbst beantworten:
+
+1. **Seegang-Zahlen aufnehmen?** Für Aussage 2 gibt es zitierfähige Zahlen (SCANS-IV:
+   167 m → 114 m effektive Suchbreite). Fachlich korrekt, aber für ein Bürgerformular
+   womöglich zu technisch. Derzeit steht dort die qualitative Fassung. → Entscheidung nötig.
+2. **Datenweitergabe:** Gehen Meldungen aus diesem Portal tatsächlich an ASCOBANS/HELCOM
+   (Jastarnia-Projekt, FTZ Büsum)? Falls ja, kann die EU-Aussage konkreter und mit
+   Nennung der Gremien formuliert werden — bitte dann als belegte Aussage eintragen.
+3. **`shipName`-Text:** Enthält jetzt „seit über 20 Jahren" aus der eigenen DB. Bitte
+   gegenprüfen, ob die Formulierung so gewünscht ist.
+4. **Datenqualität:** 365 Datensätze haben exakt `00:00:00` als Uhrzeit und einige
+   `sichtungsdatum = 1970-01-01` (Epoch-Platzhalter). Für Auswertungen relevant.
+
+---
+
+## Quellen
+
+Osiecka et al. 2020, _Sci. Rep._ 10:14876 · Amundin et al. 2022 (SAMBAH), _Ecol. Evol._ 12:e8554 ·
+Schaffeld et al. 2016, _MEPS_ · Teilmann 2003, _JCRM_ 5(1) · Gilles et al. 2023 (SCANS-IV) ·
+Wisniewska et al. 2018, _Proc. R. Soc. B_ 285:20172314 · Dyndo et al. 2015, _Sci. Rep._ 5:11083 ·
+Smith et al. 2026, _JASA_ 159(3) · Gutiérrez-Muñoz et al. 2021, _Front. Mar. Sci._ 8:642386 ·
+IPCC SROCC 2019 · HELCOM Harbour Porpoise Indicator 2023

--- a/docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md
+++ b/docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md
@@ -137,20 +137,68 @@ Negativbeispiele, Format für belegte Zahlen und die methodische Grenze der Date
 
 ---
 
-## 5. Offene Punkte für das Fachteam
+## 5. Rückmeldung des Fachteams (2026-07-27) — erledigt
 
-Diese Fragen kann nur das Haus selbst beantworten:
+Alle vier Punkte sind geklärt und umgesetzt.
 
-1. **Seegang-Zahlen aufnehmen?** Für Aussage 2 gibt es zitierfähige Zahlen (SCANS-IV:
-   167 m → 114 m effektive Suchbreite). Fachlich korrekt, aber für ein Bürgerformular
-   womöglich zu technisch. Derzeit steht dort die qualitative Fassung. → Entscheidung nötig.
-2. **Datenweitergabe:** Gehen Meldungen aus diesem Portal tatsächlich an ASCOBANS/HELCOM
-   (Jastarnia-Projekt, FTZ Büsum)? Falls ja, kann die EU-Aussage konkreter und mit
-   Nennung der Gremien formuliert werden — bitte dann als belegte Aussage eintragen.
-3. **`shipName`-Text:** Enthält jetzt „seit über 20 Jahren" aus der eigenen DB. Bitte
-   gegenprüfen, ob die Formulierung so gewünscht ist.
-4. **Datenqualität:** 365 Datensätze haben exakt `00:00:00` als Uhrzeit und einige
-   `sichtungsdatum = 1970-01-01` (Epoch-Platzhalter). Für Auswertungen relevant.
+**1. Seegang-Zahlen aufnehmen? → Ja, laienverständlich.**
+Die SCANS-IV-Werte (effektive Suchbreite 167 m bei guten, 114 m bei mäßigen Bedingungen,
+also −31,7 %) stehen jetzt als „rund ein Drittel" im Text — ohne Fachbegriffe, mit
+erkennbarer Quelle:
+
+> „Bei unruhiger See schrumpft der Streifen Meer, den Beobachter verlässlich absuchen
+> können, um rund ein Drittel (Ostsee-Erfassung SCANS 2023) …"
+
+Bewusst **ohne Beaufort-Zahl**, weil SCANS unter „gut/mäßig" Seegang, Trübung und
+Blendung zusammenfasst — eine konkrete Windstärke wäre schon wieder eine Überpräzisierung.
+
+**2. Datenweitergabe → bestätigt, Weitergabe erfolgt direkt vom DMM.**
+Damit ist die Aussage wieder konkret formulierbar und nennt die Gremien. Im Formular
+(`notes`) und in der Hilfe-Sektion, dort mit kurzer Erklärung, was HELCOM und ASCOBANS
+überhaupt sind — die Abkürzungen allein sagen Bürger:innen nichts.
+
+**3. `shipName`-Text → unverändert übernommen.**
+
+**4. Epoch-Ausschluss → festgehalten, siehe unten.**
+
+---
+
+## 6. Epoch-Platzhalter zählen nicht mit
+
+**Festgehalten als verbindliche Regel:** Datensätze mit dem Platzhalterdatum
+`1970-01-01` sind fehlerhafte Importe und fließen **nicht** in Statistiken ein.
+
+Datenlage: 280 Datensätze liegen auf exakt `1970-01-01 01:00:00`. Zwischen 1970 und 2002
+existiert kein einziger Datensatz — die älteste echte Sichtung stammt vom 08.07.2002.
+
+Umgesetzt in `sightingRepository.ts` über eine benannte Konstante:
+
+```ts
+export const EARLIEST_PLAUSIBLE_SIGHTING_DATE = new Date('1990-01-01T00:00:00Z');
+```
+
+Die Grenze liegt bewusst in der Lücke zwischen Epoch und der ältesten echten Sichtung.
+
+### Dabei gefundener Fehler
+
+Die vorherige Implementierung verglich auf **Gleichheit** mit `new Date(0)` + `setHours(2)`.
+`setHours` arbeitet in der lokalen Zeitzone:
+
+| Umgebung                | Ergebnis          | Trifft die Daten? |
+| ----------------------- | ----------------- | ----------------- |
+| Europe/Berlin (lokal)   | 1970-01-01T01:00Z | ja                |
+| UTC (Docker/Produktion) | 1970-01-01T02:00Z | **nein**          |
+
+Im Docker-Setup ist kein `TZ` gesetzt, der Container läuft also UTC. In Produktion wurden
+die 280 Epoch-Datensätze damit **mitgezählt** und `yearsOfService` sprang von 24 auf ~56
+Jahre. Die feste UTC-Grenze ist zeitzonenunabhängig; abgesichert durch
+`statisticsEpochExclusion.test.ts`, der alle 24 Stundenvarianten des 01.01.1970 prüft.
+
+### Offen geblieben
+
+365 Datensätze haben exakt `00:00:00` als Uhrzeit. Anders als die Epoch-Datensätze sind
+das plausible Sichtungen mit fehlender Uhrzeitangabe — sie werden **nicht** ausgeschlossen,
+sollten bei tageszeitlichen Auswertungen aber gefiltert werden (wie in Abschnitt 1 geschehen).
 
 ---
 

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -680,7 +680,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Wie war die Beschaffenheit der Meeresoberfläche?',
 			valueText:
-				'Bei ruhiger See sind Tiere deutlich leichter zu entdecken - Ihre Seegangsangabe hilft, Sichtungszahlen richtig einzuordnen',
+				'Bei unruhiger See schrumpft der Streifen Meer, den Beobachter verlässlich absuchen können, um rund ein Drittel (Ostsee-Erfassung SCANS 2023) - deshalb hilft Ihre Angabe, Sichtungszahlen richtig einzuordnen',
 			type: 'select',
 			options: getSeaStateOptions(),
 			icon: Waves
@@ -1114,7 +1114,8 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			placeholder: 'Zusätzliche Beobachtungen, Besonderheiten...',
 			helpText: 'Was möchten Sie noch mitteilen?',
-			valueText: 'Ergänzende Hinweise helfen dabei, ungewöhnliche Meldungen richtig zu verstehen',
+			valueText:
+				'Das Deutsche Meeresmuseum gibt die Sichtungsdaten direkt an die internationalen Gremien für den Schutz der Ostsee-Schweinswale weiter (HELCOM und ASCOBANS)',
 			type: 'textarea',
 			icon: FileText
 		})

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -516,7 +516,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Wählen Sie Ihre Beobachtungsposition',
 			valueText:
-				'Boot-Beobachtungen haben 3x höhere Entdeckungsrate als Landbeobachtungen - Ihr Standort hilft bei Populationsschätzungen',
+				'Ob vom Boot oder von Land aus beobachtet wurde, bestimmt mit, welcher Bereich überhaupt einsehbar war - das ist für die Einordnung der Meldung wichtig',
 			type: 'select',
 			options: getSightingFromOptions(),
 			icon: MapPin
@@ -558,7 +558,7 @@ export const sightingSchemaBase = yup.object().shape({
 			helpText:
 				'Wie weit waren die Tiere entfernt? (Schätzung) - Tipp: Größe einer Münze = 50m, Streichholz = 200m',
 			valueText:
-				'Entfernungsangaben helfen Forschern, Beobachtungen zu gewichten - Nahsichtungen unter 100m haben höchste wissenschaftliche Aussagekraft',
+				'Je geringer die Entfernung, desto verlässlicher lassen sich Art und Anzahl bestimmen - die Angabe hilft, Beobachtungen zu gewichten',
 			type: 'select',
 			options: getDistanceOptions(),
 			icon: Eye
@@ -637,8 +637,9 @@ export const sightingSchemaBase = yup.object().shape({
 		.label('Sonstiges Verhalten')
 		.meta({
 			placeholder: 'z.B. Spielverhalten, Jagd, Paarung, Interaktion mit Booten',
-			helpText: 'Ihre Beobachtung könnte eine noch unbekannte Verhaltensweise dokumentieren',
-			valueText: 'Neue Verhaltensbeobachtungen werden in wissenschaftlichen Journalen publiziert',
+			helpText: 'Beschreiben Sie das Verhalten in eigenen Worten',
+			valueText:
+				'Freitext erfasst auch Verhalten, für das es in der Auswahlliste keine Kategorie gibt',
 			icon: MessageCircle
 		}),
 
@@ -702,7 +703,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Wie weit konnten Sie sehen?',
 			valueText:
-				'Sichtweitenangaben ermöglichen "Distance Sampling" - die präziseste Methode für Populationsschätzungen. Auch Schätzungen sind wertvoll',
+				'Die Sichtweite bestimmt mit, welcher Bereich überhaupt einsehbar war - auch eine grobe Schätzung hilft bei der Auswertung',
 			type: 'select',
 			options: getVisibilityOptions(),
 			icon: Eye
@@ -744,7 +745,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'z.B. 3',
 			helpText: 'Welche Windstärke wurde beobachtet?',
 			valueText:
-				'Windstärke korreliert mit Tauchverhalten - bei starkem Wind tauchen Wale länger und seltener auf',
+				'Bei höherer Windstärke sind auftauchende Tiere zwischen den Wellen schwerer zu erkennen - das hilft, Sichtungszahlen einzuordnen',
 			type: 'select',
 			options: getWindStrengthOptions(),
 			icon: CloudRain
@@ -782,7 +783,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'z.B. 3 Fotos Schweinswal-Gruppe, 1 Video springender Wal',
 			helpText: 'Jedes Foto ist wertvoll - auch unscharfe Aufnahmen helfen bei der Identifikation',
 			valueText:
-				'Sichtungsfotos haben bereits 47 neue Verhaltensweisen dokumentiert und fließen in internationale Datenbanken ein',
+				'Aufnahmen machen Artbestimmung und Verhalten nachträglich überprüfbar - das erhöht den Wert Ihrer Meldung erheblich',
 			icon: Camera
 		})
 		.notRequired(),
@@ -811,7 +812,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			helpText: 'Stimmen Sie der wissenschaftlichen Nutzung der Aufnahmen zu?',
 			valueText:
-				'Ihre Fotos werden in wissenschaftlichen Publikationen verwendet und helfen bei der Öffentlichkeitsarbeit für den Meeresschutz - Sichtungsphotos überzeugen Politik und Gesellschaft',
+				'Mit Ihrer Zustimmung können die Aufnahmen für wissenschaftliche Auswertung und die Öffentlichkeitsarbeit des Meeresmuseums genutzt werden',
 			icon: Check
 		})
 		.default(false),
@@ -832,7 +833,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'z.B. MS Seelöwe, SY Nordwind, FFK Seeadler',
 			helpText: 'Name Ihres Bootes/Schiffes (optional)',
 			valueText:
-				'Schiffsnamen ermöglichen Langzeitstudien - einige Schiffe melden seit 15 Jahren regelmäßig Sichtungen',
+				'Schiffsnamen ermöglichen Langzeitauswertungen - einzelne Schiffe melden laut unserer Sichtungsdatenbank seit über 20 Jahren immer wieder Sichtungen',
 			icon: Ship
 		})
 		.notRequired(),
@@ -885,7 +886,7 @@ export const sightingSchemaBase = yup.object().shape({
 			placeholder: 'z.B. 2',
 			helpText: 'Wie viele andere Boote waren in der Nähe?',
 			valueText:
-				'Schiffsverkehr-Daten sind Gold wert - sie zeigen Lärmeinfluss auf Meerestiere. Auch "0 Schiffe" ist eine wichtige Information',
+				'Die Anzahl umliegender Schiffe hilft, den Einfluss von Unterwasserlärm einzuordnen. Auch "0 Schiffe" ist eine wichtige Information',
 			icon: CountIcon
 		})
 		.notRequired(),
@@ -1113,8 +1114,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			placeholder: 'Zusätzliche Beobachtungen, Besonderheiten...',
 			helpText: 'Was möchten Sie noch mitteilen?',
-			valueText:
-				'Diese Daten fließen in EU-Meeresschutzrichtlinien ein - Ihre Beobachtungen beeinflussen maritime Politikentscheidungen',
+			valueText: 'Ergänzende Hinweise helfen dabei, ungewöhnliche Meldungen richtig zu verstehen',
 			type: 'textarea',
 			icon: FileText
 		})
@@ -1131,7 +1131,8 @@ export const sightingSchemaBase = yup.object().shape({
 		.meta({
 			placeholder: 'Klimawandel-Effekte, Plastikverschmutzung, andere Meerestiere...',
 			helpText: 'Verhaltensänderungen zeigen Klimawandel-Einfluss auf Meerestiere',
-			valueText: 'Ihre Umweltbeobachtungen werden für den IPCC-Meeresspiegel-Report verwendet',
+			valueText:
+				'Auffälligkeiten am Lebensraum helfen, Sichtungen in ihren Umweltkontext einzuordnen',
 			icon: MessageCircle
 		})
 		.notRequired(),

--- a/src/lib/form/validation/sightingSchemaClaims.test.ts
+++ b/src/lib/form/validation/sightingSchemaClaims.test.ts
@@ -40,6 +40,11 @@ const REVIEWED_NUMERIC_TEXTS: ReadonlyArray<{ text: string; quelle: string }> = 
 		text: 'Schiffsnamen ermöglichen Langzeitauswertungen - einzelne Schiffe melden laut unserer Sichtungsdatenbank seit über 20 Jahren immer wieder Sichtungen',
 		quelle:
 			'Eigene Sichtungsdatenbank, Abfrage vom 2026-07-27: Gruppierung nach schiffsname (>5 Meldungen, sichtungsdatum > 1990 wegen 1970-Platzhaltern) ergibt u.a. "PENNY LANE" 95 Meldungen über 22,8 Jahre (2002-2025) und "SY Julka" 36 Meldungen über 21,2 Jahre. Die Aussage "über 20 Jahre" ist damit belegt und konservativ.'
+	},
+	{
+		text: 'Bei unruhiger See schrumpft der Streifen Meer, den Beobachter verlässlich absuchen können, um rund ein Drittel (Ostsee-Erfassung SCANS 2023) - deshalb hilft Ihre Angabe, Sichtungszahlen richtig einzuordnen',
+		quelle:
+			'Gilles et al. (2023), SCANS-IV Final Report, Tab. 5: effektive Suchbreite (ESW) für Schweinswal 167 m bei guten, 114 m bei mäßigen Bedingungen — Rückgang 31,7 %, im Text laienverständlich als "rund ein Drittel". Ergänzend Teilmann (2003), JCRM 5(1), DOI 10.47536/jcrm.v5i1.830 (signifikanter Seegangseffekt bereits zwischen Seastate 0-3). Hinweis: SCANS bündelt unter "gut/mäßig" Seegang, Trübung und Blendung, deshalb im Text bewusst keine Beaufort-Zahl.'
 	}
 ];
 
@@ -76,16 +81,16 @@ const INSTITUTIONAL_CLAIM_PATTERNS: ReadonlyArray<RegExp> = [
  * Geprüfte Institutions- und Verwertungsaussagen.
  *
  * Institutionen dürfen genannt werden — aber nur, wenn das Haus die Angabe
- * bestätigt hat. Absichtlich noch leer: Ob Meldungen aus diesem Portal
- * tatsächlich an ASCOBANS/HELCOM weitergegeben werden (Jastarnia-Projekt,
- * FTZ Büsum), ist bislang nur über eine Sekundärquelle belegt und liegt dem
- * Fachteam zur Klärung vor — siehe
- * `docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md`, Abschnitt 5, Punkt 2.
- *
- * Sobald das bestätigt ist: Text hier eintragen, `quelle` mit der Bestätigung
- * füllen, dann ist die Nennung im Formular wieder erlaubt.
+ * bestätigt hat. Wer eine weitere Nennung einbauen will, trägt sie hier mit
+ * Bestätigung ein; ohne Eintrag schlägt der Guard fehl.
  */
-const REVIEWED_INSTITUTIONAL_TEXTS: ReadonlyArray<{ text: string; quelle: string }> = [];
+const REVIEWED_INSTITUTIONAL_TEXTS: ReadonlyArray<{ text: string; quelle: string }> = [
+	{
+		text: 'Das Deutsche Meeresmuseum gibt die Sichtungsdaten direkt an die internationalen Gremien für den Schutz der Ostsee-Schweinswale weiter (HELCOM und ASCOBANS)',
+		quelle:
+			'Bestätigt durch das Deutsche Meeresmuseum am 2026-07-27 auf ausdrückliche Rückfrage: Die Weitergabe an HELCOM und ASCOBANS erfolgt direkt durch das DMM. Fachlicher Rahmen: Gilles et al. (2023), SCANS-IV, S. 30 f. zu den Berichtspflichten unter MSRL, FFH-Richtlinie, HELCOM HOLAS und ASCOBANS.'
+	}
+];
 
 /** Zitierte Feldwerte wie "0 Schiffe" sind Bedienhinweise, keine Statistik. */
 const stripQuotedValues = (text: string): string =>

--- a/src/lib/form/validation/sightingSchemaClaims.test.ts
+++ b/src/lib/form/validation/sightingSchemaClaims.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview Guard gegen unbelegte Zahlenangaben in Nutzertexten
+ *
+ * Hintergrund: Im Sichtungsformular standen über längere Zeit erfundene
+ * Statistiken in den `valueText`-Tooltips ("73% der Schweinswalsichtungen
+ * erfolgen morgens", "2.847 andere Sichtungen", "47 neue Verhaltensweisen").
+ * Die Plattform wird vom Deutschen Meeresmuseum betrieben — erfundene Zahlen
+ * gegenüber Bürger:innen sind ein Glaubwürdigkeitsrisiko.
+ *
+ * Regel: Zahlen in Motivationstexten (`valueText`) nur mit Quelle. Jede
+ * Zahlenangabe muss bewusst in `REVIEWED_NUMERIC_TEXTS` eingetragen und dort
+ * mit ihrer Herkunft begründet werden. Wer eine neue Zahl einbaut, wird von
+ * diesem Test gezwungen, die Quelle zu dokumentieren.
+ *
+ * Siehe `.claude/rules/design-system.md` → "Zahlen in Nutzertexten".
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sightingSchema } from './sightingSchema';
+
+interface FieldMeta {
+	valueText?: string;
+	helpText?: string;
+}
+
+/**
+ * Zahlenangaben, die geprüft und belegt sind.
+ *
+ * Jeder Eintrag braucht eine Begründung: entweder eine nachrechenbare
+ * technische Größe oder eine benannte Quelle. Reine Marketing-Zahlen
+ * gehören NICHT hierher, sondern aus dem Text heraus.
+ */
+const REVIEWED_NUMERIC_TEXTS: ReadonlyArray<{ text: string; quelle: string }> = [
+	{
+		text: 'GPS-Präzision: 6 Nachkommastellen = 11cm Genauigkeit',
+		quelle:
+			'Nachrechenbar: 1e-6° Breite ≈ 0,11 m (Erdumfang über die Pole / 360 / 1e6). Keine empirische Behauptung.'
+	},
+	{
+		text: 'Schiffsnamen ermöglichen Langzeitauswertungen - einzelne Schiffe melden laut unserer Sichtungsdatenbank seit über 20 Jahren immer wieder Sichtungen',
+		quelle:
+			'Eigene Sichtungsdatenbank, Abfrage vom 2026-07-27: Gruppierung nach schiffsname (>5 Meldungen, sichtungsdatum > 1990 wegen 1970-Platzhaltern) ergibt u.a. "PENNY LANE" 95 Meldungen über 22,8 Jahre (2002-2025) und "SY Julka" 36 Meldungen über 21,2 Jahre. Die Aussage "über 20 Jahre" ist damit belegt und konservativ.'
+	}
+];
+
+/**
+ * Muster für quantitative Behauptungen, die ohne Quelle nicht in
+ * Nutzertexte gehören (Prozentwerte, Vielfache, Zeiträume, Stückzahlen).
+ */
+const QUANTITATIVE_CLAIM_PATTERNS: ReadonlyArray<RegExp> = [
+	/\d+\s*%/, // "40% höhere Wahrscheinlichkeit"
+	/\d+\s*(?:x|-?fach)\b/i, // "3x höhere Entdeckungsrate"
+	/\bseit\s+\d+\s+Jahren\b/i, // "seit 15 Jahren"
+	/\b\d[\d.,]*\s+(?:neue|neuen|andere|anderen|weitere)\b/i // "47 neue Verhaltensweisen"
+];
+
+/**
+ * Aussagen, die fremde Institutionen vereinnahmen oder den Meldenden eine
+ * Verwertung zusichern, die die Plattform nicht garantieren kann.
+ *
+ * Anlass: In `envReport` stand "Ihre Umweltbeobachtungen werden für den
+ * IPCC-Meeresspiegel-Report verwendet" — der IPCC verarbeitet keine
+ * Sichtungsmeldungen von Bürger:innen, und einen solchen Report gibt es nicht.
+ * Namen echter Institutionen sind besonders heikel: sie sind für Nutzer:innen
+ * nicht überprüfbar und beschädigen im Zweifel deren Ruf mit.
+ */
+const INSTITUTIONAL_CLAIM_PATTERNS: ReadonlyArray<RegExp> = [
+	/\bIPCC\b/i,
+	/\bUNESCO\b/i,
+	/\bHELCOM\b/i,
+	/\bASCOBANS\b/i,
+	/werden\s+(?:in|für)\s+.*\b(?:publiziert|veröffentlicht|verwendet)\b/i
+];
+
+/** Zitierte Feldwerte wie "0 Schiffe" sind Bedienhinweise, keine Statistik. */
+const stripQuotedValues = (text: string): string =>
+	text.replace(/["„»][^"“«]*["“«]/g, ' ').replace(/'[^']*'/g, ' ');
+
+function collectMeta(): Array<{ field: string; key: keyof FieldMeta; text: string }> {
+	const described = sightingSchema.describe() as unknown as {
+		fields: Record<string, { meta?: FieldMeta }>;
+	};
+
+	const collected: Array<{ field: string; key: keyof FieldMeta; text: string }> = [];
+	for (const [field, definition] of Object.entries(described.fields)) {
+		const meta = definition?.meta;
+		if (!meta) continue;
+		for (const key of ['valueText', 'helpText'] as const) {
+			const text = meta[key];
+			if (typeof text === 'string' && text.length > 0) {
+				collected.push({ field, key, text });
+			}
+		}
+	}
+	return collected;
+}
+
+const isReviewed = (text: string): boolean =>
+	REVIEWED_NUMERIC_TEXTS.some((entry) => entry.text === text);
+
+describe('sightingSchema — Zahlenangaben in Nutzertexten', () => {
+	it('findet überhaupt Metadaten zum Prüfen', () => {
+		expect(collectMeta().length).toBeGreaterThan(20);
+	});
+
+	it('enthält in valueText keine unbelegten Zahlen', () => {
+		const offenders = collectMeta()
+			.filter(({ key }) => key === 'valueText')
+			.filter(({ text }) => /\d/.test(stripQuotedValues(text)))
+			.filter(({ text }) => !isReviewed(text))
+			.map(({ field, text }) => `${field}: "${text}"`);
+
+		expect(
+			offenders,
+			`Unbelegte Zahlen in valueText gefunden.\n` +
+				`Entweder Quelle ergänzen und in REVIEWED_NUMERIC_TEXTS eintragen,\n` +
+				`oder die Zahl durch eine nachprüfbare Aussage ersetzen:\n` +
+				offenders.join('\n')
+		).toEqual([]);
+	});
+
+	it('enthält in helpText keine unbelegten quantitativen Behauptungen', () => {
+		const offenders = collectMeta()
+			.filter(({ key }) => key === 'helpText')
+			.filter(({ text }) => QUANTITATIVE_CLAIM_PATTERNS.some((pattern) => pattern.test(text)))
+			.filter(({ text }) => !isReviewed(text))
+			.map(({ field, text }) => `${field}: "${text}"`);
+
+		expect(
+			offenders,
+			`Unbelegte quantitative Behauptung in helpText gefunden:\n` + offenders.join('\n')
+		).toEqual([]);
+	});
+
+	it('vereinnahmt keine fremden Institutionen und verspricht keine Verwertung', () => {
+		const offenders = collectMeta()
+			.filter(({ text }) => INSTITUTIONAL_CLAIM_PATTERNS.some((pattern) => pattern.test(text)))
+			.map(({ field, key, text }) => `${field}.${key}: "${text}"`);
+
+		expect(
+			offenders,
+			`Nicht belegbare Institutions- oder Verwertungszusage gefunden.\n` +
+				`Nur nennen, was die Plattform tatsächlich zusichern kann:\n` +
+				offenders.join('\n')
+		).toEqual([]);
+	});
+
+	it('nennt für jede freigegebene Zahlenangabe eine Quelle', () => {
+		for (const entry of REVIEWED_NUMERIC_TEXTS) {
+			expect(entry.quelle.trim().length, `Quelle fehlt für: "${entry.text}"`).toBeGreaterThan(20);
+		}
+	});
+});

--- a/src/lib/form/validation/sightingSchemaClaims.test.ts
+++ b/src/lib/form/validation/sightingSchemaClaims.test.ts
@@ -72,6 +72,21 @@ const INSTITUTIONAL_CLAIM_PATTERNS: ReadonlyArray<RegExp> = [
 	/werden\s+(?:in|für)\s+.*\b(?:publiziert|veröffentlicht|verwendet)\b/i
 ];
 
+/**
+ * Geprüfte Institutions- und Verwertungsaussagen.
+ *
+ * Institutionen dürfen genannt werden — aber nur, wenn das Haus die Angabe
+ * bestätigt hat. Absichtlich noch leer: Ob Meldungen aus diesem Portal
+ * tatsächlich an ASCOBANS/HELCOM weitergegeben werden (Jastarnia-Projekt,
+ * FTZ Büsum), ist bislang nur über eine Sekundärquelle belegt und liegt dem
+ * Fachteam zur Klärung vor — siehe
+ * `docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md`, Abschnitt 5, Punkt 2.
+ *
+ * Sobald das bestätigt ist: Text hier eintragen, `quelle` mit der Bestätigung
+ * füllen, dann ist die Nennung im Formular wieder erlaubt.
+ */
+const REVIEWED_INSTITUTIONAL_TEXTS: ReadonlyArray<{ text: string; quelle: string }> = [];
+
 /** Zitierte Feldwerte wie "0 Schiffe" sind Bedienhinweise, keine Statistik. */
 const stripQuotedValues = (text: string): string =>
 	text.replace(/["„»][^"“«]*["“«]/g, ' ').replace(/'[^']*'/g, ' ');
@@ -97,6 +112,9 @@ function collectMeta(): Array<{ field: string; key: keyof FieldMeta; text: strin
 
 const isReviewed = (text: string): boolean =>
 	REVIEWED_NUMERIC_TEXTS.some((entry) => entry.text === text);
+
+const isReviewedInstitutional = (text: string): boolean =>
+	REVIEWED_INSTITUTIONAL_TEXTS.some((entry) => entry.text === text);
 
 describe('sightingSchema — Zahlenangaben in Nutzertexten', () => {
 	it('findet überhaupt Metadaten zum Prüfen', () => {
@@ -135,6 +153,7 @@ describe('sightingSchema — Zahlenangaben in Nutzertexten', () => {
 	it('vereinnahmt keine fremden Institutionen und verspricht keine Verwertung', () => {
 		const offenders = collectMeta()
 			.filter(({ text }) => INSTITUTIONAL_CLAIM_PATTERNS.some((pattern) => pattern.test(text)))
+			.filter(({ text }) => !isReviewedInstitutional(text))
 			.map(({ field, key, text }) => `${field}.${key}: "${text}"`);
 
 		expect(
@@ -145,9 +164,23 @@ describe('sightingSchema — Zahlenangaben in Nutzertexten', () => {
 		).toEqual([]);
 	});
 
-	it('nennt für jede freigegebene Zahlenangabe eine Quelle', () => {
-		for (const entry of REVIEWED_NUMERIC_TEXTS) {
+	it('nennt für jede freigegebene Angabe eine Quelle', () => {
+		for (const entry of [...REVIEWED_NUMERIC_TEXTS, ...REVIEWED_INSTITUTIONAL_TEXTS]) {
 			expect(entry.quelle.trim().length, `Quelle fehlt für: "${entry.text}"`).toBeGreaterThan(20);
 		}
+	});
+
+	it('gibt freigegebene Institutionsnennungen wieder frei', () => {
+		// Schützt die Allowlist selbst: Ein Eintrag muss den Guard tatsächlich
+		// aufheben, sonst wäre die Freigabe wirkungslos.
+		const beispiel = 'Meldungen gehen an HELCOM';
+		expect(INSTITUTIONAL_CLAIM_PATTERNS.some((p) => p.test(beispiel))).toBe(true);
+
+		const freigegeben = [{ text: beispiel, quelle: 'Testbeispiel' }];
+		const blockiert = [beispiel]
+			.filter((text) => INSTITUTIONAL_CLAIM_PATTERNS.some((p) => p.test(text)))
+			.filter((text) => !freigegeben.some((entry) => entry.text === text));
+
+		expect(blockiert).toEqual([]);
 	});
 });

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -6,19 +6,14 @@
 	import SpeciesIdentificationHelp from './form/fields/SpeciesIdentificationHelp.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
-	// Reaktive Statistiken mit Fallback-Werten
-	let statistics = $state<SightingStatistics>({
-		totalSightings: 2847,
-		completionRate: 89,
-		averageOptionalFields: 8,
-		yearsOfService: 15,
-		uniqueUsers: 150,
-		sightingsWithMedia: 1200,
-		deadAnimalsFound: 25
-	});
+	// Keine Platzhalter-Zahlen: Statistiken werden erst angezeigt, wenn sie
+	// tatsächlich geladen wurden. Erfundene Fallback-Werte würden Bürgern sonst
+	// bei jedem API-Ausfall als echte Zahlen des Meeresmuseums präsentiert.
+	// Siehe .claude/rules/design-system.md → "Zahlen in Nutzertexten nur mit Quelle".
+	let statistics = $state<SightingStatistics | null>(null);
 
 	let loading = $state(true);
-	let fetchFailed = $state(false);
+	const fetchFailed = $derived(!loading && statistics === null);
 
 	// Load statistics only in browser (avoid SSR fetch warning)
 	$effect(() => {
@@ -27,15 +22,15 @@
 			try {
 				const response = await fetch('/api/statistics');
 				if (response.ok) {
-					const data = await response.json();
-					statistics = data;
+					statistics = await response.json();
+				} else {
+					logger.warn({ status: response.status }, 'Statistics endpoint returned an error');
 				}
 			} catch (error) {
 				logger.warn(
 					{ error: error instanceof Error ? error.message : error },
-					'Could not load statistics, using fallback values'
+					'Could not load statistics'
 				);
-				fetchFailed = true;
 			} finally {
 				loading = false;
 			}
@@ -76,7 +71,7 @@
 												{#if loading}
 													<span class="loading loading-dots loading-sm"></span>
 												{:else}
-													{statistics.totalSightings.toLocaleString('de-DE')}
+													{statistics?.totalSightings.toLocaleString('de-DE') ?? '–'}
 												{/if}
 											</div>
 											<div class="text-xs">Sichtungen gemeldet</div>
@@ -86,7 +81,7 @@
 												{#if loading}
 													<span class="loading loading-dots loading-sm"></span>
 												{:else}
-													{statistics.completionRate}%
+													{statistics?.completionRate ?? '–'}%
 												{/if}
 											</div>
 											<div class="text-xs">Beobachter füllen Zusatzfelder aus</div>
@@ -151,7 +146,9 @@
 										{#if loading}
 											<span class="loading loading-dots loading-xs"></span>
 										{:else}
-											{Math.round((statistics.averageOptionalFields / 12) * 100)}%
+											{statistics
+												? Math.round((statistics.averageOptionalFields / 12) * 100)
+												: '–'}%
 										{/if}
 									</strong> der Beobachter füllen Zusatzfelder aus - Sie helfen bei Populationsmodellen
 								</div>
@@ -180,52 +177,39 @@
 								<Icon icon="lucide:chart-pie" width="16" class="text-success" />
 								Ihre Daten machen den Unterschied
 							</h4>
-							<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+							<div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
 								<div class="bg-success/10 border-success/20 rounded-lg border p-4 text-center">
 									<div class="text-success mb-2 text-2xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
 										{:else}
-											3x
+											{statistics?.yearsOfService ?? '–'}
 										{/if}
 									</div>
-									<div class="text-base-content text-sm font-medium">häufiger zitiert</div>
+									<div class="text-base-content text-sm font-medium">Jahre Sichtungsmeldungen</div>
 									<div class="text-base-content/70 mt-1 text-xs">
-										werden komplette Meldungen in Studien verwendet
+										{#if !loading && statistics && statistics.uniqueUsers > 0}
+											{statistics.uniqueUsers.toLocaleString('de-DE')} Personen haben bereits gemeldet
+										{:else}
+											viele Beobachtende melden bereits regelmäßig
+										{/if}
 									</div>
 								</div>
 								<div class="bg-success/10 border-success/20 rounded-lg border p-4 text-center">
 									<div class="text-success mb-2 text-2xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
-										{:else}
-											{statistics.yearsOfService}
-										{/if}
-									</div>
-									<div class="text-base-content text-sm font-medium">Jahre Treue</div>
-									<div class="text-base-content/70 mt-1 text-xs">
-										{#if !loading && statistics.uniqueUsers > 0}
-											{statistics.uniqueUsers} verschiedene Nutzer melden bereits regelmäßig
-										{:else}
-											melden manche Nutzer bereits regelmäßig
-										{/if}
-									</div>
-								</div>
-								<div
-									class="bg-success/10 border-success/20 rounded-lg border p-4 text-center sm:col-span-2 lg:col-span-1"
-								>
-									<div class="text-success mb-2 text-2xl font-bold">
-										{#if loading}
-											<span class="loading loading-dots loading-sm"></span>
-										{:else}
+										{:else if statistics}
 											{Math.round(
 												(statistics.sightingsWithMedia / statistics.totalSightings) * 100
 											)}%
+										{:else}
+											–
 										{/if}
 									</div>
 									<div class="text-base-content text-sm font-medium">mit Fotos/Videos</div>
 									<div class="text-base-content/70 mt-1 text-xs">
-										{#if !loading}
+										{#if !loading && statistics}
 											{statistics.sightingsWithMedia.toLocaleString('de-DE')} Sichtungen mit Medien dokumentiert
 										{:else}
 											durch Ihre Fotos wissenschaftlich dokumentiert
@@ -254,7 +238,7 @@
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
 										{:else}
-											{statistics.deadAnimalsFound}
+											{statistics?.deadAnimalsFound.toLocaleString('de-DE') ?? '–'}
 										{/if}
 									</div>
 									<div class="text-base-content text-xs">
@@ -265,21 +249,15 @@
 						</div>
 					</div>
 
-					<div class="alert alert-warning">
+					<div class="alert alert-info">
 						<div>
-							<h4 class="font-semibold">🇪🇺 Einfluss auf EU-Politik</h4>
+							<h4 class="font-semibold">Wofür die Daten gebraucht werden</h4>
 							<p class="mt-1 text-xs">
-								Ihre Sichtungsdaten fließen direkt in die <strong>EU-Meeresschutzrichtlinie</strong>
-								und den
-								<strong>IPCC-Klimabericht</strong> ein. Windpark-Planungen werden anhand Ihrer
-								Koordinaten angepasst, um Meerestiere zu schützen.
-								<strong>Sie beeinflussen maritime Politik!</strong>
+								Ihre Meldung wird wissenschaftlich ausgewertet und trägt zum Bild von Verbreitung
+								und Vorkommen der Schweinswale in der Ostsee bei. Solche Beobachtungen ergänzen die
+								standardisierten Bestandserfassungen, die wiederum Grundlage für den Meeresschutz
+								sind.
 							</p>
-							<div class="mt-2 flex justify-center space-x-4 text-xs">
-								<span class="badge badge-outline">EU-MSRL</span>
-								<span class="badge badge-outline">IPCC Report</span>
-								<span class="badge badge-outline">Natura 2000</span>
-							</div>
 						</div>
 					</div>
 				</div>

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -255,10 +255,11 @@
 						<div>
 							<h4 class="font-semibold">Wofür die Daten gebraucht werden</h4>
 							<p class="mt-1 text-xs">
-								Ihre Meldung wird wissenschaftlich ausgewertet und trägt zum Bild von Verbreitung
-								und Vorkommen der Schweinswale in der Ostsee bei. Solche Beobachtungen ergänzen die
-								standardisierten Bestandserfassungen, die wiederum Grundlage für den Meeresschutz
-								sind.
+								Ihre Meldung wird vom Deutschen Meeresmuseum wissenschaftlich ausgewertet und direkt
+								an die internationalen Gremien für den Schutz der Ostsee-Schweinswale weitergegeben:
+								an <strong>HELCOM</strong>, die Helsinki-Kommission zum Schutz der Ostsee, und an
+								<strong>ASCOBANS</strong>, das internationale Abkommen zum Schutz der Kleinwale. So
+								trägt Ihre Beobachtung zum Bild von Verbreitung und Vorkommen der Tiere bei.
 							</p>
 						</div>
 					</div>

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -80,8 +80,10 @@
 											<div class="text-primary font-bold">
 												{#if loading}
 													<span class="loading loading-dots loading-sm"></span>
+												{:else if statistics}
+													{statistics.completionRate}%
 												{:else}
-													{statistics?.completionRate ?? '–'}%
+													–
 												{/if}
 											</div>
 											<div class="text-xs">Beobachter füllen Zusatzfelder aus</div>
@@ -145,10 +147,10 @@
 									✅ <strong>
 										{#if loading}
 											<span class="loading loading-dots loading-xs"></span>
+										{:else if statistics}
+											{Math.round((statistics.averageOptionalFields / 12) * 100)}%
 										{:else}
-											{statistics
-												? Math.round((statistics.averageOptionalFields / 12) * 100)
-												: '–'}%
+											–
 										{/if}
 									</strong> der Beobachter füllen Zusatzfelder aus - Sie helfen bei Populationsmodellen
 								</div>
@@ -199,7 +201,7 @@
 									<div class="text-success mb-2 text-2xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
-										{:else if statistics}
+										{:else if statistics && statistics.totalSightings > 0}
 											{Math.round(
 												(statistics.sightingsWithMedia / statistics.totalSightings) * 100
 											)}%

--- a/src/lib/server/db/sightingRepository.ts
+++ b/src/lib/server/db/sightingRepository.ts
@@ -25,7 +25,7 @@ import type { SightingFormValues } from '$lib/types/Form';
 import type { NewSighting, UpdateSighting } from '$lib/types/sighting';
 import type { SightingFileInsert } from '$lib/types/sightingFile';
 import { isImageFile } from '$lib/utils';
-import { count, eq, isNotNull, not, sql } from 'drizzle-orm';
+import { count, eq, gte, isNotNull, sql } from 'drizzle-orm';
 import { readImageExifData } from '$lib/server/media/exifUtils';
 import { mapFormToSighting } from '$lib/server/db/mapFormToSighting';
 import { setSightingIdForReferenceId } from '$lib/server/db/sightingFilesRepository';
@@ -332,12 +332,22 @@ export interface SightingStatistics {
 	deadAnimalsFound: number;
 }
 
-// Einträge mit falsch übermitteltem Datum aussortieren
-const excludedDate = (() => {
-	const res = new Date(0);
-	res.setHours(2);
-	return res;
-})();
+/**
+ * Untere Plausibilitätsgrenze für Sichtungsdaten.
+ *
+ * 280 Datensätze liegen auf dem Epoch-Platzhalter `1970-01-01 01:00:00` — das
+ * sind fehlerhafte Importe, keine Sichtungen aus dem Jahr 1970. Sie zählen in
+ * Statistiken nicht mit. Die älteste echte Sichtung stammt von 2002, zwischen
+ * 1970 und 2002 liegt kein einziger Datensatz; die Grenze ist deshalb bewusst
+ * in diese Lücke gelegt.
+ *
+ * Vorher wurde auf Gleichheit mit `new Date(0)` + `setHours(2)` verglichen.
+ * `setHours` arbeitet in der lokalen Zeitzone: in Europe/Berlin traf das die
+ * Datensätze, in einem UTC-Container (Produktion setzt kein `TZ`) nicht — dort
+ * wurde Epoch mitgezählt und `yearsOfService` sprang von 24 auf ~56 Jahre.
+ * Die feste UTC-Grenze ist zeitzonenunabhängig.
+ */
+export const EARLIEST_PLAUSIBLE_SIGHTING_DATE = new Date('1990-01-01T00:00:00Z');
 
 /**
  * Ermittelt statistische Daten über Sichtungen für die FormHelp-Komponente
@@ -419,7 +429,7 @@ export const getSightingStatistics = async (): Promise<SightingStatistics> => {
 				minDate: sql<string>`MIN(${sightings.sightingDate})`
 			})
 			.from(sightings)
-			.where(not(eq(sightings.sightingDate, excludedDate)));
+			.where(gte(sightings.sightingDate, EARLIEST_PLAUSIBLE_SIGHTING_DATE));
 
 		const firstSighting = firstSightingQuery[0]?.minDate;
 		const yearsOfService = firstSighting

--- a/src/lib/server/db/statisticsEpochExclusion.test.ts
+++ b/src/lib/server/db/statisticsEpochExclusion.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Epoch-Platzhalterdaten dürfen nicht in Statistiken einfließen
+ *
+ * In `sichtungen` liegen 280 Datensätze auf exakt `1970-01-01 01:00:00` — das
+ * sind fehlerhafte Importe, keine echten Sichtungen aus dem Jahr 1970. Die
+ * älteste echte Sichtung stammt von 2002.
+ *
+ * Die frühere Implementierung verglich auf Gleichheit mit
+ * `new Date(0)` + `setHours(2)`. `setHours` arbeitet in der **lokalen**
+ * Zeitzone: In Europe/Berlin ergibt das 1970-01-01T01:00Z und trifft die
+ * Datensätze, in einem UTC-Container (so läuft die Produktion — im Docker-Setup
+ * ist kein `TZ` gesetzt) dagegen 1970-01-01T02:00Z und trifft sie nicht.
+ * Folge: `yearsOfService` sprang in Produktion von 24 auf ~56 Jahre.
+ *
+ * Dieser Test fixiert die Grenze zeitzonenunabhängig.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from './sightingRepository';
+
+/** Die Epoch-Platzhalter, wie sie tatsächlich in der Datenbank stehen. */
+const EPOCH_PLACEHOLDER = new Date('1970-01-01T01:00:00Z');
+
+describe('Epoch-Ausschluss in Sichtungs-Statistiken', () => {
+	it('schließt den Epoch-Platzhalter aus', () => {
+		expect(EPOCH_PLACEHOLDER.getTime()).toBeLessThan(EARLIEST_PLAUSIBLE_SIGHTING_DATE.getTime());
+	});
+
+	it('schließt Epoch unabhängig von der Zeitzone aus', () => {
+		// Jede denkbare Auslegung von "1970-01-01 irgendeine Stunde" muss unter
+		// der Grenze liegen — sonst hängt das Ergebnis an der Server-Zeitzone.
+		for (let hour = 0; hour < 24; hour++) {
+			const variante = new Date(Date.UTC(1970, 0, 1, hour));
+			expect(
+				variante.getTime(),
+				`1970-01-01T${String(hour).padStart(2, '0')}:00Z wird nicht ausgeschlossen`
+			).toBeLessThan(EARLIEST_PLAUSIBLE_SIGHTING_DATE.getTime());
+		}
+	});
+
+	it('behält die älteste echte Sichtung (2002)', () => {
+		const aeltesteEchte = new Date('2002-07-08T00:00:00Z');
+		expect(aeltesteEchte.getTime()).toBeGreaterThanOrEqual(
+			EARLIEST_PLAUSIBLE_SIGHTING_DATE.getTime()
+		);
+	});
+
+	it('liegt die Grenze zwischen Epoch und der ältesten echten Sichtung', () => {
+		expect(EARLIEST_PLAUSIBLE_SIGHTING_DATE.getUTCFullYear()).toBeGreaterThan(1970);
+		expect(EARLIEST_PLAUSIBLE_SIGHTING_DATE.getUTCFullYear()).toBeLessThan(2002);
+	});
+});


### PR DESCRIPTION
Nachfolge zu #558 und #567. Die dort entfernten Zahlen waren Teil einer größeren Serie — die Ursache ist jetzt gefunden.

## Ursache

In `FormHelp.svelte` standen hartkodierte Platzhalter-Statistiken:

```ts
totalSightings: 2847,   // ← die in #558 „entfernte" Zahl
completionRate: 89,     // ← die „89 % erfahrener Beobachter"
yearsOfService: 15,     // ← die „seit 15 Jahren"
```

Jemand hat plausibel aussehende Platzhalter gesetzt und später Marketing-Texte **auf diese Platzhalter hin** geschrieben. #558 und #567 haben die Texte entfernt, die Platzhalter blieben.

Sie waren nicht bloß totes Beiwerk: Nur der erste Statistik-Block prüfte `fetchFailed`. Bei einem Ausfall von `/api/statistics` wurden die erfundenen Zahlen als Tatsachen angezeigt:

| Anzeige | Platzhalter | Echt (API) |
| --- | --- | --- |
| Jahre | 15 | **24** |
| mit Fotos | 42 % | **4 %** |
| Totfunde | 25 | **1.830** |
| Sichtungen gesamt | 2.847 | **19.877** |

Zusätzlich: eine fest verdrahtete Kachel „3× häufiger zitiert" — mit Lade-Spinner, also optisch als geladene Statistik getarnt — sowie ein Alert mit „IPCC-Klimabericht" und dem Badge „IPCC Report".

## Prüfung gegen die eigene Datenbank

| Aussage | Behauptet | Tatsächlich (19.877 Sichtungen) |
| --- | --- | --- |
| Schweinswalsichtungen 6–10 Uhr | 73 % | **10,6 %** |
| Schiffe melden seit … Jahren | 15 Jahre | **22,8 Jahre** (PENNY LANE, 95 Meldungen) |

Der tatsächliche Gipfel liegt **mittags** (11–14 Uhr ≈ 44 %) und bildet den Rhythmus der Beobachtenden ab, nicht den der Tiere.

**Methodische Grenze:** Die Tabelle `sichtungen` enthält nur positive Meldungen — kein Beobachtungsaufwand, keine Nullbeobachtungen. Aussagen der Form „bei Bedingung X werden N-mal mehr Tiere entdeckt" lassen sich daraus grundsätzlich nicht ableiten. Genau diese Form hatten alle vier ursprünglich beanstandeten Aussagen.

## Prüfung gegen die Literatur

Keine Quelle für die Boot-vs-Land-Aussage (3×), die Windrichtungs-Aussage (+40 %) und die Elektromotor-Aussage (+60 %). Den IPCC-Meeresspiegel-Report gibt es nicht, und der IPCC verarbeitet keine Sichtungsmeldungen.

Zwei Ergebnisse mit Konsequenz:
- **Seegang** ist qualitativ gut belegt (Teilmann 2003; SCANS-IV: effektive Suchbreite 167 m → 114 m) — der Faktor 5 aber nicht.
- **Elektroantrieb** wäre nicht nur unbelegt, sondern potenziell irreführend: Smith et al. 2026 (*JASA* 159(3)) zeigen hochfrequente Tonalkomponenten genau im besten Hörbereich des Schweinswals.

## Änderungen

- **`sightingSchema.ts`** — 11 Texte überarbeitet. Die einzige verbleibende Zahl ist die durch die eigene DB belegte, mit Quelle im Satz: „laut unserer Sichtungsdatenbank seit über 20 Jahren".
- **`FormHelp.svelte`** — Platzhalter → `null`, sodass keine erfundene Zahl mehr gerendert werden *kann*; `!response.ok`-Zweig korrigiert, der still die Fallbacks behielt; `3×`-Kachel und IPCC-Alert entfernt; EU-Aussage auf das Belegbare reduziert.
- **`sightingSchemaClaims.test.ts`** (neu) — macht die Regel durchsetzbar statt nur dokumentiert. Schlägt fehl, sobald ein `valueText` eine Zahl ohne Quelleneintrag enthält oder eine fremde Institution vereinnahmt. Ging vor dem Fix bei 5 echten Fundstellen rot; die IPCC-Regel ist per Mutationstest verifiziert.
- **`design-system.md`** — die Regel aus #567 war nur Prosa; jetzt mit Negativbeispielen, Format für belegte Zahlen und der methodischen Grenze, plus Verweis auf den durchsetzenden Test.
- **`docs/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md`** — vollständige Prüfung mit Quellen und offenen Punkten fürs Fachteam.

## Tests

`npm run test:quick`: 1709 Tests, 101 Dateien, alle grün. `svelte-check`: 0 Fehler. Die 2 Lint-Warnings liegen in `src/tests/contract/helpers/createEvent.ts` und sind vorbestehend.

## Offen — braucht eine Entscheidung des Hauses

1. **Seegang-Zahlen aufnehmen?** SCANS-IV liefert zitierfähige Werte, die für ein Bürgerformular aber recht technisch sind. Derzeit steht die qualitative Fassung.
2. **Datenweitergabe:** Gehen Meldungen aus diesem Portal tatsächlich an ASCOBANS/HELCOM? Falls ja, kann die EU-Aussage wieder konkreter werden — ich habe sie bewusst vorsichtig gehalten.

Nebenbefund: 365 Datensätze haben exakt `00:00:00` als Uhrzeit, einige `sichtungsdatum = 1970-01-01` (Epoch-Platzhalter). Für Auswertungen relevant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
