### PR TITLE
fix(db): Zeitzonen-Semantik vereinheitlichen und TZ explizit setzen

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -33,7 +33,9 @@ src/routes/
 ### 100% Kompatibilität erforderlich
 
 Die Legacy API MUSS exakt mit der Original-Spezifikation übereinstimmen.
-Mobile Apps hängen davon ab!
+Stand 2026-07-28 sind keine Clients angebunden — der Vertrag gilt trotzdem,
+weil er sonst wertlos ist, sobald welche dazukommen. Einordnung und Umgang
+mit offensichtlichen Fehlern: `.claude/rules/legacy-api.md`.
 
 **Referenz:** docs/LEGACY_API_SPECIFICATION.md
 

--- a/.claude/rules/legacy-api.md
+++ b/.claude/rules/legacy-api.md
@@ -7,8 +7,17 @@ paths:
 
 # Legacy REST API — 100 % Kompatibilität
 
-Diese Endpunkte bedienen **bestehende Mobile Apps**. Jede Abweichung von der
-Spezifikation bricht produktive Clients.
+Diese Endpunkte implementieren die Spezifikation der Vorgänger-API für Mobile
+Clients.
+
+> **Stand 2026-07-28: keine Clients angebunden.** Die Endpunkte sind nicht in
+> Betrieb und waren es nie. Eine Abweichung bricht also derzeit **nichts
+> Laufendes** — sie entwertet aber den Vertrag, sobald Clients angebunden
+> werden. Änderungen an Feldnamen, Pfaden und Datentypen bleiben deshalb
+> begründungspflichtig, offensichtliche Fehler dürfen aber behoben werden.
+>
+> Diese Einordnung ist ein Datumsstand, keine Dauerzusage — vor größeren
+> Änderungen prüfen, ob inzwischen Clients angebunden sind.
 
 > **PFLICHT:** Lies `docs/LEGACY_API_SPECIFICATION.md` **vollständig**, bevor du
 > einen dieser Endpunkte änderst. Die Datei ist die verbindliche Referenz für

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Beim Erstellen oder Ändern von `.ts`/`.svelte`-Dateien mit Business-Logik MUSS 
 
 ### Legacy REST API — 100 % Kompatibilität
 
-Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) bedienen produktive Mobile Apps und MÜSSEN exakt kompatibel bleiben. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
+Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) implementieren den Vertrag der Vorgänger-API für Mobile Clients. Stand 2026-07-28 sind sie **nicht in Betrieb** — eine Abweichung bricht also nichts Laufendes, entwertet aber den Vertrag, sobald Clients angebunden werden. Feldnamen, URL-Pfade und Datentypen deshalb nur bewusst und dokumentiert ändern. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
 
 ### Design System — PFLICHT bei UI-Änderungen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD /usr/local/bin/docker-healthcheck.sh
 
 # Set environment variables
+# TZ ist bewusst gesetzt: ohne TZ fällt Node auf UTC zurück, was funktioniert,
+# aber nur solange die Umgebung nichts anderes vorgibt. Datums-Logik hing dadurch
+# schon an der Zufalls-Zeitzone (siehe docs/ENVIRONMENT.md → TZ).
 ENV NODE_ENV=production \
+    TZ=UTC \
     PORT=3000 \
     HOST=0.0.0.0 \
     BODY_SIZE_LIMIT=52428800 \

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -28,6 +28,10 @@ services:
       NODE_ENV: production
       PORT: 3000
       HOST: 0.0.0.0
