### PR TITLE
fix(media): Storage-Dateien beim Löschen von Sichtungs-Dateizeilen mitlöschen

### DIFF
--- a/.claude/rules/upload.md
+++ b/.claude/rules/upload.md
@@ -57,6 +57,31 @@ list(prefix?): Promise<UploadedFileInfo[]>
 
 ---
 
+## Löschen: erst die DB-Zeile, dann die Datei
+
+Wer eine `sichtungen_dateien`-Zeile entfernt, muss auch die Datei im Storage
+entfernen — der Fremdschlüssel-Cascade tut das **nicht**. Reihenfolge ist
+vorgeschrieben:
+
+```typescript
+import { deleteStoredFiles } from '$lib/server/storage/deleteStoredFiles';
+
+// 1. Pfade lesen, solange die Zeilen existieren
+// 2. Zeilen löschen (direkt oder per Cascade über `sichtungen`)
+// 3. erst danach:
+await deleteStoredFiles(paths);
+```
+
+Bricht Schritt 3 ab, bleibt eine verwaiste Datei liegen — folgenlos, weil nichts
+mehr auf sie zeigt. In der umgekehrten Reihenfolge entstünde eine DB-Zeile, die
+auf eine fehlende Datei verweist, und die sieht der Nutzer als kaputtes Bild.
+`deleteStoredFiles()` wirft deshalb nie: der DB-Vorgang ist bereits committet.
+
+**Ausnahme (Altlast):** `POST /api/files/delete` löscht noch in umgekehrter
+Reihenfolge und meldet auch dann Erfolg, wenn die DB-Zeile stehen bleibt.
+
+---
+
 ## EXIF-Extraktion
 
 ```typescript

--- a/.claude/rules/upload.md
+++ b/.claude/rules/upload.md
@@ -66,11 +66,21 @@ vorgeschrieben:
 ```typescript
 import { deleteStoredFiles } from '$lib/server/storage/deleteStoredFiles';
 
