### PR TITLE
feat(media): Aufräum-Tool für verwaiste Medien-Uploads

### DIFF
--- a/.claude/rules/upload.md
+++ b/.claude/rules/upload.md
@@ -69,6 +69,25 @@ CEST-Zeitzonenkorrektur via `correctCestOffsetUTC()`.
 
 ---
 
+## Aufbewahrung unverknüpfter Uploads
+
+Ein Upload legt sofort eine Zeile mit `sichtung_id = NULL` an; verknüpft wird erst
+beim Absenden. Abgebrochene Formularläufe hinterlassen deshalb Zeilen und Dateien,
+die niemand mehr erreicht — samt EXIF-GPS.
+
+**Frist: 24 Stunden.** Formulardaten liegen in `sessionStorage` und überstehen das
+Schließen des Tabs nicht; was länger unverknüpft ist, kann nicht mehr abgesendet
+werden.
+
+Durchgesetzt wird die Frist derzeit **von Hand** über
+`npm run media:cleanup-orphans:dry-run` (Details: `src/tools/README.md`).
+
+**Offen:** Es gibt keinen automatischen Job — der Bestand wächst nach. Außerdem
+entfernen `DELETE /api/sightings/[id]` und `saveSightingFiles()` DB-Zeilen, ohne die
+Dateien zu löschen, und erzeugen so laufend neue Waisen.
+
+---
+
 ## Best Practices
 
 - Dateinamen basieren auf CUID, Original separat gespeichert

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
 		"db:fix-media-flags": "node src/tools/fix-media-upload-flags.js",
 		"db:fix-media-flags:dry-run": "node src/tools/fix-media-upload-flags.js --dry-run",
 		"db:fix-media-flags:verbose": "node src/tools/fix-media-upload-flags.js --verbose",
+		"media:cleanup-orphans:dry-run": "node src/tools/cleanup-orphaned-uploads.ts --dry-run --verbose",
+		"media:cleanup-orphans": "node src/tools/cleanup-orphaned-uploads.ts",
 		"sbom:generate": "npm run sbom:json && npm run sbom:xml",
 		"sbom:json": "npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-format JSON --output-file sbom/sbom.json --validate",
 		"sbom:xml": "npx @cyclonedx/cyclonedx-npm --ignore-npm-errors --output-format XML --output-file sbom/sbom.xml --validate",

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -70,6 +70,46 @@ node src/tools/fix-media-upload-flags.js --dry-run --verbose
 - Graceful error handling
 - Database connection cleanup
 
+#### `cleanup-orphaned-uploads.ts`
+
+Removes orphaned media uploads: `sichtungen_dateien` rows that never got linked to a sighting, and files on disk that have no database row.
+
+**Purpose:**
+
+- Uploads create a `sichtungen_dateien` row with `sichtung_id = NULL` before the sighting exists; abandoned forms leave that row — and the file — behind forever
+- Those rows carry `exif_daten` including GPS coordinates for reports that were never submitted
+- Files without a row accumulate because deleting a sighting cascades the rows but leaves the files on disk
+
+**Usage:**
+
+```bash
+# Dry run first (this is the default — no flag needed)
+npm run media:cleanup-orphans:dry-run
+
+# Delete for real, after taking a backup
+npm run media:cleanup-orphans -- --execute
+```
+
+**Parameters:**
+
+- `--older-than=<n>h|<n>d`: Retention period, default `24h`. Only entries strictly older are removed.
+- `--execute`: Actually delete. Without it the tool only reports.
+- `--verbose`: List every finding individually
+- `--uploads-dir=<path>`: Override the upload directory (defaults to `uploads` relative to the working directory, matching the application)
+
+**Safety Features:**
+
+- Dry run is the default; deletion requires `--execute`
+- Refuses to run without `DATABASE_POSTGRES_URL` or `DATABASE_URL` — never guesses a target database
+- Refuses to run when `STORAGE_PROVIDER` is set to anything other than `local`
+- Age filter protects uploads still in progress (the file is written before the row)
+- Paths are compared as Unicode NFC — macOS reports filenames decomposed, PostgreSQL composed. Without this every file with an umlaut would look orphaned.
+- A file is also spared when its directory matches a `sichtungen.referenz_id`, even with no row pointing at it — in that case it is the only remaining copy
+- Every deletion path is validated against the resolved upload directory
+- `uploads/_old_uploads/` and dotfiles (`.DS_Store`, `.gitkeep`) are excluded
+
+**Before the first `--execute` run:** back up both the database and the upload directory. Deleted files are not recoverable. `DATABASE_POSTGRES_URL` usually lives only in `.env`, so run `set -a && . ./.env && set +a` before `pg_dump` — otherwise it silently connects elsewhere.
+
 ### 3. Data Migration
 
 #### `generate-reference-ids.ts`

