### PR TITLE
chore(config): remove dead map configuration keys

### DIFF
--- a/docs/CONFIGURATION_USAGE.md
+++ b/docs/CONFIGURATION_USAGE.md
@@ -23,7 +23,7 @@ import {
 const maxFileSize = await ServerConfigService.getNumber('security.maxFileSize');
 
 // Client-side (in .svelte components)
-const mapConfig = await ClientConfigService.getMapConfig();
+const dateFormat = await ClientConfigService.get<string>('display.dateFormat');
 
 // Universal (automatische Erkennung)
 const maintenanceMode = await ConfigService.get('display.maintenanceMode');
@@ -37,7 +37,7 @@ Alle Konfigurationswerte haben Standardwerte in `DEFAULT_VALUES`:
 const DEFAULT_VALUES = {
 	'display.maxSightingsPerPage': 50,
 	'security.maxFileSize': 10,
-	'display.defaultMapCenter': { lat: 54.5, lng: 13.5 }
+	'display.dateFormat': 'DD.MM.YYYY'
 	// ...
 } as const;
 ```
@@ -108,24 +108,21 @@ if (isMaintenanceEnabled) {
 }
 ```
 
-### 5. **Karten-Konfiguration**
+### 5. **Karte — bewusst nicht konfigurierbar**
 
-- **Konfigurationen**:
-  - `display.defaultMapCenter` - Standard-Kartenzentrum
-  - `display.defaultMapZoom` - Standard-Zoom-Level
-  - `integration.mapTileProvider` - Karten-Tile-URL
-- **Fallback**: Ostsee-Zentrum (54.5, 13.5), Zoom 7
+Die Karte ist **nicht** über den ConfigService steuerbar. Kartenzentrum, Zoom-Stufe
+und Tile-Quellen sind in `src/lib/map/optimizedMapController.ts` fest verdrahtet
+(OSM-Basislayer plus OpenSeaMap-Overlay, Startansicht 54.5 / 12.0 bei Zoom 7).
 
-> **Status:** `ConfigService.getMapConfig()` / `ServerConfigService.getMapConfig()`
-> existieren, werden aber aktuell von keiner Route aufgerufen — `/map` lädt seine
-> Daten über `+page.ts`. Die Sichtbarkeit der öffentlichen Karte hängt
-> ausschließlich am Datenbankfilter in `src/routes/api/map/sightings/+server.ts`,
-> nicht an einer Konfiguration.
+Die früheren Schlüssel `display.defaultMapCenter`, `display.defaultMapZoom` und
+`integration.mapTileProvider` sowie beide `getMapConfig()`-Methoden wurden entfernt:
+Sie wurden von keiner Route und keiner Komponente gelesen, wurden aber über
+`/api/config/public` anonym ausgeliefert und bei jedem Aufruf von `/admin/settings`
+in die Datenbank geschrieben. Wer die Karte konfigurierbar machen will, bindet
+zuerst `optimizedMapController.ts` an — nicht umgekehrt.
 
-```typescript
-const mapConfig = await ServerConfigService.getMapConfig();
-// { center, zoom, tileProvider }
-```
+Die Sichtbarkeit der öffentlichen Karte hängt ausschließlich am Datenbankfilter in
+`src/routes/api/map/sightings/+server.ts`, nicht an einer Konfiguration.
 
 ## 🔧 Verwendungspatterns
 
@@ -137,7 +134,7 @@ const mapConfig = await ServerConfigService.getMapConfig();
 import { ServerConfigService } from '$lib/services/configService';
 
 export const load: PageServerLoad = async () => {
-	const config = await ServerConfigService.getMapConfig();
+	const config = await ServerConfigService.getPaginationConfig();
 	return { config };
 };
 ```
@@ -151,7 +148,7 @@ import { ClientConfigService } from '$lib/services/configService';
 
 // Asynchron laden
 onMount(async () => {
-	const mapConfig = await ClientConfigService.getMapConfig();
+	const dateFormat = await ClientConfigService.get<string>('display.dateFormat');
 	// Konfiguration verwenden
 });
 ```
@@ -163,9 +160,6 @@ onMount(async () => {
 const isEnabled = await ServerConfigService.getBoolean('notification.email.enabled');
 const maxSize = await ServerConfigService.getNumber('security.maxFileSize');
 const allowedTypes = await ServerConfigService.getArray<string>('security.allowedFileTypes');
-const mapCenter = await ServerConfigService.getObject<{ lat: number; lng: number }>(
-	'display.defaultMapCenter'
-);
 ```
 
 ### Grouped Configuration Access
@@ -174,7 +168,6 @@ const mapCenter = await ServerConfigService.getObject<{ lat: number; lng: number
 // Grouped configurations for specific functionality
 const uploadConfig = await ServerConfigService.getUploadConfig();
 const emailConfig = await ServerConfigService.getEmailConfig();
-const mapConfig = await ServerConfigService.getMapConfig();
 const securityConfig = await ServerConfigService.getSecurityConfig();
 ```
 
@@ -191,12 +184,11 @@ const securityConfig = await ServerConfigService.getSecurityConfig();
 
 ### 🎨 Anzeige-Einstellungen
 
-| Schlüssel                     | Typ     | Verwendung             | Fallback                 |
-| ----------------------------- | ------- | ---------------------- | ------------------------ |
-| `display.maxSightingsPerPage` | number  | Admin-Paginierung      | `50`                     |
-| `display.defaultMapCenter`    | object  | Karten-Zentrum         | `{lat: 54.5, lng: 13.5}` |
-| `display.defaultMapZoom`      | number  | Standard-Zoom          | `7`                      |
-| `display.maintenanceMode`     | boolean | Wartungsmodus-Redirect | `false`                  |
+| Schlüssel                     | Typ     | Verwendung             | Fallback       |
+| ----------------------------- | ------- | ---------------------- | -------------- |
+| `display.maxSightingsPerPage` | number  | Admin-Paginierung      | `50`           |
+| `display.dateFormat`          | string  | Datumsformat           | `'DD.MM.YYYY'` |
+| `display.maintenanceMode`     | boolean | Wartungsmodus-Redirect | `false`        |
 
 ### 🔒 Sicherheit & Validierung
 
@@ -208,10 +200,10 @@ const securityConfig = await ServerConfigService.getSecurityConfig();
 
 ### 📊 Datenverarbeitung
 
-| Schlüssel                   | Typ     | Verwendung                | Fallback                        |
-| --------------------------- | ------- | ------------------------- | ------------------------------- |
-| `data.duplicateCheckRadius` | number  | Duplikatsprüfung (km)     | `1`                             |
-| `data.exportFormats`        | array   | Verfügbare Export-Formate | `['csv', 'json', 'kml', 'xml']` |
+| Schlüssel                   | Typ    | Verwendung                | Fallback                        |
+| --------------------------- | ------ | ------------------------- | ------------------------------- |
+| `data.duplicateCheckRadius` | number | Duplikatsprüfung (km)     | `1`                             |
+| `data.exportFormats`        | array  | Verfügbare Export-Formate | `['csv', 'json', 'kml', 'xml']` |
 
 ## 🚀 Erweiterung des Systems
 

--- a/src/lib/server/config/accessControl.ts
+++ b/src/lib/server/config/accessControl.ts
@@ -25,34 +25,31 @@ const SUPERADMIN_ONLY_CONFIG_KEYS = new Set([
 	'email.smtp.secure',
 	'email.smtp.user',
 	'email.smtp.password',
-	
+
 	// Email sender configuration (system-critical)
 	'notification.email.sender',
 	'notification.email.senderName',
-	
+
 	// Advanced security settings
 	'security.allowedFileTypes',
 	'security.rateLimitPerIP',
 	'security.requireEmailVerification',
 	'security.autoApproveThreshold',
-	
+
 	// Data processing settings
 	'data.duplicateCheckRadius',
 	'data.duplicateCheckTimeframe',
 	'data.exportFormats',
 	'data.archiveAfterDays',
-	
+
 	// Advanced display settings
-	'display.defaultMapCenter',
-	'display.defaultMapZoom',
 	'display.dateFormat',
-	
+
 	// Integration settings
-	'integration.mapTileProvider',
 	'integration.weatherApiKey',
 	'integration.geoApiKey',
 	'integration.webhookUrl',
-	
+
 	// Mobile app settings
 	'mobile.minAppVersion',
 	'mobile.updateMessage',
@@ -66,17 +63,17 @@ export function canUserAccessConfigKey(user: User | null | undefined, configKey:
 	if (!user) {
 		return false;
 	}
-	
+
 	// Superadmins can access everything
 	if (isSuperAdminUser(user)) {
 		return true;
 	}
-	
+
 	// Regular admins can only access non-system-critical settings
 	if (user.roles?.includes('admin')) {
 		return ADMIN_ACCESSIBLE_CONFIG_KEYS.has(configKey);
 	}
-	
+
 	// Non-admin users cannot access any config
 	return false;
 }
@@ -84,8 +81,11 @@ export function canUserAccessConfigKey(user: User | null | undefined, configKey:
 /**
  * Filter configuration items based on user access level
  */
-export function filterConfigsByUserAccess(configs: ConfigItem[], user: User | null | undefined): ConfigItem[] {
-	return configs.filter(config => canUserAccessConfigKey(user, config.key));
+export function filterConfigsByUserAccess(
+	configs: ConfigItem[],
+	user: User | null | undefined
+): ConfigItem[] {
+	return configs.filter((config) => canUserAccessConfigKey(user, config.key));
 }
 
 /**

--- a/src/lib/server/services/configInitializer.ts
+++ b/src/lib/server/services/configInitializer.ts
@@ -235,18 +235,6 @@ const defaultConfigurations: ConfigItem[] = [
 		category: 'display'
 	},
 	{
-		key: 'display.defaultMapCenter',
-		value: { lat: 54.5, lng: 13.5 },
-		description: 'Standard Kartenzentrum (Ostsee)',
-		category: 'display'
-	},
-	{
-		key: 'display.defaultMapZoom',
-		value: 7,
-		description: 'Standard Zoom-Level für Karten',
-		category: 'display'
-	},
-	{
 		key: 'display.dateFormat',
 		value: 'DD.MM.YYYY',
 		description: 'Standard Datumsformat',
@@ -324,12 +312,6 @@ const defaultConfigurations: ConfigItem[] = [
 	},
 
 	// Integration Settings
-	{
-		key: 'integration.mapTileProvider',
-		value: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-		description: 'URL Template für Karten-Tiles',
-		category: 'integration'
-	},
 	{
 		key: 'integration.weatherApiKey',
 		value: '',

--- a/src/lib/services/configService.ts
+++ b/src/lib/services/configService.ts
@@ -13,37 +13,42 @@ const DEFAULT_VALUES = {
 	'notification.email.sender': 'noreply@ostsee-tiere.de',
 	'notification.email.senderName': 'Ostsee-Tiere',
 	'notification.email.template': '',
-	
+
 	// Display Settings
 	'display.maxSightingsPerPage': 50,
-	'display.defaultMapCenter': { lat: 54.5, lng: 13.5 },
-	'display.defaultMapZoom': 7,
 	'display.dateFormat': 'DD.MM.YYYY',
 	'display.maintenanceMode': false,
-	'display.maintenanceMessage': 'Die Anwendung wird gewartet. Bitte versuchen Sie es später erneut.',
-	
+	'display.maintenanceMessage':
+		'Die Anwendung wird gewartet. Bitte versuchen Sie es später erneut.',
+
 	// Security Settings
 	'security.maxFileSize': 10,
-	'security.allowedFileTypes': ['image/jpeg', 'image/png', 'image/webp', 'video/mp4', 'video/quicktime'],
+	'security.allowedFileTypes': [
+		'image/jpeg',
+		'image/png',
+		'image/webp',
+		'video/mp4',
+		'video/quicktime'
+	],
 	'security.rateLimitPerIP': 10,
 	'security.requireEmailVerification': false,
 	'security.autoApproveThreshold': 5,
-	
+
 	// Data Processing Settings
 	'data.duplicateCheckRadius': 1,
 	'data.duplicateCheckTimeframe': 24,
 	'data.exportFormats': ['csv', 'json', 'kml', 'xml'],
 	'data.archiveAfterDays': 0,
-	
+
 	// Integration Settings
-	'integration.mapTileProvider': 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 	'integration.weatherApiKey': '',
 	'integration.geoApiKey': '',
 	'integration.webhookUrl': '',
-	
+
 	// Mobile App Settings
 	'mobile.minAppVersion': '1.0.0',
-	'mobile.updateMessage': 'Eine neue Version der App ist verfügbar. Bitte aktualisieren Sie für die beste Erfahrung.',
+	'mobile.updateMessage':
+		'Eine neue Version der App ist verfügbar. Bitte aktualisieren Sie für die beste Erfahrung.',
 	'mobile.apiRateLimit': 100
 } as const;
 
@@ -92,13 +97,6 @@ export class ServerConfigService {
 		return Array.isArray(value) ? value : [];
 	}
 
-	static async getObject<T extends Record<string, unknown>>(key: keyof typeof DEFAULT_VALUES): Promise<T> {
-		const value = await this.get(key);
-		return typeof value === 'object' && value !== null && !Array.isArray(value) 
-			? value as T 
-			: DEFAULT_VALUES[key] as unknown as T;
-	}
-
 	/**
 	 * Check if maintenance mode is enabled
 	 */
@@ -118,17 +116,6 @@ export class ServerConfigService {
 		return {
 			maxSightingsPerPage: await this.getNumber('display.maxSightingsPerPage'),
 			defaultPageSize: Math.min(await this.getNumber('display.maxSightingsPerPage'), 50)
-		};
-	}
-
-	/**
-	 * Get map configuration
-	 */
-	static async getMapConfig() {
-		return {
-			center: await this.getObject<{ lat: number; lng: number }>('display.defaultMapCenter'),
-			zoom: await this.getNumber('display.defaultMapZoom'),
-			tileProvider: await this.getString('integration.mapTileProvider')
 		};
 	}
 
@@ -208,17 +195,6 @@ export class ClientConfigService {
 	}
 
 	/**
-	 * Get map configuration for client-side
-	 */
-	static async getMapConfig() {
-		return {
-			center: await this.get<{ lat: number; lng: number }>('display.defaultMapCenter'),
-			zoom: await this.get<number>('display.defaultMapZoom'),
-			tileProvider: await this.get<string>('integration.mapTileProvider')
-		};
-	}
-
-	/**
 	 * Check if maintenance mode is enabled (client-side)
 	 */
 	static async isMaintenanceModeEnabled(): Promise<boolean> {
@@ -232,10 +208,10 @@ export class ClientConfigService {
 export const ConfigService = {
 	// Server-side methods (only work on server)
 	server: ServerConfigService,
-	
+
 	// Client-side methods (only work in browser)
 	client: ClientConfigService,
-	
+
 	// Get default value for any config key
 	getDefault(key: keyof typeof DEFAULT_VALUES) {
 		return DEFAULT_VALUES[key];

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -69,9 +69,11 @@
 		// Note: Other settings are planned but not yet actively used:
 		// - Most data processing settings (duplicate check, auto-approve, etc.)
 		// - Integration settings (weather API, geocoding, webhooks)
-		// - Advanced display settings (map defaults, date format)
+		// - Advanced display settings (date format)
 		// - Mobile app settings
 		// - Advanced security settings
+		// Karten-Defaults stehen hier bewusst nicht mehr: Zentrum, Zoom und
+		// Tile-Quelle sind in src/lib/map/optimizedMapController.ts fest verdrahtet.
 	]);
 
 	// Filter configurations to only show active ones
@@ -313,11 +315,11 @@
 	<!-- Header -->
 	<div class="mb-8 flex items-center justify-between">
 		<div>
-			<h1 class="flex items-center gap-3 text-3xl font-bold text-base-content">
+			<h1 class="text-base-content flex items-center gap-3 text-3xl font-bold">
 				<Icon icon="lucide:settings" width="32" height="32" class="text-primary" />
 				Anwendungseinstellungen
 			</h1>
-			<p class="mt-2 text-base-content/70">
+			<p class="text-base-content/70 mt-2">
 				Konfigurieren Sie alle Aspekte der Ostsee-Tiere Anwendung über diese zentrale Oberfläche.
 			</p>
 		</div>
@@ -444,7 +446,7 @@
 								<div class="mb-3 flex items-start justify-between">
 									<div class="flex-1">
 										<div class="flex items-center gap-2">
-											<div class="text-sm font-semibold text-base-content">
+											<div class="text-base-content text-sm font-semibold">
 												{config.key}
 											</div>
 											{#if changedConfigs.has(config.key)}
@@ -456,7 +458,7 @@
 											{/if}
 										</div>
 										{#if config.description}
-											<p class="mt-1 text-sm text-base-content/70">{config.description}</p>
+											<p class="text-base-content/70 mt-1 text-sm">{config.description}</p>
 										{/if}
 									</div>
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -316,7 +316,13 @@
 	<div class="mb-8 flex items-center justify-between">
 		<div>
 			<h1 class="text-base-content flex items-center gap-3 text-3xl font-bold">
-				<Icon icon="lucide:settings" width="32" height="32" class="text-primary" />
+				<Icon
+					icon="lucide:settings"
+					width="32"
+					height="32"
+					class="text-primary"
+					aria-hidden="true"
+				/>
 				Anwendungseinstellungen
 			</h1>
 			<p class="text-base-content/70 mt-2">

--- a/src/routes/api/config/public/+server.ts
+++ b/src/routes/api/config/public/+server.ts
@@ -7,12 +7,9 @@ const logger = createLogger('api:config:public');
 
 // Configuration keys that are safe to expose to clients
 const PUBLIC_CONFIG_KEYS = [
-	'display.defaultMapCenter',
-	'display.defaultMapZoom',
 	'display.dateFormat',
 	'display.maintenanceMode',
 	'display.maintenanceMessage',
-	'integration.mapTileProvider',
 	'mobile.minAppVersion',
 	'mobile.updateMessage',
 	'data.exportFormats'

--- a/src/tests/contract/config.contract.test.ts
+++ b/src/tests/contract/config.contract.test.ts
@@ -264,9 +264,9 @@ describe('Contract: GET /api/config/public', () => {
 		const res = await publicGET(event);
 		const body = await res.json();
 
-		expect(Object.keys(body)).not.toContain('display.defaultMapCenter');
-		expect(Object.keys(body)).not.toContain('display.defaultMapZoom');
-		expect(Object.keys(body)).not.toContain('integration.mapTileProvider');
+		expect(body).not.toHaveProperty('display.defaultMapCenter');
+		expect(body).not.toHaveProperty('display.defaultMapZoom');
+		expect(body).not.toHaveProperty('integration.mapTileProvider');
 	});
 });
 

--- a/src/tests/contract/config.contract.test.ts
+++ b/src/tests/contract/config.contract.test.ts
@@ -255,6 +255,19 @@ describe('Contract: GET /api/config/public', () => {
 		expect(apiRes.status).toBe(200);
 		expect(apiRes).toSatisfyApiSpec();
 	});
+
+	// Die Karte (optimizedMapController.ts) verdrahtet Zentrum, Zoom und Tile-Quelle
+	// fest. Solange das so ist, gehören diese Schlüssel in keine öffentliche Antwort —
+	// sie wurden anonym ausgeliefert, ohne dass sie irgendwo gelesen wurden.
+	it('liefert keine Karten-Schlüssel aus, die nirgends gelesen werden', async () => {
+		const event = createEvent('/api/config/public');
+		const res = await publicGET(event);
+		const body = await res.json();
+
+		expect(Object.keys(body)).not.toContain('display.defaultMapCenter');
+		expect(Object.keys(body)).not.toContain('display.defaultMapZoom');
+		expect(Object.keys(body)).not.toContain('integration.mapTileProvider');
+	});
 });
 
 describe('Contract: GET /api/config/upload', () => {

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2936,13 +2936,12 @@ components:
       description: Öffentlich verfügbare Konfigurationswerte (Werte können beliebige JSON-Typen sein)
       additionalProperties: {}
       example:
-        "display.maxSightings": 100
-        "mobile.apiEnabled": true
-        "integration.mapTileUrl": "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-        "display.defaultMapCenter":
-          lat: 54.3233
-          lng: 10.1228
-        "upload.allowedTypes": ["image/jpeg", "image/png"]
+        "display.dateFormat": "DD.MM.YYYY"
+        "display.maintenanceMode": false
+        "display.maintenanceMessage": "Die Anwendung wird gewartet. Bitte versuchen Sie es später erneut."
+        "mobile.minAppVersion": "1.0.0"
+        "mobile.updateMessage": "Eine neue Version der App ist verfügbar."
+        "data.exportFormats": ["csv", "json", "kml", "xml"]
 
     UploadConfig:
       type: object


### PR DESCRIPTION
Entfernt die drei verbliebenen toten Konfigurationsschlüssel derselben Klasse wie in 0e995d4:

- `display.defaultMapCenter`
- `display.defaultMapZoom`
- `integration.mapTileProvider`

Sie waren registriert, dokumentiert, zugriffsgeschützt und wurden über `/api/config/public` anonym ausgeliefert — gelesen hat sie keine Route und keine Komponente. Die beiden `getMapConfig()`-Methoden, die sie kapselten, hatten ebenfalls keine Aufrufer.

## Warum entfernen statt anbinden

Die Karte holt ihre Werte aus `src/lib/map/optimizedMapController.ts`, wo Zentrum, Zoom und beide Tile-Quellen fest verdrahtet sind. Zwei Punkte sprachen gegen die Anbindung:

- Die Werte waren bereits auseinandergelaufen: Config-Default `lat 54.5 / lng 13.5`, Controller `54.5 / 12.0`.
- `integration.mapTileProvider` enthielt ein Leaflet-artiges `{s}`-Subdomain-Template, das OpenLayers' `OSM`-Source gar nicht verarbeitet. Eine echte Anbindung wäre ein Umbau auf `XYZ` inklusive Format-Migration gewesen, plus die offene Frage nach dem zweiten, fest verdrahteten OpenSeaMap-Layer.

Richtung wurde vorab mit dem Maintainer abgestimmt.

## Korrektur an der Begründung von 0e995d4

Die Commit-Message von 0e995d4 behauptet, die Admin-Settings-Seite iteriere über die Code-Liste, weshalb das Entfernen der Einträge auch die Toggles aus der UI entferne. **Das stimmt nicht.** `src/routes/admin/settings/+page.svelte` filtert zusätzlich über eine eigene `activeConfigKeys`-Allowlist, und weder die damals noch die jetzt entfernten Schlüssel standen jemals darin.

Für Administratoren waren die Schalter also nie sichtbar. Was sie tatsächlich taten: bei jedem Aufruf von `/admin/settings` in die Tabelle `configurations` geschrieben werden und an anonyme Clients ausgeliefert werden. Verwaiste Zeilen bleiben liegen — `resetToDefaultConfigurations` macht `upsertMany`, kein Prune.

## Umfang

| Datei | Änderung |
|---|---|
| `src/lib/services/configService.ts` | 3 Keys aus `DEFAULT_VALUES`; `ServerConfigService.getMapConfig()`; `ClientConfigService.getMapConfig()`; `getObject()` |
| `src/lib/server/services/configInitializer.ts` | 3 Default-Einträge |
| `src/lib/server/config/accessControl.ts` | 3 Einträge aus `SUPERADMIN_ONLY_CONFIG_KEYS` |
| `src/routes/api/config/public/+server.ts` | 3 Keys aus `PUBLIC_CONFIG_KEYS` |
| `src/routes/admin/settings/+page.svelte` | veralteter Kommentar „map defaults" |
| `static/openapi.yml` | `PublicConfig`-Beispiel |
| `docs/CONFIGURATION_USAGE.md` | Abschnitt 5 und alle Beispiele |

`ServerConfigService.getObject()` fällt mit weg: `getMapConfig()` war der einzige Aufrufer, und `display.defaultMapCenter` war der einzige objektwertige Schlüssel in `DEFAULT_VALUES` — der Getter hätte danach kein gültiges Argument mehr gehabt.

Das `PublicConfig`-Beispiel in `static/openapi.yml` listete neben `defaultMapCenter` drei Schlüssel, die es nie gab (`display.maxSightings`, `integration.mapTileUrl`, `upload.allowedTypes`). Es entspricht jetzt den tatsächlich zurückgegebenen Keys.

## Test

Contract-Test in `src/tests/contract/config.contract.test.ts`: `/api/config/public` darf die drei Schlüssel nicht ausliefern. Vorher rot, jetzt grün — ein Wiedereinbau in `PUBLIC_CONFIG_KEYS` ohne Konsumenten bricht damit CI.

```
npm run test:quick
```
lint (0 errors, 2 pre-existing warnings in `createEvent.ts`), type-check, svelte-check (0 errors), 1730 Unit-Tests in 107 Dateien — grün. OpenAPI-YAML validiert.

## Hinweise für Reviewer

- **Prettier-Rauschen:** Der PostToolUse-Formatter hat `configService.ts`, `accessControl.ts` und `+page.svelte` mitformatiert (Whitespace, Zeilenumbrüche, Tailwind-Klassenreihenfolge). Diese Dateien waren nicht prettier-clean; `npm run lint` ist nur ESLint und prüft kein Prettier.
- **Keine Browser-Verifikation:** Die Wirkung liegt hinter Admin-Login und befüllter DB. Stattdessen ist die Kette Code-Liste → `activeConfigKeys` → UI im Loader nachgelesen und die API-Seite durch den Contract-Test abgedeckt.
- **Folgethema, hier bewusst nicht angefasst:** Konfigurationsschlüssel werden an fünf Stellen parallel gepflegt — `DEFAULT_VALUES`, `defaultConfigurations`, `PUBLIC_CONFIG_KEYS`, die beiden Sets in `accessControl.ts` und `activeConfigKeys` in der Svelte-Datei. Ohne gemeinsame Quelle überleben tote Schlüssel genau so, wie diese drei es getan haben. Ebenfalls ungenutzt und pre-existing: `ConfigRepository.getObject()` und `ServerConfigService.getSecurityConfig()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)