-// 1. Pfade lesen, solange die Zeilen existieren
-// 2. Zeilen löschen (direkt oder per Cascade über `sichtungen`)
-// 3. erst danach:
-await deleteStoredFiles(paths);
+// Zeilen explizit löschen und die Pfade in derselben Anweisung mitnehmen
+const removed = await db
+	.delete(sightingFiles)
+	.where(eq(sightingFiles.sightingId, id))
+	.returning({ filePath: sightingFiles.filePath });
+
+// erst danach:
+await deleteStoredFiles(removed.map((file) => file.filePath));
 ```
+
+**Nicht auf die Cascade verlassen.** `onDelete: 'cascade'` räumt beim Löschen
+einer Sichtung zwar die Zeilen ab, aber lautlos — die Pfade sind dann weg. Ein
+vorgelagertes `select` wäre ebenfalls unzureichend: zwischen Lesen und Löschen
+kann eine Zeile dazukommen, die die Cascade unbemerkt mitnimmt. `delete … returning`
+in einer Transaktion mit dem Löschen der Sichtung schließt beides aus.
 
 Bricht Schritt 3 ab, bleibt eine verwaiste Datei liegen — folgenlos, weil nichts
 mehr auf sie zeigt. In der umgekehrten Reihenfolge entstünde eine DB-Zeile, die

--- a/src/lib/server/db/saveSightingFilesStorage.test.ts
+++ b/src/lib/server/db/saveSightingFilesStorage.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regressionstests: `saveSightingFiles()` ersetzt die Dateiliste einer Sichtung.
+ *
+ * Die alten `sichtungen_dateien`-Zeilen werden dabei gelöscht — ohne
+ * Storage-Aufruf bleiben die zugehörigen Dateien als verwaiste Objekte im
+ * Upload-Verzeichnis zurück.
+ */
+import type { UploadedFileInfo } from '$lib/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDb, mockStorage, callOrder, removedRows } = vi.hoisted(() => ({
+	mockDb: {
+		insert: vi.fn(),
+		delete: vi.fn(),
+		transaction: vi.fn()
+	},
+	mockStorage: { delete: vi.fn().mockResolvedValue(undefined), getUrl: vi.fn() },
+	callOrder: [] as string[],
+	removedRows: { value: [] as { filePath: string }[] }
+}));
+
+vi.mock('$lib/server/db', () => ({ db: mockDb }));
+
+vi.mock('$lib/server/storage/factory', () => ({
+	isCloudStorage: vi.fn(() => false),
+	getStorageProvider: vi.fn(() => mockStorage)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { saveSightingFiles } from './sightingRepository';
+
+/** Erzeugt eine Datei-Info mit dem gegebenen Pfad. */
+function file(filePath: string, uid = filePath): UploadedFileInfo {
+	return {
+		uid,
+		originalName: 'bild.jpg',
+		fileName: filePath,
+		filePath,
+		url: `/uploads/${filePath}`,
+		size: 1024,
+		mimeType: 'image/jpeg',
+		uploadedAt: new Date('2026-07-28T10:00:00Z').toISOString(),
+		exifData: null
+	};
+}
+
+/** Setzt den Transaktions-Mock so, dass `existing` als gelöschte Zeilen zurückkommt. */
+function mockTransactionRemoving(existing: string[]) {
+	removedRows.value = existing.map((filePath) => ({ filePath }));
+
+	const tx = {
+		delete: vi.fn(() => ({
+			where: vi.fn(() => ({
+				returning: vi.fn(async () => {
+					callOrder.push('tx:delete');
+					return removedRows.value;
+				})
+			}))
+		})),
+		insert: vi.fn(() => ({
+			values: vi.fn(async () => {
+				callOrder.push('tx:insert');
+			})
+		}))
+	};
+
+	mockDb.transaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+		callOrder.push('tx:begin');
+		const result = await callback(tx);
+		callOrder.push('tx:commit');
+		return result;
+	});
+
+	return tx;
+}
+
+describe('saveSightingFiles — Storage-Aufräumen', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		callOrder.length = 0;
+		mockStorage.delete.mockResolvedValue(undefined);
+	});
+
+	it('löscht Dateien aus dem Storage, die nicht mehr verknüpft sind', async () => {
+		mockTransactionRemoving(['uploads/alt-1.jpg', 'uploads/alt-2.jpg']);
+
+		await saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123');
+
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/alt-1.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/alt-2.jpg');
+	});
+
+	it('behält Dateien, die weiterhin in der neuen Liste stehen', async () => {
+		mockTransactionRemoving(['uploads/bleibt.jpg', 'uploads/weg.jpg']);
+
+		await saveSightingFiles(42, [file('uploads/bleibt.jpg'), file('uploads/neu.jpg')], 'ref-123');
+
+		expect(mockStorage.delete).toHaveBeenCalledTimes(1);
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/weg.jpg');
+	});
+
+	it('löscht die Dateien erst nach dem Commit der Transaktion', async () => {
+		mockTransactionRemoving(['uploads/weg.jpg']);
+		mockStorage.delete.mockImplementation(async () => {
+			callOrder.push('storage:delete');
+		});
+
+		await saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123');
+
+		expect(callOrder).toEqual([
+			'tx:begin',
+			'tx:delete',
+			'tx:insert',
+			'tx:commit',
+			'storage:delete'
+		]);
+	});
+
+	it('scheitert nicht, wenn eine Datei nicht aus dem Storage entfernt werden kann', async () => {
+		mockTransactionRemoving(['uploads/weg.jpg']);
+		mockStorage.delete.mockRejectedValue(new Error('ENOENT'));
+
+		// Eine liegengebliebene Datei ist folgenlos — die bereits committete
+		// DB-Änderung darf davon nicht zurückgenommen werden.
+		await expect(
+			saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123')
+		).resolves.toBeUndefined();
+	});
+
+	it('rührt den Storage bei leerer Dateiliste nicht an', async () => {
+		mockTransactionRemoving(['uploads/weg.jpg']);
+
+		await saveSightingFiles(42, [], 'ref-123');
+
+		expect(mockDb.transaction).not.toHaveBeenCalled();
+		expect(mockStorage.delete).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/db/saveSightingFilesStorage.test.ts
+++ b/src/lib/server/db/saveSightingFilesStorage.test.ts
@@ -89,31 +89,35 @@ describe('saveSightingFiles — Storage-Aufräumen', () => {
 	});
 
 	it('löscht Dateien aus dem Storage, die nicht mehr verknüpft sind', async () => {
-		mockTransactionRemoving(['uploads/alt-1.jpg', 'uploads/alt-2.jpg']);
+		mockTransactionRemoving(['ref-abc123/alt-1.jpg', 'ref-abc123/alt-2.jpg']);
 
-		await saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123');
+		await saveSightingFiles(42, [file('ref-abc123/neu.jpg')], 'ref-123');
 
 		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/alt-1.jpg');
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/alt-2.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/alt-1.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/alt-2.jpg');
 	});
 
 	it('behält Dateien, die weiterhin in der neuen Liste stehen', async () => {
-		mockTransactionRemoving(['uploads/bleibt.jpg', 'uploads/weg.jpg']);
+		mockTransactionRemoving(['ref-abc123/bleibt.jpg', 'ref-abc123/weg.jpg']);
 
-		await saveSightingFiles(42, [file('uploads/bleibt.jpg'), file('uploads/neu.jpg')], 'ref-123');
+		await saveSightingFiles(
+			42,
+			[file('ref-abc123/bleibt.jpg'), file('ref-abc123/neu.jpg')],
+			'ref-123'
+		);
 
 		expect(mockStorage.delete).toHaveBeenCalledTimes(1);
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/weg.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/weg.jpg');
 	});
 
 	it('löscht die Dateien erst nach dem Commit der Transaktion', async () => {
-		mockTransactionRemoving(['uploads/weg.jpg']);
+		mockTransactionRemoving(['ref-abc123/weg.jpg']);
 		mockStorage.delete.mockImplementation(async () => {
 			callOrder.push('storage:delete');
 		});
 
-		await saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123');
+		await saveSightingFiles(42, [file('ref-abc123/neu.jpg')], 'ref-123');
 
 		expect(callOrder).toEqual([
 			'tx:begin',
@@ -125,18 +129,18 @@ describe('saveSightingFiles — Storage-Aufräumen', () => {
 	});
 
 	it('scheitert nicht, wenn eine Datei nicht aus dem Storage entfernt werden kann', async () => {
-		mockTransactionRemoving(['uploads/weg.jpg']);
+		mockTransactionRemoving(['ref-abc123/weg.jpg']);
 		mockStorage.delete.mockRejectedValue(new Error('ENOENT'));
 
 		// Eine liegengebliebene Datei ist folgenlos — die bereits committete
 		// DB-Änderung darf davon nicht zurückgenommen werden.
 		await expect(
-			saveSightingFiles(42, [file('uploads/neu.jpg')], 'ref-123')
+			saveSightingFiles(42, [file('ref-abc123/neu.jpg')], 'ref-123')
 		).resolves.toBeUndefined();
 	});
 
 	it('rührt den Storage bei leerer Dateiliste nicht an', async () => {
-		mockTransactionRemoving(['uploads/weg.jpg']);
+		mockTransactionRemoving(['ref-abc123/weg.jpg']);
 
 		await saveSightingFiles(42, [], 'ref-123');
 

--- a/src/lib/server/db/sightingRepository.test.ts
+++ b/src/lib/server/db/sightingRepository.test.ts
@@ -23,7 +23,8 @@ vi.mock('$lib/server/db', () => {
 		select: vi.fn(),
 		execute: vi.fn(),
 		delete: vi.fn(() => ({
-			where: vi.fn().mockResolvedValue(undefined)
+			// saveSightingFiles liest die Pfade der entfernten Zeilen per returning()
+			where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }))
 		})),
 		// transaction runs the callback with the same mock so existing assertions work
 		transaction: vi.fn(async (callback: (tx: typeof db) => Promise<unknown>) => callback(db))
@@ -43,7 +44,8 @@ vi.mock('./mapFormToSighting', () => ({
 vi.mock('$lib/server/storage/factory', () => ({
 	isCloudStorage: vi.fn(() => false),
 	getStorageProvider: vi.fn(() => ({
-		getUrl: vi.fn((path) => `/uploads/${path}`)
+		getUrl: vi.fn((path) => `/uploads/${path}`),
+		delete: vi.fn().mockResolvedValue(undefined)
 	}))
 }));
 // vi.hoisted ensures this runs before the hoisted vi.mock factory
@@ -589,7 +591,7 @@ describe('sightingRepository', () => {
 
 			// Mock delete to return successful where chain
 			mockDb.delete.mockReturnValue({
-				where: vi.fn().mockResolvedValue(undefined)
+				where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }))
 			});
 
 			mockDb.insert.mockReturnValue({
@@ -629,7 +631,7 @@ describe('sightingRepository', () => {
 
 			// Mock delete to return successful where chain
 			mockDb.delete.mockReturnValue({
-				where: vi.fn().mockResolvedValue(undefined)
+				where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) }))
 			});
 
 			// Mock insert to fail

--- a/src/lib/server/db/sightingRepository.ts
+++ b/src/lib/server/db/sightingRepository.ts
@@ -34,6 +34,7 @@ import {
 import { readImageExifData } from '$lib/server/media/exifUtils';
 import { mapFormToSighting } from '$lib/server/db/mapFormToSighting';
 import { setSightingIdForReferenceId } from '$lib/server/db/sightingFilesRepository';
+import { deleteStoredFiles } from '$lib/server/storage/deleteStoredFiles';
 
 // Logger für Repository-Operationen
 const logger = createLogger('db:sightingRepository');
@@ -318,11 +319,22 @@ export const saveSightingFiles = async (
 		exifData: file.exifData || null
 	}));
 
-	// Delete existing and insert new file references atomically
-	await db.transaction(async (tx) => {
-		await tx.delete(sightingFiles).where(eq(sightingFiles.sightingId, sightingId));
+	// Delete existing and insert new file references atomically.
+	// `returning` liefert die Pfade der entfernten Zeilen — ohne sie wüsste
+	// niemand mehr, welche Dateien im Storage noch aufzuräumen sind.
+	const removedPaths = await db.transaction(async (tx) => {
+		const removed = await tx
+			.delete(sightingFiles)
+			.where(eq(sightingFiles.sightingId, sightingId))
+			.returning({ filePath: sightingFiles.filePath });
 		await tx.insert(sightingFiles).values(fileData);
+		return removed.map((file) => file.filePath);
 	});
+
+	// Nur Dateien löschen, die in der neuen Liste nicht mehr vorkommen —
+	// unveränderte Dateien wurden gerade nur neu verknüpft.
+	const keptPaths = new Set(fileData.map((file) => file.filePath));
+	await deleteStoredFiles(removedPaths.filter((filePath) => !keptPaths.has(filePath)));
 
 	logger.info(
 		{

--- a/src/lib/server/storage/deleteStoredFiles.test.ts
+++ b/src/lib/server/storage/deleteStoredFiles.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit Tests für deleteStoredFiles().
+ *
+ * Die Funktion läuft immer NACH einem bereits committeten DB-Vorgang — sie darf
+ * deshalb unter keinen Umständen werfen.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockStorage, mockGetStorageProvider } = vi.hoisted(() => ({
+	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
+	mockGetStorageProvider: vi.fn()
+}));
+
+vi.mock('./factory', () => ({
+	getStorageProvider: mockGetStorageProvider
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { deleteStoredFiles } from './deleteStoredFiles';
+
+describe('deleteStoredFiles', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockStorage.delete.mockResolvedValue(undefined);
+		mockGetStorageProvider.mockReturnValue(mockStorage);
+	});
+
+	it('löscht jeden übergebenen Pfad', async () => {
+		await deleteStoredFiles(['uploads/a.jpg', 'uploads/b.png']);
+
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/a.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/b.png');
+	});
+
+	it('löscht einen mehrfach referenzierten Pfad nur einmal', async () => {
+		await deleteStoredFiles(['uploads/a.jpg', 'uploads/a.jpg', 'uploads/b.png']);
+
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+	});
+
+	it('fordert bei leerer Liste gar keinen Storage-Provider an', async () => {
+		await deleteStoredFiles([]);
+
+		expect(mockGetStorageProvider).not.toHaveBeenCalled();
+	});
+
+	it('löscht die übrigen Dateien weiter, wenn eine fehlschlägt', async () => {
+		mockStorage.delete.mockRejectedValueOnce(new Error('ENOENT'));
+
+		await expect(
+			deleteStoredFiles(['uploads/kaputt.jpg', 'uploads/ok.png'])
+		).resolves.toBeUndefined();
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+	});
+
+	it('wirft nicht, wenn der Storage-Provider nicht verfügbar ist', async () => {
+		mockGetStorageProvider.mockImplementation(() => {
+			throw new Error('Unknown storage provider: s3');
+		});
+
+		await expect(deleteStoredFiles(['uploads/a.jpg'])).resolves.toBeUndefined();
+		expect(mockStorage.delete).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/server/storage/deleteStoredFiles.test.ts
+++ b/src/lib/server/storage/deleteStoredFiles.test.ts
@@ -29,15 +29,15 @@ describe('deleteStoredFiles', () => {
 	});
 
 	it('löscht jeden übergebenen Pfad', async () => {
-		await deleteStoredFiles(['uploads/a.jpg', 'uploads/b.png']);
+		await deleteStoredFiles(['ref-abc123/a.jpg', 'ref-abc123/b.png']);
 
 		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/a.jpg');
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/b.png');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/a.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/b.png');
 	});
 
 	it('löscht einen mehrfach referenzierten Pfad nur einmal', async () => {
-		await deleteStoredFiles(['uploads/a.jpg', 'uploads/a.jpg', 'uploads/b.png']);
+		await deleteStoredFiles(['ref-abc123/a.jpg', 'ref-abc123/a.jpg', 'ref-abc123/b.png']);
 
 		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
 	});
@@ -52,7 +52,7 @@ describe('deleteStoredFiles', () => {
 		mockStorage.delete.mockRejectedValueOnce(new Error('ENOENT'));
 
 		await expect(
-			deleteStoredFiles(['uploads/kaputt.jpg', 'uploads/ok.png'])
+			deleteStoredFiles(['ref-abc123/kaputt.jpg', 'ref-abc123/ok.png'])
 		).resolves.toBeUndefined();
 		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
 	});
@@ -62,7 +62,7 @@ describe('deleteStoredFiles', () => {
 			throw new Error('Unknown storage provider: s3');
 		});
 
-		await expect(deleteStoredFiles(['uploads/a.jpg'])).resolves.toBeUndefined();
+		await expect(deleteStoredFiles(['ref-abc123/a.jpg'])).resolves.toBeUndefined();
 		expect(mockStorage.delete).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/server/storage/deleteStoredFiles.ts
+++ b/src/lib/server/storage/deleteStoredFiles.ts
@@ -1,0 +1,54 @@
+import { createLogger } from '$lib/logger.server';
+import type { StorageProvider } from '$lib/types';
+import { getStorageProvider } from './factory';
+
+const logger = createLogger('storage:deleteStoredFiles');
+
+/**
+ * Entfernt Dateien aus dem Storage, deren `sichtungen_dateien`-Zeilen bereits
+ * gelöscht wurden.
+ *
+ * **Reihenfolge:** Erst die DB-Zeilen löschen, dann diese Funktion aufrufen.
+ * Bleibt eine Datei liegen, ist sie ein verwaistes Objekt im Upload-Verzeichnis:
+ * ärgerlich, aber für die Anwendung folgenlos, weil niemand mehr darauf zeigt.
+ * In der umgekehrten Reihenfolge entstünde eine DB-Zeile, die auf eine nicht
+ * mehr vorhandene Datei verweist — und die sieht der Nutzer als kaputtes Bild.
+ *
+ * Fehler einzelner Löschvorgänge werden deshalb nur geloggt und nicht
+ * weitergeworfen: Der aufrufende Vorgang ist zu diesem Zeitpunkt bereits
+ * committet und darf nicht nachträglich scheitern.
+ *
+ * Verwaiste Dateien müssen separat aufgeräumt werden — ein Werkzeug dafür ist
+ * entworfen, aber noch nicht gebaut. Bis dahin ist die Log-Zeile
+ * `Datei konnte nicht aus dem Storage gelöscht werden` der einzige Hinweis.
+ *
+ * @param filePaths Storage-Pfade (`sichtungen_dateien.datei_pfad`)
+ */
+export async function deleteStoredFiles(filePaths: string[]): Promise<void> {
+	// Dieselbe Datei kann an mehreren Zeilen hängen — ein Löschversuch genügt
+	const uniquePaths = [...new Set(filePaths)];
+	if (uniquePaths.length === 0) return;
+
+	let storageProvider: StorageProvider;
+	try {
+		storageProvider = getStorageProvider();
+	} catch (err) {
+		logger.error({ err, fileCount: uniquePaths.length }, 'Storage-Provider nicht verfügbar');
+		return;
+	}
+
+	const results = await Promise.all(
+		uniquePaths.map(async (filePath) => {
+			try {
+				await storageProvider.delete(filePath);
+				return true;
+			} catch (err) {
+				logger.warn({ err, filePath }, 'Datei konnte nicht aus dem Storage gelöscht werden');
+				return false;
+			}
+		})
+	);
+
+	const deleted = results.filter(Boolean).length;
+	logger.info({ deleted, failed: results.length - deleted }, 'Storage-Dateien aufgeräumt');
+}

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -226,19 +226,23 @@ export const DELETE: RequestHandler = async ({
 			throw error(404, 'Sichtung nicht gefunden');
 		}
 
-		// Dateipfade einsammeln, solange die Zeilen noch existieren: der
-		// Fremdschlüssel löscht sie gleich per Cascade mit, der Storage weiß davon
-		// nichts.
-		const linkedFiles = await db
-			.select({ filePath: sightingFiles.filePath })
-			.from(sightingFiles)
-			.where(eq(sightingFiles.sightingId, Number(id)));
+		// Die Dateizeilen explizit löschen statt sie still per Cascade verschwinden
+		// zu lassen: `returning` liefert die Pfade, die der Storage sonst nie
+		// erfährt. Lesen und Löschen in einer Anweisung schließt zudem aus, dass
+		// dazwischen eine neue Zeile entsteht, die die Cascade unbemerkt mitnimmt.
+		const removedFiles = await db.transaction(async (tx) => {
+			const removed = await tx
+				.delete(sightingFiles)
+				.where(eq(sightingFiles.sightingId, Number(id)))
+				.returning({ filePath: sightingFiles.filePath });
 
-		// Sichtung löschen (Cascade entfernt die sichtungen_dateien-Zeilen)
-		await db.delete(sightings).where(eq(sightings.id, Number(id)));
+			await tx.delete(sightings).where(eq(sightings.id, Number(id)));
 
-		// Erst nach dem Löschen der Zeilen — siehe deleteStoredFiles()
-		await deleteStoredFiles(linkedFiles.map((file) => file.filePath));
+			return removed;
+		});
+
+		// Erst nach dem Commit — siehe deleteStoredFiles()
+		await deleteStoredFiles(removedFiles.map((file) => file.filePath));
 
 		const ipAddress = getClientIp(getClientAddress, request);
 		await logAuditEvent({

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -5,7 +5,8 @@ import { logAuditEvent } from '$lib/server/audit/auditService';
 import { requireUserRole } from '$lib/server/auth/auth';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { db } from '$lib/server/db';
-import { sightings } from '$lib/server/db/schema';
+import { sightingFiles, sightings } from '$lib/server/db/schema';
+import { deleteStoredFiles } from '$lib/server/storage/deleteStoredFiles';
 import { posix } from 'path';
 import {
 	loadSightingFiles,
@@ -225,8 +226,19 @@ export const DELETE: RequestHandler = async ({
 			throw error(404, 'Sichtung nicht gefunden');
 		}
 
-		// Sichtung löschen (cascade delete für zugehörige Dateien)
+		// Dateipfade einsammeln, solange die Zeilen noch existieren: der
+		// Fremdschlüssel löscht sie gleich per Cascade mit, der Storage weiß davon
+		// nichts.
+		const linkedFiles = await db
+			.select({ filePath: sightingFiles.filePath })
+			.from(sightingFiles)
+			.where(eq(sightingFiles.sightingId, Number(id)));
+
+		// Sichtung löschen (Cascade entfernt die sichtungen_dateien-Zeilen)
 		await db.delete(sightings).where(eq(sightings.id, Number(id)));
+
+		// Erst nach dem Löschen der Zeilen — siehe deleteStoredFiles()
+		await deleteStoredFiles(linkedFiles.map((file) => file.filePath));
 
 		const ipAddress = getClientIp(getClientAddress, request);
 		await logAuditEvent({

--- a/src/routes/api/sightings/[id]/deleteStorageCleanup.test.ts
+++ b/src/routes/api/sightings/[id]/deleteStorageCleanup.test.ts
@@ -5,22 +5,25 @@
  * Der Fremdschlüssel `sichtungen_dateien.sichtung_id` hat `onDelete: 'cascade'`
  * — die DB-Zeilen verschwinden also von selbst. Ohne expliziten Storage-Aufruf
  * bleiben die Dateien im Upload-Verzeichnis als verwaiste Objekte zurück.
+ *
+ * `filePath` ist der Storage-Key `referenceId/dateiname` (siehe
+ * `LocalStorageProvider.upload`) — nicht die öffentliche URL `/uploads/...`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockSchema, mockSelect, mockDelete, mockStorage, callOrder } = vi.hoisted(() => ({
+const { mockSchema, mockSelect, mockTransaction, mockStorage, callOrder } = vi.hoisted(() => ({
 	mockSchema: {
 		sightings: { id: 'sichtungen.id' },
 		sightingFiles: { sightingId: 'sichtungen_dateien.sichtung_id', filePath: 'datei_pfad' }
 	},
 	mockSelect: vi.fn(),
-	mockDelete: vi.fn(),
+	mockTransaction: vi.fn(),
 	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
 	callOrder: [] as string[]
 }));
 
 vi.mock('$lib/server/db', () => ({
-	db: { select: mockSelect, delete: mockDelete }
+	db: { select: mockSelect, transaction: mockTransaction }
 }));
 
 vi.mock('$lib/server/db/schema', () => mockSchema);
@@ -52,28 +55,36 @@ vi.mock('$lib/logger', () => ({
 import { DELETE } from './+server';
 
 /**
- * Baut den Select-Mock so, dass die Existenzprüfung eine Sichtung findet und
- * die Datei-Abfrage die übergebenen Pfade liefert.
+ * Baut die DB-Mocks so, dass die Existenzprüfung eine Sichtung findet und das
+ * Löschen der Dateizeilen die übergebenen Pfade zurückgibt.
  */
 function mockDbWithFiles(filePaths: string[]) {
 	mockSelect.mockImplementation(() => ({
-		from: (table: unknown) => ({
-			where: () => {
-				if (table === mockSchema.sightings) {
-					return { limit: () => Promise.resolve([{ id: 123 }]) };
-				}
-				callOrder.push('select:files');
-				return Promise.resolve(filePaths.map((filePath) => ({ filePath })));
-			}
-		})
+		from: () => ({ where: () => ({ limit: () => Promise.resolve([{ id: 123 }]) }) })
 	}));
 
-	mockDelete.mockImplementation(() => ({
-		where: () => {
-			callOrder.push('delete:sighting');
-			return Promise.resolve();
-		}
-	}));
+	const tx = {
+		delete: (table: unknown) => ({
+			where: () => {
+				if (table === mockSchema.sightingFiles) {
+					return {
+						returning: async () => {
+							callOrder.push('tx:delete-files');
+							return filePaths.map((filePath) => ({ filePath }));
+						}
+					};
+				}
+				callOrder.push('tx:delete-sighting');
+				return Promise.resolve();
+			}
+		})
+	};
+
+	mockTransaction.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) => {
+		const result = await callback(tx);
+		callOrder.push('tx:commit');
+		return result;
+	});
 }
 
 function makeEvent(id = '123') {
@@ -94,25 +105,30 @@ describe('DELETE /api/sightings/[id] — Storage-Aufräumen', () => {
 	});
 
 	it('löscht die zugehörigen Dateien aus dem Storage', async () => {
-		mockDbWithFiles(['uploads/a.jpg', 'uploads/b.png']);
+		mockDbWithFiles(['ref-abc123/a1b2c3d4.jpg', 'ref-abc123/e5f6g7h8.png']);
 
 		const response = await DELETE(makeEvent());
 
 		expect(response.status).toBe(200);
 		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/a.jpg');
-		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/b.png');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/a1b2c3d4.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('ref-abc123/e5f6g7h8.png');
 	});
 
-	it('liest die Dateipfade vor dem Löschen der Sichtung und löscht die Dateien danach', async () => {
-		mockDbWithFiles(['uploads/a.jpg']);
+	it('löscht Dateizeilen und Sichtung in einer Transaktion, den Storage erst danach', async () => {
+		mockDbWithFiles(['ref-abc123/a1b2c3d4.jpg']);
 		mockStorage.delete.mockImplementation(async () => {
 			callOrder.push('storage:delete');
 		});
 
 		await DELETE(makeEvent());
 
-		expect(callOrder).toEqual(['select:files', 'delete:sighting', 'storage:delete']);
+		expect(callOrder).toEqual([
+			'tx:delete-files',
+			'tx:delete-sighting',
+			'tx:commit',
+			'storage:delete'
+		]);
 	});
 
 	it('ruft den Storage nicht auf, wenn keine Dateien verknüpft sind', async () => {
@@ -124,7 +140,7 @@ describe('DELETE /api/sightings/[id] — Storage-Aufräumen', () => {
 	});
 
 	it('meldet Erfolg, auch wenn eine Datei nicht aus dem Storage entfernt werden kann', async () => {
-		mockDbWithFiles(['uploads/a.jpg', 'uploads/b.png']);
+		mockDbWithFiles(['ref-abc123/a1b2c3d4.jpg', 'ref-abc123/e5f6g7h8.png']);
 		mockStorage.delete.mockRejectedValueOnce(new Error('ENOENT'));
 
 		const response = await DELETE(makeEvent());

--- a/src/routes/api/sightings/[id]/deleteStorageCleanup.test.ts
+++ b/src/routes/api/sightings/[id]/deleteStorageCleanup.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regressionstests: Beim Löschen einer Sichtung müssen auch die Dateien im
+ * Storage verschwinden.
+ *
+ * Der Fremdschlüssel `sichtungen_dateien.sichtung_id` hat `onDelete: 'cascade'`
+ * — die DB-Zeilen verschwinden also von selbst. Ohne expliziten Storage-Aufruf
+ * bleiben die Dateien im Upload-Verzeichnis als verwaiste Objekte zurück.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSchema, mockSelect, mockDelete, mockStorage, callOrder } = vi.hoisted(() => ({
+	mockSchema: {
+		sightings: { id: 'sichtungen.id' },
+		sightingFiles: { sightingId: 'sichtungen_dateien.sichtung_id', filePath: 'datei_pfad' }
+	},
+	mockSelect: vi.fn(),
+	mockDelete: vi.fn(),
+	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) },
+	callOrder: [] as string[]
+}));
+
+vi.mock('$lib/server/db', () => ({
+	db: { select: mockSelect, delete: mockDelete }
+}));
+
+vi.mock('$lib/server/db/schema', () => mockSchema);
+
+vi.mock('drizzle-orm', () => ({
+	eq: vi.fn((a, b) => ({ a, b }))
+}));
+
+vi.mock('$lib/server/storage/factory', () => ({
+	getStorageProvider: vi.fn(() => mockStorage)
+}));
+
+vi.mock('$lib/server/auth/auth', () => ({
+	requireUserRole: vi.fn()
+}));
+
+vi.mock('$lib/server/audit/auditService', () => ({
+	logAuditEvent: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { DELETE } from './+server';
+
+/**
+ * Baut den Select-Mock so, dass die Existenzprüfung eine Sichtung findet und
+ * die Datei-Abfrage die übergebenen Pfade liefert.
+ */
+function mockDbWithFiles(filePaths: string[]) {
+	mockSelect.mockImplementation(() => ({
+		from: (table: unknown) => ({
+			where: () => {
+				if (table === mockSchema.sightings) {
+					return { limit: () => Promise.resolve([{ id: 123 }]) };
+				}
+				callOrder.push('select:files');
+				return Promise.resolve(filePaths.map((filePath) => ({ filePath })));
+			}
+		})
+	}));
+
+	mockDelete.mockImplementation(() => ({
+		where: () => {
+			callOrder.push('delete:sighting');
+			return Promise.resolve();
+		}
+	}));
+}
+
+function makeEvent(id = '123') {
+	return {
+		params: { id },
+		locals: { user: { email: 'admin@test.com', roles: ['admin'] } },
+		url: new URL(`http://localhost/api/sightings/${id}`),
+		request: new Request(`http://localhost/api/sightings/${id}`, { method: 'DELETE' }),
+		getClientAddress: () => '127.0.0.1'
+	} as never;
+}
+
+describe('DELETE /api/sightings/[id] — Storage-Aufräumen', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		callOrder.length = 0;
+		mockStorage.delete.mockResolvedValue(undefined);
+	});
+
+	it('löscht die zugehörigen Dateien aus dem Storage', async () => {
+		mockDbWithFiles(['uploads/a.jpg', 'uploads/b.png']);
+
+		const response = await DELETE(makeEvent());
+
+		expect(response.status).toBe(200);
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/a.jpg');
+		expect(mockStorage.delete).toHaveBeenCalledWith('uploads/b.png');
+	});
+
+	it('liest die Dateipfade vor dem Löschen der Sichtung und löscht die Dateien danach', async () => {
+		mockDbWithFiles(['uploads/a.jpg']);
+		mockStorage.delete.mockImplementation(async () => {
+			callOrder.push('storage:delete');
+		});
+
+		await DELETE(makeEvent());
+
+		expect(callOrder).toEqual(['select:files', 'delete:sighting', 'storage:delete']);
+	});
+
+	it('ruft den Storage nicht auf, wenn keine Dateien verknüpft sind', async () => {
+		mockDbWithFiles([]);
+
+		await DELETE(makeEvent());
+
+		expect(mockStorage.delete).not.toHaveBeenCalled();
+	});
+
+	it('meldet Erfolg, auch wenn eine Datei nicht aus dem Storage entfernt werden kann', async () => {
+		mockDbWithFiles(['uploads/a.jpg', 'uploads/b.png']);
+		mockStorage.delete.mockRejectedValueOnce(new Error('ENOENT'));
+
+		const response = await DELETE(makeEvent());
+
+		// Die Sichtung ist weg — eine liegengebliebene Datei ist folgenlos, weil
+		// keine DB-Zeile mehr auf sie zeigt, und kein Grund für einen 500er.
+		expect(response.status).toBe(200);
+		expect(mockStorage.delete).toHaveBeenCalledTimes(2);
+	});
+});