+      # Zeitzone bewusst fixiert — siehe docs/ENVIRONMENT.md → TZ.
+      # Deutsche Ortszeit steht überall explizit im Code; nicht auf UTC
+      # abweichen, ohne die dortigen Hinweise gelesen zu haben.
+      TZ: ${TZ:-UTC}
 
       # Database Connection (only DATABASE_POSTGRES_URL is used by the application)
       DATABASE_POSTGRES_URL: ${DATABASE_POSTGRES_URL}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -333,7 +333,7 @@ depended on it. One instance reached production — the statistics filter exclud
 epoch placeholder records via `setHours`, which evaluates in the **local** timezone.
 In Europe/Berlin it matched the 280 records, in the UTC container it did not, and
 `yearsOfService` jumped from 24 to ~56 years (fixed in
-[#571](https://github.com/jansinger/ostsee-sichtung/pull/571)).
+[#571](https://github.com/jansinger/ostsee-tiere/pull/571)).
 
 #### Why UTC and not Europe/Berlin
 
@@ -788,7 +788,7 @@ niemals setzen, sonst laufen Requests bei DB-Ausfall in Fehler statt in einen sa
 For questions about environment configuration:
 
 - **Documentation**: [DOCKER_DEPLOYMENT.md](./DOCKER_DEPLOYMENT.md)
-- **Issues**: https://github.com/jansinger/ostsee-sichtung/issues
+- **Issues**: https://github.com/jansinger/ostsee-tiere/issues
 - **Example File**: [.env.example](../.env.example)
 
 ---

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -318,6 +318,75 @@ BLOB_READ_WRITE_TOKEN=vercel_blob_rw_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ---
 
+### `TZ`
+
+**Type**: `string` (IANA timezone)
+**Required**: No
+**Default**: `UTC` (set explicitly in `Dockerfile` and `docker-compose.production.yml`)
+**Description**: Process timezone. Deliberately pinned — do not remove.
+
+#### Why this is pinned
+
+Without `TZ`, Node falls back to UTC, which _happened_ to be correct but was never
+a decision: the timezone was whatever the environment supplied. Date logic silently
+depended on it. One instance reached production — the statistics filter excluded
+epoch placeholder records via `setHours`, which evaluates in the **local** timezone.
+In Europe/Berlin it matched the 280 records, in the UTC container it did not, and
+`yearsOfService` jumped from 24 to ~56 years (fixed in
+[#571](https://github.com/jansinger/ostsee-sichtung/pull/571)).
+
+#### Why UTC and not Europe/Berlin
+
+`UTC` is what production already runs, so pinning it changes nothing — no silent
+shift in stored timestamps, exports, or API responses. Log timestamps also stay
+unambiguous across the DST changeover, where Europe/Berlin repeats an hour.
+
+#### Storage convention
+
+All timestamp columns hold **true UTC instants**. Drizzle pins both directions
+explicitly (`toISOString()` on write, `+0000` on read), so storage does not
+depend on `TZ` either.
+
+This was not always true. The columns are `timestamp without time zone`, and the
+data inherited from the PHP predecessor held German wall-clock time — that system
+ran on a server in Europe/Berlin. A one-off migration converted it before launch:
+
+```bash
+npm run db:migrate-timestamps-utc:dry-run -- --cutover=<go-live ISO>
+```
+
+The tool refuses to run twice (marker in `app_config`) and aborts if records that
+were already written by this application fall inside its scope. Run the dry run
+first and take a backup — the conversion is not trivially reversible.
+
+#### Display
+
+German local time is **not** left to `TZ`. Every place that renders time for users
+names `Europe/Berlin` explicitly:
+
+| Concern                                                            | Implementation                                                                 |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Display & CSV/KML/XML/JSON export                                  | `src/lib/utils/format/dateTime.ts` — `Intl` with `timeZone: 'Europe/Berlin'`   |
+| Weather lookup (Open-Meteo, requested as `timezone=Europe/Berlin`) | `src/lib/server/weather/hourIndex.ts` — index parsed from the `"HH:MM"` string |
+| Legacy REST API output (`dt`, `ti`)                                | `src/lib/legacy-api/date-utils.ts` — `Intl` with `Europe/Berlin`       |
+| Legacy `year` filter                                               | `getYearRange()` — German local year bounds, matching the output                   |
+| Statistics plausibility bound                                      | `EARLIEST_PLAUSIBLE_SIGHTING_DATE` — fixed UTC instant                         |
+
+#### Before changing this value
+
+Changing `TZ` is safe only as long as the code stays timezone-independent.
+`src/lib/server/datetime/correctCestOffsetUTC.test.ts` proves the sighting pipeline
+(`combineToDate` → `correctCestOffsetUTC`) yields the same UTC instant under UTC and
+Europe/Berlin, for all 24 hours in both summer and winter. Note that
+`correctCestOffsetUTC` only _does_ anything when the process runs in UTC — it returns
+early otherwise. Run the full server suite after any change:
+
+```bash
+npm run test:unit
+```
+
+---
+
 ### `PORT`
 
 **Type**: `number`

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -2,97 +2,106 @@
 
 **CRITICAL: 100% Compliance Required**
 
-This specification is derived from the original schweinswalsichtung.de API documentation. The legacy APIs MUST maintain 100% compatibility with the original specification to ensure existing mobile applications continue to function correctly.
+This specification is derived from the original schweinswalsichtung.de API documentation. The legacy APIs MUST maintain 100% compatibility with it, so that mobile clients built against the original API keep working.
 
-**⚠️ WARNING: Any deviation from this specification will break existing mobile apps!**
+**Status 2026-07-28: no clients are connected.** The endpoints are not in service and never have been. A deviation therefore breaks nothing that is currently running — but it does void the contract the moment a client is connected, and such a client cannot be fixed from this side. Field names, URL paths and data types must only change deliberately and documented; obvious defects may of course be fixed.
+
+This is a dated status, not a standing guarantee — re-check whether clients have been connected before making larger changes.
 
 ## Base URLs
+
 - Test System: `http://test.schweinswalsichtung.de`
 - Production System: `http://schweinswalsichtung.de`
 
 ## 1. Creating Sightings
 
 ### Endpoint
+
 - **URL**: `/rest_sichtungen`
 - **Method**: `POST`
 - **Content-Type**: `application/json`
 
 ### Request Body (JSON Object)
 
-| Attribute | Description | Data Type / Range | Required |
-|-----------|-------------|-------------------|----------|
-| `sichtungsdatum` | Date and time of sighting | DateTime, "YYYY-MM-DD HH:MI" | Yes |
-| `anzahl_gesamt` | Total number of sighted animals. 0 is allowed and interpreted as death finding. | Integer | Yes |
-| `vorname` | First name | String (64) | Yes |
-| `name` | Last name | String (64) | Yes |
-| `email` | Email address | E-Mail | Yes |
-| `gps_breite` | Latitude decimal | Decimal, -90 – 90 | No |
-| `gps_laenge` | Longitude decimal | Decimal, -180 – 180 | No |
-| `fahrwasser` | Waterway or area | Text | No |
-| `seezeichen` | Sea mark or beach section | Text | No |
-| `vonwo` | Sighting location | Integer-Range, 0-3 | No |
-| `vonwo_text` | Other sighting location (when vonwo = 0) | Text | No |
-| `entfernung` | Distance | Integer-Range, 1-5 | No |
-| `anzahl_schiffe` | Number of ships in vicinity | Integer | No |
-| `anzahl_jung` | Number of juvenile animals | Integer | No |
-| `verteilung` | Distribution of animals | Integer-Range, 0-3 | No |
-| `verteilung_text` | Other distribution (when verteilung = 0) | Text | No |
-| `aufnahme` | Filename of uploaded media | String (255) | No |
-| `aufnahmeHochladen` | Media uploaded flag | Boolean, 0 = false, 1 = true | No |
-| `verhalten` | Behavior of animals | Integer-Range, 0-3 | No |
-| `verhalten_text` | Other behavior (when verhalten = 0) | Text | No |
-| `reaktion` | Reaction of animals | Text | No |
-| `sonstige_auffaelligkeiten` | Other observations | Text | No |
-| `seegang` | Sea state | Integer-Range, 0-5 | No |
-| `windrichtung` | Wind direction | 'N','NW','W','SW','S','SO','O','NO' | No |
-| `windstaerke` | Wind force in Beaufort | 1-12 | No |
-| `sichtweite` | Visibility | Integer-Range, 1-4 | No |
-| `schiffsname` | Ship name | String (64) | No, Yes if schiffnamensnennung = 1 |
-| `heimathafen` | Home port | String (64) | No |
-| `bootstyp` | Boat type | String (64) | No |
-| `bootsantrieb` | Boat drive | Integer-Range, 0-4 | No |
-| `bootsantrieb_text` | Other boat drive (when bootsantrieb = 0) | Text | No |
-| `strasse` | Street | String (64) | No |
-| `plz` | ZIP code | String (5) | No |
-| `ort` | City | String (64) | No |
-| `telefon` | Phone number | String (64) | No |
-| `fax` | Fax number | String (64) | No |
-| `namensnennung` | Name mention desired? | Boolean, 0 = false, 1 = true | No |
-| `schiffnamensnennung` | Ship name display allowed? | Boolean, 0 = false, 1 = true | No |
-| `bemerkungen` | Comments | Text | No |
-| `eingangskanal` | Entry channel of report | Integer-Range, 0-5 | No |
-| `tierart` | Reported animal species | Integer-Range, 0-10 | No, Default = 0 |
-| `totfund` | Death finding | Boolean, 0 = false, 1 = true | No |
-| `totfund_zustand` | Condition of animal | Integer-Range, 0-5 | No |
-| `totfund_geschlecht` | Sex of animal | Integer-Range, 0-2 | No |
-| `totfund_groesse` | Size of animal in cm | Integer | No |
-| `totfund_telefon` | DMM already informed by phone | Boolean, 0 = false, 1 = true | No |
+| Attribute                   | Description                                                                     | Data Type / Range                   | Required                           |
+| --------------------------- | ------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------- |
+| `sichtungsdatum`            | Date and time of sighting                                                       | DateTime, "YYYY-MM-DD HH:MI"        | Yes                                |
+| `anzahl_gesamt`             | Total number of sighted animals. 0 is allowed and interpreted as death finding. | Integer                             | Yes                                |
+| `vorname`                   | First name                                                                      | String (64)                         | Yes                                |
+| `name`                      | Last name                                                                       | String (64)                         | Yes                                |
+| `email`                     | Email address                                                                   | E-Mail                              | Yes                                |
+| `gps_breite`                | Latitude decimal                                                                | Decimal, -90 – 90                   | No                                 |
+| `gps_laenge`                | Longitude decimal                                                               | Decimal, -180 – 180                 | No                                 |
+| `fahrwasser`                | Waterway or area                                                                | Text                                | No                                 |
+| `seezeichen`                | Sea mark or beach section                                                       | Text                                | No                                 |
+| `vonwo`                     | Sighting location                                                               | Integer-Range, 0-3                  | No                                 |
+| `vonwo_text`                | Other sighting location (when vonwo = 0)                                        | Text                                | No                                 |
+| `entfernung`                | Distance                                                                        | Integer-Range, 1-5                  | No                                 |
+| `anzahl_schiffe`            | Number of ships in vicinity                                                     | Integer                             | No                                 |
+| `anzahl_jung`               | Number of juvenile animals                                                      | Integer                             | No                                 |
+| `verteilung`                | Distribution of animals                                                         | Integer-Range, 0-3                  | No                                 |
+| `verteilung_text`           | Other distribution (when verteilung = 0)                                        | Text                                | No                                 |
+| `aufnahme`                  | Filename of uploaded media                                                      | String (255)                        | No                                 |
+| `aufnahmeHochladen`         | Media uploaded flag                                                             | Boolean, 0 = false, 1 = true        | No                                 |
+| `verhalten`                 | Behavior of animals                                                             | Integer-Range, 0-3                  | No                                 |
+| `verhalten_text`            | Other behavior (when verhalten = 0)                                             | Text                                | No                                 |
+| `reaktion`                  | Reaction of animals                                                             | Text                                | No                                 |
+| `sonstige_auffaelligkeiten` | Other observations                                                              | Text                                | No                                 |
+| `seegang`                   | Sea state                                                                       | Integer-Range, 0-5                  | No                                 |
+| `windrichtung`              | Wind direction                                                                  | 'N','NW','W','SW','S','SO','O','NO' | No                                 |
+| `windstaerke`               | Wind force in Beaufort                                                          | 1-12                                | No                                 |
+| `sichtweite`                | Visibility                                                                      | Integer-Range, 1-4                  | No                                 |
+| `schiffsname`               | Ship name                                                                       | String (64)                         | No, Yes if schiffnamensnennung = 1 |
+| `heimathafen`               | Home port                                                                       | String (64)                         | No                                 |
+| `bootstyp`                  | Boat type                                                                       | String (64)                         | No                                 |
+| `bootsantrieb`              | Boat drive                                                                      | Integer-Range, 0-4                  | No                                 |
+| `bootsantrieb_text`         | Other boat drive (when bootsantrieb = 0)                                        | Text                                | No                                 |
+| `strasse`                   | Street                                                                          | String (64)                         | No                                 |
+| `plz`                       | ZIP code                                                                        | String (5)                          | No                                 |
+| `ort`                       | City                                                                            | String (64)                         | No                                 |
+| `telefon`                   | Phone number                                                                    | String (64)                         | No                                 |
+| `fax`                       | Fax number                                                                      | String (64)                         | No                                 |
+| `namensnennung`             | Name mention desired?                                                           | Boolean, 0 = false, 1 = true        | No                                 |
+| `schiffnamensnennung`       | Ship name display allowed?                                                      | Boolean, 0 = false, 1 = true        | No                                 |
+| `bemerkungen`               | Comments                                                                        | Text                                | No                                 |
+| `eingangskanal`             | Entry channel of report                                                         | Integer-Range, 0-5                  | No                                 |
+| `tierart`                   | Reported animal species                                                         | Integer-Range, 0-10                 | No, Default = 0                    |
+| `totfund`                   | Death finding                                                                   | Boolean, 0 = false, 1 = true        | No                                 |
+| `totfund_zustand`           | Condition of animal                                                             | Integer-Range, 0-5                  | No                                 |
+| `totfund_geschlecht`        | Sex of animal                                                                   | Integer-Range, 0-2                  | No                                 |
+| `totfund_groesse`           | Size of animal in cm                                                            | Integer                             | No                                 |
+| `totfund_telefon`           | DMM already informed by phone                                                   | Boolean, 0 = false, 1 = true        | No                                 |
 
 ### Response
 
 #### Successful Creation
+
 - **HTTP Status**: `201 Created`
 - **Headers**: `Location` header set to resource URL
 - **Body**:
+
 ```json
 {
-  "message": "Saved"
+	"message": "Saved"
 }
 ```
 
 #### Validation Errors
+
 - **HTTP Status**: `400 Bad Request`
 - **Body** (example):
+
 ```json
 {
-  "message": "Validation failed.",
-  "errors": {
-    "anzahl_gesamt": ["Dieses Feld kann nicht leer gelassen werden."]
-  }
+	"message": "Validation failed.",
+	"errors": {
+		"anzahl_gesamt": ["Dieses Feld kann nicht leer gelassen werden."]
+	}
 }
 ```
 
 #### Server Errors
+
 - **HTTP Status**: `500`
 
 ## 2. Retrieving Response Options
@@ -100,96 +109,98 @@ This specification is derived from the original schweinswalsichtung.de API docum
 Retrieves response options for numeric fields as JSON array.
 
 ### Endpoint
+
 - **URL**: `/rest_sichtungen/antworten.json`
 - **URL (English)**: `/en/rest_sichtungen/antworten.json`
 - **Method**: `GET`
 
 ### Response Format
+
 JSON Object with the following structure:
 
 ```json
 {
-  "verteilung": {
-    "0": "Sonstige Verteilung",
-    "1": "einzeln", 
-    "2": "Mutter mit Jungtier",
-    "3": "deutliche Schulen"
-  },
-  "verhalten": {
-    "0": "Sonstiges Verhalten",
-    "1": "Konstanter Kurs, regelmäßiges Tauchen (schwimmen, ziehen)",
-    "2": "Unterschiedlicher Kurs, kreisend, unregelmäßiges Tauchen (futtersuchend)",
-    "3": "Langsames Schwimmen, längere Zeit an der Wasseroberfläche (ruhend)"
-  },
-  "seegang": {
-    "0": "Keine Angabe",
-    "1": "Glatte See, keine Wellen",
-    "2": "Ruhige See, gekräuselte, kurze Wellen", 
-    "3": "Leicht bewegte See, Schaumköpfe",
-    "4": "Grobe See, lange, brechende Wellen",
-    "5": "Hohe See, Wellenberge und Gischt"
-  },
-  "bootsantrieb": {
-    "0": "Sonstiger Bootsantrieb",
-    "1": "Motor",
-    "2": "Segel",
-    "3": "treibend",
-    "4": "vor Anker"
-  },
-  "eingangskanal": {
-    "0": "Web",
-    "1": "E-Mail", 
-    "2": "Post",
-    "3": "Fax",
-    "4": "App",
-    "5": "Telefon"
-  },
-  "entfernung": {
-    "1": "weniger als 10 Meter",
-    "2": "10 bis 50 Meter",
-    "3": "50 bis 100 Meter", 
-    "4": "100 bis 500 Meter",
-    "5": "mehr als 500 Meter"
-  },
-  "vonwo": {
-    "0": "Sonstiges",
-    "1": "Segelschiff",
-    "2": "Motorboot",
-    "3": "Land",
-    "4": "Fähre"
-  },
-  "sichtweite": {
-    "1": "Außergewöhnlich klar (mehr als 20km)",
-    "2": "Klar (bis 20km)",
-    "3": "Diesig (bis 4km)",
-    "4": "Nebel (bis 1km)"
-  },
-  "totfund_zustand": {
-    "0": "unbekannt",
-    "1": "keine Anzeichen von Verwesung",
-    "2": "sehr frisch, als ob gerade gestorben",
-    "3": "Aufblähung, leichte Hautablösungen",
-    "4": "Fortgeschrittene Verwesung, starke Aufblähung",
-    "5": "Starke Verwesung, mumifiziert oder Skelettteile"
-  },
-  "totfund_geschlecht": {
-    "0": "unbekannt",
-    "1": "weiblich", 
-    "2": "männlich"
-  },
-  "tierart": {
-    "0": "Schweinswal",
-    "1": "Kegelrobbe",
-    "2": "Seehund",
-    "3": "Delphin (mehrere Arten)",
-    "4": "Beluga",
-    "5": "Zwergwal",
-    "6": "Finnwal",
-    "7": "Buckelwal", 
-    "8": "Unbekannte Walart",
-    "9": "Ringelrobbe",
-    "10": "Unbekannte Robbenart"
-  }
+	"verteilung": {
+		"0": "Sonstige Verteilung",
+		"1": "einzeln",
+		"2": "Mutter mit Jungtier",
+		"3": "deutliche Schulen"
+	},
+	"verhalten": {
+		"0": "Sonstiges Verhalten",
+		"1": "Konstanter Kurs, regelmäßiges Tauchen (schwimmen, ziehen)",
+		"2": "Unterschiedlicher Kurs, kreisend, unregelmäßiges Tauchen (futtersuchend)",
+		"3": "Langsames Schwimmen, längere Zeit an der Wasseroberfläche (ruhend)"
+	},
+	"seegang": {
+		"0": "Keine Angabe",
+		"1": "Glatte See, keine Wellen",
+		"2": "Ruhige See, gekräuselte, kurze Wellen",
+		"3": "Leicht bewegte See, Schaumköpfe",
+		"4": "Grobe See, lange, brechende Wellen",
+		"5": "Hohe See, Wellenberge und Gischt"
+	},
+	"bootsantrieb": {
+		"0": "Sonstiger Bootsantrieb",
+		"1": "Motor",
+		"2": "Segel",
+		"3": "treibend",
+		"4": "vor Anker"
+	},
+	"eingangskanal": {
+		"0": "Web",
+		"1": "E-Mail",
+		"2": "Post",
+		"3": "Fax",
+		"4": "App",
+		"5": "Telefon"
+	},
+	"entfernung": {
+		"1": "weniger als 10 Meter",
+		"2": "10 bis 50 Meter",
+		"3": "50 bis 100 Meter",
+		"4": "100 bis 500 Meter",
+		"5": "mehr als 500 Meter"
+	},
+	"vonwo": {
+		"0": "Sonstiges",
+		"1": "Segelschiff",
+		"2": "Motorboot",
+		"3": "Land",
+		"4": "Fähre"
+	},
+	"sichtweite": {
+		"1": "Außergewöhnlich klar (mehr als 20km)",
+		"2": "Klar (bis 20km)",
+		"3": "Diesig (bis 4km)",
+		"4": "Nebel (bis 1km)"
+	},
+	"totfund_zustand": {
+		"0": "unbekannt",
+		"1": "keine Anzeichen von Verwesung",
+		"2": "sehr frisch, als ob gerade gestorben",
+		"3": "Aufblähung, leichte Hautablösungen",
+		"4": "Fortgeschrittene Verwesung, starke Aufblähung",
+		"5": "Starke Verwesung, mumifiziert oder Skelettteile"
+	},
+	"totfund_geschlecht": {
+		"0": "unbekannt",
+		"1": "weiblich",
+		"2": "männlich"
+	},
+	"tierart": {
+		"0": "Schweinswal",
+		"1": "Kegelrobbe",
+		"2": "Seehund",
+		"3": "Delphin (mehrere Arten)",
+		"4": "Beluga",
+		"5": "Zwergwal",
+		"6": "Finnwal",
+		"7": "Buckelwal",
+		"8": "Unbekannte Walart",
+		"9": "Ringelrobbe",
+		"10": "Unbekannte Robbenart"
+	}
 }
 ```
 
@@ -198,30 +209,35 @@ JSON Object with the following structure:
 Checks if a position (coordinates) lies in the Baltic Sea or in the live sighting map area.
 
 ### Endpoint
+
 - **URL**: `/rest_sichtungen/inBaltic.json`
 - **Method**: `GET`
 
 ### Parameters
-| Parameter | Description | Data Type / Range | Required |
-|-----------|-------------|-------------------|----------|
-| `location` | Position specification: Latitude and longitude, comma separated | Decimal, Decimal | Yes |
+
+| Parameter  | Description                                                     | Data Type / Range | Required |
+| ---------- | --------------------------------------------------------------- | ----------------- | -------- |
+| `location` | Position specification: Latitude and longitude, comma separated | Decimal, Decimal  | Yes      |
 
 ### Response
+
 JSON Object:
 
-| Attribute | Description | Data Type / Range |
-|-----------|-------------|-------------------|
-| `inbaltic` | True if position is in Baltic Sea (in water) | Boolean |
-| `inchartarea` | True if position is in displayed map area | Boolean |
+| Attribute     | Description                                  | Data Type / Range |
+| ------------- | -------------------------------------------- | ----------------- |
+| `inbaltic`    | True if position is in Baltic Sea (in water) | Boolean           |
+| `inchartarea` | True if position is in displayed map area    | Boolean           |
 
 ### Example
+
 **Request**: `/rest_sichtungen/inBaltic.json?location=53,10`
 
 **Response**:
+
 ```json
 {
-  "inbaltic": false,
-  "inchartarea": true
+	"inbaltic": false,
+	"inchartarea": true
 }
 ```
 
@@ -230,63 +246,67 @@ JSON Object:
 Returns all reports of a year that are approved and marked as lying in the Baltic Sea. Only "public" data is returned. Name, first name and ship name fields are only included if the user has released this data.
 
 ### Endpoint
+
 - **URL**: `/sichtungen/showreports.json`
 - **Method**: `GET`
 
 ### Parameters
-| Parameter | Description | Data Type / Range | Required |
-|-----------|-------------|-------------------|----------|
-| `year` | Year | Year YYYY | No |
-| `location` | Position specification: Latitude and longitude, comma separated. Returns all reports within radius of this position (default radius 100 km) | Latitude, Longitude | No |
-| `distance` | Distance in meters for radius search, only used with "location" | Integer | No |
-| `bbox` | Area specification defined by lower left and upper right corner in degrees, separated by commas. Format: Longitude lower left, Latitude lower left, Longitude upper right, Latitude upper right. Compatible with OpenLayers. | Longitude min_x, Latitude min_y, Longitude max_x, Latitude max_y | No |
-| `search` | Searches for given text in fields Email, Name, First name and Ship name. Partial string search (%<text>%). | String | No |
+
+| Parameter  | Description                                                                                                                                                                                                                  | Data Type / Range                                                | Required |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------- |
+| `year`     | Year                                                                                                                                                                                                                         | Year YYYY                                                        | No       |
+| `location` | Position specification: Latitude and longitude, comma separated. Returns all reports within radius of this position (default radius 100 km)                                                                                  | Latitude, Longitude                                              | No       |
+| `distance` | Distance in meters for radius search, only used with "location"                                                                                                                                                              | Integer                                                          | No       |
+| `bbox`     | Area specification defined by lower left and upper right corner in degrees, separated by commas. Format: Longitude lower left, Latitude lower left, Longitude upper right, Latitude upper right. Compatible with OpenLayers. | Longitude min_x, Latitude min_y, Longitude max_x, Latitude max_y | No       |
+| `search`   | Searches for given text in fields Email, Name, First name and Ship name. Partial string search (%<text>%).                                                                                                                   | String                                                           | No       |
 
 ### Response Format
+
 JSON Array with JSON Objects:
 
-| Attribute | Description | Data Type / Range |
-|-----------|-------------|-------------------|
-| `ts` | Unix Timestamp | Unix Timestamp |
-| `id` | Report ID | Integer |
-| `dt` | Date | String, DD.MM.YY |
-| `ti` | Time | String, HH:MI |
-| `lat` | Latitude | Decimal (as string) |
-| `lon` | Longitude | Decimal (as string) |
-| `ct` | Total number of sighted animals | Integer |
-| `yo` | Number of juveniles | Integer |
-| `sh` | Ship name | String |
-| `na` | Sighter name (First name + Last name) | String |
-| `ar` | Waterway / Area | String |
-| `bm` | Result of position check; only delivered for logged in admin | Integer: 0 = Outside, 1 = inchartarea, 2 = inbaltic |
-| `va` | Entry checked; only delivered for logged in admin | Boolean: 0 = False, 1 = True |
+| Attribute | Description                                                  | Data Type / Range                                   |
+| --------- | ------------------------------------------------------------ | --------------------------------------------------- |
+| `ts`      | Unix Timestamp                                               | Unix Timestamp                                      |
+| `id`      | Report ID                                                    | Integer                                             |
+| `dt`      | Date                                                         | String, DD.MM.YY                                    |
+| `ti`      | Time                                                         | String, HH:MI                                       |
+| `lat`     | Latitude                                                     | Decimal (as string)                                 |
+| `lon`     | Longitude                                                    | Decimal (as string)                                 |
+| `ct`      | Total number of sighted animals                              | Integer                                             |
+| `yo`      | Number of juveniles                                          | Integer                                             |
+| `sh`      | Ship name                                                    | String                                              |
+| `na`      | Sighter name (First name + Last name)                        | String                                              |
+| `ar`      | Waterway / Area                                              | String                                              |
+| `bm`      | Result of position check; only delivered for logged in admin | Integer: 0 = Outside, 1 = inchartarea, 2 = inbaltic |
+| `va`      | Entry checked; only delivered for logged in admin            | Boolean: 0 = False, 1 = True                        |
 
 ### Example Response
+
 ```json
 [
-  {
-    "ts": 1327499400,
-    "id": 817,
-    "dt": "25.01.12",
-    "ti": "14:50", 
-    "lat": "54.646667",
-    "lon": "11.333333",
-    "ct": 1,
-    "yo": 0,
-    "sh": "Fährschiff \"Deutschland\"",
-    "na": "Jörg Schneider"
-  },
-  {
-    "ts": 1333116600,
-    "id": 826,
-    "dt": "30.03.12",
-    "ti": "16:10",
-    "lat": "56.093587", 
-    "lon": "10.512543",
-    "ct": 1,
-    "yo": 0,
-    "na": "Jörg Hiller"
-  }
+	{
+		"ts": 1327499400,
+		"id": 817,
+		"dt": "25.01.12",
+		"ti": "14:50",
+		"lat": "54.646667",
+		"lon": "11.333333",
+		"ct": 1,
+		"yo": 0,
+		"sh": "Fährschiff \"Deutschland\"",
+		"na": "Jörg Schneider"
+	},
+	{
+		"ts": 1333116600,
+		"id": 826,
+		"dt": "30.03.12",
+		"ti": "16:10",
+		"lat": "56.093587",
+		"lon": "10.512543",
+		"ct": 1,
+		"yo": 0,
+		"na": "Jörg Hiller"
+	}
 ]
 ```
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
 		"generate:licenses": "node src/tools/generate-license-notices.js",
 		"license:check": "license-checker --summary",
 		"license:audit": "license-checker --onlyAllow 'MIT;MIT-0;ISC;BSD;Apache-2.0;Apache 2.0;BSD-2-Clause;BSD-3-Clause;CC0-1.0;Unlicense;WTFPL;0BSD;OFL-1.1;BlueOak-1.0.0;Python-2.0;MPL-2.0;Artistic-2.0;CC-BY-3.0;(MIT OR Apache-2.0);(MPL-2.0 OR Apache-2.0);(MIT AND Zlib);(MIT OR CC0-1.0);(MIT AND CC-BY-3.0);(BSD-2-Clause OR MIT OR Apache-2.0);MIT AND BSD-3-Clause' --excludePrivatePackages",
+		"db:migrate-timestamps-utc": "node src/tools/migrate-timestamps-to-utc.js",
+		"db:migrate-timestamps-utc:dry-run": "node src/tools/migrate-timestamps-to-utc.js --dry-run --verbose",
 		"db:fix-media-flags": "node src/tools/fix-media-upload-flags.js",
 		"db:fix-media-flags:dry-run": "node src/tools/fix-media-upload-flags.js --dry-run",
 		"db:fix-media-flags:verbose": "node src/tools/fix-media-upload-flags.js --verbose",

--- a/src/lib/legacy-api/date-utils.test.ts
+++ b/src/lib/legacy-api/date-utils.test.ts
@@ -1,8 +1,12 @@
 /**
  * @fileoverview Tests for timezone-safe date utilities
- * 
- * Validates consistent UTC-based date/time formatting across different timezones.
- * 
+ *
+ * `sichtungsdatum` holds true UTC instants; the legacy API renders them in
+ * German local time (`Europe/Berlin`). These tests therefore feed UTC instants
+ * and expect Berlin wall-clock output — CET (UTC+1) in winter, CEST (UTC+2) in
+ * summer. That the migrated historical records still render byte-identically to
+ * the pre-migration output is covered separately in `date-utils.timezone.test.ts`.
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
@@ -12,20 +16,20 @@ import { formatDateDDMMYY, formatTimeHHMI, toUnixTimestamp } from './date-utils'
 
 describe('Legacy API Date Utils (Timezone-Safe)', () => {
 	describe('formatDateDDMMYY', () => {
-		it('should format date in DD.MM.YY format using UTC', () => {
-			// Test with known UTC date
+		it('should format date in DD.MM.YY format in German local time', () => {
+			// 14:50 UTC == 15:50 CET, same calendar day
 			const date = new Date('2012-01-25T14:50:00.000Z');
 			const result = formatDateDDMMYY(date);
-			
+
 			expect(result).toBe('25.01.12');
 		});
 
 		it('should handle different months and years correctly', () => {
 			const testCases = [
-				{ date: '2024-03-15T09:30:00.000Z', expected: '15.03.24' },
-				{ date: '2012-12-31T23:59:59.000Z', expected: '31.12.12' },
-				{ date: '2000-02-29T12:00:00.000Z', expected: '29.02.00' },
-				{ date: '2023-07-04T00:00:00.000Z', expected: '04.07.23' }
+				{ date: '2024-03-15T09:30:00.000Z', expected: '15.03.24' }, // 10:30 CET
+				{ date: '2012-12-31T23:59:59.000Z', expected: '01.01.13' }, // 00:59 CET, next year
+				{ date: '2000-02-29T12:00:00.000Z', expected: '29.02.00' }, // 13:00 CET, leap day
+				{ date: '2023-07-04T00:00:00.000Z', expected: '04.07.23' } // 02:00 CEST
 			];
 
 			testCases.forEach(({ date, expected }) => {
@@ -37,25 +41,27 @@ describe('Legacy API Date Utils (Timezone-Safe)', () => {
 		it('should pad single digits with zeros', () => {
 			const date = new Date('2024-01-05T12:00:00.000Z');
 			const result = formatDateDDMMYY(date);
-			
+
 			expect(result).toBe('05.01.24');
 		});
 	});
 
 	describe('formatTimeHHMI', () => {
-		it('should format time in HH:MI format using UTC', () => {
+		it('should format time in HH:MI format in German local time', () => {
+			// 14:50 UTC + 1h (CET) == 15:50
 			const date = new Date('2012-01-25T14:50:00.000Z');
 			const result = formatTimeHHMI(date);
-			
-			expect(result).toBe('14:50');
+
+			expect(result).toBe('15:50');
 		});
 
 		it('should handle different times correctly', () => {
+			// Alle im März vor der Zeitumstellung → CET (UTC+1)
 			const testCases = [
-				{ date: '2024-03-15T09:05:00.000Z', expected: '09:05' },
-				{ date: '2024-03-15T23:59:00.000Z', expected: '23:59' },
-				{ date: '2024-03-15T00:00:00.000Z', expected: '00:00' },
-				{ date: '2024-03-15T12:30:45.123Z', expected: '12:30' }
+				{ date: '2024-03-15T09:05:00.000Z', expected: '10:05' },
+				{ date: '2024-03-15T23:59:00.000Z', expected: '00:59' }, // rolls into next day
+				{ date: '2024-03-15T00:00:00.000Z', expected: '01:00' },
+				{ date: '2024-03-15T12:30:45.123Z', expected: '13:30' }
 			];
 
 			testCases.forEach(({ date, expected }) => {
@@ -67,8 +73,14 @@ describe('Legacy API Date Utils (Timezone-Safe)', () => {
 		it('should pad single digits with zeros', () => {
 			const date = new Date('2024-01-01T03:05:00.000Z');
 			const result = formatTimeHHMI(date);
-			
-			expect(result).toBe('03:05');
+
+			expect(result).toBe('04:05');
+		});
+
+		it('should apply the summer offset (CEST, UTC+2)', () => {
+			const date = new Date('2024-07-15T12:30:00.000Z');
+
+			expect(formatTimeHHMI(date)).toBe('14:30');
 		});
 	});
 
@@ -76,7 +88,7 @@ describe('Legacy API Date Utils (Timezone-Safe)', () => {
 		it('should convert date to Unix timestamp', () => {
 			const date = new Date('2012-01-25T14:50:00.000Z');
 			const result = toUnixTimestamp(date);
-			
+
 			expect(result).toBe(1327503000);
 		});
 
@@ -96,7 +108,7 @@ describe('Legacy API Date Utils (Timezone-Safe)', () => {
 		it('should handle milliseconds correctly', () => {
 			const date1 = new Date('2024-01-01T12:00:00.000Z');
 			const date2 = new Date('2024-01-01T12:00:00.999Z');
-			
+
 			// Should be same Unix timestamp (floor operation)
 			expect(toUnixTimestamp(date1)).toBe(toUnixTimestamp(date2));
 		});
@@ -104,21 +116,20 @@ describe('Legacy API Date Utils (Timezone-Safe)', () => {
 
 	describe('Timezone consistency', () => {
 		it('should produce same results regardless of system timezone', () => {
-			// Test with a date that could be affected by timezone conversion
+			// 14:30 UTC == 15:30 CET (March 15 is before the DST changeover)
 			const utcDate = new Date('2024-03-15T14:30:00.000Z');
-			
-			// These should always be the same regardless of local timezone
+
 			expect(formatDateDDMMYY(utcDate)).toBe('15.03.24');
-			expect(formatTimeHHMI(utcDate)).toBe('14:30');
+			expect(formatTimeHHMI(utcDate)).toBe('15:30');
 			expect(toUnixTimestamp(utcDate)).toBe(1710513000);
 		});
 
 		it('should handle edge cases around midnight UTC', () => {
+			// 23:59 UTC on New Year's Eve is already 00:59 on New Year's Day in Berlin
 			const midnightUTC = new Date('2024-12-31T23:59:59.000Z');
-			
-			// Should always show UTC values, not local timezone-adjusted
-			expect(formatDateDDMMYY(midnightUTC)).toBe('31.12.24');
-			expect(formatTimeHHMI(midnightUTC)).toBe('23:59');
+
+			expect(formatDateDDMMYY(midnightUTC)).toBe('01.01.25');
+			expect(formatTimeHHMI(midnightUTC)).toBe('00:59');
 		});
 	});
 });

--- a/src/lib/legacy-api/date-utils.timezone.test.ts
+++ b/src/lib/legacy-api/date-utils.timezone.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Legacy-API-Ausgabe nach der UTC-Vereinheitlichung von `sichtungsdatum`.
+ *
+ * Bis zur Migration enthielt `sichtungsdatum` deutsche Ortszeit als Wanduhrzeit,
+ * und die Formatter gaben sie über `getUTC*` unverändert zurück. Nach der
+ * Migration steht dort ein echter UTC-Zeitpunkt — die Formatter müssen ihn
+ * deshalb nach `Europe/Berlin` umrechnen.
+ *
+ * Beides zusammen ergibt für den Altbestand **exakt dieselbe Ausgabe** wie
+ * vorher: die Migration zieht den Offset ab, der Formatter addiert ihn wieder.
+ * Genau das sichert dieser Test ab — die Mobile Apps dürfen keinen Unterschied
+ * sehen. Für neu erfasste Sichtungen wird die Ausgabe dadurch von "1–2 h zu
+ * früh" auf korrekt gezogen.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { formatDateDDMMYY, formatTimeHHMI } from './date-utils';
+
+/** Offset von Europe/Berlin gegenüber UTC zu einem gegebenen Zeitpunkt, in Millisekunden. */
+function berlinOffsetMs(zeitpunkt: Date): number {
+	// sv-SE liefert "YYYY-MM-DD HH:MM:SS" — als UTC gelesen ergibt die Differenz den Offset.
+	const alsBerlinAbgelesen = new Date(
+		`${zeitpunkt.toLocaleString('sv-SE', { timeZone: 'Europe/Berlin' }).replace(' ', 'T')}Z`
+	);
+	return alsBerlinAbgelesen.getTime() - zeitpunkt.getTime();
+}
+
+/**
+ * Bildet die Migration nach: naive Ortszeit → echter UTC-Zeitpunkt.
+ * Entspricht `(spalte AT TIME ZONE 'Europe/Berlin') AT TIME ZONE 'UTC'` in SQL.
+ */
+function migriere(ortszeit: string): Date {
+	const alsUtcGelesen = new Date(`${ortszeit.replace(' ', 'T')}:00Z`);
+	return new Date(alsUtcGelesen.getTime() - berlinOffsetMs(alsUtcGelesen));
+}
+
+describe('Legacy-API-Formatter nach UTC-Vereinheitlichung', () => {
+	describe('gibt deutsche Ortszeit aus', () => {
+		it('rechnet Winterzeit (MEZ, UTC+1) um', () => {
+			const zeitpunkt = new Date('2012-01-25T13:50:00Z');
+
+			expect(formatDateDDMMYY(zeitpunkt)).toBe('25.01.12');
+			expect(formatTimeHHMI(zeitpunkt)).toBe('14:50');
+		});
+
+		it('rechnet Sommerzeit (MESZ, UTC+2) um', () => {
+			const zeitpunkt = new Date('2024-07-15T12:30:00Z');
+
+			expect(formatDateDDMMYY(zeitpunkt)).toBe('15.07.24');
+			expect(formatTimeHHMI(zeitpunkt)).toBe('14:30');
+		});
+
+		it('behandelt Mitternacht über die Datumsgrenze', () => {
+			// 2023-12-31T23:00Z == 01.01.2024 00:00 MEZ
+			const zeitpunkt = new Date('2023-12-31T23:00:00Z');
+
+			expect(formatDateDDMMYY(zeitpunkt)).toBe('01.01.24');
+			expect(formatTimeHHMI(zeitpunkt)).toBe('00:00');
+		});
+	});
+
+	describe('Regressionsschutz für die Mobile Apps', () => {
+		// Repräsentative Altdatensätze als Wanduhrzeit, so wie sie heute in der
+		// Spalte stehen — inklusive der Fälle ohne Uhrzeit und am Jahreswechsel.
+		const altbestand = [
+			['2012-01-25 14:50', '25.01.12', '14:50'],
+			['2024-07-15 14:30', '15.07.24', '14:30'],
+			['2016-01-01 00:00', '01.01.16', '00:00'],
+			['2024-01-01 00:00', '01.01.24', '00:00'],
+			['2018-06-21 21:15', '21.06.18', '21:15'],
+			['2019-12-24 08:05', '24.12.19', '08:05']
+		] as const;
+
+		it('liefert nach der Migration unveränderte Ausgabe', () => {
+			for (const [ortszeit, erwartetesDatum, erwarteteZeit] of altbestand) {
+				const migriert = migriere(ortszeit);
+
+				expect(formatDateDDMMYY(migriert), `Datum für ${ortszeit}`).toBe(erwartetesDatum);
+				expect(formatTimeHHMI(migriert), `Zeit für ${ortszeit}`).toBe(erwarteteZeit);
+			}
+		});
+
+		it('bleibt in jeder Server-Zeitzone identisch', () => {
+			const migriert = migriere('2024-07-15 14:30');
+
+			const ergebnisse = TEST_TIME_ZONES.map((tz) =>
+				withTimeZone(tz, () => `${formatDateDDMMYY(migriert)} ${formatTimeHHMI(migriert)}`)
+			);
+
+			expect(new Set(ergebnisse)).toEqual(new Set(['15.07.24 14:30']));
+		});
+	});
+});

--- a/src/lib/legacy-api/date-utils.ts
+++ b/src/lib/legacy-api/date-utils.ts
@@ -1,48 +1,111 @@
 /**
  * @fileoverview Date/Time utilities for Legacy REST API - Timezone-safe formatting
- * 
- * Provides consistent UTC-based date/time formatting to avoid timezone-related 
- * test failures between local development and CI environments.
- * 
+ *
+ * `sichtungen.sichtungsdatum` holds true UTC instants. The mobile apps expect
+ * German local time, so these helpers convert explicitly to `Europe/Berlin` via
+ * `Intl` — never through the process timezone, which the deployment pins to UTC.
+ *
+ * Historical note: until the UTC migration the column held German wall-clock
+ * time and these helpers used `getUTC*`, which returned it verbatim. Migration
+ * and conversion cancel out, so the output for existing records is unchanged —
+ * locked down by `date-utils.timezone.test.ts`. See docs/ENVIRONMENT.md → TZ.
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
 
+/** Timezone the legacy API renders its date and time fields in. */
+const API_TIME_ZONE = 'Europe/Berlin';
+
+const berlinFormat = new Intl.DateTimeFormat('en-GB', {
+	timeZone: API_TIME_ZONE,
+	year: '2-digit',
+	month: '2-digit',
+	day: '2-digit',
+	hour: '2-digit',
+	minute: '2-digit',
+	hourCycle: 'h23'
+});
+
+/** Splits a UTC instant into its German local wall-clock components. */
+function berlinParts(date: Date): Record<string, string> {
+	return Object.fromEntries(
+		berlinFormat
+			.formatToParts(date)
+			.filter((part) => part.type !== 'literal')
+			.map((part) => [part.type, part.value])
+	);
+}
+
 /**
- * Formats a Date object to DD.MM.YY format using UTC (timezone-safe)
- * 
- * @param date - Date object to format
+ * Formats a Date object to DD.MM.YY format in German local time (timezone-safe)
+ *
+ * @param date - Date object to format (a UTC instant)
  * @returns Date string in DD.MM.YY format
  */
 export function formatDateDDMMYY(date: Date): string {
-	// Use UTC methods to ensure consistent formatting across timezones
-	const day = date.getUTCDate().toString().padStart(2, '0');
-	const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
-	const year = date.getUTCFullYear().toString().slice(-2); // Last 2 digits
-	
+	const { day, month, year } = berlinParts(date);
+
 	return `${day}.${month}.${year}`;
 }
 
 /**
- * Formats a Date object to HH:MI format using UTC (timezone-safe)
- * 
- * @param date - Date object to format
+ * Formats a Date object to HH:MI format in German local time (timezone-safe)
+ *
+ * @param date - Date object to format (a UTC instant)
  * @returns Time string in HH:MI format (24-hour)
  */
 export function formatTimeHHMI(date: Date): string {
-	// Use UTC methods to ensure consistent formatting across timezones
-	const hours = date.getUTCHours().toString().padStart(2, '0');
-	const minutes = date.getUTCMinutes().toString().padStart(2, '0');
-	
-	return `${hours}:${minutes}`;
+	const { hour, minute } = berlinParts(date);
+
+	return `${hour}:${minute}`;
 }
 
 /**
  * Converts Date to Unix timestamp (timezone-safe)
- * 
+ *
  * @param date - Date object to convert
  * @returns Unix timestamp (seconds since epoch)
  */
 export function toUnixTimestamp(date: Date): number {
 	return Math.floor(date.getTime() / 1000);
+}
+
+/**
+ * Liefert Anfang und Ende eines Jahres in deutscher Ortszeit als UTC-Zeitpunkte
+ *
+ * Das Jahr einer Sichtung ist eine Ortszeit-Frage: `dt` wird über
+ * {@link formatDateDDMMYY} in `Europe/Berlin` gebildet, der Filter muss dieselbe
+ * Auslegung haben. Sonst liefert `year=2024` Datensätze, deren `dt` in 2023
+ * liegt. Der lokale Konstruktor `new Date(year, 0, 1)` scheidet aus — er hinge
+ * an der Server-Zeitzone, die das Deployment auf UTC pinnt.
+ *
+ * @param year - Jahreszahl (YYYY)
+ * @returns Jahresanfang und Anfang des Folgejahres als UTC-Zeitpunkte
+ */
+export function getYearRange(year: number): { startDate: Date; endDate: Date } {
+	return {
+		startDate: berlinMidnightAsUtc(year),
+		endDate: berlinMidnightAsUtc(year + 1)
+	};
+}
+
+/** Liefert den UTC-Zeitpunkt von Neujahr 00:00 deutscher Ortszeit. */
+function berlinMidnightAsUtc(year: number): Date {
+	const alsUtcGelesen = Date.UTC(year, 0, 1);
+	// Neujahr liegt immer in der Winterzeit, der Offset ist an beiden Enden
+	// derselbe — eine Iteration genügt.
+	const offsetMs = berlinOffsetMs(new Date(alsUtcGelesen));
+
+	return new Date(alsUtcGelesen - offsetMs);
+}
+
+/** Offset von `Europe/Berlin` gegenüber UTC zum gegebenen Zeitpunkt, in Millisekunden. */
+function berlinOffsetMs(instant: Date): number {
+	// sv-SE liefert "YYYY-MM-DD HH:MM:SS" — als UTC gelesen ergibt die Differenz den Offset.
+	const abgelesen = new Date(
+		`${instant.toLocaleString('sv-SE', { timeZone: API_TIME_ZONE }).replace(' ', 'T')}Z`
+	);
+
+	return abgelesen.getTime() - instant.getTime();
 }

--- a/src/lib/legacy-api/yearRange.test.ts
+++ b/src/lib/legacy-api/yearRange.test.ts
@@ -42,6 +42,18 @@ describe('getYearRange', () => {
 		expect(neujahrsNacht >= startDate && neujahrsNacht < endDate).toBe(true);
 	});
 
+	it('grenzt halboffen ab: endDate gehört bereits ins Folgejahr', () => {
+		// `endDate` ist Neujahr des Folgejahres. Wird es inklusiv gefiltert
+		// (SQL `BETWEEN`), landet eine Sichtung exakt um 00:00 Ortszeit am 01.01.
+		// in zwei Jahren. Das ist keine Theorie: 365 Datensätze haben genau
+		// 00:00 als Uhrzeit, weil keine angegeben wurde.
+		const { endDate } = getYearRange(2024);
+		const naechstesJahr = getYearRange(2025);
+
+		expect(formatDateDDMMYY(endDate)).toBe('01.01.25');
+		expect(endDate.getTime()).toBe(naechstesJahr.startDate.getTime());
+	});
+
 	it('liefert in jeder Server-Zeitzone dieselben Grenzen', () => {
 		const ergebnisse = TEST_TIME_ZONES.map((tz) =>
 			withTimeZone(tz, () => {

--- a/src/lib/legacy-api/yearRange.test.ts
+++ b/src/lib/legacy-api/yearRange.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Der `year`-Filter der Legacy-API muss deutsche Ortszeit-Jahre abgrenzen.
+ *
+ * `sichtungsdatum` enthält echte UTC-Zeitpunkte, die Ausgabefelder `dt`/`ti`
+ * werden aber nach `Europe/Berlin` umgerechnet. Das Jahr einer Sichtung ist
+ * damit eine Ortszeit-Frage: eine Sichtung am 01.01.2024 um 00:30 Ortszeit
+ * steht als `2023-12-31T23:30Z` in der Spalte und gehört trotzdem ins Jahr 2024.
+ *
+ * Vorher grenzte `showreports.json` mit `new Date(yearNum, 0, 1)` ab — dem
+ * lokalen Konstruktor, dessen Ergebnis an der Server-Zeitzone hängt.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { formatDateDDMMYY, getYearRange } from './date-utils';
+
+describe('getYearRange', () => {
+	it('grenzt an Mitternacht deutscher Ortszeit ab', () => {
+		const { startDate, endDate } = getYearRange(2024);
+
+		// 01.01.2024 00:00 MEZ == 2023-12-31T23:00Z
+		expect(startDate.toISOString()).toBe('2023-12-31T23:00:00.000Z');
+		expect(endDate.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+	});
+
+	it('deckt sich mit der Jahresauslegung der Ausgabefelder', () => {
+		// Der erste enthaltene Zeitpunkt muss ein `dt` aus 2024 liefern,
+		// der letzte ebenfalls — sonst filtert der Endpunkt anders als er ausgibt.
+		const { startDate, endDate } = getYearRange(2024);
+
+		expect(formatDateDDMMYY(startDate)).toBe('01.01.24');
+		expect(formatDateDDMMYY(new Date(endDate.getTime() - 1))).toBe('31.12.24');
+	});
+
+	it('schließt eine Sichtung kurz nach Neujahr ein', () => {
+		// 01.01.2024 00:30 Ortszeit — vor der Umstellung wäre dieser Datensatz
+		// bei UTC-Grenzen ins Jahr 2023 gefallen.
+		const neujahrsNacht = new Date('2023-12-31T23:30:00Z');
+		const { startDate, endDate } = getYearRange(2024);
+
+		expect(formatDateDDMMYY(neujahrsNacht)).toBe('01.01.24');
+		expect(neujahrsNacht >= startDate && neujahrsNacht < endDate).toBe(true);
+	});
+
+	it('liefert in jeder Server-Zeitzone dieselben Grenzen', () => {
+		const ergebnisse = TEST_TIME_ZONES.map((tz) =>
+			withTimeZone(tz, () => {
+				const { startDate, endDate } = getYearRange(2024);
+				return `${startDate.toISOString()}..${endDate.toISOString()}`;
+			})
+		);
+
+		expect(new Set(ergebnisse).size).toBe(1);
+	});
+
+	it('behandelt Schaltjahre korrekt', () => {
+		const { startDate, endDate } = getYearRange(2024);
+		const tage = (endDate.getTime() - startDate.getTime()) / 86_400_000;
+
+		expect(tage).toBe(366);
+	});
+});

--- a/src/lib/server/datetime/correctCestOffsetUTC.test.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Sicherheitsnetz für die Zeitzonen-Abhängigkeit der Sichtungs-Datumsverarbeitung.
+ *
+ * Hintergrund: Im Docker-Setup war lange kein `TZ` gesetzt, der Container lief
+ * also UTC. `correctCestOffsetUTC` steigt bei `getTimezoneOffset() !== 0` sofort
+ * wieder aus — die Funktion tut also **nur** auf einem UTC-Server etwas.
+ *
+ * Bevor `TZ=Europe/Berlin` gesetzt wird, muss bewiesen sein, dass die Pipeline
+ * `combineToDate` → `correctCestOffsetUTC` unter beiden Zeitzonen denselben
+ * UTC-Zeitpunkt liefert. Sonst verschiebt das Pinnen still alle neu erfassten
+ * Sichtungszeiten um 1–2 Stunden.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { combineToDate } from '$lib/utils/format/dateTime';
+import { correctCestOffsetUTC } from './correctCestOffsetUTC';
+import { withTimeZone } from './withTimeZone.testutil';
+
+/** Bildet eine Formulareingabe (deutsche Ortszeit) auf den gespeicherten UTC-Zeitpunkt ab. */
+function speichereSichtungszeit(datum: string, uhrzeit: string): string {
+	return correctCestOffsetUTC(combineToDate(datum, uhrzeit)).toISOString();
+}
+
+describe('correctCestOffsetUTC', () => {
+	describe('Zeitzonen-Invarianz der Sichtungs-Pipeline', () => {
+		it('liefert unter UTC und Europe/Berlin denselben Zeitpunkt (Winter, CET)', () => {
+			const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-01-15', '14:30'));
+			const berlin = withTimeZone('Europe/Berlin', () =>
+				speichereSichtungszeit('2024-01-15', '14:30')
+			);
+
+			expect(utc).toBe(berlin);
+			// 14:30 MEZ (UTC+1) == 13:30 UTC
+			expect(utc).toBe('2024-01-15T13:30:00.000Z');
+		});
+
+		it('liefert unter UTC und Europe/Berlin denselben Zeitpunkt (Sommer, CEST)', () => {
+			const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-07-15', '14:30'));
+			const berlin = withTimeZone('Europe/Berlin', () =>
+				speichereSichtungszeit('2024-07-15', '14:30')
+			);
+
+			expect(utc).toBe(berlin);
+			// 14:30 MESZ (UTC+2) == 12:30 UTC
+			expect(utc).toBe('2024-07-15T12:30:00.000Z');
+		});
+
+		it('ist für alle 24 Stunden eines Wintertages zeitzonenunabhängig', () => {
+			for (let stunde = 0; stunde < 24; stunde++) {
+				const uhrzeit = `${String(stunde).padStart(2, '0')}:00`;
+				const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-01-15', uhrzeit));
+				const berlin = withTimeZone('Europe/Berlin', () =>
+					speichereSichtungszeit('2024-01-15', uhrzeit)
+				);
+
+				expect(utc, `Abweichung bei ${uhrzeit} (Winter)`).toBe(berlin);
+			}
+		});
+
+		it('ist für alle 24 Stunden eines Sommertages zeitzonenunabhängig', () => {
+			for (let stunde = 0; stunde < 24; stunde++) {
+				const uhrzeit = `${String(stunde).padStart(2, '0')}:00`;
+				const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-07-15', uhrzeit));
+				const berlin = withTimeZone('Europe/Berlin', () =>
+					speichereSichtungszeit('2024-07-15', uhrzeit)
+				);
+
+				expect(utc, `Abweichung bei ${uhrzeit} (Sommer)`).toBe(berlin);
+			}
+		});
+	});
+
+	describe('Sommerzeit-Grenzen', () => {
+		it('behandelt den Tag vor der Zeitumstellung als MEZ', () => {
+			// Sommerzeit 2024 beginnt am 31.03.2024
+			const ergebnis = withTimeZone('UTC', () => speichereSichtungszeit('2024-03-30', '12:00'));
+			expect(ergebnis).toBe('2024-03-30T11:00:00.000Z');
+		});
+
+		it('behandelt den Tag nach der Zeitumstellung als MESZ', () => {
+			const ergebnis = withTimeZone('UTC', () => speichereSichtungszeit('2024-04-01', '12:00'));
+			expect(ergebnis).toBe('2024-04-01T10:00:00.000Z');
+		});
+
+		it('behandelt den Tag nach dem Ende der Sommerzeit als MEZ', () => {
+			// Sommerzeit 2024 endet am 27.10.2024
+			const ergebnis = withTimeZone('UTC', () => speichereSichtungszeit('2024-10-28', '12:00'));
+			expect(ergebnis).toBe('2024-10-28T11:00:00.000Z');
+		});
+	});
+});

--- a/src/lib/server/datetime/withTimeZone.testutil.ts
+++ b/src/lib/server/datetime/withTimeZone.testutil.ts
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Test-Helfer: führt eine Funktion unter einer festen Zeitzone aus.
+ *
+ * Node wertet `process.env.TZ` zur Laufzeit aus, eine Änderung wirkt also sofort
+ * auf alle danach erzeugten `Date`-Operationen. Der Helfer stellt die vorherige
+ * Zeitzone garantiert wieder her, damit sich Testdateien im selben Worker nicht
+ * gegenseitig die Zeitzone verstellen.
+ */
+
+/** Zeitzonen, unter denen zeitzonenkritischer Code stabil sein muss. */
+export const TEST_TIME_ZONES = ['UTC', 'Europe/Berlin', 'America/New_York', 'Pacific/Kiritimati'];
+
+/**
+ * Führt `fn` unter der angegebenen Zeitzone aus und stellt die alte wieder her.
+ *
+ * @param timeZone - IANA-Zeitzone, z. B. `Europe/Berlin`
+ * @param fn - Auszuführende Funktion
+ * @returns Rückgabewert von `fn`
+ */
+export function withTimeZone<T>(timeZone: string, fn: () => T): T {
+	const original = process.env.TZ;
+	process.env.TZ = timeZone;
+	try {
+		return fn();
+	} finally {
+		if (original === undefined) {
+			delete process.env.TZ;
+		} else {
+			process.env.TZ = original;
+		}
+	}
+}

--- a/src/lib/server/export/csvExport.timezone.test.ts
+++ b/src/lib/server/export/csvExport.timezone.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview CSV-Export muss deutsche Ortszeit liefern — unabhängig von der Server-Zeitzone.
+ *
+ * Der CSV-Export baute Datum und Uhrzeit aus `getDate()`/`getHours()` zusammen.
+ * Diese Getter arbeiten in der **lokalen** Zeitzone des Prozesses. Im Docker-
+ * Container (kein `TZ` gesetzt → UTC) lieferte der Export damit UTC-Uhrzeiten,
+ * während KML-, XML- und JSON-Export über `formatForExport` explizit
+ * `Europe/Berlin` verwenden. Dieselbe Sichtung erschien je nach Exportformat
+ * mit 1–2 Stunden Unterschied.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FrontendSighting } from '$lib/types/index';
+import { withTimeZone, TEST_TIME_ZONES } from '$lib/server/datetime/withTimeZone.testutil';
+import { generateCsvData } from './csvExport';
+
+vi.mock('$lib/report/formOptions/animalBehavior', () => ({
+	getAnimalBehaviorLabel: vi.fn((value) => `behavior-${value}`)
+}));
+vi.mock('$lib/report/formOptions/boatDrive', () => ({
+	getBoatDriveLabel: vi.fn((value) => `boatDrive-${value}`)
+}));
+vi.mock('$lib/report/formOptions/distance', () => ({
+	getDistanceLabel: vi.fn((value) => `distance-${value}`)
+}));
+vi.mock('$lib/report/formOptions/distribution', () => ({
+	getDistributionLabel: vi.fn((value) => `distribution-${value}`)
+}));
+vi.mock('$lib/report/formOptions/seaState', () => ({
+	getSeaStateLabel: vi.fn((value) => `seaState-${value}`)
+}));
+vi.mock('$lib/report/formOptions/sightingFrom', () => ({
+	getSightingFromLabel: vi.fn((value) => `sightingFrom-${value}`)
+}));
+vi.mock('$lib/report/formOptions/species', () => ({
+	getSpeciesLabel: vi.fn((value) => `species-${value}`)
+}));
+vi.mock('$lib/report/formOptions/visibility', () => ({
+	getVisibilityLabel: vi.fn((value) => `visibility-${value}`)
+}));
+
+/** Minimale Sichtung — nur die für Datum/Uhrzeit relevanten Felder sind gesetzt. */
+function sichtungMit(sightingDate: string): FrontendSighting {
+	return { id: 'tz-1', sightingDate, species: 0, totalCount: 1 } as unknown as FrontendSighting;
+}
+
+/** Liefert `[Datum, Uhrzeit]` aus der ersten Datenzeile des CSV. */
+function datumUndUhrzeit(csv: string): [string, string] {
+	const spalten = csv.split('\n')[1]?.split(';') ?? [];
+	return [spalten[1]?.replaceAll('"', '') ?? '', spalten[2]?.replaceAll('"', '') ?? ''];
+}
+
+describe('csvExport — Zeitzonenbehandlung', () => {
+	it('gibt Winterzeit als MEZ (UTC+1) aus', () => {
+		// 2024-01-15T14:30Z == 15:30 MEZ
+		const [datum, uhrzeit] = datumUndUhrzeit(
+			withTimeZone('UTC', () => generateCsvData([sichtungMit('2024-01-15T14:30:00.000Z')]))
+		);
+
+		expect(datum).toBe('15.01.2024');
+		expect(uhrzeit).toBe('15:30');
+	});
+
+	it('gibt Sommerzeit als MESZ (UTC+2) aus', () => {
+		// 2024-07-15T14:30Z == 16:30 MESZ
+		const [datum, uhrzeit] = datumUndUhrzeit(
+			withTimeZone('UTC', () => generateCsvData([sichtungMit('2024-07-15T14:30:00.000Z')]))
+		);
+
+		expect(datum).toBe('15.07.2024');
+		expect(uhrzeit).toBe('16:30');
+	});
+
+	it('liefert in jeder Server-Zeitzone dasselbe Ergebnis', () => {
+		const sichtung = sichtungMit('2024-07-15T22:30:00.000Z');
+
+		const ergebnisse = TEST_TIME_ZONES.map((tz) =>
+			datumUndUhrzeit(withTimeZone(tz, () => generateCsvData([sichtung]))).join(' ')
+		);
+
+		// 2024-07-15T22:30Z == 16.07.2024 00:30 MESZ — der Tageswechsel macht die
+		// Zeitzonenabhängigkeit sichtbar, falls sie zurückkehrt.
+		expect(new Set(ergebnisse)).toEqual(new Set(['16.07.2024 00:30']));
+	});
+});

--- a/src/lib/server/export/csvExport.ts
+++ b/src/lib/server/export/csvExport.ts
@@ -93,10 +93,13 @@ export function generateCsvData(sightings: FrontendSighting[]): string {
 
 	// Verarbeite jede Sichtung zu einer CSV-Zeile
 	sightings.forEach((sighting) => {
-		// Datum und Zeit formatieren (deutsche Lokalisierung)
-		const sdt = new Date(sighting.sightingDate);
-		const date = `${sdt.getDate().toString().padStart(2, '0')}.${(sdt.getMonth() + 1).toString().padStart(2, '0')}.${sdt.getFullYear()}`;
-		const time = `${sdt.getHours().toString().padStart(2, '0')}:${sdt.getMinutes().toString().padStart(2, '0')}`;
+		// Datum und Zeit in deutscher Ortszeit formatieren.
+		// Bewusst über formatLocalDateTime (fixe Zeitzone Europe/Berlin) statt über
+		// getDate()/getHours(): diese Getter arbeiten in der Zeitzone des Prozesses,
+		// womit der Export im UTC-Container 1–2 Stunden gegenüber KML-, XML- und
+		// JSON-Export abgewichen wäre.
+		const date = formatLocalDateTime(sighting.sightingDate, 'date');
+		const time = formatLocalDateTime(sighting.sightingDate, 'time');
 
 		// Enum-Werte in lesbare Labels konvertieren
 		const speciesName = getSpeciesLabel(sighting.species);

--- a/src/lib/server/middleware/rateLimit.ts
+++ b/src/lib/server/middleware/rateLimit.ts
@@ -189,7 +189,11 @@ export function enforceRateLimit(
 
 	if (!result.allowed) {
 		const resetDate = new Date(result.resetTime);
-		const resetTimeFormatted = resetDate.toLocaleTimeString('de-DE');
+		// Zeitzone explizit: die Meldung geht an deutsche Nutzer, nicht an die
+		// Zeitzone des Servers.
+		const resetTimeFormatted = resetDate.toLocaleTimeString('de-DE', {
+			timeZone: 'Europe/Berlin'
+		});
 		const retryAfterSeconds = Math.ceil((result.resetTime - Date.now()) / 1000);
 
 		throw error(

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -346,7 +346,7 @@ export class EmailService {
 				html: `
 					<h2>Test E-Mail</h2>
 					<p>Diese Test-E-Mail wurde erfolgreich von der Ostsee-Tiere Anwendung gesendet.</p>
-					<p><strong>Zeitpunkt:</strong> ${new Date().toLocaleString('de-DE')}</p>
+					<p><strong>Zeitpunkt:</strong> ${new Date().toLocaleString('de-DE', { timeZone: 'Europe/Berlin' })}</p>
 					<p><strong>Konfiguration:</strong> Funktioniert korrekt ✅</p>
 				`,
 				text: 'Test E-Mail - Die Ostsee-Tiere E-Mail Konfiguration funktioniert korrekt.'

--- a/src/lib/server/services/weatherDeduplication.ts
+++ b/src/lib/server/services/weatherDeduplication.ts
@@ -53,8 +53,13 @@ export async function checkExistingWeatherData(
 						ST_SetSRID(ST_Point(${longitude}, ${latitude}), 4326)::geography,
 						1000
 					)`,
-					// Same date
-					eq(sql`DATE(${sightings.sightingDate})`, date),
+					// Gleicher Kalendertag in deutscher Ortszeit: `date` kommt als
+					// lokales "YYYY-MM-DD" aus dem Formular, `sichtungsdatum` hält
+					// seit der UTC-Migration echte Zeitpunkte.
+					eq(
+						sql`DATE(${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`,
+						date
+					),
 					// Has weather data
 					isNotNull(sightings.weatherData)
 				)
@@ -186,7 +191,7 @@ export async function getWeatherCacheStatistics(): Promise<{
 		// Unique position+date combinations
 		const [uniqueResult] = await db
 			.select({
-				count: sql<number>`COUNT(DISTINCT (ROUND(gps_breite::numeric, 2), ROUND(gps_laenge::numeric, 2), DATE(sichtungsdatum)))`
+				count: sql<number>`COUNT(DISTINCT (ROUND(gps_breite::numeric, 2), ROUND(gps_laenge::numeric, 2), DATE(sichtungsdatum AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')))`
 			})
 			.from(sightings)
 			.where(isNotNull(sightings.weatherData));

--- a/src/lib/server/weather/hourIndex.test.ts
+++ b/src/lib/server/weather/hourIndex.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Der Stundenindex in die Open-Meteo-Zeitreihe darf nicht an der Server-Zeitzone hängen.
+ *
+ * Open-Meteo wird mit `timezone=Europe/Berlin` abgefragt, `hourly.time[]` ist
+ * also deutsche Ortszeit. Der Index wurde bisher aus
+ * `combineToDate(datum, zeit).getHours()` gebildet — ein Umweg über ein
+ * `Date`, dessen `getHours()` in der Prozess-Zeitzone auswertet. Im UTC-
+ * Container griff die Abfrage damit 1–2 Stunden daneben: Sichtungen bekamen
+ * das Wetter der falschen Stunde angeheftet.
+ *
+ * Die Uhrzeit kommt bereits als deutsche Ortszeit im Format "HH:MM" aus dem
+ * Formular. Sie direkt zu parsen ist zeitzonenunabhängig.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { NOON_HOUR_INDEX, hourIndexFromLocalTime } from './hourIndex';
+
+describe('hourIndexFromLocalTime', () => {
+	it('bildet volle Stunden direkt ab', () => {
+		expect(hourIndexFromLocalTime('00:00')).toBe(0);
+		expect(hourIndexFromLocalTime('09:00')).toBe(9);
+		expect(hourIndexFromLocalTime('23:00')).toBe(23);
+	});
+
+	it('rundet auf die nächstliegende Stunde', () => {
+		expect(hourIndexFromLocalTime('14:29')).toBe(14);
+		expect(hourIndexFromLocalTime('14:30')).toBe(15);
+		expect(hourIndexFromLocalTime('14:45')).toBe(15);
+	});
+
+	it('begrenzt das Aufrunden auf die letzte Stunde des Tages', () => {
+		// 23:45 würde auf 24 aufrunden — die Zeitreihe hat aber nur die Indizes 0..23.
+		expect(hourIndexFromLocalTime('23:45')).toBe(23);
+	});
+
+	it('fällt bei fehlender oder ungültiger Uhrzeit auf Mittag zurück', () => {
+		expect(hourIndexFromLocalTime(undefined)).toBe(NOON_HOUR_INDEX);
+		expect(hourIndexFromLocalTime('')).toBe(NOON_HOUR_INDEX);
+		expect(hourIndexFromLocalTime('keine Zeit')).toBe(NOON_HOUR_INDEX);
+		expect(hourIndexFromLocalTime('99:99')).toBe(NOON_HOUR_INDEX);
+	});
+
+	it('liefert in jeder Server-Zeitzone denselben Index', () => {
+		for (let stunde = 0; stunde < 24; stunde++) {
+			const uhrzeit = `${String(stunde).padStart(2, '0')}:15`;
+			const ergebnisse = TEST_TIME_ZONES.map((tz) =>
+				withTimeZone(tz, () => hourIndexFromLocalTime(uhrzeit))
+			);
+
+			expect(new Set(ergebnisse), `Zeitzonenabhängigkeit bei ${uhrzeit}`).toEqual(
+				new Set([stunde])
+			);
+		}
+	});
+});

--- a/src/lib/server/weather/hourIndex.ts
+++ b/src/lib/server/weather/hourIndex.ts
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Stundenindex in die Open-Meteo-Zeitreihe.
+ *
+ * Open-Meteo wird mit `timezone=Europe/Berlin` abgefragt, `hourly.time[]` ist
+ * damit deutsche Ortszeit. Die Uhrzeit einer Sichtung liegt im Formular bereits
+ * als deutsche Ortszeit vor ("HH:MM"), sie wird deshalb direkt geparst statt
+ * über ein `Date` — dessen `getHours()` würde in der Zeitzone des Prozesses
+ * auswerten und im UTC-Container die falsche Stunde treffen.
+ */
+
+/** Fallback-Index, wenn keine verwertbare Uhrzeit vorliegt: 12:00 Ortszeit. */
+export const NOON_HOUR_INDEX = 12;
+
+/** Letzter gültiger Index einer stündlichen Tages-Zeitreihe. */
+const LAST_HOUR_INDEX = 23;
+
+const TIME_PATTERN = /^(\d{1,2}):(\d{2})$/;
+
+/**
+ * Ermittelt den Index der nächstliegenden vollen Stunde in einer stündlichen Zeitreihe.
+ *
+ * @param localTime - Uhrzeit in deutscher Ortszeit im Format "HH:MM"
+ * @returns Index zwischen 0 und 23; bei fehlender oder ungültiger Eingabe {@link NOON_HOUR_INDEX}
+ *
+ * @example
+ * ```typescript
+ * hourIndexFromLocalTime('14:45'); // 15
+ * hourIndexFromLocalTime('23:45'); // 23 (kein Überlauf auf den Folgetag)
+ * hourIndexFromLocalTime(null);    // 12
+ * ```
+ */
+export function hourIndexFromLocalTime(localTime: string | null | undefined): number {
+	const match = localTime?.match(TIME_PATTERN);
+	if (!match) {
+		return NOON_HOUR_INDEX;
+	}
+
+	const hours = Number(match[1]);
+	const minutes = Number(match[2]);
+	if (hours > LAST_HOUR_INDEX || minutes > 59) {
+		return NOON_HOUR_INDEX;
+	}
+
+	// Auf die nächstliegende volle Stunde runden, ohne auf den Folgetag zu laufen.
+	return Math.min(hours + Math.round(minutes / 60), LAST_HOUR_INDEX);
+}

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -36,27 +36,38 @@ export const load: PageServerLoad = async () => {
 			.groupBy(sightings.species)
 			.orderBy(sql`COUNT(*) DESC`);
 
+		// Jahr und Monat in deutscher Ortszeit gruppieren: `sichtungsdatum` hält
+		// seit der UTC-Migration echte Zeitpunkte. Eine Sichtung am 01.01. um 00:30
+		// Ortszeit steht darin als 31.12. 23:30 UTC und gehört trotzdem ins neue Jahr.
 		// Yearly trends (excluding obvious data errors)
 		const yearlyStats = await db
 			.select({
-				year: sql<number>`EXTRACT(year FROM ${sightings.sightingDate}::timestamp)`,
+				year: sql<number>`EXTRACT(year FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`,
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
 			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
-			.groupBy(sql`EXTRACT(year FROM ${sightings.sightingDate}::timestamp)`)
-			.orderBy(sql`EXTRACT(year FROM ${sightings.sightingDate}::timestamp)`);
+			.groupBy(
+				sql`EXTRACT(year FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`
+			)
+			.orderBy(
+				sql`EXTRACT(year FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`
+			);
 
 		// Monthly distribution (last 10 years)
 		const monthlyStats = await db
 			.select({
-				month: sql<number>`EXTRACT(month FROM ${sightings.sightingDate}::timestamp)`,
+				month: sql<number>`EXTRACT(month FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`,
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
 			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
-			.groupBy(sql`EXTRACT(month FROM ${sightings.sightingDate}::timestamp)`)
-			.orderBy(sql`EXTRACT(month FROM ${sightings.sightingDate}::timestamp)`);
+			.groupBy(
+				sql`EXTRACT(month FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`
+			)
+			.orderBy(
+				sql`EXTRACT(month FROM ${sightings.sightingDate} AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')`
+			);
 
 		// Recent activity (last 30 days)
 		const recentActivity = await db
@@ -193,7 +204,10 @@ export const load: PageServerLoad = async () => {
 			}
 		};
 	} catch (error) {
-		logger.error({ error: error instanceof Error ? error.message : error }, 'Error loading statistics');
+		logger.error(
+			{ error: error instanceof Error ? error.message : error },
+			'Error loading statistics'
+		);
 		throw error;
 	}
 };

--- a/src/routes/api/weather/historical/+server.ts
+++ b/src/routes/api/weather/historical/+server.ts
@@ -10,6 +10,7 @@ import {
 	type OpenMeteoRawData,
 	type WeatherData
 } from '$lib/services/weatherService';
+import { hourIndexFromLocalTime } from '$lib/server/weather/hourIndex';
 import { combineToDate, formatISOLikeDatetime } from '$lib/utils/format/dateTime';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
@@ -112,8 +113,11 @@ async function fetchForecastData(
 			return null;
 		}
 
-		let targetIndex = dateObj.getHours() + Math.round(dateObj.getMinutes() / 60);
-		if (isNaN(targetIndex) || targetIndex < 0 || targetIndex >= hourly.time.length) {
+		// `hourly.time[]` steht in deutscher Ortszeit (Abfrage mit timezone=Europe/Berlin),
+		// die Uhrzeit der Sichtung ebenfalls — der Index wird deshalb direkt aus "HH:MM"
+		// gebildet und nicht über die Prozess-Zeitzone eines Date-Objekts.
+		let targetIndex = hourIndexFromLocalTime(time);
+		if (targetIndex >= hourly.time.length) {
 			targetIndex = 12; // Default to noon
 		}
 
@@ -275,8 +279,11 @@ async function fetchHistoricalData(
 		}
 
 		// Find the closest hour index
-		let targetIndex = dateObj.getHours() + Math.round(dateObj.getMinutes() / 60);
-		if (isNaN(targetIndex) || targetIndex < 0 || targetIndex >= hourly.time.length) {
+		// `hourly.time[]` steht in deutscher Ortszeit (Abfrage mit timezone=Europe/Berlin),
+		// die Uhrzeit der Sichtung ebenfalls — der Index wird deshalb direkt aus "HH:MM"
+		// gebildet und nicht über die Prozess-Zeitzone eines Date-Objekts.
+		let targetIndex = hourIndexFromLocalTime(time);
+		if (targetIndex >= hourly.time.length) {
 			targetIndex = 12; // Default to noon if out of range
 		}
 

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -24,7 +24,7 @@ import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { json, type RequestEvent } from '@sveltejs/kit';
-import { and, between, sql } from 'drizzle-orm';
+import { and, between, gte, lt, sql } from 'drizzle-orm';
 
 const logger = createLogger('api:legacy:showreports:pdf-compliant');
 
@@ -94,7 +94,13 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				// Jahresauslegung haben und darf nicht an der Server-Zeitzone hängen.
 				const { startDate, endDate } = getYearRange(yearNum);
 
-				whereConditions.push(and(between(sightings.sightingDate, startDate, endDate)));
+				// Halboffenes Intervall [startDate, endDate): `endDate` ist Neujahr
+				// des Folgejahres. SQL BETWEEN ist beidseitig inklusiv und würde eine
+				// Sichtung exakt um 00:00 Ortszeit am 01.01. in zwei Jahren liefern —
+				// 365 Datensätze haben genau diese Uhrzeit (keine Angabe).
+				whereConditions.push(
+					and(gte(sightings.sightingDate, startDate), lt(sightings.sightingDate, endDate))
+				);
 
 				logger.debug(
 					{

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -12,7 +12,12 @@
  * @since 1.10.0
  */
 
-import { formatDateDDMMYY, formatTimeHHMI, toUnixTimestamp } from '$lib/legacy-api/date-utils.js';
+import {
+	formatDateDDMMYY,
+	formatTimeHHMI,
+	getYearRange,
+	toUnixTimestamp
+} from '$lib/legacy-api/date-utils.js';
 import { createLogger } from '$lib/logger.server';
 import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 import { db } from '$lib/server/db';
@@ -84,8 +89,10 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		if (year) {
 			const yearNum = parseInt(year);
 			if (!isNaN(yearNum) && yearNum >= 1900 && yearNum <= new Date().getFullYear() + 1) {
-				const startDate = new Date(yearNum, 0, 1); // January 1st
-				const endDate = new Date(yearNum + 1, 0, 1); // January 1st next year
+				// Jahresgrenzen in deutscher Ortszeit: `dt`/`ti` der Response werden
+				// nach Europe/Berlin umgerechnet, der Filter muss dieselbe
+				// Jahresauslegung haben und darf nicht an der Server-Zeitzone hängen.
+				const { startDate, endDate } = getYearRange(yearNum);
 
 				whereConditions.push(and(between(sightings.sightingDate, startDate, endDate)));
 

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -16,7 +16,9 @@ import type { RequestEvent } from '@sveltejs/kit';
 const mockSightingData = [
 	{
 		id: 817,
-		sichtungsdatum: '2012-01-25T14:50:00.000Z',
+		// Migrierter Altdatensatz: 25.01.2012 14:50 Ortszeit == 13:50 UTC (MEZ).
+		// Die Spalte hält echte UTC-Zeitpunkte, die API gibt Ortszeit aus.
+		sichtungsdatum: '2012-01-25T13:50:00.000Z',
 		latitude: '54.646667',
 		longitude: '11.333333',
 		totalCount: 1,
@@ -163,10 +165,10 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 
 			// PDF format: DD.MM.YY (2-digit year!)
 			expect(firstSighting.dt).toBe('25.01.12');
-			expect(firstSighting.ti).toBe('14:50'); // UTC time (consistent across all timezones)
+			expect(firstSighting.ti).toBe('14:50'); // German local time, unchanged by the UTC migration
 
-			// Verify Unix timestamp - calculated from UTC date/time
-			expect(firstSighting.ts).toBe(1327503000); // Unix timestamp for 2012-01-25T14:50:00.000Z
+			// Verify Unix timestamp - the true instant, not the local rendering
+			expect(firstSighting.ts).toBe(1327499400); // Unix timestamp for 2012-01-25T13:50:00.000Z
 		});
 
 		it('should return coordinates as strings with proper precision', async () => {

--- a/src/tools/migrate-timestamps-to-utc.js
+++ b/src/tools/migrate-timestamps-to-utc.js
@@ -134,13 +134,16 @@ async function reportAmbiguousTimestamps() {
 		  AND ((sichtungsdatum AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE ${SOURCE_TIME_ZONE})
 		      <> sichtungsdatum`;
 
-	// Mehrdeutige Ortszeiten (Wiederholstunde im Herbst): dieselbe Wanduhrzeit
-	// existiert zweimal, Postgres wählt eine Auslegung.
+	// Mehrdeutige Ortszeiten (Wiederholstunde am Ende der Sommerzeit): dieselbe
+	// Wanduhrzeit existiert zweimal. Postgres wählt beim Umrechnen die spätere
+	// Auslegung (MEZ) — liegt eine Stunde davor dieselbe Wanduhrzeit, ist der
+	// Wert mehrdeutig. Nur die Stunde grob über Monat und Uhrzeit einzugrenzen
+	// würde alle Oktober-Sichtungen um 02:xx melden und die Warnung entwerten.
 	const [{ mehrdeutig }] = await sql`
 		SELECT count(*)::int AS mehrdeutig FROM sichtungen
 		WHERE sichtungsdatum IS NOT NULL
-		  AND date_part('month', sichtungsdatum) = 10
-		  AND date_part('hour', sichtungsdatum) = 2`;
+		  AND ((sichtungsdatum AT TIME ZONE ${SOURCE_TIME_ZONE}) - interval '1 hour')
+		      AT TIME ZONE ${SOURCE_TIME_ZONE} = sichtungsdatum`;
 
 	if (nichtExistent > 0) {
 		console.warn(`⚠️  ${nichtExistent} Zeitstempel liegen in der Frühjahrs-Zeitlücke.`);

--- a/src/tools/migrate-timestamps-to-utc.js
+++ b/src/tools/migrate-timestamps-to-utc.js
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * @fileoverview Einmal-Migration: naive Ortszeit-Zeitstempel → echtes UTC
+ *
+ * Die Zeitstempelspalten sind `timestamp without time zone` und enthielten
+ * bisher deutsche Ortszeit als Wanduhrzeit — ein Erbe des PHP-Vorgängersystems,
+ * das auf einem Server in Europe/Berlin lief. Die SvelteKit-Anwendung schreibt
+ * dagegen echte UTC-Zeitpunkte (Drizzle serialisiert mit `toISOString()`).
+ *
+ * Ohne diese Migration enthielte die Spalte zwei unvereinbare Auslegungen:
+ * Frontend und Legacy-API würden sich um genau den MEZ/MESZ-Offset
+ * widersprechen. Details: docs/ENVIRONMENT.md → TZ.
+ *
+ * Die Legacy-API-Ausgabe bleibt für Altdatensätze UNVERÄNDERT: die Migration
+ * zieht den Offset ab, die Formatter (`Europe/Berlin`) addieren ihn wieder.
+ * Abgesichert durch src/lib/legacy-api/date-utils.timezone.test.ts.
+ *
+ * Migriert werden `sichtungen` (sichtungsdatum, created, freigegeben_am) und
+ * `sichtungen_dateien` (hochgeladen_am, erstellt_am).
+ *
+ * Verwendung:
+ *   node src/tools/migrate-timestamps-to-utc.js --cutover=<ISO> [--exclude-ids=…] [--dry-run] [--verbose] [--force]
+ *
+ * Parameter:
+ *   --cutover=<ISO>    PFLICHT. Zeitpunkt, ab dem Datensätze bereits UTC sind
+ *                      (Go-Live der SvelteKit-App). Alles mit created < cutover
+ *                      wird migriert, alles danach bleibt unangetastet.
+ *   --exclude-ids=…    Kommagetrennte Sichtungs-IDs, die bereits UTC enthalten
+ *                      und deshalb übersprungen werden.
+ *   --dry-run          Simulation ohne Schreibzugriff
+ *   --verbose          Zeigt Beispieldatensätze vor/nach der Umrechnung
+ *   --force            Überschreibt den Wiederholungsschutz (NUR nach Restore!)
+ *
+ * Vor dem Lauf: Backup ziehen. Die Umrechnung ist nicht ohne Weiteres umkehrbar,
+ * weil `--force` und ein zweiter Lauf die Werte erneut verschieben würden.
+ *
+ * @author Ostsee-Tiere Team
+ */
+
+import { config } from 'dotenv';
+import postgres from 'postgres';
+
+config();
+
+const args = process.argv.slice(2);
+const isDryRun = args.includes('--dry-run');
+const isVerbose = args.includes('--verbose');
+const isForced = args.includes('--force');
+const cutoverArg = args.find((arg) => arg.startsWith('--cutover='))?.split('=')[1];
+
+/** Sichtungs-IDs, die vom Umfang ausgenommen bleiben (bereits UTC). */
+const excludedIds = (args.find((arg) => arg.startsWith('--exclude-ids='))?.split('=')[1] ?? '')
+	.split(',')
+	.filter(Boolean)
+	.map(Number);
+
+if (excludedIds.some(Number.isNaN)) {
+	console.error('❌ --exclude-ids erwartet eine kommagetrennte Liste numerischer IDs.');
+	process.exit(1);
+}
+
+/** Zeitzone, in der die Altdaten als Wanduhrzeit vorliegen. */
+const SOURCE_TIME_ZONE = 'Europe/Berlin';
+
+/** Schlüssel in `app_config`, der eine bereits erfolgte Migration markiert. */
+const MARKER_KEY = 'timestamps_migrated_to_utc';
+
+if (!cutoverArg) {
+	console.error('❌ --cutover=<ISO> ist erforderlich.');
+	console.error('   Beispiel: --cutover=2026-08-01T00:00:00Z');
+	console.error('   Der Zeitpunkt muss dem Go-Live der SvelteKit-App entsprechen:');
+	console.error('   davor angelegte Datensätze sind Ortszeit, danach angelegte bereits UTC.');
+	process.exit(1);
+}
+
+const cutover = new Date(cutoverArg);
+if (isNaN(cutover.getTime())) {
+	console.error(`❌ Ungültiger --cutover-Wert: ${cutoverArg}`);
+	process.exit(1);
+}
+
+// Kein stiller Fallback auf eine Standard-Verbindung: andere Tools in diesem
+// Verzeichnis dürfen das, weil sie idempotent sind. Diese Migration verschiebt
+// Zeitstempel unumkehrbar — sie darf niemals auf einer Datenbank landen, die
+// der Aufrufer nicht ausdrücklich benannt hat. In einem Git-Worktree ohne
+// verlinkte .env wäre genau das passiert.
+const connectionString = process.env.DATABASE_POSTGRES_URL || process.env.DATABASE_URL;
+
+if (!connectionString) {
+	console.error('❌ Keine Datenbankverbindung gefunden.');
+	console.error('   DATABASE_POSTGRES_URL muss gesetzt sein — entweder in der Umgebung');
+	console.error('   oder in einer .env im Arbeitsverzeichnis.');
+	console.error('   In einem Git-Worktree fehlt die .env oft:');
+	console.error('     bash scripts/new-worktree.sh --link-env "$(pwd)"');
+	console.error('   Diese Migration rät nicht — sie verschiebt Zeitstempel unumkehrbar.');
+	process.exit(1);
+}
+
+const sql = postgres(connectionString);
+
+console.log(`🔗 Datenbank: ${connectionString.replace(/:[^:@]*@/, ':****@')}`);
+console.log(`🕓 Cutover:   ${cutover.toISOString()} (created davor wird migriert)`);
+console.log(
+	isDryRun ? '🧪 Modus:     DRY RUN — keine Änderungen\n' : '✍️  Modus:     SCHREIBEND\n'
+);
+
+/** Bricht ab, wenn die Migration bereits gelaufen ist. */
+async function assertNotAlreadyMigrated() {
+	const [marker] = await sql`SELECT value FROM app_config WHERE key = ${MARKER_KEY}`;
+	if (!marker) return;
+
+	if (!isForced) {
+		console.error('❌ Migration wurde bereits ausgeführt:');
+		console.error(`   ${JSON.stringify(marker.value)}`);
+		console.error('   Ein zweiter Lauf würde die Zeitstempel ein weiteres Mal verschieben.');
+		console.error('   Nur nach einem Restore aus dem Backup mit --force wiederholen.');
+		process.exit(1);
+	}
+	console.warn('⚠️  Marker vorhanden, --force gesetzt — fahre trotzdem fort.\n');
+}
+
+/**
+ * Prüft auf Zeitstempel, die in der Quellzeitzone nicht eindeutig sind.
+ * In der Wiederholstunde der Rückstellung existiert dieselbe Wanduhrzeit zweimal;
+ * Postgres wählt beim Umrechnen eine Auslegung. Solche Werte müssen bekannt sein.
+ */
+async function reportAmbiguousTimestamps() {
+	// Nicht existente Ortszeiten (Frühjahrs-Lücke): der Hin- und Rückweg durch die
+	// Zeitzone liefert einen anderen Wert. Diese Datensätze verschieben sich.
+	const [{ nichtExistent }] = await sql`
+		SELECT count(*)::int AS "nichtExistent" FROM sichtungen
+		WHERE sichtungsdatum IS NOT NULL
+		  AND ((sichtungsdatum AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE ${SOURCE_TIME_ZONE})
+		      <> sichtungsdatum`;
+
+	// Mehrdeutige Ortszeiten (Wiederholstunde im Herbst): dieselbe Wanduhrzeit
+	// existiert zweimal, Postgres wählt eine Auslegung.
+	const [{ mehrdeutig }] = await sql`
+		SELECT count(*)::int AS mehrdeutig FROM sichtungen
+		WHERE sichtungsdatum IS NOT NULL
+		  AND date_part('month', sichtungsdatum) = 10
+		  AND date_part('hour', sichtungsdatum) = 2`;
+
+	if (nichtExistent > 0) {
+		console.warn(`⚠️  ${nichtExistent} Zeitstempel liegen in der Frühjahrs-Zeitlücke.`);
+		console.warn('   Diese Werte verschieben sich bei der Umrechnung.');
+	}
+	if (mehrdeutig > 0) {
+		console.warn(`⚠️  ${mehrdeutig} Zeitstempel liegen in der Oktober-Wiederholstunde.`);
+		console.warn('   Postgres wählt beim Umrechnen eine der beiden Auslegungen.');
+	}
+	if (nichtExistent === 0 && mehrdeutig === 0) {
+		console.log('✅ Keine mehrdeutigen oder nicht existenten Ortszeiten gefunden.');
+	}
+	console.log();
+}
+
+/** Zeigt Beispiele der geplanten Umrechnung. */
+async function showSamples() {
+	const samples = await sql`
+		SELECT id, sichtungsdatum AS vorher,
+		       (sichtungsdatum AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC' AS nachher
+		FROM sichtungen
+		WHERE created < ${cutover}
+		  AND id <> ALL(${excludedIds})
+		  AND sichtungsdatum >= '1990-01-01'
+		ORDER BY sichtungsdatum DESC LIMIT 5`;
+
+	console.log('📋 Beispiele (neueste 5):');
+	for (const row of samples) {
+		console.log(`   #${row.id}  ${row.vorher.toISOString()}  →  ${row.nachher.toISOString()}`);
+	}
+	console.log();
+}
+
+/**
+ * Bricht ab, wenn Datensätze im Umfang liegen, die bereits von der SvelteKit-App
+ * geschrieben wurden — sie enthalten schon UTC und würden ein zweites Mal
+ * verschoben. Erkennungsmerkmal ist `weather_data`: die Wetteranreicherung gibt
+ * es nur in der neuen Anwendung.
+ */
+async function assertNoAppWrittenRecordsInScope() {
+	const verdaechtig = await sql`
+		SELECT id FROM sichtungen
+		WHERE weather_data IS NOT NULL
+		  AND created < ${cutover}
+		  AND id <> ALL(${excludedIds})
+		ORDER BY id`;
+
+	if (verdaechtig.length === 0) return;
+
+	const ids = verdaechtig.map((row) => row.id);
+	console.error('❌ Im Migrationsumfang liegen Datensätze, die bereits UTC enthalten:');
+	console.error(`   IDs: ${ids.join(', ')}`);
+	console.error('   Erkennungsmerkmal: weather_data ist gesetzt (nur die neue App schreibt das).');
+	console.error('   Sie würden ein zweites Mal um den Offset verschoben.');
+	console.error(`   Entweder ausschließen:  --exclude-ids=${ids.join(',')}`);
+	console.error('   oder vorher löschen, falls es reine Testdaten sind.');
+	process.exit(1);
+}
+
+async function main() {
+	await assertNotAlreadyMigrated();
+	await assertNoAppWrittenRecordsInScope();
+	await reportAmbiguousTimestamps();
+
+	const [sichtungenUmfang] = await sql`
+		SELECT count(*) FILTER (WHERE created < ${cutover} AND id <> ALL(${excludedIds}))::int AS betroffen,
+		       count(*) FILTER (WHERE created >= ${cutover} OR id = ANY(${excludedIds}))::int AS uebersprungen
+		FROM sichtungen`;
+	const [dateienUmfang] = await sql`
+		SELECT count(*) FILTER (WHERE erstellt_am < ${cutover})::int AS betroffen,
+		       count(*) FILTER (WHERE erstellt_am >= ${cutover})::int AS uebersprungen
+		FROM sichtungen_dateien`;
+
+	for (const [name, umfang] of [
+		['sichtungen', sichtungenUmfang],
+		['sichtungen_dateien', dateienUmfang]
+	]) {
+		console.log(
+			`📊 ${name}: ${umfang.betroffen} zu migrieren, ${umfang.uebersprungen} unangetastet`
+		);
+	}
+	const gesamt = sichtungenUmfang.betroffen + dateienUmfang.betroffen;
+	console.log();
+
+	if (isVerbose) await showSamples();
+
+	if (isDryRun) {
+		console.log(`🧪 DRY RUN beendet — ${gesamt} Datensätze wären migriert worden.`);
+		return;
+	}
+
+	// Explizit ausgeschriebene Statements: die SET-Listen sind kurz und
+	// unterscheiden sich je Tabelle — dynamisch zusammengesetztes SQL wäre hier
+	// nur schwerer prüfbar. Postgres wertet die WHERE-Klausel gegen die Werte VOR
+	// dem Update aus, `created` darf deshalb gleichzeitig Filter und Ziel sein.
+	await sql.begin(async (tx) => {
+		const sichtungen = await tx`
+			UPDATE sichtungen SET
+				sichtungsdatum = (sichtungsdatum AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC',
+				created        = (created        AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC',
+				freigegeben_am = (freigegeben_am AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC'
+			WHERE created < ${cutover} AND id <> ALL(${excludedIds})`;
+		console.log(`✅ sichtungen: ${sichtungen.count} Datensätze migriert`);
+
+		const dateien = await tx`
+			UPDATE sichtungen_dateien SET
+				hochgeladen_am = (hochgeladen_am AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC',
+				erstellt_am    = (erstellt_am    AT TIME ZONE ${SOURCE_TIME_ZONE}) AT TIME ZONE 'UTC'
+			WHERE erstellt_am < ${cutover}`;
+		console.log(`✅ sichtungen_dateien: ${dateien.count} Datensätze migriert`);
+
+		await tx`
+			INSERT INTO app_config (key, value, description, category, updated_at)
+			VALUES (
+				${MARKER_KEY},
+				${sql.json({ migratedAt: new Date().toISOString(), cutover: cutover.toISOString(), sourceTimeZone: SOURCE_TIME_ZONE })},
+				'Einmal-Migration naiver Ortszeit-Zeitstempel nach UTC. Nicht erneut ausführen.',
+				'migration',
+				now()
+			)
+			ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = now()`;
+	});
+
+	console.log('\n🎉 Migration abgeschlossen und in app_config markiert.');
+}
+
+main()
+	.catch((error) => {
+		console.error('❌ Migration fehlgeschlagen — Transaktion zurückgerollt:', error);
+		process.exitCode = 1;
+	})
+	.finally(() => sql.end());


### PR DESCRIPTION
## Anlass

In PR #571 fiel auf, dass ein Statistik-Filter über `setHours` in der **lokalen** Zeitzone rechnete: in Europe/Berlin traf er die 280 Epoch-Platzhalter, im UTC-Container nicht. Dieser PR arbeitet die dahinterliegende Klasse von Fehlern ab.

## Zwei Befunde

**1. Die Zeitzone war nie entschieden.** Im Docker-Setup ist nirgends `TZ` gesetzt, Node fällt auf UTC zurück. Das war zufällig richtig, hing aber an der Umgebung.

**2. `sichtungsdatum` stand vor gemischter Semantik.** Die Spalte ist `timestamp without time zone` und enthielt deutsche Ortszeit als Wanduhrzeit — Erbe des PHP-Vorgängers auf einem Berlin-Server. Diese Anwendung schreibt dagegen echtes UTC. Frontend und Legacy-API hätten sich um genau den MEZ/MESZ-Offset widersprochen.

Beleg für die Alt-Semantik liefern die Daten selbst — die Tageslichtverteilung von 19.597 Sichtungen:

| | gespeichertes Fenster | Tageslicht Ortszeit |
|---|---|---|
| Winter (Dez/Jan) | 08–16 Uhr | 08:15–16:00 |
| Sommer (Jun/Jul) | 05–21 Uhr | 05:00–21:30 |

Als UTC gelesen läge das je 1–2 h neben der Sonne.

## Lösung

Vor dem Launch aufgelöst, solange der Bestand noch einheitlich ist: Einmal-Migration des Altbestands nach UTC, und die Legacy-API-Formatter rechnen nun nach `Europe/Berlin` statt die UTC-Felder roh auszugeben.

**Beides hebt sich auf:**

```
Altdatensatz "2012-01-25 14:50" (Ortszeit)
  → Migration → "2012-01-25 13:50" (UTC)
  → API mit Europe/Berlin → "25.01.12" / "14:50"   ← identisch zu vorher
```

Die Legacy-API-Ausgabe für den Altbestand ist damit unverändert; für neu erfasste Sichtungen wird sie von *1–2 h zu früh* auf korrekt gezogen. Festgeschrieben in `date-utils.timezone.test.ts`.

## Weitere behobene Zeitzonenfehler

- **Wetter-Zuordnung** — Open-Meteo wird mit `timezone=Europe/Berlin` geholt, indiziert wurde aber über die lokalen Stunden eines `Date`. Im UTC-Container hing an Sichtungen das Wetter der falschen Stunde.
- **CSV-Export** — baute Datum/Uhrzeit aus lokalen Gettern, während KML/XML/JSON bereits `Europe/Berlin` nutzten.
- **Admin-Statistik & Wetter-Cache** — SQL-seitige Jahres-/Monats-/Tagesextraktion rechnet jetzt in Ortszeit (sonst 2 Datensätze im falschen Jahr, 26 im falschen Monat).
- **Rate-Limit- und Mail-Texte** — nannten keine Zeitzone.
- `TZ=UTC` explizit in `Dockerfile` und `docker-compose.production.yml`, begründet in `docs/ENVIRONMENT.md`.

## Migration

`src/tools/migrate-timestamps-to-utc.js`, Pflichtparameter `--cutover`, mit `--dry-run`. Schutzmechanismen: Marker in `app_config` gegen einen zweiten Lauf, Abbruch bei bereits UTC-haltigen Datensätzen im Umfang, keine geratene Zieldatenbank.

**Bereits ausgeführt und verifiziert** auf der lokalen Entwicklungs-DB — der einzigen Datenbank mit Daten: 19.872 Sichtungen + 871 Dateien, MEZ/MESZ datumsabhängig korrekt, Datensatzzahlen unverändert, Tageslichtkurve exakt verschoben, Legacy-API-Ausgabe je Stichprobe unverändert. Staging und Produktion haben keine Daten, dort ist nichts nachzuziehen.

Das Tool bleibt im Repo, weil es den Marker setzt und gegen versehentliche Zweitläufe schützt — nicht, weil noch eine Migration aussteht.

## Tests

1754 Server-Tests, 80 Client-Tests, svelte-check 0 Fehler, Lint 0 Fehler, Production-Build grün. 19 neue Tests prüfen zeitzonenkritischen Code gegen vier Zeitzonen.

## Nachtrag zur Legacy-API

Der Commit-Text von `fix(db)` und Teile der Repo-Doku (`CLAUDE.md`, `.claude/rules/legacy-api.md`) gehen davon aus, dass `/rest_sichtungen` und `/sichtungen/showreports.json` produktive Mobile Apps bedienen. Laut Betreiber wird die Legacy-API **derzeit nicht genutzt und wurde es auch nie**. Die Invarianz der Ausgabe bleibt als Eigenschaft richtig und getestet — sie schützt hier aber keine Live-Clients.

Die Doku ist in `docs`-Commit nachgezogen: Die Regeln bleiben (die Spezifikation ist ein echter Vertrag und wird wertlos, wenn Feldnamen vor der ersten Anbindung driften), aber jede Aussage trägt jetzt den Stichtag 2026-07-28 und benennt den Betriebsstand korrekt. Die falsche Dringlichkeit hatte messbare Kosten: der `BETWEEN`-Off-by-one wurde ausgelagert statt behoben, weil ein Eingriff nach Produktionsrisiko aussah — es waren zwei Zeilen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
