### PR TITLE
feat(map): UX quick wins from sightings map review

### DIFF
--- a/docs/SICHTUNGSKARTE_QUICKWINS_SPEC_2026-07-28.md
+++ b/docs/SICHTUNGSKARTE_QUICKWINS_SPEC_2026-07-28.md
@@ -1,0 +1,138 @@
+# Spec: Sichtungskarte — Quick-Win-Fixes aus dem UX-Review
+
+**Datum:** 2026-07-28 · **Basis:** `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md`
+**Scope:** Die acht Quick Wins (§8 des Reviews). Größere Maßnahmen (K3-A11y, ARIA-Sanierung, Bottom-Sheet, Farbsystem, URL-State) sind **nicht** Teil dieser Spec — sie werden als separate Follow-Up-Tasks angelegt.
+
+**Verbindlich für alle Punkte:** Test-First gemäß `.claude/rules/testing.md` (reproduzierender Test vor dem Fix; reine CSS-/Textänderungen sind dokumentierte Ausnahmen). API-Änderungen aktualisieren `static/openapi.yml`. Design-Tokens gemäß `.claude/rules/design-system.md`.
+
+---
+
+## Priorisierung & Wellen
+
+| Prio | ID   | Titel                                                       | Review-Ref | Welle            | Dateien (führend)                                           |
+| ---- | ---- | ----------------------------------------------------------- | ---------- | ---------------- | ----------------------------------------------------------- |
+| 1    | QW1  | Ungültige Koordinaten serverseitig filtern                  | K2         | 1 (Server)       | `api/map/sightings/+server.ts`                              |
+| 2    | QW2a | Endpoint „verfügbare Jahre mit Anzahl"                      | K1         | 1 (Server)       | `api/map/sightings/years/+server.ts` (neu)                  |
+| 3    | QW2b | Default-Jahr = jüngstes Jahr mit Daten + Empty-State-Button | K1         | 2 (Client)       | `SightingsMapView.svelte`, `FilterPanel.svelte`             |
+| 4    | QW3  | Popup bei Jahr-/Filterwechsel schließen; Escape-Kaskade     | H1         | 2 (Client)       | `optimizedMapController.ts`, `SightingsMapView.svelte`      |
+| 5    | QW4  | Zeitslider-Reset bei Jahreswechsel                          | H2         | 2 (Client)       | `timeSliderManager.ts`                                      |
+| 6    | QW5  | Suche ehrlich: Placeholder, Hilfetext, echter Ladeindikator | H3         | 2 (Client)       | `FilterPanel.svelte`, `SightingsMapView.svelte`             |
+| 7    | QW6  | Controls ≥ 44 px + deutscher Zoom-Tooltip                   | H4, M9     | 1 (CSS/Controls) | `mapStyles.css`, `optimizedMapController.ts`                |
+| 8    | QW7  | „Z" → Icon-Button; Zoom-alle auf Ostsee begrenzt            | M5, K2     | 1 (CSS/Controls) | `ZoomAllControl.ts`, `optimizedMapController.ts`            |
+| 9    | QW8  | Mobile Panelbreite reparieren (tote `.w-90`-Regel)          | H6         | 1 (CSS/Controls) | `mapStyles.css`, `FilterPanel.svelte`, `LegendPanel.svelte` |
+
+Welle 1 läuft parallel (Server-Agent ∥ CSS/Controls-Agent, disjunkte Dateien). Welle 2 startet danach (ein Client-UX-Agent; hängt von QW2a ab und fasst Controller/Panels an, die Welle 1 punktuell ändert).
+
+---
+
+## Welle 1 — Server
+
+### QW1: Ungültige Koordinaten filtern (K2)
+
+**Problem:** 165/817 Features (2025) mit `[0,0]` bzw. Nordpol-Koordinaten; Ursache NULL-Koordinaten → `sightingsToGeoJSON`-Fallback auf 0.
+
+**Lösung:** In `GET /api/map/sightings` zusätzliche WHERE-Bedingungen:
+
+- `latitude IS NOT NULL AND longitude IS NOT NULL`
+- Plausibilitätsfenster Ostsee: `longitude BETWEEN 9.4 AND 30.2 AND latitude BETWEEN 53.0 AND 66.0` — Konstanten aus `BALTIC_SEA_BBOX` (`src/lib/utils/geo/checkBalticSea.ts`) importieren, nicht duplizieren.
+
+**Akzeptanz:**
+
+- `/api/map/sightings?year=2025` liefert 0 Features außerhalb der BBox (vorher 165).
+- Test (Erweiterung von `src/routes/api/map/sightings/yearFilter.test.ts` oder neue Co-located-Testdatei): mit gemockter DB-Query wird verifiziert, dass die Bedingungen Teil der Query sind bzw. dass Null-Island-Datensätze nicht im GeoJSON landen.
+- `static/openapi.yml`: Beschreibung des Endpoints ergänzt („liefert nur Sichtungen mit plausiblen Ostsee-Koordinaten").
+- Kein Umbau von `sightingsToGeoJSON` (der 0-Fallback wird durch den Serverfilter unerreichbar für die Karte; Verhalten anderer Aufrufer unverändert).
+
+### QW2a: Endpoint verfügbare Jahre (K1)
+
+**Lösung:** Neuer Endpoint `GET /api/map/sightings/years` → `{ years: [{ year: number, count: number }, …] }`, absteigend sortiert. Grundmenge identisch zur Karte: `approvedAt IS NOT NULL` **und** gültige Koordinaten (QW1-Bedingungen). Jahresgrenzen wie im Hauptendpoint über `berlinDayRangeUtc`-Konvention (Gruppierung per `berlinDatePart`-Ausdruck aus `src/lib/server/db/sqlTimeZone.ts`, damit vorhandene Indizes greifen).
+
+**Akzeptanz:**
+
+- Liefert für den Prod-Datenstand u. a. `{year: 2025, count: >0}`, `{year: 2024, count: >0}`; 2026 erscheint nicht (count 0 wird nicht geliefert).
+- Co-located Test (gemockte DB) + OpenAPI-Eintrag (Pfad, Schema).
+- Kein zweiter Freigabe-Filterpfad: dieselbe `approvedOnly()`-Semantik wie überall (`.claude/rules/api.md`).
+
+---
+
+## Welle 1 — CSS/Controls
+
+### QW6: Touch-Targets & deutsche Tooltips (H4, M9)
+
+- `mapStyles.css`: `.ol-zoom button`, `.zoom-all-control button`, `.location-control button` auf **min. 44×44 px** (Desktop wie Mobile; die `!important`-`1.375em`-Blöcke und die 2.2em-Mobile-Variante ersetzen). Abstände/Offsets (`top`) der Controls entsprechend nachziehen, damit nichts überlappt (Zoom oben links unter dem Titel, Z darunter).
+- Popup-Closer (`createPopup` in `optimizedMapController.ts`): Hit-Target auf min. 44×44 px (Padding), Symbol darf optisch klein bleiben.
+- `defaultControls({ rotate: false, zoomOptions: { zoomInTipLabel: 'Vergrößern', zoomOutTipLabel: 'Verkleinern' } })`.
+
+**Akzeptanz:** `getBoundingClientRect()` der drei Control-Buttons ≥ 44 px in beiden Dimensionen (manuelle Verifikation im Browser genügt, CSS-Ausnahme von Test-First — im Commit dokumentieren). Tooltips deutsch.
+
+### QW7: Zoom-alle: Icon + Ostsee-Klemme (M5, K2-Symptom)
+
+- `ZoomAllControl.ts`: statt `'Z'` ein Inline-SVG (z. B. Maximize-/Extent-Icon, `aria-hidden="true"` am SVG, `aria-label` bleibt am Button), Title „Auf alle Sichtungen zoomen".
+- `zoomAllFeatures()` im Controller: Extent vor `view.fit()` mit dem Ostsee-Extent verschneiden (`BALTIC_SEA_BBOX` → `fromLonLat`-transformierte `boundingExtent`); wenn der Feature-Extent leer/unendlich ist → auf Ostsee-Default zoomen statt nichts zu tun. Damit zoomt „Z" nie mehr auf die Weltansicht, selbst wenn künftig wieder Ausreißer in den Daten sind.
+
+**Akzeptanz:** Test für die neue Extent-Klemm-Logik (pure Funktion `clampExtentToBaltic(extent)` in `mapUtils.ts` o. ä., Test-First). Browser-Verifikation: Z zoomt auf Ostsee.
+
+### QW8: Mobile Panelbreite (H6-Teilfix)
+
+- Tote Regel `.w-90 { width: 100vw !important }` (`mapStyles.css:241-243`) entfernen.
+- Panels (`FilterPanel.svelte`, `LegendPanel.svelte`): `w-100` → zusätzlich `max-w-[100vw]`; Toggle-Button-Transform von hartem `-400px` auf `calc(-1 * min(400px, 100vw))`, damit der Button auf schmalen Viewports an der Panelkante bleibt statt ins Layout zu ragen.
+
+**Akzeptanz:** Bei 375 px Viewport: Panel ≤ Viewportbreite, Toggle-Button sichtbar an der linken Panelkante, Schließen-X erreichbar. (CSS-Ausnahme von Test-First, Browser-Verifikation mit Screenshot.)
+
+---
+
+## Welle 2 — Client-UX (nach Welle 1)
+
+### QW2b: Default-Jahr mit Daten + Empty-State-Aktion (K1)
+
+- `SightingsMapView.svelte`: vor Karteninitialisierung `GET /api/map/sightings/years` laden. Default-Jahr = `pickDefaultYear(availableYears, getDefaultSightingYear())` — neue **pure Funktion** in `src/lib/utils/date/defaultYear.ts`: jüngstes Jahr mit `count > 0`, das ≤ dem bisherigen Default liegt; gibt es keins, das jüngste Jahr mit Daten überhaupt; Fallback bei leerem/fehlgeschlagenem Response: bisheriges Verhalten. (Test-First in `defaultYear.test.ts`.)
+- Jahres-Dropdown: weiterhin die letzten 10 Jahre, aber Jahre mit Daten kennzeichnen bzw. Anzahl anzeigen („2025 (817)") — Jahre ohne Daten bleiben wählbar.
+- Empty-State „Keine Sichtungen für {Jahr} vorhanden." bekommt einen Button `btn btn-primary btn-sm` „Sichtungen {jüngstes Jahr mit Daten} anzeigen", der das Jahr umschaltet (gleicher Pfad wie Dropdown-Änderung). Button nur wenn ein solches Jahr existiert.
+- Fehlerpfad: `years`-Request scheitert → stilles Fallback auf bisheriges Verhalten (kein Fehler-Toast dafür).
+
+**Akzeptanz:** Erststart auf lokalem Prod-Stand zeigt 2025er-Daten statt leerer Karte; Test für `pickDefaultYear` (Grenzfälle: leere Liste, nur ältere Jahre, aktuelles Jahr mit Daten).
+
+### QW3: Stale Popup schließen + Escape (H1)
+
+- Controller: öffentliche Methode `closePopup()` (setzt `popup.setPosition(undefined)`), aufgerufen am Anfang von `setYear()`, `applyFilter()`, `setSpeciesVisibility()`, `setColorVisibility()`, `setFilter()` (Zeitslider).
+- `SightingsMapView.svelte` Escape-Kaskade neu: **Popup → Hilfe-Modal → Filter-Panel → Legende** (Popup-offen-Abfrage über neue Methode `isPopupOpen()` oder `closePopup()` gibt `boolean` zurück, ob eines offen war).
+
+**Akzeptanz:** Test-First soweit sinnvoll: Die Schließ-Aufrufe sind OL-lastig — zulässige Abdeckung: schlanker Unit-Test, der per Mock-Overlay verifiziert, dass `setYear`/`applyFilter`/Visibility-Setter `closePopup()` auslösen (Controller-Instanziierung ist im jsdom schwer — alternativ die Aufrufe in eine testbare private Hilfsstruktur ziehen oder als dokumentierte Browser-Verifikation). Browser-Verifikation: Jahr wechseln → Popup zu; Escape schließt zuerst das Popup.
+
+### QW4: Zeitslider-Reset bei Jahreswechsel (H2)
+
+- `MapTimeSliderManager` erhält `reset(daysInYear: number)`: Start-Slider → 0, Ende-Slider → `daysInYear - 1`, `max`-Attribute aktualisieren.
+- Aufruf beim Jahreswechsel (im bestehenden `yearChangeCallback`-Fluss in `SightingsMapView.svelte`, der auch `currentDisplayedYear` setzt).
+- Dabei die bestehende ±1-Zwangskorrektur so anpassen, dass Start == Ende erlaubt ist (Review M10-Teilaspekt, ein Zeilenfix: Klemmen statt Verschieben).
+
+**Akzeptanz:** Test-First: `timeSliderManager.test.ts` (jsdom: zwei Range-Inputs, Manager initialisieren, `reset(366)` → Werte 0/365 und `max` 365; Start==Ende möglich). Browser-Verifikation: Slider auf Juli, Jahr wechseln → Thumbs auf 01.01./31.12.
+
+### QW5: Suche ehrlich machen (H3)
+
+- Placeholder: `„Fahrwasser, Schiffsname, Name…"` (keine E-Mail — die API durchsucht sie nicht).
+- Hilfetext: `„Filtert automatisch beim Tippen"`.
+- `title`-Attribut des Inputs entsprechend anpassen.
+- **Echter Ladeindikator:** `FilterPanel` bekommt Prop `isLoading: boolean`; `SightingsMapView` reicht `isLoadingData` durch. Der 800-ms-Fake (`handleFilterApply`, `filterFeedbackTimeout`) und das `disabled` am Jahres-Select während des Fakes entfallen ersatzlos; Spinner/„Filter wird angewendet…" hängen an `isLoading`. Enter im Suchfeld: kein eigener Handler mehr nötig (Debounce filtert ohnehin) — Enter darf zusätzlich sofort filtern (Debounce-Bypass ist optional, nicht gefordert).
+
+**Akzeptanz:** Textänderungen (Ausnahme Test-First, da reine Copy). Prop-Verdrahtung per vorhandenem Komponenten-Testmuster, falls ein FilterPanel-Test existiert — sonst Browser-Verifikation: Tippen zeigt Spinner während des echten Requests, danach aus.
+
+---
+
+## Nicht in dieser Spec (→ Follow-Up-Tasks / Chips)
+
+| Thema                                                              | Review-Ref      |
+| ------------------------------------------------------------------ | --------------- |
+| Tastaturbedienung + Listen-/Tabellenalternative                    | K3              |
+| ARIA-/Fokus-Sanierung der Panels (inert, region, Fokus-Management) | H5, H7          |
+| Mobile Bottom-Sheet für Filter/Legende                             | H6 (Vollausbau) |
+| Marker-/Legenden-Farbsystem vereinheitlichen                       | M1, M8          |
+| URL-State, Filter-Chips, Reset                                     | M4, N6          |
+| OpenSeaMap-Toggle, Loading-Konzept, Dual-Range-Slider              | M3, M7, M10     |
+
+---
+
+## Abnahme gesamt
+
+1. `npm run test:quick` grün.
+2. Browser-Verifikation Desktop + 375 px: Erststart zeigt Daten; Z zoomt auf Ostsee; Popup schließt bei Filterwechsel; Slider konsistent nach Jahreswechsel; Controls ≥ 44 px; Panel mobil ≤ Viewport.
+3. `static/openapi.yml` validiert (js-yaml-Check aus `.claude/rules/api.md`).

--- a/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
+++ b/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
@@ -1,0 +1,305 @@
+# UX- und Funktionsreview: Sichtungskarte (`/map`)
+
+**Datum:** 2026-07-28
+**Methode:** Code-Review aller Karten-Module, Live-Test im Browser (Desktop 1151×756 und Mobile 375×812, Chrome), Abgleich gegen aktuelle Best Practices für interaktive Webkarten (OpenLayers, Google Maps Platform, Leaflet/Mapbox, NN/g, Baymard, W3C/WAI — Quellen am Ende).
+**Getesteter Stand:** Branch `claude/sichtungskarte-ux-review-a2737a`, lokale DB mit Prod-Datenstand.
+
+---
+
+## 1. Zusammenfassung
+
+Die Karte ist funktional solide gebaut (Clustering, Abbruch laufender Requests, Consent-basierte Namensanzeige, Co-located-Cluster-Liste) — aber im Live-Test zeigen sich **drei kritische Probleme**, die den Ersteindruck bzw. die Nutzbarkeit grundlegend beeinträchtigen:
+
+| #      | Befund                                                                                                                                            | Schwere  |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| K1     | Erststart zeigt eine **leere Karte** („Keine Sichtungen für 2026")                                                                                | Kritisch |
+| K2     | **165 von 817 Features (2025) mit ungültigen Koordinaten** (Null Island 0/0, Nordpol) werden gerendert; „Auf alle zoomen" springt auf Weltansicht | Kritisch |
+| K3     | Karte ist **per Tastatur nicht bedienbar**, Marker/Popups unerreichbar, keine Datenalternative → WCAG-2.1-Verstoß                                 | Kritisch |
+| H1–H7  | Stale Popup, Zeitslider-Inkonsistenz, irreführende Suche, 19-px-Controls, ARIA-Fehler, Panel-Layout mobil kaputt, globale Einzeltasten-Shortcuts  | Hoch     |
+| M1–M10 | Doppelte Farbcodierung, Cluster-Overlap, OpenSeaMap-Rauschen, fehlender URL-State, fehlender Reset u. a.                                          | Mittel   |
+
+Alles Weitere unten mit Evidenz (Datei:Zeile bzw. Test-Beobachtung) und konkreter Empfehlung.
+
+---
+
+## 2. Was gut funktioniert (im Test verifiziert)
+
+- **Cluster-Klick zoomt sinnvoll hinein** (`optimizedMapController.ts:407-417`), und bei ortsgleichen Sichtungen erscheint stattdessen eine **scrollbare Liste mit Detail-Ansicht und Zurück-Link** — das ist die richtige Alternative zum Spiderfy-Pattern und funktionierte im Test einwandfrei.
+- **Hover-Zusammenfassung auf Clustern** („44 Sichtungen — Schweinswal: 23, Kegelrobbe: 10, …") ist ein echtes Plus; nur Desktop, auf Touch korrekt deaktiviert.
+- **Nur ein Popup gleichzeitig**; Klick auf leere Karte schließt es (Best Practice erfüllt).
+- **Race-Condition-Schutz** beim Jahres-/Suchwechsel via `AbortController` (`optimizedMapController.ts:698-735`) — schnelles Umschalten produzierte im Test keine Fehler.
+- **Datenschutz:** Name/Schiffsname erscheinen nur mit Consent — serverseitig gefiltert (`mapUtils.ts:164-167`, `+server.ts:44-50`), nicht nur clientseitig versteckt. Suche respektiert Consent-Flags ebenfalls serverseitig.
+- **Legende mit sichtbar/gesamt-Zählern** pro Art und Live-Update beim Filtern (im Test: Schweinswal-Toggle → 0/585, Marker verschwinden sofort).
+- **XSS-Härtung** der Popup-Inhalte über `sanitizeText`.
+- Leere Zustände existieren („Keine Sichtungen für …", „Keine Sichtungen für den aktuellen Filter sichtbar" mit Hinweistext) und ein Fehler-Toast mit Dismiss.
+- `100dvh`-basierte Höhe (mobile Browserleisten korrekt berücksichtigt), Tastatur-Hilfemodal mit dokumentierten Shortcuts.
+
+---
+
+## 3. Kritische Befunde
+
+### K1 — Erststart zeigt eine leere Karte
+
+**Beobachtung:** Beim Aufruf von `/map` erscheint „Keine Sichtungen für 2026 vorhanden." auf leerer Ostsee-Karte. Die API liefert für 2026 **0 Features** (2025: 817, 2024: 1060).
+
+**Ursachen:**
+
+- `getDefaultSightingYear()` (`src/lib/utils/date/defaultYear.ts:13`) wählt ab April das laufende Jahr — ohne zu prüfen, ob es Daten gibt.
+- Verschärfend: Seit dem Altsystem-Cutoff (Nov 2025) setzt die neue App `freigegeben_am` beim Freigeben — aber der Rückstand ungeprüfter Meldungen ist groß; öffentlich sichtbar ist nur `approvedAt IS NOT NULL`. In Produktion ist die 2026er-Karte damit real leer oder fast leer.
+
+Der erste Eindruck für jeden Besucher ist eine leere Karte — das klassische „Empty-State-Dead-End". Die Empty-State-Meldung bietet zudem **keine Aktion** an.
+
+**Empfehlung (kurzfristig):** Default-Jahr = jüngstes Jahr **mit freigegebenen Daten** (die API kann das in einem kleinen Meta-Endpoint oder Response-Header liefern). In den Empty-State einen Button „Sichtungen \<Jahr\> anzeigen" aufnehmen.
+**Empfehlung (mittelfristig):** Option „Alle Jahre" bzw. Zeitraum über Jahresgrenzen hinweg (siehe M4/M10) — eBird/iNaturalist zeigen standardmäßig einen kumulierten Bestand, nicht ein leeres Kalenderjahr.
+
+### K2 — Ungültige Koordinaten werden gerendert; „Auf alle zoomen" springt auf Weltansicht
+
+**Beobachtung (verifiziert per API-Abfrage im Test):** Für 2025 liegen **165 von 817 Features außerhalb der Ostsee-Bounding-Box**, überwiegend exakt bei `[0, 0]` („Null Island", Golf von Guinea), eine bei `[-88.77, 90]` (Nordpol). Auf der Karte erscheint dadurch ein großer Cluster (im Test „134") im Atlantik; die Taste **Z / „Auf alle Sichtungen zoomen" zoomt auf die halbe Weltkugel** statt auf die Ostsee. Danach gibt es keinen einfachen Weg zurück (kein Home-Button, siehe M5).
+
+**Ursachen:**
+
+- Sichtungen ohne GPS-Koordinaten (NULL in DB) werden in `sightingsToGeoJSON` auf `0` gemappt (`mapUtils.ts:137-145`, „Fallback auf 0 für ungültige Koordinaten").
+- Der API-Endpoint (`src/routes/api/map/sightings/+server.ts`) filtert weder NULL-Koordinaten noch Ausreißer außerhalb der Ostsee-Box, obwohl `BALTIC_SEA_BBOX` im Projekt existiert (`src/lib/utils/geo/checkBalticSea.ts`).
+
+**Empfehlung:** Features ohne gültige Koordinaten serverseitig ausfiltern (`latitude IS NOT NULL AND longitude IS NOT NULL` + Plausibilitätsfenster, z. B. die vorhandene Baltic-BBox mit Toleranz). Falls solche Meldungen zählbar bleiben sollen, als „ohne Position: N" in der Legende ausweisen statt sie auf Null Island zu stapeln. `zoomAllFeatures()` zusätzlich defensiv auf die Ostsee-Extent begrenzen.
+
+### K3 — Tastaturbedienung und Screenreader: Karte nicht zugänglich
+
+**Beobachtung/Prüfung (per DOM-Inspektion im Live-Test):**
+
+- `#map` hat **kein `tabindex`** (`mapFocusable: -1`) → die Karte ist nicht fokussierbar; OpenLayers' eingebaute Tastaturnavigation (Pfeiltasten pannen, +/− zoomen) ist damit faktisch abgeschaltet. Genau dafür dokumentiert OpenLayers das `tabindex="0"`-Pattern (Beispiel „accessible").
+- **Marker und Popups sind per Tastatur überhaupt nicht erreichbar** (Canvas-Rendering ohne fokussierbare Stellvertreter).
+- Es gibt **keine Alternative in Tabellen-/Listenform** mit derselben Datengrundlage — laut WCAG-Praxis (u. a. Leitfaden Minnesota IT, W3C-Maps-Workshop) die Pflicht-Alternative für Karten.
+- `role="application"` auf `#map` (`SightingsMapView.svelte:321`) suggeriert Screenreadern eine bedienbare Anwendung, die es per Tastatur nicht ist.
+
+**Empfehlung:**
+
+1. `tabindex="0"` auf das Karten-Target + sichtbarer Fokusring; OL-`KeyboardPan`/`KeyboardZoom` funktionieren dann sofort.
+2. Eine zugängliche **Listen-/Tabellenansicht der aktuell gefilterten Sichtungen** anbieten (gleiches Jahr, gleiche Filter; z. B. Toggle „Karte / Liste"). Das löst gleichzeitig das Popup-Erreichbarkeitsproblem.
+3. Skip-Link („Karte überspringen") vor der Karte für Tastaturnutzer.
+
+---
+
+## 4. Befunde mit hoher Priorität
+
+### H1 — Popup veraltet bei Filter-/Jahreswechsel (Stale Popup)
+
+**Beobachtung:** Popup einer Schweinswal-Sichtung vom 14.8.**2025** blieb geöffnet, während die Karte bereits auf **2024** und Suchbegriff „Rügen" stand — das Popup zeigt Daten, deren Feature längst entfernt ist. Auch beim Ausblenden der Art per Legende bleibt das Popup offen. **Escape schließt das Popup nicht** (der Escape-Handler kennt nur Hilfe-Modal und Panels, `SightingsMapView.svelte:284-301`).
+
+**Empfehlung:** Bei `setYear`, `applyFilter`, Sichtbarkeits-Toggles und Zeitslider-Änderung `popup.setPosition(undefined)` aufrufen; Escape-Kaskade um das Popup erweitern (Popup → Hilfe → Panels).
+
+### H2 — Zeitslider und Filterzustand laufen nach Jahreswechsel auseinander
+
+**Beobachtung (verifiziert):** Start-Slider auf 06.07. gezogen, dann Jahr gewechselt → `timeFilter` wird korrekt auf das ganze Jahr zurückgesetzt und die Labels zeigen 01.01./31.12., **aber die Slider-Thumbs bleiben bei Tag 186** stehen. Der sichtbare Zustand (Thumb-Position) widerspricht dem tatsächlichen Filter.
+
+**Ursache:** `setYear` resettet `timeFilter` (`optimizedMapController.ts:677-687`), aber niemand setzt `time-range-start/end` zurück — der `TimeSliderManager` kennt den Jahreswechsel nicht.
+
+**Empfehlung:** Beim Jahreswechsel Slider-Values auf 0/max zurücksetzen (oder — besser — die Zeitspanne beibehalten und auf das neue Jahr anwenden, dann aber Labels und Filter konsistent).
+
+### H3 — Suche: dreifach irreführend
+
+1. **Placeholder verspricht E-Mail-Suche** („E-Mail, Name, Schiff…"), die API durchsucht aber Fahrwasser, Seezeichen, Name (nur mit Consent) und Schiffsname (nur mit Consent) — **keine E-Mail** (`+server.ts:40-52`). Gut so (Datenschutz!), aber der Placeholder ist falsch.
+2. **„Enter-Taste zum Filtern drücken" ist falsch:** Der Controller filtert automatisch 300 ms nach der Eingabe (`optimizedMapController.ts:788-795`; im Test verifiziert: Fetch ohne Enter).
+3. **Enter erzeugt nur Fake-Feedback:** Der Enter-Handler im Panel (`FilterPanel.svelte:135-139`) startet lediglich einen 800-ms-Spinner (`handleFilterApply`), der vom echten Ladezustand entkoppelt ist. Gleiches Muster beim Jahreswechsel (Spinner läuft pauschal 800 ms, egal wie lange der Request dauert).
+
+**Empfehlung:** Placeholder ehrlich machen („Fahrwasser, Schiff, Name…"), Hilfetext auf „filtert automatisch beim Tippen" ändern, Fake-Spinner durch den echten `onLoading`-Zustand ersetzen (existiert bereits als Callback). Zusätzlich Ergebnisanzahl anzeigen („817 Sichtungen · 3 gefunden") — Best Practice „Ergebnisanzahl sichtbar" (NN/g, Pencil&Paper).
+
+### H4 — Bedienelemente weit unter Mindest-Touchgröße
+
+**Gemessen im Live-Test:** Zoom +/− **19×19 px**, „Z"-Control **19×19 px**, Popup-Schließen **10×27 px**, Legenden-Checkboxen 20×20 px. Das Projekt-Minimum sind **44×44 px** (`.claude/rules/design-system.md`), WCAG 2.5.8 (AA) verlangt mindestens 24 px. Die Größen sind in `mapStyles.css:30-41` per `!important` auf `1.375em` fixiert; die Mobile-Variante (`2.2em` ≈ 35 px, `mapStyles.css:246-256`) bleibt ebenfalls unter 44 px.
+
+**Empfehlung:** Controls auf min. 44×44 px (Desktop wie Mobile) anheben; Popup-Closer als 44-px-Button mit größerem Hit-Target.
+
+### H5 — ARIA-Semantik in Panels und Overlays fehlerhaft
+
+- **`aria-modal="true"` auf nicht-modalen Seitenpanels** (`FilterPanel.svelte:82`, `LegendPanel.svelte:82`): Es gibt keinen Fokus-Trap, kein Backdrop, die Karte bleibt bedienbar — für Screenreader wird fälschlich „alles andere ist inaktiv" verkündet.
+- **`aria-hidden="true"` bei 18 fokussierbaren Elementen** (gemessen): Das geschlossene Panel ist nur per `translateX` verschoben; alle Inputs/Buttons bleiben im Tab-Zyklus → „focusable but hidden"-Verstoß (WCAG 4.1.2). `inert` oder `visibility: hidden` nach Transition-Ende wäre korrekt.
+- **Kein Fokus-Management:** Beim Öffnen der Panels wandert der Fokus nicht hinein, beim Schließen nicht zurück zum Auslöser (Google-Maps-Referenzpattern: Fokusrückgabe an den Marker/Toggle).
+- **LoadingOverlay:** `role="dialog"`/`aria-modal` sitzt auf dem leeren Backdrop-Div, `aria-labelledby="loading-title"` referenziert ein Element in einem _anderen_ Teilbaum (`LoadingOverlay.svelte:31-37`).
+- Tastatur-Shortcuts steuern Panels über `document.querySelector('[aria-label*="Filter"]')?.click()` (`SightingsMapView.svelte:258`) — funktioniert, ist aber fragil (Treffer hängt von DOM-Reihenfolge ab; der Schließen-Button matcht dasselbe Muster).
+
+**Empfehlung:** Panels als nicht-modale `role="region"` + `aria-expanded` am Toggle; `inert` fürs geschlossene Panel; Fokus rein/raus managen; LoadingOverlay-ARIA auf das Inhaltselement setzen (oder schlicht `role="status"` + `aria-live="polite"`).
+
+### H6 — Panel-Layout: 400 px fix, mobil defekt, verdeckt die Datenfläche
+
+- Beide Panels sind fix **400 px** breit (`w-100`). Am Desktop verdecken sie genau den Kartenbereich, in dem die meisten Daten liegen (Mecklenburger/Vorpommersche Küste), inklusive halb verdeckter Marker an der Panelkante (im Test beobachtet).
+- **Mobil (375 px)** ist das Panel breiter als der Viewport; der Toggle-Button wird um `-400px` verschoben und landet mitten im Layout über dem Titel (Screenshot-Beleg im Test). Die als Fix gedachte CSS-Regel **zielt auf eine nicht mehr existierende Klasse**: `.w-90 { width: 100vw }` (`mapStyles.css:241-243`) — die Panels heißen inzwischen `w-100`. Toter Code, der Bug bleibt.
+- Panel ist `top-20` mit `h-full` → der untere Rand liegt 5 rem unterhalb des Viewports; der interne Scrollbereich ist entsprechend abgeschnitten.
+- Beide Panels können gleichzeitig „offen" sein und überlagern sich dann an identischer Position; der LEGENDE-Toggle schwebt bei offenem Panel mitten über Popup-/Karteninhalten.
+
+**Empfehlung:** Mobil als Bottom-Sheet (Best Practice für Karten-Details/Filter auf Touch) oder mindestens `max-width: 100vw` + korrekte Klasse; Desktop-Breite auf ~320 px reduzieren oder Panel andocken statt überlagern; Öffnen des einen Panels schließt das andere; `h-[calc(100%-5rem)]` statt `h-full`.
+
+### H7 — Globale Einzeltasten-Shortcuts ohne Modifier
+
+H, F, L, Z, ? feuern dokumentweit (`SightingsMapView.svelte:247-283`). Eingabefelder sind ausgenommen — trotzdem verstößt das Muster gegen **WCAG 2.1.4 (Character Key Shortcuts)**: Einzeltasten-Shortcuts müssen abschaltbar, remapbar oder nur bei Fokus aktiv sein (Problem u. a. für Spracheingabe-Nutzer). Im Test genügte beiläufiges Tippen („thisisunsafe" für die Zertifikatswarnung), um Hilfe-Modal und Filter-Panel zu öffnen — vier „z" zoomten anschließend ungewollt auf die Weltansicht.
+
+**Empfehlung:** Shortcuts nur bei Fokus innerhalb der Karten-Region aktivieren (nach K3-Fix natürlich vorhanden) oder abschaltbar machen; mindestens „Z" (destruktivste Wirkung) entschärfen.
+
+---
+
+## 5. Befunde mittlerer Priorität
+
+### M1 — Marker-Codierung: zwei konkurrierende Farbsysteme, Legende zeigt Falsches
+
+- Auf der Karte codiert die **Ringfarbe die Anzahl** (gelb=1 … blau=>15, schwarz=Totfund), das **Emoji die Art**. In der Legende zeigen die Arten-Chips dagegen `baseColor`-Farben (`styleUtils.ts:64-142`), die auf der Karte **nirgends vorkommen** — die Legende erklärt also Farben, die es nicht gibt.
+- Drei Robbenarten teilen sich dasselbe 🦭, drei Walarten dasselbe 🐋 — Arten sind auf der Karte de facto nicht unterscheidbar; die versprochene Differenzierung existiert nur in der Legende.
+- **Beluga-Badge: weiße Schrift auf `#F0F8FF`** (fast weiß) — unlesbar (im Test sichtbar); Verstoß gegen die Projekt-`*-content`-Regel sinngemäß.
+- Cluster nutzen ein **eigenes Blau-Spektrum** (`#51C2D5…#0F2933`), das mit der „>15"-Farbe `#0066CC` der Einzelmarker kollidiert; Cluster-Farben/Größen sind in der Legende gar nicht erklärt.
+- Hex-Farben sind dreifach dupliziert (styleUtils, LegendPanel-Inline-Styles, Cluster-Logik in zwei Dateien — `styleUtils.ts:386-454` ist eine ungenutzte Kopie von `createFilteredClusterStyle`).
+
+**Empfehlung:** Ein Codierungssystem wählen (Empfehlung: Farbe = Art-Gruppe mit ≤6 colorblind-sicheren Farben + Form/Symbol als zweitem Kanal, Anzahl als Badge-Zahl im Marker — so machen es iNaturalist/eBird); Legende aus denselben Konstanten rendern wie die Karte; Cluster-Skala in der Legende erklären.
+
+### M2 — Cluster überlappen sich bei niedrigen Zoomstufen
+
+Bei Zoom 7 lagen im Test 4 Cluster (37/50/27/78) deckungsgleich übereinander. `minDistance: 10` bei `distance: 40-50` (`optimizedMapController.ts:141-145`) erlaubt fast vollständige Überlappung. **Empfehlung:** `minDistance` ≈ `distance × 0.6` oder Radius-abhängig erhöhen.
+
+### M3 — OpenSeaMap-Layer dominiert ab mittleren Zoomstufen
+
+Ab Zoom ~12 fluten Seezeichen, Ankerplätze, Bojen (magenta/blau/gelb) die Karte und konkurrieren visuell mit den Sichtungsmarkern (Screenshot Wustrow im Test). Es gibt **keinen Layer-Umschalter**. Für die Zielgruppe (Bürger, die Sichtungen ansehen) ist die Seekarten-Ebene sekundär. **Empfehlung:** OpenSeaMap optional machen (Layer-Toggle in der Legende, Default aus oder Opacity weiter runter) — „Basemap lenkt nicht ab" ist Standard-Guidance.
+
+### M4 — Kein URL-State, kein Filter-Reset, keine Filter-Chips
+
+Jahr, Suche, Zeitraum, Arten-Toggles und Kartenausschnitt sind nicht in der URL → gefilterte Ansichten sind **nicht teilbar/bookmarkbar**, Reload verwirft alles. Es gibt keinen „Filter zurücksetzen"-Button und keine sichtbaren aktiven Filter (Chips), sobald das Panel zu ist — die Karte kann kommentarlos „leer" wirken, wenn ein vergessener Suchbegriff/Slider aktiv ist (der Hinweis-State existiert nur beim Totalausfall aller Marker). **Empfehlung:** Query-Params (`?year=&q=&from=&to=`) + `replaceState`; Chips über der Karte mit Einzel-Entfernen + „Alle zurücksetzen".
+
+### M5 — Kein Weg zurück zur Ausgangsansicht; „Z"-Control kryptisch
+
+Nach Pan/Zoom (oder dem Welt-Zoom aus K2) gibt es keinen Home-Button; das einzige Extent-Control zeigt nur den Buchstaben „Z". **Empfehlung:** Home-Control (Ostsee-Extent) mit Icon + Tooltip; „Z" durch Icon (z. B. `lucide:maximize`) ersetzen.
+
+### M6 — Popup-Inhalt: Textfehler, fehlende Tiefe, hartkodierte Styles
+
+- „Sichtung vom :" (Leerzeichen vor Doppelpunkt, `translations.report_date = 'Sichtung vom '` + `:`), „Anzahl Tiere: 3 Tiere" (doppelt).
+- Kein Fahrwasser/Position im Popup, obwohl Übersetzungen (`position`, `latitude`, `longitude`) definiert sind; keine Fotos; kein Link auf eine Detailansicht.
+- Popup und Hover-Info sind mit Inline-Hex-Styles gebaut (`optimizedMapController.ts:275-332`), am Theme vorbei.
+  **Empfehlung:** Texte korrigieren; Popup schlank halten (Titel, Datum, Anzahl, Totfund-Badge) + „Details"-Weg; Styles über CSS-Klassen aus dem Theme.
+
+### M7 — Loading-UX: modaler Vollbild-Blocker für jede Filteränderung
+
+Jede Datenoperation (auch ein schneller Jahreswechsel) blendet ein **vollflächiges modales Overlay mit Backdrop-Blur** ein (`LoadingOverlay.svelte`), das die gesamte Seite blockiert — für Sub-Sekunden-Requests überdimensioniert; zudem existiert ein zweites, totes Lade-Overlay (`#overlay-load`, `SightingsMapView.svelte:329-334`). **Empfehlung:** Vollbild-Overlay nur beim Initial-Load; danach dezenter Inline-Indikator (z. B. Balken am Kartenrand oder Spinner im Panel — der existierende `isApplyingFilter`-Spinner, nur echt verdrahtet). Totes Overlay entfernen.
+
+### M8 — Legende: Rauschen und Inkonsistenzen
+
+Arten mit 0/0 (Beluga, Zwergwal, Finnwal, Buckelwal) werden gleichwertig gelistet; „Unbekannte Walart" trägt das Badge „Großwal"; ℹ️-Emoji statt Icon-System; Farbchips als Inline-Hex. **Empfehlung:** 0/0-Arten ausblenden oder ausgrauen ans Ende sortieren; Kategorie „Unbekannt" ehrlich benennen; Icons vereinheitlichen.
+
+### M9 — Sprach-Inkonsistenz der OL-Defaults
+
+Zoom-Buttons tragen englische Titles/Labels („Zoom in", „Zoom out") in ansonsten deutscher UI. **Empfehlung:** `zoomInTipLabel`/`zoomOutTipLabel` deutsch konfigurieren.
+
+### M10 — Zeitfilter: zwei Single-Slider statt Dual-Range, ohne zugängliche Werte
+
+- Zwei getrennte native Slider; der „Ende"-Track ist bei 31.12. **komplett gefüllt** und suggeriert „alles ausgewählt", während der Start-Track leer wirkt — der ausgewählte _Bereich_ ist nicht visualisiert (Baymard: Dual-Slider werden schon im besten Fall von >50 % missverstanden).
+- Kein `aria-valuetext`: Screenreader lesen „186" (Tag-Index) statt „6. Juli".
+- Start/Ende können nicht denselben Tag wählen (erzwungenes ±1, `timeSliderManager.ts:31,44`).
+- Kein numerischer Fallback (Datumsfelder).
+  **Empfehlung:** Echten Dual-Range (ein Track, zwei Handles, gefüllter Zwischenbereich) oder zwei Datums-Inputs; `aria-valuetext` mit Datum; Single-Day zulassen.
+
+---
+
+## 6. Kleinere Befunde / Code-Hygiene
+
+- **N1:** `MapPanelManager.initializePanels()` ist funktionsloser Platzhalter (`panelManager.ts:15-29`); `updateTimeFilter()` im Controller ebenso (`optimizedMapController.ts:853-859`). Tote Pfade entfernen.
+- **N2:** `LocationControl`/Geolocation ist vollständig implementiert, aber deaktiviert (`enableLocationControl: false`, `SightingsMapView.svelte:131`) — entweder aktivieren („Mein Standort" ist Standard bei Sichtungskarten) oder Code entfernen.
+- **N3:** `createClusterStyle` (`styleUtils.ts:386`) wird nirgends verwendet (Duplikat der Controller-Logik ohne Filterunterstützung).
+- **N4:** Jahresliste ist auf 10 Jahre begrenzt (`getAvailableYears(10)`), obwohl Daten bis 2007 zurückreichen — ältere Jahrgänge sind unerreichbar.
+- **N5:** Sichtungen an Land (im Test: Marker bei Hamburg-Zentrum und südlich von Hamburg) — Hinweis auf fehlende Plausibilitätsprüfung im Altbestand; auf der Karte wirken sie wie Fehler.
+- **N6:** Titel-Chip „Sichtungskarte 2026" aktualisiert korrekt bei Jahreswechsel (gut), kommuniziert aber nicht aktive Such-/Zeitfilter (siehe M4).
+- **N7:** Der Hilfe-„?"-Button unten links bleibt bestehen — gut sichtbar, aber sein Modal erwähnt die automatische Suche nicht und listet Escape nur für „Dialoge".
+
+---
+
+## 7. Best-Practice-Checkliste (Bewertung)
+
+Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
+
+| Kriterium                                           | Status                                                 | Verweis |
+| --------------------------------------------------- | ------------------------------------------------------ | ------- |
+| **Navigation/Controls**                             |                                                        |         |
+| Zoom-Buttons sichtbar, ≥44 px                       | ❌ 19×19 px                                            | H4      |
+| Kein Verdecken relevanter Daten durch UI            | ❌ Panels über Datenfläche                             | H6      |
+| Zustand teilbar (URL)                               | ❌                                                     | M4      |
+| Home-/Ausgangsansicht                               | ❌                                                     | M5      |
+| „Locate me"                                         | ❌ implementiert, deaktiviert                          | N2      |
+| Basemap lenkt nicht ab                              | ⚠️ OpenSeaMap dominiert ab Z12                         | M3      |
+| **Marker/Cluster**                                  |                                                        |         |
+| Clustering mit Zählern                              | ✅                                                     | —       |
+| Cluster-Klick zoomt / ortsgleiche auffächerbar      | ✅ Liste statt Spiderfy                                | —       |
+| Cluster überlappen nicht                            | ❌                                                     | M2      |
+| ≤6 colorblind-sichere Farben, Farbe + zweiter Kanal | ⚠️ Anzahl-Farben ok, Artcodierung faktisch wirkungslos | M1      |
+| Selected-State des Markers                          | ❌                                                     | M6      |
+| **Popups/Details**                                  |                                                        |         |
+| Nur Identifikations-Kern + Weg zu Details           | ⚠️ kein Detail-Link                                    | M6      |
+| Escape + X, Fokusrückgabe                           | ❌ Escape fehlt, kein Fokus-Mgmt                       | H1/H5   |
+| Nur ein Popup zugleich                              | ✅                                                     | —       |
+| Popup konsistent mit Filterzustand                  | ❌ Stale Popup                                         | H1      |
+| **Filter/Legende**                                  |                                                        |         |
+| Wirkung sofort sichtbar                             | ✅                                                     | —       |
+| Ergebnisanzahl sichtbar                             | ⚠️ nur in Legende (sichtbar/gesamt), nicht am Suchfeld | H3      |
+| Aktive Filter als Chips + Reset                     | ❌                                                     | M4      |
+| Slider mit numerischem Fallback                     | ❌                                                     | M10     |
+| Legende konsistent mit Kartendarstellung            | ❌                                                     | M1      |
+| Ladeindikator bei Filteranwendung                   | ⚠️ vorhanden, aber fake-getimt bzw. überblockierend    | H3/M7   |
+| **Mobile/Touch**                                    |                                                        |         |
+| Kein Layout-Bruch auf 375 px                        | ❌ Panel > Viewport                                    | H6      |
+| Details als Bottom Sheet                            | ❌ Desktop-Popup auch mobil                            | H6      |
+| Touch-Targets ≥44 px                                | ❌                                                     | H4      |
+| Pinch/Drag + Button-Alternativen                    | ✅                                                     | —       |
+| **Performance/Laden**                               |                                                        |         |
+| Clustering statt DOM-Marker                         | ✅ Canvas + Cluster                                    | —       |
+| Request-Abbruch bei schnellen Wechseln              | ✅ AbortController                                     | —       |
+| Kein Layout-Shift                                   | ✅                                                     | —       |
+| **Accessibility**                                   |                                                        |         |
+| Karte fokussierbar, Tastatur-Pan/Zoom               | ❌                                                     | K3      |
+| Marker per Tastatur/SR erreichbar                   | ❌                                                     | K3      |
+| Datenalternative (Tabelle/Liste)                    | ❌                                                     | K3      |
+| Korrekte ARIA-Semantik                              | ❌                                                     | H5      |
+| Einzeltasten-Shortcuts abschaltbar                  | ❌                                                     | H7      |
+| Kontraste in Panels/Popups                          | ⚠️ Beluga-Badge, sonst ok                              | M1      |
+
+---
+
+## 8. Priorisierte Maßnahmen
+
+**Quick Wins (je < 1 Tag):**
+
+1. K2-Serverfilter: NULL-/0-Koordinaten aus `/api/map/sightings` ausschließen.
+2. K1: Default-Jahr auf jüngstes Jahr mit Daten + Empty-State-Button.
+3. H1: Popup bei Jahr-/Filterwechsel schließen; Escape-Kaskade erweitern.
+4. H2: Slider-Reset bei Jahreswechsel.
+5. H3: Placeholder/Hilfetext/Spinner der Suche ehrlich machen.
+6. H4: Control-Größen auf 44 px; M9: deutsche Zoom-Tooltips.
+7. M5: „Z" → Icon-Button mit Ostsee-Home; `zoomAllFeatures` auf Ostsee-Extent klemmen.
+8. H6 (Teilfix): tote `.w-90`-Regel auf `w-100`-Panels korrigieren bzw. `max-w-[100vw]`.
+
+**Mittelfristig:**
+
+- K3: `tabindex` + Fokusring + Skip-Link; Listen-/Tabellenansicht der gefilterten Sichtungen.
+- H5: ARIA-Sanierung der Panels (inert, region, Fokus-Management).
+- M1: Einheitliches Marker-/Legenden-Codierungssystem (colorblind-safe, Legende aus gemeinsamen Konstanten).
+- M4: URL-State + Filter-Chips + Reset.
+- M7: Loading-Konzept (Vollbild nur initial).
+- H6: Mobile Bottom-Sheet für Filter/Legende.
+
+**Strategisch:**
+
+- Jahresübergreifende Ansicht („Alle Jahre", Heatmap/Hexbin für ältere Bestände — vgl. OBIS/eBird).
+- Detailseite pro Sichtung (Popup verlinkt), inkl. Fotos mit Consent.
+- Marker-Selected-State + Fokus-Stellvertreter für Tastatur (macht Popups zugänglich).
+
+---
+
+## 9. Quellen (Auswahl)
+
+- OpenLayers Accessible-Beispiel (tabindex/Keyboard): https://openlayers.org/en/latest/examples/accessible.html
+- Google Maps Platform — Marker/Info-Window-Zugänglichkeit & Clustering: https://developers.google.com/maps/documentation/javascript/markers · https://developers.google.com/maps/documentation/javascript/marker-clustering
+- W3C/OGC Maps for the Web Workshop (kein Framework WCAG-konform): https://www.w3.org/2020/maps/ · WCAG-Evaluation: https://github.com/Malvoz/web-maps-wcag-evaluation
+- Leitfaden „Accessible Interactive Web Maps" (Minnesota IT, Datenalternative): https://mn.gov/mnit/assets/Accessibility%20Guide%20for%20Interactive%20Web%20Maps_tcm38-403564.pdf
+- Map UI Patterns (Pattern-Katalog: Cluster, Info-Popup, Attribute Filter, Timeline): https://mapuipatterns.com/
+- Baymard — Slider-Interfaces (Dual-Slider-Verständlichkeit): https://baymard.com/blog/slider-interfaces · NN/g Sliders: https://www.nngroup.com/articles/sliders-knobs/
+- Smashing Magazine — Accessible Tap Targets: https://www.smashingmagazine.com/2023/04/accessible-tap-target-sizes-rage-taps-clicks/
+- Leaflet.markercluster (Spiderfy-Pattern): https://github.com/Leaflet/Leaflet.markercluster
+- Eleken — Map UI Design (Basemap-Zurückhaltung, Scroll-Hijacking): https://www.eleken.co/blog-posts/map-ui-design
+- Referenz-Karten: https://www.inaturalist.org/observations · https://ebird.org/map · https://mapper.obis.org
+- ColorBrewer (colorblind-safe Paletten): https://colorbrewer2.org/
+
+---
+
+_Erstellt im Rahmen des UX-Reviews vom 2026-07-28. Testumgebung: lokaler Dev-Server (`npm run dev`, Port 4000), Chrome, lokale DB mit Produktionsdatenstand vom 2026-07-28._

--- a/e2e/map-time-slider.spec.ts
+++ b/e2e/map-time-slider.spec.ts
@@ -51,7 +51,7 @@ test.describe.serial('Map Time Slider', () => {
 		await expect(mapPage.getEndSlider()).toHaveValue('270');
 	});
 
-	test('Start-Slider wird auf Ende-1 geclampt wenn er Ende überschreitet', async () => {
+	test('Start-Slider wird auf Ende geclampt wenn er Ende überschreitet', async () => {
 		const result = await sharedPage.evaluate(() => {
 			const start = document.getElementById('time-range-start') as HTMLInputElement;
 			const end = document.getElementById('time-range-end') as HTMLInputElement;
@@ -69,11 +69,12 @@ test.describe.serial('Map Time Slider', () => {
 			return { startValue: start.value, endValue: end.value };
 		});
 
-		// Constraint: start (200) >= end (100) → start is clamped to end - 1 = 99
-		expect(result.startValue).toBe('99');
+		// Constraint (QW4): start (200) > end (100) → start wird auf end geklemmt;
+		// start == end ist erlaubt (Auswahl eines einzelnen Tages)
+		expect(result.startValue).toBe('100');
 	});
 
-	test('Ende-Slider wird auf Start+1 geclampt wenn er Start unterschreitet', async () => {
+	test('Ende-Slider wird auf Start geclampt wenn er Start unterschreitet', async () => {
 		const result = await sharedPage.evaluate(() => {
 			const start = document.getElementById('time-range-start') as HTMLInputElement;
 			const end = document.getElementById('time-range-end') as HTMLInputElement;
@@ -91,8 +92,9 @@ test.describe.serial('Map Time Slider', () => {
 			return { startValue: start.value, endValue: end.value };
 		});
 
-		// Constraint: end (50) <= start (200) → end is clamped to start + 1 = 201
-		expect(result.endValue).toBe('201');
+		// Constraint (QW4): end (50) < start (200) → end wird auf start geklemmt;
+		// start == end ist erlaubt (Auswahl eines einzelnen Tages)
+		expect(result.endValue).toBe('200');
 	});
 
 	test('Zeitraum-Anzeige-Elemente sind im DOM vorhanden', async () => {

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -2,14 +2,20 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { getDaysInYear } from '$lib/map/dateUtils';
 
-	let { years = [], defaultYear } = $props<{
+	let {
+		years = [],
+		defaultYear,
+		yearCounts = {},
+		isLoading = false
+	} = $props<{
 		years?: number[];
 		defaultYear?: number;
+		yearCounts?: Record<number, number>;
+		isLoading?: boolean;
 	}>();
 
 	// Reactive state für Panel-Sichtbarkeit (Svelte 5 runes)
 	let isOpen = $state(false);
-	let isApplyingFilter = $state(false);
 	// Explizite User-Auswahl (undefined = noch keine manuelle Wahl getroffen)
 	let userSelectedYear: number | undefined = $state(undefined);
 	// Effektiv gewähltes Jahr: User-Auswahl hat Vorrang, sonst Prop-Default
@@ -30,28 +36,9 @@
 		isOpen = false;
 	}
 
-	// Kurze visuelle Rückmeldung bei Filter-Änderung
-	let filterFeedbackTimeout: ReturnType<typeof setTimeout> | null = null;
-	function handleFilterApply() {
-		isApplyingFilter = true;
-		if (filterFeedbackTimeout) clearTimeout(filterFeedbackTimeout);
-		filterFeedbackTimeout = setTimeout(() => {
-			isApplyingFilter = false;
-			filterFeedbackTimeout = null;
-		}, 800);
-	}
-
-	// Cleanup bei Unmount
-	$effect(() => {
-		return () => {
-			if (filterFeedbackTimeout) clearTimeout(filterFeedbackTimeout);
-		};
-	});
-
 	function handleYearChange(e: Event) {
 		const year = parseInt((e.target as HTMLSelectElement).value, 10);
 		if (!isNaN(year)) userSelectedYear = year;
-		handleFilterApply();
 	}
 </script>
 
@@ -59,12 +46,12 @@
 <button
 	onclick={togglePanel}
 	class="glass text-base-content hover:bg-base-200 border-primary/20 fixed top-20 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
-	style="transform: translateX({isOpen ? '-400px' : '0px'});"
+	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
 	aria-label="Filter {isOpen ? 'schließen' : 'öffnen'}"
 >
 	<Icon
-		icon={isApplyingFilter ? 'lucide:loader-2' : 'lucide:filter'}
-		class="mb-1 h-4 w-4 {isApplyingFilter ? 'animate-spin' : ''}"
+		icon={isLoading ? 'lucide:loader-2' : 'lucide:filter'}
+		class="mb-1 h-4 w-4 {isLoading ? 'animate-spin' : ''}"
 	/>
 	<div
 		class="text-xs whitespace-nowrap"
@@ -76,7 +63,7 @@
 
 <!-- Panel Container -->
 <div
-	class="glass border-primary/20 fixed top-20 right-0 z-40 h-full w-100 overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
+	class="glass border-primary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
 	style="transform: translateX({isOpen ? '0px' : '100%'});"
 	role="dialog"
 	aria-modal="true"
@@ -100,21 +87,22 @@
 				<div class="fieldset w-full">
 					<label for="year-select" class="label py-1">
 						<span class="text-sm font-medium">Jahr</span>
-						{#if isApplyingFilter}
+						{#if isLoading}
 							<Icon icon="lucide:loader-2" class="text-primary ml-2 h-3 w-3 animate-spin" />
 						{/if}
 					</label>
 					<select
 						id="year-select"
-						class="select select-sm focus:select-primary w-full text-sm {isApplyingFilter
+						class="select select-sm focus:select-primary w-full text-sm {isLoading
 							? 'loading'
 							: ''}"
 						title="Wählen Sie das Jahr aus, für das Sichtungen angezeigt werden sollen"
 						onchange={handleYearChange}
-						disabled={isApplyingFilter}
 					>
 						{#each years.toReversed() as year (year)}
-							<option value={year} selected={year === selectedYear}>{year}</option>
+							<option value={year} selected={year === selectedYear}>
+								{yearCounts[year] ? `${year} (${yearCounts[year]})` : year}
+							</option>
 						{/each}
 					</select>
 				</div>
@@ -128,17 +116,12 @@
 							id="filter-input"
 							type="text"
 							bind:value={searchValue}
-							placeholder="E-Mail, Name, Schiff..."
+							placeholder="Fahrwasser, Schiffsname, Name…"
 							class="input input-sm focus:input-primary w-full pr-10"
-							title="Nach E-Mail, Schiffsname, Name oder Vorname filtern (Return zum filtern)."
+							title="Nach Fahrwasser, Seezeichen, Schiffsname oder Name filtern. Filtert automatisch beim Tippen."
 							aria-describedby="filter-help"
-							onkeydown={(e) => {
-								if (e.key === 'Enter') {
-									handleFilterApply();
-								}
-							}}
 						/>
-						{#if isApplyingFilter}
+						{#if isLoading}
 							<div class="absolute top-1/2 right-3 -translate-y-1/2 transform">
 								<Icon icon="lucide:loader-2" class="text-primary h-4 w-4 animate-spin" />
 							</div>
@@ -146,7 +129,7 @@
 					</div>
 					<label class="label py-0" for="filter-input">
 						<span id="filter-help" class="text-base-content/60 text-xs">
-							{isApplyingFilter ? 'Filter wird angewendet...' : 'Enter-Taste zum Filtern drücken'}
+							{isLoading ? 'Filter wird angewendet...' : 'Filtert automatisch beim Tippen'}
 						</span>
 					</label>
 				</div>

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -62,7 +62,7 @@
 <button
 	onclick={togglePanel}
 	class="glass text-base-content hover:bg-base-200 border-secondary/20 fixed top-52 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
-	style="transform: translateX({isOpen ? '-400px' : '0px'});"
+	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
 	aria-label="Legende {isOpen ? 'schließen' : 'öffnen'}"
 >
 	<Icon icon="lucide:list" class="mb-1 h-4 w-4" />
@@ -76,7 +76,7 @@
 
 <!-- Panel Container -->
 <div
-	class="glass border-secondary/20 fixed top-20 right-0 z-40 h-full w-100 overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
+	class="glass border-secondary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
 	style="transform: translateX({isOpen ? '0px' : '100%'});"
 	role="dialog"
 	aria-modal="true"
@@ -124,7 +124,7 @@
 									{symbol.symbol}
 								</span>
 							{:else}
-								<div class="h-4 w-4 rounded-full bg-base-content/40"></div>
+								<div class="bg-base-content/40 h-4 w-4 rounded-full"></div>
 							{/if}
 						</div>
 

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { MapCountManager, type CountData } from '$lib/map/countManager';
+	import { getDaysInYear } from '$lib/map/dateUtils';
 	import type { MapTranslations } from '$lib/map/mapUtils';
 	import { SichtungenMap } from '$lib/map/optimizedMapController';
 	import { MapPanelManager } from '$lib/map/panelManager';
 	import { MapTimeSliderManager } from '$lib/map/timeSliderManager';
 	import { speciesLabels } from '$lib/report/formOptions/species';
-	import { getAvailableYears, getDefaultSightingYear } from '$lib/utils/date/defaultYear';
+	import {
+		getAvailableYears,
+		getDefaultSightingYear,
+		pickDefaultYear,
+		type YearWithCount
+	} from '$lib/utils/date/defaultYear';
 	import { setMapCountManager } from '$lib/map/mapContext';
 	import 'ol/ol.css';
 	import LoadingOverlay from './LoadingOverlay.svelte';
@@ -53,7 +59,9 @@
 	};
 
 	// Manager-Instanzen
-	let mapInstance: SichtungenMap | null = null;
+	// $state: Die Instanz entsteht erst nach dem async Jahres-Fetch — der
+	// Callback-Registrierungs-$effect unten muss auf die Zuweisung reagieren.
+	let mapInstance = $state<SichtungenMap | null>(null);
 	let panelManager: MapPanelManager | null = null;
 	let timeSliderManager: MapTimeSliderManager | null = null;
 
@@ -71,7 +79,28 @@
 
 	// Verfügbare Jahre für den Filter (10 Jahre zurück)
 	const years = getAvailableYears(10);
-	const defaultYear = getDefaultSightingYear();
+	// Bisheriges Fallback-Jahr, synchron verfügbar für den allerersten Render
+	// (bevor GET /api/map/sightings/years geladen ist). Als Konstante erfasst,
+	// damit die beiden $state-Deklarationen unten nicht voneinander abhängen.
+	const initialFallbackYear = getDefaultSightingYear();
+	// Default-Jahr: wird aktualisiert, sobald die verfügbaren Jahre geladen
+	// sind (QW2b). Bei fehlgeschlagenem Request bleibt der Fallback.
+	let defaultYear = $state(initialFallbackYear);
+	// Rohdaten der verfügbaren Jahre (Antwort von GET /api/map/sightings/years)
+	let availableYearsData = $state<YearWithCount[]>([]);
+	// Sichtungsanzahl je Jahr für die Jahres-Dropdown-Beschriftung ("2025 (817)")
+	let yearCounts = $derived(
+		Object.fromEntries(availableYearsData.map((entry) => [entry.year, entry.count]))
+	);
+	// Jüngstes Jahr mit tatsächlichen Daten (für den Empty-State-Button, QW2b)
+	let latestYearWithData = $derived(
+		availableYearsData
+			.filter((entry) => entry.count > 0)
+			.reduce<number | undefined>(
+				(latest, entry) => (latest === undefined || entry.year > latest ? entry.year : latest),
+				undefined
+			)
+	);
 
 	// UI-Zustände
 	let showKeyboardHelp = $state(false);
@@ -81,7 +110,7 @@
 	let errorMessage = $state<string | null>(null);
 
 	// Aktuell angezeigtes Jahr für den Titel
-	let currentDisplayedYear = $state(defaultYear);
+	let currentDisplayedYear = $state(initialFallbackYear);
 
 	// Feature-Anzahl direkt vom Map-Controller abfragen (robuster als counts-basiert)
 	let featureCount = $state(0);
@@ -109,17 +138,68 @@
 	// Event Handler für Cleanup
 	let keyboardHandler: ((event: KeyboardEvent) => void) | null = null;
 
+	/**
+	 * Lädt die verfügbaren Jahre (QW2a-Endpoint) und ermittelt daraus das
+	 * Default-Jahr (QW2b). Fehlerpfad: stiller Fallback auf das bisherige
+	 * Verhalten (getDefaultSightingYear()) — kein Fehler-Toast dafür, da es
+	 * sich um eine reine Komfort-Optimierung handelt.
+	 */
+	async function loadAvailableYears(): Promise<number> {
+		let fetchedYears: YearWithCount[] = [];
+		try {
+			const response = await fetch('/api/map/sightings/years');
+			if (response.ok) {
+				const data = await response.json();
+				if (Array.isArray(data?.years)) {
+					fetchedYears = data.years;
+				}
+			}
+		} catch (err) {
+			console.warn('Konnte verfügbare Jahre nicht laden, nutze Standard-Jahr:', err);
+		}
+
+		availableYearsData = fetchedYears;
+
+		return pickDefaultYear(fetchedYears, initialFallbackYear);
+	}
+
+	/**
+	 * Schaltet das angezeigte Jahr um — über denselben Pfad wie das
+	 * Jahres-Dropdown im Filter-Panel (DOM-Wert setzen + `change`-Event), damit
+	 * genau ein Code-Pfad für den Jahreswechsel existiert. Wird vom
+	 * Empty-State-Button (QW2b) verwendet.
+	 */
+	function switchToYear(year: number) {
+		const yearSelect = document.getElementById('year-select') as HTMLSelectElement | null;
+		if (!yearSelect) return;
+		yearSelect.value = year.toString();
+		yearSelect.dispatchEvent(new Event('change', { bubbles: true }));
+	}
+
 	// Modern $effect for map initialization and cleanup
 	$effect(() => {
 		// Check if we have the required DOM element
 		const mapElement = document.getElementById(mapContainerId);
-		if (mapElement) {
+		if (!mapElement) {
+			return;
+		}
+
+		let cancelled = false;
+		let firstLoadComplete = false;
+
+		void (async () => {
+			// QW2b: Verfügbare Jahre vor Karteninitialisierung laden, damit die
+			// Karte direkt mit einem Jahr startet, das tatsächlich Daten hat.
+			const initialYear = await loadAvailableYears();
+			if (cancelled) return;
+
+			defaultYear = initialYear;
+
 			// Initialisiere Manager
 			panelManager = new MapPanelManager();
 			timeSliderManager = new MapTimeSliderManager();
 
 			// Initialisiere Karte mit Loading-Callback (muss vor initialem setYear gesetzt sein)
-			let firstLoadComplete = false;
 			mapInstance = new SichtungenMap({
 				translations,
 				target: mapContainerId,
@@ -129,6 +209,7 @@
 				timeStartId: 'time-start',
 				timeEndId: 'time-end',
 				enableLocationControl: false,
+				initialYear,
 				onLoading: (loading) => {
 					isLoadingData = loading;
 					if (loading) {
@@ -163,15 +244,14 @@
 
 			// Tastatur-Navigation Setup
 			setupKeyboardNavigation();
+		})();
 
-			// Cleanup function (replaces onDestroy)
-			return () => {
-				cleanup();
-			};
-		}
-
-		// Return undefined if mapElement is not available yet
-		return;
+		// Cleanup function (replaces onDestroy) — auch relevant, falls die
+		// Komponente zerstört wird, bevor der obige async Block fertig ist.
+		return () => {
+			cancelled = true;
+			cleanup();
+		};
 	});
 
 	// Effect zum Registrieren des Jahr-Änderungs-Callbacks
@@ -180,6 +260,9 @@
 			const instance = mapInstance;
 			instance.setYearChangeCallback((newYear: number) => {
 				currentDisplayedYear = newYear;
+				// QW4: Zeitslider auf den vollen neuen Jahresbereich zurücksetzen,
+				// sonst bleiben die Thumbs auf der zuvor gewählten Position stehen.
+				timeSliderManager?.reset(getDaysInYear(newYear));
 			});
 
 			return () => {
@@ -281,24 +364,30 @@
 					zoomButton?.click();
 					break;
 				}
-				case 'Escape':
+				case 'Escape': {
+					// QW3: Kaskade Popup → Hilfe-Modal → Filter-Panel → Legende.
+					// Jede Stufe schließt nur genau eine Ebene pro Tastendruck.
+					if (mapInstance?.closePopup()) {
+						break;
+					}
 					if (showKeyboardHelp) {
 						showKeyboardHelp = false;
-					} else {
-						// Schließe offene Panels in der Priorität: Filter → Legende
-						const filterPanel = document.querySelector('[aria-labelledby="filter-title"]');
-						const legendPanel = document.querySelector('[aria-labelledby="legend-title"]');
-						if (filterPanel?.getAttribute('aria-hidden') === 'false') {
-							filterPanel
-								.querySelector<HTMLButtonElement>('[aria-label="Filter schließen"]')
-								?.click();
-						} else if (legendPanel?.getAttribute('aria-hidden') === 'false') {
-							legendPanel
-								.querySelector<HTMLButtonElement>('[aria-label="Legende schließen"]')
-								?.click();
-						}
+						break;
+					}
+					// Schließe offene Panels in der Priorität: Filter → Legende
+					const filterPanel = document.querySelector('[aria-labelledby="filter-title"]');
+					const legendPanel = document.querySelector('[aria-labelledby="legend-title"]');
+					if (filterPanel?.getAttribute('aria-hidden') === 'false') {
+						filterPanel
+							.querySelector<HTMLButtonElement>('[aria-label="Filter schließen"]')
+							?.click();
+					} else if (legendPanel?.getAttribute('aria-hidden') === 'false') {
+						legendPanel
+							.querySelector<HTMLButtonElement>('[aria-label="Legende schließen"]')
+							?.click();
 					}
 					break;
+				}
 			}
 		};
 		document.addEventListener('keydown', keyboardHandler);
@@ -348,6 +437,15 @@
 				<p class="text-base-content text-sm font-medium">
 					Keine Sichtungen für {currentDisplayedYear} vorhanden.
 				</p>
+				{#if latestYearWithData !== undefined && latestYearWithData !== currentDisplayedYear}
+					<button
+						type="button"
+						class="btn btn-primary btn-sm mt-2"
+						onclick={() => switchToYear(latestYearWithData!)}
+					>
+						Sichtungen {latestYearWithData} anzeigen
+					</button>
+				{/if}
 			</div>
 		{/if}
 
@@ -398,7 +496,7 @@
 	</div>
 
 	<!-- Filter-Panel Komponente -->
-	<FilterPanel {years} {defaultYear} />
+	<FilterPanel {years} {defaultYear} {yearCounts} isLoading={isLoadingData} />
 
 	<!-- Legende-Panel Komponente -->
 	<LegendPanel {translations} {counts} />

--- a/src/lib/map/controls/ZoomAllControl.ts
+++ b/src/lib/map/controls/ZoomAllControl.ts
@@ -4,10 +4,14 @@ import type { MapController } from '$lib/map/optimizedMapController';
 /**
  * Control zum Zoomen auf alle Features
  */
+// Maximize/Fit-Extent-Icon (Lucide "maximize"), 20x20, currentColor.
+const MAXIMIZE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg>`;
+
 export class ZoomAllControl extends Control {
 	constructor(mapInstance: MapController) {
 		const button = document.createElement('button');
-		button.innerHTML = 'Z';
+		button.type = 'button';
+		button.innerHTML = MAXIMIZE_ICON_SVG;
 		button.title = 'Auf alle Sichtungen zoomen';
 		button.setAttribute('aria-label', 'Auf alle Sichtungen zoomen');
 

--- a/src/lib/map/extentUtils.test.ts
+++ b/src/lib/map/extentUtils.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { boundingExtent } from 'ol/extent';
+import { fromLonLat } from 'ol/proj';
+import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
+import { clampExtentToBaltic, type Extent } from './extentUtils';
+
+// Referenz-Extent, unabhängig von der Implementierung berechnet, damit der Test
+// eine echte Aussage über das Verschneidungsverhalten trifft.
+const BALTIC_EXTENT = boundingExtent([
+	fromLonLat([BALTIC_SEA_BBOX.minLongitude, BALTIC_SEA_BBOX.minLatitude]),
+	fromLonLat([BALTIC_SEA_BBOX.maxLongitude, BALTIC_SEA_BBOX.maxLatitude])
+]) as Extent;
+
+describe('clampExtentToBaltic', () => {
+	it('gibt den Ostsee-Extent zurück, wenn der Input komplett außerhalb liegt (z. B. Null Island)', () => {
+		// [0,0] in EPSG:3857 entspricht Lon/Lat (0,0) — weit westlich der Ostsee-BBox (minLon 9.4°)
+		const nullIslandExtent: Extent = [-1000, -1000, 1000, 1000];
+		expect(clampExtentToBaltic(nullIslandExtent)).toEqual(BALTIC_EXTENT);
+	});
+
+	it('gibt den Ostsee-Extent zurück bei unendlichem Extent (leere reportsSource)', () => {
+		expect(clampExtentToBaltic([Infinity, Infinity, -Infinity, -Infinity])).toEqual(BALTIC_EXTENT);
+	});
+
+	it('gibt den Ostsee-Extent zurück bei NaN-Werten', () => {
+		expect(clampExtentToBaltic([NaN, NaN, NaN, NaN])).toEqual(BALTIC_EXTENT);
+	});
+
+	it('verschneidet einen die Ostsee überragenden Extent auf die Ostsee-Grenzen', () => {
+		const hugeEuropeExtent: Extent = [...fromLonLat([-20, 30]), ...fromLonLat([40, 70])] as Extent;
+		expect(clampExtentToBaltic(hugeEuropeExtent)).toEqual(BALTIC_EXTENT);
+	});
+
+	it('lässt einen Extent innerhalb der Ostsee unverändert', () => {
+		const kielExtent: Extent = [...fromLonLat([10, 54]), ...fromLonLat([11, 55])] as Extent;
+		expect(clampExtentToBaltic(kielExtent)).toEqual(kielExtent);
+	});
+
+	it('gibt den Ostsee-Extent zurück bei einem invertierten (leeren) Extent', () => {
+		expect(clampExtentToBaltic([10, 10, 5, 5])).toEqual(BALTIC_EXTENT);
+	});
+});

--- a/src/lib/map/extentUtils.ts
+++ b/src/lib/map/extentUtils.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Extent-Hilfsfunktionen für die OpenLayers-Karte.
+ *
+ * Eigenes Modul statt Ergänzung von `mapUtils.ts`: `mapUtils.ts` wird auch
+ * serverseitig importiert (`src/routes/api/map/sightings/+server.ts`) und
+ * importiert aktuell kein `ol`. Die hier benötigten OL-Extent-/Proj-Helfer
+ * bleiben deshalb in einem separaten, browser-orientierten Modul.
+ */
+import { boundingExtent, getIntersection, isEmpty } from 'ol/extent';
+import { fromLonLat } from 'ol/proj';
+import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
+
+/** [minX, minY, maxX, maxY] in der Kartenprojektion (EPSG:3857). */
+export type Extent = [number, number, number, number];
+
+let cachedBalticExtent: Extent | null = null;
+
+/**
+ * Ostsee-BBox (`BALTIC_SEA_BBOX`, WGS84) nach EPSG:3857 transformiert.
+ * Wird lazy berechnet und gecacht, da sie sich zur Laufzeit nie ändert.
+ */
+function getBalticExtent(): Extent {
+	if (!cachedBalticExtent) {
+		cachedBalticExtent = boundingExtent([
+			fromLonLat([BALTIC_SEA_BBOX.minLongitude, BALTIC_SEA_BBOX.minLatitude]),
+			fromLonLat([BALTIC_SEA_BBOX.maxLongitude, BALTIC_SEA_BBOX.maxLatitude])
+		]) as Extent;
+	}
+	return cachedBalticExtent;
+}
+
+function isFiniteExtent(extent: Extent): boolean {
+	return extent.every((value) => Number.isFinite(value));
+}
+
+/**
+ * Klemmt einen EPSG:3857-Extent auf den Ostsee-Kartenbereich.
+ *
+ * Hintergrund: Datensätze mit ungültigen Koordinaten (z. B. Null Island
+ * [0,0]) lassen den Feature-Extent auf Weltgröße anwachsen — „Auf alle
+ * Sichtungen zoomen" (ZoomAllControl) würde dann auf die Weltansicht statt
+ * auf die Ostsee zoomen. Diese Funktion verschneidet den übergebenen Extent
+ * mit dem Ostsee-Extent; ist die Schnittmenge leer oder der Input
+ * ungültig/unendlich, wird der Ostsee-Extent selbst zurückgegeben.
+ *
+ * @param extent EPSG:3857-Extent, z. B. aus `VectorSource.getExtent()`
+ * @returns Extent innerhalb der Ostsee-Grenzen
+ */
+export function clampExtentToBaltic(extent: Extent): Extent {
+	const balticExtent = getBalticExtent();
+
+	if (!isFiniteExtent(extent) || isEmpty(extent)) {
+		return balticExtent;
+	}
+
+	const intersection = getIntersection(extent, balticExtent) as Extent;
+	if (isEmpty(intersection)) {
+		return balticExtent;
+	}
+
+	return intersection;
+}

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -35,9 +35,13 @@
 	font-weight: bold !important;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
 	margin: 2px !important;
-	height: 1.375em !important;
-	width: 1.375em !important;
-	font-size: 14px !important;
+	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
+	height: 44px !important;
+	width: 44px !important;
+	font-size: 20px !important;
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
 }
 
 .ol-zoom button:hover {
@@ -71,8 +75,10 @@
 }
 
 /* Zoom All Control */
+/* top: 11rem — ol-zoom (top 4.5rem) + zwei 44px-Buttons + Control-Padding, damit
+   die größeren Touch-Targets aus QW6 nicht mit dem Zoom-Control kollidieren. */
 .zoom-all-control {
-	top: 8.5rem;
+	top: 11rem;
 	left: 0.5rem;
 }
 
@@ -82,12 +88,16 @@
 	border-radius: 4px !important;
 	color: #444 !important;
 	cursor: pointer;
-	height: 1.375em !important;
-	width: 1.375em !important;
+	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
+	height: 44px !important;
+	width: 44px !important;
 	font-weight: bold !important;
-	font-size: 14px !important;
+	font-size: 20px !important;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
 	margin: 2px !important;
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
 }
 
 .zoom-all-control button:hover {
@@ -95,8 +105,9 @@
 }
 
 /* Location Control */
+/* top: 14.5rem — analog zur Zoom-All-Control-Berechnung, ein 44px-Button darunter. */
 .location-control {
-	top: 12.5rem;
+	top: 14.5rem;
 	left: 0.5rem;
 }
 
@@ -106,12 +117,16 @@
 	border-radius: 4px !important;
 	color: #444 !important;
 	cursor: pointer;
-	height: 1.375em !important;
-	width: 1.375em !important;
+	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
+	height: 44px !important;
+	width: 44px !important;
 	font-weight: bold !important;
-	font-size: 14px !important;
+	font-size: 20px !important;
 	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
 	margin: 2px !important;
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
 	transition: all 0.2s ease;
 }
 
@@ -144,7 +159,7 @@
 	border-color: #3b82f6;
 }
 
-.gps-control .gps-button[style*="background-color: rgb(59, 130, 246)"] {
+.gps-control .gps-button[style*='background-color: rgb(59, 130, 246)'] {
 	border-color: #3b82f6;
 }
 
@@ -237,29 +252,12 @@
 		padding: 0.5rem !important;
 	}
 
-	/* Panel-Breite auf mobilen Geräten anpassen */
-	.w-90 {
-		width: 100vw !important;
-	}
+	/* QW8: .w-90-Regel entfernt — die Panels heißen inzwischen w-100 (siehe
+	   FilterPanel.svelte/LegendPanel.svelte), diese Regel griff nie mehr. */
 
-	/* OpenLayers Zoom-Buttons größer auf Touch-Geräten */
-	.ol-zoom button {
-		height: 2.2em !important;
-		width: 2.2em !important;
-		font-size: 16px !important;
-	}
-
-	.zoom-all-control button {
-		height: 2.2em !important;
-		width: 2.2em !important;
-		font-size: 16px !important;
-	}
-
-	.location-control button {
-		height: 2.2em !important;
-		width: 2.2em !important;
-		font-size: 16px !important;
-	}
+	/* OpenLayers Zoom-/Zoom-All-/Location-Buttons: 44px-Touch-Target ist bereits
+	   die Desktop-Basisgröße (siehe oben) und gilt unverändert auch mobil — keine
+	   separate Mobile-Größe mehr nötig. */
 
 	/* GPS Control größer auf mobilen Geräten */
 	.gps-control .gps-button {

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -18,6 +18,7 @@ import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
 import { LocationControl } from './controls/LocationControl.js';
 import { ZoomAllControl } from './controls/ZoomAllControl.js';
 import { getDefaultSightingYear } from '$lib/utils/date/defaultYear';
+import { clampExtentToBaltic, type Extent } from './extentUtils';
 import { areExtentsColocated, type MapTranslations } from './mapUtils';
 import { clearStyleCache, createFeatureStyle, getFeatureColorGroup } from './styleUtils';
 import { sanitizeText } from '$lib/utils/sanitize';
@@ -51,6 +52,12 @@ export interface MapOptions {
 	timeStartId?: string;
 	timeEndId?: string;
 	enableLocationControl?: boolean;
+	/**
+	 * Überschreibt das über `getDefaultSightingYear()` ermittelte Default-Jahr,
+	 * z. B. mit dem Ergebnis von `pickDefaultYear()` (QW2b) sobald die
+	 * verfügbaren Jahre vom Server geladen sind.
+	 */
+	initialYear?: number;
 	onLoading?: (isLoading: boolean) => void;
 	onError?: (error: Error) => void;
 }
@@ -179,7 +186,7 @@ export class SichtungenMap {
 		const defaultZoom = 7;
 
 		// Initialize the timeFilter with sensible defaults (zeige das ganze Jahr)
-		this.displayedYear = getDefaultSightingYear();
+		this.displayedYear = options.initialYear ?? getDefaultSightingYear();
 		const yearStart = new Date(this.displayedYear, 0, 1).getTime();
 		const yearEnd = new Date(this.displayedYear, 11, 31, 23, 59, 59).getTime();
 		this.timeFilter = {
@@ -238,7 +245,13 @@ export class SichtungenMap {
 				minZoom: 2,
 				maxZoom: 18
 			}),
-			controls: defaultControls({ rotate: false }).extend(this.createCustomControls())
+			controls: defaultControls({
+				rotate: false,
+				zoomOptions: {
+					zoomInTipLabel: 'Vergrößern',
+					zoomOutTipLabel: 'Verkleinern'
+				}
+			}).extend(this.createCustomControls())
 		});
 
 		// Popup hinzufügen
@@ -294,11 +307,13 @@ export class SichtungenMap {
 		`;
 
 		// Style the popup
+		// padding-top berücksichtigt den 44px hohen Schließen-Button, damit dieser
+		// den Inhalt (Überschrift) nicht überlappt.
 		this.popupElement.style.cssText = `
 			position: absolute;
 			background-color: white;
 			box-shadow: 0 1px 4px rgba(0,0,0,0.2);
-			padding: 15px;
+			padding: 44px 15px 15px 15px;
 			border-radius: 10px;
 			border: 1px solid #cccccc;
 			bottom: 12px;
@@ -307,13 +322,18 @@ export class SichtungenMap {
 			z-index: 1000;
 		`;
 
-		// Close button
+		// Close button — Hit-Target min. 44x44px (WCAG 2.5.5), Symbol bleibt optisch klein
 		const closer = this.popupElement.querySelector('.ol-popup-closer') as HTMLButtonElement;
-		closer.onclick = () => this.popup.setPosition(undefined);
+		closer.onclick = () => this.closePopup();
 		closer.style.cssText = `
 			position: absolute;
-			top: 2px;
-			right: 8px;
+			top: 0;
+			right: 0;
+			width: 44px;
+			height: 44px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
 			border: none;
 			background: none;
 			font-size: 18px;
@@ -412,7 +432,7 @@ export class SichtungenMap {
 					this.showPopup(event.coordinate, feature as Feature<Geometry>);
 				}
 			} else {
-				this.popup.setPosition(undefined);
+				this.closePopup();
 			}
 		});
 
@@ -655,6 +675,23 @@ export class SichtungenMap {
 		this.clusterSource.setDistance(distance);
 	}
 
+	/**
+	 * Schließt ein offenes Popup, falls eines geöffnet ist.
+	 *
+	 * QW3: Ein Popup bleibt sonst über Jahres-/Filterwechsel hinweg sichtbar
+	 * und zeigt Stammdaten eines Features, das nach dem Wechsel gar nicht
+	 * mehr in der aktuellen Auswahl enthalten ist ("stale popup"). Wird daher
+	 * am Anfang jeder Methode aufgerufen, die die sichtbare Feature-Menge
+	 * ändert, und zusätzlich von der Escape-Kaskade in SightingsMapView.
+	 *
+	 * @returns `true` wenn ein Popup offen war (und geschlossen wurde), sonst `false`.
+	 */
+	public closePopup(): boolean {
+		const wasOpen = this.popup.getPosition() !== undefined;
+		this.popup.setPosition(undefined);
+		return wasOpen;
+	}
+
 	public setYearChangeCallback(callback: (year: number) => void): void {
 		this.yearChangeCallback = callback;
 	}
@@ -665,6 +702,7 @@ export class SichtungenMap {
 
 	// Behalte alle bestehenden Public-Methoden für Kompatibilität
 	public async setYear(year: number): Promise<void> {
+		this.closePopup();
 		this.displayedYear = year;
 		this.yearChangeCallback?.(year);
 		this.loadingCallback?.(true);
@@ -834,6 +872,7 @@ export class SichtungenMap {
 	}
 
 	private applyFilter(searchTerm: string): void {
+		this.closePopup();
 		this.searchTerm = searchTerm;
 		this.loadingCallback?.(true);
 		void this.loadSightings(this.displayedYear, searchTerm)
@@ -879,14 +918,17 @@ export class SichtungenMap {
 	}
 
 	public zoomAllFeatures(): void {
-		const extent = this.reportsSource.getExtent();
-		if (extent && extent.every((val) => isFinite(val))) {
-			this.map.getView().fit(extent, {
-				padding: [50, 50, 50, 50],
-				duration: 1000,
-				maxZoom: 12
-			});
-		}
+		// Extent immer auf die Ostsee klemmen: Datensätze mit ungültigen
+		// Koordinaten (z. B. Null Island) ließen den Feature-Extent sonst auf
+		// Weltgröße anwachsen, und "Z" zoomte auf die Weltansicht. Ist der
+		// Feature-Extent leer/unendlich, wird stattdessen auf die Ostsee gezoomt
+		// statt gar nicht zu reagieren.
+		const extent = clampExtentToBaltic(this.reportsSource.getExtent() as Extent);
+		this.map.getView().fit(extent, {
+			padding: [50, 50, 50, 50],
+			duration: 1000,
+			maxZoom: 12
+		});
 	}
 
 	public toggleGeolocation(): boolean {
@@ -961,6 +1003,7 @@ export class SichtungenMap {
 	}
 
 	public setSpeciesVisibility(speciesId: string, visible: boolean): void {
+		this.closePopup();
 		this.hiddenSpecies[speciesId] = !visible;
 		this.reportsLayer.changed();
 		if (this.legendUpdateCallback) {
@@ -969,6 +1012,7 @@ export class SichtungenMap {
 	}
 
 	public setColorVisibility(colorGroup: string, visible: boolean): void {
+		this.closePopup();
 		this.hiddenColors[colorGroup] = !visible;
 		this.reportsLayer.changed();
 		if (this.legendUpdateCallback) {
@@ -977,6 +1021,7 @@ export class SichtungenMap {
 	}
 
 	public setFilter(start?: number, end?: number): void {
+		this.closePopup();
 		if (start) this.timeFilter.lower = start;
 		if (end) this.timeFilter.upper = end;
 		this.reportsLayer.changed();

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -1022,8 +1022,8 @@ export class SichtungenMap {
 
 	public setFilter(start?: number, end?: number): void {
 		this.closePopup();
-		if (start) this.timeFilter.lower = start;
-		if (end) this.timeFilter.upper = end;
+		if (start !== undefined) this.timeFilter.lower = start;
+		if (end !== undefined) this.timeFilter.upper = end;
 		this.reportsLayer.changed();
 		if (this.legendUpdateCallback) {
 			this.legendUpdateCallback();

--- a/src/lib/map/timeSliderManager.test.ts
+++ b/src/lib/map/timeSliderManager.test.ts
@@ -1,0 +1,139 @@
+// Server-Testprojekt läuft mit environment: 'node' (kein jsdom/happy-dom, siehe
+// vitest.config.ts). MapTimeSliderManager braucht nur zwei <input type="range">
+// als reine Werte-Träger (value/max) plus addEventListener — dafür reichen
+// schlanke Objekt-Stubs, ein vollständiges DOM ist nicht nötig.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MapTimeSliderManager } from './timeSliderManager';
+import type { SichtungenMap } from './optimizedMapController';
+
+class FakeRangeInput {
+	value = '0';
+	max = '0';
+	private listeners: Record<string, Array<() => void>> = {};
+
+	addEventListener(type: string, handler: () => void): void {
+		(this.listeners[type] ??= []).push(handler);
+	}
+
+	dispatch(type: string): void {
+		(this.listeners[type] ?? []).forEach((handler) => handler());
+	}
+}
+
+function createMockMapInstance(): SichtungenMap {
+	return {
+		getDisplayedYear: vi.fn(() => 2024),
+		setFilter: vi.fn()
+	} as unknown as SichtungenMap;
+}
+
+describe('MapTimeSliderManager', () => {
+	let startSlider: FakeRangeInput;
+	let endSlider: FakeRangeInput;
+	let elements: Record<string, FakeRangeInput>;
+
+	beforeEach(() => {
+		startSlider = new FakeRangeInput();
+		endSlider = new FakeRangeInput();
+		elements = {
+			'time-range-start': startSlider,
+			'time-range-end': endSlider
+		};
+
+		vi.stubGlobal('document', {
+			getElementById: (id: string) => elements[id] ?? null
+		});
+	});
+
+	describe('reset()', () => {
+		it('setzt Start auf 0, Ende auf daysInYear - 1 und passt max an (Schaltjahr)', () => {
+			const manager = new MapTimeSliderManager();
+			manager.initialize(createMockMapInstance());
+
+			// Simuliere eine vorherige Nutzer-Auswahl (z. B. Juli)
+			startSlider.value = '180';
+			startSlider.max = '364';
+			endSlider.value = '210';
+			endSlider.max = '364';
+
+			manager.reset(366);
+
+			expect(startSlider.value).toBe('0');
+			expect(startSlider.max).toBe('365');
+			expect(endSlider.value).toBe('365');
+			expect(endSlider.max).toBe('365');
+		});
+
+		it('setzt die Slider auch bei einem normalen Jahr (365 Tage) korrekt zurück', () => {
+			const manager = new MapTimeSliderManager();
+			manager.initialize(createMockMapInstance());
+
+			manager.reset(365);
+
+			expect(startSlider.value).toBe('0');
+			expect(startSlider.max).toBe('364');
+			expect(endSlider.value).toBe('364');
+			expect(endSlider.max).toBe('364');
+		});
+
+		it('tut nichts, wenn die Slider-Elemente nicht im DOM sind', () => {
+			vi.stubGlobal('document', { getElementById: () => null });
+			const manager = new MapTimeSliderManager();
+
+			expect(() => manager.reset(366)).not.toThrow();
+		});
+	});
+
+	describe('±1-Zwangskorrektur — Klemmen statt Verschieben', () => {
+		it('erlaubt Start == Ende (klemmt Start auf den Ende-Wert)', () => {
+			const mapInstance = createMockMapInstance();
+			const manager = new MapTimeSliderManager();
+			manager.initialize(mapInstance);
+
+			endSlider.value = '100';
+			startSlider.value = '150'; // Nutzer zieht Start über Ende hinaus
+			startSlider.dispatch('input');
+
+			expect(startSlider.value).toBe('100');
+			expect(endSlider.value).toBe('100');
+		});
+
+		it('erlaubt Ende == Start (klemmt Ende auf den Start-Wert)', () => {
+			const mapInstance = createMockMapInstance();
+			const manager = new MapTimeSliderManager();
+			manager.initialize(mapInstance);
+
+			startSlider.value = '200';
+			endSlider.value = '100'; // Nutzer zieht Ende unter Start
+			endSlider.dispatch('input');
+
+			expect(endSlider.value).toBe('200');
+			expect(startSlider.value).toBe('200');
+		});
+
+		it('lässt Start und Ende unverändert, wenn Start < Ende bleibt', () => {
+			const mapInstance = createMockMapInstance();
+			const manager = new MapTimeSliderManager();
+			manager.initialize(mapInstance);
+
+			startSlider.value = '10';
+			endSlider.value = '20';
+			startSlider.dispatch('input');
+
+			expect(startSlider.value).toBe('10');
+			expect(endSlider.value).toBe('20');
+		});
+
+		it('propagiert den Zeitfilter über setFilter() an die Map-Instanz', () => {
+			const mapInstance = createMockMapInstance();
+			const manager = new MapTimeSliderManager();
+			manager.initialize(mapInstance);
+
+			startSlider.value = '0';
+			endSlider.value = '10';
+			endSlider.dispatch('input');
+
+			expect(mapInstance.setFilter).toHaveBeenCalledOnce();
+		});
+	});
+});

--- a/src/lib/map/timeSliderManager.ts
+++ b/src/lib/map/timeSliderManager.ts
@@ -6,6 +6,7 @@ import type { SichtungenMap } from './optimizedMapController';
 
 export interface TimeSliderManager {
 	initialize(mapInstance: SichtungenMap): void;
+	reset(daysInYear: number): void;
 }
 
 export class MapTimeSliderManager implements TimeSliderManager {
@@ -27,9 +28,10 @@ export class MapTimeSliderManager implements TimeSliderManager {
 			const startValue = parseInt(startSlider.value, 10);
 			const endValue = parseInt(endSlider.value, 10);
 
-			// Stelle sicher, dass Start nicht größer als End ist
-			if (startValue >= endValue) {
-				startSlider.value = (endValue - 1).toString();
+			// Klemmen statt Verschieben: Start darf gleich Ende sein (ein einzelner
+			// Tag als Zeitraum), aber nicht darüber hinaus.
+			if (startValue > endValue) {
+				startSlider.value = endValue.toString();
 			}
 
 			this.updateTimeFilter(startSlider, endSlider);
@@ -40,13 +42,37 @@ export class MapTimeSliderManager implements TimeSliderManager {
 			const startValue = parseInt(startSlider.value, 10);
 			const endValue = parseInt(endSlider.value, 10);
 
-			// Stelle sicher, dass End nicht kleiner als Start ist
-			if (endValue <= startValue) {
-				endSlider.value = (startValue + 1).toString();
+			// Klemmen statt Verschieben: Ende darf gleich Start sein.
+			if (endValue < startValue) {
+				endSlider.value = startValue.toString();
 			}
 
 			this.updateTimeFilter(startSlider, endSlider);
 		});
+	}
+
+	/**
+	 * Setzt beide Slider auf den vollen Jahresbereich zurück (0 bis
+	 * `daysInYear - 1`) und aktualisiert deren `max`-Attribut.
+	 *
+	 * QW4: Bei einem Jahreswechsel bleiben die Slider-Werte sonst auf der
+	 * zuvor gewählten Position (z. B. Juli) stehen, während der Controller den
+	 * Datenfilter bereits auf das volle neue Jahr zurücksetzt — sichtbarer
+	 * Widerspruch zwischen Slider-Stellung und tatsächlich gefilterten Daten.
+	 * Reine DOM-Aktualisierung; den Datenfilter selbst setzt `setYear()` im
+	 * Controller bereits korrekt auf das volle Jahr.
+	 */
+	reset(daysInYear: number): void {
+		const startSlider = document.getElementById('time-range-start') as HTMLInputElement | null;
+		const endSlider = document.getElementById('time-range-end') as HTMLInputElement | null;
+
+		if (!startSlider || !endSlider) return;
+
+		const maxValue = (daysInYear - 1).toString();
+		startSlider.max = maxValue;
+		endSlider.max = maxValue;
+		startSlider.value = '0';
+		endSlider.value = maxValue;
 	}
 
 	/**

--- a/src/lib/utils/date/defaultYear.test.ts
+++ b/src/lib/utils/date/defaultYear.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getDefaultSightingYear, isInTransitionPeriod, getAvailableYears } from './defaultYear';
+import {
+	getDefaultSightingYear,
+	isInTransitionPeriod,
+	getAvailableYears,
+	pickDefaultYear
+} from './defaultYear';
 
 describe('defaultYear utilities', () => {
 	describe('getDefaultSightingYear', () => {
@@ -46,11 +51,11 @@ describe('defaultYear utilities', () => {
 			// Test at the very beginning of January
 			vi.setSystemTime(new Date('2025-01-01T00:00:00'));
 			expect(getDefaultSightingYear()).toBe(2024);
-			
+
 			// Test at the very end of March
 			vi.setSystemTime(new Date('2025-03-31T23:59:59'));
 			expect(getDefaultSightingYear()).toBe(2024);
-			
+
 			// Test at the very beginning of April
 			vi.setSystemTime(new Date('2025-04-01T00:00:00'));
 			expect(getDefaultSightingYear()).toBe(2025);
@@ -124,6 +129,62 @@ describe('defaultYear utilities', () => {
 		it('should handle 0 years back', () => {
 			const years = getAvailableYears(0);
 			expect(years).toEqual([2024]);
+		});
+	});
+
+	describe('pickDefaultYear', () => {
+		it('gibt den Fallback zurück, wenn die Liste leer ist', () => {
+			expect(pickDefaultYear([], 2025)).toBe(2025);
+		});
+
+		it('gibt den Fallback zurück, wenn kein Jahr Daten hat (count 0)', () => {
+			const years = [
+				{ year: 2025, count: 0 },
+				{ year: 2024, count: 0 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2025);
+		});
+
+		it('gibt das aktuelle Jahr zurück, wenn es Daten hat', () => {
+			const years = [
+				{ year: 2025, count: 817 },
+				{ year: 2024, count: 620 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2025);
+		});
+
+		it('gibt das jüngste Jahr mit Daten zurück, wenn nur ältere Jahre Daten haben', () => {
+			const years = [
+				{ year: 2025, count: 0 },
+				{ year: 2024, count: 620 },
+				{ year: 2023, count: 400 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2024);
+		});
+
+		it('ignoriert Jahre nach dem Fallback-Jahr, wenn ältere Jahre mit Daten existieren', () => {
+			const years = [
+				{ year: 2026, count: 5 },
+				{ year: 2024, count: 620 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2024);
+		});
+
+		it('greift auf das jüngste Jahr mit Daten überhaupt zurück, wenn alle Jahre mit Daten in der Zukunft liegen', () => {
+			const years = [
+				{ year: 2027, count: 3 },
+				{ year: 2026, count: 5 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2027);
+		});
+
+		it('ist unabhängig von der Reihenfolge der Eingabeliste', () => {
+			const years = [
+				{ year: 2022, count: 10 },
+				{ year: 2024, count: 20 },
+				{ year: 2023, count: 15 }
+			];
+			expect(pickDefaultYear(years, 2025)).toBe(2024);
 		});
 	});
 });

--- a/src/lib/utils/date/defaultYear.ts
+++ b/src/lib/utils/date/defaultYear.ts
@@ -1,25 +1,25 @@
 /**
  * Ermittelt das Standard-Jahr für den Abruf von Sichtungen.
- * 
+ *
  * Logik gemäß API-Dokumentation:
  * - Von Januar bis einschließlich März: Vorjahr
  * - Ab April: Aktuelles Jahr
- * 
+ *
  * Diese Logik berücksichtigt, dass zu Beginn eines neuen Jahres
  * noch hauptsächlich Sichtungen aus dem Vorjahr relevant sind.
- * 
+ *
  * @returns Das Jahr, das standardmäßig für Sichtungsabfragen verwendet werden soll
  */
 export function getDefaultSightingYear(): number {
 	const now = new Date();
 	const currentYear = now.getFullYear();
 	const currentMonth = now.getMonth(); // 0-basiert: 0 = Januar, 2 = März
-	
+
 	// Januar (0), Februar (1), März (2) -> Vorjahr
 	if (currentMonth <= 2) {
 		return currentYear - 1;
 	}
-	
+
 	// Ab April (3) -> Aktuelles Jahr
 	return currentYear;
 }
@@ -27,7 +27,7 @@ export function getDefaultSightingYear(): number {
 /**
  * Prüft, ob wir uns in der Übergangsphase befinden (Januar-März),
  * in der standardmäßig das Vorjahr angezeigt wird.
- * 
+ *
  * @returns true wenn Januar-März, sonst false
  */
 export function isInTransitionPeriod(): boolean {
@@ -38,17 +38,55 @@ export function isInTransitionPeriod(): boolean {
 /**
  * Gibt eine Liste von Jahren für Auswahlfelder zurück.
  * Beginnt mit dem aktuellen Jahr und geht die angegebene Anzahl Jahre zurück.
- * 
+ *
  * @param yearsBack Anzahl der Jahre, die zurück gegangen werden soll (Standard: 10)
  * @returns Array von Jahren in absteigender Reihenfolge
  */
 export function getAvailableYears(yearsBack: number = 10): number[] {
 	const currentYear = new Date().getFullYear();
 	const years: number[] = [];
-	
+
 	for (let i = 0; i <= yearsBack; i++) {
 		years.push(currentYear - i);
 	}
-	
+
 	return years;
+}
+
+/**
+ * Ein Jahr mit der Anzahl an Sichtungen darin (z. B. Antwort von
+ * `GET /api/map/sightings/years`).
+ */
+export interface YearWithCount {
+	year: number;
+	count: number;
+}
+
+/**
+ * Ermittelt das Default-Jahr für die Sichtungskarte anhand tatsächlich
+ * vorhandener Daten.
+ *
+ * Reine Funktion (kein Fetch, kein Datum) — testbar ohne Fake-Timer.
+ * Logik gemäß Spec (QW2b):
+ * 1. Jüngstes Jahr mit `count > 0`, das ≤ `fallbackYear` ist.
+ * 2. Gibt es keins (alle Jahre mit Daten liegen in der Zukunft von
+ *    `fallbackYear`), das jüngste Jahr mit Daten überhaupt.
+ * 3. Gibt es gar keine Jahre mit Daten (leere Liste oder nur `count === 0`),
+ *    den `fallbackYear` selbst (bisheriges Verhalten).
+ *
+ * @param availableYears Jahre mit Sichtungsanzahl, beliebige Reihenfolge
+ * @param fallbackYear Bisheriges Default-Jahr (z. B. `getDefaultSightingYear()`)
+ * @returns Das zu verwendende Default-Jahr
+ */
+export function pickDefaultYear(availableYears: YearWithCount[], fallbackYear: number): number {
+	const withData = availableYears.filter((entry) => entry.count > 0);
+
+	if (withData.length === 0) {
+		return fallbackYear;
+	}
+
+	const eligible = withData.filter((entry) => entry.year <= fallbackYear);
+	const pool = eligible.length > 0 ? eligible : withData;
+
+	return pool.reduce((latest, entry) => (entry.year > latest ? entry.year : latest), pool[0]!.year);
 }

--- a/src/routes/api/map/sightings/+server.ts
+++ b/src/routes/api/map/sightings/+server.ts
@@ -4,7 +4,8 @@ import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
 import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { json } from '@sveltejs/kit';
-import { and, gte, isNotNull, lt, sql } from 'drizzle-orm';
+import { and, gte, lt, sql } from 'drizzle-orm';
+import { publicMapSightingConditions } from './publicMapConditions';
 import type { RequestHandler } from './$types';
 
 const logger = createLogger('api:map:sightings');
@@ -17,10 +18,12 @@ export const GET: RequestHandler = async ({ url }) => {
 	try {
 		// Erstellen der Abfrage-Bedingungen
 		const conditions = [
-			// Geprüft heißt veröffentlicht: dieselbe Grundmenge wie die Legacy-API
-			// (/sichtungen/showreports.json), damit beide öffentlichen Flächen
-			// nachweislich an derselben Spalte hängen.
-			isNotNull(sightingsTable.approvedAt)
+			// Geprüft heißt veröffentlicht (dieselbe Grundmenge wie die Legacy-API,
+			// /sichtungen/showreports.json) UND plausible Ostsee-Koordinaten.
+			// Ohne den Koordinatenfilter fallen NULL-Koordinaten in
+			// sightingsToGeoJSON auf [0,0] zurück ("Null Island"). Identische
+			// Grundmenge wie /api/map/sightings/years — siehe publicMapConditions.ts.
+			...publicMapSightingConditions()
 		];
 
 		// Jahr-Filter hinzufügen, wenn vorhanden

--- a/src/routes/api/map/sightings/coordinateFilter.test.ts
+++ b/src/routes/api/map/sightings/coordinateFilter.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockWhere, mockOrderBy } = vi.hoisted(() => {
+	const mockOrderBy = vi.fn().mockResolvedValue([]);
+	const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+	return { mockWhere, mockOrderBy };
+});
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({ where: mockWhere, orderBy: mockOrderBy })
+		})
+	}
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: {
+		sightingDate: 'sightingDate',
+		approvedAt: 'approvedAt',
+		latitude: 'latitude',
+		longitude: 'longitude'
+	}
+}));
+
+// Drizzle wird durch Marker-Objekte ersetzt, damit die WHERE-Bedingungen
+// direkt geprüft werden können, statt generiertes SQL zu parsen.
+vi.mock('drizzle-orm', () => ({
+	and: vi.fn((...conditions) => conditions),
+	between: vi.fn((column, from, to) => ({ op: 'between', column, from, to })),
+	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	sql: Object.assign(
+		vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
+		{ raw: vi.fn((s: string) => s) }
+	)
+}));
+
+vi.mock('$lib/map/mapUtils', () => ({
+	sightingsToGeoJSON: vi.fn().mockReturnValue({ type: 'FeatureCollection', features: [] })
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { GET } from './+server';
+import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
+
+type Condition = { op: string; column: string; value?: string };
+
+async function queryConditions(): Promise<Condition[]> {
+	const url = new URL('http://localhost/api/map/sightings');
+	await GET({ url } as Parameters<typeof GET>[0]);
+
+	return mockWhere.mock.calls.at(-1)?.[0] as Condition[];
+}
+
+describe('GET /api/map/sightings — Koordinatenfilter gegen Null Island', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it('verlangt NOT NULL für Breiten- und Längengrad', async () => {
+		const conditions = await queryConditions();
+		const notNullColumns = conditions
+			.filter((condition) => condition.op === 'isNotNull')
+			.map((condition) => condition.column);
+
+		expect(notNullColumns).toContain('latitude');
+		expect(notNullColumns).toContain('longitude');
+	});
+
+	it('klemmt den Breitengrad auf die Ostsee-Bounding-Box', async () => {
+		const conditions = await queryConditions();
+		const latConditions = conditions.filter((condition) => condition.column === 'latitude');
+
+		expect(latConditions.find((condition) => condition.op === 'gte')?.value).toBe(
+			BALTIC_SEA_BBOX.minLatitude.toString()
+		);
+		expect(latConditions.find((condition) => condition.op === 'lte')?.value).toBe(
+			BALTIC_SEA_BBOX.maxLatitude.toString()
+		);
+	});
+
+	it('klemmt den Längengrad auf die Ostsee-Bounding-Box', async () => {
+		const conditions = await queryConditions();
+		const lonConditions = conditions.filter((condition) => condition.column === 'longitude');
+
+		expect(lonConditions.find((condition) => condition.op === 'gte')?.value).toBe(
+			BALTIC_SEA_BBOX.minLongitude.toString()
+		);
+		expect(lonConditions.find((condition) => condition.op === 'lte')?.value).toBe(
+			BALTIC_SEA_BBOX.maxLongitude.toString()
+		);
+	});
+
+	it('nutzt die Konstanten aus checkBalticSea.ts (kein duplizierter Wert)', () => {
+		expect(BALTIC_SEA_BBOX).toEqual({
+			minLongitude: 9.4,
+			maxLongitude: 30.2,
+			minLatitude: 53.0,
+			maxLatitude: 66.0
+		});
+	});
+
+	it('behält den Freigabe-Filter bei (approvedAt)', async () => {
+		const conditions = await queryConditions();
+
+		expect(
+			conditions.some(
+				(condition) => condition.op === 'isNotNull' && condition.column === 'approvedAt'
+			)
+		).toBe(true);
+	});
+});

--- a/src/routes/api/map/sightings/publicMapConditions.ts
+++ b/src/routes/api/map/sightings/publicMapConditions.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Geteilte Grundmenge für die öffentliche Sichtungskarte.
+ *
+ * Der Feature-Endpoint (`GET /api/map/sightings`) und der Jahres-Endpoint
+ * (`GET /api/map/sightings/years`) müssen exakt dieselben Sichtungen zählen —
+ * sonst zeigt das Jahres-Dropdown Zahlen, die auf der Karte nicht auftauchen.
+ * Die Bedingungsliste liegt deshalb hier einmal statt doppelt in beiden Routen.
+ *
+ * Zusätzlich zur öffentlichen Freigabe (`approvedOnly()`, siehe
+ * `.claude/rules/api.md`) werden NULL- und unplausible Koordinaten
+ * herausgefiltert: `sightingsToGeoJSON` (`$lib/map/mapUtils`) fällt bei
+ * NULL-Koordinaten auf `[0, 0]` zurück ("Null Island"). Dieser Serverfilter
+ * macht den Fallback für die Karte unerreichbar, ohne die Funktion selbst
+ * anzufassen — andere Aufrufer von `sightingsToGeoJSON` bleiben unverändert.
+ */
+
+import { approvedOnly } from '$lib/server/db/approvalFilter';
+import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
+import { gte, isNotNull, lte, type SQL } from 'drizzle-orm';
+
+/**
+ * Bedingungen für die öffentliche Grundmenge der Sichtungskarte: freigegeben
+ * und mit plausiblen Ostsee-Koordinaten (Bounding Box aus `checkBalticSea.ts`,
+ * nicht dupliziert).
+ *
+ * Wird per `...publicMapSightingConditions()` in ein `and(...)` gespreizt.
+ */
+export function publicMapSightingConditions(): SQL[] {
+	return [
+		approvedOnly(),
+		isNotNull(sightingsTable.latitude),
+		isNotNull(sightingsTable.longitude),
+		gte(sightingsTable.latitude, BALTIC_SEA_BBOX.minLatitude.toString()),
+		lte(sightingsTable.latitude, BALTIC_SEA_BBOX.maxLatitude.toString()),
+		gte(sightingsTable.longitude, BALTIC_SEA_BBOX.minLongitude.toString()),
+		lte(sightingsTable.longitude, BALTIC_SEA_BBOX.maxLongitude.toString())
+	];
+}

--- a/src/routes/api/map/sightings/yearFilter.test.ts
+++ b/src/routes/api/map/sightings/yearFilter.test.ts
@@ -15,7 +15,12 @@ vi.mock('$lib/server/db', () => ({
 }));
 
 vi.mock('$lib/server/db/schema', () => ({
-	sightings: { sightingDate: 'sightingDate', approvedAt: 'approvedAt' }
+	sightings: {
+		sightingDate: 'sightingDate',
+		approvedAt: 'approvedAt',
+		latitude: 'latitude',
+		longitude: 'longitude'
+	}
 }));
 
 // Drizzle wird durch Marker-Objekte ersetzt, damit die erzeugten Grenz-Instants
@@ -24,6 +29,7 @@ vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...conditions) => conditions),
 	between: vi.fn((column, from, to) => ({ op: 'between', column, from, to })),
 	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
 	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
 	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
 	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
@@ -70,14 +76,16 @@ describe('GET /api/map/sightings — Jahresfilter meint Berliner Kalenderjahre',
 	});
 
 	it('nutzt kein BETWEEN, sondern das halboffene Intervall gte/lt', async () => {
-		const { between, gte, lt } = vi.mocked(await import('drizzle-orm'));
+		const { between, gte, lte, lt } = vi.mocked(await import('drizzle-orm'));
 
 		await GET({
 			url: new URL('http://localhost/api/map/sightings?year=2024')
 		} as Parameters<typeof GET>[0]);
 
 		expect(between).not.toHaveBeenCalled();
-		expect(gte).toHaveBeenCalledTimes(1);
+		// 1x sightingDate-Jahresgrenze + 2x Ostsee-Bounding-Box (Lat/Lon) — QW1
+		expect(gte).toHaveBeenCalledTimes(3);
+		expect(lte).toHaveBeenCalledTimes(2);
 		expect(lt).toHaveBeenCalledTimes(1);
 	});
 

--- a/src/routes/api/map/sightings/years/+server.ts
+++ b/src/routes/api/map/sightings/years/+server.ts
@@ -1,0 +1,49 @@
+import { createLogger } from '$lib/logger.server';
+import { db } from '$lib/server/db';
+import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { berlinDatePart } from '$lib/server/db/sqlTimeZone';
+import { json } from '@sveltejs/kit';
+import { and, sql } from 'drizzle-orm';
+import { publicMapSightingConditions } from '../publicMapConditions';
+import type { RequestHandler } from './$types';
+
+const logger = createLogger('api:map:sightings:years');
+
+/**
+ * Verfügbare Jahre für die Sichtungskarte, jeweils mit Anzahl der Sichtungen.
+ *
+ * Grundmenge identisch zu `GET /api/map/sightings` (`publicMapConditions.ts`):
+ * freigegeben und mit plausiblen Ostsee-Koordinaten. Kalenderjahr wird über
+ * `berlinDatePart('year', ...)` gebildet — derselbe Ausdruck wie überall sonst
+ * im Projekt, damit der vorhandene Ausdrucksindex (`idx_year_sichtungen`) greift.
+ */
+export const GET: RequestHandler = async () => {
+	try {
+		const yearExpression = berlinDatePart('year', sightingsTable.sightingDate);
+
+		const rows = await db
+			.select({
+				year: sql<number | string>`${yearExpression}`,
+				count: sql<number | string>`COUNT(*)`
+			})
+			.from(sightingsTable)
+			.where(and(...publicMapSightingConditions()))
+			.groupBy(yearExpression)
+			.orderBy(sql`${yearExpression} DESC`);
+
+		const years = rows
+			.map((row) => ({ year: Number(row.year), count: Number(row.count) }))
+			.filter((entry) => entry.count > 0);
+
+		return json({ years });
+	} catch (error) {
+		logger.error(
+			{ error: error instanceof Error ? error.message : error },
+			'Fehler beim Abrufen der verfügbaren Jahre für die Karte'
+		);
+
+		// Fehlerantwort zurückgeben — keine internen Fehlerdetails an den Client leaken
+		// (der konkrete Fehler wurde oben serverseitig geloggt).
+		return json({ error: 'Fehler beim Abrufen der verfügbaren Jahre' }, { status: 500 });
+	}
+};

--- a/src/routes/api/map/sightings/years/availableYears.test.ts
+++ b/src/routes/api/map/sightings/years/availableYears.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const { mockWhere, mockGroupBy, mockOrderBy } = vi.hoisted(() => {
+	const mockOrderBy = vi.fn().mockResolvedValue([]);
+	const mockGroupBy = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+	const mockWhere = vi.fn().mockReturnValue({ groupBy: mockGroupBy });
+	return { mockWhere, mockGroupBy, mockOrderBy };
+});
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn().mockReturnValue({
+			from: vi.fn().mockReturnValue({ where: mockWhere })
+		})
+	}
+}));
+
+vi.mock('$lib/server/db/schema', () => ({
+	sightings: {
+		sightingDate: 'sightingDate',
+		approvedAt: 'approvedAt',
+		latitude: 'latitude',
+		longitude: 'longitude'
+	}
+}));
+
+// Drizzle wird durch Marker-Objekte ersetzt, damit die WHERE-Bedingungen
+// direkt geprüft werden können, statt generiertes SQL zu parsen. `sql` wird
+// so gemockt, dass es (wie im Original) beliebig verschachtelt werden kann —
+// berlinDatePart() aus sqlTimeZone.ts nutzt genau dieses Verhalten.
+vi.mock('drizzle-orm', () => ({
+	and: vi.fn((...conditions) => conditions),
+	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	sql: Object.assign(
+		vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+			op: 'sql',
+			strings: strings.raw,
+			values
+		})),
+		{ raw: vi.fn((s: string) => ({ op: 'sql.raw', value: s })) }
+	)
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { GET } from './+server';
+
+type Condition = { op: string; column: string };
+
+describe('GET /api/map/sightings/years', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockReturnValue({ groupBy: mockGroupBy });
+		mockGroupBy.mockReturnValue({ orderBy: mockOrderBy });
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it('nutzt dieselbe Grundmenge wie die Karte (Freigabe + Koordinatenfilter)', async () => {
+		await GET({} as Parameters<typeof GET>[0]);
+
+		const conditions = mockWhere.mock.calls.at(-1)?.[0] as Condition[];
+		const notNullColumns = conditions
+			.filter((condition) => condition.op === 'isNotNull')
+			.map((condition) => condition.column);
+
+		expect(notNullColumns).toEqual(expect.arrayContaining(['approvedAt', 'latitude', 'longitude']));
+		expect(conditions.filter((condition) => condition.op === 'gte')).toHaveLength(2);
+		expect(conditions.filter((condition) => condition.op === 'lte')).toHaveLength(2);
+	});
+
+	it('liefert Jahre absteigend sortiert und filtert count=0 heraus', async () => {
+		mockOrderBy.mockResolvedValueOnce([
+			{ year: 2025, count: 42 },
+			{ year: 2024, count: 0 },
+			{ year: 2023, count: 7 }
+		]);
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body).toEqual({
+			years: [
+				{ year: 2025, count: 42 },
+				{ year: 2023, count: 7 }
+			]
+		});
+	});
+
+	it('wandelt String-Werte (bigint/numeric aus Postgres) in Zahlen um', async () => {
+		mockOrderBy.mockResolvedValueOnce([{ year: '2025', count: '42' }]);
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body).toEqual({ years: [{ year: 2025, count: 42 }] });
+	});
+
+	it('liefert ein leeres Array, wenn keine Sichtungen vorhanden sind', async () => {
+		mockOrderBy.mockResolvedValueOnce([]);
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body).toEqual({ years: [] });
+	});
+
+	it('fängt DB-Fehler ab und liefert 500 ohne interne Details', async () => {
+		mockOrderBy.mockRejectedValueOnce(new Error('boom - interne Details'));
+
+		const response = await GET({} as Parameters<typeof GET>[0]);
+
+		expect(response.status).toBe(500);
+		const body = await response.json();
+		expect(body).toEqual({ error: expect.any(String) });
+		expect(JSON.stringify(body)).not.toContain('boom');
+	});
+});

--- a/src/tests/contract/map-sightings.contract.test.ts
+++ b/src/tests/contract/map-sightings.contract.test.ts
@@ -47,6 +47,7 @@ vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn((a, b, c) => ({ a, b, c })),
 	gte: vi.fn((a, b) => ({ a, b })),
+	lte: vi.fn((a, b) => ({ a, b })),
 	lt: vi.fn((a, b) => ({ a, b })),
 	eq: vi.fn((a, b) => ({ a, b })),
 	isNotNull: vi.fn((a) => ({ isNotNull: a })),

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1448,6 +1448,12 @@ paths:
       description: |
         Ruft Sichtungsdaten für die Kartendarstellung ab.
         Optimiert für große Datenmengen mit räumlicher Filterung.
+
+        Liefert nur freigegebene Sichtungen (`freigegeben_am IS NOT NULL`) mit
+        plausiblen Ostsee-Koordinaten (Bounding Box `9.4–30.2°O`, `53.0–66.0°N`).
+        Sichtungen mit fehlenden oder unplausiblen Koordinaten werden serverseitig
+        ausgeschlossen, damit keine "Null Island"-Marker ([0,0]) auf der Karte
+        erscheinen.
       parameters:
         - name: bbox
           in: query
@@ -1517,6 +1523,68 @@ paths:
                     example: "Fehler beim Abrufen der Sichtungen"
               example:
                 error: "Fehler beim Abrufen der Sichtungen"
+
+  /api/map/sightings/years:
+    get:
+      tags:
+        - map
+      summary: Verfügbare Jahre für die Sichtungskarte
+      description: |
+        Liefert die Jahre, für die freigegebene Sichtungen mit plausiblen
+        Ostsee-Koordinaten vorliegen, jeweils mit Anzahl — absteigend nach Jahr
+        sortiert. Jahre ohne Treffer (`count = 0`) werden nicht ausgegeben.
+
+        Dieselbe Grundmenge wie `GET /api/map/sightings` (Freigabe- und
+        Koordinatenfilter identisch), damit Jahres-Dropdown und Kartendaten nie
+        auseinanderlaufen. Das Kalenderjahr wird in deutscher Ortszeit gebildet
+        (Europe/Berlin), nicht UTC.
+      responses:
+        '200':
+          description: Verfügbare Jahre mit Anzahl der Sichtungen
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - years
+                properties:
+                  years:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - year
+                        - count
+                      properties:
+                        year:
+                          type: integer
+                          example: 2025
+                        count:
+                          type: integer
+                          example: 817
+              example:
+                years:
+                  - year: 2025
+                    count: 817
+                  - year: 2024
+                    count: 632
+        '500':
+          description: >-
+            Interner Serverfehler. Es wird ausschließlich eine generische
+            Fehlermeldung zurückgegeben; interne Fehlerdetails (`details`,
+            Exception-Message) werden aus Sicherheitsgründen NICHT an den Client
+            geleakt (der konkrete Fehler wird nur serverseitig geloggt).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Generische Fehlermeldung ohne interne Details
+                    example: "Fehler beim Abrufen der verfügbaren Jahre"
+              example:
+                error: "Fehler beim Abrufen der verfügbaren Jahre"
 
   /rest_sichtungen:
     post:


### PR DESCRIPTION
## Zusammenfassung

Umfassendes UX-Review der Sichtungskarte (`/map`) plus Umsetzung der acht daraus abgeleiteten Quick Wins. Review-Report: `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md`, Spec: `docs/SICHTUNGSKARTE_QUICKWINS_SPEC_2026-07-28.md`.

### Kritische Fixes
- **Kein leerer Erststart mehr:** Default-Jahr ist jetzt das jüngste Jahr mit veröffentlichten Daten (neuer Endpoint `GET /api/map/sightings/years`); der Empty-State bietet einen Button „Sichtungen {Jahr} anzeigen".
- **Null-Island beseitigt:** `/api/map/sightings` filtert Sichtungen ohne plausible Ostsee-Koordinaten serverseitig (gemeinsames Bedingungsmodul `publicMapSightingConditions`, 165 ungültige Features für 2025 entfernt). Zusätzlich klemmt `clampExtentToBaltic` den „Auf alle zoomen"-Extent — Welt-Zoom ist damit doppelt ausgeschlossen.

### UX-Fixes
- Popups schließen bei Jahres-/Filter-/Sichtbarkeitswechsel (kein Stale Popup mehr); Escape-Kaskade: Popup → Hilfe → Filter → Legende
- Zeitslider springt beim Jahreswechsel auf den vollen Jahresbereich zurück; Start == Ende erlaubt
- Ehrliche Suche: Placeholder ohne E-Mail-Versprechen, „Filtert automatisch beim Tippen", echter Ladeindikator statt 800-ms-Fake
- Alle Karten-Controls 44×44 px (vorher 19×19), deutsche Zoom-Tooltips, Fit-Icon statt „Z", 44-px-Popup-Schließer
- Mobile Panelbreite repariert (tote `.w-90`-Regel entfernt, `max-w-[100vw]` + `min()`-Transform)
- Jahres-Dropdown zeigt Sichtungsanzahl je Jahr („2025 (652)")

### Technisch
- `mapInstance` in `SightingsMapView` ist jetzt `$state` — der Jahreswechsel-Callback-$effect muss auf die (neuerdings asynchrone) Initialisierung reagieren
- OpenAPI-Spec für beide Endpoints aktualisiert und validiert
- Jahres-Gruppierung nutzt den zeichengleichen `berlinDatePart`-Ausdruck (Ausdrucksindex greift)

## Tests
- 2014/2014 Unit-Tests grün (14 neue: coordinateFilter, availableYears, extentUtils, timeSliderManager, pickDefaultYear)
- Lint, type-check, svelte-check sauber; projektspezifisches Anti-Pattern-Review ohne Befunde
- Browser-verifiziert (Desktop + schmaler Viewport): Erststart mit Daten, Escape-Kaskade, Slider-Reset, Empty-State-Button, 44-px-Targets, Panelbreite mobil

## Offene Follow-Ups (separat, als Task-Chips angelegt)
Tastaturbedienung + Listenansicht (K3), ARIA-/Fokus-Sanierung der Panels (H5/H7), mobile Bottom-Sheets (H6), Marker-/Legenden-Farbsystem (M1/M8), URL-State + Filter-Chips (M4) — Details in Report §5–6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)