### PR TITLE
test(db): cover the DST switch boundary to the millisecond

### DIFF
--- a/src/lib/server/datetime/correctCestOffsetUTC.test.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.test.ts
@@ -88,4 +88,65 @@ describe('correctCestOffsetUTC', () => {
 			expect(ergebnis).toBe('2024-10-28T11:00:00.000Z');
 		});
 	});
+
+	/**
+	 * Die Tests oben prüfen die Pipeline an Tagen *neben* der Umstellung und nur
+	 * für 2024. Das lässt zwei Dinge offen, die hier direkt an der Funktion
+	 * geprüft werden:
+	 *
+	 * 1. Die Grenze selbst liegt bei 01:00 UTC (MEZ-Beginn einschließlich,
+	 *    MESZ-Ende ausschließlich) — ein Vertauschen von `>=` und `>` fällt bei
+	 *    einem 12:00-Test nicht auf.
+	 * 2. 2024 ist der Sonderfall, in dem der letzte Sonntag im März tatsächlich
+	 *    der 31. ist. Würde `lastMarchSunday` fest auf 31 stehen, wäre das mit
+	 *    Testdaten aus 2024 allein nicht zu erkennen.
+	 */
+	describe('Umstellungszeitpunkt auf die Millisekunde', () => {
+		/** Wendet die Korrektur auf einen UTC-Zeitpunkt an (immer unter TZ=UTC). */
+		function korrigiere(utcMillis: number): number {
+			return withTimeZone('UTC', () => correctCestOffsetUTC(new Date(utcMillis)).getTime());
+		}
+
+		const EINE_STUNDE = 3_600_000;
+		const ZWEI_STUNDEN = 7_200_000;
+
+		// Reale EU-Umstellungstermine: letzter Sonntag im März bzw. Oktober.
+		const sommerzeitBeginn: Array<[jahr: number, monat: number, tag: number]> = [
+			[2023, 2, 26],
+			[2024, 2, 31],
+			[2025, 2, 30],
+			[2026, 2, 29]
+		];
+
+		it.each(sommerzeitBeginn)(
+			'%i: 01:00 UTC im März schaltet exakt von MEZ auf MESZ',
+			(jahr, monat, tag) => {
+				const grenze = Date.UTC(jahr, monat, tag, 1, 0, 0, 0);
+
+				// Eine Millisekunde davor gilt noch MEZ (−1 h) …
+				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - EINE_STUNDE);
+				// … exakt auf der Grenze bereits MESZ (−2 h).
+				expect(korrigiere(grenze)).toBe(grenze - ZWEI_STUNDEN);
+			}
+		);
+
+		const sommerzeitEnde: Array<[jahr: number, monat: number, tag: number]> = [
+			[2023, 9, 29],
+			[2024, 9, 27],
+			[2025, 9, 26],
+			[2026, 9, 25]
+		];
+
+		it.each(sommerzeitEnde)(
+			'%i: 01:00 UTC im Oktober schaltet exakt von MESZ auf MEZ',
+			(jahr, monat, tag) => {
+				const grenze = Date.UTC(jahr, monat, tag, 1, 0, 0, 0);
+
+				// Eine Millisekunde davor gilt noch MESZ (−2 h) …
+				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - ZWEI_STUNDEN);
+				// … exakt auf der Grenze wieder MEZ (−1 h).
+				expect(korrigiere(grenze)).toBe(grenze - EINE_STUNDE);
+			}
+		);
+	});
 });

