### PR TITLE
fix(config): UPLOAD_PATH wird gelesen statt hartkodiert

### DIFF
--- a/.claude/rules/upload.md
+++ b/.claude/rules/upload.md
@@ -38,7 +38,10 @@ exists(filePath): Promise<boolean>
 list(prefix?): Promise<UploadedFileInfo[]>
 ```
 
-**Local:** Dateien in `uploads/`, Path-Traversal-Schutz via `normalize()` + `relative()`
+**Local:** Basisverzeichnis aus `UPLOAD_PATH` (Standard `uploads`, relativ zum Arbeitsverzeichnis).
+Einzige Auswertungsstelle: `src/lib/server/storage/uploadPath.ts` — Schreibpfad (`LocalStorageProvider`)
+und Lesepfad (`getUploadPath()` in `$lib/server/uploads`) beziehen ihr Verzeichnis beide von dort.
+Path-Traversal-Schutz via `normalize()` + `relative()`
 **Vercel Blob:** Token aus `BLOB_READ_WRITE_TOKEN`, öffentliche URLs
 
 ---

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -270,14 +270,24 @@ PUBLIC_SITE_URL=https://sightings.meeresmuseum.de
 
 **Type**: `string` (Path)
 **Required**: When `STORAGE_PROVIDER=local`
-**Default**: `/app/uploads` (Docker), `uploads` (non-Docker)
-**Description**: Directory path for uploaded files.
+**Default**: `/app/uploads` (Docker, set in the image), `uploads` (non-Docker)
+**Description**: Directory path for uploaded files. Determines both where the application
+writes uploads and where it reads them back from.
+
+Relative values are resolved against the process working directory (`/app` inside the
+container, so the default `uploads` maps to `/app/uploads`). Absolute values are used as
+given. The Docker entrypoint validates this exact path for existence and write permission
+before the application starts, so entrypoint check and application behaviour cannot drift
+apart.
 
 **Example**:
 
 ```bash
 UPLOAD_PATH=/app/uploads
 ```
+
+**Note**: When running outside Docker with a working directory other than the project root,
+set an absolute path — otherwise uploads land next to wherever the process was started.
 
 ---
 

--- a/src/lib/server/storage/factory.test.ts
+++ b/src/lib/server/storage/factory.test.ts
@@ -4,7 +4,8 @@ import type { StorageProviderType } from '$lib/types';
 // Mutable mock environment object
 const mockEnv: Record<string, string> = {
 	STORAGE_PROVIDER: '',
-	VERCEL: ''
+	VERCEL: '',
+	UPLOAD_PATH: ''
 };
 
 // Mock the app environment
@@ -84,6 +85,7 @@ describe('Storage Factory', () => {
 		// Reset mock environment variables
 		mockEnv.STORAGE_PROVIDER = '';
 		mockEnv.VERCEL = '';
+		mockEnv.UPLOAD_PATH = '';
 
 		// Clear all mocks
 		vi.clearAllMocks();
@@ -142,7 +144,9 @@ describe('Storage Factory', () => {
 			mockEnv.STORAGE_PROVIDER = 'gcs';
 			mockEnv.VERCEL = '';
 
-			expect(() => getStorageProvider()).toThrow('Google Cloud Storage provider not implemented yet');
+			expect(() => getStorageProvider()).toThrow(
+				'Google Cloud Storage provider not implemented yet'
+			);
 		});
 
 		test('should throw error for unknown provider', () => {
@@ -155,8 +159,8 @@ describe('Storage Factory', () => {
 
 		test('should default to local storage for unknown environments', () => {
 			// No special environment variables set
-			mockEnv.VERCEL = "";
-			mockEnv.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = '';
 
 			const provider = getStorageProvider();
 			expect(provider).toBeDefined();
@@ -306,12 +310,12 @@ describe('Storage Factory', () => {
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Undefined should be falsy
-			mockEnv.STORAGE_PROVIDER = "";
+			mockEnv.STORAGE_PROVIDER = '';
 			mockEnv.VERCEL = '1';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 
 			// Any truthy value for VERCEL should work
-			mockEnv.VERCEL = "";
+			mockEnv.VERCEL = '';
 			mockEnv.VERCEL = 'true';
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 		});
@@ -326,6 +330,49 @@ describe('Storage Factory', () => {
 			// Access the mocked module
 			const localModule = await import('./local');
 			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith('uploads', '/uploads');
+		});
+
+		test('should use UPLOAD_PATH as base directory for LocalStorageProvider', async () => {
+			mockEnv.STORAGE_PROVIDER = 'local';
+			mockEnv.UPLOAD_PATH = '/srv/ostsee/uploads';
+
+			getStorageProvider();
+
+			const localModule = await import('./local');
+			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith(
+				'/srv/ostsee/uploads',
+				'/uploads'
+			);
+		});
+
+		test('should fall back to "uploads" when UPLOAD_PATH is not set', async () => {
+			mockEnv.STORAGE_PROVIDER = 'local';
+			mockEnv.UPLOAD_PATH = '';
+
+			getStorageProvider();
+
+			const localModule = await import('./local');
+			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith('uploads', '/uploads');
+		});
+
+		test('should fall back to "uploads" when UPLOAD_PATH contains only whitespace', async () => {
+			mockEnv.STORAGE_PROVIDER = 'local';
+			mockEnv.UPLOAD_PATH = '   ';
+
+			getStorageProvider();
+
+			const localModule = await import('./local');
+			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith('uploads', '/uploads');
+		});
+
+		test('should trim surrounding whitespace from UPLOAD_PATH', async () => {
+			mockEnv.STORAGE_PROVIDER = 'local';
+			mockEnv.UPLOAD_PATH = '  /app/uploads  ';
+
+			getStorageProvider();
+
+			const localModule = await import('./local');
+			expect(localModule.LocalStorageProvider).toHaveBeenCalledWith('/app/uploads', '/uploads');
 		});
 
 		test('should create VercelBlobStorageProvider with no parameters', async () => {
@@ -406,7 +453,7 @@ describe('Storage Factory', () => {
 			// Simulate production deployment on Vercel
 			process.env.NODE_ENV = 'production';
 			mockEnv.VERCEL = '1';
-			mockEnv.STORAGE_PROVIDER = "";
+			mockEnv.STORAGE_PROVIDER = '';
 
 			expect(getCurrentStorageProvider()).toBe('vercel-blob');
 			expect(isCloudStorage()).toBe(true);
@@ -421,8 +468,8 @@ describe('Storage Factory', () => {
 				dev: true
 			}));
 
-			mockEnv.VERCEL = "";
-			mockEnv.STORAGE_PROVIDER = "";
+			mockEnv.VERCEL = '';
+			mockEnv.STORAGE_PROVIDER = '';
 
 			// Dynamically import to get updated environment
 			const factory = await import('./factory');

--- a/src/lib/server/storage/factory.ts
+++ b/src/lib/server/storage/factory.ts
@@ -1,16 +1,16 @@
 /**
  * Storage Factory - Abstrakte Speicher-Providererstellung und -verwaltung
- * 
+ *
  * Diese Datei implementiert das Factory-Pattern für Speicher-Provider und ermöglicht
- * die dynamische Auswahl des geeigneten Speicher-Backends basierend auf der 
+ * die dynamische Auswahl des geeigneten Speicher-Backends basierend auf der
  * Laufzeitumgebung und Konfiguration.
- * 
+ *
  * Das System unterstützt verschiedene Speicher-Provider:
  * - Local: Lokaler Dateisystem-Speicher (Entwicklung)
  * - Vercel Blob: Vercel's Cloud-Speicher (Produktion auf Vercel)
  * - S3: Amazon S3 (geplant)
  * - GCS: Google Cloud Storage (geplant)
- * 
+ *
  * Die Auswahl erfolgt automatisch oder über Umgebungsvariablen.
  */
 import { dev } from '$app/environment';
@@ -18,9 +18,17 @@ import { createLogger } from '$lib/logger.server';
 import type { StorageProvider, StorageProviderType } from '$lib/types';
 import { env } from '$env/dynamic/private';
 import { LocalStorageProvider } from './local';
+import { getUploadBasePath, resolveUploadBasePath } from './uploadPath';
 import { VercelBlobStorageProvider } from './vercel-blob';
 
 const logger = createLogger('storage:factory');
+
+/**
+ * Öffentliche URL-Basis für lokal gespeicherte Dateien.
+ * Unabhängig vom Ablageort auf der Platte — die Route `/uploads/[...path]`
+ * liefert die Dateien aus, egal wo sie liegen.
+ */
+const LOCAL_PUBLIC_URL_BASE = '/uploads';
 
 /**
  * Singleton-Instanz des aktuell aktiven Speicher-Providers.
@@ -30,25 +38,25 @@ let storageProvider: StorageProvider | null = null;
 
 /**
  * Erstellt oder gibt den konfigurierten Speicher-Provider zurück.
- * 
+ *
  * Diese Funktion implementiert das Singleton-Pattern und stellt sicher,
  * dass immer derselbe Provider verwendet wird. Die Auswahl des Providers
  * erfolgt basierend auf:
- * 
+ *
  * 1. STORAGE_PROVIDER Umgebungsvariable (explizite Konfiguration)
  * 2. Automatische Erkennung der Laufzeitumgebung:
  *    - Vercel-Umgebung → vercel-blob
  *    - Entwicklungsmodus → local
  *    - Andere Umgebungen → local (Fallback)
- * 
+ *
  * @returns Konfigurierter und betriebsbereiter StorageProvider
  * @throws {Error} Wenn ein unbekannter oder nicht implementierter Provider angefordert wird
- * 
+ *
  * @example
  * ```typescript
  * // Automatische Provider-Auswahl
  * const storage = getStorageProvider();