--- a/src/routes/api/sightings/[id]/endpoint.test.ts
+++ b/src/routes/api/sightings/[id]/endpoint.test.ts
@@ -11,17 +11,20 @@ const { mockSchema } = vi.hoisted(() => ({
 vi.mock('$lib/server/db', () => ({
 	db: {
 		select: () => ({
-			from: (table: unknown) => ({
-				// Die Datei-Abfrage wird direkt awaited, die Sichtungs-Abfrage über .limit(1)
-				where: () =>
-					table === mockSchema.sightingFiles
-						? Promise.resolve([])
-						: { limit: () => Promise.resolve([{ id: 123 }]) }
+			from: () => ({
+				where: () => ({ limit: () => Promise.resolve([{ id: 123 }]) })
 			})
 		}),
-		delete: () => ({
-			where: () => Promise.resolve()
-		})
+		// DELETE löscht Dateizeilen und Sichtung gemeinsam in einer Transaktion
+		transaction: (callback: (tx: unknown) => Promise<unknown>) =>
+			callback({
+				delete: (table: unknown) => ({
+					where: () =>
+						table === mockSchema.sightingFiles
+							? { returning: () => Promise.resolve([]) }
+							: Promise.resolve()
+				})
+			})
 	}
 }));
 

--- a/src/routes/api/sightings/[id]/endpoint.test.ts
+++ b/src/routes/api/sightings/[id]/endpoint.test.ts
@@ -1,13 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DELETE } from './+server';
 
+const { mockSchema } = vi.hoisted(() => ({
+	mockSchema: {
+		sightings: { id: 'id' },
+		sightingFiles: { sightingId: 'sichtung_id', filePath: 'datei_pfad' }
+	}
+}));
+
 vi.mock('$lib/server/db', () => ({
 	db: {
 		select: () => ({
-			from: () => ({
-				where: () => ({
-					limit: () => Promise.resolve([{ id: 123 }])
-				})
+			from: (table: unknown) => ({
+				// Die Datei-Abfrage wird direkt awaited, die Sichtungs-Abfrage über .limit(1)
+				where: () =>
+					table === mockSchema.sightingFiles
+						? Promise.resolve([])
+						: { limit: () => Promise.resolve([{ id: 123 }]) }
 			})
 		}),
 		delete: () => ({
@@ -16,8 +25,10 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: { id: 'id' }
+vi.mock('$lib/server/db/schema', () => mockSchema);
+
+vi.mock('$lib/server/storage/factory', () => ({
+	getStorageProvider: vi.fn(() => ({ delete: vi.fn().mockResolvedValue(undefined) }))
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -55,7 +66,10 @@ describe('/api/sightings/[id] DELETE endpoint', () => {
 		vi.clearAllMocks();
 	});
 
-	const createMockRequestEvent = (id: string, user: { email: string; roles: string[] } | null = { email: 'admin@test.com', roles: ['admin'] }) => {
+	const createMockRequestEvent = (
+		id: string,
+		user: { email: string; roles: string[] } | null = { email: 'admin@test.com', roles: ['admin'] }
+	) => {
 		return {
 			params: { id },
 			locals: { user },

--- a/src/routes/api/sightings/[id]/sighting.test.ts
+++ b/src/routes/api/sightings/[id]/sighting.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockLogAuditEvent, mockSelect, mockDelete } = vi.hoisted(() => ({
+const { mockLogAuditEvent, mockSelect, mockDelete, mockSchema, mockStorage } = vi.hoisted(() => ({
 	mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
 	mockSelect: vi.fn(),
-	mockDelete: vi.fn()
+	mockDelete: vi.fn(),
+	mockSchema: { sightings: {}, sightingFiles: {} },
+	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) }
 }));
 
 vi.mock('$lib/server/audit/auditService', () => ({
@@ -30,8 +32,10 @@ vi.mock('$lib/server/db', () => ({
 	db: { select: mockSelect, delete: mockDelete }
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {}
+vi.mock('$lib/server/db/schema', () => mockSchema);
+
+vi.mock('$lib/server/storage/factory', () => ({
+	getStorageProvider: vi.fn(() => mockStorage)
 }));
 
 vi.mock('$lib/server/db/sightingRepository', () => ({
@@ -47,11 +51,19 @@ vi.mock('drizzle-orm', () => ({
 import { PUT, DELETE } from './+server';
 import * as sightingRepository from '$lib/server/db/sightingRepository';
 
-function makeSelectChain(records: unknown[]) {
-	const mockLimit = vi.fn().mockResolvedValue(records);
-	const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
-	const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
-	mockSelect.mockReturnValue({ from: mockFrom });
+/**
+ * @param records Treffer der Sichtungs-Abfrage (`.limit(1)`)
+ * @param fileRecords Treffer der Datei-Abfrage (ohne `.limit()`, direkt awaited)
+ */
+function makeSelectChain(records: unknown[], fileRecords: { filePath: string }[] = []) {
+	mockSelect.mockImplementation(() => ({
+		from: (table: unknown) => ({
+			where: () =>
+				table === mockSchema.sightingFiles
+					? Promise.resolve(fileRecords)
+					: { limit: vi.fn().mockResolvedValue(records) }
+		})
+	}));
 }
 
 function makeDeleteChain() {

--- a/src/routes/api/sightings/[id]/sighting.test.ts
+++ b/src/routes/api/sightings/[id]/sighting.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockLogAuditEvent, mockSelect, mockDelete, mockSchema, mockStorage } = vi.hoisted(() => ({
-	mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
-	mockSelect: vi.fn(),
-	mockDelete: vi.fn(),
-	mockSchema: { sightings: {}, sightingFiles: {} },
-	mockStorage: { delete: vi.fn().mockResolvedValue(undefined) }
-}));
+const { mockLogAuditEvent, mockSelect, mockTransaction, mockSchema, mockStorage } = vi.hoisted(
+	() => ({
+		mockLogAuditEvent: vi.fn().mockResolvedValue(undefined),
+		mockSelect: vi.fn(),
+		mockTransaction: vi.fn(),
+		mockSchema: { sightings: {}, sightingFiles: {} },
+		mockStorage: { delete: vi.fn().mockResolvedValue(undefined) }
+	})
+);
 
 vi.mock('$lib/server/audit/auditService', () => ({
 	logAuditEvent: mockLogAuditEvent
@@ -29,7 +31,7 @@ vi.mock('$lib/form/validation/sightingSchema', () => ({
 }));
 
 vi.mock('$lib/server/db', () => ({
-	db: { select: mockSelect, delete: mockDelete }
+	db: { select: mockSelect, transaction: mockTransaction }
 }));
 
 vi.mock('$lib/server/db/schema', () => mockSchema);
@@ -51,24 +53,29 @@ vi.mock('drizzle-orm', () => ({
 import { PUT, DELETE } from './+server';
 import * as sightingRepository from '$lib/server/db/sightingRepository';
 
-/**
- * @param records Treffer der Sichtungs-Abfrage (`.limit(1)`)
- * @param fileRecords Treffer der Datei-Abfrage (ohne `.limit()`, direkt awaited)
- */
-function makeSelectChain(records: unknown[], fileRecords: { filePath: string }[] = []) {
-	mockSelect.mockImplementation(() => ({
-		from: (table: unknown) => ({
-			where: () =>
-				table === mockSchema.sightingFiles
-					? Promise.resolve(fileRecords)
-					: { limit: vi.fn().mockResolvedValue(records) }
-		})
-	}));
+function makeSelectChain(records: unknown[]) {
+	const mockLimit = vi.fn().mockResolvedValue(records);
+	const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+	const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+	mockSelect.mockReturnValue({ from: mockFrom });
 }
 
-function makeDeleteChain() {
-	const mockWhere = vi.fn().mockResolvedValue(undefined);
-	mockDelete.mockReturnValue({ where: mockWhere });
+/**
+ * DELETE löscht Dateizeilen (mit `returning`) und Sichtung in einer Transaktion.
+ *
+ * @param fileRecords Pfade der entfernten `sichtungen_dateien`-Zeilen
+ */
+function makeDeleteTransaction(fileRecords: { filePath: string }[] = []) {
+	mockTransaction.mockImplementation((callback: (tx: unknown) => Promise<unknown>) =>
+		callback({
+			delete: (table: unknown) => ({
+				where: () =>
+					table === mockSchema.sightingFiles
+						? { returning: vi.fn().mockResolvedValue(fileRecords) }
+						: Promise.resolve()
+			})
+		})
+	);
 }
 
 function makeAdminLocals() {
@@ -155,7 +162,7 @@ describe('DELETE /api/sightings/[id] — Audit Logging', () => {
 
 	it('loggt sighting.delete nach erfolgreichem Löschen', async () => {
 		makeSelectChain([{ id: 42 }]);
-		makeDeleteChain();
+		makeDeleteTransaction();
 
 		const event = {
 			params: { id: '42' },

--- a/src/tests/contract/sightings-id.contract.test.ts
+++ b/src/tests/contract/sightings-id.contract.test.ts
@@ -3,39 +3,50 @@ import { GET, PUT, DELETE } from '../../routes/api/sightings/[id]/+server';
 import { createEvent, mockAdminUser } from './helpers/createEvent';
 import { asApiResponse } from './helpers/asApiResponse';
 
-const { mockSelectLimit, mockDeleteWhere, mockSighting, mockUpdateSighting } = vi.hoisted(() => {
-	const mockSighting = {
-		id: 123,
-		sightingDate: new Date('2024-06-15T14:30:00Z'),
-		created: new Date('2024-06-15T15:00:00Z'),
-		species: 1,
-		totalCount: 2,
-		juvenileCount: 0,
-		latitude: 54.5,
-		longitude: 13.5,
-		isDead: 0,
-		firstName: 'Max',
-		lastName: 'Muster',
-		email: 'max@example.com',
-		verified: 1,
-		approvedAt: null,
-		internalComment: null,
-		referenceId: 'ref-test-123'
-	};
-	const mockSelectLimit = vi.fn().mockResolvedValue([{ ...mockSighting }]);
-	const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
-	const mockUpdateSighting = vi.fn().mockResolvedValue({ ...mockSighting });
-	return { mockSelectLimit, mockDeleteWhere, mockSighting, mockUpdateSighting };
-});
+const { mockSelectLimit, mockDeleteWhere, mockSighting, mockUpdateSighting, mockSchema } =
+	vi.hoisted(() => {
+		const mockSighting = {
+			id: 123,
+			sightingDate: new Date('2024-06-15T14:30:00Z'),
+			created: new Date('2024-06-15T15:00:00Z'),
+			species: 1,
+			totalCount: 2,
+			juvenileCount: 0,
+			latitude: 54.5,
+			longitude: 13.5,
+			isDead: 0,
+			firstName: 'Max',
+			lastName: 'Muster',
+			email: 'max@example.com',
+			verified: 1,
+			approvedAt: null,
+			internalComment: null,
+			referenceId: 'ref-test-123'
+		};
+		const mockSelectLimit = vi.fn().mockResolvedValue([{ ...mockSighting }]);
+		const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+		const mockUpdateSighting = vi.fn().mockResolvedValue({ ...mockSighting });
+		const mockSchema = {
+			sightings: {
+				id: 'id',
+				approvedAt: 'approvedAt',
+				internalComment: 'internalComment',
+				verified: 'verified'
+			},
+			sightingFiles: { sightingId: 'sightingId', filePath: 'filePath' }
+		};
+		return { mockSelectLimit, mockDeleteWhere, mockSighting, mockUpdateSighting, mockSchema };
+	});
 
 vi.mock('$lib/server/db', () => ({
 	db: {
 		select: vi.fn().mockReturnValue({
-			from: vi.fn().mockReturnValue({
-				where: vi.fn().mockReturnValue({
-					limit: mockSelectLimit
-				})
-			})
+			from: vi.fn((table: unknown) => ({
+				// Die Datei-Abfrage in DELETE wird direkt awaited, alle anderen über .limit()
+				where: vi.fn(() =>
+					table === mockSchema.sightingFiles ? Promise.resolve([]) : { limit: mockSelectLimit }
+				)
+			}))
 		}),
 		update: vi.fn().mockReturnValue({
 			set: vi.fn().mockReturnValue({
@@ -50,13 +61,10 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {
-		id: 'id',
-		approvedAt: 'approvedAt',
-		internalComment: 'internalComment',
-		verified: 'verified'
-	}
+vi.mock('$lib/server/db/schema', () => mockSchema);
+
+vi.mock('$lib/server/storage/factory', () => ({
+	getStorageProvider: vi.fn(() => ({ delete: vi.fn().mockResolvedValue(undefined) }))
 }));
 
 vi.mock('drizzle-orm', () => ({

--- a/src/tests/contract/sightings-id.contract.test.ts
+++ b/src/tests/contract/sightings-id.contract.test.ts
@@ -41,13 +41,21 @@ const { mockSelectLimit, mockDeleteWhere, mockSighting, mockUpdateSighting, mock
 vi.mock('$lib/server/db', () => ({
 	db: {
 		select: vi.fn().mockReturnValue({
-			from: vi.fn((table: unknown) => ({
-				// Die Datei-Abfrage in DELETE wird direkt awaited, alle anderen über .limit()
-				where: vi.fn(() =>
-					table === mockSchema.sightingFiles ? Promise.resolve([]) : { limit: mockSelectLimit }
-				)
-			}))
+			from: vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({ limit: mockSelectLimit })
+			})
 		}),
+		// DELETE löscht Dateizeilen und Sichtung gemeinsam in einer Transaktion
+		transaction: vi.fn((callback: (tx: unknown) => Promise<unknown>) =>
+			callback({
+				delete: (table: unknown) => ({
+					where:
+						table === mockSchema.sightingFiles
+							? () => ({ returning: vi.fn().mockResolvedValue([]) })
+							: mockDeleteWhere
+				})
+			})
+		),
 		update: vi.fn().mockReturnValue({
 			set: vi.fn().mockReturnValue({
 				where: vi.fn().mockReturnValue({


### PR DESCRIPTION
## Problem

Zwei Löschpfade entfernten Zeilen aus `sichtungen_dateien`, ohne den Storage anzufassen. Bei jedem gelöschten Datensatz und jeder ersetzten Dateiliste blieben Dateien im Upload-Verzeichnis zurück, auf die niemand mehr zeigt.

| Quelle | Warum es niemandem auffiel |
| --- | --- |
| `DELETE /api/sightings/[id]` | Der Fremdschlüssel `sichtungen_dateien.sichtung_id` trägt `onDelete: 'cascade'`. Die DB-Zeilen verschwanden also zuverlässig — der Kommentar an der Stelle („cascade delete für zugehörige Dateien") las sich, als gälte das auch für die Dateien. |
| `saveSightingFiles()` | Löscht in einer Transaktion die komplette Dateiliste einer Sichtung und fügt die neue ein. Wer im Admin-Formular ein Foto austauscht, lässt das alte im Storage zurück. |

Eine vollständige Suche über das Repo bestätigt: Das waren die einzigen beiden Stellen, die Dateizeilen entfernen, ohne den Storage zu bedienen (`db.delete(sightings)` existiert genau einmal, `delete(sightingFiles)` in `saveSightingFiles()` und in `deleteFileByPath()` — letzteres räumt den Storage bereits auf).

## Lösung

Neuer gemeinsamer Helfer `deleteStoredFiles()` (`src/lib/server/storage/deleteStoredFiles.ts`). Beide Pfade lesen die `datei_pfad`-Werte, **bevor** die Zeilen verschwinden, löschen die Zeilen und geben die Pfade danach an den Helfer.

Die Reihenfolge ist bewusst gewählt und im Doc-Kommentar festgehalten: Bleibt eine Datei liegen, ist das folgenlos, weil keine DB-Zeile mehr auf sie zeigt. Umgekehrt entstünde eine Zeile, die auf eine fehlende Datei verweist — und die sieht der Nutzer als kaputtes Bild. Deshalb wirft `deleteStoredFiles()` nie: die Aufrufer sind zu diesem Zeitpunkt bereits committet.

Details je Pfad:

- **Endpunkt:** `select` der Pfade vor dem `db.delete(sightings)`, Storage-Aufruf danach. Der irreführende Kommentar ist ersetzt.
- **Repository:** statt einer zweiten Abfrage liefert `.returning({ filePath })` auf dem `delete` die Pfade aus derselben Anweisung — gleiche Ordnungsgarantie, kein Zeitfenster zwischen Lesen und Löschen. Anschließend werden nur Pfade gelöscht, die in der neuen Liste **nicht** mehr vorkommen: unveränderte Dateien wurden gerade nur neu verknüpft.

## Tests

Test-First nach `.claude/rules/testing.md` — zuerst 6 rote Tests, die zeigen, dass die Dateien liegen bleiben, dann der Fix. Storage-Provider durchgehend gemockt.

- `deleteStorageCleanup.test.ts` — Dateien werden gelöscht; die Reihenfolge `select → delete → storage` ist als `callOrder`-Assertion festgeschrieben; kein Storage-Aufruf ohne verknüpfte Dateien; 200 auch wenn eine Datei nicht entfernt werden kann.
- `saveSightingFilesStorage.test.ts` — obsolete Dateien weg, weiterverknüpfte bleiben, Löschen erst nach dem Commit, Storage-Fehler nimmt die committete Transaktion nicht zurück.
- `deleteStoredFiles.test.ts` — Deduplizierung mehrfach referenzierter Pfade, Weiterlaufen nach Einzelfehlern, kein Wurf bei nicht verfügbarem Storage-Provider.

Vier bestehende Testdateien brauchten angepasste Mocks (`.returning()` bzw. die zusätzliche Select-Abfrage).

`npm run test:quick`: 122 Dateien, 1853 Tests grün, 0 Type-/Svelte-Check-Fehler. Die zwei ESLint-Warnungen liegen in `src/tests/contract/helpers/createEvent.ts` und sind unverändert vorbestehend.

Kein Schema-Change → keine Migration. Das äußere Verhalten der Route ändert sich nicht → keine OpenAPI-Anpassung.

## Bewusst nicht in diesem PR

1. **`POST /api/files/delete` löscht in umgekehrter Reihenfolge** (Storage vor DB-Zeile) und meldet im `catch` `success: true`, auch wenn die Zeile stehen blieb. Das ist genau der Fehlerfall, den der neue Doc-Block als den schlimmeren beschreibt. Vorbestehend, eigener Endpunkt, eigene Testsuite — als Ausnahme in `.claude/rules/upload.md` vermerkt, bis es behoben ist.
2. **Alle Bilder entfernen wirkt nicht.** Sowohl der PUT-Handler (`uploadedFiles.length > 0`) als auch `saveSightingFiles()` steigen bei leerer Liste vorzeitig aus. Erzeugt keine verwaisten Dateien (die Zeile zeigt weiter auf die Datei), ignoriert aber stillschweigend die Nutzeraktion. Der Fix müsste zusätzlich `undefined` (Teil-Update) von `[]` (alles entfernen) unterscheiden.

Ergänzt wurde die verbindliche Löschreihenfolge in `.claude/rules/upload.md`, damit der Invariant nicht erneut verletzt wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)