### PR TITLE
fix(report): Schweinswal-Angaben der Bestimmungshilfe an DMM-Steckbrief angleichen

### DIFF
--- a/docs/FACHREVIEW_BESTIMMUNGSHILFE_2026-07-27.md
+++ b/docs/FACHREVIEW_BESTIMMUNGSHILFE_2026-07-27.md
@@ -9,6 +9,15 @@
 > liegen jetzt in `src/lib/report/formOptions/speciesIdentification.ts` und sind durch
 > `speciesIdentification.test.ts` abgesichert. Die fachliche Abnahme durch das Deutsche
 > Meeresmuseum steht weiterhin aus (siehe Abschnitt E).
+>
+> **Nachkontrolle 2026-07-28:** Erneuter Abgleich gegen die vier DMM-Steckbriefe
+> (Schweinswal, Kegelrobbe, Seehund, Ringelrobbe — mehr gibt es dort nicht). Rest-Abweichungen
+> ausschließlich beim Schweinswal: Maximallänge ohne den Zusatz „sehr selten auch 2 m",
+> Kälbergröße 70–90 statt 65–90 cm, unbelegte Spannen „meist 1,4–1,7 m" und
+> „Ostsee-Tiere meist 45–60 kg", fehlender Größendimorphismus. Alle fünf Punkte korrigiert
+> und in `speciesIdentification.test.ts` (Block „Abgleich mit den DMM-Artensteckbriefen")
+> festgeschrieben. Für die übrigen sieben Formular-Einträge existiert beim DMM kein
+> Steckbrief; sie bleiben auf die in den Quellen genannten Referenzen gestützt.
 
 ## Zusammenfassung
 

--- a/src/lib/report/formOptions/speciesIdentification.test.ts
+++ b/src/lib/report/formOptions/speciesIdentification.test.ts
@@ -80,6 +80,35 @@ describe('Merkmale', () => {
 	});
 });
 