- * 
+ *
  * // Datei hochladen
  * const result = await storage.uploadFile(
  *   Buffer.from('Hello World'),
@@ -68,11 +76,17 @@ export function getStorageProvider(): StorageProvider {
 
 	// Provider-spezifische Initialisierung
 	switch (providerType) {
-		case 'local':
+		case 'local': {
 			// Lokaler Speicher mit konfigurierten Pfaden
-			storageProvider = new LocalStorageProvider('uploads', '/uploads');
-			logger.info('Using local file storage');
+			const uploadPath = getUploadBasePath();
+			storageProvider = new LocalStorageProvider(uploadPath, LOCAL_PUBLIC_URL_BASE);
+			// Beide Werte loggen: konfiguriert (evtl. relativ) und das tatsächliche Zielverzeichnis
+			logger.info(
+				{ uploadPath, resolvedUploadPath: resolveUploadBasePath() },
+				'Using local file storage'
+			);
 			break;
+		}
 
 		case 'vercel-blob':
 			// Vercel Blob Storage (Standardkonfiguration aus Umgebungsvariablen)
@@ -98,24 +112,24 @@ export function getStorageProvider(): StorageProvider {
 
 /**
  * Ermittelt den zu verwendenden Speicher-Provider-Typ.
- * 
+ *
  * Diese interne Funktion implementiert die Logik zur automatischen
  * Provider-Auswahl. Die Priorität ist:
- * 
+ *
  * 1. **Explizite Konfiguration**: STORAGE_PROVIDER Umgebungsvariable
  * 2. **Vercel-Erkennung**: VERCEL Umgebungsvariable vorhanden
  * 3. **Entwicklungsmodus**: SvelteKit dev-Flag aktiv
  * 4. **Fallback**: Lokaler Speicher als sicherer Standard
- * 
+ *
  * @returns Der ermittelte StorageProviderType
  * @internal
- * 
+ *
  * @example
  * ```typescript
  * // Umgebungsvariable setzen
  * process.env.STORAGE_PROVIDER = 'vercel-blob';
  * const type = getStorageProviderType(); // 'vercel-blob'
- * 
+ *
  * // Automatische Vercel-Erkennung
  * process.env.VERCEL = '1';
  * const type = getStorageProviderType(); // 'vercel-blob'
@@ -154,13 +168,13 @@ function getStorageProviderType(): StorageProviderType {
 
 /**
  * Setzt den Storage-Provider zurück (hauptsächlich für Tests).
- * 
+ *
  * Diese Funktion ermöglicht es, den Singleton-Provider zu resetten,
  * um in Tests verschiedene Provider-Konfigurationen zu testen.
- * 
+ *
  * **Achtung**: Diese Funktion sollte nur in Tests verwendet werden,
  * da ein Reset während der Laufzeit zu inkonsistentem Verhalten führen kann.
- * 
+ *
  * @example
  * ```typescript
  * // In Tests
@@ -176,15 +190,15 @@ export function resetStorageProvider(): void {
 
 /**
  * Prüft, ob ein Cloud-basierter Speicher-Provider verwendet wird.
- * 
+ *
  * Diese Hilfsfunktion ermöglicht es, unterschiedliche Verhaltensweisen
  * für lokale und Cloud-Speicher zu implementieren, z.B.:
  * - Verschiedene URL-Generierung
  * - Unterschiedliche Caching-Strategien
  * - Verschiedene Fehlerbehandlung
- * 
+ *
  * @returns `true` wenn ein Cloud-Provider aktiv ist, `false` für lokalen Speicher
- * 
+ *
  * @example
  * ```typescript
  * if (isCloudStorage()) {
@@ -203,20 +217,20 @@ export function isCloudStorage(): boolean {
 
 /**
  * Gibt den aktuell konfigurierten Storage-Provider-Typ zurück.
- * 
+ *
  * Diese Funktion ermöglicht es anderen Modulen, den aktiven Provider-Typ
  * zu ermitteln, ohne den Provider selbst zu instanziieren. Nützlich für:
  * - Conditional Logic basierend auf Provider-Typ
  * - Debugging und Logging
  * - Konfigurationsprüfungen
- * 
+ *
  * @returns Der aktuell konfigurierte StorageProviderType
- * 
+ *
  * @example
  * ```typescript
  * const currentProvider = getCurrentStorageProvider();
  * logger.info(`Active storage provider: ${currentProvider}`);
- * 
+ *
  * if (currentProvider === 'vercel-blob') {
  *   // Vercel-spezifische Konfiguration
  * }

--- a/src/lib/server/storage/uploadPath.ts
+++ b/src/lib/server/storage/uploadPath.ts
@@ -1,0 +1,63 @@
+/**
+ * Auflösung des Basisverzeichnisses für den lokalen Datei-Speicher.
+ *
+ * Einzige Stelle, an der `UPLOAD_PATH` ausgewertet wird. Sowohl der
+ * Schreibpfad (`LocalStorageProvider` über die Storage-Factory) als auch
+ * der Lesepfad (`getUploadPath()` in `$lib/server/uploads`) leiten ihr
+ * Verzeichnis hierüber ab — andernfalls würden Uploads an einer Stelle
+ * geschrieben und an einer anderen gesucht.
+ *
+ * `UPLOAD_PATH` ist dieselbe Variable, die der Docker-Entrypoint vor dem
+ * Start auf Existenz und Schreibrechte prüft.
+ */
+import { env } from '$env/dynamic/private';
+import { resolve } from 'path';
+
+/**
+ * Basisverzeichnis, wenn `UPLOAD_PATH` nicht gesetzt ist.
+ * Relativ — wird gegen das Arbeitsverzeichnis des Prozesses aufgelöst
+ * (im Container `/app`, also `/app/uploads`).
+ */
+const DEFAULT_UPLOAD_PATH = 'uploads';
+
+/**
+ * Gibt das konfigurierte Upload-Basisverzeichnis zurück, so wie es in
+ * `UPLOAD_PATH` steht (kann relativ sein).
+ *
+ * @returns Wert aus `UPLOAD_PATH` oder `uploads` als Standard
+ *
+ * @example
+ * ```typescript
+ * // UPLOAD_PATH=/app/uploads
+ * getUploadBasePath(); // '/app/uploads'
+ *
+ * // UPLOAD_PATH nicht gesetzt
+ * getUploadBasePath(); // 'uploads'
+ * ```
+ */
+export function getUploadBasePath(): string {
+	// Whitespace tolerieren: .env-Dateien liefern gelegentlich gepolsterte Werte
+	const configuredPath = (env.UPLOAD_PATH ?? '').trim();
+	return configuredPath || DEFAULT_UPLOAD_PATH;
+}
+
+/**
+ * Gibt das Upload-Basisverzeichnis als absoluten Pfad zurück.
+ *
+ * Relative Werte werden gegen das Arbeitsverzeichnis des Prozesses
+ * aufgelöst, absolute Werte unverändert übernommen.
+ *
+ * @returns Absoluter Pfad zum Upload-Verzeichnis
+ *
+ * @example
+ * ```typescript
+ * // UPLOAD_PATH=/srv/uploads
+ * resolveUploadBasePath(); // '/srv/uploads'
+ *
+ * // UPLOAD_PATH=data/uploads, cwd=/app
+ * resolveUploadBasePath(); // '/app/data/uploads'
+ * ```
+ */
+export function resolveUploadBasePath(): string {
+	return resolve(getUploadBasePath());
+}

--- a/src/lib/server/uploads.test.ts
+++ b/src/lib/server/uploads.test.ts
@@ -1,13 +1,5 @@
 import path from 'path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import {
-	ALLOWED_UPLOAD_MIME_TYPES,
-	getFileInfo,
-	getMimeTypeFromExtension,
-	getUploadPath,
-	isAllowedMimeType,
-	isValidUploadPath
-} from './uploads';
 
 // Mutable mock environment object
 const mockEnv: Record<string, string> = {
@@ -49,6 +41,16 @@ vi.mock('fs', () => ({
 	existsSync: vi.fn(),
 	statSync: vi.fn()
 }));
+
+// Import after mocks are set up
+import {
+	ALLOWED_UPLOAD_MIME_TYPES,
+	getFileInfo,
+	getMimeTypeFromExtension,
+	getUploadPath,
+	isAllowedMimeType,
+	isValidUploadPath
+} from './uploads';
 
 describe('uploads utilities', () => {
 	let mockExistsSync: any;

--- a/src/lib/server/uploads.test.ts
+++ b/src/lib/server/uploads.test.ts
@@ -9,6 +9,22 @@ import {
 	isValidUploadPath
 } from './uploads';
 
+// Mutable mock environment object
+const mockEnv: Record<string, string> = {
+	UPLOAD_PATH: ''
+};
+
+// Mock environment variables (dynamic env) with getter to allow runtime changes
+vi.mock('$env/dynamic/private', () => ({
+	env: new Proxy({} as Record<string, string>, {
+		get: (_target, prop: string) => mockEnv[prop] ?? '',
+		set: (_target, prop: string, value: string) => {
+			mockEnv[prop] = value;
+			return true;
+		}
+	})
+}));
+
 // Mock the logger
 vi.mock('$lib/logger.server', () => ({
 	createLogger: () => ({
@@ -291,6 +307,38 @@ describe('uploads utilities', () => {
 	});
 
 	describe('getUploadPath', () => {
+		beforeEach(() => {
+			mockEnv.UPLOAD_PATH = '';
+		});
+
+		test('should use UPLOAD_PATH as base directory when set', () => {
+			mockEnv.UPLOAD_PATH = '/srv/ostsee/uploads';
+
+			expect(getUploadPath('user123/photo.jpg')).toBe('/srv/ostsee/uploads/user123/photo.jpg');
+		});
+
+		test('should resolve a relative UPLOAD_PATH against the working directory', () => {
+			mockEnv.UPLOAD_PATH = 'data/uploads';
+
+			expect(getUploadPath('photo.jpg')).toBe(
+				path.join(process.cwd(), 'data/uploads', 'photo.jpg')
+			);
+		});
+
+		test('should fall back to "uploads" when UPLOAD_PATH is not set', () => {
+			mockEnv.UPLOAD_PATH = '';
+
+			expect(getUploadPath('photo.jpg')).toBe(path.join(process.cwd(), 'uploads', 'photo.jpg'));
+		});
+
+		test('should reflect UPLOAD_PATH changes at runtime', () => {
+			mockEnv.UPLOAD_PATH = '/mnt/a';
+			expect(getUploadPath('x.jpg')).toBe('/mnt/a/x.jpg');
+
+			mockEnv.UPLOAD_PATH = '/mnt/b';
+			expect(getUploadPath('x.jpg')).toBe('/mnt/b/x.jpg');
+		});
+
 		test('should construct correct upload path', () => {
 			const expectedPath = path.join(process.cwd(), 'uploads', 'user123/photo.jpg');
 			expect(getUploadPath('user123/photo.jpg')).toBe(expectedPath);

--- a/src/lib/server/uploads.ts
+++ b/src/lib/server/uploads.ts
@@ -21,6 +21,7 @@
  * ausführlich getestet werden. Jeder Fehler kann zu Sicherheitslücken führen.
  */
 import { createLogger } from '$lib/logger.server';
+import { resolveUploadBasePath } from '$lib/server/storage/uploadPath';
 import { existsSync, statSync } from 'fs';
 import path from 'path';
 
@@ -236,9 +237,10 @@ export function isAllowedMimeType(mimeType: string): boolean {
 /**
  * Konstruiert sicheren absoluten Pfad für Upload-Dateien.
  *
- * Diese Funktion erstellt den vollständigen Pfad zu einer Upload-Datei
- * relativ zum Projektverzeichnis. Der resultierende Pfad ist sicher
- * und kann für Dateisystem-Operationen verwendet werden.
+ * Das Basisverzeichnis stammt aus `UPLOAD_PATH` (Standard: `uploads`
+ * relativ zum Arbeitsverzeichnis) — dieselbe Quelle, aus der auch der
+ * `LocalStorageProvider` beim Schreiben sein Verzeichnis bezieht.
+ * Lesen und Schreiben zeigen dadurch immer auf denselben Ort.
  *
  * **Sicherheitshinweis:**
  * Der Input sollte bereits mit `isValidUploadPath()` validiert sein.
@@ -248,14 +250,18 @@ export function isAllowedMimeType(mimeType: string): boolean {
  *
  * @example
  * ```typescript
- * // Annahme: process.cwd() = '/app'
+ * // Annahme: UPLOAD_PATH nicht gesetzt, process.cwd() = '/app'
  * getUploadPath('user123/photo.jpg')
  * // Returns: '/app/uploads/user123/photo.jpg'
+ *
+ * // Annahme: UPLOAD_PATH=/srv/ostsee/uploads
+ * getUploadPath('user123/photo.jpg')
+ * // Returns: '/srv/ostsee/uploads/user123/photo.jpg'
  * ```
  */
 export function getUploadPath(filePath: string): string {
-	// Sicheren absoluten Pfad zum Upload-Verzeichnis konstruieren
-	return path.join(process.cwd(), 'uploads', filePath);
+	// Sicheren absoluten Pfad zum konfigurierten Upload-Verzeichnis konstruieren
+	return path.join(resolveUploadBasePath(), filePath);
 }
 
 /**

--- a/src/tools/migrate-old-uploads.ts
+++ b/src/tools/migrate-old-uploads.ts
@@ -7,7 +7,8 @@
  * 2. Ensures aufnahmeHochladen is set to "1" for all found rows
  * 3. Creates new entries in sichtung_files table with complete metadata
  * 4. Extracts EXIF data from image files (GPS, camera info, etc.)
- * 5. Copies files from uploads/_old_uploads/ to uploads/{referenz_id}/ (preserves originals)
+ * 5. Copies files from <UPLOAD_PATH>/_old_uploads/ to <UPLOAD_PATH>/{referenz_id}/
+ *    (preserves originals; UPLOAD_PATH defaults to `uploads` relative to the working directory)
  */
 
 import type { ExifData } from '$lib/types';
@@ -271,7 +272,9 @@ async function main() {
 	const client = postgres(databaseUrl);
 	const db = drizzle(client, { schema });
 
-	const baseUploadPath = path.join(process.cwd(), 'uploads');
+	// Same UPLOAD_PATH contract as the app (src/lib/server/storage/uploadPath.ts).
+	// Standalone script — cannot use $env/dynamic/private, so read process.env directly.
+	const baseUploadPath = path.resolve((process.env.UPLOAD_PATH ?? '').trim() || 'uploads');
 	const oldUploadPath = path.join(baseUploadPath, '_old_uploads');
 
 	try {


### PR DESCRIPTION
## Problem

`UPLOAD_PATH` war dokumentiert, im `Dockerfile` und in `docker-compose.production.yml` gesetzt und wurde vom Entrypoint auf Existenz und Schreibrechte geprüft — **gelesen hat die Variable aber niemand**.

Betroffen waren beide Richtungen:

| | vorher | Auflösung |
| --- | --- | --- |
| Schreiben | `new LocalStorageProvider('uploads', '/uploads')` | `resolve('uploads')` → `<cwd>/uploads` |
| Lesen / Löschen | `getUploadPath()` | `path.join(process.cwd(), 'uploads', …)` |

Im Container funktionierte das nur, weil `WORKDIR` zufällig `/app` ist und `resolve('uploads')` dort `/app/uploads` ergibt. Bei jedem abweichenden `UPLOAD_PATH` hätte der Entrypoint einen Pfad validiert, in den die Anwendung nie geschrieben hätte — Deployments außerhalb von `/app` wären still gebrochen.

## Lösung

Die Auswertung liegt jetzt an genau einer Stelle: `src/lib/server/storage/uploadPath.ts`

- `getUploadBasePath()` — Rohwert, Default `uploads`, getrimmt
- `resolveUploadBasePath()` — absolut, relative Werte gegen das Arbeitsverzeichnis

Die Storage-Factory übergibt den konfigurierten Wert an `LocalStorageProvider` (der ihn wie bisher im Konstruktor auflöst), `getUploadPath()` baut auf derselben Basis auf. Ausliefern über `/uploads/[...path]` und Löschen über `sightingRepository` können dadurch nicht mehr von dem Ort abweichen, an den geschrieben wurde.

Die öffentliche URL-Basis bleibt fest `/uploads` — sie gehört zur Route, nicht zum Ablageort.

### Zweiter Fundort

Hätte nur `factory.ts` `UPLOAD_PATH` gelesen, wären Uploads bei gesetzter Variable zwar korrekt geschrieben, aber weiter unter `<cwd>/uploads` gesucht worden. Der Bug wäre von „schreibt woanders hin" zu „findet nichts mehr" geworden. Deshalb ist `src/lib/server/uploads.ts` Teil dieses PRs.

## Tests

Test-First, 8 neue Fälle — 5 davon waren vor der Änderung rot:

- `factory.test.ts` — `UPLOAD_PATH` bestimmt das Basisverzeichnis, Fallback bei leer, Fallback bei Whitespace-only, Trimming
- `uploads.test.ts` — absoluter Pfad, relativer Pfad gegen cwd, Fallback, Änderung zur Laufzeit

`npm run test:quick`: 1847 Tests grün, 0 Lint-Errors (die 2 Warnings in `src/tests/contract/helpers/createEvent.ts` sind vorbestehend).

## Bewusste Abweichung von Test-First

`src/tools/migrate-old-uploads.ts` hatte denselben Literal-Pfad. Als Standalone-`tsx`-Skript kann es `$env/dynamic/private` nicht importieren und liest deshalb `process.env.UPLOAD_PATH` direkt, mit identischer Default- und Resolve-Semantik. Dafür gibt es keinen Test: Das Skript hat keine Testdatei, und ein Harness für ein Einmal-Migrationsskript wäre unverhältnismäßig.

## Verhaltensänderung

Für bestehende Deployments ändert sich nichts — `/app/uploads` ist weiterhin das Ziel, jetzt aber weil die Variable gelesen wird und nicht, weil das Arbeitsverzeichnis zufällig passt. Neu ist, dass ein abweichender `UPLOAD_PATH` tatsächlich wirkt. Wer außerhalb von Docker mit einem anderen Arbeitsverzeichnis startet, sollte einen absoluten Pfad setzen; `docs/ENVIRONMENT.md` weist darauf hin.

## Offener Punkt

`UPLOAD_PATHS.BASE = 'uploads'` in `src/lib/constants/upload.ts` ist eine tote Konstante (nur in `src/lib/utils/index.ts` re-exportiert, sonst nirgends benutzt). Sie untergräbt die Single-Source-of-Truth-Aussage, sobald jemand danach greift — separat zu entfernen, nicht Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
