### PR TITLE
fix(db): compare DST boundaries on wall-clock time, not the UTC instant

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -368,8 +368,8 @@ names `Europe/Berlin` explicitly:
 | ------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
 | Display & CSV/KML/XML/JSON export                                  | `src/lib/utils/format/dateTime.ts` — `Intl` with `timeZone: 'Europe/Berlin'`   |
 | Weather lookup (Open-Meteo, requested as `timezone=Europe/Berlin`) | `src/lib/server/weather/hourIndex.ts` — index parsed from the `"HH:MM"` string |
-| Legacy REST API output (`dt`, `ti`)                                | `src/lib/legacy-api/date-utils.ts` — `Intl` with `Europe/Berlin`       |
-| Legacy `year` filter                                               | `getYearRange()` — German local year bounds, matching the output                   |
+| Legacy REST API output (`dt`, `ti`)                                | `src/lib/legacy-api/date-utils.ts` — `Intl` with `Europe/Berlin`               |
+| Legacy `year` filter                                               | `getYearRange()` — German local year bounds, matching the output               |
 | Statistics plausibility bound                                      | `EARLIEST_PLAUSIBLE_SIGHTING_DATE` — fixed UTC instant                         |
 
 #### Before changing this value
@@ -377,9 +377,15 @@ names `Europe/Berlin` explicitly:
 Changing `TZ` is safe only as long as the code stays timezone-independent.
 `src/lib/server/datetime/correctCestOffsetUTC.test.ts` proves the sighting pipeline
 (`combineToDate` → `correctCestOffsetUTC`) yields the same UTC instant under UTC and
