### PR TITLE
chore(build): exclude claude worktrees from lint and sync lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 test-results
 node_modules
 .worktrees
+.claude/worktrees/
 
 # AI planning artifacts (Claude Code superpowers plans)
 docs/superpowers/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@paralleldrive/cuid2": "^3.3.0",
-				"@rollup/rollup-linux-x64-gnu": "4.62.3",
 				"@turf/boolean-point-in-polygon": "^7.3.5",
 				"@turf/helpers": "^7.3.4",
 				"@vercel/blob": "^2.6.1",


### PR DESCRIPTION
## Problem

Zwei Routine-Kommandos liefen im Hauptverzeichnis nicht mehr durch. Beide Ursachen sind unabhängig vom Feature-Stand — `main` war zum Zeitpunkt der Analyse sauber und identisch mit `origin/main`.

### 1. `npm run test:quick` bricht mit 9402 Lint-Fehlern ab

ESLint bezieht seine Ignores über `includeIgnoreFile()` in `eslint.config.js:13` **ausschließlich aus `.gitignore`**. Dort war `.claude/worktrees/` nicht eingetragen — es stand nur in der lokalen `.git/info/exclude`, die ESLint nicht liest. Deshalb war `git status` sauber, ESLint aber nicht.

Folge: Alle sieben Worktree-Kopien wurden mitgelintet, inklusive ihrer generierten `.svelte-kit/types/**`. Der Eintrag `/.svelte-kit` in der `.gitignore` ist root-verankert und greift für Unterverzeichnisse nicht.

### 2. `git pull` scheitert nach jedem `npm install`

`@rollup/rollup-linux-x64-gnu` steht in `package.json:132` unter `optionalDependencies`. Im Lockfile war es zusätzlich noch unter `dependencies` des Root-Packages eingetragen — ein Rest aus der Zeit vor der Verschiebung. `npm install` entfernt diesen toten Eintrag reproduzierbar, der korrigierte Stand wurde nie committet. Ergebnis: `package-lock.json` war nach jedem Install dirty und `git pull` verweigerte den Merge.

Kein plattformabhängiges Oszillieren: Ein zweiter `npm install` erzeugt exakt denselben Ein-Zeilen-Diff, und der Root-Block enthält den Eintrag danach korrekt nur noch unter `optionalDependencies`. Das einmalige Committen behebt es daher dauerhaft, auch für Linux und CI.

## Änderung

| Datei | Änderung |
|---|---|
| `.gitignore` | `.claude/worktrees/` ergänzt, direkt neben der bestehenden `.worktrees`-Zeile |
| `package-lock.json` | Veralteter `dependencies`-Eintrag für `@rollup/rollup-linux-x64-gnu` entfernt |

Zwei Zeilen, keine Logikänderung.

## Verifikation

- `npm run lint` im Hauptverzeichnis: **9402 Fehler → 0** (verbleiben die zwei bekannten `no-explicit-any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`). Geprüft, indem die geänderte `.gitignore` temporär im Hauptverzeichnis angewendet und danach zurückgesetzt wurde.
- `npm run test:quick`: grün — **1742 Tests in 108 Dateien**, Lint, Type-Check und Svelte-Check inklusive.

## Tests

Kein Test hinzugefügt. Reine Build-/Konfigurationsänderung ohne Business-Logik — gedeckt durch die Ausnahmeregel in `.claude/rules/testing.md`. Der Fix ist selbst dadurch verifiziert, dass die Test-Pipeline wieder läuft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)