+describe('Abgleich mit den DMM-Artensteckbriefen', () => {
+	// Quelle: https://www.deutsches-meeresmuseum.de/wissenschaft/infothek/artensteckbriefe/schweinswale
+	const schweinswal = speciesIdentification[SpeciesEnum.HARBOR_PORPOISE];
+
+	it('nennt Durchschnitts- und Maximallänge des Schweinswals wie das Meeresmuseum', () => {
+		expect(schweinswal.size).toContain('1,60 m');
+		expect(schweinswal.size).toContain('1,85 m');
+		// Ohne "sehr selten auch 2 m" wirkt ein größerer Totfund nach dem Text unmöglich.
+		expect(schweinswal.size).toMatch(/selten\s+2 m/);
+	});
+
+	it('nennt die Kälbergröße des Meeresmuseums (65–90 cm)', () => {
+		expect(schweinswal.size).toContain('65–90 cm');
+	});
+
+	it('gibt beim Schweinswal nur die belegte Gewichtsspanne an', () => {
+		// "Ostsee-Tiere meist 45–60 kg" steht in keinem Steckbrief.
+		expect(schweinswal.weight).toBe('40–90 kg');
+	});
+
+	it('führt den Größendimorphismus des Schweinswals als Hintergrundwissen', () => {
+		const dimorphismus = schweinswal.distinguishing.find(
+			(f) => f.text.includes('Weibchen') && f.text.includes('Männchen')
+		);
+		expect(dimorphismus, 'Merkmal zum Größenunterschied fehlt').toBeDefined();
+		expect(dimorphismus?.observability).toBe('background');
+	});
+});
+
 describe('Bilder', () => {
 	it('hat für jede Tierart mindestens ein Bild', () => {
 		for (const species of allSpecies) {

--- a/src/lib/report/formOptions/speciesIdentification.ts
+++ b/src/lib/report/formOptions/speciesIdentification.ts
@@ -67,8 +67,8 @@ export const speciesIdentification: Record<SpeciesEnum, SpeciesIdentificationEnt
 	[SpeciesEnum.HARBOR_PORPOISE]: {
 		name: 'Schweinswal',
 		scientificName: 'Phocoena phocoena',
-		size: 'meist 1,4–1,7 m, maximal ca. 1,85 m (Kälber 70–90 cm)',
-		weight: '40–90 kg (Ostsee-Tiere meist 45–60 kg)',
+		size: 'im Mittel 1,60 m, bis 1,85 m, sehr selten 2 m (Kälber 65–90 cm)',
+		weight: '40–90 kg',
 		frequency: {
 			level: 'resident',
 			text: 'Die einzige dauerhaft in der Ostsee lebende Walart. Fast alle Meldungen betreffen ihn.'
@@ -98,6 +98,10 @@ export const speciesIdentification: Record<SpeciesEnum, SpeciesIdentificationEnt
 			{
 				text: 'Heller, oft fast weißer Bauch; dunkler Streifen vom Mundwinkel zur Brustflosse',
 				observability: 'closeup'
+			},
+			{
+				text: 'Weibchen werden größer und schwerer als Männchen',
+				observability: 'background'
 			}
 		],
 		behavior: [


### PR DESCRIPTION
## Was

Abgleich der Bestimmungshilfe im Sichtungsformular mit den [Artensteckbriefen des Deutschen Meeresmuseums](https://www.deutsches-meeresmuseum.de/wissenschaft/infothek/artensteckbriefe) — Nachkontrolle zum Fachreview vom 27.07.

Ergebnis: Die schweren Befunde des Reviews (falsches Seelöwen-Foto, verdrehte Atemfrequenz, Seehund-Verhalten) sind erledigt. Übrig waren vier kleine Abweichungen, alle beim Schweinswal:

| Feld | Vorher | Jetzt (= DMM-Steckbrief) |
| --- | --- | --- |
| `size` | `meist 1,4–1,7 m, maximal ca. 1,85 m (Kälber 70–90 cm)` | `im Mittel 1,60 m, bis 1,85 m, sehr selten 2 m (Kälber 65–90 cm)` |
| `weight` | `40–90 kg (Ostsee-Tiere meist 45–60 kg)` | `40–90 kg` |
| `distinguishing` | — | neu: `Weibchen werden größer und schwerer als Männchen` (`background`) |

## Warum

- **„maximal ca. 1,85 m"** ließ ein größeres Tier nach dem Text unmöglich erscheinen. Das DMM schreibt „bis zu 1,85 m, sehr selten auch 2 m" — relevant, weil Totfunde vermessen gemeldet werden.
- **„Kälber 70–90 cm"** vs. belegte 65–90 cm.
- **„meist 1,4–1,7 m"** und **„Ostsee-Tiere meist 45–60 kg"** standen in keiner Quelle; der Steckbrief nennt nur den Durchschnitt 1,60 m und 40–90 kg.
- Der **Größendimorphismus** (Weibchen größer) steht beim DMM, fehlte aber, obwohl Kegelrobbe und Ringelrobbe ihn führen.

## Tests

Neuer Block „Abgleich mit den DMM-Artensteckbriefen" in `speciesIdentification.test.ts` mit Quellen-URL im Kommentar, 4 Tests. Test-first geschrieben: erst rot (4 failed / 14 passed), nach der Korrektur grün.

`npm run test:quick` grün — lint, `tsc --noEmit`, `svelte-check`, 1984 Unit-Tests in 133 Dateien.

## Für Reviewer

- **Das DMM hat nur vier Artensteckbriefe** (Schweinswal, Kegelrobbe, Seehund, Ringelrobbe). Kegelrobbe, Seehund und Ringelrobbe stimmen bereits vollständig überein — kein Änderungsbedarf. Für die übrigen sieben Formular-Einträge (Delphin, Beluga, Zwergwal, Finnwal, Buckelwal, 2× „Unbekannt") existiert dort keine Referenz; sie bleiben auf DMM-Buckelwalseite, Jensen & Kinze, NABU/WDC gestützt.
- **Die fachliche Abnahme durch die Meeressäuger-Abteilung des DMM steht weiterhin aus** (Abschnitt E des Reviews).
- Bewusst nicht in diesem PR: die DMM-Fotos übernehmen (Bildrechte werden separat geklärt) und der fehlende Hinweis „(Tier in menschlicher Obhut)" im Alt-Text von `grey-seal-head-profile.jpg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)