-Europe/Berlin, for all 24 hours in both summer and winter. Note that
-`correctCestOffsetUTC` only _does_ anything when the process runs in UTC — it returns
-early otherwise. Run the full server suite after any change:
+Europe/Berlin, for all 24 hours in both summer and winter, including the two DST
+transition days themselves. Note that `correctCestOffsetUTC` only _does_ anything when
+the process runs in UTC — it returns early otherwise.
+
+The date it receives carries German **wall-clock** time, not a true UTC instant, so the
+DST boundaries inside it are wall-clock too (02:00 for the start of CEST, 03:00 for its
+end) — not the 01:00Z instant at which the changeover actually happens. Comparing the two
+against each other is what caused the one-hour shift fixed in this file's history. Run the
+full server suite after any change:
 
 ```bash
 npm run test:unit

--- a/src/lib/server/datetime/correctCestOffsetUTC.test.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.test.ts
@@ -90,6 +90,30 @@ describe('correctCestOffsetUTC', () => {
 	});
 
 	/**
+	 * Die Eintrittsbedingung ist `getTimezoneOffset() !== 0`, also der Offset —
+	 * nicht der Name der Zeitzone. Das ist Absicht: `combineToDate` setzt die
+	 * Uhrzeit per `setHours`, und ob dabei ein Offset einfließt, entscheidet
+	 * allein der Offset des Prozesses.
+	 *
+	 * `Europe/London` im Winter ist der Prüffall dafür — Offset 0, aber nicht
+	 * `UTC`. Ein Namensvergleich statt des Offset-Vergleichs würde die Korrektur
+	 * hier überspringen und die Wanduhrzeit unkorrigiert speichern.
+	 */
+	describe('Zonen mit Offset 0, die nicht UTC heißen', () => {
+		it('korrigiert unter Europe/London im Winter wie unter UTC', () => {
+			const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-01-15', '14:30'));
+			const london = withTimeZone('Europe/London', () =>
+				speichereSichtungszeit('2024-01-15', '14:30')
+			);
+
+			// London ist im Winter GMT (Offset 0), verhält sich in `combineToDate`
+			// also exakt wie UTC — dieselbe Korrektur muss greifen.
+			expect(london).toBe(utc);
+			expect(london).toBe('2024-01-15T13:30:00.000Z');
+		});
+	});
+
+	/**
 	 * Regression: Am Umstellungstag selbst lieferte die Korrektur in der Stunde
 	 * 01:00–01:59 Ortszeit einen um eine Stunde verschobenen Zeitpunkt.
 	 *

--- a/src/lib/server/datetime/correctCestOffsetUTC.test.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.test.ts
@@ -90,65 +90,92 @@ describe('correctCestOffsetUTC', () => {
 	});
 
 	/**
-	 * Die Tests oben prüfen die Pipeline an Tagen *neben* der Umstellung und nur
-	 * für 2024. Das lässt zwei Dinge offen, die hier direkt an der Funktion
-	 * geprüft werden:
+	 * Regression: Am Umstellungstag selbst lieferte die Korrektur in der Stunde
+	 * 01:00–01:59 Ortszeit einen um eine Stunde verschobenen Zeitpunkt.
 	 *
-	 * 1. Beide Grenzen liegen bei 01:00 UTC, und die MESZ-Spanne ist am Beginn
-	 *    einschließlich, am Ende ausschließlich (`time >= cestStart && time <
-	 *    cestEnd`). Ein Vertauschen von `>=` und `>` fällt bei einem 12:00-Test
-	 *    nicht auf.
+	 * Ursache war ein Vergleich über Systemgrenzen hinweg: `cestStart`/`cestEnd`
+	 * lagen auf dem echten UTC-Instant der Umstellung (01:00 UTC), verglichen
+	 * wurde aber mit `date.getTime()` — und das ist die von `combineToDate` als
+	 * UTC verpackte deutsche Wanduhrzeit. Die Grenzen liegen deshalb jetzt
+	 * ebenfalls auf Wanduhrzeit: 02:00 (MEZ→MESZ) bzw. 03:00 (MESZ→MEZ).
+	 *
+	 * Die Tests oben treffen das nicht, weil sie nur 12:00 prüfen.
+	 */
+	describe('Umstellungstag: Stunde 01:00–01:59 Ortszeit', () => {
+		it('verschiebt eine Sichtung um 01:30 am Tag des MESZ-Beginns nicht', () => {
+			const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-03-31', '01:30'));
+			const berlin = withTimeZone('Europe/Berlin', () =>
+				speichereSichtungszeit('2024-03-31', '01:30')
+			);
+
+			expect(utc).toBe(berlin);
+			// 01:30 liegt vor der Umstellung um 02:00, gilt also noch als MEZ (UTC+1).
+			expect(utc).toBe('2024-03-31T00:30:00.000Z');
+		});
+
+		it('verschiebt eine Sichtung um 01:30 am Tag des MESZ-Endes nicht', () => {
+			const utc = withTimeZone('UTC', () => speichereSichtungszeit('2024-10-27', '01:30'));
+			const berlin = withTimeZone('Europe/Berlin', () =>
+				speichereSichtungszeit('2024-10-27', '01:30')
+			);
+
+			expect(utc).toBe(berlin);
+			// 01:30 liegt vor der Rückstellung um 03:00, gilt also noch als MESZ (UTC+2).
+			expect(utc).toBe('2024-10-26T23:30:00.000Z');
+		});
+	});
+
+	/**
+	 * Die Pipeline-Tests oben prüfen nur 2024 und nur volle Stunden abseits der
+	 * Grenze. Hier wird die Funktion direkt geprüft, um zwei Dinge abzudecken:
+	 *
+	 * 1. Die Umschaltung erfolgt exakt auf der Wanduhr-Grenze (02:00 für den
+	 *    MESZ-Beginn einschließlich, 03:00 für das MESZ-Ende ausschließlich) —
+	 *    ein Vertauschen von `>=` und `>` fällt bei einem 12:00-Test nicht auf.
 	 * 2. 2024 ist der Sonderfall, in dem der letzte Sonntag im März tatsächlich
 	 *    der 31. ist. Würde `lastMarchSunday` fest auf 31 stehen, wäre das mit
 	 *    Testdaten aus 2024 allein nicht zu erkennen.
 	 */
 	describe('Umstellungszeitpunkt auf die Millisekunde', () => {
-		/** Wendet die Korrektur auf einen UTC-Zeitpunkt an (immer unter TZ=UTC). */
-		function korrigiere(utcMillis: number): number {
-			return withTimeZone('UTC', () => correctCestOffsetUTC(new Date(utcMillis)).getTime());
+		/** Wendet die Korrektur auf eine als UTC verpackte Wanduhrzeit an. */
+		function korrigiere(wanduhrMillis: number): number {
+			return withTimeZone('UTC', () => correctCestOffsetUTC(new Date(wanduhrMillis)).getTime());
 		}
 
 		const EINE_STUNDE = 3_600_000;
 		const ZWEI_STUNDEN = 7_200_000;
 
 		// Reale EU-Umstellungstermine: letzter Sonntag im März bzw. Oktober.
-		// `monatIndex` ist 0-basiert wie in `Date.UTC` — März = 2, Oktober = 9.
-		const sommerzeitBeginn: Array<[jahr: number, monatIndex: number, tag: number]> = [
-			[2023, 2, 26],
-			[2024, 2, 31],
-			[2025, 2, 30],
-			[2026, 2, 29]
-		];
+		const MAERZ = 2;
+		const OKTOBER = 9;
 
-		it.each(sommerzeitBeginn)(
-			'%i: 01:00 UTC im März schaltet exakt von MEZ auf MESZ',
-			(jahr, monatIndex, tag) => {
-				const grenze = Date.UTC(jahr, monatIndex, tag, 1, 0, 0, 0);
+		it.each([
+			[2023, 26],
+			[2024, 31],
+			[2025, 30],
+			[2026, 29]
+		])('%i: MESZ beginnt exakt um 02:00 Ortszeit', (jahr, tag) => {
+			const grenze = Date.UTC(jahr, MAERZ, tag, 2, 0, 0, 0);
 
-				// Eine Millisekunde davor gilt noch MEZ (−1 h) …
-				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - EINE_STUNDE);
-				// … exakt auf der Grenze bereits MESZ (−2 h).
-				expect(korrigiere(grenze)).toBe(grenze - ZWEI_STUNDEN);
-			}
-		);
+			// Eine Millisekunde davor gilt noch MEZ (−1 h) …
+			expect(korrigiere(grenze - 1)).toBe(grenze - 1 - EINE_STUNDE);
+			// … ab der Grenze MESZ (−2 h). 02:00–02:59 existiert real nicht,
+			// die Funktion legt dieses Loch bewusst auf MESZ.
+			expect(korrigiere(grenze)).toBe(grenze - ZWEI_STUNDEN);
+		});
 
-		const sommerzeitEnde: Array<[jahr: number, monatIndex: number, tag: number]> = [
-			[2023, 9, 29],
-			[2024, 9, 27],
-			[2025, 9, 26],
-			[2026, 9, 25]
-		];
+		it.each([
+			[2023, 29],
+			[2024, 27],
+			[2025, 26],
+			[2026, 25]
+		])('%i: MESZ endet exakt um 03:00 Ortszeit', (jahr, tag) => {
+			const grenze = Date.UTC(jahr, OKTOBER, tag, 3, 0, 0, 0);
 
-		it.each(sommerzeitEnde)(
-			'%i: 01:00 UTC im Oktober schaltet exakt von MESZ auf MEZ',
-			(jahr, monatIndex, tag) => {
-				const grenze = Date.UTC(jahr, monatIndex, tag, 1, 0, 0, 0);
-
-				// Eine Millisekunde davor gilt noch MESZ (−2 h) …
-				expect(korrigiere(grenze - 1)).toBe(grenze - 1 - ZWEI_STUNDEN);
-				// … exakt auf der Grenze wieder MEZ (−1 h).
-				expect(korrigiere(grenze)).toBe(grenze - EINE_STUNDE);
-			}
-		);
+			// Eine Millisekunde davor gilt noch MESZ (−2 h) …
+			expect(korrigiere(grenze - 1)).toBe(grenze - 1 - ZWEI_STUNDEN);
+			// … ab der Grenze wieder MEZ (−1 h).
+			expect(korrigiere(grenze)).toBe(grenze - EINE_STUNDE);
+		});
 	});
 });

--- a/src/lib/server/datetime/correctCestOffsetUTC.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.ts
@@ -1,9 +1,20 @@
 /**
- * Corrects the UTC offset for Central European Summer Time (CEST).
- * This function adjusts the given UTC date to account for daylight saving time in Central Europe.
+ * Rechnet eine deutsche Wanduhrzeit in den echten UTC-Zeitpunkt um.
  *
- * @param date - The UTC date to be corrected. Must be a UTC date.
- * @returns The corrected date, adjusted for CEST or CET as appropriate.
+ * Läuft der Prozess in UTC, erzeugt `combineToDate` aus der Formulareingabe ein
+ * `Date`, dessen UTC-Felder die *Wanduhrzeit* tragen (14:30 Eingabe → 14:30Z).
+ * Diese Funktion zieht den passenden MEZ/MESZ-Offset ab und macht daraus den
+ * tatsächlichen Zeitpunkt.
+ *
+ * In jeder anderen Prozess-Zeitzone hat `combineToDate` den Offset bereits
+ * korrekt angewandt — dann ist diese Funktion ein No-op.
+ *
+ * WICHTIG: `date` trägt Wanduhrzeit, keinen echten UTC-Zeitpunkt. Die
+ * Umstellungsgrenzen unten liegen deshalb ebenfalls auf Wanduhrzeit (02:00 bzw.
+ * 03:00) und nicht auf dem UTC-Instant der Umstellung (01:00Z).
+ *
+ * @param date - Als UTC verpackte deutsche Wanduhrzeit. Wird in-place verändert.
+ * @returns Dasselbe (mutierte) Date-Objekt, um den MEZ/MESZ-Offset zurückgesetzt.
  */
 export function correctCestOffsetUTC(date: Date): Date {
 	// Nur, wenn die Server Timezone UTC ist
@@ -11,20 +22,19 @@ export function correctCestOffsetUTC(date: Date): Date {
 	if (date.getTimezoneOffset() !== 0) {
 		return date;
 	}
-	// Das Datum muss ein UTC-Datum sein!
 	const year = date.getUTCFullYear();
 
 	// Letzter Sonntag im März (Sommerzeit beginnt)
 	const march = new Date(Date.UTC(year, 2, 31)); // 31. März
 	const marchDay = march.getUTCDay();
 	const lastMarchSunday = 31 - marchDay;
-	const cestStart = Date.UTC(year, 2, lastMarchSunday, 1); // 2:00 MEZ == 1:00 UTC
+	const cestStart = Date.UTC(year, 2, lastMarchSunday, 2); // Wanduhr 2:00, danach gilt MESZ
 
 	// Letzter Sonntag im Oktober (Sommerzeit endet)
 	const october = new Date(Date.UTC(year, 9, 31)); // 31. Oktober
 	const octoberDay = october.getUTCDay();
 	const lastOctoberSunday = 31 - octoberDay;
-	const cestEnd = Date.UTC(year, 9, lastOctoberSunday, 1); // 3:00 MESZ == 1:00 UTC
+	const cestEnd = Date.UTC(year, 9, lastOctoberSunday, 3); // Wanduhr 3:00, danach gilt MEZ
 
 	const time = date.getTime();
 

--- a/src/lib/server/datetime/correctCestOffsetUTC.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.ts
@@ -1,13 +1,20 @@
 /**
  * Rechnet eine deutsche Wanduhrzeit in den echten UTC-Zeitpunkt um.
  *
- * Läuft der Prozess in UTC, erzeugt `combineToDate` aus der Formulareingabe ein
+ * Ist der Prozess-Offset 0, erzeugt `combineToDate` aus der Formulareingabe ein
  * `Date`, dessen UTC-Felder die *Wanduhrzeit* tragen (14:30 Eingabe → 14:30Z).
  * Diese Funktion zieht den passenden MEZ/MESZ-Offset ab und macht daraus den
  * tatsächlichen Zeitpunkt.
  *
- * In jeder anderen Prozess-Zeitzone hat `combineToDate` den Offset bereits
- * korrekt angewandt — dann ist diese Funktion ein No-op.
+ * Bei einem Offset ungleich 0 hat `combineToDate` per `setHours` bereits einen
+ * Offset angewandt — dann ist diese Funktion ein No-op.
+ *
+ * Die Bedingung ist bewusst der **Offset**, nicht der Name der Zeitzone.
+ * Entscheidend ist allein, was `setHours` in `combineToDate` gerechnet hat.
+ * Zonen mit Offset 0, die nicht `UTC` heißen (`Europe/London` im Winter,
+ * `Atlantic/Reykjavik`), verhalten sich dort identisch zu UTC und brauchen
+ * dieselbe Korrektur — ein Namensvergleich würde sie fälschlich überspringen
+ * und die Wanduhrzeit ununterschieden speichern.
  *
  * WICHTIG: `date` trägt Wanduhrzeit, keinen echten UTC-Zeitpunkt. Die
  * Umstellungsgrenzen unten liegen deshalb ebenfalls auf Wanduhrzeit (02:00 bzw.
@@ -17,8 +24,8 @@
  * @returns Dasselbe (mutierte) Date-Objekt, um den MEZ/MESZ-Offset zurückgesetzt.
  */
 export function correctCestOffsetUTC(date: Date): Date {
-	// Nur, wenn die Server Timezone UTC ist
-	// Dann soll das Datum als CE(S)T Interpretiert werden
+	// Nur bei Prozess-Offset 0 trägt `date` Wanduhrzeit und muss umgerechnet
+	// werden (siehe Kopfkommentar — Offset, nicht Zonenname).
 	if (date.getTimezoneOffset() !== 0) {
 		return date;
 	}


### PR DESCRIPTION
Korrigiert einen Vergleich über Systemgrenzen hinweg in `correctCestOffsetUTC` — **und die Tests aus #573, die den Fehler festgeschrieben hatten.**

## Der Fehler

`cestStart` und `cestEnd` lagen auf dem echten UTC-Instant der Umstellung (01:00 UTC). Verglichen wird damit aber `date.getTime()` — und dieses Date trägt die **deutsche Wanduhrzeit**, die `combineToDate` in UTC-Felder verpackt hat (Eingabe `14:30` → `14:30Z`). Zwei verschiedene Bezugssysteme im selben `<`-Vergleich.

Die Grenzen liegen jetzt ebenfalls auf Wanduhrzeit: **02:00** für den MESZ-Beginn, **03:00** für das MESZ-Ende.

## Auswirkung

Begrenzt auf die beiden Umstellungstage selbst, dort auf die Stunde 01:00–01:59 Ortszeit:

| Eingabe | vorher | nachher |
| --- | --- | --- |
| 31.03.2024, 01:30 | `2024-03-30T23:30:00Z` ❌ | `2024-03-31T00:30:00Z` ✓ |
| 27.10.2024, 01:30 | `2024-10-27T00:30:00Z` ❌ | `2024-10-26T23:30:00Z` ✓ |

Eine Stunde daneben — im März zusätzlich auf dem falschen Kalendertag.

## Korrektur an #573

Die dort ergänzten Millisekunden-Tests prüften die Grenze bei 01:00 UTC und haben damit genau diesen Bug als Sollverhalten zementiert. Sie werden hier durch Tests auf der Wanduhr-Grenze ersetzt, plus zwei Regressionstests auf Pipeline-Ebene für den 01:30-Fall.

Der Mutationstest in #573 hat das nicht aufgedeckt: Dass `>=` → `>` die Tests rot färbt, beweist nur, dass sie die damalige Implementierung abbilden — nicht, dass die Grenze inhaltlich stimmt. Bei einer Funktion, deren Kernfrage die Eingabe-Semantik ist (Wanduhr vs. Instant), war das die falsche Prüfrichtung.

## Verifikation

Diesmal andersherum geprüft — die neuen Tests gegen die **alte** Implementierung laufen lassen:

| Kombination | Ergebnis |
| --- | --- |
| neue Tests + neue Implementierung (Wanduhr 02:00/03:00) | grün |
| neue Tests + alte Implementierung (01:00 UTC) | **rot** |
| wiederhergestellt | grün |

`npm run test:quick` vollständig grün (106 Dateien, 1757 Tests, dazu Lint / Type-Check / Svelte-Check).

`docs/ENVIRONMENT.md` hält die Wanduhr-Semantik fest, damit der Vergleich nicht erneut vermischt wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)