### PR TITLE
fix: konsistente Zeitzonen-Behandlung vor Inbetriebnahme

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -44,6 +44,14 @@ als DDL-Skript unter `scripts/migrations/` ablegen und beim Deployment ausführe
 > ```sql
 > SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'sichtungen';
 > ```
+>
+> **Warum diese Ausdrücke überhaupt existieren:** Die Zeitstempelspalten sind
+> UTC, aber Kalenderfragen (Tag/Monat/Jahr) sind fachlich immer Berlin-Ortszeit
+> gemeint — der Ausdruck rechnet das bei jeder Abfrage um, statt eine zweite
+> Spalte zu pflegen. Der SQL-Text muss dabei **zeichengleich** mit
+> `berlinCalendarDate`/`berlinDatePart` aus `src/lib/server/db/sqlTimeZone.ts`
+> sein, sonst greift der Index nicht. Zentrale Referenz für die
+> Zeitzonen-Konvention: `docs/ENVIRONMENT.md`, Abschnitt `TZ`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,16 +119,16 @@ Automatisiert über **release-please**: Commits auf `main` werden analysiert, ei
 
 ## Weitere Dokumentation
 
-| Dokument                           | Inhalt                                   |
-| ---------------------------------- | ---------------------------------------- |
-| `.claude/README.md`                | Aufbau der Claude-Konfiguration          |
-| `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen  |
-| `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)   |
-| `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                    |
-| `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung) |
-| `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)     |
-| `docs/ENVIRONMENT.md`              | Umgebungsvariablen                       |
-| `docs/DATABASE_MIGRATION.md`       | DB Migrationen                           |
+| Dokument                           | Inhalt                                                          |
+| ---------------------------------- | --------------------------------------------------------------- |
+| `.claude/README.md`                | Aufbau der Claude-Konfiguration                                 |
+| `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen                         |
+| `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)                          |
+| `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                                           |
+| `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                        |
+| `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                            |
+| `docs/ENVIRONMENT.md`              | Umgebungsvariablen, inkl. Zeitzonen-Konvention (Abschnitt `TZ`) |
+| `docs/DATABASE_MIGRATION.md`       | DB Migrationen                                                  |
 
 Themenspezifische Regeln in `.claude/rules/` laden automatisch, sobald passende Dateien bearbeitet werden — sie müssen hier nicht aufgezählt werden.
 

--- a/docs/DATABASE_MIGRATION.md
+++ b/docs/DATABASE_MIGRATION.md
@@ -29,7 +29,18 @@ The migration process involves:
 4. **Post-Migration Scripts**: Running scripts to:
    - Generate reference IDs for all sightings
    - Migrate old file uploads to the new structure
+   - Convert legacy local-time timestamps to UTC
    - Update field mappings