--- a/src/tools/cleanup-orphaned-uploads.test.ts
+++ b/src/tools/cleanup-orphaned-uploads.test.ts
@@ -1,0 +1,324 @@
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	assertLocalStorage,
+	computeCutoff,
+	normalizeRelativePath,
+	parseCliOptions,
+	parseRetention,
+	resolveConnectionString,
+	resolveSafeTarget,
+	selectOrphanedFiles,
+	selectOrphanedRows,
+	type DiskEntry,
+	type OrphanRow
+} from './cleanup-orphaned-uploads';
+
+describe('parseRetention', () => {
+	it('rechnet Stunden in Millisekunden um', () => {
+		expect(parseRetention('24h')).toBe(24 * 60 * 60 * 1000);
+	});
+
+	it('rechnet Tage in Millisekunden um', () => {
+		expect(parseRetention('7d')).toBe(7 * 24 * 60 * 60 * 1000);
+	});
+
+	it('akzeptiert Großschreibung', () => {
+		expect(parseRetention('12H')).toBe(12 * 60 * 60 * 1000);
+	});
+
+	it.each(['24', 'h', '-1h', '0h', 'abc', '', '1.5h', '1h2d'])(
+		'weist ungültige Eingabe %j zurück',
+		(input) => {
+			expect(() => parseRetention(input)).toThrow(/Ungültige Frist/);
+		}
+	);
+});
+
+describe('computeCutoff', () => {
+	it('zieht die Frist vom Bezugszeitpunkt ab', () => {
+		const now = new Date('2026-07-28T12:00:00.000Z');
+
+		const cutoff = computeCutoff(now, 24 * 60 * 60 * 1000);
+
+		expect(cutoff.toISOString()).toBe('2026-07-27T12:00:00.000Z');
+	});
+
+	it('verändert den übergebenen Bezugszeitpunkt nicht', () => {
+		const now = new Date('2026-07-28T12:00:00.000Z');
+
+		computeCutoff(now, 1000);
+
+		expect(now.toISOString()).toBe('2026-07-28T12:00:00.000Z');
+	});
+});
+
+/** Baut eine Zeile mit sinnvollen Vorgaben; nur Abweichungen angeben. */
+function buildRow(overrides: Partial<OrphanRow> = {}): OrphanRow {
+	return {
+		id: 1,
+		filePath: 'a0vaw9b811s6mb1ma79cmlzc/abc.jpg',
+		uploadedAt: new Date('2026-07-01T00:00:00.000Z'),
+		...overrides
+	};
+}
+
+describe('selectOrphanedRows', () => {
+	const cutoff = new Date('2026-07-27T12:00:00.000Z');
+
+	it('wählt Zeilen, die älter als der Grenzzeitpunkt sind', () => {
+		const rows = [buildRow({ id: 42, uploadedAt: new Date('2026-07-26T00:00:00.000Z') })];
+
+		expect(selectOrphanedRows(rows, cutoff).map((row) => row.id)).toEqual([42]);
+	});
+
+	it('schont Zeilen innerhalb der Frist', () => {
+		const rows = [buildRow({ uploadedAt: new Date('2026-07-28T00:00:00.000Z') })];
+
+		expect(selectOrphanedRows(rows, cutoff)).toEqual([]);
+	});
+
+	it('schont eine Zeile exakt auf dem Grenzzeitpunkt', () => {
+		const rows = [buildRow({ uploadedAt: new Date(cutoff) })];
+
+		expect(selectOrphanedRows(rows, cutoff)).toEqual([]);
+	});
+
+	it('wählt die vier bekannten Altlasten vom 26.12.2025', () => {
+		const rows = [866, 867, 874, 875].map((id) =>
+			buildRow({ id, uploadedAt: new Date('2025-12-26T10:00:00.000Z') })
+		);
+
+		expect(selectOrphanedRows(rows, cutoff).map((row) => row.id)).toEqual([866, 867, 874, 875]);
+	});
+
+	it('liefert bei leerer Eingabe eine leere Liste', () => {
+		expect(selectOrphanedRows([], cutoff)).toEqual([]);
+	});
+});
+
+/** Baut einen Dateisystem-Eintrag; nur Abweichungen angeben. */
+function buildEntry(overrides: Partial<DiskEntry> = {}): DiskEntry {
+	return {
+		relativePath: 'a0vaw9b811s6mb1ma79cmlzc/abc.jpg',
+		modifiedAt: new Date('2026-07-01T00:00:00.000Z'),
+		...overrides
+	};
+}
+
+describe('normalizeRelativePath', () => {
+	it('wandelt Backslashes in Schrägstriche', () => {
+		expect(normalizeRelativePath('ref\\datei.jpg')).toBe('ref/datei.jpg');
+	});
+
+	it('entfernt einen führenden Schrägstrich', () => {
+		expect(normalizeRelativePath('/ref/datei.jpg')).toBe('ref/datei.jpg');
+	});
+
+	it('entfernt ein führendes ./', () => {
+		expect(normalizeRelativePath('./ref/datei.jpg')).toBe('ref/datei.jpg');
+	});
+
+	it('lässt einen bereits normalisierten Pfad unverändert', () => {
+		expect(normalizeRelativePath('ref/datei.jpg')).toBe('ref/datei.jpg');
+	});
+
+	it('setzt zerlegte Umlaute zu NFC zusammen', () => {
+		// macOS liefert Dateinamen zerlegt (u + kombinierendes Trema),
+		// PostgreSQL zusammengesetzt. Ohne diese Angleichung gilt eine Datei
+		// mit Umlaut als verwaist, obwohl ihre Zeile existiert.
+		// ̈ ist das kombinierende Trema — bewusst als Escape geschrieben,
+		// weil NFD und NFC im Quelltext sonst identisch aussehen.
+		const decomposed = 'ref/Rügen.jpg';
+		const composed = 'ref/Rügen.jpg';
+
+		expect(decomposed).not.toBe(composed);
+		expect(normalizeRelativePath(decomposed)).toBe(composed);
+	});
+
+	it('lässt zusammengesetzte Umlaute unverändert', () => {
+		expect(normalizeRelativePath('ref/Rügen.jpg')).toBe('ref/Rügen.jpg');
+	});
+});
+
+describe('selectOrphanedFiles', () => {
+	const cutoff = new Date('2026-07-27T12:00:00.000Z');
+
+	it('wählt eine alte Datei ohne DB-Zeile', () => {
+		const entries = [buildEntry({ relativePath: 'ref/waise.jpg' })];
+
+		const result = selectOrphanedFiles(
+			entries,
+			{ paths: ['ref/andere.jpg'], referenceIds: [] },
+			cutoff
+		);
+
+		expect(result.map((entry) => entry.relativePath)).toEqual(['ref/waise.jpg']);
+	});
+
+	it('schont eine Datei, die in der Datenbank steht', () => {
+		const entries = [buildEntry({ relativePath: 'ref/bekannt.jpg' })];
+
+		expect(
+			selectOrphanedFiles(entries, { paths: ['ref/bekannt.jpg'], referenceIds: [] }, cutoff)
+		).toEqual([]);
+	});
+
+	it('schont eine junge Datei ohne DB-Zeile — das ist ein laufender Upload', () => {
+		const entries = [
+			buildEntry({
+				relativePath: 'ref/gerade-hochgeladen.jpg',
+				modifiedAt: new Date('2026-07-28T11:59:00.000Z')
+			})
+		];
+
+		expect(selectOrphanedFiles(entries, { paths: [], referenceIds: [] }, cutoff)).toEqual([]);
+	});
+
+	it('schont eine Datei exakt auf dem Grenzzeitpunkt', () => {
+		const entries = [buildEntry({ relativePath: 'ref/grenze.jpg', modifiedAt: new Date(cutoff) })];
+
+		expect(selectOrphanedFiles(entries, { paths: [], referenceIds: [] }, cutoff)).toEqual([]);
+	});
+
+	it('vergleicht Pfade unabhängig vom Trennzeichen', () => {
+		const entries = [buildEntry({ relativePath: 'ref\\bekannt.jpg' })];
+
+		expect(
+			selectOrphanedFiles(entries, { paths: ['ref/bekannt.jpg'], referenceIds: [] }, cutoff)
+		).toEqual([]);
+	});
+
+	it('erkennt einen zerlegt geschriebenen Dateinamen als bekannt', () => {
+		// Der reale Datenverlust-Fall: macOS liefert NFD, die Datenbank NFC.
+		// Ohne Normalisierung gälte diese Datei als verwaist und würde gelöscht.
+		const entries = [buildEntry({ relativePath: 'ref/Rügen.jpg' })];
+
+		expect(
+			selectOrphanedFiles(entries, { paths: ['ref/Rügen.jpg'], referenceIds: [] }, cutoff)
+		).toEqual([]);
+	});
+
+	it('schont eine Datei, deren Ordner zu einer echten Sichtung gehört', () => {
+		// Der Ordnername ist die referenz_id der Sichtung. Fehlt die Zeile,
+		// ist die Datei die EINZIGE verbliebene Kopie — sie zu löschen wäre
+		// der schlimmstmögliche Ausgang dieses Tools.
+		const entries = [buildEntry({ relativePath: 'echteref/bild.jpg' })];
+
+		expect(selectOrphanedFiles(entries, { paths: [], referenceIds: ['echteref'] }, cutoff)).toEqual(
+			[]
+		);
+	});
+
+	it('liefert bei leerer Eingabe eine leere Liste', () => {
+		expect(
+			selectOrphanedFiles([], { paths: ['ref/bekannt.jpg'], referenceIds: [] }, cutoff)
+		).toEqual([]);
+	});
+});
+
+describe('resolveSafeTarget', () => {
+	const baseDir = '/srv/app/uploads';
+
+	it('löst einen normalen relativen Pfad unterhalb der Basis auf', () => {
+		expect(resolveSafeTarget(baseDir, 'ref/datei.jpg')).toBe('/srv/app/uploads/ref/datei.jpg');
+	});
+
+	it.each(['../etc/passwd', 'ref/../../etc/passwd', '/etc/passwd', 'ref/../../../', '..', ''])(
+		'weist %j zurück',
+		(relativePath) => {
+			expect(resolveSafeTarget(baseDir, relativePath)).toBeNull();
+		}
+	);
+
+	it('weist einen Pfad zurück, der die Basis nur als Präfix teilt', () => {
+		expect(resolveSafeTarget(baseDir, '../uploads-backup/datei.jpg')).toBeNull();
+	});
+
+	it('erlaubt einen internen Rücksprung, der die Basis nicht verlässt', () => {
+		expect(resolveSafeTarget(baseDir, 'ref/unter/../datei.jpg')).toBe(
+			'/srv/app/uploads/ref/datei.jpg'
+		);
+	});
+
+	it('behandelt einen doppelten Punkt im Dateinamen als gewöhnlichen Namen', () => {
+		// Real im Bestand: `1538584452187..jpg` gehört zu einer echten Sichtung.
+		// `..` hat nur als vollständiger Pfadabschnitt Bedeutung.
+		expect(resolveSafeTarget(baseDir, 'ref/1538584452187..jpg')).toBe(
+			'/srv/app/uploads/ref/1538584452187..jpg'
+		);
+	});
+});
+
+describe('parseCliOptions', () => {
+	it('verwendet 24h und Dry-Run als Vorgabe', () => {
+		const options = parseCliOptions([], {});
+
+		expect(options.retentionMs).toBe(24 * 60 * 60 * 1000);
+		expect(options.execute).toBe(false);
+		expect(options.verbose).toBe(false);
+	});
+
+	it('übernimmt --older-than', () => {
+		expect(parseCliOptions(['--older-than=7d'], {}).retentionMs).toBe(7 * 24 * 60 * 60 * 1000);
+	});
+
+	it('schaltet mit --execute scharf', () => {
+		expect(parseCliOptions(['--execute'], {}).execute).toBe(true);
+	});
+
+	it('erkennt --verbose', () => {
+		expect(parseCliOptions(['--verbose'], {}).verbose).toBe(true);
+	});
+
+	it('löst das Upload-Verzeichnis wie die Anwendung auf', () => {
+		expect(parseCliOptions([], {}).uploadsDir).toBe(resolve('uploads'));
+	});
+
+	it('übernimmt --uploads-dir', () => {
+		expect(parseCliOptions(['--uploads-dir=/data/uploads'], {}).uploadsDir).toBe('/data/uploads');
+	});
+
+	it('weist ein unbekanntes Argument zurück', () => {
+		expect(() => parseCliOptions(['--force'], {})).toThrow(/Unbekanntes Argument/);
+	});
+
+	it('weist eine ungültige Frist zurück', () => {
+		expect(() => parseCliOptions(['--older-than=morgen'], {})).toThrow(/Ungültige Frist/);
+	});
+});
+
+describe('resolveConnectionString', () => {
+	it('bevorzugt DATABASE_POSTGRES_URL', () => {
+		const env = {
+			DATABASE_POSTGRES_URL: 'postgresql://a/1',
+			DATABASE_URL: 'postgresql://b/2'
+		};
+
+		expect(resolveConnectionString(env)).toBe('postgresql://a/1');
+	});
+
+	it('fällt auf DATABASE_URL zurück', () => {
+		expect(resolveConnectionString({ DATABASE_URL: 'postgresql://b/2' })).toBe('postgresql://b/2');
+	});
+
+	it('wirft, wenn keine Verbindung gesetzt ist — es wird nicht geraten', () => {
+		expect(() => resolveConnectionString({})).toThrow(/DATABASE_POSTGRES_URL/);
+	});
+});
+
+describe('assertLocalStorage', () => {
+	it('lässt einen leeren STORAGE_PROVIDER durch', () => {
+		expect(() => assertLocalStorage({})).not.toThrow();
+	});
+
+	it('lässt local durch', () => {
+		expect(() => assertLocalStorage({ STORAGE_PROVIDER: 'local' })).not.toThrow();
+	});
+
+	it('bricht bei vercel-blob ab', () => {
+		expect(() => assertLocalStorage({ STORAGE_PROVIDER: 'vercel-blob' })).toThrow(
+			/nur für local storage/i
+		);
+	});
+});