--- a/src/lib/server/datetime/correctCestOffsetUTC.test.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.test.ts
@@ -94,9 +94,10 @@ describe('correctCestOffsetUTC', () => {
 	 * für 2024. Das lässt zwei Dinge offen, die hier direkt an der Funktion
 	 * geprüft werden:
 	 *
-	 * 1. Die Grenze selbst liegt bei 01:00 UTC (MEZ-Beginn einschließlich,
-	 *    MESZ-Ende ausschließlich) — ein Vertauschen von `>=` und `>` fällt bei
-	 *    einem 12:00-Test nicht auf.
+	 * 1. Beide Grenzen liegen bei 01:00 UTC, und die MESZ-Spanne ist am Beginn
+	 *    einschließlich, am Ende ausschließlich (`time >= cestStart && time <
+	 *    cestEnd`). Ein Vertauschen von `>=` und `>` fällt bei einem 12:00-Test
+	 *    nicht auf.
 	 * 2. 2024 ist der Sonderfall, in dem der letzte Sonntag im März tatsächlich
 	 *    der 31. ist. Würde `lastMarchSunday` fest auf 31 stehen, wäre das mit
 	 *    Testdaten aus 2024 allein nicht zu erkennen.
@@ -111,7 +112,8 @@ describe('correctCestOffsetUTC', () => {
 		const ZWEI_STUNDEN = 7_200_000;
 
 		// Reale EU-Umstellungstermine: letzter Sonntag im März bzw. Oktober.
-		const sommerzeitBeginn: Array<[jahr: number, monat: number, tag: number]> = [
+		// `monatIndex` ist 0-basiert wie in `Date.UTC` — März = 2, Oktober = 9.
+		const sommerzeitBeginn: Array<[jahr: number, monatIndex: number, tag: number]> = [
 			[2023, 2, 26],
 			[2024, 2, 31],
 			[2025, 2, 30],
@@ -120,8 +122,8 @@ describe('correctCestOffsetUTC', () => {
 
 		it.each(sommerzeitBeginn)(
 			'%i: 01:00 UTC im März schaltet exakt von MEZ auf MESZ',
-			(jahr, monat, tag) => {
-				const grenze = Date.UTC(jahr, monat, tag, 1, 0, 0, 0);
+			(jahr, monatIndex, tag) => {
+				const grenze = Date.UTC(jahr, monatIndex, tag, 1, 0, 0, 0);
 
 				// Eine Millisekunde davor gilt noch MEZ (−1 h) …
 				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - EINE_STUNDE);
@@ -130,7 +132,7 @@ describe('correctCestOffsetUTC', () => {
 			}
 		);
 
-		const sommerzeitEnde: Array<[jahr: number, monat: number, tag: number]> = [
+		const sommerzeitEnde: Array<[jahr: number, monatIndex: number, tag: number]> = [
 			[2023, 9, 29],
 			[2024, 9, 27],
 			[2025, 9, 26],
@@ -139,8 +141,8 @@ describe('correctCestOffsetUTC', () => {
 
 		it.each(sommerzeitEnde)(
 			'%i: 01:00 UTC im Oktober schaltet exakt von MESZ auf MEZ',
-			(jahr, monat, tag) => {
-				const grenze = Date.UTC(jahr, monat, tag, 1, 0, 0, 0);
+			(jahr, monatIndex, tag) => {
+				const grenze = Date.UTC(jahr, monatIndex, tag, 1, 0, 0, 0);
 
 				// Eine Millisekunde davor gilt noch MESZ (−2 h) …
 				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - ZWEI_STUNDEN);


### PR DESCRIPTION
Ergänzt die Zeitzonen-Absicherung aus #572 um den Punkt, den sie offenlässt: den Umstellungszeitpunkt selbst.

## Warum

Die vorhandenen Tests für `correctCestOffsetUTC` prüfen Tage *neben* der Zeitumstellung (30.03., 01.04., 28.10.) und ausschließlich das Jahr 2024. Zwei Fehler rutschen dadurch durch:

1. **Die Grenze liegt bei 01:00 UTC** — MESZ-Beginn einschließlich, MESZ-Ende ausschließlich. Ein vertauschtes `>=` / `>` fällt bei einem 12:00-Test nicht auf.
2. **2024 ist der Sonderfall**, in dem der letzte Sonntag im März tatsächlich der 31. ist. Stünde `lastMarchSunday` fest auf 31, wäre das mit Testdaten allein aus 2024 nicht zu erkennen.

## Was

Ein zusätzlicher `describe`-Block, der beide Umstellungszeitpunkte auf die Millisekunde prüft — jeweils eine Millisekunde davor und exakt auf der Grenze — über die realen EU-Umstellungstermine 2023 bis 2026.

Kein Produktionscode geändert, nur Tests.

## Verifikation

Die Tests wurden gegen beide Fehler geprüft, die sie abdecken sollen:

| Mutation in `correctCestOffsetUTC.ts` | Ergebnis |
| --- | --- |
| Baseline (unverändert) | grün |
| `time >= cestStart` → `time > cestStart` | **rot** |
| `lastMarchSunday = 31 - marchDay` → `= 31` | **rot** |
| nach Wiederherstellung | grün |

`npm run test:quick` vollständig grün (108 Dateien, 1763 Tests, dazu Lint / Type-Check / Svelte-Check).

## Herkunft

Die Tests lagen uncommitted in einem verwaisten Worktree einer abgebrochenen Session. Die dortige Testdatei nutzte bereits den Zwei-Argument-Helfer `withTimeZone(tz, fn)`, den `main` hat — der Block ließ sich deshalb unverändert übernehmen.

Der konkurrierende Ein-Argument-Helfer aus demselben Worktree (registriert `beforeEach`/`afterEach` statt einen Wert zurückzugeben) wurde **bewusst nicht** übernommen: Er ist inkompatibel mit `main` und würde `yearRange.test.ts` brechen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)