### PR TITLE
fix(a11y): add status icons to alerts that had none

### DIFF
--- a/src/lib/components/docs/ApiDocumentation.svelte
+++ b/src/lib/components/docs/ApiDocumentation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import Icon from '$lib/components/Icon.svelte';
 
 	// Props
 	let {
@@ -52,8 +53,8 @@
 <div class={containerClass}>
 	<!-- Header Section -->
 	<div class="mb-8 text-center">
-		<h1 class="mb-4 text-4xl font-bold text-base-content">{title}</h1>
-		<p class="mx-auto max-w-3xl text-lg text-base-content/70">
+		<h1 class="text-base-content mb-4 text-4xl font-bold">{title}</h1>
+		<p class="text-base-content/70 mx-auto max-w-3xl text-lg">
 			{description}
 		</p>
 
@@ -81,35 +82,35 @@
 			<div class="grid gap-6 md:grid-cols-2">
 				<div>
 					<h3 class="mb-2 text-lg font-medium">Öffentliche Endpunkte</h3>
-					<p class="mb-3 text-sm text-base-content/70">
+					<p class="text-base-content/70 mb-3 text-sm">
 						Einige Endpunkte sind öffentlich verfügbar und benötigen keine Authentifizierung:
 					</p>
 					<ul class="space-y-1 text-sm">
 						<li>
-							• <code class="rounded bg-base-200 px-1">GET /api/sightings</code> - Öffentliche Sichtungen
+							• <code class="bg-base-200 rounded px-1">GET /api/sightings</code> - Öffentliche Sichtungen
 						</li>
 						<li>
-							• <code class="rounded bg-base-200 px-1">POST /api/sightings</code> - Neue Sichtung melden
+							• <code class="bg-base-200 rounded px-1">POST /api/sightings</code> - Neue Sichtung melden
 						</li>
 						<li>
-							• <code class="rounded bg-base-200 px-1">GET /api/geo/inBaltic</code> - Koordinaten prüfen
+							• <code class="bg-base-200 rounded px-1">GET /api/geo/inBaltic</code> - Koordinaten prüfen
 						</li>
 						<li>
-							• <code class="rounded bg-base-200 px-1">POST /api/files/upload</code> - Dateien hochladen
+							• <code class="bg-base-200 rounded px-1">POST /api/files/upload</code> - Dateien hochladen
 						</li>
 						<li>
-							• <code class="rounded bg-base-200 px-1">GET /api/media/{'{path}'}</code> - Sichere Medien
+							• <code class="bg-base-200 rounded px-1">GET /api/media/{'{path}'}</code> - Sichere Medien
 							abrufen
 						</li>
 					</ul>
 				</div>
 				<div>
 					<h3 id="authentication" class="mb-2 text-lg font-medium">🔐 Admin-Authentifizierung</h3>
-					<p class="mb-3 text-sm text-base-content/70">
+					<p class="text-base-content/70 mb-3 text-sm">
 						Für Admin-Funktionen ist eine Anmeldung erforderlich:
 					</p>
 					<ol class="space-y-1 text-sm">
-						<li>1. <code class="rounded bg-base-200 px-1">GET /api/auth/login</code> aufrufen</li>
+						<li>1. <code class="bg-base-200 rounded px-1">GET /api/auth/login</code> aufrufen</li>
 						<li>2. Auth0-Login-Flow durchlaufen</li>
 						<li>3. Session-Cookie wird automatisch gesetzt</li>
 						<li>4. Admin-Endpunkte sind nun verfügbar</li>
@@ -121,7 +122,7 @@
 
 	<!-- API Reference Container -->
 	{#if isLoading}
-		<div class="py-8 text-center text-base-content/60">
+		<div class="text-base-content/60 py-8 text-center">
 			<div class="loading loading-spinner loading-lg"></div>
 			<p class="mt-4">API-Dokumentation wird geladen...</p>
 			<p class="mt-2 text-sm">
@@ -130,6 +131,7 @@
 		</div>
 	{:else if hasError}
 		<div class="alert alert-error">
+			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<div>
 				<span>{errorMessage}</span>
 				<div class="mt-4 flex gap-2">
@@ -165,7 +167,7 @@
 
 		<!-- Fallback notice -->
 		<div class="mt-4 text-center">
-			<p class="text-sm text-base-content/60">
+			<p class="text-base-content/60 text-sm">
 				Falls die interaktive Dokumentation nicht funktioniert, nutzen Sie die
 				<a href="/docs/api/fallback" class="link link-primary">Fallback-Dokumentation</a>
 				oder laden Sie die

--- a/src/lib/components/docs/ApiDocumentation.svelte
+++ b/src/lib/components/docs/ApiDocumentation.svelte
@@ -130,7 +130,7 @@
 			</p>
 		</div>
 	{:else if hasError}
-		<div class="alert alert-error">
+		<div class="alert alert-error" role="alert">
 			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<div>
 				<span>{errorMessage}</span>

--- a/src/lib/components/map/LazyMapWrapper.svelte
+++ b/src/lib/components/map/LazyMapWrapper.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Component } from 'svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import LoadingOverlay from './LoadingOverlay.svelte';
 
 	// Props
@@ -59,7 +60,10 @@
 {#if loadError}
 	<div class={containerClass}>
 		<div class="flex h-full flex-col items-center justify-center gap-4">
-			<div class="alert alert-error" role="alert">{loadError}</div>
+			<div class="alert alert-error" role="alert">
+				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
+				<span>{loadError}</span>
+			</div>
 			<button
 				type="button"
 				class="btn btn-primary"

--- a/src/lib/components/weather/WeatherDataFetcher.svelte
+++ b/src/lib/components/weather/WeatherDataFetcher.svelte
@@ -2,6 +2,7 @@
 	import type { WeatherData, WeatherFormFields } from '$lib/services/weatherService';
 	import type { WeatherDataWithMetadata } from '$lib/types';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import Icon from '$lib/components/Icon.svelte';
 	import WeatherDisplay from './WeatherDisplay.svelte';
 
 	interface Props {
@@ -112,12 +113,12 @@
 			onWeatherDataFetched(weatherData);
 		}
 	}
-
 </script>
 
 <div class="weather-fetcher">
 	{#if error}
 		<div class="alert alert-error mt-2" role="alert">
+			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<span>{error}</span>
 		</div>
 	{/if}

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -262,6 +262,7 @@
 					</div>
 
 					<div class="alert alert-info">
+						<Icon icon="lucide:info" class="shrink-0" aria-hidden="true" />
 						<div>
 							<h4 class="font-semibold">Wofür die Daten gebraucht werden</h4>
 							<p class="mt-1 text-xs">

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -5,6 +5,7 @@
 	import RequiredConsent from './form/RequiredConsent.svelte';
 
 	import { browser } from '$app/environment';
+	import Icon from '$lib/components/Icon.svelte';
 	import { submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
@@ -236,6 +237,7 @@
 	<!-- Error Message -->
 	{#if submissionError}
 		<div class="alert alert-error mb-6" role="alert">
+			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<span>{submissionError}</span>
 		</div>
 	{/if}

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
 	import { validateStep } from '$lib/form/validation/stepValidation';
 	import { createLogger } from '$lib/logger';
 	import { getFormContext } from '$lib/report/formContext';
@@ -180,6 +181,7 @@
 <!-- Inline validation error above navigation — only after a failed "Weiter"-attempt -->
 {#if showStepAlert && stepErrorMessages.length > 0}
 	<div class="alert alert-warning mb-2" role="alert">
+		<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
 		{#if stepErrorMessages.length === 1}
 			<span>{stepErrorMessages[0]?.message}</span>
 		{:else}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1022,7 +1022,7 @@
 				<span class="loading loading-spinner loading-md"></span>
 			</div>
 		{:else if spamCheckModal.error}
-			<div class="alert alert-error mt-4">
+			<div class="alert alert-error mt-4" role="alert">
 				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 				<span>{spamCheckModal.error}</span>
 			</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1023,6 +1023,7 @@
 			</div>
 		{:else if spamCheckModal.error}
 			<div class="alert alert-error mt-4">
+				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 				<span>{spamCheckModal.error}</span>
 			</div>
 		{:else if spamCheckModal.result}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -365,15 +365,15 @@
 
 	<!-- Messages -->
 	{#if saveMessage}
-		<div class="alert alert-success mb-6">
+		<div class="alert alert-success mb-6" role="status">
 			<Icon icon="lucide:circle-check" class="shrink-0" aria-hidden="true" />
 			<span>{saveMessage}</span>
 		</div>
 	{/if}
 
 	{#if errorMessage}
-		<div class="alert alert-error mb-6">
-			<Icon icon="lucide:circle-alert" class="size-5" />
+		<div class="alert alert-error mb-6" role="alert">
+			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<span>{errorMessage}</span>
 		</div>
 	{/if}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -366,6 +366,7 @@
 	<!-- Messages -->
 	{#if saveMessage}
 		<div class="alert alert-success mb-6">
+			<Icon icon="lucide:circle-check" class="shrink-0" aria-hidden="true" />
 			<span>{saveMessage}</span>
 		</div>
 	{/if}
@@ -571,6 +572,7 @@
 	<!-- Summary -->
 	{#if changedConfigs.size > 0}
 		<div class="alert alert-info mt-8">
+			<Icon icon="lucide:info" class="shrink-0" aria-hidden="true" />
 			<div>
 				<h3 class="text-lg font-semibold">Ungespeicherte Änderungen</h3>
 				<p>

--- a/src/routes/admin/settings/CleanupPanel.svelte
+++ b/src/routes/admin/settings/CleanupPanel.svelte
@@ -74,10 +74,12 @@
 
 		{#if errorMessage}
 			<div class="alert alert-error mt-4" role="alert">
+				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 				<span class="text-sm">Aufräumen fehlgeschlagen: {errorMessage}</span>
 			</div>
 		{:else if report}
 			<div class="alert alert-info mt-4">
+				<Icon icon="lucide:info" class="shrink-0" aria-hidden="true" />
 				<span class="text-sm">
 					{report.rowsFound} Zeilen ohne Sichtung,
 					{report.filesFound ?? 'nicht anwendbar'} Dateien ohne Zeile (Frist: {report.retentionHours}

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -158,7 +158,14 @@
 									: insight.type === 'warning'
 										? 'alert-warning'
 										: 'alert-info'}
+							{@const alertIcon =
+								insight.type === 'critical'
+									? 'lucide:circle-alert'
+									: insight.type === 'warning'
+										? 'lucide:triangle-alert'
+										: 'lucide:info'}
 							<div class="alert {alertClass} alert-sm">
+								<Icon icon={alertIcon} class="shrink-0" aria-hidden="true" />
 								<div>
 									<div class="font-semibold">{insight.title}</div>
 									<div class="text-sm">{insight.description}</div>

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -80,7 +80,7 @@
 			<p class="mt-4">OpenAPI-Spezifikation wird geladen...</p>
 		</div>
 	{:else if error}
-		<div class="alert alert-error">
+		<div class="alert alert-error" role="alert">
 			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<span>Fehler beim Laden der API-Spezifikation: {error}</span>
 		</div>

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import Icon from '$lib/components/Icon.svelte';
 
 	let openApiSpec = $state<string | null>(null);
 	let isLoading = $state(true);
@@ -59,7 +60,7 @@
 <div class="mx-auto max-w-6xl p-4">
 	<div class="mb-8">
 		<h1 class="mb-4 text-3xl font-bold">📄 API-Dokumentation (Fallback)</h1>
-		<p class="mb-4 text-base-content/70">
+		<p class="text-base-content/70 mb-4">
 			Diese vereinfachte Ansicht zeigt die OpenAPI-Spezifikation an, falls die interaktive
 			Scalar-Dokumentation nicht geladen werden kann.
 		</p>
@@ -80,6 +81,7 @@
 		</div>
 	{:else if error}
 		<div class="alert alert-error">
+			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 			<span>Fehler beim Laden der API-Spezifikation: {error}</span>
 		</div>
 	{:else if openApiSpec}
@@ -160,7 +162,7 @@
 		</div>
 
 		<!-- Authentication Info -->
-		<div class="mb-8 rounded-lg border border-warning/30 bg-warning/10 p-6">
+		<div class="border-warning/30 bg-warning/10 mb-8 rounded-lg border p-6">
 			<h2 class="mb-4 text-xl font-semibold">🔐 Authentifizierung</h2>
 			<div class="grid gap-6 md:grid-cols-2">
 				<div>
@@ -192,7 +194,7 @@
 					YAML-Inhalt anzeigen
 				</summary>
 				<div class="collapse-content">
-					<pre class="max-h-96 overflow-auto rounded border bg-base-200 p-4 text-xs"><code
+					<pre class="bg-base-200 max-h-96 overflow-auto rounded border p-4 text-xs"><code
 							>{openApiSpec}</code
 						></pre>
 				</div>
@@ -200,23 +202,23 @@
 		</div>
 
 		<!-- Alternative Tools -->
-		<div class="rounded-lg border border-info/30 bg-info/10 p-6">
+		<div class="border-info/30 bg-info/10 rounded-lg border p-6">
 			<h2 class="mb-4 text-xl font-semibold">🔧 Alternative Tools</h2>
-			<p class="mb-4 text-sm text-base-content/70">
+			<p class="text-base-content/70 mb-4 text-sm">
 				Sie können die OpenAPI-Spezifikation in diesen Tools verwenden:
 			</p>
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Postman</h3>
-					<p class="text-xs text-base-content/70">Importieren Sie die YAML-Datei für API-Tests</p>
+					<p class="text-base-content/70 text-xs">Importieren Sie die YAML-Datei für API-Tests</p>
 				</div>
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Insomnia</h3>
-					<p class="text-xs text-base-content/70">Laden Sie die Spezifikation für REST-Tests</p>
+					<p class="text-base-content/70 text-xs">Laden Sie die Spezifikation für REST-Tests</p>
 				</div>
 				<div class="rounded border bg-white p-4">
 					<h3 class="mb-2 font-medium">Swagger Editor</h3>
-					<p class="text-xs text-base-content/70">Online-Editor für OpenAPI-Specs</p>
+					<p class="text-base-content/70 text-xs">Online-Editor für OpenAPI-Specs</p>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Warum

Seit abee0f3 setzt der Alert-Override in `src/app.css` für
`.alert-info/.alert-success/.alert-warning/.alert-error` die Textfarbe auf
`var(--color-base-content)` statt auf die Statusfarbe — die alten Werte lagen bei
2,45–3,84:1 und damit unter den von WCAG 1.4.3 geforderten 4,5:1.

Die Statusbedeutung trägt seitdem das **Icon** plus der Hintergrund-Ton. Der 4px
breite linke Rahmen erreicht nur ~1,1:1 gegen die Alert-Fläche und ist reine
Dekoration. Genau so dokumentiert in `.claude/rules/daisyui.md` und
`.claude/rules/design-system.md`.

Alerts ohne Icon sehen dadurch in allen vier Varianten praktisch gleich aus.
Text und `role="alert"` transportieren die Bedeutung weiterhin — es ist also
**keine WCAG-Verletzung, sondern eine Design-Lücke**. Eine Warnung sollte
trotzdem nicht aussehen wie ein Fehler.

## Was geändert wurde

Pro Variante das kanonische Icon über `$lib/components/Icon.svelte`, jeweils mit
`aria-hidden="true"` und `class="shrink-0"`, nach dem Beispiel unter „Alerts" in
`.claude/rules/design-system.md`:

| Variante  | Icon                   |
| --------- | ---------------------- |
| `success` | `lucide:circle-check`  |
| `error`   | `lucide:circle-alert`  |
| `warning` | `lucide:triangle-alert`|
| `info`    | `lucide:info`          |

13 Aufrufstellen in 11 Dateien:

- `src/lib/components/map/LazyMapWrapper.svelte:63`
- `src/lib/report/components/ModernReportForm.svelte:239`
- `src/lib/report/components/form/StepNavigation.svelte:183`
- `src/routes/admin/settings/+page.svelte:368` und `:574`
- `src/routes/admin/+page.svelte:1025`
- `src/routes/admin/statistics/+page.svelte:167`
- `src/routes/admin/settings/CleanupPanel.svelte:76` und `:81`
- `src/lib/components/docs/ApiDocumentation.svelte:133`
- `src/lib/components/weather/WeatherDataFetcher.svelte:120`
- `src/lib/report/components/FormHelp.svelte:264`
- `src/routes/docs/api/fallback/+page.svelte:83`

`src/app.css` bleibt bewusst unberührt.

## Für Reviewer

**Eine Stelle stand nicht auf der Ausgangsliste.** `CleanupPanel.svelte:80`
(`alert-info`) ist der `{:else if}`-Zweig zum dort gelisteten Error-Alert auf
`:76` — beide rendern an derselben Stelle und waren damit das am leichtesten zu
verwechselnde Paar im ganzen Set. Die Ausgangsliste kam aus einem heuristischen
Grep; ich habe alle 12 Einträge einzeln geprüft (alle bestätigt) und zusätzlich
das gesamte Repo nach `alert-(info|success|warning|error)` durchsucht, um die
Lücke zu finden.

**`admin/statistics` leitet seine Variante aus `insight.type` ab**, brauchte also
ein paralleles `@const alertIcon` neben dem bestehenden `@const alertClass`.

**Zwei Dateien zeigen mehr Diff-Churn als die Icon-Zeile.**
`ApiDocumentation.svelte` (+14/−12) und `docs/api/fallback/+page.svelte` (+10/−8)
waren bisher unformatiert; beim Editieren lief der Format-Hook des Repos mit
Prettiers Tailwind-Class-Order-Plugin darüber. Die zusätzlichen Zeilen sind
ausschließlich Klassen-Umsortierung (`mb-4 text-base-content/70` →
`text-base-content/70 mb-4`), kein Verhaltensunterschied.

## Tests

- `npm run test:quick` — grün: Lint (0 Fehler; 2 vorbestehende `any`-Warnungen in
  `src/tests/contract/helpers/createEvent.ts`), `type-check`, `svelte-check`,
  2038 Unit-Tests in 137 Dateien.
- `npm run test:e2e` — 98 bestanden, 1 übersprungen.
- Zusätzlich per Wegwerf-Playwright-Test verifiziert, dass der
  StepNavigation-Alert ein echtes lucide-SVG rendert
  (`class="shrink-0" aria-hidden="true"`) und nicht den `?`-Platzhalter, den
  `Icon.svelte` bei unbekanntem Namen ausgibt. Der Test wurde nach der Prüfung
  wieder entfernt.

**Keine neuen Tests:** reine Markup-Änderung, die dekorative, `aria-hidden`
gesetzte Icons ergänzt — fällt unter die Ausnahme „Reine UI-Styling-Änderungen"
in `.claude/rules/testing.md`.

## Vorbestehende Befunde aus dem Review — bewusst NICHT in diesem PR

Beim Review aufgetaucht, alle verifiziert, alle außerhalb des Auftrags. Separat
zu entscheiden:

**Drei Icon-Namen fehlen in der Map von `Icon.svelte` und rendern heute sichtbar
ein `?`:**

- `src/lib/report/components/form/fields/DropzoneEnhanced.svelte:849` —
  `lucide:map-pin-off`, steht in einem `alert alert-warning`. Das ist exakt
  dieselbe Lücke, die dieser PR schließt: der Alert hat weiterhin kein nutzbares
  Icon.
- `src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte:198` —
  `lucide:zoom-in`
- `src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte:256` —
  `lucide:git-compare-arrows`

**Kontrast in `FormHelp.svelte`** (Datei berührt, aber nicht in den geänderten
Zeilen): `:238` setzt `class="text-warning"` auf den `alert-warning`-Tint
(~2,46:1 gegen ≥3:1 für grafische Objekte), `:249` `text-warning` auf
`bg-warning/10` (~2,26:1). Das ist die `*-content`-auf-Tint-Falle aus
`.claude/rules/design-system.md`; Fix wäre, die Farbklasse wegzulassen und
`base-content` erben zu lassen. Gleiches Muster in
`src/lib/components/MaintenanceBanner.svelte:16`.

**Falsche Icon-Form bei drei bestehenden Warnungen.** Da der Textton jetzt bei
allen Varianten neutral ist, unterscheidet nur noch die Icon-Form Fehler von
Warnung. Diese drei `alert-warning` nutzen die Fehler-Form `circle-alert` statt
`triangle-alert`: `PositionPanel.svelte:259`, `VerifyLocation.svelte:152`,
`DropzoneEnhanced.svelte:891`. Dieser PR macht icon-lose Alerts unterscheidbar —
die drei sind unterscheidbar, aber *falsch*, was wohl schlechter ist.

Zwei weitere Stellen nutzen noch Inline-`<svg>` statt der `Icon`-Komponente:
`SightingsMapView.svelte:375`, `AdminSightingEditForm.svelte:117`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