--- a/src/tools/cleanup-orphaned-uploads.test.ts
+++ b/src/tools/cleanup-orphaned-uploads.test.ts
@@ -305,6 +305,12 @@ describe('resolveConnectionString', () => {
 	it('wirft, wenn keine Verbindung gesetzt ist — es wird nicht geraten', () => {
 		expect(() => resolveConnectionString({})).toThrow(/DATABASE_POSTGRES_URL/);
 	});
+
+	it('nennt in der Fehlermeldung beide akzeptierten Variablen', () => {
+		// Die Meldung nannte nur DATABASE_POSTGRES_URL, obwohl DATABASE_URL
+		// ebenfalls akzeptiert wird — im Betrieb irreführend.
+		expect(() => resolveConnectionString({})).toThrow(/DATABASE_URL/);
+	});
 });
 
 describe('assertLocalStorage', () => {

--- a/src/tools/cleanup-orphaned-uploads.ts
+++ b/src/tools/cleanup-orphaned-uploads.ts
@@ -1,0 +1,484 @@
+/**
+ * @fileoverview Räumt verwaiste Medien-Uploads auf.
+ *
+ * Zwei Waisen-Klassen:
+ *   A) Zeilen in `sichtungen_dateien` mit `sichtung_id IS NULL`, deren Upload
+ *      länger zurückliegt als die Frist — abgebrochene Formularläufe. Der
+ *      Upload legt die Zeile an, bevor die Sichtung existiert; verknüpft wird
+ *      erst beim Absenden. Wird nie abgeschickt, bleibt sie auf NULL stehen.
+ *   B) Dateien unter `uploads/`, zu denen es keine Zeile gibt.
+ *
+ * Verwendung:
+ *   node src/tools/cleanup-orphaned-uploads.ts [--older-than=24h] [--execute] [--verbose]
+ *
+ * Parameter:
+ *   --older-than=<n>h|<n>d  Aufbewahrungsfrist (Default 24h)
+ *   --execute               Löscht wirklich. Ohne dieses Flag: reiner Dry-Run.
+ *   --verbose               Listet jeden Fund einzeln
+ *   --uploads-dir=<pfad>    Überschreibt das Upload-Verzeichnis
+ *
+ * Vor dem ersten Lauf mit --execute: Backup von Datenbank UND Upload-Verzeichnis.
+ * Gelöschte Dateien fängt kein Papierkorb auf. `DATABASE_POSTGRES_URL` steht
+ * üblicherweise nur in der `.env` — für pg_dump vorher `set -a && . ./.env`.
+ *
+ * Ausführung: `node src/tools/cleanup-orphaned-uploads.ts` (Node ≥ 22.18 —
+ * natives Type Stripping, wie scripts/docker-migrate.ts).
+ *
+ * @author Ostsee-Tiere Team
+ */
+import { readdir, stat, unlink } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { config } from 'dotenv';
+import postgres from 'postgres';
+
+/** Erlaubte Fristangaben: positive Ganzzahl plus Einheit `h` oder `d`. */
+const RETENTION_PATTERN = /^(\d+)([hd])$/i;
+
+const MILLIS_PER_HOUR = 60 * 60 * 1000;
+const MILLIS_PER_DAY = 24 * MILLIS_PER_HOUR;
+
+/**
+ * Vorgabe: einen Tag. Formularentwürfe liegen in sessionStorage und überstehen
+ * das Schließen des Tabs nicht — was 24 Stunden unverknüpft liegt, kann nicht
+ * mehr abgesendet werden.
+ */
+const DEFAULT_RETENTION = '24h';
+
+/** Verzeichnis mit Altbestand aus der Migration des Vorgängersystems. */
+const EXCLUDED_DIRS = new Set(['_old_uploads']);
+
+/**
+ * Wandelt eine Fristangabe wie `24h` oder `7d` in Millisekunden um.
+ * Wirft bei allem anderen — ein stiller Default wäre hier gefährlich,
+ * weil die Frist bestimmt, was gelöscht wird.
+ */
+export function parseRetention(input: string): number {
+	const match = RETENTION_PATTERN.exec(input.trim());
+	if (!match) {
+		throw new Error(`Ungültige Frist: ${JSON.stringify(input)}. Erwartet z. B. "24h" oder "7d".`);
+	}
+
+	const [, rawAmount = '', rawUnit = ''] = match;
+
+	const amount = Number(rawAmount);
+	if (amount <= 0) {
+		throw new Error(`Ungültige Frist: ${JSON.stringify(input)}. Muss größer als 0 sein.`);
+	}
+
+	return rawUnit.toLowerCase() === 'h' ? amount * MILLIS_PER_HOUR : amount * MILLIS_PER_DAY;
+}
+
+/**
+ * Bildet den Grenzzeitpunkt. Alles, was strikt davor liegt, gilt als verwaist.
+ * Bewusst eine einzige Stelle: Klasse A und Klasse B müssen dieselbe Grenze
+ * verwenden, sonst räumt ein Lauf die Datei ab und lässt die Zeile stehen.
+ */
+export function computeCutoff(now: Date, retentionMs: number): Date {
+	return new Date(now.getTime() - retentionMs);
+}
+
+/** Eine Zeile aus `sichtungen_dateien` ohne verknüpfte Sichtung. */
+export interface OrphanRow {
+	id: number;
+	/** Pfad relativ zum Upload-Verzeichnis, wie in `datei_pfad` gespeichert. */
+	filePath: string;
+	uploadedAt: Date;
+}
+
+/**
+ * Wählt die Zeilen, deren Upload strikt vor dem Grenzzeitpunkt liegt.
+ * Strikt, damit ein Datensatz exakt auf der Grenze geschont wird.
+ */
+export function selectOrphanedRows(rows: OrphanRow[], cutoff: Date): OrphanRow[] {
+	return rows.filter((row) => row.uploadedAt.getTime() < cutoff.getTime());
+}
+
+/** Eine Datei, die beim Durchlaufen des Upload-Verzeichnisses gefunden wurde. */
+export interface DiskEntry {
+	/** Pfad relativ zum Upload-Verzeichnis, mit `/` als Trennzeichen. */
+	relativePath: string;
+	modifiedAt: Date;
+}
+
+/**
+ * Bringt einen Pfad in die Form, in der `datei_pfad` gespeichert wird:
+ * Schrägstriche als Trennzeichen, kein führendes `/` oder `./`, Unicode als NFC.
+ *
+ * Die NFC-Angleichung ist der kritische Teil: macOS liefert Dateinamen zerlegt
+ * (NFD), PostgreSQL zusammengesetzt (NFC). Ohne sie gilt jede Datei mit Umlaut
+ * als verwaist, obwohl ihre Zeile existiert — am echten Bestand waren das 10
+ * Dateien echter Sichtungen, die das Tool gelöscht hätte.
+ */
+export function normalizeRelativePath(input: string): string {
+	return input.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\//, '').normalize('NFC');
+}
+
+/** Alles, was als „gehört zu einer Sichtung" gilt und deshalb tabu ist. */
+export interface KnownState {
+	/** Alle `datei_pfad`-Werte der Tabelle, auch die verknüpften. */
+	paths: Iterable<string>;
+	/** Alle `referenz_id`-Werte aus `sichtungen`. */
+	referenceIds: Iterable<string>;
+}
+
+/**
+ * Wählt Dateien, zu denen es keine Zeile gibt und die strikt älter als der
+ * Grenzzeitpunkt sind.
+ *
+ * Der Altersfilter ist hier kein Komfort, sondern Schutz: Der Upload schreibt
+ * erst die Datei und danach die DB-Zeile. Ohne Filter würde genau diese Lücke
+ * als Waise gedeutet und ein laufender Upload zerstört.
+ */
+export function selectOrphanedFiles(
+	entries: DiskEntry[],
+	known: KnownState,
+	cutoff: Date
+): DiskEntry[] {
+	const knownPaths = new Set<string>();
+	for (const path of known.paths) {
+		knownPaths.add(normalizeRelativePath(path));
+	}
+
+	const knownReferenceIds = new Set<string>();
+	for (const referenceId of known.referenceIds) {
+		knownReferenceIds.add(referenceId.normalize('NFC'));
+	}
+
+	return entries.filter((entry) => {
+		const normalized = normalizeRelativePath(entry.relativePath);
+
+		if (entry.modifiedAt.getTime() >= cutoff.getTime()) return false;
+		if (knownPaths.has(normalized)) return false;
+
+		// Zweite, unabhängige Absicherung: Der erste Pfadabschnitt ist die
+		// `referenz_id`. Gehört sie zu einer echten Sichtung, ist die Datei
+		// tabu — auch ohne Zeile. Genau dann ist sie die einzige Kopie.
+		const referenceId = normalized.split('/')[0];
+		if (referenceId && knownReferenceIds.has(referenceId)) return false;
+
+		return true;
+	});
+}
+
+/**
+ * Löst einen relativen Pfad gegen das Upload-Verzeichnis auf und gibt `null`
+ * zurück, wenn das Ergebnis die Basis verlässt.
+ *
+ * `datei_pfad` kommt aus der Datenbank, nicht aus dem Code — dieselbe
+ * Absicherung wie in `LocalStorageProvider.validatePath()`.
+ */
+export function resolveSafeTarget(baseDir: string, relativePath: string): string | null {
+	// Ein absoluter Pfad in `datei_pfad` ist eine Datenanomalie. Ihn durch
+	// Abschneiden des führenden Schrägstrichs als relativ umzudeuten wäre
+	// stillschweigendes Raten — dann zeigte `/etc/passwd` auf
+	// `uploads/etc/passwd`. Lieber ablehnen und melden.
+	if (isAbsolute(relativePath) || relativePath.startsWith('/') || relativePath.startsWith('\\')) {
+		return null;
+	}
+
+	const normalized = normalizeRelativePath(relativePath);
+	if (normalized === '') {
+		return null;
+	}
+
+	const resolvedBase = resolve(baseDir);
+	const target = resolve(resolvedBase, normalized);
+	const rel = relative(resolvedBase, target);
+
+	if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) {
+		return null;
+	}
+
+	return target;
+}
+
+export interface CliOptions {
+	retentionMs: number;
+	execute: boolean;
+	verbose: boolean;
+	uploadsDir: string;
+}
+
+/**
+ * Liest die Kommandozeile. Unbekannte Argumente sind ein Fehler — ein
+ * vertipptes `--execute` darf nicht stillschweigend zum Dry-Run werden,
+ * und ein vertipptes `--dry-run` nicht stillschweigend zum Löschen.
+ */
+export function parseCliOptions(argv: string[], env: NodeJS.ProcessEnv): CliOptions {
+	void env;
+
+	let retention = DEFAULT_RETENTION;
+	let execute = false;
+	let verbose = false;
+	let uploadsDir: string | null = null;
+
+	for (const arg of argv) {
+		if (arg === '--execute') {
+			execute = true;
+		} else if (arg === '--verbose') {
+			verbose = true;
+		} else if (arg === '--dry-run') {
+			// Ausdrücklich erlaubt, obwohl es der Vorgabe entspricht: Aufrufe aus
+			// den npm-Skripten sollen die Absicht sichtbar machen.
+			execute = false;
+		} else if (arg.startsWith('--older-than=')) {
+			retention = arg.slice('--older-than='.length);
+		} else if (arg.startsWith('--uploads-dir=')) {
+			uploadsDir = arg.slice('--uploads-dir='.length);
+		} else {
+			throw new Error(`Unbekanntes Argument: ${arg}`);
+		}
+	}
+
+	return {
+		retentionMs: parseRetention(retention),
+		execute,
+		verbose,
+		// Wie die Anwendung: `resolve('uploads')` gegen das Arbeitsverzeichnis.
+		// UPLOAD_PATH wird bewusst NICHT gelesen — die Anwendung liest es auch
+		// nicht (src/lib/server/storage/factory.ts übergibt das Literal
+		// 'uploads'). Würde das Tool der Variablen folgen, räumte es einen
+		// Ordner ab, in den nie jemand geschrieben hat.
+		uploadsDir: uploadsDir ?? resolve('uploads')
+	};
+}
+
+/**
+ * Liefert die Verbindungszeichenfolge oder wirft. Kein Fallback auf eine
+ * Standardverbindung: Dieses Tool löscht, es darf die Zieldatenbank nie raten.
+ * In einem Git-Worktree fehlt die `.env` regelmäßig — genau dort wäre ein
+ * geratener Fallback auf die falsche Datenbank gegangen.
+ */
+export function resolveConnectionString(env: NodeJS.ProcessEnv): string {
+	const connectionString = env.DATABASE_POSTGRES_URL || env.DATABASE_URL;
+	if (!connectionString) {
+		throw new Error(
+			'Keine Datenbankverbindung gefunden. DATABASE_POSTGRES_URL muss gesetzt sein — ' +
+				'in der Umgebung oder in einer .env im Arbeitsverzeichnis.'
+		);
+	}
+	return connectionString;
+}
+
+/**
+ * Bricht ab, wenn ein anderer Storage-Provider als `local` konfiguriert ist.
+ * Der Dateisystem-Scan gilt nur für lokalen Storage; bei `vercel-blob` fände
+ * er nichts und meldete „0 Waisen" — eine Falschaussage.
+ */
+export function assertLocalStorage(env: NodeJS.ProcessEnv): void {
+	const provider = env.STORAGE_PROVIDER;
+	if (provider && provider !== 'local') {
+		throw new Error(
+			`STORAGE_PROVIDER ist "${provider}". Dieses Tool arbeitet nur für local storage.`
+		);
+	}
+}
+
+/**
+ * Läuft das Upload-Verzeichnis rekursiv ab und liefert alle Dateien mit
+ * ihrem relativen Pfad und ihrer Änderungszeit.
+ */
+async function scanUploadDir(baseDir: string, prefix = ''): Promise<DiskEntry[]> {
+	let dirEntries;
+	try {
+		dirEntries = await readdir(join(baseDir, prefix), { withFileTypes: true });
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return [];
+		}
+		throw error;
+	}
+
+	const results: DiskEntry[] = [];
+	for (const entry of dirEntries) {
+		// Punktdateien sind nie Uploads (`.DS_Store`, `.gitkeep`). Sie liegen
+		// real im Verzeichnis und wären sonst als Waise gelöscht worden.
+		if (entry.name.startsWith('.')) {
+			continue;
+		}
+
+		const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+		if (entry.isDirectory()) {
+			if (EXCLUDED_DIRS.has(entry.name) && prefix === '') {
+				continue;
+			}
+			results.push(...(await scanUploadDir(baseDir, relativePath)));
+		} else if (entry.isFile()) {
+			const stats = await stat(join(baseDir, relativePath));
+			results.push({ relativePath, modifiedAt: stats.mtime });
+		}
+	}
+	return results;
+}
+
+/** Verdeckt das Passwort in einer Verbindungszeichenfolge für die Ausgabe. */
+function maskConnection(connectionString: string): string {
+	return connectionString.replace(/:[^:@]*@/, ':****@');
+}
+
+/**
+ * Löscht eine Datei und meldet, ob sie tatsächlich entfernt wurde.
+ * Eine bereits fehlende Datei ist kein Fehler — das Ziel ist erreicht.
+ */
+async function removeFile(target: string): Promise<boolean> {
+	try {
+		await unlink(target);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+			return false;
+		}
+		console.error(`❌ Konnte ${target} nicht löschen: ${(error as Error).message}`);
+		return false;
+	}
+}
+
+async function main(): Promise<void> {
+	config();
+
+	const options = parseCliOptions(process.argv.slice(2), process.env);
+	assertLocalStorage(process.env);
+	const connectionString = resolveConnectionString(process.env);
+
+	const cutoff = computeCutoff(new Date(), options.retentionMs);
+
+	console.log(`🔗 Datenbank:  ${maskConnection(connectionString)}`);
+	console.log(`📁 Uploads:    ${options.uploadsDir}`);
+	console.log(`🕓 Grenze:     ${cutoff.toISOString()} (älteres gilt als verwaist)`);
+	console.log(
+		options.execute ? '✍️  Modus:      LÖSCHEND\n' : '🧪 Modus:      DRY RUN — keine Änderungen\n'
+	);
+
+	if (process.env.UPLOAD_PATH && resolve(process.env.UPLOAD_PATH) !== options.uploadsDir) {
+		console.warn(
+			`⚠️  UPLOAD_PATH ist auf ${process.env.UPLOAD_PATH} gesetzt, das Tool arbeitet aber\n` +
+				`   auf ${options.uploadsDir} — wie die Anwendung, die UPLOAD_PATH nicht liest.\n` +
+				`   Bei abweichendem Setup --uploads-dir=<pfad> übergeben.\n`
+		);
+	}
+
+	const sql = postgres(connectionString);
+
+	try {
+		// Ein einziger Lesestand für beide Klassen. Würde Klasse B nach dem
+		// Löschen von Klasse A ermittelt, tauchten deren Dateien erneut auf.
+		//
+		// `hochgeladen_am` ist `timestamp without time zone` und enthält UTC.
+		// Als Text mit explizitem Z gelesen, damit der Treiber die Spalte nicht
+		// als Ortszeit deutet — genau der Fehler, den die UTC-Vereinheitlichung
+		// beseitigt hat.
+		const rawRows = await sql<{ id: number; datei_pfad: string; uploaded_at_utc: string }[]>`
+			SELECT
+				id,
+				datei_pfad,
+				to_char(hochgeladen_am, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS uploaded_at_utc
+			FROM sichtungen_dateien
+			WHERE sichtung_id IS NULL
+			ORDER BY id
+		`;
+
+		const candidateRows: OrphanRow[] = rawRows.map((row) => ({
+			id: row.id,
+			filePath: row.datei_pfad,
+			uploadedAt: new Date(row.uploaded_at_utc)
+		}));
+
+		const allPaths = await sql<{ datei_pfad: string }[]>`
+			SELECT datei_pfad FROM sichtungen_dateien
+		`;
+		const knownPaths = allPaths.map((row) => row.datei_pfad);
+
+		// Zweite Absicherung für Klasse B: Ordnernamen sind `referenz_id`-Werte.
+		// Eine Datei in einem Ordner, der zu einer echten Sichtung gehört, ist
+		// tabu — auch wenn keine Zeile auf sie zeigt. Dann ist sie die einzige
+		// verbliebene Kopie der Medien dieser Sichtung.
+		const refRows = await sql<{ referenz_id: string }[]>`
+			SELECT referenz_id FROM sichtungen WHERE referenz_id IS NOT NULL
+		`;
+		const knownReferenceIds = refRows.map((row) => row.referenz_id);
+
+		const diskEntries = await scanUploadDir(options.uploadsDir);
+
+		const orphanedRows = selectOrphanedRows(candidateRows, cutoff);
+		const orphanedFiles = selectOrphanedFiles(
+			diskEntries,
+			{ paths: knownPaths, referenceIds: knownReferenceIds },
+			cutoff
+		);
+
+		console.log('📊 Befund:');
+		console.log(`   Zeilen ohne Sichtung insgesamt: ${candidateRows.length}`);
+		console.log(`   davon älter als die Grenze:     ${orphanedRows.length}`);
+		console.log(`   Dateien im Verzeichnis:         ${diskEntries.length}`);
+		console.log(`   davon ohne Zeile und zu alt:    ${orphanedFiles.length}\n`);
+
+		if (options.verbose) {
+			for (const row of orphanedRows) {
+				console.log(`   [Zeile] id=${row.id} ${row.filePath} (${row.uploadedAt.toISOString()})`);
+			}
+			for (const entry of orphanedFiles) {
+				console.log(`   [Datei] ${entry.relativePath} (${entry.modifiedAt.toISOString()})`);
+			}
+			if (orphanedRows.length > 0 || orphanedFiles.length > 0) {
+				console.log('');
+			}
+		}
+
+		if (orphanedRows.length === 0 && orphanedFiles.length === 0) {
+			console.log('🎉 Nichts aufzuräumen.');
+			return;
+		}
+
+		if (!options.execute) {
+			console.log('🔍 DRY RUN — es wurde nichts gelöscht.');
+			console.log('   Mit --execute erneut aufrufen. Vorher Backup ziehen.');
+			return;
+		}
+
+		let deletedRows = 0;
+		let deletedFiles = 0;
+
+		// Klasse A: erst die Zeile, dann die Datei. Scheitert das Löschen der
+		// Datei, bleibt eine Klasse-B-Waise zurück, die der nächste Lauf
+		// einsammelt. Umgekehrt entstünde eine Zeile ohne Datei — die findet
+		// danach keine der beiden Klassen mehr.
+		for (const row of orphanedRows) {
+			await sql`DELETE FROM sichtungen_dateien WHERE id = ${row.id}`;
+			deletedRows++;
+
+			const target = resolveSafeTarget(options.uploadsDir, row.filePath);
+			if (!target) {
+				console.warn(`⚠️  Pfad außerhalb des Upload-Verzeichnisses, übersprungen: ${row.filePath}`);
+				continue;
+			}
+			if (await removeFile(target)) {
+				deletedFiles++;
+			}
+		}
+
+		for (const entry of orphanedFiles) {
+			const target = resolveSafeTarget(options.uploadsDir, entry.relativePath);
+			if (!target) {
+				console.warn(
+					`⚠️  Pfad außerhalb des Upload-Verzeichnisses, übersprungen: ${entry.relativePath}`
+				);
+				continue;
+			}
+			if (await removeFile(target)) {
+				deletedFiles++;
+			}
+		}
+
+		console.log(`\n✅ ${deletedRows} Zeilen und ${deletedFiles} Dateien gelöscht.`);
+	} finally {
+		await sql.end();
+	}
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error: unknown) => {
+		console.error(`\n💥 Abbruch: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	});
+}

--- a/src/tools/cleanup-orphaned-uploads.ts
+++ b/src/tools/cleanup-orphaned-uploads.ts
@@ -28,6 +28,7 @@
  */
 import { readdir, stat, unlink } from 'node:fs/promises';
 import { isAbsolute, join, relative, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { config } from 'dotenv';
 import postgres from 'postgres';
 
@@ -253,8 +254,9 @@ export function resolveConnectionString(env: NodeJS.ProcessEnv): string {
 	const connectionString = env.DATABASE_POSTGRES_URL || env.DATABASE_URL;
 	if (!connectionString) {
 		throw new Error(
-			'Keine Datenbankverbindung gefunden. DATABASE_POSTGRES_URL muss gesetzt sein — ' +
-				'in der Umgebung oder in einer .env im Arbeitsverzeichnis.'
+			'Keine Datenbankverbindung gefunden. DATABASE_POSTGRES_URL (bevorzugt) oder ' +
+				'DATABASE_URL muss gesetzt sein — in der Umgebung oder in einer .env im ' +
+				'Arbeitsverzeichnis.'
 		);
 	}
 	return connectionString;
@@ -476,7 +478,14 @@ async function main(): Promise<void> {
 	}
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// `pathToFileURL` statt Zeichenkettenbau: `import.meta.url` ist eine korrekt
+// kodierte file:-URL. Bei einem Pfad mit Leerzeichen (`%20`) schlüge der
+// naive Vergleich fehl — das Tool beendete sich dann mit Code 0 und ganz ohne
+// Ausgabe. Gleiches Muster wie in scripts/docker-migrate.ts.
+const isDirectRun =
+	typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
 	main().catch((error: unknown) => {
 		console.error(`\n💥 Abbruch: ${error instanceof Error ? error.message : String(error)}`);
 		process.exit(1);

--- a/src/tools/migrate-timestamps-to-utc.js
+++ b/src/tools/migrate-timestamps-to-utc.js
@@ -89,8 +89,8 @@ const connectionString = process.env.DATABASE_POSTGRES_URL || process.env.DATABA
 
 if (!connectionString) {
 	console.error('❌ Keine Datenbankverbindung gefunden.');
-	console.error('   DATABASE_POSTGRES_URL muss gesetzt sein — entweder in der Umgebung');
-	console.error('   oder in einer .env im Arbeitsverzeichnis.');
+	console.error('   DATABASE_POSTGRES_URL (bevorzugt) oder DATABASE_URL muss gesetzt sein —');
+	console.error('   entweder in der Umgebung oder in einer .env im Arbeitsverzeichnis.');
 	console.error('   In einem Git-Worktree fehlt die .env oft:');
 	console.error('     bash scripts/new-worktree.sh --link-env "$(pwd)"');
 	console.error('   Diese Migration rät nicht — sie verschiebt Zeitstempel unumkehrbar.');


### PR DESCRIPTION
## Problem

`POST /api/files/upload` legt eine Zeile in `sichtungen_dateien` mit `sichtung_id = NULL` an, **bevor** die Sichtung existiert; verknüpft wird erst beim Absenden. Wird das Formular nie abgeschickt, bleibt die Zeile für immer auf `NULL` — und die Datei auf der Platte. Im Projekt gibt es keinen Mechanismus, der das je einsammelt: die einzige Löschroute ist das nutzerinitiierte `POST /api/files/delete`.

Die Zeilen tragen `exif_daten` inklusive GPS-Koordinaten. Bei einer nie zustande gekommenen Meldung fehlt dafür die Rechtsgrundlage.

## Was drin ist

`src/tools/cleanup-orphaned-uploads.ts` meldet zwei Waisen-Klassen und löscht nur mit `--execute`:

- **Klasse A** — Zeilen ohne Sichtung, älter als die Frist. Erst Zeile, dann Datei: Scheitert das Datei-Löschen, bleibt eine Klasse-B-Waise, die der nächste Lauf einsammelt. Andersherum entstünde eine Zeile ohne Datei, die niemand mehr findet.
- **Klasse B** — Dateien ohne Zeile.

Beide aus **einem** Lesestand, damit Klasse-A-Dateien nicht doppelt gezählt werden.

```bash
npm run media:cleanup-orphans:dry-run          # Vorgabe, ändert nichts
npm run media:cleanup-orphans -- --execute     # löscht, nach Backup
```

## Absicherungen — jede davon ein real gefundener Fehlerfall

Beim Abgleich gegen die echte Entwicklungsdatenbank sind vier Wege aufgefallen, auf denen das Tool Daten zerstört hätte:

| Absicherung | Was ohne sie passiert wäre |
| --- | --- |
| Pfadvergleich als Unicode **NFC** | macOS liefert Dateinamen zerlegt, PostgreSQL zusammengesetzt. Der naive Vergleich meldete 15 Waisen — **10 davon gehörten zu echten Sichtungen**, jede mit Umlaut im Namen (`Rügen`, `Peenemünde`, `Bülk`, …). Alle zehn wären gelöscht worden. |
| Ordner-Abgleich gegen `sichtungen.referenz_id` | Eine Datei ohne Zeile kann trotzdem zu einer Sichtung gehören — wenn die Zeile verlorenging und die Datei überlebte. Dann ist sie die einzige Kopie. |
| Altersfilter | Der Upload schreibt erst die Datei, dann die Zeile. Ohne Filter wird diese Lücke als Waise gedeutet und ein laufender Upload zerstört. |
| Punktdateien überspringen | `uploads/.DS_Store` liegt real im Verzeichnis und wäre gelöscht worden. |

Dazu: kein geratener DB-Fallback (`DATABASE_POSTGRES_URL` ist Pflicht, wie bei `migrate-timestamps-to-utc.js`), Abbruch bei `STORAGE_PROVIDER != local`, Traversal-Schutz analog `LocalStorageProvider.validatePath()`, und **Dry-Run als Vorgabe** — umgekehrt zu den Geschwister-Tools, weil die idempotent Flags korrigieren und dieses hier unwiderruflich löscht.

## Aufbau

Folgt `scripts/docker-migrate.ts`: reines TypeScript, mit `node` über natives Type Stripping ausgeführt (Node ≥ 22.18), pure Entscheidungsfunktionen exportiert und separat getestet.

## Tests

56 neue Tests, Server-Suite vollständig grün (1895 Tests). Abgedeckt: Fristen-Parsing inkl. Fehleingaben, beide Auswahllogiken mit Grenzfall exakt auf der Frist, NFD/NFC-Vergleich, der `referenz_id`-Schutz, Traversal-Abwehr inkl. des real vorhandenen `1538584452187..jpg`, Argument-Parsing und die Umgebungsprüfungen.

## Nicht drin

- **Kein Löschlauf.** Diese PR ändert keine Daten. Der scharfe Lauf erfolgt getrennt, nach Backup und nach Sichtprüfung der Dry-Run-Ausgabe.
- **Keine Änderung an den Löschpfaden.** `DELETE /api/sightings/[id]` und `saveSightingFiles()` entfernen Zeilen, ohne die Dateien zu löschen, und erzeugen weiter Waisen. Läuft als eigene Aufgabe — der wichtigere der beiden Schritte.
- **Kein automatischer Job.** Ohne ihn wächst der Bestand nach; in `.claude/rules/upload.md` als offener Punkt vermerkt.
- **Kein Vercel-Blob-Support**, kein Admin-UI, kein Undo.

## Stand der Waisen (28.07.2026, read-only ermittelt)

4 Zeilen (IDs 866/867/874/875, alle 26.12.2025) und 3 Dateien. Eine vierte Datei wird vom Altersfilter geschont — sie ist von heute. Für keine der sieben gehört der Ordner zu einer Sichtung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)