+
+> **WARNING — Timestamp time zone:** The `sichtungsdatum`, `created` and
+> `freigegeben_am` columns are `timestamp without time zone` and store real
+> UTC instants. Data exported from the legacy schweinswalsichtung.de system
+> (or any other pre-migration source) is **German local time (Europe/Berlin
+> wall-clock)**, not UTC. Anyone who imports legacy data via Steps 1–3 below
+> **MUST** run `src/tools/migrate-timestamps-to-utc.js` (see
+> [Step 4.4](#44-convert-legacy-timestamps-to-utc)) afterwards — otherwise the
+> imported rows disagree with every UTC timestamp the application writes by
+> exactly the CET/CEST offset. Background: `docs/ENVIRONMENT.md#tz`.
 
 ---
 
@@ -283,6 +294,47 @@ npx tsx --env-file=.env src/tools/migrate-old-uploads.ts
 [INFO] Original files preserved in _old_uploads directory: 456 files
 ```
 
+#### 4.4 Convert Legacy Timestamps to UTC
+
+**Purpose:** Legacy data imported in Steps 1–3 has its `sichtungsdatum`,
+`created` and `freigegeben_am` values in German local time (Europe/Berlin
+wall-clock), because the old PHP application ran on a server pinned to that
+zone. The new application always writes real UTC instants, so the naive
+`timestamp without time zone` columns would otherwise mix two irreconcilable
+interpretations — off by exactly the CET/CEST offset. This is a **one-time**
+conversion; do not run it against a database that already contains
+app-written UTC timestamps in the same range (the script detects and refuses
+that automatically). Full rationale: `docs/ENVIRONMENT.md#tz`.
+
+**Before running:** take a database backup. The conversion is not easily
+reversible — a second accidental run (or a run after restoring the same
+backup without `--force`) would shift the same timestamps a second time.
+
+```bash
+# Dry run first — no writes, shows scope and sample conversions
+npm run db:migrate-timestamps-utc:dry-run -- --cutover=<ISO>
+
+# Example: legacy app went live 2026-08-01T00:00:00Z
+npm run db:migrate-timestamps-utc:dry-run -- --cutover=2026-08-01T00:00:00Z
+
+# Live run once the dry run looks correct
+npm run db:migrate-timestamps-utc -- --cutover=2026-08-01T00:00:00Z
+```
+
+**What this script does:**
+
+- Converts `sichtungen.sichtungsdatum/created/freigegeben_am` and
+  `sichtungen_dateien.hochgeladen_am/erstellt_am` from Europe/Berlin
+  wall-clock to UTC for all rows with `created`/`erstellt_am` before
+  `--cutover`
+- Refuses to run twice: it records a marker in `app_config` and aborts unless
+  `--force` is passed (only after restoring from backup)
+- Refuses to touch rows that already look like app-written UTC data
+  (detected via `weather_data IS NOT NULL`), unless explicitly excluded via
+  `--exclude-ids=…`
+- Reports timestamps that fall in the DST spring-forward gap or the autumn
+  repeated hour, since those are inherently ambiguous when converting
+
 ### Step 5: Migrate Uploaded Files
 
 **Verify file migration:**
@@ -312,10 +364,11 @@ rm -rf uploads/_old_uploads
 
 ## Migration Scripts Reference
 
-| Script                      | Purpose                                               | Command                                                       |
-| --------------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
-| `generate-reference-ids.ts` | Generate CUID2 reference IDs for all sightings        | `npx tsx --env-file=.env src/tools/generate-reference-ids.ts` |
-| `migrate-old-uploads.ts`    | Migrate files and create `sichtungen_dateien` entries | `npx tsx --env-file=.env src/tools/migrate-old-uploads.ts`    |
+| Script                         | Purpose                                                                 | Command                                                        |
+| ------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `generate-reference-ids.ts`    | Generate CUID2 reference IDs for all sightings                          | `npx tsx --env-file=.env src/tools/generate-reference-ids.ts`  |
+| `migrate-old-uploads.ts`       | Migrate files and create `sichtungen_dateien` entries                   | `npx tsx --env-file=.env src/tools/migrate-old-uploads.ts`     |
+| `migrate-timestamps-to-utc.js` | Convert legacy Europe/Berlin timestamps to real UTC (one-time, see 4.4) | `npm run db:migrate-timestamps-utc:dry-run -- --cutover=<ISO>` |
 
 ---
 

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -23,54 +23,54 @@ This is a dated status, not a standing guarantee — re-check whether clients ha
 
 ### Request Body (JSON Object)
 
-| Attribute                   | Description                                                                     | Data Type / Range                   | Required                           |
-| --------------------------- | ------------------------------------------------------------------------------- | ----------------------------------- | ---------------------------------- |
-| `sichtungsdatum`            | Date and time of sighting                                                       | DateTime, "YYYY-MM-DD HH:MI"        | Yes                                |
-| `anzahl_gesamt`             | Total number of sighted animals. 0 is allowed and interpreted as death finding. | Integer                             | Yes                                |
-| `vorname`                   | First name                                                                      | String (64)                         | Yes                                |
-| `name`                      | Last name                                                                       | String (64)                         | Yes                                |
-| `email`                     | Email address                                                                   | E-Mail                              | Yes                                |
-| `gps_breite`                | Latitude decimal                                                                | Decimal, -90 – 90                   | No                                 |
-| `gps_laenge`                | Longitude decimal                                                               | Decimal, -180 – 180                 | No                                 |
-| `fahrwasser`                | Waterway or area                                                                | Text                                | No                                 |
-| `seezeichen`                | Sea mark or beach section                                                       | Text                                | No                                 |
-| `vonwo`                     | Sighting location                                                               | Integer-Range, 0-3                  | No                                 |
-| `vonwo_text`                | Other sighting location (when vonwo = 0)                                        | Text                                | No                                 |
-| `entfernung`                | Distance                                                                        | Integer-Range, 1-5                  | No                                 |
-| `anzahl_schiffe`            | Number of ships in vicinity                                                     | Integer                             | No                                 |
-| `anzahl_jung`               | Number of juvenile animals                                                      | Integer                             | No                                 |
-| `verteilung`                | Distribution of animals                                                         | Integer-Range, 0-3                  | No                                 |
-| `verteilung_text`           | Other distribution (when verteilung = 0)                                        | Text                                | No                                 |
-| `aufnahme`                  | Filename of uploaded media                                                      | String (255)                        | No                                 |
-| `aufnahmeHochladen`         | Media uploaded flag                                                             | Boolean, 0 = false, 1 = true        | No                                 |
-| `verhalten`                 | Behavior of animals                                                             | Integer-Range, 0-3                  | No                                 |
-| `verhalten_text`            | Other behavior (when verhalten = 0)                                             | Text                                | No                                 |
-| `reaktion`                  | Reaction of animals                                                             | Text                                | No                                 |
-| `sonstige_auffaelligkeiten` | Other observations                                                              | Text                                | No                                 |
-| `seegang`                   | Sea state                                                                       | Integer-Range, 0-5                  | No                                 |
-| `windrichtung`              | Wind direction                                                                  | 'N','NW','W','SW','S','SO','O','NO' | No                                 |
-| `windstaerke`               | Wind force in Beaufort                                                          | 1-12                                | No                                 |
-| `sichtweite`                | Visibility                                                                      | Integer-Range, 1-4                  | No                                 |
-| `schiffsname`               | Ship name                                                                       | String (64)                         | No, Yes if schiffnamensnennung = 1 |
-| `heimathafen`               | Home port                                                                       | String (64)                         | No                                 |
-| `bootstyp`                  | Boat type                                                                       | String (64)                         | No                                 |
-| `bootsantrieb`              | Boat drive                                                                      | Integer-Range, 0-4                  | No                                 |
-| `bootsantrieb_text`         | Other boat drive (when bootsantrieb = 0)                                        | Text                                | No                                 |
-| `strasse`                   | Street                                                                          | String (64)                         | No                                 |
-| `plz`                       | ZIP code                                                                        | String (5)                          | No                                 |
-| `ort`                       | City                                                                            | String (64)                         | No                                 |
-| `telefon`                   | Phone number                                                                    | String (64)                         | No                                 |
-| `fax`                       | Fax number                                                                      | String (64)                         | No                                 |
-| `namensnennung`             | Name mention desired?                                                           | Boolean, 0 = false, 1 = true        | No                                 |
-| `schiffnamensnennung`       | Ship name display allowed?                                                      | Boolean, 0 = false, 1 = true        | No                                 |
-| `bemerkungen`               | Comments                                                                        | Text                                | No                                 |
-| `eingangskanal`             | Entry channel of report                                                         | Integer-Range, 0-5                  | No                                 |
-| `tierart`                   | Reported animal species                                                         | Integer-Range, 0-10                 | No, Default = 0                    |
-| `totfund`                   | Death finding                                                                   | Boolean, 0 = false, 1 = true        | No                                 |
-| `totfund_zustand`           | Condition of animal                                                             | Integer-Range, 0-5                  | No                                 |
-| `totfund_geschlecht`        | Sex of animal                                                                   | Integer-Range, 0-2                  | No                                 |
-| `totfund_groesse`           | Size of animal in cm                                                            | Integer                             | No                                 |
-| `totfund_telefon`           | DMM already informed by phone                                                   | Boolean, 0 = false, 1 = true        | No                                 |
+| Attribute                   | Description                                                                                                  | Data Type / Range                   | Required                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------- | ---------------------------------- |
+| `sichtungsdatum`            | Date and time of sighting (German local time, Europe/Berlin — see [Zeitzonen-Semantik](#zeitzonen-semantik)) | DateTime, "YYYY-MM-DD HH:MI"        | Yes                                |
+| `anzahl_gesamt`             | Total number of sighted animals. 0 is allowed and interpreted as death finding.                              | Integer                             | Yes                                |
+| `vorname`                   | First name                                                                                                   | String (64)                         | Yes                                |
+| `name`                      | Last name                                                                                                    | String (64)                         | Yes                                |
+| `email`                     | Email address                                                                                                | E-Mail                              | Yes                                |
+| `gps_breite`                | Latitude decimal                                                                                             | Decimal, -90 – 90                   | No                                 |
+| `gps_laenge`                | Longitude decimal                                                                                            | Decimal, -180 – 180                 | No                                 |
+| `fahrwasser`                | Waterway or area                                                                                             | Text                                | No                                 |
+| `seezeichen`                | Sea mark or beach section                                                                                    | Text                                | No                                 |
+| `vonwo`                     | Sighting location                                                                                            | Integer-Range, 0-3                  | No                                 |
+| `vonwo_text`                | Other sighting location (when vonwo = 0)                                                                     | Text                                | No                                 |
+| `entfernung`                | Distance                                                                                                     | Integer-Range, 1-5                  | No                                 |
+| `anzahl_schiffe`            | Number of ships in vicinity                                                                                  | Integer                             | No                                 |
+| `anzahl_jung`               | Number of juvenile animals                                                                                   | Integer                             | No                                 |
+| `verteilung`                | Distribution of animals                                                                                      | Integer-Range, 0-3                  | No                                 |
+| `verteilung_text`           | Other distribution (when verteilung = 0)                                                                     | Text                                | No                                 |
+| `aufnahme`                  | Filename of uploaded media                                                                                   | String (255)                        | No                                 |
+| `aufnahmeHochladen`         | Media uploaded flag                                                                                          | Boolean, 0 = false, 1 = true        | No                                 |
+| `verhalten`                 | Behavior of animals                                                                                          | Integer-Range, 0-3                  | No                                 |
+| `verhalten_text`            | Other behavior (when verhalten = 0)                                                                          | Text                                | No                                 |
+| `reaktion`                  | Reaction of animals                                                                                          | Text                                | No                                 |
+| `sonstige_auffaelligkeiten` | Other observations                                                                                           | Text                                | No                                 |
+| `seegang`                   | Sea state                                                                                                    | Integer-Range, 0-5                  | No                                 |
+| `windrichtung`              | Wind direction                                                                                               | 'N','NW','W','SW','S','SO','O','NO' | No                                 |
+| `windstaerke`               | Wind force in Beaufort                                                                                       | 1-12                                | No                                 |
+| `sichtweite`                | Visibility                                                                                                   | Integer-Range, 1-4                  | No                                 |
+| `schiffsname`               | Ship name                                                                                                    | String (64)                         | No, Yes if schiffnamensnennung = 1 |
+| `heimathafen`               | Home port                                                                                                    | String (64)                         | No                                 |
+| `bootstyp`                  | Boat type                                                                                                    | String (64)                         | No                                 |
+| `bootsantrieb`              | Boat drive                                                                                                   | Integer-Range, 0-4                  | No                                 |
+| `bootsantrieb_text`         | Other boat drive (when bootsantrieb = 0)                                                                     | Text                                | No                                 |
+| `strasse`                   | Street                                                                                                       | String (64)                         | No                                 |
+| `plz`                       | ZIP code                                                                                                     | String (5)                          | No                                 |
+| `ort`                       | City                                                                                                         | String (64)                         | No                                 |
+| `telefon`                   | Phone number                                                                                                 | String (64)                         | No                                 |
+| `fax`                       | Fax number                                                                                                   | String (64)                         | No                                 |
+| `namensnennung`             | Name mention desired?                                                                                        | Boolean, 0 = false, 1 = true        | No                                 |
+| `schiffnamensnennung`       | Ship name display allowed?                                                                                   | Boolean, 0 = false, 1 = true        | No                                 |
+| `bemerkungen`               | Comments                                                                                                     | Text                                | No                                 |
+| `eingangskanal`             | Entry channel of report                                                                                      | Integer-Range, 0-5                  | No                                 |
+| `tierart`                   | Reported animal species                                                                                      | Integer-Range, 0-10                 | No, Default = 0                    |
+| `totfund`                   | Death finding                                                                                                | Boolean, 0 = false, 1 = true        | No                                 |
+| `totfund_zustand`           | Condition of animal                                                                                          | Integer-Range, 0-5                  | No                                 |
+| `totfund_geschlecht`        | Sex of animal                                                                                                | Integer-Range, 0-2                  | No                                 |
+| `totfund_groesse`           | Size of animal in cm                                                                                         | Integer                             | No                                 |
+| `totfund_telefon`           | DMM already informed by phone                                                                                | Boolean, 0 = false, 1 = true        | No                                 |
 
 ### Response
 
@@ -264,21 +264,21 @@ Returns all reports of a year that are approved and marked as lying in the Balti
 
 JSON Array with JSON Objects:
 
-| Attribute | Description                                                  | Data Type / Range                                   |
-| --------- | ------------------------------------------------------------ | --------------------------------------------------- |
-| `ts`      | Unix Timestamp                                               | Unix Timestamp                                      |
-| `id`      | Report ID                                                    | Integer                                             |
-| `dt`      | Date                                                         | String, DD.MM.YY                                    |
-| `ti`      | Time                                                         | String, HH:MI                                       |
-| `lat`     | Latitude                                                     | Decimal (as string)                                 |
-| `lon`     | Longitude                                                    | Decimal (as string)                                 |
-| `ct`      | Total number of sighted animals                              | Integer                                             |
-| `yo`      | Number of juveniles                                          | Integer                                             |
-| `sh`      | Ship name                                                    | String                                              |
-| `na`      | Sighter name (First name + Last name)                        | String                                              |
-| `ar`      | Waterway / Area                                              | String                                              |
-| `bm`      | Result of position check; only delivered for logged in admin | Integer: 0 = Outside, 1 = inchartarea, 2 = inbaltic |
-| `va`      | Entry checked; only delivered for logged in admin            | Boolean: 0 = False, 1 = True                        |
+| Attribute | Description                                                                             | Data Type / Range                                   |
+| --------- | --------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `ts`      | Unix Timestamp                                                                          | Unix Timestamp                                      |
+| `id`      | Report ID                                                                               | Integer                                             |
+| `dt`      | Date (German local time, Europe/Berlin — see [Zeitzonen-Semantik](#zeitzonen-semantik)) | String, DD.MM.YY                                    |
+| `ti`      | Time (German local time, Europe/Berlin — see [Zeitzonen-Semantik](#zeitzonen-semantik)) | String, HH:MI                                       |
+| `lat`     | Latitude                                                                                | Decimal (as string)                                 |
+| `lon`     | Longitude                                                                               | Decimal (as string)                                 |
+| `ct`      | Total number of sighted animals                                                         | Integer                                             |
+| `yo`      | Number of juveniles                                                                     | Integer                                             |
+| `sh`      | Ship name                                                                               | String                                              |
+| `na`      | Sighter name (First name + Last name)                                                   | String                                              |
+| `ar`      | Waterway / Area                                                                         | String                                              |
+| `bm`      | Result of position check; only delivered for logged in admin                            | Integer: 0 = Outside, 1 = inchartarea, 2 = inbaltic |
+| `va`      | Entry checked; only delivered for logged in admin                                       | Boolean: 0 = False, 1 = True                        |
 
 ### Example Response
 
@@ -318,6 +318,7 @@ JSON Array with JSON Objects:
    - Coordinates in showreports.json MUST be strings, not numbers
    - Boolean fields use 0/1 integers, not true/false
    - Date formats must match exactly (DD.MM.YY for showreports, YYYY-MM-DD HH:MI for input)
+   - All date/time values are German local time (Europe/Berlin), never UTC — see [Zeitzonen-Semantik](#zeitzonen-semantik)
 
 3. **URL Paths**: URLs must match exactly - no additional prefixes like `/api/legacy/`
 
@@ -326,3 +327,30 @@ JSON Array with JSON Objects:
 5. **Wind Direction**: Must include all values: 'N','NW','W','SW','S','SO','O','NO' (note 'SO' for southeast)
 
 6. **Backward Compatibility**: Any changes that break existing mobile app functionality are strictly forbidden.
+
+## Zeitzonen-Semantik
+
+Alle Datums-/Uhrzeitwerte dieser Legacy API sind **deutsche Ortszeit
+(Europe/Berlin)** — nie UTC. Das gilt für Eingabe und Ausgabe gleichermaßen:
+
+- **Eingabe** — `sichtungsdatum` (`POST /rest_sichtungen`, Format
+  `"YYYY-MM-DD HH:MI"`): Der Wert wird als deutsche Wanduhrzeit interpretiert
+  und serverseitig nach UTC umgerechnet, bevor er in der Datenbank
+  (`sichtungsdatum`, `timestamp without time zone`, echtes UTC) gespeichert
+  wird.
+- **Ausgabe** — `dt`/`ti` (`GET /sichtungen/showreports.json`): Beide Felder
+  werden aus dem gespeicherten UTC-Zeitpunkt zurück nach Europe/Berlin
+  konvertiert, nicht roh ausgegeben.
+
+**Warum deutsche Ortszeit und nicht UTC:** Die Ostsee-Daten haben als
+fachliche Konvention einen einheitlichen Bezugszeitpunkt — deutsche Ortszeit.
+Das gilt bewusst auch für Sichtungen in östlichen Randgewässern (z. B.
+estnische/finnische Küste, EET/EEST), die eine Stunde vor Berlin liegen: Es
+wird nicht nach Sichtungsort umgerechnet, sondern einheitlich die deutsche
+Ortszeit als Referenz verwendet.
+
+Die interne Speicherung als UTC (seit der Migration
+`src/tools/migrate-timestamps-to-utc.js`, siehe
+`docs/DATABASE_MIGRATION.md`) ist reine Implementierungsdetail und ändert an
+dieser vertraglichen Ein-/Ausgabe-Semantik nichts. Referenz für die
+zugrundeliegende Zeitzonen-Konvention: `docs/ENVIRONMENT.md`, Abschnitt `TZ`.

--- a/docs/TIMEZONE_REVIEW_2026-07-28.md
+++ b/docs/TIMEZONE_REVIEW_2026-07-28.md
@@ -1,0 +1,235 @@
+# Zeitzonen-Konsistenz-Review vor Inbetriebnahme (2026-07-28)
+
+Vier unabhängige Audits (SQL-/DB-Schicht, Schreibpfad, Lesepfad/Anzeige, Dokumentation)
+über den Stand nach der UTC-Migration und den Commits #572–#577. Alle Aussagen zur
+laufenden Datenbank wurden gegen die lokale Entwicklungs-DB verifiziert
+(PostgreSQL 18.4, 19.872 Sichtungen — die einzige DB mit Datenbestand).
+
+**Gesamturteil: Die Regeln sind richtig definiert und im Kern sauber umgesetzt,
+aber noch nicht überall angewandt.** Vor der Inbetriebnahme sind 3 kritische und
+5 hohe Befunde zu beheben; die zentrale Infrastruktur (sqlTimeZone.ts,
+date-utils.ts, correctCestOffsetUTC, formatLocalDateTime) ist verifiziert korrekt.
+
+---
+
+## Die geltenden Regeln (Ist-Semantik)
+
+1. **Speicherung:** Alle naiven `timestamp without time zone`-Spalten
+   (`sichtungsdatum`, `created`, `freigegeben_am`, …) halten **echte
+   UTC-Zeitpunkte** (seit der Einmal-Migration `migrate-timestamps-to-utc.js`
+   am 2026-07-28). `auditLogs.timestamp` ist `timestamptz` — dort stellt sich
+   die Frage nicht.
+2. **Eingabe-Interpretation:** Nutzereingaben (Datum + Uhrzeit) sind **deutsche
+   Wanduhrzeit** und werden **serverseitig** via `combineToDate` +
+   `correctCestOffsetUTC` nach UTC umgerechnet.
+3. **Anzeige/Export/Legacy-API:** Immer **Europe/Berlin**, immer über `Intl`
+   mit explizitem `timeZone` (`formatLocalDateTime`, `legacy-api/date-utils.ts`) —
+   nie über die Prozess-Zeitzone.
+4. **SQL-Kalenderfragen** (Tag/Monat/Jahr): ausschließlich über
+   `berlinCalendarDate`/`berlinDatePart` aus `src/lib/server/db/sqlTimeZone.ts`
+   (`AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin'`), zeichengleich mit den
+   Ausdrucksindizes in `schema.ts`; Index-DDL zusätzlich manuell über
+   `scripts/migrations/` (weil `db:push` Ausdrucksindex-Änderungen nicht erkennt).
+5. **Prozess-Zeitzone:** `TZ=UTC` gepinnt (Dockerfile:118,
+   docker-compose.production.yml:34); Code soll unabhängig von `TZ` korrekt sein.
+
+Referenzdokumentation: `docs/ENVIRONMENT.md` (Abschnitt `TZ`) — inhaltlich
+vorbildlich, aber schwer auffindbar (siehe Doku-Befunde).
+
+---
+
+## KRITISCH — Blocker vor Inbetriebnahme
+
+### K1 — Web-Formular speichert die Sichtungszeit in der Browser-Zeitzone
+
+`src/lib/report/components/ModernReportForm.svelte:83-91` baut `sightingDatetime`
+**im Browser** per `combineToDate`; `src/lib/server/db/mapFormToSighting.ts:74-75`
+übernimmt diesen Wert **ungeprüft und bevorzugt** (die Feld-Allowlist
+`requestValidation.ts:22` dokumentiert das sogar: „browser timezone!").
+
+- Melder mit Browser-TZ ≠ Berlin (z. B. nachträgliche Meldung aus dem Urlaub,
+  UTC+8): Eingabe „15.07. 14:30" → gespeichert `06:30Z` statt `12:30Z` →
+  Anzeige/Export/Forschungsdaten 6 h daneben. `SubmissionSuccess.svelte:138`
+  zeigt dem Melder sofort die verschobene Zeit.
+- Zusätzlich: `combineToDate` (`dateTime.ts:195-209`) mischt UTC-Parse
+  (`new Date("YYYY-MM-DD")` = UTC-Mitternacht) mit lokalem `setHours` — in
+  West-Zeitzonen (America/*) kippt dadurch auch der **Kalendertag auf den Vortag**.
+- Der parallel existierende Server-Pfad (Fallback aus `sightingDate`/`sightingTime`,
+  genutzt von Legacy-API und Admin-Edit) ist **korrekt** — dieselbe Eingabe
+  erzeugt je nach Pfad einen anderen Instant.
+- Folgefehler: Der EXIF-Prefill (serverseitig korrekt via `correctCestOffsetUTC`)
+  wird beim Absenden über diesen Client-Pfad wieder verfälscht
+  (`DropzoneEnhanced.svelte:173-176,238-246`).
+
+**Fix-Richtung:** `sightingDatetime` aus Client-Submit und Allowlist entfernen
+bzw. serverseitig ignorieren — der getestete Berlin-Pfad existiert bereits.
+`mapFormToSighting.test.ts` hat derzeit **keinen** `sightingDatetime`-Testfall.
+
+### K2 — Live-Export-Routen geben rohes UTC aus; die korrekten Exporter sind toter Code
+
+- `src/routes/api/sightings/export/csv/+server.ts:71-72`: `sighting.sightingDate`
+  landet als unformatiertes `Date`-Objekt in der CSV-Zelle →
+  `"Mon Jun 15 2024 18:30:00 GMT+0000 …"` (UTC-Wanduhrzeit statt 20:30 Berlin).
+- `src/routes/api/sightings/export/kml/+server.ts:50,73`: identisch im
+  KML-Template.
+- Die getesteten, korrekten Berlin-Exporter `generateCsvData`/`generateKmlData`/
+  `generateXmlData` (`src/lib/server/export/*.ts`, inkl. eigener
+  Timezone-Tests) werden **von keiner Route aufgerufen** — die Admin-UI
+  (`ExportModal.svelte:113,155`) ruft die Inline-Implementierungen auf.
+
+**Fix-Richtung:** Routen auf die vorhandenen `generate*Data`-Funktionen
+umstellen — nicht beide Implementierungen parallel lassen.
+
+### K3 — Export-Datumsfilter verliert den letzten Tag und filtert in UTC
+
+`src/routes/api/sightings/export/exportFilterParams.ts:52`:
+`between(sightingDate, new Date(fromDate), new Date(toDate))` — die Obergrenze
+ist `toDate` **00:00 UTC**, alles am letzten Tag nach 01:00/02:00 Berlin fehlt.
+Beide Grenzen sind UTC- statt Berlin-Mitternacht (Sichtung 01.01. 00:30 Berlin
+= 31.12. 23:30Z fällt aus `fromDate=01.01.` heraus). Betrifft CSV, JSON, XML,
+KML und den Vorschau-Count → **stiller Datenverlust in wissenschaftlichen
+Exporten**.
+
+**Fix-Richtung:** Helper analog `getYearRange` (Berlin-Mitternacht, halboffenes
+Intervall `[from, to+1 Tag)`), gemeinsam mit H1 nutzen.
+
+---
+
+## HOCH
+
+### H1 — Öffentliche Karte: 31.12. fehlt komplett, Jahresgrenzen in UTC
+
+`src/routes/api/map/sightings/+server.ts:27-29`: `yearEnd = new Date("YYYY-12-31")`
+= 31.12. **00:00** UTC als inklusive Obergrenze. **Verifiziert am Ist-Bestand:
+alle 10 freigegebenen 31.12.-Sichtungen verschwinden bei gesetztem Jahresfilter.**
+Zudem UTC- statt Berlin-Jahresgrenzen (Silvester-Off-by-one). Die Legacy-API
+(`getYearRange`, halboffenes Intervall) macht es korrekt vor — zwei öffentliche
+Flächen, zwei Jahresauslegungen.
+
+### H2 — `GET /api/sightings`: `dt`/`ti` in UTC unter Legacy-Feldnamen
+
+`src/routes/api/sightings/+server.ts:51-52`: `to_char(sichtungsdatum, …)` ohne
+`AT TIME ZONE` → UTC-Wanduhrzeit. Die Feldnamen (`dt`, `ti`, …) sind exakt die
+von `showreports.json` — dort korrekt Berlin. **Dieselben Felder liefern je nach
+Endpunkt 1–2 h abweichende Werte**; um Mitternacht auch den falschen Kalendertag
+(29.06. statt 30.06.). Zusätzlich Zeilen 38-42: Jahresgrenzen über lokale
+`Date`-Konstruktoren (prozess-TZ-abhängig) statt `getYearRange`.
+
+### H3 — Admin-Wetter-Refresh holt Wetter für die falsche Stunde (persistiert)
+
+`src/routes/api/admin/weather/[id]/refresh/+server.ts:44-46`: Datum + Uhrzeit
+per `toISOString()` (UTC) geschnitten, aber `fetchWeatherData`
+(`weatherRefreshService.ts:200-212`) matcht gegen das Open-Meteo-Stundenraster
+in **Europe/Berlin**. Sommer: Wetter 2 h daneben; Sichtungen 00:00–02:00 Berlin:
+**falscher Kalendertag**. Der Refresh überschreibt korrekt erfasste Wetterdaten
+mit falschen. Betroffene Grundmenge im Bestand: 375 Datensätze mit abweichendem
+UTC-/Berlin-Kalendertag. (Der öffentliche Pfad `/api/weather/historical` +
+`hourIndexFromLocalTime` ist korrekt.)
+
+### H4 — Zeitzonen-Indizes sind in der laufenden DB nicht ausgerollt
+
+`scripts/migrations/2026-07-28-timezone-aware-indexes.sql` ist auf der
+Entwicklungs-DB (der einzigen mit Daten) **nicht angewandt** — `pg_indexes`
+zeigt noch die naiven Ausdrücke (`date_part('year', sichtungsdatum)`,
+`date(sichtungsdatum)`). Die Abfragen sind dadurch nicht falsch, laufen aber
+ohne Index (EXPLAIN verifiziert: Prädikat nur als Filter; nach Anwendung des
+Skripts in einer Test-Transaktion: `Index Cond` greift). **Vor/beim Go-Live das
+Skript auf jeder Zielumgebung ausführen**; es gibt keinen automatisierten
+Abgleich Schema ↔ Ist-DB.
+
+### H5 — OpenAPI behauptet UTC, wo Berlin geliefert wird
+
+`static/openapi.yml:2757`: `ti`-Feld als „HH:MI (24h, **UTC**)" beschrieben —
+tatsächlich liefert `showreports.json` Berlin. Ein Mobile-Client, der der Spec
+folgt, zeigt 1–2 h falsch an. `docs/LEGACY_API_SPECIFICATION.md` (verbindliche
+Referenz) erwähnt Zeitzonen **gar nicht** — weder für das Eingabefeld
+`sichtungsdatum` noch für `dt`/`ti`.
+
+---
+
+## MITTEL
+
+| #   | Stelle                                                                                 | Problem                                                                                                                                                       |
+| --- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | `admin/statistics/+page.server.ts:175-176`                                             | `MIN/MAX(created)::date` naiv (UTC-Tag) — dieselbe Datei rechnet 60 Zeilen darüber korrekt mit `berlinCalendarDate`                                           |
+| M2  | `emailService.ts:176`                                                                  | Benachrichtigungsmail: `sightingDate` als UTC-ISO-Datum → um Mitternacht Vortag; wird aktuell vom Berlin-Formatter überschrieben, bleibt aber eine Falle      |
+| M3  | `sightingSchema.ts:299-310`                                                            | „Zukunft"-Validierung + „heute"-Default in UTC: Nutzer östlich von UTC (bzw. Berlin 00:00–02:00) bekommen für heutige Sichtungen „Datum liegt in der Zukunft" |
+| M4  | `weatherService.ts:185` + `WeatherDisplay.svelte:111`, `WeatherDataDisplay.svelte:135` | `observation_time` ist zonenloser Berlin-String, wird per `formatLocalDateTime` **erneut** konvertiert → bei SSR (UTC) oder Nicht-DE-Browser +2 h             |
+| M5  | `optimizedMapController.ts:457,545,991,998,1009`                                       | Karten-Popups/Zeitslider: `toLocaleDateString('de-DE')` ohne `timeZone` → Browser-Zone, bis zu ±1 Tag                                                         |
+| M6  | `dateTime.ts:257-270`                                                                  | `formatISOLikeDatetime` ohne `timeZone`-Option — aktuell nur „zufällig richtig" (Identitäts-Roundtrip unter Prozess-TZ), fragil bei jedem neuen Aufrufer      |
+| M7  | `admin/+page.server.ts:36-38`                                                          | Datumsfilter semantisch korrekt (`berlinCalendarDate`), aber ohne Ausdrucksindex → Seq Scan pro Listenaufruf (2×: Daten + Count)                              |
+
+## NIEDRIG (Auswahl)
+
+- „Heute"-Checks in UTC (Fenster 00:00–02:00 Berlin): `api/weather/historical/+server.ts:32-36` (heute → Archiv statt Forecast → 404), `weatherRefreshService.ts:59`, `Environment.svelte:33`
+- Admin-Re-Save trunkiert Sekunden (`splitDateTime` HH:MM + `combineToDate` nullt Sekunden)
+- DST-Doppelstunde (letzter Oktobersonntag 02:00–03:00): Re-Save verschiebt −1 h — inhärente Wanduhr-Mehrdeutigkeit, 1-h-Fenster/Jahr
+- `admin/statistics/+page.svelte:557-558`: Heatmap-Raster aus UTC-Tagen gegen Berlin-Daten-Keys; `:458-459` `getFullYear()` in Browser-Zone
+- `ExportModal.svelte:72,77`, `DropzoneEnhanced.svelte:469,543,610`, `fileAnalysis.ts:41-44`: Anzeige/Client-EXIF in Browser-Zone statt Berlin
+- `correctCestOffsetUTC.ts:29`: Eintrittsbedingung `getTimezoneOffset() !== 0` — unter `TZ=Europe/London` im Sommer 1 h falsch (unter UTC/Berlin irrelevant; `TZ` ist aber per Compose überschreibbar)
+- `showreports.json/+server.ts:95`: Jahres-Obergrenze aus Server-Jahr (nur Silvester relevant)
+
+---
+
+## Dokumentations-Befunde
+
+**Gut:** `docs/ENVIRONMENT.md` (TZ-Abschnitt, vorbildlich), Docblocks in
+`sqlTimeZone.ts` / `date-utils.ts` / `correctCestOffsetUTC.ts` /
+`migrate-timestamps-to-utc.js`, das DDL-Skript — alles korrekt, aktuell,
+widerspruchsfrei zur Implementierung.
+
+**Lücken/Fehler:**
+
+1. `static/openapi.yml:2757` — „UTC" ist falsch (→ H5); `PublicSighting.dt/.ti`
+   ohne Zonenangabe, obwohl `/api/sightings` und `showreports.json` identische
+   Feldnamen derzeit unterschiedlich füllen (→ H2)
+2. `docs/LEGACY_API_SPECIFICATION.md` — Zeitzonen-Semantik fehlt vollständig
+3. `docs/DATABASE_MIGRATION.md` — beschreibt den Altsystem-Import (Ortszeit!),
+   erwähnt `migrate-timestamps-to-utc.js` aber nicht; wer dem Leitfaden folgt,
+   importiert Ortszeit in eine UTC-Spalte
+4. `src/tools/README.md` — Migrationstool fehlt im Katalog
+5. `.claude/rules/database.md` — verweist nicht auf `sqlTimeZone.ts`/
+   `docs/ENVIRONMENT.md` (Zeichengleichheits-Regel ohne Begründung)
+6. Auffindbarkeit: Die zentrale Zeitzonen-Referenz „versteckt" sich unter der
+   Env-Var `TZ`; weder CLAUDE.md noch die DB-/API-Regeln verlinken dorthin
+
+---
+
+## Testlage
+
+- 152 zeitzonenbezogene Tests in 58 Suites: **alle grün** (sqlTimeZone,
+  dateTime, Legacy-Date-Utils inkl. DST-Grenzen 2023–2026 millisekundengenau,
+  CSV-Timezone, mapFormToSighting, Wetter-Dedup, hourIndex)
+- Lücken: kein Test für den `sightingDatetime`-Zweig (K1); `vitest.config.ts:84`
+  pinnt `TZ=UTC` und versteckt damit TZ-abhängige Fehler (nur
+  `correctCestOffsetUTC.test.ts` bricht das gezielt auf); `sqlTimeZone.test.ts`
+  prüft SQL-Text, nicht Postgres-Semantik oder den Ist-Zustand der DB (→ H4
+  blieb dadurch unbemerkt); kein Abgleich `scripts/migrations/*.sql` ↔
+  `sqlTimeZone.ts`; keine DST-Tests für die Leseseite gegen echtes Postgres
+
+## Verifiziert korrekt (Positivliste, Kurzfassung)
+
+`sqlTimeZone.ts` (Doppel-`AT TIME ZONE` in PG 18.4 semantisch verifiziert,
+IMMUTABLE belegt), beide Ausdrucksindizes in `schema.ts` + Zeichengleichheits-Test,
+DDL-Skript (parse-tree-gleich, `Index Cond` greift nach Anwendung),
+`weatherDeduplication`, `admin/statistics`-Aggregation (bis auf M1),
+`showreports.json` (Filter + Format in derselben Jahresauslegung),
+`legacy-api/date-utils.ts` komplett, Legacy-POST-Roundtrip
+(`field-mapping.ts:143` Mittags-UTC-Anker), Admin-Edit-Roundtrip
+(browser-TZ-unabhängig, bis auf Sekunden/DST-Doppelstunde), Verify-Endpunkt,
+alle Server-Timestamps (`created`, `uploadedAt`, …), `hourIndex.ts`,
+`/api/weather/historical`-Stundenmatching, `formatLocalDateTime`-Familie,
+E-Mail-Anzeigeformatter, `rateLimit.ts`, Epoch-Ausschluss, `TZ=UTC`-Pinning
+in Dockerfile/Compose.
+
+## Empfohlene Reihenfolge vor Inbetriebnahme
+
+1. **K1** — `sightingDatetime` serverseitig ignorieren (+ Regressionstest)
+2. **K2** — Export-Routen auf `generate*Data` umstellen
+3. **K3 + H1** — gemeinsamer Berlin-Datumsgrenzen-Helper (halboffenes Intervall)
+4. **H3** — Refresh-Route auf Berlin-Wanduhrzeit (`splitDateTime`-Äquivalent)
+5. **H2** — `to_char(… AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin', …)` + `getYearRange`
+6. **H4** — DDL-Skript auf allen Zielumgebungen ausführen, ins Deployment-Runbook
+7. **H5 + Doku** — openapi.yml korrigieren, Zeitzonen-Absatz in
+   LEGACY_API_SPECIFICATION.md und DATABASE_MIGRATION.md ergänzen
+8. M-Befunde nach Gelegenheit; M4 (Wetteranzeige) und M3 (Validierung) zuerst

--- a/scripts/migrations/2026-07-28-timezone-aware-indexes.sql
+++ b/scripts/migrations/2026-07-28-timezone-aware-indexes.sql
@@ -47,6 +47,16 @@ CREATE INDEX idx_year_sichtungen ON sichtungen USING btree (
 	EXTRACT(year FROM sichtungsdatum AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')
 );
 
+-- Kalendertag-Index in deutscher Ortszeit.
+-- Passend zum Datumsfilter der Admin-Liste (admin/+page.server.ts), der über
+-- berlinCalendarDate() filtert — ohne diesen Index läuft jeder gefilterte
+-- Listenaufruf (Daten + Count) als Seq Scan.
+DROP INDEX IF EXISTS idx_sichtungsdatum_berlin_tag;
+
+CREATE INDEX idx_sichtungsdatum_berlin_tag ON sichtungen (
+	DATE(sichtungsdatum AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')
+);
+
 COMMIT;
 
 ANALYZE sichtungen;

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -4,6 +4,7 @@
 	import { downloadHandlers, createTimestampedFilename } from '$lib/utils/download';
 	import type { FrontendSighting } from '$lib/types';
 	import { formatFileSize } from '$lib/utils/file/fileSize';
+	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('ExportModal');
@@ -63,23 +64,18 @@
 		return recordCount * (bytesPerRecord[format as keyof typeof bytesPerRecord] || 500);
 	}
 
-	// `fromDate`/`toDate` sind reine Kalendertag-Strings ("YYYY-MM-DD") aus dem
-	// Datumsfilter, kein Zeitpunkt. Direkt umsortiert statt über ein Date-Objekt
-	// formatiert — sonst bestimmt die Browser-Zone den Tag mit (bis zu ±1 Tag).
-	function formatFilterDate(isoDate: string): string {
-		const [year, month, day] = isoDate.split('-');
-		return `${day}.${month}.${year}`;
-	}
-
-	// Aktive Filter als lesbare Strings formatieren
+	// Aktive Filter als lesbare Strings formatieren. `fromDate`/`toDate` sind
+	// reine Kalendertag-Strings ("YYYY-MM-DD") aus dem Datumsfilter, kein
+	// Zeitpunkt — formatWallClockDateTime sortiert nur um, ohne Date-Objekt
+	// (sonst bestimmt die Browser-Zone den Tag mit, bis zu ±1 Tag).
 	function getActiveFiltersDisplay(): string[] {
 		const filterDisplays: string[] = [];
 
 		if (currentFilters.fromDate) {
-			filterDisplays.push(`Von: ${formatFilterDate(currentFilters.fromDate as string)}`);
+			filterDisplays.push(`Von: ${formatWallClockDateTime(currentFilters.fromDate as string)}`);
 		}
 		if (currentFilters.toDate) {
-			filterDisplays.push(`Bis: ${formatFilterDate(currentFilters.toDate as string)}`);
+			filterDisplays.push(`Bis: ${formatWallClockDateTime(currentFilters.toDate as string)}`);
 		}
 		if (currentFilters.verified === '1') {
 			filterDisplays.push('Nur geprüfte Sichtungen');

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -63,19 +63,23 @@
 		return recordCount * (bytesPerRecord[format as keyof typeof bytesPerRecord] || 500);
 	}
 
+	// `fromDate`/`toDate` sind reine Kalendertag-Strings ("YYYY-MM-DD") aus dem
+	// Datumsfilter, kein Zeitpunkt. Direkt umsortiert statt über ein Date-Objekt
+	// formatiert — sonst bestimmt die Browser-Zone den Tag mit (bis zu ±1 Tag).
+	function formatFilterDate(isoDate: string): string {
+		const [year, month, day] = isoDate.split('-');
+		return `${day}.${month}.${year}`;
+	}
+
 	// Aktive Filter als lesbare Strings formatieren
 	function getActiveFiltersDisplay(): string[] {
 		const filterDisplays: string[] = [];
 
 		if (currentFilters.fromDate) {
-			filterDisplays.push(
-				`Von: ${new Date(currentFilters.fromDate as string).toLocaleDateString('de-DE')}`
-			);
+			filterDisplays.push(`Von: ${formatFilterDate(currentFilters.fromDate as string)}`);
 		}
 		if (currentFilters.toDate) {
-			filterDisplays.push(
-				`Bis: ${new Date(currentFilters.toDate as string).toLocaleDateString('de-DE')}`
-			);
+			filterDisplays.push(`Bis: ${formatFilterDate(currentFilters.toDate as string)}`);
 		}
 		if (currentFilters.verified === '1') {
 			filterDisplays.push('Nur geprüfte Sichtungen');

--- a/src/lib/components/admin/weather/WeatherDataDisplay.svelte
+++ b/src/lib/components/admin/weather/WeatherDataDisplay.svelte
@@ -2,7 +2,9 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import WeatherDisplay from '$lib/components/weather/WeatherDisplay.svelte';
 	import type { StoredWeatherData } from '$lib/services/weatherService';
-	import { formatISOLikeDatetime, formatLocalDateTime } from '$lib/utils/format/dateTime';
+	// `observation_time` ist zonenlose Berlin-Wanduhrzeit, `fetched_at` ein echter
+	// UTC-Instant — deshalb formatObservationTime bzw. formatLocalDateTime (M4).
+	import { formatLocalDateTime, formatObservationTime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
 	import { toast } from '$lib/stores/toastState.svelte';
 
@@ -84,18 +86,6 @@
 		} finally {
 			isRefreshing = false;
 		}
-	}
-
-	// `observation_time` ist ein zonenloser Berlin-Wanduhrzeit-String (siehe
-	// weatherService.ts) — anders als `fetched_at` (echter UTC-Instant, unten
-	// weiter über formatLocalDateTime formatiert). formatLocalDateTime würde
-	// observation_time fälschlich ein zweites Mal nach Berlin konvertieren (M4).
-	function formatObservationTime(time: string | Date | null | undefined): string {
-		const iso = formatISOLikeDatetime(time);
-		if (!iso) return '';
-		const [datePart, timePart] = iso.split(' ');
-		const [year, month, day] = (datePart ?? '').split('-');
-		return `${day}.${month}.${year}, ${timePart}`;
 	}
 </script>
 

--- a/src/lib/components/admin/weather/WeatherDataDisplay.svelte
+++ b/src/lib/components/admin/weather/WeatherDataDisplay.svelte
@@ -2,7 +2,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import WeatherDisplay from '$lib/components/weather/WeatherDisplay.svelte';
 	import type { StoredWeatherData } from '$lib/services/weatherService';
-	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
+	import { formatISOLikeDatetime, formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
 	import { toast } from '$lib/stores/toastState.svelte';
 
@@ -85,6 +85,18 @@
 			isRefreshing = false;
 		}
 	}
+
+	// `observation_time` ist ein zonenloser Berlin-Wanduhrzeit-String (siehe
+	// weatherService.ts) — anders als `fetched_at` (echter UTC-Instant, unten
+	// weiter über formatLocalDateTime formatiert). formatLocalDateTime würde
+	// observation_time fälschlich ein zweites Mal nach Berlin konvertieren (M4).
+	function formatObservationTime(time: string | Date | null | undefined): string {
+		const iso = formatISOLikeDatetime(time);
+		if (!iso) return '';
+		const [datePart, timePart] = iso.split(' ');
+		const [year, month, day] = (datePart ?? '').split('-');
+		return `${day}.${month}.${year}, ${timePart}`;
+	}
 </script>
 
 {#if weatherData && sourceInfo}
@@ -132,7 +144,7 @@
 					</div>
 					<div class="flex items-center gap-2">
 						<Icon icon="lucide:calendar" width="12" />
-						<span>{formatLocalDateTime(weatherData.observation_time, 'datetime')}</span>
+						<span>{formatObservationTime(weatherData.observation_time)}</span>
 					</div>
 					{#if weatherData.location.elevation}
 						<div class="flex items-center gap-2">

--- a/src/lib/components/weather/WeatherDisplay.svelte
+++ b/src/lib/components/weather/WeatherDisplay.svelte
@@ -7,9 +7,13 @@
 	import { getSeaStateLabel } from '$lib/report/formOptions/seaState';
 	import { getVisibilityLabel } from '$lib/report/formOptions/visibility';
 	import { getWindStrengthLabel } from '$lib/report/formOptions/windStrength';
-	import type { WeatherData, WeatherFormFields, StoredWeatherData } from '$lib/services/weatherService';
+	import type {
+		WeatherData,
+		WeatherFormFields,
+		StoredWeatherData
+	} from '$lib/services/weatherService';
 	import type { WeatherDataWithMetadata } from '$lib/types';
-	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
+	import { formatISOLikeDatetime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
 	import { getWeatherIconClass, getWindDirectionIconClass } from '$lib/utils/weather/weatherIcons';
 
@@ -46,9 +50,11 @@
 		}
 
 		// For admin display (StoredWeatherData) - check if it has all required properties
-		const hasProcessed = weatherData && typeof weatherData === 'object' && 'processed' in weatherData;
+		const hasProcessed =
+			weatherData && typeof weatherData === 'object' && 'processed' in weatherData;
 		const hasLocation = weatherData && typeof weatherData === 'object' && 'location' in weatherData;
-		const hasObservationTime = weatherData && typeof weatherData === 'object' && 'observation_time' in weatherData;
+		const hasObservationTime =
+			weatherData && typeof weatherData === 'object' && 'observation_time' in weatherData;
 
 		if (hasProcessed && hasLocation && hasObservationTime) {
 			const processed = weatherData.processed;
@@ -95,6 +101,19 @@
 			}
 		};
 	});
+
+	// `time`/`observation_time` ist ein zonenloser Berlin-Wanduhrzeit-String
+	// (siehe weatherService.ts). formatLocalDateTime würde ihn fälschlich ein
+	// zweites Mal nach Berlin konvertieren (M4) — formatISOLikeDatetime reicht
+	// zonenlose Strings verbatim durch. Nur umsortiert für die Anzeige, ohne
+	// Umweg über ein Date-Objekt (bliebe sonst an der Laufzeit-Zone hängen).
+	function formatObservationTime(time: string | Date | null | undefined): string {
+		const iso = formatISOLikeDatetime(time);
+		if (!iso) return '';
+		const [datePart, timePart] = iso.split(' ');
+		const [year, month, day] = (datePart ?? '').split('-');
+		return `${day}.${month}.${year}, ${timePart}`;
+	}
 </script>
 
 {#if displayData && Object.keys(displayData).length > 0}
@@ -108,7 +127,7 @@
 				{#if showTime && displayData.time}
 					<span class="flex items-center gap-1">
 						<Icon icon="lucide:calendar" width="16" class="text-primary" />
-						{formatLocalDateTime(displayData.time)}
+						{formatObservationTime(displayData.time)}
 					</span>
 				{/if}
 			</div>
@@ -132,7 +151,7 @@
 				</div>
 			{/if}
 
-			{#if displayData.windSpeed !== undefined && displayData.windSpeed !== null || formFields?.windForce}
+			{#if (displayData.windSpeed !== undefined && displayData.windSpeed !== null) || formFields?.windForce}
 				<div class="flex items-center gap-2">
 					<Icon icon="lucide:wind" width="18" class="text-primary" />
 					<span>
@@ -155,12 +174,13 @@
 					></i>
 					<span>
 						Windrichtung: <strong>{displayData.windDirectionCardinal || 'unbekannt'}</strong>
-						{#if displayData.windDirection !== undefined && displayData.windDirection !== null} - {displayData.windDirection}°{/if}
+						{#if displayData.windDirection !== undefined && displayData.windDirection !== null}
+							- {displayData.windDirection}°{/if}
 					</span>
 				</div>
 			{/if}
 
-			{#if displayData.seaState !== undefined && displayData.seaState !== null || formFields?.seaState}
+			{#if (displayData.seaState !== undefined && displayData.seaState !== null) || formFields?.seaState}
 				<div class="flex items-center gap-2">
 					<Icon icon="lucide:waves" width="18" class="text-primary" />
 					<span>
@@ -175,7 +195,7 @@
 				</div>
 			{/if}
 
-			{#if displayData.visibility !== undefined && displayData.visibility !== null || formFields?.visibility}
+			{#if (displayData.visibility !== undefined && displayData.visibility !== null) || formFields?.visibility}
 				<div class="flex items-center gap-2">
 					<Icon icon="lucide:eye" width="18" class="text-primary" />
 					<span>

--- a/src/lib/components/weather/WeatherDisplay.svelte
+++ b/src/lib/components/weather/WeatherDisplay.svelte
@@ -13,7 +13,9 @@
 		StoredWeatherData
 	} from '$lib/services/weatherService';
 	import type { WeatherDataWithMetadata } from '$lib/types';
-	import { formatISOLikeDatetime } from '$lib/utils/format/dateTime';
+	// `time`/`observation_time` ist zonenlose Berlin-Wanduhrzeit (siehe
+	// weatherService.ts) — formatObservationTime reicht sie unkonvertiert durch (M4).
+	import { formatObservationTime } from '$lib/utils/format/dateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
 	import { getWeatherIconClass, getWindDirectionIconClass } from '$lib/utils/weather/weatherIcons';
 
@@ -101,19 +103,6 @@
 			}
 		};
 	});
-
-	// `time`/`observation_time` ist ein zonenloser Berlin-Wanduhrzeit-String
-	// (siehe weatherService.ts). formatLocalDateTime würde ihn fälschlich ein
-	// zweites Mal nach Berlin konvertieren (M4) — formatISOLikeDatetime reicht
-	// zonenlose Strings verbatim durch. Nur umsortiert für die Anzeige, ohne
-	// Umweg über ein Date-Objekt (bliebe sonst an der Laufzeit-Zone hängen).
-	function formatObservationTime(time: string | Date | null | undefined): string {
-		const iso = formatISOLikeDatetime(time);
-		if (!iso) return '';
-		const [datePart, timePart] = iso.split(' ');
-		const [year, month, day] = (datePart ?? '').split('-');
-		return `${day}.${month}.${year}, ${timePart}`;
-	}
 </script>
 
 {#if displayData && Object.keys(displayData).length > 0}

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -39,6 +39,46 @@ import { getWindStrengthOptions } from '$lib/report/formOptions/windStrength';
 import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
 import * as yup from 'yup';
 
+/**
+ * Heutiger Kalendertag in Deutschland als "YYYY-MM-DD".
+ *
+ * Der Sichtungstag ist fachlich immer Berlin-Ortszeit. Über UTC gerechnet
+ * (`toISOString()`) wäre der Tag zwischen 00:00 und 02:00 deutscher Zeit noch
+ * der Vortag — heutige Sichtungen gälten dann als „Zukunft".
+ *
+ * Diese Datei läuft auch im Browser: Die Zone wird deshalb explizit angegeben
+ * und nicht der Geräte-Zeitzone überlassen. `sv-SE` liefert die ISO-Reihenfolge.
+ */
+function berlinToday(): string {
+	return new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
+}
+
+/**
+ * Reduziert eine Datumseingabe auf ihren Kalendertag "YYYY-MM-DD".
+ *
+ * Akzeptiert sowohl das Formularformat als auch einen ISO-Zeitstempel (so
+ * liefert die Legacy-API). Der Vergleich läuft anschließend als String — bei
+ * ISO-Datum ist die lexikalische Ordnung die chronologische, und damit hängt
+ * das Urteil an keiner Zeitzone.
+ *
+ * @returns Der Kalendertag oder `null`, wenn die Eingabe kein gültiges Datum ist
+ */
+function toCalendarDay(value: string | undefined): string | null {
+	const match = typeof value === 'string' ? /^(\d{4}-\d{2}-\d{2})/.exec(value) : null;
+	if (!match) {
+		return null;
+	}
+
+	const calendarDay = match[1] as string;
+	// Fängt Angaben wie "2026-13-45" ab, die zwar zum Muster passen, aber keinen Tag benennen.
+	const parsed = new Date(`${calendarDay}T00:00:00.000Z`);
+	if (isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== calendarDay) {
+		return null;
+	}
+
+	return calendarDay;
+}
+
 // Icon names for the schema - using unplugin-icons format with lucide: prefix
 // These will be mapped to actual icon components in the UI layer
 const icons = {
@@ -297,8 +337,8 @@ export const sightingSchemaBase = yup.object().shape({
 		.string()
 		.required('Das Datum ist erforderlich')
 		.test('is-valid-date', 'Das Datum liegt in der Zukunft - bitte korrigieren Sie es', (value) => {
-			const date = new Date(value);
-			return !isNaN(date.getTime()) && date <= new Date();
+			const calendarDay = toCalendarDay(value);
+			return calendarDay !== null && calendarDay <= berlinToday();
 		})
 		.label('Sichtungsdatum')
 		.meta({
@@ -307,7 +347,7 @@ export const sightingSchemaBase = yup.object().shape({
 			type: 'date',
 			icon: Calendar
 		})
-		.default(new Date().toISOString().split('T')[0]), // Standard auf heute setzen
+		.default(() => berlinToday()), // Standard auf heute setzen
 
 	/**
 	 * Uhrzeit der Sichtung im Format HH:MM

--- a/src/lib/form/validation/sightingSchemaDate.test.ts
+++ b/src/lib/form/validation/sightingSchemaDate.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { sightingSchema } from './sightingSchema';
+
+/**
+ * Der Kalendertag ist fachlich immer Berlin-Ortszeit. Zwischen 22:00 und 24:00 UTC
+ * ist in Berlin bereits der Folgetag — genau dort scheiterte die Zukunftsprüfung.
+ */
+const BERLIN_IST_EINEN_TAG_VORAUS = new Date('2026-07-28T22:30:00.000Z');
+const BERLIN_HEUTE = '2026-07-29';
+
+const validiereDatum = (sightingDate: string): Promise<unknown> =>
+	sightingSchema.validateAt('sightingDate', { sightingDate });
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe('sightingSchema — sightingDate auf Berlin-Kalendertag', () => {
+	it('akzeptiert den heutigen Berliner Kalendertag, auch wenn in UTC noch gestern ist', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(BERLIN_IST_EINEN_TAG_VORAUS);
+
+		await expect(validiereDatum(BERLIN_HEUTE)).resolves.toBeDefined();
+	});
+
+	it('weist einen echten Zukunftstag weiterhin ab', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(BERLIN_IST_EINEN_TAG_VORAUS);
+
+		await expect(validiereDatum('2026-07-30')).rejects.toThrow(/Zukunft/);
+	});
+
+	it('akzeptiert vergangene Tage', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(BERLIN_IST_EINEN_TAG_VORAUS);
+
+		await expect(validiereDatum('2024-01-15')).resolves.toBeDefined();
+	});
+
+	it('weist unlesbare Datumsangaben ab', async () => {
+		await expect(validiereDatum('15.07.2026')).rejects.toThrow();
+		await expect(validiereDatum('2026-13-45')).rejects.toThrow();
+	});
+
+	it('urteilt in jeder Zeitzone gleich', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(BERLIN_IST_EINEN_TAG_VORAUS);
+
+		for (const timeZone of TEST_TIME_ZONES) {
+			const akzeptiert = await withTimeZone(timeZone, () =>
+				validiereDatum(BERLIN_HEUTE).then(
+					() => true,
+					() => false
+				)
+			);
+			expect(akzeptiert, `Zeitzone ${timeZone}`).toBe(true);
+		}
+	});
+
+	it('setzt den Default auf den heutigen Berliner Kalendertag', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(BERLIN_IST_EINEN_TAG_VORAUS);
+
+		const defaults = sightingSchema.getDefault() as { sightingDate?: string };
+
+		expect(defaults.sightingDate).toBe(BERLIN_HEUTE);
+	});
+});

--- a/src/lib/form/validation/sightingSchemaDefaults.test.ts
+++ b/src/lib/form/validation/sightingSchemaDefaults.test.ts
@@ -54,15 +54,17 @@ describe('sightingSchema — entfernte Defaults', () => {
 		expect(defaults.totalCount).toBe(1);
 	});
 
-	it('behält einen Default für sightingDate (heute)', () => {
-		// Der Schema-Default wird beim Modul-Load berechnet, der Vergleichswert erst
-		// zur Testlaufzeit. Läuft der Test über Mitternacht, liegen beide einen Tag
-		// auseinander — deshalb gilt "heute oder gestern" als korrekt.
+	it('behält einen Default für sightingDate (heute in Berlin)', () => {
+		// Maßgeblich ist der Berliner Kalendertag, nicht der UTC-Tag — siehe
+		// sightingSchemaDate.test.ts. Läuft der Test über Mitternacht, liegen
+		// Default und Vergleichswert einen Tag auseinander; deshalb gilt
+		// "heute oder gestern" als korrekt.
+		const alsBerlinerTag = (d: Date) =>
+			d.toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
 		const heute = new Date();
 		const gestern = new Date(heute.getTime() - 24 * 60 * 60 * 1000);
-		const alsDatum = (d: Date) => d.toISOString().split('T')[0];
 
-		expect([alsDatum(heute), alsDatum(gestern)]).toContain(defaults.sightingDate);
+		expect([alsBerlinerTag(heute), alsBerlinerTag(gestern)]).toContain(defaults.sightingDate);
 	});
 });
 

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -454,7 +454,11 @@ export class SichtungenMap {
 		const speciesName = sanitizeText(
 			speciesMap[props.ta.toString()] || `Unbekannte Art (${props.ta})`
 		);
-		const date = props.ts ? new Date(props.ts * 1000).toLocaleDateString('de-DE') : 'Unbekannt';
+		// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum
+		// (bis zu ±1 Tag Abweichung von der Berlin-Anzeige).
+		const date = props.ts
+			? new Date(props.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
+			: 'Unbekannt';
 
 		let content = `
 			<div class="sighting-popup">
@@ -542,7 +546,10 @@ export class SichtungenMap {
 			const speciesName = sanitizeText(
 				this.translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`
 			);
-			const date = props.ts ? new Date(props.ts * 1000).toLocaleDateString('de-DE') : 'Unbekannt';
+			// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum.
+			const date = props.ts
+				? new Date(props.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
+				: 'Unbekannt';
 			const deadBadge = props.tf
 				? '<span style="color: #dc2626; font-weight: 600; margin-left: 4px;">&#x2020;</span>'
 				: '';
@@ -987,17 +994,20 @@ export class SichtungenMap {
 		const timeStartElement = document.getElementById('time-start');
 		const timeEndElement = document.getElementById('time-end');
 
+		// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum.
 		if (timeStartElement) {
 			timeStartElement.innerText = new Date(this.timeFilter.lower).toLocaleDateString('de-DE', {
 				day: '2-digit',
-				month: '2-digit'
+				month: '2-digit',
+				timeZone: 'Europe/Berlin'
 			});
 		}
 
 		if (timeEndElement) {
 			timeEndElement.innerText = new Date(this.timeFilter.upper).toLocaleDateString('de-DE', {
 				day: '2-digit',
-				month: '2-digit'
+				month: '2-digit',
+				timeZone: 'Europe/Berlin'
 			});
 		}
 	}
@@ -1005,8 +1015,9 @@ export class SichtungenMap {
 	private createInfoText(properties: SightingProperties): string {
 		const species = sanitizeText(this.translations.speciesMap[properties.ta] || 'Unbekannte Art');
 		const count = properties.ct || 0;
+		// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum.
 		const date = properties.ts
-			? new Date(properties.ts * 1000).toLocaleDateString('de-DE')
+			? new Date(properties.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
 			: 'Unbekanntes Datum';
 		const isDead = properties.tf ? ` (${sanitizeText(this.translations.found_dead)})` : '';
 		return `

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -23,7 +23,6 @@
 	import type { FormContext, SightingFormData, UserContactData } from '$lib/types';
 	import type { SightingFormValues } from '$lib/types/Form';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
-	import { combineToDate } from '$lib/utils/format/dateTime';
 	import { createId } from '@paralleldrive/cuid2';
 	import { formStepsConfig } from '$lib/report/formConfig';
 	import { ValidationError } from 'yup';
@@ -80,15 +79,12 @@
 		validationSchema: sightingSchema,
 		onSubmit: async (values: SightingFormData) => {
 			try {
-				const sightingDatetime = combineToDate(
-					String(values.sightingDate),
-					String(values.sightingTime)
-				);
 				// Remove admin only attributes and uploaded files (already uploaded)
 				const { verified, internalComment, uploadedFiles, ...submitValuesTemp } = values;
 				let submitValues: SightingFormValues = submitValuesTemp as SightingFormValues;
-				// set full datetime from browser to get the locale timezone of the user!
-				submitValues.sightingDatetime = sightingDatetime;
+				// Datum und Uhrzeit gehen als Strings (deutsche Wanduhrzeit) raus — den
+				// Zeitpunkt bildet ausschließlich der Server, sonst ginge die Zeitzone
+				// des Browsers in den gespeicherten Instant ein.
 				// set mediaUpload indicator
 				submitValues.mediaUpload = uploadedFiles ? uploadedFiles.length > 0 : false;
 

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import type { SightingFormValues } from '$lib/types/Form';
-	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
+	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
 	import { formatLocation } from '$lib/utils/format/formatLocation';
 	import { maskEmail } from '$lib/utils/privacy/emailMask';
 	import Icon from '$lib/components/Icon.svelte';
@@ -135,7 +135,7 @@
 						</div>
 						<div>
 							<span class="font-medium">Datum:</span>
-							{formatLocalDateTime(new Date(submittedData.sightingDatetime))}
+							{formatWallClockDateTime(submittedData.sightingDate, submittedData.sightingTime)}
 						</div>
 						<div>
 							<span class="font-medium">Position:</span>

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -466,7 +466,7 @@
 										<div class="mt-1">
 											<p class="text-base-content/60 flex items-center gap-1 text-xs">
 												<Icon icon="lucide:calendar" width="12" height="12" class="text-primary" />
-												{mediaFile.timestamp.toLocaleString('de-DE')}
+												{mediaFile.timestamp.toLocaleString('de-DE', { timeZone: 'Europe/Berlin' })}
 											</p>
 										</div>
 									{/if}
@@ -540,7 +540,9 @@
 						<div class="mt-3 text-center">
 							<p class="text-base-content/60 flex items-center justify-center gap-1 text-xs">
 								<Icon icon="lucide:calendar" width="12" height="12" class="text-primary" />
-								Aufnahmezeit: {positionMediaFile.timestamp.toLocaleString('de-DE')}
+								Aufnahmezeit: {positionMediaFile.timestamp.toLocaleString('de-DE', {
+									timeZone: 'Europe/Berlin'
+								})}
 							</p>
 						</div>
 					{/if}
@@ -607,7 +609,9 @@
 						<div class="mt-3 text-center">
 							<p class="text-base-content/60 flex items-center justify-center gap-1 text-xs">
 								<Icon icon="lucide:calendar" width="12" height="12" class="text-primary" />
-								Aufnahmezeit: {positionMediaFile.timestamp.toLocaleString('de-DE')}
+								Aufnahmezeit: {positionMediaFile.timestamp.toLocaleString('de-DE', {
+									timeZone: 'Europe/Berlin'
+								})}
 							</p>
 						</div>
 					{/if}

--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -7,6 +7,7 @@
 		OpenMeteoRawData
 	} from '$lib/services/weatherService';
 	import { convertToStoredWeatherData } from '$lib/services/weatherService';
+	import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
 
@@ -31,7 +32,7 @@
 	function handleFullWeatherData(weatherData: WeatherData) {
 		// Bestimme automatisch den data_type basierend auf dem Sichtungsdatum
 		// (NIEDRIG: Berlin-Datum statt UTC — läuft im Browser, kein Server-Import).
-		const today = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
+		const today = berlinCalendarDayIso();
 		const sightingDateStr = sightingDate || '';
 		const dataType = sightingDateStr >= today ? 'forecast' : 'historical';
 

--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -30,7 +30,8 @@
 	// Handle full weather data storage
 	function handleFullWeatherData(weatherData: WeatherData) {
 		// Bestimme automatisch den data_type basierend auf dem Sichtungsdatum
-		const today = new Date().toISOString().split('T')[0] || '';
+		// (NIEDRIG: Berlin-Datum statt UTC — läuft im Browser, kein Server-Import).
+		const today = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
 		const sightingDateStr = sightingDate || '';
 		const dataType = sightingDateStr >= today ? 'forecast' : 'historical';
 

--- a/src/lib/server/datetime/berlinDayRange.test.ts
+++ b/src/lib/server/datetime/berlinDayRange.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { berlinDayRangeUtc, berlinMidnightUtc } from './berlinDayRange';
+import { TEST_TIME_ZONES, withTimeZone } from './withTimeZone.testutil';
+
+describe('berlinMidnightUtc', () => {
+	it('liefert für einen Sommertag 22:00 UTC des Vortags', () => {
+		expect(berlinMidnightUtc('2026-07-15').toISOString()).toBe('2026-07-14T22:00:00.000Z');
+	});
+
+	it('liefert für einen Wintertag 23:00 UTC des Vortags', () => {
+		expect(berlinMidnightUtc('2026-01-15').toISOString()).toBe('2026-01-14T23:00:00.000Z');
+	});
+
+	it('liefert für Neujahr denselben Instant wie die Legacy-Jahresgrenze', () => {
+		expect(berlinMidnightUtc('2027-01-01').toISOString()).toBe('2026-12-31T23:00:00.000Z');
+	});
+
+	it('behandelt den Tag der Sommerzeit-Umstellung korrekt (Mitternacht noch MEZ)', () => {
+		// 29.03.2026 ist der letzte März-Sonntag: Mitternacht liegt vor der
+		// Umstellung um 02:00, der Offset ist also noch +1.
+		expect(berlinMidnightUtc('2026-03-29').toISOString()).toBe('2026-03-28T23:00:00.000Z');
+	});
+
+	it('behandelt den Tag der Winterzeit-Umstellung korrekt (Mitternacht noch MESZ)', () => {
+		// 25.10.2026 ist der letzte Oktober-Sonntag: Mitternacht liegt vor der
+		// Umstellung um 03:00, der Offset ist also noch +2. Dieser Fall braucht
+		// die zweite Fixpunkt-Iteration — eine einzelne Offset-Ablesung am
+		// UTC-Mitternachts-Schätzwert liefert bereits den Winter-Offset.
+		expect(berlinMidnightUtc('2026-10-25').toISOString()).toBe('2026-10-24T22:00:00.000Z');
+	});
+
+	it('ist unabhängig von der Prozess-Zeitzone', () => {
+		for (const zone of TEST_TIME_ZONES) {
+			withTimeZone(zone, () => {
+				expect(berlinMidnightUtc('2026-07-15').toISOString()).toBe('2026-07-14T22:00:00.000Z');
+				expect(berlinMidnightUtc('2026-10-25').toISOString()).toBe('2026-10-24T22:00:00.000Z');
+			});
+		}
+	});
+
+	it('weist Eingaben außerhalb von YYYY-MM-DD zurück', () => {
+		expect(() => berlinMidnightUtc('15.07.2026')).toThrow();
+		expect(() => berlinMidnightUtc('2026-7-5')).toThrow();
+		expect(() => berlinMidnightUtc('2026-07-15T12:00')).toThrow();
+	});
+});
+
+describe('berlinDayRangeUtc', () => {
+	it('liefert ein halboffenes Intervall über Berlin-Kalendertage', () => {
+		const { start, endExclusive } = berlinDayRangeUtc('2026-07-01', '2026-07-31');
+		expect(start.toISOString()).toBe('2026-06-30T22:00:00.000Z');
+		// Obergrenze exklusiv: Mitternacht des Folgetags — der 31.07. gehört
+		// damit vollständig zum Intervall.
+		expect(endExclusive.toISOString()).toBe('2026-07-31T22:00:00.000Z');
+	});
+
+	it('deckt einen einzelnen Tag vollständig ab', () => {
+		const { start, endExclusive } = berlinDayRangeUtc('2026-12-31', '2026-12-31');
+		expect(start.toISOString()).toBe('2026-12-30T23:00:00.000Z');
+		expect(endExclusive.toISOString()).toBe('2026-12-31T23:00:00.000Z');
+	});
+
+	it('überspannt den Jahreswechsel inklusive Silvester-Randstunde', () => {
+		const { start, endExclusive } = berlinDayRangeUtc('2026-01-01', '2026-12-31');
+		// Eine Sichtung am 01.01. um 00:30 Berlin (= 31.12. 23:30 UTC des
+		// Vorjahrs) muss im Intervall liegen.
+		const neujahrsnacht = new Date('2025-12-31T23:30:00.000Z');
+		expect(neujahrsnacht.getTime()).toBeGreaterThanOrEqual(start.getTime());
+		expect(neujahrsnacht.getTime()).toBeLessThan(endExclusive.getTime());
+		// Eine Sichtung am 31.12. um 23:30 Berlin (= 22:30 UTC) ebenfalls.
+		const silvesterabend = new Date('2026-12-31T22:30:00.000Z');
+		expect(silvesterabend.getTime()).toBeLessThan(endExclusive.getTime());
+	});
+});

--- a/src/lib/server/datetime/berlinDayRange.ts
+++ b/src/lib/server/datetime/berlinDayRange.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Berlin-Kalendertagsgrenzen als UTC-Instants.
+ *
+ * Die Zeitstempelspalten halten echte UTC-Zeitpunkte, Datumsfilter meinen aber
+ * deutsche Kalendertage: „Sichtungen vom 01.06. bis 30.06." heißt „ab 01.06.
+ * 00:00 deutscher Zeit bis vor 01.07. 00:00 deutscher Zeit". Naive
+ * `new Date('YYYY-MM-DD')`-Grenzen (UTC-Mitternacht) verlieren dagegen die
+ * Randstunden — und mit einer inklusiven 00:00-Obergrenze den ganzen letzten Tag.
+ *
+ * Gleiche Grenzsemantik wie `getYearRange` in `src/lib/legacy-api/date-utils.ts`:
+ * halboffenes Intervall `[start, endExclusive)`, prozesszonen-unabhängig.
+ */
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const BERLIN_TIME_ZONE = 'Europe/Berlin';
+
+/**
+ * UTC-Zeitpunkt von 00:00 deutscher Ortszeit des angegebenen Kalendertags.
+ *
+ * Fixpunkt-Iteration über den Offset: Der erste Schätzwert liest den Offset am
+ * UTC-Mitternachts-Instant ab. Am Tag der Winterzeit-Umstellung liegt dieser
+ * Instant bereits hinter der Umstellung (02:00 MEZ) und liefert den falschen
+ * Offset — die zweite Ablesung am korrigierten Kandidaten konvergiert.
+ * Berlin-Mitternacht selbst liegt nie in einer Umstellungslücke (die Umstellung
+ * passiert um 02:00/03:00), zwei Iterationen genügen daher immer.
+ *
+ * @param isoDate - Kalendertag im Format `YYYY-MM-DD` (deutsche Ortszeit)
+ * @returns UTC-Instant der Berliner Mitternacht dieses Tages
+ * @throws {TypeError} wenn `isoDate` nicht dem Format `YYYY-MM-DD` entspricht
+ */
+export function berlinMidnightUtc(isoDate: string): Date {
+	const match = ISO_DATE_PATTERN.exec(isoDate);
+	if (!match) {
+		throw new TypeError(`Erwartet YYYY-MM-DD, erhalten: "${isoDate}"`);
+	}
+
+	const [, year, month, day] = match;
+	const alsUtcGelesen = Date.UTC(Number(year), Number(month) - 1, Number(day));
+
+	let kandidat = alsUtcGelesen - berlinOffsetMs(new Date(alsUtcGelesen));
+	kandidat = alsUtcGelesen - berlinOffsetMs(new Date(kandidat));
+
+	return new Date(kandidat);
+}
+
+/**
+ * Halboffenes UTC-Intervall über Berliner Kalendertage: `[start, endExclusive)`.
+ *
+ * `endExclusive` ist die Berliner Mitternacht des Folgetags von `toIsoDate` —
+ * der letzte Tag gehört damit vollständig zum Intervall. Abfragen müssen
+ * `>= start AND < endExclusive` verwenden (kein `BETWEEN`).
+ *
+ * @param fromIsoDate - erster Kalendertag (`YYYY-MM-DD`, inklusiv)
+ * @param toIsoDate - letzter Kalendertag (`YYYY-MM-DD`, inklusiv)
+ */
+export function berlinDayRangeUtc(
+	fromIsoDate: string,
+	toIsoDate: string
+): { start: Date; endExclusive: Date } {
+	return {
+		start: berlinMidnightUtc(fromIsoDate),
+		endExclusive: berlinMidnightUtc(naechsterKalendertag(toIsoDate))
+	};
+}
+
+/** Folgetag eines `YYYY-MM-DD`-Strings, über UTC-Arithmetik zonenneutral. */
+function naechsterKalendertag(isoDate: string): string {
+	const match = ISO_DATE_PATTERN.exec(isoDate);
+	if (!match) {
+		throw new TypeError(`Erwartet YYYY-MM-DD, erhalten: "${isoDate}"`);
+	}
+	const [, year, month, day] = match;
+	const folgetag = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day) + 1));
+
+	return folgetag.toISOString().slice(0, 10);
+}
+
+/** Offset von `Europe/Berlin` gegenüber UTC zum gegebenen Zeitpunkt, in Millisekunden. */
+function berlinOffsetMs(instant: Date): number {
+	// sv-SE liefert "YYYY-MM-DD HH:MM:SS" — als UTC gelesen ergibt die Differenz den Offset.
+	const abgelesen = new Date(
+		`${instant.toLocaleString('sv-SE', { timeZone: BERLIN_TIME_ZONE }).replace(' ', 'T')}Z`
+	);
+
+	return abgelesen.getTime() - instant.getTime();
+}

--- a/src/lib/server/datetime/berlinWallClockToUtc.ts
+++ b/src/lib/server/datetime/berlinWallClockToUtc.ts
@@ -1,0 +1,45 @@
+import { berlinWallClockToInstant } from '$lib/utils/format/berlinWallClock';
+
+/** Uhrzeit-Eingabe im Format "HH:MM" (Formular und Legacy-API). */
+const TIME_PATTERN = /^(\d{2}):(\d{2})$/;
+
+/**
+ * Kombiniert Datum und Uhrzeit einer Formulareingabe zum echten UTC-Zeitpunkt.
+ *
+ * Datum und Uhrzeit sind **deutsche Wanduhrzeit** — so hat der Melder sie
+ * eingegeben. Die Funktion baut daraus den tatsächlichen Instant, indem sie den
+ * für diesen Kalendertag geltenden MEZ/MESZ-Offset abzieht.
+ *
+ * Anders als `combineToDate` + `correctCestOffsetUTC` rechnet sie ausschließlich
+ * mit UTC-Feldern und hängt damit **nicht** an der Zeitzone des Prozesses. Der
+ * Server ist zwar auf `TZ=UTC` gepinnt, das Ergebnis darf davon aber nicht
+ * abhängen.
+ *
+ * @param localDate - Datum als "YYYY-MM-DD" (auch ein ISO-Zeitstempel wird akzeptiert,
+ *                    davon zählt dann der UTC-Kalendertag — so liefert die Legacy-API)
+ * @param localTime - Uhrzeit als "HH:MM"; fehlt oder passt sie nicht, bleibt die
+ *                    Tageszeit aus `localDate` erhalten (i. d. R. Mitternacht)
+ * @returns Echter UTC-Zeitpunkt; bei ungültigem Datum der aktuelle Zeitpunkt
+ */
+export function berlinWallClockToUtc(localDate: string, localTime?: string | null): Date {
+	if (!localDate) {
+		return new Date();
+	}
+
+	const parsed = new Date(localDate);
+	if (isNaN(parsed.getTime())) {
+		return new Date();
+	}
+
+	const timeMatch = localTime ? TIME_PATTERN.exec(localTime) : null;
+
+	return berlinWallClockToInstant({
+		year: parsed.getUTCFullYear(),
+		month: parsed.getUTCMonth() + 1,
+		day: parsed.getUTCDate(),
+		hours: timeMatch ? Number(timeMatch[1]) : parsed.getUTCHours(),
+		minutes: timeMatch ? Number(timeMatch[2]) : parsed.getUTCMinutes(),
+		seconds: timeMatch ? 0 : parsed.getUTCSeconds(),
+		milliseconds: timeMatch ? 0 : parsed.getUTCMilliseconds()
+	});
+}

--- a/src/lib/server/datetime/correctCestOffsetUTC.ts
+++ b/src/lib/server/datetime/correctCestOffsetUTC.ts
@@ -1,3 +1,5 @@
+import { berlinOffsetHoursForWallClock } from '$lib/utils/format/berlinWallClock';
+
 /**
  * Rechnet eine deutsche Wanduhrzeit in den echten UTC-Zeitpunkt um.
  *
@@ -29,28 +31,7 @@ export function correctCestOffsetUTC(date: Date): Date {
 	if (date.getTimezoneOffset() !== 0) {
 		return date;
 	}
-	const year = date.getUTCFullYear();
 
-	// Letzter Sonntag im März (Sommerzeit beginnt)
-	const march = new Date(Date.UTC(year, 2, 31)); // 31. März
-	const marchDay = march.getUTCDay();
-	const lastMarchSunday = 31 - marchDay;
-	const cestStart = Date.UTC(year, 2, lastMarchSunday, 2); // Wanduhr 2:00, danach gilt MESZ
-
-	// Letzter Sonntag im Oktober (Sommerzeit endet)
-	const october = new Date(Date.UTC(year, 9, 31)); // 31. Oktober
-	const octoberDay = october.getUTCDay();
-	const lastOctoberSunday = 31 - octoberDay;
-	const cestEnd = Date.UTC(year, 9, lastOctoberSunday, 3); // Wanduhr 3:00, danach gilt MEZ
-
-	const time = date.getTime();
-
-	// CEST gilt von cestStart (einschließlich) bis cestEnd (ausschließlich)
-	if (time >= cestStart && time < cestEnd) {
-		date.setHours(date.getHours() - 2); // UTC+2 (CEST)
-		return date;
-	} else {
-		date.setHours(date.getHours() - 1); // UTC+1 (CET)
-		return date;
-	}
+	date.setHours(date.getHours() - berlinOffsetHoursForWallClock(date));
+	return date;
 }

--- a/src/lib/server/db/mapFormToSighting.test.ts
+++ b/src/lib/server/db/mapFormToSighting.test.ts
@@ -1,5 +1,7 @@
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import type { SightingFormData } from '$lib/report/types';
+import type { SightingFormValues } from '$lib/types/Form';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mapFormToSighting } from './mapFormToSighting';
 
@@ -384,6 +386,47 @@ describe('mapFormToSighting', () => {
 			expect(parsedDate.getUTCDate()).toBe(14); // Überlauf auf Vortag durch CET-Korrektur
 			expect(parsedDate.getUTCHours()).toBe(23); // midnight - 1h = 23:00 UTC
 			expect(parsedDate.getUTCMinutes()).toBe(0);
+		});
+	});
+
+	describe('Zeitzonen-Robustheit (K1)', () => {
+		it('ignoriert ein mitgeschicktes sightingDatetime und kombiniert Sommerzeit selbst', () => {
+			const formData = createMinimalFormData();
+			formData.sightingDate = '2026-07-15';
+			formData.sightingTime = '14:30';
+			// Ein Client könnte (mit seiner eigenen Zeitzone) einen abweichenden
+			// Instant mitschicken — der Server darf ihn nicht übernehmen.
+			(formData as Record<string, unknown>).sightingDatetime = new Date('2026-07-15T20:30:00.000Z');
+
+			const result = mapFormToSighting(formData as SightingFormValues);
+
+			// Berlin ist im Juli MESZ (UTC+2): 14:30 Wanduhr → 12:30 UTC
+			expect(new Date(result.sightingDate).toISOString()).toBe('2026-07-15T12:30:00.000Z');
+		});
+
+		it('ignoriert ein mitgeschicktes sightingDatetime und kombiniert Winterzeit selbst', () => {
+			const formData = createMinimalFormData();
+			formData.sightingDate = '2026-01-15';
+			formData.sightingTime = '14:30';
+			(formData as Record<string, unknown>).sightingDatetime = new Date('2026-01-15T20:30:00.000Z');
+
+			const result = mapFormToSighting(formData as SightingFormValues);
+
+			// Berlin ist im Januar MEZ (UTC+1): 14:30 Wanduhr → 13:30 UTC
+			expect(new Date(result.sightingDate).toISOString()).toBe('2026-01-15T13:30:00.000Z');
+		});
+
+		it('liefert in jeder Prozess-Zeitzone denselben Instant', () => {
+			const results = TEST_TIME_ZONES.map((timeZone) =>
+				withTimeZone(timeZone, () => {
+					const formData = createMinimalFormData();
+					formData.sightingDate = '2026-07-15';
+					formData.sightingTime = '14:30';
+					return new Date(mapFormToSighting(formData).sightingDate).toISOString();
+				})
+			);
+
+			expect(results).toEqual(TEST_TIME_ZONES.map(() => '2026-07-15T12:30:00.000Z'));
 		});
 	});
 

--- a/src/lib/server/db/mapFormToSighting.ts
+++ b/src/lib/server/db/mapFormToSighting.ts
@@ -1,9 +1,8 @@
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import type { SightingFormValues } from '$lib/types/Form';
 import type { NewSighting } from '$lib/types/sighting';
-import { combineToDate } from '$lib/utils/format/dateTime';
 import { sql } from 'drizzle-orm';
-import { correctCestOffsetUTC } from '$lib/server/datetime/correctCestOffsetUTC';
+import { berlinWallClockToUtc } from '$lib/server/datetime/berlinWallClockToUtc';
 import { checkBalticSeaFile } from '$lib/server/geo/checkBalticSeaFile';
 
 /**
@@ -67,18 +66,13 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 
 	/**
 	 * SCHRITT 2: Datum/Zeit-Verarbeitung
-	 * Kombiniert Datum und Zeit zu einem vollständigen DateTime-Objekt
+	 *
+	 * Datum und Uhrzeit sind deutsche Wanduhrzeit und werden ausschließlich hier
+	 * kombiniert. Ein vom Client mitgeschickter Zeitstempel wird bewusst nicht
+	 * ausgewertet — er trüge die Zeitzone des Browsers und verschöbe den
+	 * gespeicherten Zeitpunkt.
 	 */
-
-	let fullDateTime;
-	if (formData.sightingDatetime) {
-		fullDateTime = new Date(formData.sightingDatetime);
-	} else {
-		// Zeit verarbeiten und mit Datum kombinieren wenn vorhanden
-		fullDateTime = combineToDate(formData.sightingDate, formData.sightingTime);
-		// UTC-Korrektur anwenden (SERVER ONLY)
-		fullDateTime = correctCestOffsetUTC(fullDateTime);
-	}
+	const fullDateTime = berlinWallClockToUtc(formData.sightingDate, formData.sightingTime);
 
 	/**
 	 * SCHRITT 3: Datenbankschema-Objekt erstellen

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -100,6 +100,9 @@ export const sightings = pgTable(
 			table.location.asc().nullsLast().op('gist_geometry_ops_2d')
 		),
 		index('idx_sichtungsdatum').on(table.sightingDate),
+		// Berliner Kalendertag — muss zum Ausdruck des Admin-Datumsfilters passen
+		// (admin/+page.server.ts), sonst greift der Index nicht.
+		index('idx_sichtungsdatum_berlin_tag').using('btree', berlinCalendarDate(table.sightingDate)),
 		// Jahr in deutscher Ortszeit — muss zum Ausdruck der Statistik-Gruppierung
 		// passen (admin/statistics/+page.server.ts), sonst greift der Index nicht.
 		index('idx_year_sichtungen').using('btree', berlinDatePart('year', table.sightingDate)),

--- a/src/lib/server/db/sqlTimeZone.test.ts
+++ b/src/lib/server/db/sqlTimeZone.test.ts
@@ -94,6 +94,12 @@ describe('berlinToChar', () => {
 
 		expect(query.params).toEqual([]);
 	});
+
+	it('escapet Anführungszeichen im Muster (kein SQL-Bruch möglich)', () => {
+		// Vorgesehen sind nur Modulkonstanten — aber ein versehentlich
+		// durchgereichtes Muster mit ' darf das SQL-Literal nicht aufbrechen.
+		expect(toSql(berlinToChar(sightings.sightingDate, "HH24'MI"))).toContain(`'HH24''MI'`);
+	});
 });
 
 describe('Index-/Abfrage-Übereinstimmung', () => {

--- a/src/lib/server/db/sqlTimeZone.test.ts
+++ b/src/lib/server/db/sqlTimeZone.test.ts
@@ -11,7 +11,7 @@
 import { PgDialect, getTableConfig } from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 import { sightings } from './schema';
-import { DISPLAY_TIME_ZONE, berlinCalendarDate, berlinDatePart } from './sqlTimeZone';
+import { DISPLAY_TIME_ZONE, berlinCalendarDate, berlinDatePart, berlinToChar } from './sqlTimeZone';
 
 const dialect = new PgDialect();
 
@@ -76,6 +76,26 @@ describe('berlinDatePart', () => {
 	});
 });
 
+describe('berlinToChar', () => {
+	it('formatiert die UTC-Spalte über to_char in Europe/Berlin', () => {
+		expect(toSql(berlinToChar(sightings.sightingDate, 'DD.MM.YYYY'))).toBe(
+			`to_char("sichtungen"."sichtungsdatum" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin', 'DD.MM.YYYY')`
+		);
+	});
+
+	it('unterstützt beliebige to_char-Muster (z. B. Uhrzeit)', () => {
+		expect(toSql(berlinToChar(sightings.sightingDate, 'HH24:MI'))).toBe(
+			`to_char("sichtungen"."sichtungsdatum" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin', 'HH24:MI')`
+		);
+	});
+
+	it('bettet Zone und Muster als Literale ein, nicht als Parameter', () => {
+		const query = dialect.sqlToQuery(berlinToChar(sightings.sightingDate, 'DD.MM.YYYY'));
+
+		expect(query.params).toEqual([]);
+	});
+});
+
 describe('Index-/Abfrage-Übereinstimmung', () => {
 	it('nutzt im Dedup-Index denselben Datumsausdruck wie die Dedup-Abfrage', () => {
 		const dedupIndex = getTableConfig(sightings).indexes.find(
@@ -89,6 +109,18 @@ describe('Index-/Abfrage-Übereinstimmung', () => {
 
 		// Postgres nutzt einen Ausdrucksindex nur bei exakter Übereinstimmung.
 		expect(toSql(datumsSpalte as never)).toBe(toSql(berlinCalendarDate(sightings.sightingDate)));
+	});
+
+	it('nutzt im Kalendertag-Index denselben Ausdruck wie der Admin-Datumsfilter', () => {
+		const tagIndex = getTableConfig(sightings).indexes.find(
+			(index) => index.config.name === 'idx_sichtungsdatum_berlin_tag'
+		);
+
+		expect(tagIndex, 'idx_sichtungsdatum_berlin_tag fehlt im Schema').toBeDefined();
+		expect(toSql(tagIndex?.config.columns.at(-1) as never)).toContain('Europe/Berlin');
+		expect(toSql(tagIndex?.config.columns.at(-1) as never)).toBe(
+			toSql(berlinCalendarDate(sightings.sightingDate))
+		);
 	});
 
 	it('nutzt im Jahres-Index denselben Ausdruck wie die Statistik-Gruppierung', () => {

--- a/src/lib/server/db/sqlTimeZone.ts
+++ b/src/lib/server/db/sqlTimeZone.ts
@@ -76,3 +76,17 @@ export function berlinCalendarDate(column: SQLWrapper): SQL {
 export function berlinDatePart(part: 'year' | 'month' | 'day', column: SQLWrapper): SQL {
 	return sql`EXTRACT(${sql.raw(part)} FROM ${asLocalTime(column)})`;
 }
+
+/**
+ * Formatiert eine UTC-Zeitstempelspalte über `to_char` als String in deutscher
+ * Ortszeit (z. B. für Legacy-kompatible Feldnamen wie `dt`/`ti`, die dieselbe
+ * Zeitzone wie die übrigen Legacy-Endpunkte tragen müssen).
+ *
+ * @param column - Zeitstempelspalte, die UTC-Zeitpunkte hält
+ * @param pattern - `to_char`-Formatmuster, z. B. `'DD.MM.YYYY'` oder `'HH24:MI'`.
+ *   **Nur Modulkonstanten/Literale übergeben, niemals Nutzereingabe** — das
+ *   Muster landet unparametrisiert (`sql.raw`) im SQL-Text.
+ */
+export function berlinToChar(column: SQLWrapper, pattern: string): SQL {
+	return sql`to_char(${asLocalTime(column)}, ${sql.raw(`'${pattern}'`)})`;
+}

--- a/src/lib/server/db/sqlTimeZone.ts
+++ b/src/lib/server/db/sqlTimeZone.ts
@@ -85,8 +85,12 @@ export function berlinDatePart(part: 'year' | 'month' | 'day', column: SQLWrappe
  * @param column - Zeitstempelspalte, die UTC-Zeitpunkte hält
  * @param pattern - `to_char`-Formatmuster, z. B. `'DD.MM.YYYY'` oder `'HH24:MI'`.
  *   **Nur Modulkonstanten/Literale übergeben, niemals Nutzereingabe** — das
- *   Muster landet unparametrisiert (`sql.raw`) im SQL-Text.
+ *   Muster landet unparametrisiert (`sql.raw`) im SQL-Text. Anführungszeichen
+ *   werden defensiv SQL-standardkonform verdoppelt, damit ein versehentlich
+ *   durchgereichtes Muster das Literal nicht aufbrechen kann.
  */
 export function berlinToChar(column: SQLWrapper, pattern: string): SQL {
-	return sql`to_char(${asLocalTime(column)}, ${sql.raw(`'${pattern}'`)})`;
+	const escaped = pattern.replaceAll("'", "''");
+
+	return sql`to_char(${asLocalTime(column)}, ${sql.raw(`'${escaped}'`)})`;
 }

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -401,6 +401,35 @@ describe('EmailService', () => {
 			expect(result).toBe(false);
 		});
 
+		it('formatiert sightingDate über formatLocalDateTime (Berlin) statt UTC-ISO-Split (M2)', async () => {
+			// Sichtung 22:30 UTC am 14.07. = 00:30 Berliner Sommerzeit am 15.07.
+			// `toISOString().split('T')[0]` läse fälschlich den 14.07. (UTC-Vortag).
+			const mockSighting = createMockSighting({
+				sightingDate: new Date('2024-07-14T22:30:00Z')
+			});
+			vi.mocked(db.select).mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([mockSighting])
+					})
+				})
+			} as any);
+
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com' });
+			await EmailService.initialize(false);
+
+			await EmailService.sendNewSightingNotification(42);
+
+			// formatLocalDateTime muss mit dem rohen Sichtungsdatum und Format 'date'
+			// aufgerufen werden — nicht per toISOString().split('T')[0] umgangen.
+			expect(formatLocalDateTime).toHaveBeenCalledWith(mockSighting.sightingDate, 'date');
+
+			// formatSightingForDisplay (komplett gemockt) darf nur das Berlin-
+			// formatierte Datum erhalten, nie den rohen UTC-Tag (wäre der Vortag).
+			const callArg = vi.mocked(formatSightingForDisplay).mock.calls[0]?.[0];
+			expect(callArg?.sightingDate).not.toBe('2024-07-14');
+		});
+
 		it('gibt false zurück wenn DB-Abfrage fehlschlägt', async () => {
 			vi.mocked(db.select).mockReturnValue({
 				from: vi.fn().mockReturnValue({

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -173,7 +173,9 @@ export class EmailService {
 				// Required core fields
 				latitude: sighting.latitude != null ? parseFloat(sighting.latitude) : null,
 				longitude: sighting.longitude != null ? parseFloat(sighting.longitude) : null,
-				sightingDate: (sighting.sightingDate || new Date()).toISOString().split('T')[0] as string,
+				// Berlin-Datum statt UTC-ISO-Split (M2): toISOString().split('T')[0]
+				// läse eine Sichtung um 00:30 Berliner Zeit als UTC-Vortag.
+				sightingDate: formatLocalDateTime(sighting.sightingDate || new Date(), 'date'),
 				sightingDatetime: sighting.sightingDate || undefined,
 				species: sighting.species || 0,
 				totalCount: sighting.totalCount || 1,

--- a/src/lib/server/services/weatherRefreshService.test.ts
+++ b/src/lib/server/services/weatherRefreshService.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { StoredWeatherData } from '$lib/services/weatherService';
+import { withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
 
 vi.mock('$lib/logger.server', () => ({
 	createLogger: () => ({
@@ -106,6 +107,10 @@ describe('fetchWeatherData', () => {
 	beforeEach(() => {
 		vi.stubGlobal('fetch', vi.fn());
 		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	it('wirft Fehler wenn fetch einen Netzwerkfehler wirft', async () => {
@@ -267,23 +272,38 @@ describe('fetchWeatherData', () => {
 		await expect(fetchWeatherData(54.5, 10.5, HISTORICAL_DATE)).rejects.toThrow();
 	});
 
-	it('wählt den zeitlich nächstgelegenen Datenpunkt bei Angabe einer Uhrzeit', async () => {
+	it('wählt den Index über die Ortszeit-Stunde (positionsbasiert), nicht über die kleinste Zeitdifferenz', async () => {
+		// N6: `hourly.time[]` ist durch `timezone=Europe/Berlin` bereits ortszeit-
+		// indiziert (Index i = Stunde i). Der Index muss deshalb über
+		// `hourIndexFromLocalTime` kommen statt über eine Date-Differenz-Suche.
+		// Um beide Implementierungen zu unterscheiden, trägt Index 14 hier absichtlich
+		// einen "falschen" Zeitstempel, während Index 2 zufällig den Zieltext "14:00"
+		// trägt — eine Differenz-Suche (alter Code) würde Index 2 wählen, die
+		// Ortszeit-Stunde muss trotzdem Index 14 liefern.
 		const { convertToStoredWeatherData } = await import('$lib/services/weatherService');
+
+		const time = Array.from(
+			{ length: 24 },
+			(_, i) => `${HISTORICAL_DATE}T${String(i).padStart(2, '0')}:00`
+		);
+		time[14] = `${HISTORICAL_DATE}T02:00`; // falsch beschriftet
+		time[2] = `${HISTORICAL_DATE}T14:00`; // trägt zufällig den Zieltext
+
+		const temperature_2m = Array.from({ length: 24 }, (_, i) => i);
+		temperature_2m[14] = 99;
+		temperature_2m[2] = 11;
+
 		vi.mocked(fetch)
 			.mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({
 					hourly: {
-						time: [
-							`${HISTORICAL_DATE}T10:00`,
-							`${HISTORICAL_DATE}T11:00`,
-							`${HISTORICAL_DATE}T14:00`
-						],
-						temperature_2m: [10, 12, 18],
-						wind_speed_10m: [5, 8, 15],
-						wind_direction_10m: [180, 180, 180],
-						weather_code: [0, 0, 0],
-						visibility: [10000, 10000, 10000]
+						time,
+						temperature_2m,
+						wind_speed_10m: new Array(24).fill(10),
+						wind_direction_10m: new Array(24).fill(180),
+						weather_code: new Array(24).fill(0),
+						visibility: new Array(24).fill(10000)
 					}
 				})
 			} as Response)
@@ -294,15 +314,67 @@ describe('fetchWeatherData', () => {
 
 		await fetchWeatherData(54.5, 10.5, HISTORICAL_DATE, '14:00');
 
-		// convertToStoredWeatherData wird mit dem WeatherData-Objekt aufgerufen,
-		// dessen time dem nächstgelegenen Slot entspricht (14:00)
 		expect(vi.mocked(convertToStoredWeatherData)).toHaveBeenCalledWith(
-			expect.objectContaining({ time: `${HISTORICAL_DATE}T14:00` }),
+			expect.objectContaining({ time: time[14], temperature: 99 }),
 			expect.anything(),
 			expect.anything(),
 			54.5,
 			10.5
 		);
+	});
+
+	it('wählt denselben Index unabhängig von der Prozess-Zeitzone', async () => {
+		// Positionsbasierte Auswahl über hourIndexFromLocalTime ist per Konstruktion
+		// prozesszonen-fest (String-Parsing statt Date-Arithmetik). Abgesichert unter
+		// einer von Berlin/UTC abweichenden Zone, damit eine Rückkehr zu Date-Diffs
+		// hier auffällt.
+		const { convertToStoredWeatherData } = await import('$lib/services/weatherService');
+
+		await withTimeZone('America/New_York', async () => {
+			vi.mocked(fetch)
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => makeWeatherResponse(HISTORICAL_DATE)
+				} as Response)
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => makeMarineResponse()
+				} as Response);
+
+			await fetchWeatherData(54.5, 10.5, HISTORICAL_DATE, '12:00');
+
+			expect(vi.mocked(convertToStoredWeatherData)).toHaveBeenCalledWith(
+				expect.objectContaining({ time: `${HISTORICAL_DATE}T12:00` }),
+				expect.anything(),
+				expect.anything(),
+				54.5,
+				10.5
+			);
+		});
+	});
+
+	it('bestimmt "heute" über die Berliner Ortszeit, nicht über UTC (N5)', async () => {
+		// 23:30 UTC entspricht im Sommer (Berlin = UTC+2) bereits 01:30 Uhr des
+		// Folgetages in Berlin — UTC- und Berlin-Kalendertag weichen 30 Minuten lang
+		// voneinander ab. Das angefragte Datum ist zu diesem Zeitpunkt in Berlin
+		// bereits "gestern" und muss die Archive-API treffen, nicht die Forecast-API.
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-07-14T23:30:00Z'));
+
+		vi.mocked(fetch)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => makeWeatherResponse('2024-07-14')
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				json: async () => makeMarineResponse()
+			} as Response);
+
+		await fetchWeatherData(54.5, 10.5, '2024-07-14');
+
+		const firstCallUrl = vi.mocked(fetch).mock.calls[0]?.[0] as string;
+		expect(firstCallUrl).toContain('archive-api.open-meteo.com');
 	});
 
 	it('übergibt latitude und longitude korrekt an convertToStoredWeatherData', async () => {

--- a/src/lib/server/services/weatherRefreshService.ts
+++ b/src/lib/server/services/weatherRefreshService.ts
@@ -10,6 +10,7 @@ import {
 	calculateSeaState
 } from '$lib/constants/weather';
 import { hourIndexFromLocalTime } from '$lib/server/weather/hourIndex';
+import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 
 const logger = createLogger('service:weather-refresh');
 
@@ -59,7 +60,7 @@ export async function fetchWeatherData(
 	// Prüfe ob das Datum heute oder in der Zukunft ist (N5: deutsche Ortszeit,
 	// nicht UTC — sonst wird in den ersten 1-2 Stunden nach Mitternacht Berlin
 	// noch der UTC-Vortag als "heute" gewertet).
-	const today = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
+	const today = berlinCalendarDayIso();
 	const isToday = date >= today;
 
 	// Build Open-Meteo API URL - verwende Forecast API für heutige/zukünftige Daten

--- a/src/lib/server/services/weatherRefreshService.ts
+++ b/src/lib/server/services/weatherRefreshService.ts
@@ -9,6 +9,7 @@ import {
 	getWeatherDescription,
 	calculateSeaState
 } from '$lib/constants/weather';
+import { hourIndexFromLocalTime } from '$lib/server/weather/hourIndex';
 
 const logger = createLogger('service:weather-refresh');
 
@@ -55,8 +56,10 @@ export async function fetchWeatherData(
 	const startDate = date;
 	const endDate = date;
 
-	// Prüfe ob das Datum heute oder in der Zukunft ist
-	const today = new Date().toISOString().split('T')[0] || '';
+	// Prüfe ob das Datum heute oder in der Zukunft ist (N5: deutsche Ortszeit,
+	// nicht UTC — sonst wird in den ersten 1-2 Stunden nach Mitternacht Berlin
+	// noch der UTC-Vortag als "heute" gewertet).
+	const today = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
 	const isToday = date >= today;
 
 	// Build Open-Meteo API URL - verwende Forecast API für heutige/zukünftige Daten
@@ -197,19 +200,13 @@ export async function fetchWeatherData(
 			'Available weather data slots from Open-Meteo'
 		);
 
-		// Find the closest time match
-		let bestIndex = 0;
-		if (time) {
-			const targetTime = `${date}T${time}:00`;
-			let minDiff = Infinity;
-
-			data.hourly.time.forEach((t, i) => {
-				const diff = Math.abs(new Date(t).getTime() - new Date(targetTime).getTime());
-				if (diff < minDiff) {
-					minDiff = diff;
-					bestIndex = i;
-				}
-			});
+		// N6: Index über die deutsche Ortszeit-Stunde ermitteln, nicht über eine
+		// Date-Differenz-Suche. `hourly.time[]` ist durch `timezone=Europe/Berlin`
+		// bereits ortszeit-indiziert (Index i = Stunde i) — `new Date(t)`-Vergleiche
+		// hingen dagegen an der Prozess-Zeitzone.
+		let bestIndex = hourIndexFromLocalTime(time);
+		if (bestIndex >= data.hourly.time.length) {
+			bestIndex = 0;
 		}
 
 		// Extract weather data for the best matching time

--- a/src/lib/server/validation/requestValidation.test.ts
+++ b/src/lib/server/validation/requestValidation.test.ts
@@ -51,6 +51,27 @@ describe('requestValidation', () => {
 			expect(result.error).toContain('Unerlaubte Felder');
 		});
 
+		it('lehnt ein clientseitig berechnetes sightingDatetime ab', () => {
+			// Der Instant wird ausschließlich serverseitig aus sightingDate/sightingTime
+			// gebildet — ein mitgeschickter Zeitstempel trüge die Browser-Zeitzone.
+			const dataWithClientDatetime = {
+				referenceId: 'test-123',
+				species: 0,
+				totalCount: 1,
+				firstName: 'John',
+				lastName: 'Doe',
+				email: 'john@example.com',
+				sightingDate: '2024-01-15',
+				sightingDatetime: '2024-01-15T14:30:00.000Z',
+				privacyConsent: true
+			};
+
+			const result = validateSightingFormData(dataWithClientDatetime);
+
+			expect(result.isValid).toBe(false);
+			expect(result.rejectedFields).toContain('sightingDatetime');
+		});
+
 		it('should reject requests with unknown fields', () => {
 			const dataWithUnknownFields = {
 				referenceId: 'test-123',
@@ -101,7 +122,7 @@ describe('requestValidation', () => {
 
 		it('should handle empty object', () => {
 			const result = validateSightingFormData({});
-			
+
 			expect(result.isValid).toBe(true);
 			expect(result.data).toEqual({});
 		});
@@ -140,7 +161,7 @@ describe('requestValidation', () => {
 
 		it('should handle empty object', () => {
 			const result = checkForbiddenAdminFields({});
-			
+
 			expect(result.hasForbiddenFields).toBe(false);
 			expect(result.forbiddenFields).toEqual([]);
 		});

--- a/src/lib/server/validation/requestValidation.ts
+++ b/src/lib/server/validation/requestValidation.ts
@@ -16,10 +16,12 @@ export type AllowedSightingFormData = yup.InferType<typeof sightingSchemaBase> &
  * Set of allowed field names for sighting POST requests
  * These are the fields from sightingSchemaBase plus entryChannel, excluding administrative fields
  */
+// `sightingDatetime` steht bewusst NICHT auf der Liste: Der Zeitpunkt wird
+// serverseitig aus sightingDate/sightingTime gebildet — ein vom Browser
+// berechneter Instant trüge dessen Zeitzone.
 const ALLOWED_SIGHTING_FIELDS = new Set([
 	...Object.keys(sightingSchemaBase.fields),
-	'entryChannel', // This field is in sightingSchema but not in sightingSchemaBase
-	'sightingDatetime' // additional sighting time with browser timezone!
+	'entryChannel' // This field is in sightingSchema but not in sightingSchemaBase
 ]);
 
 /**

--- a/src/lib/services/weatherService.ts
+++ b/src/lib/services/weatherService.ts
@@ -33,11 +33,11 @@ export interface StoredWeatherData {
 		elevation?: number;
 	};
 	observation_time: string; // ISO timestamp of sighting
-	
+
 	// Complete raw data from Open-Meteo API
 	raw_data: {
 		temperature_2m: number;
-		wind_speed_10m: number; 
+		wind_speed_10m: number;
 		wind_direction_10m: number;
 		weather_code: number;
 		visibility: number;
@@ -45,14 +45,14 @@ export interface StoredWeatherData {
 		relative_humidity_2m?: number;
 		precipitation?: number;
 		cloud_cover?: number;
-		
+
 		// Additional parameters for Marine API (if available)
 		wave_height?: number;
-		wave_direction?: number; 
+		wave_direction?: number;
 		wave_period?: number;
 		sea_surface_temperature?: number;
 	};
-	
+
 	// Processed/calculated values (as currently implemented)
 	processed: {
 		temperature: number; // °C
@@ -66,11 +66,11 @@ export interface StoredWeatherData {
 		pressure?: number; // hPa
 		humidity?: number; // %
 	};
-	
+
 	// Quality information
 	quality: {
 		confidence: number; // 0.0 - 1.0
-		data_source: string; // 'era5_reanalysis' or 'gfs_forecast' 
+		data_source: string; // 'era5_reanalysis' or 'gfs_forecast'
 		notes?: string;
 	};
 }
@@ -171,7 +171,7 @@ export function convertToStoredWeatherData(
 	longitude: number
 ): StoredWeatherData {
 	const now = new Date().toISOString();
-	
+
 	return {
 		provider: 'open-meteo',
 		fetched_at: now,
@@ -182,26 +182,39 @@ export function convertToStoredWeatherData(
 			longitude,
 			...(rawApiData.elevation !== undefined && { elevation: rawApiData.elevation })
 		},
+		// `weather.time` ist ein zonenloser String (Open-Meteo liefert ihn mit
+		// `timezone=Europe/Berlin`, siehe weather.md) — bereits Berlin-Wanduhrzeit,
+		// keine UTC/Instant-Angabe. Anzeigecode darf ihn deshalb nicht nochmal per
+		// formatLocalDateTime nach Berlin konvertieren (M4) — formatISOLikeDatetime
+		// reicht ihn stattdessen verbatim durch.
 		observation_time: weather.time,
-		
+
 		raw_data: {
 			temperature_2m: rawApiData.temperature_2m || weather.temperature,
 			wind_speed_10m: rawApiData.wind_speed_10m || weather.windSpeed,
 			wind_direction_10m: rawApiData.wind_direction_10m || weather.windDirection,
 			weather_code: rawApiData.weather_code || weather.weatherCode,
 			visibility: rawApiData.visibility || weather.visibility,
-			...(rawApiData.surface_pressure !== undefined && { surface_pressure: rawApiData.surface_pressure }),
-			...(weather.pressure !== undefined && !rawApiData.surface_pressure && { surface_pressure: weather.pressure }),
-			...(rawApiData.relative_humidity_2m !== undefined && { relative_humidity_2m: rawApiData.relative_humidity_2m }),
-			...(weather.humidity !== undefined && !rawApiData.relative_humidity_2m && { relative_humidity_2m: weather.humidity }),
+			...(rawApiData.surface_pressure !== undefined && {
+				surface_pressure: rawApiData.surface_pressure
+			}),
+			...(weather.pressure !== undefined &&
+				!rawApiData.surface_pressure && { surface_pressure: weather.pressure }),
+			...(rawApiData.relative_humidity_2m !== undefined && {
+				relative_humidity_2m: rawApiData.relative_humidity_2m
+			}),
+			...(weather.humidity !== undefined &&
+				!rawApiData.relative_humidity_2m && { relative_humidity_2m: weather.humidity }),
 			...(rawApiData.precipitation !== undefined && { precipitation: rawApiData.precipitation }),
 			...(rawApiData.cloud_cover !== undefined && { cloud_cover: rawApiData.cloud_cover }),
 			...(rawApiData.wave_height !== undefined && { wave_height: rawApiData.wave_height }),
 			...(rawApiData.wave_direction !== undefined && { wave_direction: rawApiData.wave_direction }),
 			...(rawApiData.wave_period !== undefined && { wave_period: rawApiData.wave_period }),
-			...(rawApiData.sea_surface_temperature !== undefined && { sea_surface_temperature: rawApiData.sea_surface_temperature })
+			...(rawApiData.sea_surface_temperature !== undefined && {
+				sea_surface_temperature: rawApiData.sea_surface_temperature
+			})
 		},
-		
+
 		processed: {
 			temperature: weather.temperature,
 			windSpeed: weather.windSpeed,
@@ -214,7 +227,7 @@ export function convertToStoredWeatherData(
 			...(weather.pressure !== undefined && { pressure: weather.pressure }),
 			...(weather.humidity !== undefined && { humidity: weather.humidity })
 		},
-		
+
 		quality: {
 			confidence: dataType === 'historical' ? 0.95 : 0.85, // Historical data more reliable
 			data_source: dataType === 'historical' ? 'era5_reanalysis' : 'gfs_forecast',
@@ -222,4 +235,3 @@ export function convertToStoredWeatherData(
 		}
 	};
 }
-

--- a/src/lib/types/Form.ts
+++ b/src/lib/types/Form.ts
@@ -25,6 +25,14 @@ export interface FormProgress {
 export type SightingFormData = yup.InferType<typeof sightingSchema>;
 
 export type SightingFormValues = Omit<SightingFormData, 'uploadedFiles'> & {
+	/**
+	 * Echter UTC-Zeitpunkt der Sichtung.
+	 *
+	 * Wird **ausschließlich serverseitig** aus der Datenbank befüllt (E-Mail-
+	 * Aufbereitung). Clients dürfen das Feld nicht mitschicken — es steht deshalb
+	 * nicht auf der Allowlist in `requestValidation.ts`, und `mapFormToSighting`
+	 * bildet den Zeitpunkt selbst aus `sightingDate`/`sightingTime`.
+	 */
 	sightingDatetime?: Date;
 	inBalticSea?: boolean;
 	inBalticSeaGeo?: boolean;

--- a/src/lib/utils/client/fileAnalysis.test.ts
+++ b/src/lib/utils/client/fileAnalysis.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { analyzeClientFile } from './fileAnalysis';
+import * as exifr from 'exifr';
+
+vi.mock('exifr', () => ({
+	gps: vi.fn(),
+	parse: vi.fn()
+}));
+
+/**
+ * exifr belebt den EXIF-String "YYYY:MM:DD HH:MM:SS" in der Zeitzone des
+ * Browsers wieder — die lokalen Felder tragen also die Wanduhrzeit der Kamera.
+ */
+const kameraWanduhrzeit = (
+	jahr: number,
+	monat: number,
+	tag: number,
+	stunde: number,
+	minute: number
+) => new Date(jahr, monat - 1, tag, stunde, minute, 0, 0);
+
+const bild = () => new File(['x'], 'sichtung.jpg', { type: 'image/jpeg' });
+
+beforeEach(() => {
+	vi.mocked(exifr.gps).mockResolvedValue(
+		undefined as unknown as { latitude: number; longitude: number }
+	);
+});
+
+describe('analyzeClientFile — EXIF-Zeitstempel', () => {
+	it('liest die Kamera-Wanduhrzeit als deutsche Zeit (Winter)', async () => {
+		vi.mocked(exifr.parse).mockImplementation(async () => ({
+			DateTimeOriginal: kameraWanduhrzeit(2024, 1, 15, 14, 30)
+		}));
+
+		const metadata = await analyzeClientFile(bild());
+
+		// 14:30 MEZ = 13:30 UTC
+		expect(metadata.exifData?.dateTimeOriginal?.toISOString()).toBe('2024-01-15T13:30:00.000Z');
+	});
+
+	it('liest die Kamera-Wanduhrzeit als deutsche Zeit (Sommer)', async () => {
+		vi.mocked(exifr.parse).mockImplementation(async () => ({
+			DateTimeOriginal: kameraWanduhrzeit(2024, 7, 15, 14, 30)
+		}));
+
+		const metadata = await analyzeClientFile(bild());
+
+		// 14:30 MESZ = 12:30 UTC
+		expect(metadata.exifData?.dateTimeOriginal?.toISOString()).toBe('2024-07-15T12:30:00.000Z');
+	});
+
+	it('fällt auf DateTime zurück, wenn DateTimeOriginal fehlt', async () => {
+		vi.mocked(exifr.parse).mockImplementation(async () => ({
+			DateTime: kameraWanduhrzeit(2024, 7, 15, 9, 5)
+		}));
+
+		const metadata = await analyzeClientFile(bild());
+
+		expect(metadata.exifData?.dateTimeOriginal?.toISOString()).toBe('2024-07-15T07:05:00.000Z');
+	});
+
+	it('liefert in jeder Browser-Zeitzone denselben Zeitpunkt', async () => {
+		const ergebnisse: string[] = [];
+
+		for (const timeZone of TEST_TIME_ZONES) {
+			// `withTimeZone` ist synchron und stellt die Zone vor dem `await` zurück —
+			// hier muss sie über den gesamten Aufruf stehen, wie im echten Browser.
+			const vorher = process.env.TZ;
+			process.env.TZ = timeZone;
+			try {
+				vi.mocked(exifr.parse).mockImplementation(async () => ({
+					DateTimeOriginal: kameraWanduhrzeit(2024, 7, 15, 14, 30)
+				}));
+
+				const metadata = await analyzeClientFile(bild());
+				ergebnisse.push(metadata.exifData?.dateTimeOriginal?.toISOString() ?? 'fehlt');
+			} finally {
+				if (vorher === undefined) {
+					delete process.env.TZ;
+				} else {
+					process.env.TZ = vorher;
+				}
+			}
+		}
+
+		expect(ergebnisse).toEqual(TEST_TIME_ZONES.map(() => '2024-07-15T12:30:00.000Z'));
+	});
+
+	it('liest auch den rohen EXIF-String zonenunabhängig', async () => {
+		const ergebnisse = [];
+
+		for (const timeZone of TEST_TIME_ZONES) {
+			vi.mocked(exifr.parse).mockImplementation(async () => ({
+				DateTimeOriginal: '2024:07:15 14:30:00'
+			}));
+
+			const metadata = await withTimeZone(timeZone, () => analyzeClientFile(bild()));
+			ergebnisse.push((await metadata).exifData?.dateTimeOriginal?.toISOString());
+		}
+
+		expect(ergebnisse).toEqual(TEST_TIME_ZONES.map(() => '2024-07-15T12:30:00.000Z'));
+	});
+});

--- a/src/lib/utils/client/fileAnalysis.ts
+++ b/src/lib/utils/client/fileAnalysis.ts
@@ -3,7 +3,58 @@
  * Diese funktionen nutzen die browser APIs für basic file validation und analysis
  */
 import type { BrowserFileMetadata, ExifData } from '$lib/types';
+import { berlinWallClockToInstant } from '$lib/utils/format/berlinWallClock';
 import * as exifr from 'exifr';
+
+/** EXIF-Zeitstempel, wie exifr sie liefert: entweder roher String oder belebtes Date. */
+type ExifTimestamp = Date | string;
+
+/** Rohes EXIF-Format: "YYYY:MM:DD HH:MM:SS". */
+const EXIF_DATETIME_PATTERN = /^(\d{4}):(\d{2}):(\d{2})[ T](\d{2}):(\d{2})(?::(\d{2}))?/;
+
+/**
+ * Wandelt einen EXIF-Zeitstempel in den echten Zeitpunkt der Aufnahme um.
+ *
+ * EXIF speichert reine Wanduhrzeit ohne Zonenangabe. Konvention im Projekt:
+ * Die Kamera stand auf deutscher Zeit (so normalisiert es auch `exifUtils.ts`
+ * serverseitig). `exifr` belebt den Zeitstempel dagegen in der Zeitzone des
+ * Browsers — der abgelesene Wert wandert dadurch für Melder außerhalb
+ * Deutschlands um den Zonenunterschied. Deshalb werden hier die **lokalen**
+ * Felder gelesen (sie tragen die Wanduhrzeit verbatim) und anschließend als
+ * deutsche Zeit verankert.
+ *
+ * @param value - EXIF-Zeitstempel als Date oder als roher "YYYY:MM:DD HH:MM:SS"-String
+ * @returns Der Aufnahmezeitpunkt in UTC, oder `undefined` bei unlesbarer Angabe
+ */
+function exifWallClockToInstant(value: ExifTimestamp): Date | undefined {
+	if (typeof value === 'string') {
+		const match = EXIF_DATETIME_PATTERN.exec(value);
+		if (!match) {
+			return undefined;
+		}
+		return berlinWallClockToInstant({
+			year: Number(match[1]),
+			month: Number(match[2]),
+			day: Number(match[3]),
+			hours: Number(match[4]),
+			minutes: Number(match[5]),
+			seconds: Number(match[6] ?? 0)
+		});
+	}
+
+	if (isNaN(value.getTime())) {
+		return undefined;
+	}
+
+	return berlinWallClockToInstant({
+		year: value.getFullYear(),
+		month: value.getMonth() + 1,
+		day: value.getDate(),
+		hours: value.getHours(),
+		minutes: value.getMinutes(),
+		seconds: value.getSeconds()
+	});
+}
 
 /**
  * Extrahiert EXIF-Daten client-seitig aus einem Bild
@@ -38,10 +89,9 @@ async function extractExifData(file: File): Promise<ExifData> {
 		// Extract timestamp
 		result.dateTime = exifData.DateTime;
 
-		if (exifData.DateTimeOriginal) {
-			result.dateTimeOriginal = new Date(exifData.DateTimeOriginal);
-		} else if (exifData.DateTime) {
-			result.dateTimeOriginal = new Date(exifData.DateTime);
+		const wallClock = exifData.DateTimeOriginal ?? exifData.DateTime;
+		if (wallClock) {
+			result.dateTimeOriginal = exifWallClockToInstant(wallClock);
 		}
 
 		return result;

--- a/src/lib/utils/format/berlinWallClock.ts
+++ b/src/lib/utils/format/berlinWallClock.ts
@@ -1,0 +1,72 @@
+/**
+ * Umrechnung deutscher Wanduhrzeit in den echten UTC-Zeitpunkt.
+ *
+ * Reine Arithmetik auf UTC-Feldern — das Ergebnis hängt an keiner Laufzeit-Zeitzone
+ * und die Funktionen sind deshalb auch im Browser einsetzbar.
+ */
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+/**
+ * Liefert den deutschen UTC-Offset in Stunden für eine als UTC verpackte Wanduhrzeit.
+ *
+ * Die Umstellungsgrenzen liegen auf Wanduhrzeit (02:00 bzw. 03:00) und nicht auf
+ * dem UTC-Instant der Umstellung — `wallClock` trägt keine echte UTC-Zeit.
+ *
+ * @param wallClock - Deutsche Wanduhrzeit, in den UTC-Feldern eines Date abgelegt
+ * @returns 2 während MESZ (Sommerzeit), sonst 1 (MEZ)
+ */
+export function berlinOffsetHoursForWallClock(wallClock: Date): 1 | 2 {
+	const year = wallClock.getUTCFullYear();
+
+	// Letzter Sonntag im März (Sommerzeit beginnt)
+	const march = new Date(Date.UTC(year, 2, 31)); // 31. März
+	const marchDay = march.getUTCDay();
+	const lastMarchSunday = 31 - marchDay;
+	const cestStart = Date.UTC(year, 2, lastMarchSunday, 2); // Wanduhr 2:00, danach gilt MESZ
+
+	// Letzter Sonntag im Oktober (Sommerzeit endet)
+	const october = new Date(Date.UTC(year, 9, 31)); // 31. Oktober
+	const octoberDay = october.getUTCDay();
+	const lastOctoberSunday = 31 - octoberDay;
+	const cestEnd = Date.UTC(year, 9, lastOctoberSunday, 3); // Wanduhr 3:00, danach gilt MEZ
+
+	const time = wallClock.getTime();
+
+	// CEST gilt von cestStart (einschließlich) bis cestEnd (ausschließlich)
+	return time >= cestStart && time < cestEnd ? 2 : 1;
+}
+
+/** Kalender- und Uhrzeitfelder einer deutschen Wanduhrzeit. */
+export type BerlinWallClockParts = {
+	year: number;
+	/** 1–12, nicht der 0-basierte `Date`-Monat. */
+	month: number;
+	day: number;
+	hours: number;
+	minutes: number;
+	seconds?: number;
+	milliseconds?: number;
+};
+
+/**
+ * Baut aus deutscher Wanduhrzeit den echten UTC-Zeitpunkt.
+ *
+ * @param parts - Kalender- und Uhrzeitfelder, wie sie ein Mensch abliest
+ * @returns Der Zeitpunkt, den diese Wanduhrzeit in Deutschland bezeichnet
+ */
+export function berlinWallClockToInstant(parts: BerlinWallClockParts): Date {
+	const wallClock = new Date(
+		Date.UTC(
+			parts.year,
+			parts.month - 1,
+			parts.day,
+			parts.hours,
+			parts.minutes,
+			parts.seconds ?? 0,
+			parts.milliseconds ?? 0
+		)
+	);
+
+	return new Date(wallClock.getTime() - berlinOffsetHoursForWallClock(wallClock) * MS_PER_HOUR);
+}

--- a/src/lib/utils/format/dateTime.test.ts
+++ b/src/lib/utils/format/dateTime.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	combineToDate,
 	formatForExport,
+	formatISOLikeDatetime,
 	formatForKmlExport,
 	formatForXmlExport,
 	formatLocalDateTime,
@@ -575,6 +576,46 @@ describe('dateTime - Zentrale Zeitzonenverwaltung', () => {
 			// Großzügige Limits für langsame CI-Runner
 			expect(combineDuration).toBeLessThan(100);
 			expect(splitDuration).toBeLessThan(2000);
+		});
+	});
+
+	describe('formatISOLikeDatetime', () => {
+		it('reicht zonenlose Wanduhrzeit-Strings unverändert durch (nur Umformatierung)', () => {
+			// Open-Meteo liefert Berlin-Wanduhrzeit ohne Zonenangabe — die darf
+			// nicht über ein Date-Objekt laufen, sonst hängt das Ergebnis an der
+			// Prozess-Zeitzone.
+			expect(formatISOLikeDatetime('2024-06-15T14:00')).toBe('2024-06-15 14:00');
+			expect(formatISOLikeDatetime('2024-06-15 14:00')).toBe('2024-06-15 14:00');
+			expect(formatISOLikeDatetime('2024-06-15T14:00:30')).toBe('2024-06-15 14:00');
+		});
+
+		it('ist für zonenlose Strings unabhängig von der Prozess-Zeitzone', () => {
+			for (const zone of TEST_TIME_ZONES) {
+				withTimeZone(zone, () => {
+					expect(formatISOLikeDatetime('2024-06-15T14:00')).toBe('2024-06-15 14:00');
+				});
+			}
+		});
+
+		it('formatiert echte Instants (Date oder ISO mit Zone) in Europe/Berlin', () => {
+			for (const zone of TEST_TIME_ZONES) {
+				withTimeZone(zone, () => {
+					expect(formatISOLikeDatetime(new Date('2024-06-15T12:30:00.000Z'))).toBe(
+						'2024-06-15 14:30'
+					);
+					expect(formatISOLikeDatetime('2024-06-15T12:30:00.000Z')).toBe('2024-06-15 14:30');
+					// Winter: +1 statt +2
+					expect(formatISOLikeDatetime(new Date('2024-01-15T23:30:00.000Z'))).toBe(
+						'2024-01-16 00:30'
+					);
+				});
+			}
+		});
+
+		it('liefert leeren String für fehlende oder ungültige Eingaben', () => {
+			expect(formatISOLikeDatetime(null)).toBe('');
+			expect(formatISOLikeDatetime(undefined)).toBe('');
+			expect(formatISOLikeDatetime('kein Datum')).toBe('');
 		});
 	});
 });

--- a/src/lib/utils/format/dateTime.test.ts
+++ b/src/lib/utils/format/dateTime.test.ts
@@ -11,12 +11,14 @@
 import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
 import { describe, expect, it } from 'vitest';
 import {
+	berlinCalendarDayIso,
 	combineToDate,
 	formatForExport,
 	formatISOLikeDatetime,
 	formatForKmlExport,
 	formatForXmlExport,
 	formatLocalDateTime,
+	formatObservationTime,
 	isValidDate,
 	splitDateTime
 } from './dateTime';
@@ -616,6 +618,56 @@ describe('dateTime - Zentrale Zeitzonenverwaltung', () => {
 			expect(formatISOLikeDatetime(null)).toBe('');
 			expect(formatISOLikeDatetime(undefined)).toBe('');
 			expect(formatISOLikeDatetime('kein Datum')).toBe('');
+		});
+	});
+
+	describe('formatObservationTime', () => {
+		it('formatiert zonenlose Berlin-Wanduhrzeit-Strings ohne Umrechnung', () => {
+			for (const zone of TEST_TIME_ZONES) {
+				withTimeZone(zone, () => {
+					expect(formatObservationTime('2024-06-15T14:00')).toBe('15.06.2024, 14:00');
+					expect(formatObservationTime('2024-06-15 14:00:30')).toBe('15.06.2024, 14:00');
+				});
+			}
+		});
+
+		it('konvertiert echte Instants nach Europe/Berlin', () => {
+			for (const zone of TEST_TIME_ZONES) {
+				withTimeZone(zone, () => {
+					expect(formatObservationTime(new Date('2024-06-15T12:30:00.000Z'))).toBe(
+						'15.06.2024, 14:30'
+					);
+					// Winter: +1 statt +2, Kalendertag kippt über Mitternacht
+					expect(formatObservationTime(new Date('2024-01-15T23:30:00.000Z'))).toBe(
+						'16.01.2024, 00:30'
+					);
+				});
+			}
+		});
+
+		it('liefert leeren String für fehlende oder ungültige Eingaben', () => {
+			expect(formatObservationTime(null)).toBe('');
+			expect(formatObservationTime(undefined)).toBe('');
+			expect(formatObservationTime('kein Datum')).toBe('');
+		});
+	});
+
+	describe('berlinCalendarDayIso', () => {
+		it('liefert den Berliner Kalendertag eines Instants als YYYY-MM-DD', () => {
+			for (const zone of TEST_TIME_ZONES) {
+				withTimeZone(zone, () => {
+					// 23:30 UTC im Winter = 00:30 Berlin am Folgetag
+					expect(berlinCalendarDayIso(new Date('2024-01-15T23:30:00.000Z'))).toBe('2024-01-16');
+					// 22:30 UTC im Sommer = 00:30 Berlin am Folgetag (MESZ +2)
+					expect(berlinCalendarDayIso(new Date('2024-06-15T22:30:00.000Z'))).toBe('2024-06-16');
+					// Mittags kein Tageswechsel
+					expect(berlinCalendarDayIso(new Date('2024-06-15T12:00:00.000Z'))).toBe('2024-06-15');
+				});
+			}
+		});
+
+		it('nutzt ohne Argument den aktuellen Zeitpunkt', () => {
+			expect(berlinCalendarDayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
 		});
 	});
 });

--- a/src/lib/utils/format/dateTime.ts
+++ b/src/lib/utils/format/dateTime.ts
@@ -186,7 +186,13 @@ export function formatForXmlExport(utcDateTime: string | Date): {
 /**
  * Kombiniert ein Datum und eine Uhrzeit zu einem vollständigen Date-Objekt.
  *
- * Interpretiert das Datum in der browser locale
+ * NUR SERVERSEITIG verwenden, gepaart mit `correctCestOffsetUTC`: Das Datum
+ * wird als UTC-Mitternacht geparst, `setHours` arbeitet aber in der
+ * Laufzeit-Zeitzone — nur unter dem gepinnten `TZ=UTC` des Servers ergibt das
+ * die Wanduhrzeit als UTC-Instant, den `correctCestOffsetUTC` anschließend
+ * Berlin→UTC verschiebt. Im Browser hinge das Ergebnis an der Gerätezone
+ * (westlich von UTC kippt sogar der Kalendertag) — Formulare übertragen
+ * deshalb Datum und Uhrzeit als Strings und kombinieren erst auf dem Server.
  *
  * @param localDate - Das lokale Datum im Format "YYYY-MM-DD"
  * @param localTime - Die lokale Uhrzeit im Format "HH:MM" (optional)
@@ -249,18 +255,34 @@ export function isValidDate(date: string | Date | null | undefined): boolean {
 }
 
 /**
- * Format datetime in ISO-like format (YYYY-MM-DD HH:MM)
- * Used for weather data timestamps and API responses
- * @param dateTime Date object or ISO datetime string  
- * @returns Formatted datetime as "YYYY-MM-DD HH:MM"
+ * Formatiert Datum/Zeit als "YYYY-MM-DD HH:MM" (Wetterzeitstempel, API-Antworten).
+ *
+ * Zonenlose Strings (z. B. Open-Meteo-`hourly.time` mit `timezone=Europe/Berlin`)
+ * sind bereits Berlin-Wanduhrzeit und werden nur umformatiert — ohne den Umweg
+ * über ein Date-Objekt, der das Ergebnis an die Laufzeit-Zeitzone binden würde.
+ * Echte Instants (Date-Objekte, ISO-Strings mit Zonenangabe) werden explizit
+ * nach Europe/Berlin konvertiert.
+ *
+ * @param dateTime - Date-Objekt oder Datums-/Zeit-String
+ * @returns Formatiertes Datum als "YYYY-MM-DD HH:MM", leer bei ungültiger Eingabe
  */
 export function formatISOLikeDatetime(dateTime: string | Date | null | undefined): string {
 	if (!dateTime) return '';
 
+	if (typeof dateTime === 'string') {
+		const wanduhrzeit = dateTime.match(
+			/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})(?::\d{2}(?:\.\d+)?)?$/
+		);
+		if (wanduhrzeit) {
+			return `${wanduhrzeit[1]} ${wanduhrzeit[2]}`;
+		}
+	}
+
 	const date = new Date(dateTime);
 	if (isNaN(date.getTime())) return '';
 
-	return date.toLocaleDateString('sv-SE', {
+	return date.toLocaleString('sv-SE', {
+		timeZone: APP_TIMEZONE,
 		year: 'numeric',
 		month: '2-digit',
 		day: '2-digit',

--- a/src/lib/utils/format/dateTime.ts
+++ b/src/lib/utils/format/dateTime.ts
@@ -292,6 +292,41 @@ export function formatISOLikeDatetime(dateTime: string | Date | null | undefined
 }
 
 /**
+ * Formatiert einen Beobachtungszeitstempel für die Anzeige: "DD.MM.YYYY, HH:MM".
+ *
+ * Für zonenlose Berlin-Wanduhrzeit-Strings (z. B. `observation_time` aus
+ * `weatherService.ts`, geliefert von Open-Meteo mit `timezone=Europe/Berlin`):
+ * `formatLocalDateTime` würde sie fälschlich ein zweites Mal nach Berlin
+ * konvertieren — hier werden sie über `formatISOLikeDatetime` nur umsortiert,
+ * ohne Umweg über ein Date-Objekt (bliebe sonst an der Laufzeit-Zone hängen).
+ * Echte Instants (Date, ISO mit Zonenangabe) werden nach Europe/Berlin
+ * konvertiert.
+ *
+ * @param time - Zonenloser Wanduhrzeit-String, Instant-String oder Date
+ * @returns "DD.MM.YYYY, HH:MM", leer bei fehlender oder ungültiger Eingabe
+ */
+export function formatObservationTime(time: string | Date | null | undefined): string {
+	const iso = formatISOLikeDatetime(time);
+	if (!iso) return '';
+	const [datePart, timePart] = iso.split(' ');
+	const [year, month, day] = (datePart ?? '').split('-');
+	return `${day}.${month}.${year}, ${timePart}`;
+}
+
+/**
+ * Berliner Kalendertag eines Zeitpunkts als "YYYY-MM-DD".
+ *
+ * Für „Heute"-Vergleiche mit Kalendertag-Strings aus Formularen und APIs:
+ * in den 1–2 Stunden nach Mitternacht Berlin hat UTC den Tageswechsel noch
+ * nicht vollzogen — ein `toISOString()`-Schnitt läge dann einen Tag daneben.
+ *
+ * @param instant - Zeitpunkt, Standard: jetzt
+ */
+export function berlinCalendarDayIso(instant: Date = new Date()): string {
+	return instant.toLocaleDateString('sv-SE', { timeZone: APP_TIMEZONE });
+}
+
+/**
  * Hilfsfunktion: Formatiert ein Datum/Zeit-Objekt in einer bestimmten
  * Format zur Nutzung in Eingabefeldern
  *

--- a/src/lib/utils/format/formatWallClockDateTime.test.ts
+++ b/src/lib/utils/format/formatWallClockDateTime.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { formatWallClockDateTime } from './formatWallClockDateTime';
+
+describe('formatWallClockDateTime', () => {
+	it('formatiert Datum und Uhrzeit als deutsche Wanduhrzeit', () => {
+		expect(formatWallClockDateTime('2026-07-15', '14:30')).toBe('15.07.2026, 14:30');
+	});
+
+	it('formatiert nur das Datum wenn keine Uhrzeit vorliegt', () => {
+		expect(formatWallClockDateTime('2026-01-05')).toBe('05.01.2026');
+	});
+
+	it('ignoriert eine unplausible Uhrzeit', () => {
+		expect(formatWallClockDateTime('2026-01-05', 'irgendwann')).toBe('05.01.2026');
+	});
+
+	it('meldet fehlende oder unlesbare Datumsangaben', () => {
+		expect(formatWallClockDateTime(undefined)).toBe('Nicht angegeben');
+		expect(formatWallClockDateTime('15.07.2026')).toBe('Nicht angegeben');
+	});
+
+	it('liefert in jeder Zeitzone dieselbe Ausgabe', () => {
+		const results = TEST_TIME_ZONES.map((timeZone) =>
+			withTimeZone(timeZone, () => formatWallClockDateTime('2026-07-15', '00:30'))
+		);
+
+		expect(results).toEqual(TEST_TIME_ZONES.map(() => '15.07.2026, 00:30'));
+	});
+});

--- a/src/lib/utils/format/formatWallClockDateTime.ts
+++ b/src/lib/utils/format/formatWallClockDateTime.ts
@@ -1,0 +1,34 @@
+/** Datum wie es das Formular liefert: "YYYY-MM-DD". */
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/** Uhrzeit wie sie das Formular liefert: "HH:MM". */
+const TIME_PATTERN = /^([0-1]?\d|2[0-3]):[0-5]\d$/;
+
+/**
+ * Formatiert die Formulareingaben Datum und Uhrzeit für die Anzeige.
+ *
+ * Beide Werte sind deutsche Wanduhrzeit und werden hier **nur umformatiert** —
+ * ohne Umweg über ein `Date`-Objekt, der die Ausgabe an die Zeitzone des
+ * Browsers binden würde (westlich von UTC kippt sonst sogar der Kalendertag).
+ *
+ * @param localDate - Datum als "YYYY-MM-DD"
+ * @param localTime - Uhrzeit als "HH:MM" (optional)
+ * @returns "DD.MM.YYYY, HH:MM", "DD.MM.YYYY" ohne Uhrzeit, sonst "Nicht angegeben"
+ */
+export function formatWallClockDateTime(
+	localDate: string | null | undefined,
+	localTime?: string | null
+): string {
+	const dateMatch = localDate ? DATE_PATTERN.exec(localDate) : null;
+	if (!dateMatch) {
+		return 'Nicht angegeben';
+	}
+
+	const formattedDate = `${dateMatch[3]}.${dateMatch[2]}.${dateMatch[1]}`;
+
+	if (localTime && TIME_PATTERN.test(localTime)) {
+		return `${formattedDate}, ${localTime}`;
+	}
+
+	return formattedDate;
+}

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -86,12 +86,8 @@ export const load: PageServerLoad = async () => {
 			})
 			.from(sightings)
 			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
-			.groupBy(
-				berlinDatePart('year', sightings.sightingDate)
-			)
-			.orderBy(
-				berlinDatePart('year', sightings.sightingDate)
-			);
+			.groupBy(berlinDatePart('year', sightings.sightingDate))
+			.orderBy(berlinDatePart('year', sightings.sightingDate));
 
 		// Monthly distribution (last 10 years)
 		const monthlyStats = await db
@@ -101,12 +97,8 @@ export const load: PageServerLoad = async () => {
 			})
 			.from(sightings)
 			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
-			.groupBy(
-				berlinDatePart('month', sightings.sightingDate)
-			)
-			.orderBy(
-				berlinDatePart('month', sightings.sightingDate)
-			);
+			.groupBy(berlinDatePart('month', sightings.sightingDate))
+			.orderBy(berlinDatePart('month', sightings.sightingDate));
 
 		// Recent activity (last 30 days)
 		const recentActivity = await db
@@ -118,6 +110,18 @@ export const load: PageServerLoad = async () => {
 			// `created` ist naives timestamp mit UTC-Inhalt. Der Vergleich gegen das
 			// timestamptz von NOW() würde sonst über die DB-Session-Zeitzone gecastet,
 			// die die Anwendung nirgends pinnt.
+			//
+			// N3 (bewusst so belassen): Die Fenstergrenze ist ein UTC-Instant, die
+			// Gruppierung darunter aber Berlin-Kalendertage (`berlinCalendarDate`).
+			// Das verschiebt höchstens den ältesten der 30 angezeigten Tage um bis zu
+			// 2 h (Sommerzeit) — kein Tag *innerhalb* des Fensters bekommt dadurch
+			// falsche Werte, nur der Rand zeigt ggf. 29 statt 30 volle Tage. Eine
+			// exakte Berlin-Mitternacht-Grenze bräuchte mehrere verkettete
+			// `AT TIME ZONE`-Hops (Berlin-Tag → Instant → UTC-naiv), die sich ohne
+			// Postgres-Semantiktest (siehe sqlTimeZone.test.ts-Lücke im Review) nicht
+			// zuverlässig verifizieren lassen — das Risiko eines neuen, unbemerkten
+			// Zeitzonenfehlers wiegt hier schwerer als der kosmetische Rand-Tag einer
+			// „letzte 30 Tage"-Trendanzeige.
 			.where(sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`)
 			.groupBy(berlinCalendarDate(sightings.created))
 			.orderBy(sql`${berlinCalendarDate(sightings.created)} DESC`)
@@ -172,8 +176,10 @@ export const load: PageServerLoad = async () => {
 			.select({
 				email: sightings.email,
 				sightingCount: sql<number>`COUNT(*)::integer`,
-				firstSighting: sql<string>`MIN(${sightings.created})::date`,
-				lastSighting: sql<string>`MAX(${sightings.created})::date`,
+				// Berlin-Kalendertag statt naivem UTC-Cast (M1) — sonst rutscht eine
+				// Sichtung um 00:30 Ortszeit auf den UTC-Vortag.
+				firstSighting: sql<string>`${berlinCalendarDate(sql`MIN(${sightings.created})`)}`,
+				lastSighting: sql<string>`${berlinCalendarDate(sql`MAX(${sightings.created})`)}`,
 				avgGroupSize: sql<number>`AVG(${sightings.totalCount})::numeric`
 			})
 			.from(sightings)

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
+	import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 	import Icon from '$lib/components/Icon.svelte';
 	import type { PageData } from './$types';
 
@@ -455,14 +456,10 @@
 										</td>
 										<td>{formatNumber(parseFloat(String(observer.avgGroupSize)).toFixed(1))}</td>
 										<td class="text-sm">
-											{new Date(observer.firstSighting).toLocaleDateString('de-DE', {
-												year: 'numeric',
-												timeZone: 'Europe/Berlin'
-											})} -
-											{new Date(observer.lastSighting).toLocaleDateString('de-DE', {
-												year: 'numeric',
-												timeZone: 'Europe/Berlin'
-											})}
+											<!-- Bereits Berliner Kalendertag-Strings (berlinCalendarDate im Loader) —
+											     Jahr direkt abschneiden, kein Date-Umweg nötig. -->
+											{observer.firstSighting.slice(0, 4)} -
+											{observer.lastSighting.slice(0, 4)}
 										</td>
 										<td>
 											<div class="text-xs">
@@ -561,9 +558,7 @@
 								.fill(null)
 								.map((_, i) => i) as dayIndex (dayIndex)}
 								{@const targetDate = new Date(Date.now() - (29 - dayIndex) * 24 * 60 * 60 * 1000)}
-								{@const dateStr = targetDate.toLocaleDateString('sv-SE', {
-									timeZone: 'Europe/Berlin'
-								})}
+								{@const dateStr = berlinCalendarDayIso(targetDate)}
 								{@const activity = data.recentActivity.find((a) => a.date === dateStr)}
 								{@const count = activity ? Number(activity.count) : 0}
 								{@const maxCount = Math.max(...data.recentActivity.map((a) => Number(a.count)))}

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -455,8 +455,14 @@
 										</td>
 										<td>{formatNumber(parseFloat(String(observer.avgGroupSize)).toFixed(1))}</td>
 										<td class="text-sm">
-											{new Date(observer.firstSighting).getFullYear()} -
-											{new Date(observer.lastSighting).getFullYear()}
+											{new Date(observer.firstSighting).toLocaleDateString('de-DE', {
+												year: 'numeric',
+												timeZone: 'Europe/Berlin'
+											})} -
+											{new Date(observer.lastSighting).toLocaleDateString('de-DE', {
+												year: 'numeric',
+												timeZone: 'Europe/Berlin'
+											})}
 										</td>
 										<td>
 											<div class="text-xs">
@@ -555,7 +561,9 @@
 								.fill(null)
 								.map((_, i) => i) as dayIndex (dayIndex)}
 								{@const targetDate = new Date(Date.now() - (29 - dayIndex) * 24 * 60 * 60 * 1000)}
-								{@const dateStr = targetDate.toISOString().split('T')[0]}
+								{@const dateStr = targetDate.toLocaleDateString('sv-SE', {
+									timeZone: 'Europe/Berlin'
+								})}
 								{@const activity = data.recentActivity.find((a) => a.date === dateStr)}
 								{@const count = activity ? Number(activity.count) : 0}
 								{@const maxCount = Math.max(...data.recentActivity.map((a) => Number(a.count)))}

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview M1 — `firstSighting`/`lastSighting` in der Top-Observers-Abfrage
+ * müssen den Kalendertag in deutscher Ortszeit liefern, nicht den naiven
+ * UTC-Tag.
+ *
+ * Bug: `MIN(${sightings.created})::date` castet die naive UTC-Spalte direkt zu
+ * `date` — das ist der UTC-Kalendertag. Eine Sichtung um 00:30 Berliner Zeit
+ * (23:30 UTC am Vortag) würde als „gestern" gezählt, obwohl dieselbe Datei
+ * 60 Zeilen darüber (`recentActivity`) korrekt `berlinCalendarDate` verwendet.
+ *
+ * Testansatz: wie `statisticsApprovalScope.test.ts` — ein aufzeichnender
+ * `db.select`-Mock erfasst die Spalten-Definitionen jedes `select({...})`-Laufs;
+ * der SQL-Text der `firstSighting`/`lastSighting`-Spalten wird über den echten
+ * `PgDialect` kompiliert und mit dem erwarteten Berlin-Ausdruck verglichen.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { describe, expect, it, vi } from 'vitest';
+import { sightings } from '$lib/server/db/schema';
+import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
+
+const dialect = new PgDialect();
+const toSqlText = (expression: SQLWrapper): string => dialect.sqlToQuery(expression.getSQL()).sql;
+
+/** Alle Spalten-Objekte, die je an `db.select({...})` übergeben wurden. */
+let recordedSelectColumns: Array<Record<string, unknown>> = [];
+
+/**
+ * Minimaler, aufzeichnender Drizzle-Query-Builder.
+ *
+ * Deckt jede Verkettung ab, die `load()` in `+page.server.ts` verwendet
+ * (`from`, `innerJoin`, `where`, `groupBy`, `orderBy`, `having`, `limit`) und
+ * löst beim `await` auf eine leere Ergebnisliste auf — die Werte selbst sind
+ * für diesen Test irrelevant, nur die Spalten-Definitionen zählen.
+ */
+function createRecordingBuilder() {
+	const builder = {
+		from: () => builder,
+		innerJoin: () => builder,
+		where: () => builder,
+		groupBy: () => builder,
+		orderBy: () => builder,
+		having: () => builder,
+		limit: () => builder,
+		then: (
+			resolve: (rows: Array<Record<string, unknown>>) => unknown,
+			reject?: (error: unknown) => unknown
+		) => Promise.resolve([]).then(resolve, reject)
+	};
+	return builder;
+}
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: (columns?: Record<string, unknown>) => {
+			if (columns) recordedSelectColumns.push(columns);
+			return createRecordingBuilder();
+		}
+	}
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const { load } = await import('./+page.server');
+
+describe('admin/statistics load() — Top-Observers Datumsspalten (M1)', () => {
+	it('berechnet firstSighting/lastSighting in Berlin-Ortszeit statt UTC-Tag', async () => {
+		recordedSelectColumns = [];
+
+		await load({} as any);
+
+		const topObserversColumns = recordedSelectColumns.find(
+			(columns) => 'firstSighting' in columns && 'lastSighting' in columns
+		);
+		expect(
+			topObserversColumns,
+			'Top-Observers-Query mit firstSighting/lastSighting wurde nicht gefunden'
+		).toBeDefined();
+
+		const firstSightingSql = toSqlText(topObserversColumns!.firstSighting as SQL);
+		const lastSightingSql = toSqlText(topObserversColumns!.lastSighting as SQL);
+
+		const expectedFirst = toSqlText(berlinCalendarDate(sql`MIN(${sightings.created})`));
+		const expectedLast = toSqlText(berlinCalendarDate(sql`MAX(${sightings.created})`));
+
+		expect(firstSightingSql).toBe(expectedFirst);
+		expect(lastSightingSql).toBe(expectedLast);
+
+		// Der naive UTC-Cast darf nicht mehr vorkommen.
+		expect(firstSightingSql).not.toContain('::date');
+		expect(lastSightingSql).not.toContain('::date');
+		expect(firstSightingSql).toContain('Europe/Berlin');
+		expect(lastSightingSql).toContain('Europe/Berlin');
+	});
+});

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -70,7 +70,7 @@ describe('admin/statistics load() — Top-Observers Datumsspalten (M1)', () => {
 	it('berechnet firstSighting/lastSighting in Berlin-Ortszeit statt UTC-Tag', async () => {
 		recordedSelectColumns = [];
 
-		await load({} as any);
+		await load({} as unknown as Parameters<typeof load>[0]);
 
 		const topObserversColumns = recordedSelectColumns.find(
 			(columns) => 'firstSighting' in columns && 'lastSighting' in columns

--- a/src/routes/api/admin/weather/[id]/refresh/+server.ts
+++ b/src/routes/api/admin/weather/[id]/refresh/+server.ts
@@ -3,6 +3,7 @@ import { requireUserRole } from '$lib/server/auth/auth';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { getSightingById, updateSightingWeatherData } from '$lib/server/db/sightingRepository';
 import { fetchWeatherData } from '$lib/server/services/weatherRefreshService';
+import { splitDateTime } from '$lib/utils/format/dateTime';
 import { json, type RequestEvent } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -40,10 +41,11 @@ export const POST: RequestHandler = async ({ params, locals, url }: RequestEvent
 			);
 		}
 
-		// Format date for weather API
-		const sightingDateStr = sighting.sightingDate.toISOString().split('T')[0] || '';
-		const sightingTimeStr =
-			sighting.sightingDate.toISOString().split('T')[1]?.split(':').slice(0, 2).join(':') || '';
+		// H3: Berlin-Wanduhrzeit ableiten, nicht den UTC-Instant zerschneiden.
+		// Open-Meteo wird mit timezone=Europe/Berlin abgefragt (fetchWeatherData);
+		// ein toISOString()-Schnitt liefert dagegen UTC und trifft im Sommer die
+		// falsche Stunde, um Mitternacht sogar den falschen Kalendertag.
+		const { date: sightingDateStr, time: sightingTimeStr } = splitDateTime(sighting.sightingDate);
 
 		logger.debug(
 			{

--- a/src/routes/api/admin/weather/[id]/refresh/endpoint.test.ts
+++ b/src/routes/api/admin/weather/[id]/refresh/endpoint.test.ts
@@ -29,7 +29,21 @@ vi.mock('$lib/server/db/sightingRepository', () => ({
 }));
 
 vi.mock('$lib/server/services/weatherRefreshService', () => ({
-	fetchWeatherData: vi.fn()
+	fetchWeatherData: vi.fn().mockResolvedValue({
+		provider: 'open-meteo',
+		fetched_at: new Date().toISOString(),
+		api_version: 'v1',
+		data_type: 'historical',
+		location: { latitude: 54.5, longitude: 13.5 },
+		observation_time: '2024-07-15T14:00',
+		raw_data: {},
+		processed: {},
+		quality: {}
+	})
+}));
+
+vi.mock('$lib/server/audit/auditService', () => ({
+	logAuditEvent: vi.fn()
 }));
 
 const createMockEvent = (id: string, user: { email: string; roles: string[] } | null = null) => ({
@@ -92,5 +106,49 @@ describe('/api/admin/weather/[id]/refresh POST endpoint', () => {
 		expect(body.success).toBe(false);
 		expect(body.error).not.toContain('postgresql://');
 		expect(body.error).not.toContain('DB connection failed');
+	});
+
+	// H3: Datum + Uhrzeit müssen als Berlin-Wanduhrzeit an fetchWeatherData
+	// gehen, nicht als UTC-Instant-Bestandteile (toISOString()).
+	it('leitet Datum und Uhrzeit als Berlin-Wanduhrzeit ab (Sommerzeit, kein Tageswechsel)', async () => {
+		const { getSightingById, updateSightingWeatherData } =
+			await import('$lib/server/db/sightingRepository');
+		const { fetchWeatherData } = await import('$lib/server/services/weatherRefreshService');
+		vi.mocked(getSightingById).mockResolvedValue({
+			id: 1,
+			latitude: '54.5',
+			longitude: '13.5',
+			// 12:30 UTC entspricht im Sommer (Berlin = UTC+2) 14:30 Uhr Berlin
+			sightingDate: new Date('2024-07-15T12:30:00Z')
+		} as never);
+		vi.mocked(updateSightingWeatherData).mockResolvedValue(true);
+
+		const event = createMockEvent('1', { email: 'admin@test.com', roles: ['admin'] });
+		const response = await POST(event as Parameters<typeof POST>[0]);
+
+		expect(response.status).toBe(200);
+		expect(vi.mocked(fetchWeatherData)).toHaveBeenCalledWith(54.5, 13.5, '2024-07-15', '14:30');
+	});
+
+	it('leitet Datum und Uhrzeit als Berlin-Wanduhrzeit ab (Tageswechsel über Mitternacht)', async () => {
+		const { getSightingById, updateSightingWeatherData } =
+			await import('$lib/server/db/sightingRepository');
+		const { fetchWeatherData } = await import('$lib/server/services/weatherRefreshService');
+		vi.mocked(getSightingById).mockResolvedValue({
+			id: 2,
+			latitude: '54.5',
+			longitude: '13.5',
+			// 22:30 UTC am 14.07. entspricht im Sommer 00:30 Uhr Berlin am 15.07. —
+			// der UTC-Kalendertag liegt hier noch auf dem 14., der Berlin-Tag schon
+			// auf dem 15.
+			sightingDate: new Date('2024-07-14T22:30:00Z')
+		} as never);
+		vi.mocked(updateSightingWeatherData).mockResolvedValue(true);
+
+		const event = createMockEvent('2', { email: 'admin@test.com', roles: ['admin'] });
+		const response = await POST(event as Parameters<typeof POST>[0]);
+
+		expect(response.status).toBe(200);
+		expect(vi.mocked(fetchWeatherData)).toHaveBeenCalledWith(54.5, 13.5, '2024-07-15', '00:30');
 	});
 });

--- a/src/routes/api/map/sightings/+server.ts
+++ b/src/routes/api/map/sightings/+server.ts
@@ -2,8 +2,9 @@ import { createLogger } from '$lib/logger.server';
 import { sightingsToGeoJSON, type DBSighting } from '$lib/map/mapUtils';
 import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { json } from '@sveltejs/kit';
-import { and, between, isNotNull, sql } from 'drizzle-orm';
+import { and, gte, isNotNull, lt, sql } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:map:sightings');
@@ -24,9 +25,11 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		// Jahr-Filter hinzufügen, wenn vorhanden
 		if (year) {
-			const yearStart = new Date(`${year}-01-01`);
-			const yearEnd = new Date(`${year}-12-31`);
-			conditions.push(between(sightingsTable.sightingDate, yearStart, yearEnd));
+			// Jahresgrenzen sind Berliner Mitternacht, die Spalte hält UTC. Halboffenes
+			// Intervall statt BETWEEN, sonst fehlt der gesamte 31.12.
+			const { start, endExclusive } = berlinDayRangeUtc(`${year}-01-01`, `${year}-12-31`);
+			conditions.push(gte(sightingsTable.sightingDate, start));
+			conditions.push(lt(sightingsTable.sightingDate, endExclusive));
 		}
 
 		// Suchfilter hinzufügen, wenn vorhanden

--- a/src/routes/api/map/sightings/yearFilter.test.ts
+++ b/src/routes/api/map/sightings/yearFilter.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockWhere, mockOrderBy } = vi.hoisted(() => {
+	const mockOrderBy = vi.fn().mockResolvedValue([]);
+	const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+	return { mockWhere, mockOrderBy };
+});
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({ where: mockWhere, orderBy: mockOrderBy })
+		})
+	}
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: { sightingDate: 'sightingDate', approvedAt: 'approvedAt' }
+}));
+
+// Drizzle wird durch Marker-Objekte ersetzt, damit die erzeugten Grenz-Instants
+// direkt geprüft werden können statt über generiertes SQL.
+vi.mock('drizzle-orm', () => ({
+	and: vi.fn((...conditions) => conditions),
+	between: vi.fn((column, from, to) => ({ op: 'between', column, from, to })),
+	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	sql: Object.assign(
+		vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
+		{ raw: vi.fn((s: string) => s) }
+	)
+}));
+
+vi.mock('$lib/map/mapUtils', () => ({
+	sightingsToGeoJSON: vi.fn().mockReturnValue({ type: 'FeatureCollection', features: [] })
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { GET } from './+server';
+
+type Condition = { op: string; column: string; value?: Date };
+
+async function yearRange(year: string): Promise<{ start: Date; endExclusive: Date }> {
+	const url = new URL(`http://localhost/api/map/sightings?year=${year}`);
+	await GET({ url } as Parameters<typeof GET>[0]);
+
+	const conditions = mockWhere.mock.calls.at(-1)?.[0] as Condition[];
+	const onDate = conditions.filter((condition) => condition.column === 'sightingDate');
+	expect(onDate.map((condition) => condition.op)).toEqual(['gte', 'lt']);
+
+	return { start: onDate[0]!.value as Date, endExclusive: onDate[1]!.value as Date };
+}
+
+/** Bildet das halboffene Intervall der Abfrage nach: `>= start AND < endExclusive`. */
+function includes(range: { start: Date; endExclusive: Date }, instant: string): boolean {
+	const time = new Date(instant).getTime();
+	return time >= range.start.getTime() && time < range.endExclusive.getTime();
+}
+
+describe('GET /api/map/sightings — Jahresfilter meint Berliner Kalenderjahre', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it('nutzt kein BETWEEN, sondern das halboffene Intervall gte/lt', async () => {
+		const { between, gte, lt } = vi.mocked(await import('drizzle-orm'));
+
+		await GET({
+			url: new URL('http://localhost/api/map/sightings?year=2024')
+		} as Parameters<typeof GET>[0]);
+
+		expect(between).not.toHaveBeenCalled();
+		expect(gte).toHaveBeenCalledTimes(1);
+		expect(lt).toHaveBeenCalledTimes(1);
+	});
+
+	it('setzt die Jahresgrenzen auf Berliner Mitternacht', async () => {
+		const range = await yearRange('2024');
+
+		expect(range.start.toISOString()).toBe('2023-12-31T23:00:00.000Z');
+		expect(range.endExclusive.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+	});
+
+	it('enthält den 31.12. vollständig', async () => {
+		const range = await yearRange('2024');
+
+		// 31.12.2024 14:00 Berlin = 13:00Z
+		expect(includes(range, '2024-12-31T13:00:00.000Z')).toBe(true);
+		// 31.12.2024 23:30 Berlin = 22:30Z
+		expect(includes(range, '2024-12-31T22:30:00.000Z')).toBe(true);
+	});
+
+	it('enthält den 01.01. ab Berliner Mitternacht und schließt den Jahreswechsel korrekt ab', async () => {
+		const range = await yearRange('2024');
+
+		// 01.01.2024 00:30 Berlin = 31.12.2023 23:30Z
+		expect(includes(range, '2023-12-31T23:30:00.000Z')).toBe(true);
+		// 31.12.2023 23:30 Berlin = 22:30Z — gehört noch zu 2023
+		expect(includes(range, '2023-12-31T22:30:00.000Z')).toBe(false);
+		// 01.01.2025 00:30 Berlin = 31.12.2024 23:30Z
+		expect(includes(range, '2024-12-31T23:30:00.000Z')).toBe(false);
+	});
+
+	it('filtert ohne Jahresparameter nicht auf das Sichtungsdatum', async () => {
+		await GET({
+			url: new URL('http://localhost/api/map/sightings')
+		} as Parameters<typeof GET>[0]);
+
+		const conditions = mockWhere.mock.calls.at(-1)?.[0] as Condition[];
+		expect(conditions.some((condition) => condition.column === 'sightingDate')).toBe(false);
+	});
+});

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -5,6 +5,8 @@ import { getClientIp } from '$lib/server/utils/getClientIp';
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
+import { berlinToChar } from '$lib/server/db/sqlTimeZone';
+import { getYearRange } from '$lib/legacy-api/date-utils';
 import { saveSighting } from '$lib/server/db/sightingRepository';
 import { EmailService } from '$lib/server/services/emailService';
 import type { StoredWeatherData } from '$lib/services/weatherService';
@@ -37,9 +39,11 @@ export async function GET(event: RequestEvent) {
 			? parseInt(event.url.searchParams.get('year') as string)
 			: new Date().getFullYear();
 
-		// Zeitraum für das angegebene Jahr festlegen
-		const startDate = new Date(year, 0, 1); // 1. Januar des angegebenen Jahres
-		const endDate = new Date(year + 1, 0, 1); // 1. Januar des nächsten Jahres
+		// Zeitraum für das angegebene Jahr in deutscher Ortszeit (halboffenes
+		// Intervall) — `new Date(year, 0, 1)` hinge an der Prozess-Zeitzone;
+		// `dt`/`ti` werden unten nach Europe/Berlin formatiert, der Filter muss
+		// dieselbe Jahresauslegung haben.
+		const { startDate, endDate } = getYearRange(year);
 
 		logger.debug({ year, startDate, endDate }, 'Sichtungen abrufen');
 
@@ -48,8 +52,11 @@ export async function GET(event: RequestEvent) {
 			.select({
 				id: sightings.id,
 				ts: sightings.created,
-				dt: sql<string>`to_char(${sightings.sightingDate}, 'DD.MM.YYYY')`,
-				ti: sql<string>`to_char(${sightings.sightingDate}, 'HH24:MI')`,
+				// H2: dt/ti in Europe/Berlin — dieselben Feldnamen liefert
+				// showreports.json bereits in Berlin, ein rohes to_char() ohne
+				// AT TIME ZONE wäre UTC-Wanduhrzeit und würde 1-2 h abweichen.
+				dt: berlinToChar(sightings.sightingDate, 'DD.MM.YYYY'),
+				ti: berlinToChar(sightings.sightingDate, 'HH24:MI'),
 				lat: sightings.latitude,
 				lon: sightings.longitude,
 				ct: sightings.totalCount,

--- a/src/routes/api/sightings/export/csv/+server.ts
+++ b/src/routes/api/sightings/export/csv/+server.ts
@@ -1,14 +1,13 @@
 import { createLogger } from '$lib/logger.server';
-import { getDistanceLabel } from '$lib/report/formOptions/distance';
-import { getDistributionLabel } from '$lib/report/formOptions/distribution';
-import { getSpeciesLabel } from '$lib/report/formOptions/species';
 import { requireUserRole } from '$lib/server/auth/auth';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { generateCsvData } from '$lib/server/export/csvExport';
 import { text } from '@sveltejs/kit';
 import { and } from 'drizzle-orm';
 import { buildExportConditions, parseExportFilterParams } from '../exportFilterParams';
+import { toFrontendSighting } from '../toFrontendSighting';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:sightings:export:csv');
@@ -37,67 +36,9 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			.where(conditions.length > 0 ? and(...conditions) : undefined)
 			.orderBy(sightingsTable.sightingDate);
 
-		// CSV-Header
-		const headers = [
-			'Referenz-ID',
-			'Sichtungsdatum',
-			'Meldedatum',
-			'Email',
-			'Name',
-			'Telefon',
-			'Tierart',
-			'Anzahl Total',
-			'Anzahl Jungtiere',
-			'Entfernung',
-			'Verteilung',
-			'Längengrad',
-			'Breitengrad',
-			'Ort',
-			'Position Unsicher',
-			'Totfund',
-			'Kommentar',
-			'Seegang',
-			'Wind',
-			'Sicht',
-			'Aufnahme',
-			'Ostsee',
-			'Verifiziert',
-			'Eingangskanal'
-		];
-
-		// CSV-Zeilen erstellen
-		const csvRows = sightings.map((sighting) => [
-			sighting.referenceId || '',
-			sighting.sightingDate || '',
-			sighting.created || '',
-			sighting.email || '',
-			sighting.lastName || '',
-			sighting.phone || '',
-			getSpeciesLabel(sighting.species || 0),
-			sighting.totalCount || '',
-			sighting.juvenileCount || '',
-			getDistanceLabel(sighting.distance || 0),
-			getDistributionLabel(sighting.distribution || 0),
-			sighting.longitude || '',
-			sighting.latitude || '',
-			sighting.city || '', // Using city instead of location
-			'', // positionUncertain doesn't exist in schema
-			sighting.isDead ? 'Ja' : 'Nein',
-			(sighting.notes || '').replace(/"/g, '""'), // Using notes instead of comment
-			sighting.seaState || '',
-			sighting.windForce || '',
-			sighting.visibility || '',
-			sighting.mediaUpload ? 'Ja' : 'Nein',
-			sighting.inBalticSeaGeo ? 'Ja' : 'Nein',
-			sighting.verified ? 'Ja' : 'Nein',
-			sighting.entryChannel || ''
-		]);
-
-		// CSV-String erstellen
-		const csvContent = [
-			headers.map((header) => `"${header}"`).join(','),
-			...csvRows.map((row) => row.map((cell) => `"${cell}"`).join(','))
-		].join('\n');
+		// Formatierung ausschließlich über den getesteten Exporter — er rechnet
+		// die UTC-Zeitstempel nach Europe/Berlin um.
+		const csvContent = generateCsvData(sightings.map(toFrontendSighting));
 
 		// Audit-Log schreiben
 		await logAuditEvent({

--- a/src/routes/api/sightings/export/dateValidation.test.ts
+++ b/src/routes/api/sightings/export/dateValidation.test.ts
@@ -37,6 +37,8 @@ vi.mock('$lib/server/db/schema', () => ({
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn(),
+	gte: vi.fn(),
+	lt: vi.fn(),
 	eq: vi.fn()
 }));
 

--- a/src/routes/api/sightings/export/exportFilterParams.test.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Drizzle wird durch Marker-Objekte ersetzt, damit die erzeugten Grenz-Instants
+// direkt geprüft werden können statt über generiertes SQL.
+vi.mock('drizzle-orm', () => ({
+	and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+	between: vi.fn((column, from, to) => ({ op: 'between', column, from, to })),
+	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+	eq: vi.fn((column, value) => ({ op: 'eq', column, value }))
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: {
+		sightingDate: 'sightingDate',
+		verified: 'verified',
+		entryChannel: 'entryChannel',
+		mediaUpload: 'mediaUpload'
+	}
+}));
+
+import { buildExportConditions } from './exportFilterParams';
+
+type Condition = { op: string; column: string; value?: Date; from?: Date; to?: Date };
+
+function dateRange(fromDate: string, toDate: string): { start: Date; endExclusive: Date } {
+	const conditions = buildExportConditions({
+		fromDate,
+		toDate,
+		verified: null,
+		entryChannel: null,
+		mediaUpload: null
+	}) as unknown as Condition[];
+
+	const onDate = conditions.filter((condition) => condition.column === 'sightingDate');
+	expect(onDate.map((condition) => condition.op)).toEqual(['gte', 'lt']);
+
+	return { start: onDate[0]!.value as Date, endExclusive: onDate[1]!.value as Date };
+}
+
+/** Bildet das halboffene Intervall der Abfrage nach: `>= start AND < endExclusive`. */
+function includes(range: { start: Date; endExclusive: Date }, instant: string): boolean {
+	const time = new Date(instant).getTime();
+	return time >= range.start.getTime() && time < range.endExclusive.getTime();
+}
+
+describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', () => {
+	it('nutzt kein BETWEEN, sondern das halboffene Intervall gte/lt', async () => {
+		const { between, gte, lt } = vi.mocked(await import('drizzle-orm'));
+		vi.clearAllMocks();
+
+		buildExportConditions({
+			fromDate: '2024-06-01',
+			toDate: '2024-06-30',
+			verified: null,
+			entryChannel: null,
+			mediaUpload: null
+		});
+
+		expect(between).not.toHaveBeenCalled();
+		expect(gte).toHaveBeenCalledTimes(1);
+		expect(lt).toHaveBeenCalledTimes(1);
+	});
+
+	it('setzt die Grenzen im Sommer auf Berliner Mitternacht (MESZ, UTC+2)', () => {
+		const range = dateRange('2024-06-01', '2024-06-30');
+
+		expect(range.start.toISOString()).toBe('2024-05-31T22:00:00.000Z');
+		expect(range.endExclusive.toISOString()).toBe('2024-06-30T22:00:00.000Z');
+	});
+
+	it('setzt die Grenzen im Winter auf Berliner Mitternacht (MEZ, UTC+1)', () => {
+		const range = dateRange('2024-01-01', '2024-01-31');
+
+		expect(range.start.toISOString()).toBe('2023-12-31T23:00:00.000Z');
+		expect(range.endExclusive.toISOString()).toBe('2024-01-31T23:00:00.000Z');
+	});
+
+	it('enthält den letzten Tag vollständig (23:30 Berlin) und nicht den Folgetag', () => {
+		const range = dateRange('2024-06-01', '2024-06-30');
+
+		// 30.06.2024 23:30 Berlin = 21:30Z
+		expect(includes(range, '2024-06-30T21:30:00.000Z')).toBe(true);
+		// 01.07.2024 00:30 Berlin = 30.06. 22:30Z
+		expect(includes(range, '2024-06-30T22:30:00.000Z')).toBe(false);
+	});
+
+	it('enthält die frühen Randstunden des ersten Tages (00:30 Berlin)', () => {
+		const range = dateRange('2024-01-01', '2024-01-31');
+
+		// 01.01.2024 00:30 Berlin = 31.12.2023 23:30Z
+		expect(includes(range, '2023-12-31T23:30:00.000Z')).toBe(true);
+		// 31.12.2023 23:30 Berlin = 22:30Z
+		expect(includes(range, '2023-12-31T22:30:00.000Z')).toBe(false);
+	});
+
+	it('deckt Silvester als Einzeltag vollständig ab', () => {
+		const range = dateRange('2024-12-31', '2024-12-31');
+
+		expect(range.start.toISOString()).toBe('2024-12-30T23:00:00.000Z');
+		expect(range.endExclusive.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+		// 31.12.2024 14:00 Berlin = 13:00Z
+		expect(includes(range, '2024-12-31T13:00:00.000Z')).toBe(true);
+		// 31.12.2024 23:30 Berlin = 22:30Z
+		expect(includes(range, '2024-12-31T22:30:00.000Z')).toBe(true);
+		// 01.01.2025 00:30 Berlin = 31.12. 23:30Z
+		expect(includes(range, '2024-12-31T23:30:00.000Z')).toBe(false);
+	});
+
+	it('lässt den Datumsfilter weg, wenn nur eine Grenze gesetzt ist', () => {
+		const conditions = buildExportConditions({
+			fromDate: '2024-06-01',
+			toDate: '',
+			verified: null,
+			entryChannel: null,
+			mediaUpload: null
+		}) as unknown as Condition[];
+
+		expect(conditions).toHaveLength(0);
+	});
+});

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -1,5 +1,6 @@
 import { isValidDateParam } from '../../../admin/dateParam';
-import { between, eq } from 'drizzle-orm';
+import { eq, gte, lt } from 'drizzle-orm';
+import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
 
 export function xmlEscape(str: string | null | undefined): string {
@@ -49,7 +50,12 @@ export function buildExportConditions(params: ExportFilterParams) {
 	const conditions = [];
 
 	if (isValidDateParam(fromDate) && isValidDateParam(toDate)) {
-		conditions.push(between(sightingsTable.sightingDate, new Date(fromDate), new Date(toDate)));
+		// fromDate/toDate meinen Berliner Kalendertage, die Spalte hält UTC.
+		// Halboffenes Intervall statt BETWEEN, damit der letzte Tag vollständig
+		// enthalten ist; beide Grenzen treffen den Index auf der rohen Spalte.
+		const { start, endExclusive } = berlinDayRangeUtc(fromDate, toDate);
+		conditions.push(gte(sightingsTable.sightingDate, start));
+		conditions.push(lt(sightingsTable.sightingDate, endExclusive));
 	}
 	if (verified === '1') {
 		conditions.push(eq(sightingsTable.verified, 1));

--- a/src/routes/api/sightings/export/exportRoutes.timezone.test.ts
+++ b/src/routes/api/sightings/export/exportRoutes.timezone.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Naht-Tests: Die Export-Routen müssen die getesteten Berlin-Exporter aus
+ * `$lib/server/export/*` benutzen — nicht eigene Inline-Implementierungen, die
+ * rohe `Date`-Objekte bzw. UTC-ISO-Strings ausgeben.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/server/auth/auth', () => ({ requireUserRole: vi.fn() }));
+
+vi.mock('$lib/server/audit/auditService', () => ({
+	logAuditEvent: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+const { mockOrderBy } = vi.hoisted(() => ({ mockOrderBy: vi.fn() }));
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({ orderBy: mockOrderBy }),
+				orderBy: mockOrderBy
+			})
+		})
+	}
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: {
+		id: 'id',
+		sightingDate: 'sightingDate',
+		latitude: 'latitude',
+		longitude: 'longitude',
+		verified: 'verified',
+		entryChannel: 'entryChannel',
+		mediaUpload: 'mediaUpload'
+	}
+}));
+
+import { GET as csvGET } from './csv/+server';
+import { GET as jsonGET } from './json/+server';
+import { GET as kmlGET } from './kml/+server';
+import { GET as xmlGET } from './xml/+server';
+import { generateCsvData } from '$lib/server/export/csvExport';
+import { generateKmlData } from '$lib/server/export/kmlExport';
+import { generateXmlData } from '$lib/server/export/xmlExport';
+import type { FrontendSighting } from '$lib/types/index';
+
+/** 15.06.2024 18:30 UTC = 20:30 Berlin (MESZ). */
+const SIGHTING_ROW = {
+	id: 4711,
+	referenceId: 'REF-001',
+	sightingDate: new Date('2024-06-15T18:30:00.000Z'),
+	created: new Date('2024-06-15T19:00:00.000Z'),
+	species: 0,
+	totalCount: 2,
+	juvenileCount: 0,
+	distribution: 0,
+	distance: 0,
+	sightingFrom: 0,
+	boatDrive: 0,
+	seaState: 0,
+	visibility: 0,
+	behavior: 0,
+	latitude: '54.500000',
+	longitude: '13.500000',
+	location: null,
+	isDead: 0,
+	waterway: 'Kadetrinne',
+	seaMark: null,
+	windDirection: 'NW',
+	windForce: 3,
+	shipName: 'Seestern',
+	shipNameConsent: 1,
+	homePort: 'Sassnitz',
+	boatType: 'Segelboot',
+	shipCount: 1,
+	mediaUpload: 0,
+	firstName: 'Max',
+	lastName: 'Muster',
+	nameConsent: 1,
+	email: 'max@example.com',
+	phone: null,
+	fax: null,
+	street: null,
+	zipCode: null,
+	city: 'Rostock',
+	notes: null,
+	otherObservations: null,
+	inBalticSeaGeo: true,
+	verified: 1,
+	entryChannel: 0
+};
+
+/** Dieselbe Zeile als FrontendSighting — Referenzwert für den Vergleich mit den Exportern. */
+const SIGHTING = SIGHTING_ROW as unknown as FrontendSighting;
+
+function event(path: string) {
+	return {
+		url: new URL(`http://localhost${path}`),
+		locals: { user: { email: 'admin@test.com', roles: ['admin'] } }
+	} as never;
+}
+
+describe('Export-Routen benutzen die Berlin-Exporter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockOrderBy.mockResolvedValue([SIGHTING_ROW]);
+	});
+
+	it('CSV: Ausgabe entspricht generateCsvData und zeigt Berliner Ortszeit', async () => {
+		const res = await csvGET(event('/api/sightings/export/csv'));
+		const body = await res.text();
+
+		expect(body).toBe(generateCsvData([SIGHTING]));
+		expect(body).toContain('"15.06.2024";"20:30"');
+		expect(body).not.toContain('GMT');
+		expect(res.headers.get('content-type')).toContain('text/csv');
+		expect(res.headers.get('content-disposition')).toContain('sichtungen-export.csv');
+	});
+
+	it('KML: Ausgabe entspricht generateKmlData und zeigt Berliner Ortszeit', async () => {
+		const res = await kmlGET(event('/api/sightings/export/kml'));
+		const body = await res.text();
+
+		expect(body).toBe(generateKmlData([SIGHTING]));
+		expect(body).toContain('15.06.24 20:30');
+		expect(body).not.toContain('GMT');
+		expect(res.headers.get('content-type')).toContain('vnd.google-earth.kml+xml');
+		expect(res.headers.get('content-disposition')).toContain('sichtungen-export.kml');
+	});
+
+	it('XML: Ausgabe entspricht generateXmlData und zeigt Berliner Ortszeit', async () => {
+		const res = await xmlGET(event('/api/sightings/export/xml'));
+		const body = await res.text();
+
+		expect(body).toBe(generateXmlData([SIGHTING]));
+		expect(body).toContain('<datum>15.06.24</datum>');
+		expect(body).toContain('<uhrzeit>2030</uhrzeit>');
+		expect(res.headers.get('content-type')).toContain('application/xml');
+		expect(res.headers.get('content-disposition')).toContain('sichtungen-export.xml');
+	});
+
+	it('JSON bleibt bewusst maschinenlesbares UTC-ISO', async () => {
+		const res = await jsonGET(event('/api/sightings/export/json'));
+		const body = JSON.parse(await res.text());
+
+		expect(body.sichtungen[0].sightingDate).toBe('2024-06-15T18:30:00.000Z');
+	});
+});

--- a/src/routes/api/sightings/export/json/+server.ts
+++ b/src/routes/api/sightings/export/json/+server.ts
@@ -34,7 +34,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			.where(conditions.length > 0 ? and(...conditions) : undefined)
 			.orderBy(sightingsTable.sightingDate);
 
-		// Export-Metadaten hinzufügen
+		// Export-Metadaten hinzufügen.
+		// Bewusst kein Berlin-Formatter: JSON ist das Maschinenformat des Exports
+		// und gibt die Zeitstempel als UTC-ISO-Strings aus (`Date#toJSON`).
+		// Menschenlesbare Ortszeit liefern CSV, KML und XML.
 		const exportData = {
 			metadata: {
 				exportDate: new Date().toISOString(),

--- a/src/routes/api/sightings/export/kml/+server.ts
+++ b/src/routes/api/sightings/export/kml/+server.ts
@@ -1,12 +1,13 @@
 import { createLogger } from '$lib/logger.server';
-import { getSpeciesLabel } from '$lib/report/formOptions/species';
 import { requireUserRole } from '$lib/server/auth/auth';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { generateKmlData } from '$lib/server/export/kmlExport';
 import { text } from '@sveltejs/kit';
 import { and, isNotNull } from 'drizzle-orm';
 import { buildExportConditions, parseExportFilterParams, xmlEscape } from '../exportFilterParams';
+import { toFrontendSighting } from '../toFrontendSighting';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:sightings:export:kml');
@@ -39,63 +40,9 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			.where(and(...conditions))
 			.orderBy(sightingsTable.sightingDate);
 
-		// KML-Placemarks erstellen
-		const placemarks = sightings
-			.map((sighting) => {
-				const species = getSpeciesLabel(sighting.species || 0);
-				const description = `
-				<![CDATA[
-				<b>Tierart:</b> ${species}<br/>
-				<b>Anzahl:</b> ${sighting.totalCount || 'Unbekannt'}<br/>
-				<b>Sichtungsdatum:</b> ${sighting.sightingDate || 'Unbekannt'}<br/>
-				<b>Ort:</b> ${sighting.city || 'Unbekannt'}<br/>
-				${sighting.notes ? `<b>Kommentar:</b> ${sighting.notes}<br/>` : ''}
-				<b>Referenz-ID:</b> ${sighting.referenceId || ''}<br/>
-				<b>Verifiziert:</b> ${sighting.verified ? 'Ja' : 'Nein'}
-				]]>
-			`;
-
-				return `
-			<Placemark>
-				<name>${species} - ${sighting.referenceId || sighting.id}</name>
-				<description>${description}</description>
-				<Point>
-					<coordinates>${sighting.longitude},${sighting.latitude},0</coordinates>
-				</Point>
-				<ExtendedData>
-					<Data name="species">
-						<value>${species}</value>
-					</Data>
-					<Data name="totalCount">
-						<value>${sighting.totalCount || ''}</value>
-					</Data>
-					<Data name="sightingDate">
-						<value>${sighting.sightingDate || ''}</value>
-					</Data>
-					<Data name="verified">
-						<value>${sighting.verified ? 'true' : 'false'}</value>
-					</Data>
-				</ExtendedData>
-			</Placemark>`;
-			})
-			.join('');
-
-		// Vollständige KML-Datei erstellen
-		const kmlContent = `<?xml version="1.0" encoding="UTF-8"?>
-<kml xmlns="http://www.opengis.net/kml/2.2">
-	<Document>
-		<name>Ostsee-Sichtungen Export</name>
-		<description>Exportierte Meerestier-Sichtungen aus der Ostsee-Datenbank</description>
-		<Style id="defaultStyle">
-			<IconStyle>
-				<Icon>
-					<href>http://maps.google.com/mapfiles/kml/shapes/marine.png</href>
-				</Icon>
-			</IconStyle>
-		</Style>
-		${placemarks}
-	</Document>
-</kml>`;
+		// Formatierung ausschließlich über den getesteten Exporter — er rechnet
+		// die UTC-Zeitstempel nach Europe/Berlin um.
+		const kmlContent = generateKmlData(sightings.map(toFrontendSighting));
 
 		// Audit-Log schreiben
 		await logAuditEvent({

--- a/src/routes/api/sightings/export/toFrontendSighting.ts
+++ b/src/routes/api/sightings/export/toFrontendSighting.ts
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Adapter DB-Zeile → `FrontendSighting` für die Export-Routen.
+ *
+ * Die Exporter in `$lib/server/export/*` arbeiten auf `FrontendSighting`. Eine
+ * Select-Zeile aus `sichtungen` ist feldgleich; nur die numerischen Codes sind
+ * dort als Enum typisiert und die PostGIS-Geometrie gehört nicht zum Export.
+ */
+
+import type { AnimalBehavior } from '$lib/report/formOptions/animalBehavior';
+import type { BoatDrive } from '$lib/report/formOptions/boatDrive';
+import type { Distance } from '$lib/report/formOptions/distance';
+import type { Distribution } from '$lib/report/formOptions/distribution';
+import type { SeaState } from '$lib/report/formOptions/seaState';
+import type { SightingFrom } from '$lib/report/formOptions/sightingFrom';
+import type { Species } from '$lib/report/formOptions/species';
+import type { Visibility } from '$lib/report/formOptions/visibility';
+import type { sightings } from '$lib/server/db/schema';
+import type { FrontendSighting } from '$lib/types/index';
+import type { InferSelectModel } from 'drizzle-orm';
+
+type SightingRow = InferSelectModel<typeof sightings>;
+
+export function toFrontendSighting(row: SightingRow): FrontendSighting {
+	const { location: _location, ...rest } = row;
+
+	return {
+		...rest,
+		species: rest.species as Species,
+		distribution: rest.distribution as Distribution,
+		distance: rest.distance as Distance,
+		sightingFrom: rest.sightingFrom as SightingFrom,
+		boatDrive: rest.boatDrive as BoatDrive,
+		seaState: rest.seaState as SeaState,
+		visibility: rest.visibility as Visibility,
+		behavior: rest.behavior as AnimalBehavior
+	};
+}

--- a/src/routes/api/sightings/export/xml/+server.ts
+++ b/src/routes/api/sightings/export/xml/+server.ts
@@ -1,14 +1,13 @@
 import { createLogger } from '$lib/logger.server';
-import { getDistanceLabel } from '$lib/report/formOptions/distance';
-import { getDistributionLabel } from '$lib/report/formOptions/distribution';
-import { getSpeciesLabel } from '$lib/report/formOptions/species';
 import { requireUserRole } from '$lib/server/auth/auth';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { generateXmlData } from '$lib/server/export/xmlExport';
 import { text } from '@sveltejs/kit';
 import { and } from 'drizzle-orm';
 import { buildExportConditions, parseExportFilterParams, xmlEscape } from '../exportFilterParams';
+import { toFrontendSighting } from '../toFrontendSighting';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:sightings:export:xml');
@@ -24,7 +23,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			{ status: 400, headers: { 'Content-Type': 'application/xml' } }
 		);
 	}
-	const { fromDate, toDate, verified, entryChannel, mediaUpload } = filterResult.params;
+	const { fromDate, toDate } = filterResult.params;
 
 	try {
 		// Erstellen der Abfrage-Bedingungen
@@ -37,64 +36,9 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 			.where(conditions.length > 0 ? and(...conditions) : undefined)
 			.orderBy(sightingsTable.sightingDate);
 
-		// XML-Einträge für Sichtungen erstellen
-		const sightingXml = sightings
-			.map(
-				(sighting) => `
-		<sichtung>
-			<referenzId>${xmlEscape(sighting.referenceId)}</referenzId>
-			<sichtungsdatum>${xmlEscape(sighting.sightingDate.toISOString())}</sichtungsdatum>
-			<meldedatum>${xmlEscape(sighting.created.toISOString())}</meldedatum>
-			<kontakt>
-				<email>${xmlEscape(sighting.email)}</email>
-				<name>${xmlEscape(sighting.lastName)}</name>
-				<telefon>${xmlEscape(sighting.phone)}</telefon>
-			</kontakt>
-			<tierart>${xmlEscape(getSpeciesLabel(sighting.species || 0))}</tierart>
-			<anzahl>
-				<total>${sighting.totalCount || 0}</total>
-				<jungtiere>${sighting.juvenileCount || 0}</jungtiere>
-			</anzahl>
-			<entfernung>${xmlEscape(getDistanceLabel(sighting.distance || 0))}</entfernung>
-			<verteilung>${xmlEscape(getDistributionLabel(sighting.distribution || 0))}</verteilung>
-			<position>
-				<laengengrad>${sighting.longitude || ''}</laengengrad>
-				<breitengrad>${sighting.latitude || ''}</breitengrad>
-				<ort>${xmlEscape(sighting.city)}</ort>
-				<unsicher>false</unsicher>
-			</position>
-			<totfund>${sighting.isDead ? 'true' : 'false'}</totfund>
-			<kommentar>${xmlEscape(sighting.notes)}</kommentar>
-			<umweltbedingungen>
-				<seegang>${sighting.seaState || ''}</seegang>
-				<wind>${sighting.windForce || ''}</wind>
-				<sicht>${sighting.visibility || ''}</sicht>
-			</umweltbedingungen>
-			<aufnahme>${sighting.mediaUpload ? 'true' : 'false'}</aufnahme>
-			<ostsee>${sighting.inBalticSeaGeo ? 'true' : 'false'}</ostsee>
-			<verifiziert>${sighting.verified ? 'true' : 'false'}</verifiziert>
-			<eingangskanal>${sighting.entryChannel || ''}</eingangskanal>
-		</sichtung>`
-			)
-			.join('');
-
-		// Vollständige XML-Datei erstellen
-		const xmlContent = `<?xml version="1.0" encoding="UTF-8"?>
-<ostsee-sichtungen>
-	<metadaten>
-		<exportDatum>${new Date().toISOString()}</exportDatum>
-		<anzahlDatensaetze>${sightings.length}</anzahlDatensaetze>
-		<filter>
-			<datumVon>${xmlEscape(fromDate)}</datumVon>
-			<datumBis>${xmlEscape(toDate)}</datumBis>
-			<verifiziert>${xmlEscape(verified)}</verifiziert>
-			<eingangskanal>${xmlEscape(entryChannel)}</eingangskanal>
-			<aufnahme>${xmlEscape(mediaUpload)}</aufnahme>
-		</filter>
-	</metadaten>
-	<sichtungen>${sightingXml}
-	</sichtungen>
-</ostsee-sichtungen>`;
+		// Formatierung ausschließlich über den getesteten Exporter — er rechnet
+		// die UTC-Zeitstempel nach Europe/Berlin um.
+		const xmlContent = generateXmlData(sightings.map(toFrontendSighting));
 
 		// Audit-Log schreiben
 		await logAuditEvent({

--- a/src/routes/api/sightings/getEndpoint.test.ts
+++ b/src/routes/api/sightings/getEndpoint.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview H2 — GET /api/sightings muss `dt`/`ti` in Europe/Berlin liefern
+ * (nicht UTC) und die Jahresgrenzen über `getYearRange` (Berlin-Mitternacht,
+ * halboffenes Intervall) statt über prozesszonen-abhängige `Date`-Konstruktoren
+ * bilden. Die Feldnamen sind identisch mit `showreports.json`, das bereits
+ * korrekt in Berlin formatiert — beide Endpunkte dürfen nicht mehr auseinanderlaufen.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockOrderBy, mockWhere } = vi.hoisted(() => {
+	const mockOrderBy = vi.fn().mockResolvedValue([]);
+	const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+	return { mockOrderBy, mockWhere };
+});
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({ where: mockWhere, orderBy: mockOrderBy })
+		})
+	}
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: {
+		id: 'id',
+		created: 'created',
+		sightingDate: 'sightingDate',
+		latitude: 'latitude',
+		longitude: 'longitude',
+		totalCount: 'totalCount',
+		juvenileCount: 'juvenileCount',
+		species: 'species',
+		isDead: 'isDead',
+		nameConsent: 'nameConsent',
+		firstName: 'firstName',
+		lastName: 'lastName',
+		waterway: 'waterway',
+		shipNameConsent: 'shipNameConsent',
+		shipName: 'shipName'
+	}
+}));
+
+// Drizzle wird durch Marker-Objekte ersetzt, damit die erzeugten Grenz-Instants
+// und Feld-Ausdrücke direkt geprüft werden können statt über generiertes SQL
+// (gleiches Muster wie `api/map/sightings/yearFilter.test.ts`).
+vi.mock('drizzle-orm', () => ({
+	and: vi.fn((...conditions) => conditions),
+	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+	sql: Object.assign(
+		vi.fn(() => 'sql-fragment'),
+		{ raw: vi.fn((s: string) => s) }
+	)
+}));
+
+vi.mock('$lib/legacy-api/date-utils', () => ({
+	getYearRange: vi.fn((year: number) => ({
+		startDate: new Date(Date.UTC(year - 1, 11, 31, 23, 0, 0)),
+		endDate: new Date(Date.UTC(year, 11, 31, 23, 0, 0))
+	}))
+}));
+
+vi.mock('$lib/server/db/sqlTimeZone', () => ({
+	berlinToChar: vi.fn((column: string, pattern: string) => `berlinToChar(${column},${pattern})`)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+import { GET } from './+server';
+
+type Condition = { op: string; column: string; value?: Date };
+
+const createMockGetEvent = (url: string) =>
+	({
+		url: new URL(url),
+		setHeaders: vi.fn()
+	}) as unknown as Parameters<typeof GET>[0];
+
+describe('GET /api/sightings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it('nutzt getYearRange (Berlin-Mitternacht) statt lokaler Date-Konstruktoren', async () => {
+		const { getYearRange } = await import('$lib/legacy-api/date-utils');
+
+		await GET(createMockGetEvent('http://localhost/api/sightings?year=2024'));
+
+		expect(getYearRange).toHaveBeenCalledWith(2024);
+
+		const conditions = mockWhere.mock.calls.at(-1)?.[0] as Condition[];
+		expect(conditions.map((c) => c.op)).toEqual(['gte', 'lt']);
+		expect(conditions[0]?.value?.toISOString()).toBe('2023-12-31T23:00:00.000Z');
+		expect(conditions[1]?.value?.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+	});
+
+	it('formatiert dt/ti über berlinToChar (Europe/Berlin), nicht über rohes to_char', async () => {
+		const { berlinToChar } = await import('$lib/server/db/sqlTimeZone');
+		const { db } = await import('$lib/server/db');
+
+		await GET(createMockGetEvent('http://localhost/api/sightings?year=2024'));
+
+		expect(berlinToChar).toHaveBeenCalledWith('sightingDate', 'DD.MM.YYYY');
+		expect(berlinToChar).toHaveBeenCalledWith('sightingDate', 'HH24:MI');
+
+		const selectArg = vi.mocked(db.select).mock.calls.at(-1)?.[0] as unknown as {
+			dt: string;
+			ti: string;
+		};
+		expect(selectArg.dt).toBe('berlinToChar(sightingDate,DD.MM.YYYY)');
+		expect(selectArg.ti).toBe('berlinToChar(sightingDate,HH24:MI)');
+	});
+});

--- a/src/routes/api/weather/historical/+server.ts
+++ b/src/routes/api/weather/historical/+server.ts
@@ -11,7 +11,11 @@ import {
 	type WeatherData
 } from '$lib/services/weatherService';
 import { hourIndexFromLocalTime } from '$lib/server/weather/hourIndex';
-import { combineToDate, formatISOLikeDatetime } from '$lib/utils/format/dateTime';
+import {
+	berlinCalendarDayIso,
+	combineToDate,
+	formatISOLikeDatetime
+} from '$lib/utils/format/dateTime';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -37,8 +41,7 @@ interface MarineResponse {
  * Forecast-API routen — das Archiv kennt den laufenden Tag noch nicht.
  */
 function isTodayDate(date: string): boolean {
-	const berlinToday = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
-	return date === berlinToday;
+	return date === berlinCalendarDayIso();
 }
 
 /**

--- a/src/routes/api/weather/historical/+server.ts
+++ b/src/routes/api/weather/historical/+server.ts
@@ -27,12 +27,18 @@ interface MarineResponse {
 }
 
 /**
- * Determine if sighting date is today (Issue #110)
+ * Determine if sighting date is today (Issue #110).
+ *
+ * N4: Vergleich in deutscher Ortszeit, nicht in Prozesszone. `date` ist bereits
+ * ein "YYYY-MM-DD"-Kalendertag (deutsche Ortszeit); ein `Date`-basierter
+ * Vergleich in UTC-Prozesszone würde in den ersten 1-2 Stunden nach Mitternacht
+ * Berlin (UTC hat den Tageswechsel noch nicht vollzogen) ein heutiges
+ * Berlin-Datum fälschlich als "nicht heute" werten und ans Archiv statt an die
+ * Forecast-API routen — das Archiv kennt den laufenden Tag noch nicht.
  */
 function isTodayDate(date: string): boolean {
-	const sightingDate = new Date(date);
-	const today = new Date();
-	return sightingDate.toDateString() === today.toDateString();
+	const berlinToday = new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' });
+	return date === berlinToday;
 }
 
 /**

--- a/src/routes/api/weather/historical/isTodayDate.test.ts
+++ b/src/routes/api/weather/historical/isTodayDate.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview N4 — `isTodayDate` verglich in Prozesszone statt in Europe/Berlin.
+ * In den ersten 1-2 Stunden nach Mitternacht Berlin (UTC hat den Tageswechsel
+ * noch nicht vollzogen) wurde ein heutiges Berlin-Datum fälschlich als
+ * "nicht heute" gewertet und ans Archiv statt an die Forecast-API geroutet —
+ * das Archiv kennt den laufenden Tag noch nicht (404/leere Antwort).
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('$lib/server/db/sightingRepository', () => ({
+	getCachedWeatherForSighting: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+import { GET } from './+server';
+
+function makeHourlyResponse(date: string) {
+	return {
+		hourly: {
+			time: Array.from({ length: 24 }, (_, i) => `${date}T${String(i).padStart(2, '0')}:00`),
+			temperature_2m: new Array(24).fill(18),
+			wind_speed_10m: new Array(24).fill(15),
+			wind_direction_10m: new Array(24).fill(180),
+			weather_code: new Array(24).fill(0),
+			visibility: new Array(24).fill(10000),
+			surface_pressure: new Array(24).fill(1013),
+			relative_humidity_2m: new Array(24).fill(60)
+		}
+	};
+}
+
+describe('GET /api/weather/historical — "heute" in Berliner Ortszeit', () => {
+	beforeEach(() => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => makeHourlyResponse('2024-07-15')
+			} as Response)
+		);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it('routet ein Berlin-heutiges Datum an die Forecast-API, auch wenn UTC den Tag noch nicht gewechselt hat', async () => {
+		// 23:30 UTC am 14.07. entspricht im Sommer (Berlin = UTC+2) bereits
+		// 01:30 Uhr Berlin am 15.07. — UTC hat den Tageswechsel noch nicht vollzogen.
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-07-14T23:30:00Z'));
+
+		const url = new URL(
+			'http://localhost/api/weather/historical?lat=54.5&lng=13.5&date=2024-07-15&time=00:30'
+		);
+		const response = await GET({ url } as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body.metadata.dataType).toBe('forecast');
+
+		const firstCallUrl = vi.mocked(fetch).mock.calls[0]?.[0] as string;
+		expect(firstCallUrl).toContain('api.open-meteo.com/v1/forecast');
+		expect(firstCallUrl).not.toContain('archive-api');
+	});
+
+	it('routet ein tatsächlich vergangenes Berlin-Datum weiterhin an die Archiv-API', async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2024-07-14T23:30:00Z'));
+
+		const url = new URL(
+			'http://localhost/api/weather/historical?lat=54.5&lng=13.5&date=2024-07-13&time=12:00'
+		);
+		const response = await GET({ url } as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body.metadata.dataType).toBe('historical');
+
+		const firstCallUrl = vi.mocked(fetch).mock.calls[0]?.[0] as string;
+		expect(firstCallUrl).toContain('archive-api.open-meteo.com');
+	});
+});

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -92,7 +92,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		// Year filter - PDF specification behavior
 		if (year) {
 			const yearNum = parseInt(year);
-			if (!isNaN(yearNum) && yearNum >= 1900 && yearNum <= new Date().getFullYear() + 1) {
+			// NIEDRIG: Jahres-Obergrenze in Berliner Ortszeit statt Server-Prozesszone
+			// (nur an Silvester relevant) — sonst zeichengleiches Verhalten.
+			const currentBerlinYear = Number(
+				new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' }).slice(0, 4)
+			);
+			if (!isNaN(yearNum) && yearNum >= 1900 && yearNum <= currentBerlinYear + 1) {
 				// Jahresgrenzen in deutscher Ortszeit: `dt`/`ti` der Response werden
 				// nach Europe/Berlin umgerechnet, der Filter muss dieselbe
 				// Jahresauslegung haben und darf nicht an der Server-Zeitzone hängen.

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -23,6 +23,7 @@ import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
+import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 import { json, type RequestEvent } from '@sveltejs/kit';
 import { and, between, gte, lt, sql } from 'drizzle-orm';
 
@@ -94,9 +95,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			const yearNum = parseInt(year);
 			// NIEDRIG: Jahres-Obergrenze in Berliner Ortszeit statt Server-Prozesszone
 			// (nur an Silvester relevant) — sonst zeichengleiches Verhalten.
-			const currentBerlinYear = Number(
-				new Date().toLocaleDateString('sv-SE', { timeZone: 'Europe/Berlin' }).slice(0, 4)
-			);
+			const currentBerlinYear = Number(berlinCalendarDayIso().slice(0, 4));
 			if (!isNaN(yearNum) && yearNum >= 1900 && yearNum <= currentBerlinYear + 1) {
 				// Jahresgrenzen in deutscher Ortszeit: `dt`/`ti` der Response werden
 				// nach Europe/Berlin umgerechnet, der Filter muss dieselbe

--- a/src/tests/contract/export.contract.test.ts
+++ b/src/tests/contract/export.contract.test.ts
@@ -37,6 +37,8 @@ vi.mock('$lib/server/db/schema', () => ({
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn((a, b, c) => ({ a, b, c })),
+	gte: vi.fn((a, b) => ({ a, b })),
+	lt: vi.fn((a, b) => ({ a, b })),
 	eq: vi.fn((a, b) => ({ a, b })),
 	isNotNull: vi.fn((a) => ({ a }))
 }));
@@ -175,7 +177,9 @@ describe('Contract: GET /api/sightings/export/csv', () => {
 		const body = await res.text();
 
 		expect(body.split('\n').length).toBeGreaterThanOrEqual(2);
-		expect(body).toContain('REF-001');
+		// Spaltensatz und Zeitzone kommen aus generateCsvData (Europe/Berlin)
+		expect(body).toContain('"Schweinswal"');
+		expect(body).toContain('"15.06.2024";"16:30"');
 	});
 });
 
@@ -206,7 +210,9 @@ describe('Contract: GET /api/sightings/export/xml', () => {
 		const body = await res.text();
 
 		expect(body).toContain('<sichtung>');
-		expect(body).toContain('REF-001');
+		// Legacy-Feldnamen und Berliner Ortszeit kommen aus generateXmlData
+		expect(body).toContain('<nr>1</nr>');
+		expect(body).toContain('<datum>15.06.24</datum>');
 	});
 });
 
@@ -237,7 +243,9 @@ describe('Contract: GET /api/sightings/export/kml', () => {
 		const body = await res.text();
 
 		expect(body).toContain('<Placemark>');
-		expect(body).toContain('13.5,54.5,0');
+		// Koordinatenformat und Berliner Ortszeit kommen aus generateKmlData
+		expect(body).toContain('<coordinates>13.5,54.5</coordinates>');
+		expect(body).toContain('15.06.24 16:30');
 	});
 });
 

--- a/src/tests/contract/map-sightings.contract.test.ts
+++ b/src/tests/contract/map-sightings.contract.test.ts
@@ -46,6 +46,8 @@ vi.mock('$lib/server/db/schema', () => ({
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn((a, b, c) => ({ a, b, c })),
+	gte: vi.fn((a, b) => ({ a, b })),
+	lt: vi.fn((a, b) => ({ a, b })),
 	eq: vi.fn((a, b) => ({ a, b })),
 	isNotNull: vi.fn((a) => ({ isNotNull: a })),
 	sql: Object.assign(

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -70,6 +70,60 @@ node src/tools/fix-media-upload-flags.js --dry-run --verbose
 - Graceful error handling
 - Database connection cleanup
 
+### 3. Data Migration
+
+#### `generate-reference-ids.ts`
+
+Generates CUID2 `referenceId` values for all sightings that don't have one yet — needed for the reference-ID-based URL structure and upload paths.
+
+**Purpose:**
+
+- Reuses an existing `referenceId` from associated `sichtungen_dateien` rows if present
+- Otherwise generates a new CUID2 and writes it to `sichtungen.referenz_id`
+- Never overwrites a `referenceId` that is already set
+
+**Usage:**
+
+```bash
+npx tsx --env-file=.env src/tools/generate-reference-ids.ts
+```
+
+#### `migrate-old-uploads.ts`
+
+Migrates files from the legacy `sichtungen.aufnahme` column into the `sichtungen_dateien` table and the new `uploads/{referenz_id}/` file layout.
+
+**Purpose:**
+
+- Sets `aufnahmeHochladen = 1` for sightings with a legacy upload
+- Creates `sichtungen_dateien` entries with full metadata, extracting EXIF data (GPS, camera info) from images
+- Copies files from `uploads/_old_uploads/` to `uploads/{referenz_id}/`, preserving the originals
+
+**Usage:**
+
+```bash
+npx tsx --env-file=.env src/tools/migrate-old-uploads.ts
+```
+
+#### `migrate-timestamps-to-utc.js`
+
+One-time migration converting naive legacy timestamps (`sichtungsdatum`, `created`, `freigegeben_am`, `hochgeladen_am`, `erstellt_am`) from German local time (Europe/Berlin wall-clock) to real UTC. Required after importing any pre-migration data — see `docs/DATABASE_MIGRATION.md` and `docs/ENVIRONMENT.md#tz`.
+
+**Purpose:**
+
+- Converts all rows created before a given `--cutover` timestamp from Europe/Berlin wall-clock to UTC
+- Refuses to run twice (marker in `app_config`) and refuses to touch rows that already look like app-written UTC data, unless explicitly excluded
+- Reports timestamps affected by the DST spring-forward gap or autumn repeated hour
+
+**Usage:**
+
+```bash
+# Dry run first (required before any live run) — take a DB backup beforehand
+npm run db:migrate-timestamps-utc:dry-run -- --cutover=<ISO>
+
+# Live run
+npm run db:migrate-timestamps-utc -- --cutover=<ISO>
+```
+
 ## Development Guidelines
 
 ### Creating New Tools

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1479,7 +1479,7 @@ paths:
         Erstellt eine neue Sichtung im Legacy-Format der ursprünglichen schweinswalsichtung.de API.
         
         Wichtige Hinweise:
-        - Unterstützt das kombinierte Datetime-Format "YYYY-MM-DD HH:MI"
+        - Unterstützt das kombinierte Datetime-Format "YYYY-MM-DD HH:MI" (deutsche Ortszeit, Europe/Berlin)
         - Feldnamen müssen exakt dem PDF-Spezifikation entsprechen
         - Boolean-Werte werden als 0/1 Integer übertragen
         - Totfunde werden durch `anzahl_gesamt = 0` signalisiert
@@ -1648,8 +1648,8 @@ paths:
         **WICHTIG: PDF-konforme abgekürzte Feldnamen**
         - ts: Unix Timestamp
         - id: Sichtungs-ID
-        - dt: Datum (DD.MM.YY)
-        - ti: Zeit (HH:MI)
+        - dt: Datum (DD.MM.YY), deutsche Ortszeit (Europe/Berlin)
+        - ti: Zeit (HH:MI), deutsche Ortszeit (Europe/Berlin)
         - lat, lon: Koordinaten als STRINGS
         - ct: Gesamtanzahl
         - yo: Jungtiere
@@ -1983,11 +1983,11 @@ components:
           example: 1672531200
         dt:
           type: string
-          description: Datum der Sichtung (DD.MM.YYYY)
+          description: Datum der Sichtung (DD.MM.YYYY), Kalendertag in deutscher Ortszeit (Europe/Berlin)
           example: "01.01.2024"
         ti:
           type: string
-          description: Uhrzeit der Sichtung (HH:MM)
+          description: Uhrzeit der Sichtung (HH:MM), deutsche Ortszeit (Europe/Berlin)
           example: "14:30"
         lat:
           type: number
@@ -2543,7 +2543,9 @@ components:
         # Pflichtfelder
         sichtungsdatum:
           type: string
-          description: 'Datum und Uhrzeit der Sichtung im Format "YYYY-MM-DD HH:MI"'
+          description: >-
+            Datum und Uhrzeit der Sichtung im Format "YYYY-MM-DD HH:MI"; wird als
+            deutsche Ortszeit (Europe/Berlin) interpretiert, nicht als UTC
           pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$'
           example: "2024-01-01 14:30"
         anzahl_gesamt:
@@ -2749,12 +2751,12 @@ components:
           example: 817
         dt:
           type: string
-          description: 'Datum der Sichtung im Format DD.MM.YY (2-stelliges Jahr!)'
+          description: 'Datum der Sichtung im Format DD.MM.YY (2-stelliges Jahr!), Kalendertag in deutscher Ortszeit (Europe/Berlin)'
           pattern: '^\d{2}\.\d{2}\.\d{2}$'
           example: "25.01.12"
         ti:
           type: string
-          description: 'Zeit der Sichtung im Format HH:MI (24h, UTC)'
+          description: 'Zeit der Sichtung im Format HH:MI (24h, deutsche Ortszeit / Europe/Berlin)'
           pattern: '^\d{2}:\d{2}$'
           example: "14:50"
         lat:


### PR DESCRIPTION
## Zusammenfassung

Behebt alle Befunde des Zeitzonen-Reviews vor der Inbetriebnahme (vollständiger Report: `docs/TIMEZONE_REVIEW_2026-07-28.md`, erstellt durch vier unabhängige Audits von SQL-Schicht, Schreibpfad, Lesepfad und Dokumentation).

**Verbindliche Semantik (jetzt überall durchgesetzt):** Speicherung als echtes UTC, Nutzereingaben als deutsche Wanduhrzeit (ausschließlich serverseitig kombiniert), jede Anzeige/jeder Export/die Legacy-API in Europe/Berlin, SQL-Kalenderfragen über die zentralen Helper in `sqlTimeZone.ts` (zeichengleich mit den Ausdrucksindizes).

## Kritische Fixes

- **Schreibpfad:** Das Formular berechnet `sightingDatetime` nicht mehr im Browser (Geräte-Zeitzone verfälschte den gespeicherten Instant, West-Zeitzonen kippten den Kalendertag); Datum/Zeit gehen als Strings zum Server und werden dort mit zonenunabhängiger Berlin-Arithmetik kombiniert. Mitgeschickte `sightingDatetime`-Felder werden abgewiesen.
- **Exporte:** CSV/KML/XML-Routen nutzen die getesteten Berlin-Exporter statt roher UTC-`Date`-Ausgaben (die korrekten `generate*Data`-Funktionen waren toter Code). ⚠️ **Dadurch ändert sich der sichtbare Aufbau der Exporte** (CSV-Spaltensatz, Namen nur mit Consent, XML im Legacy-Format) — bitte den Museums-Nutzern ankündigen.
- **Datumsfilter:** Export-Filter und öffentlicher Karten-Jahresfilter nutzen halboffene Berlin-Kalendertagsgrenzen (`berlinDayRangeUtc`) — vorher fehlte der komplette letzte Tag bzw. der 31.12. (verifiziert: 10 freigegebene Silvester-Sichtungen verschwanden von der Karte).

## Hohe Fixes

- `GET /api/sightings` liefert `dt`/`ti` jetzt in Berlin-Zeit (neuer `berlinToChar`-Helper) statt UTC unter identischen Feldnamen wie `showreports.json`.
- Admin-Wetter-Refresh matcht die Berlin-Stunde über `hourIndexFromLocalTime` statt UTC (überschrieb korrekte Wetterdaten mit 1–2 h versetzten).
- Neuer Ausdrucksindex `idx_sichtungsdatum_berlin_tag` für den Admin-Datumsfilter; Migrations-Skript erweitert und auf der Entwicklungs-DB ausgerollt (EXPLAIN: Index Cond). **Beim Deployment auf jeder Zielumgebung ausführen:** `psql "$DATABASE_POSTGRES_URL" -v ON_ERROR_STOP=1 -f scripts/migrations/2026-07-28-timezone-aware-indexes.sql`
- OpenAPI korrigiert (`ti` war fälschlich als UTC dokumentiert), Zeitzonen-Abschnitt in `LEGACY_API_SPECIFICATION.md`, UTC-Migrationsschritt in `DATABASE_MIGRATION.md`.

## Mittlere/kleine Fixes

Statistik-Randdaten, Benachrichtigungsmail, Wetterzeitstempel (keine Doppelkonvertierung mehr), Karten-Popups, Heatmap, Export-Modal, Dropzone, Zukunfts-Validierung und „heute"-Checks — alles fest auf Europe/Berlin bzw. Berliner Kalendertag.

## Tests

Durchgängig test-first (RED→GREEN je Fix). `npm run test:quick` grün: Lint, Type-Check, Svelte-Check (0 Fehler), **1811 Unit-Tests in 118 Dateien**. Neue zonenkritische Tests laufen über `withTimeZone` in vier Referenz-Zeitzonen. Code-Review (`/review` + `/simplify`) ohne Verstöße; Konsolidierungen im letzten Commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
