### PR TITLE
feat(config): set up new git worktrees automatically

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -30,11 +30,11 @@ Bei jedem Session-Start werden geladen:
 
 | Datei                   | Zeilen | Warum                    |
 | ----------------------- | ------ | ------------------------ |
-| `CLAUDE.md`             | ~138   | Projekt-Einstieg         |
+| `CLAUDE.md`             | ~166   | Projekt-Einstieg         |
 | `rules/architecture.md` | ~187   | kein `paths`-Frontmatter |
 | `rules/testing.md`      | ~96    | kein `paths`-Frontmatter |
 
-Zusammen ~420 Zeilen. Die beiden Rules enthalten bewusst nur noch **Vorschriften**
+Zusammen ~450 Zeilen. Die beiden Rules enthalten bewusst nur noch **Vorschriften**
 (Test-First-Pflicht, Runes-Pflicht, Clean-Code-Standards, Datei-Konventionen). Die
 zugehörigen **Rezepte** liegen in `testing-patterns.md` und `svelte-patterns.md` und
 laden erst, wenn eine Test- bzw. Komponentendatei angefasst wird.
@@ -198,9 +198,14 @@ oben einmal selbst ausführen — anders als bei `.mcp.json`, das automatisch gr
 
 In [`settings.json`](settings.json):
 
-| Hook     | Event                    | Aktion                           |
-| -------- | ------------------------ | -------------------------------- |
-| Prettier | PostToolUse (Write/Edit) | Auto-Format nach Dateiänderungen |
+| Hook           | Event                    | Aktion                              |
+| -------------- | ------------------------ | ----------------------------------- |
+| Prettier       | PostToolUse (Write/Edit) | Auto-Format nach Dateiänderungen    |
+| Worktree-Setup | SessionStart             | `scripts/setup-worktree.sh --quiet` |
+
+Das Worktree-Setup verlinkt `.env` und `uploads/` ins Haupt-Repo und erzeugt
+`.svelte-kit/`. Es ist idempotent und im Haupt-Repo ein No-Op, kostet dort also nur
+einen Prozessstart. Hintergrund: [`../docs/WORKTREES.md`](../docs/WORKTREES.md).
 
 ---
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,27 @@
 {
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path' | while IFS= read -r f; do case \"$f\" in *.svelte|*.ts|*.js|*.json|*.css|*.html|*.md) npx prettier --write \"$f\" ;; esac; done 2>/dev/null || true",
-            "statusMessage": "Formatting..."
-          }
-        ]
-      }
-    ]
-  }
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash scripts/setup-worktree.sh --quiet 2>&1 || true",
+						"statusMessage": "Worktree-Setup prüfen..."
+					}
+				]
+			}
+		],
+		"PostToolUse": [
+			{
+				"matcher": "Write|Edit",
+				"hooks": [
+					{
+						"type": "command",
+						"command": "jq -r '.tool_input.file_path' | while IFS= read -r f; do case \"$f\" in *.svelte|*.ts|*.js|*.json|*.css|*.html|*.md) npx prettier --write \"$f\" ;; esac; done 2>/dev/null || true",
+						"statusMessage": "Formatting..."
+					}
+				]
+			}
+		]
+	}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,21 @@ npm run test:quick   # Schnell-Test (lint + types + check + unit)
 
 Vollständige Test-Befehle: `.claude/rules/testing.md`
 
+### Worktrees
+
+Ein neuer Worktree ist nach `npm run worktree:setup` einsatzbereit (läuft automatisch
+per `SessionStart`-Hook). Drei Dinge, die dabei erfahrungsgemäß schiefgehen:
+
+- **Kein `npm install` im Worktree.** Node löst `node_modules` aus dem Haupt-Repo auf —
+  eigene Installation kostet ~800 MB ohne Gegenwert. Ausnahme: Der Branch ändert
+  `package-lock.json`.
+- **Nur ein Dev-Server auf Port 4000.** `PUBLIC_SITE_URL` ist fest auf 4000 und baut die
+  Auth0-Callback-URL; ein anderer Port bricht den Login.
+- **Datenbank und `uploads/` sind geteilt.** `db:push` und `media:cleanup-orphans`
+  wirken auf alle Worktrees.
+
+Details, Belege und Aufräum-Befehle: `docs/WORKTREES.md`
+
 ---
 
 ## Architektur
@@ -131,6 +146,7 @@ Automatisiert über **release-please**: Commits auf `main` werden analysiert, ei
 | `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                        |
 | `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                            |
 | `docs/ENVIRONMENT.md`              | Umgebungsvariablen, inkl. Zeitzonen-Konvention (Abschnitt `TZ`) |
+| `docs/WORKTREES.md`                | Worktree-Setup, geteilte Ressourcen, Ports                      |
 | `docs/DATABASE_MIGRATION.md`       | DB Migrationen                                                  |
 
 Themenspezifische Regeln in `.claude/rules/` laden automatisch, sobald passende Dateien bearbeitet werden — sie müssen hier nicht aufgezählt werden.

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -39,13 +39,13 @@ in zwei Fällen:
 
 ## Was von selbst funktioniert
 
-| Thema           | Warum kein Setup nötig                                                                                      |
-| --------------- | ----------------------------------------------------------------------------------------------------------- |
-| TLS-Zertifikate | `npm run dev` ruft `scripts/setup-dev-certs.mjs` auf und stellt sie pro Worktree aus (mkcert-CA ist global) |
-| Git-Hooks       | `core.hooksPath = .husky/_` löst gegen das Haupt-Repo auf — prüfbar mit `git rev-parse --git-path hooks`    |
-| MCP-Server      | `.mcp.json` ist committet und wird mit ausgecheckt                                                          |
-| Rules & Skills  | `.claude/rules/`, `.claude/agents/`, `.claude/skills/` sind committet                                       |
-| Playwright      | Browser liegen global in `~/Library/Caches/ms-playwright`                                                   |
+| Thema           | Warum kein Setup nötig                                                                                                                                                      |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TLS-Zertifikate | `npm run dev` ruft `scripts/setup-dev-certs.mjs` auf und stellt sie pro Worktree aus (mkcert-CA ist global)                                                                 |
+| Git-Hooks       | `core.hooksPath = .husky/_` löst gegen das Haupt-Repo auf — prüfbar mit `git rev-parse --git-path hooks`                                                                    |
+| MCP-Server      | `.mcp.json` ist committet und wird mit ausgecheckt                                                                                                                          |
+| Rules & Skills  | `.claude/rules/`, `.claude/agents/`, `.claude/skills/` sind committet                                                                                                       |
+| Playwright      | Browser liegen in einem globalen Cache außerhalb des Repos (macOS `~/Library/Caches/ms-playwright`, Linux `~/.cache/ms-playwright`, Windows `%LOCALAPPDATA%\ms-playwright`) |
 
 Nicht mit übernommen wird `.claude/settings.local.json` (global gitignoriert) — lokale
 Permissions gelten pro Worktree neu. Bei Bedarf verlinken:

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -1,0 +1,109 @@
+# Git Worktrees — Setup und Betrieb
+
+Claude Code legt Worktrees unter `.claude/worktrees/<name>/` an, manuelle liegen in
+`.worktrees/`. Beide Verzeichnisse sind gitignoriert.
+
+## Einrichtung
+
+```bash
+npm run worktree:setup
+```
+
+Das Skript ([`scripts/setup-worktree.sh`](../scripts/setup-worktree.sh)) ist idempotent
+und im Haupt-Repo ein No-Op. Es läuft zusätzlich automatisch über den
+`SessionStart`-Hook in [`.claude/settings.json`](../.claude/settings.json), ein
+frischer Worktree ist also ohne Zutun einsatzbereit.
+
+| Schritt                 | Warum                                                                      |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `.env` → Haupt-Repo     | Symlink statt Kopie: keine driftenden Zweitfassungen der Secrets           |
+| `uploads/` → Haupt-Repo | `UPLOAD_PATH` ist relativ, die DB teilen sich aber alle Worktrees          |
+| `svelte-kit sync`       | ohne `.svelte-kit/tsconfig.json` bricht `npm run type-check` mit TS5083 ab |
+| Lockfile-Vergleich      | warnt, wenn der Branch andere Abhängigkeiten braucht als das Haupt-Repo    |
+
+## Kein `npm install` im Worktree
+
+Node und npm suchen `node_modules` in **allen übergeordneten Verzeichnissen**. Weil die
+Worktrees unter `<repo>/.claude/worktrees/` liegen, greifen sie automatisch auf
+`<repo>/node_modules` zu — inklusive `node_modules/.bin`, also auch `npm run …`.
+
+Verifiziert in einem Worktree ganz ohne eigenes `node_modules`: `npm run lint`,
+`npx svelte-kit sync` und `npm run test:unit` (2038 Tests) liefen durch.
+
+Eine eigene Installation kostet ~800 MB pro Worktree ohne Gegenwert. Nötig ist sie nur
+in zwei Fällen:
+
+- der Branch ändert `package.json`/`package-lock.json` — dann `npm install` **im
+  Worktree** (das lokale `node_modules` verdeckt das des Haupt-Repos)
+- der Worktree liegt außerhalb des Repo-Baums — dann greift die Auflösung nach oben nicht
+
+## Was von selbst funktioniert
+
+| Thema           | Warum kein Setup nötig                                                                                      |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| TLS-Zertifikate | `npm run dev` ruft `scripts/setup-dev-certs.mjs` auf und stellt sie pro Worktree aus (mkcert-CA ist global) |
+| Git-Hooks       | `core.hooksPath = .husky/_` löst gegen das Haupt-Repo auf — prüfbar mit `git rev-parse --git-path hooks`    |
+| MCP-Server      | `.mcp.json` ist committet und wird mit ausgecheckt                                                          |
+| Rules & Skills  | `.claude/rules/`, `.claude/agents/`, `.claude/skills/` sind committet                                       |
+| Playwright      | Browser liegen global in `~/Library/Caches/ms-playwright`                                                   |
+
+Nicht mit übernommen wird `.claude/settings.local.json` (global gitignoriert) — lokale
+Permissions gelten pro Worktree neu. Bei Bedarf verlinken:
+
+```bash
+ln -s ../../settings.local.json .claude/settings.local.json
+```
+
+## Dev-Server: nur einer auf Port 4000
+
+`PUBLIC_SITE_URL` steht in `.env` fest auf `https://localhost:4000` und baut daraus die
+Auth0-Callback-URL (`src/routes/api/auth/login/+server.ts`). Ein Dev-Server auf einem
+anderen Port schickt Auth0 deshalb zurück auf 4000 — verifiziert: mit
+`VITE_DEV_PORT=4005` enthält der `/api/auth/login`-Redirect weiterhin
+`redirect_uri=https://localhost:4000/…`.
+
+Für einen zweiten Server parallel:
+
+```bash
+echo 'PUBLIC_SITE_URL="https://localhost:4005"' > .env.local   # überschreibt .env
+VITE_DEV_PORT=4005 npm run dev
+```
+
+`.env.local` hat in Vite Vorrang vor `.env` und ist gitignoriert (verifiziert: der
+Redirect zeigt danach auf 4005). **Login funktioniert trotzdem nur**, wenn genau diese
+Callback-URL in den Auth0-Einstellungen als _Allowed Callback URL_ hinterlegt ist.
+Ohne Auth0-Eintrag: Dev-Server auf 4000 lassen und immer nur einen laufen lassen.
+
+E2E-Tests nutzen ohnehin Port 4001 (`npm run test:e2e`).
+
+## Geteilte Ressourcen — Vorsicht
+
+Alle Worktrees zeigen über den `.env`-Symlink auf **dieselbe** Datenbank und dieselben
+Uploads.
+
+- `npm run db:push` aus einem Worktree ändert das Schema für alle
+- `npm run media:cleanup-orphans` löscht Dateien für alle
+- Migrations-Branches deshalb bevorzugt gegen die Docker-DB (Port 5433) testen
+
+## Code-Graph-Tools
+
+`.tokensave/` und `.codegraph/` liegen nur im Haupt-Repo und sind nicht committet.
+Abfragen aus einem Worktree beantworten sie aus dem Index des Haupt-Repos — Symbole,
+die es nur auf dem Branch gibt, fehlen dort. `tokensave` warnt in dem Fall selbst.
+Bei branch-spezifischen Fragen mit Read/Grep gegenprüfen.
+
+## Aufräumen
+
+```bash
+git worktree list                         # Übersicht
+git worktree remove .claude/worktrees/<name>
+git worktree prune                        # verwaiste Einträge
+```
+
+Alte Worktrees mit eigenem `node_modules` (aus der Zeit vor diesem Setup) lassen sich
+gefahrlos verschlanken:
+
+```bash
+du -sh .claude/worktrees/*/node_modules   # Kandidaten finden
+rm -rf .claude/worktrees/<name>/node_modules
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	"scripts": {
 		"dev": "npm run certs:setup && vite dev",
 		"certs:setup": "node scripts/setup-dev-certs.mjs",
+		"worktree:setup": "bash scripts/setup-worktree.sh",
 		"build": "svelte-kit sync && vite build",
 		"build:docker": "USE_NODE_ADAPTER=true svelte-kit sync && vite build",
 		"preview": "vite preview",

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Richtet einen frisch angelegten git-Worktree für die lokale Entwicklung ein.
+#
+# Idempotent und im Haupt-Repo ein No-Op — deshalb kann das Skript gefahrlos bei
+# jedem Session-Start laufen (SessionStart-Hook in .claude/settings.json).
+#
+#   bash scripts/setup-worktree.sh            # mit Ausgabe
+#   bash scripts/setup-worktree.sh --quiet    # nur Warnungen (Hook-Modus)
+#
+# Was es NICHT tut — und warum:
+#   * kein `npm install`: Node und npm suchen node_modules in allen übergeordneten
+#     Verzeichnissen. Weil die Worktrees unter <repo>/.claude/worktrees/ liegen,
+#     greifen sie automatisch auf <repo>/node_modules zu. Eine eigene Installation
+#     kostet ~800 MB pro Worktree ohne Gegenwert.
+#   * keine Zertifikate: `npm run dev` ruft scripts/setup-dev-certs.mjs selbst auf.
+#   * kein husky-Setup: core.hooksPath ist relativ und löst gegen das Haupt-Repo
+#     auf (`git rev-parse --git-path hooks`), die Hooks greifen also ohnehin.
+#
+set -euo pipefail
+
+QUIET=0
+[ "${1:-}" = "--quiet" ] && QUIET=1
+
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+warn() { printf 'worktree-setup: %s\n' "$*" >&2; }
+
+# --- Nur in verlinkten Worktrees arbeiten ------------------------------------
+# Im Haupt-Repo sind git-dir und git-common-dir identisch, im Worktree nicht.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+[ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] || exit 0
+
+cd "$(git rev-parse --show-toplevel)"
+MAIN="$(git worktree list --porcelain | sed -n '1s/^worktree //p')"
+[ -n "$MAIN" ] && [ -d "$MAIN" ] || { warn "Haupt-Worktree nicht gefunden"; exit 0; }
+
+DID_SOMETHING=0
+
+# --- .env verlinken ----------------------------------------------------------
+# Symlink statt Kopie: Credentials-Änderungen im Haupt-Repo gelten sofort überall,
+# und es entstehen keine driftenden Zweitfassungen der Secrets.
+if [ ! -e .env ]; then
+	if [ -f "$MAIN/.env" ]; then
+		ln -s "$MAIN/.env" .env
+		say "worktree-setup: .env → $MAIN/.env verlinkt"
+		DID_SOMETHING=1
+	else
+		warn ".env fehlt auch im Haupt-Repo — aus .env.example anlegen"
+	fi
+fi
+
+# --- uploads/ verlinken ------------------------------------------------------
+# UPLOAD_PATH ist relativ ("uploads"), die Datenbank teilen sich aber alle
+# Worktrees. Ohne Symlink zeigen Medien-Datensätze auf lokal fehlende Dateien.
+if [ ! -e uploads ] && [ -d "$MAIN/uploads" ]; then
+	ln -s "$MAIN/uploads" uploads
+	say "worktree-setup: uploads → $MAIN/uploads verlinkt"
+	DID_SOMETHING=1
+fi
+
+# --- SvelteKit-Typen erzeugen ------------------------------------------------
+# `npm run check`, `build` und `dev` synchronisieren selbst; `npm run type-check`
+# (tsc --noEmit) nicht — ohne .svelte-kit/tsconfig.json bricht es mit TS5083 ab.
+if [ ! -f .svelte-kit/tsconfig.json ]; then
+	if npx --no-install svelte-kit sync >/dev/null 2>&1; then
+		say "worktree-setup: .svelte-kit/ erzeugt (svelte-kit sync)"
+		DID_SOMETHING=1
+	else
+		warn "svelte-kit sync fehlgeschlagen — 'npm install' im Haupt-Repo nötig?"
+	fi
+fi
+
+# --- Abhängigkeiten prüfen ---------------------------------------------------
+if [ ! -d node_modules ] && [ ! -d "$MAIN/node_modules" ]; then
+	warn "weder hier noch im Haupt-Repo liegt node_modules — bitte 'npm install' in $MAIN"
+elif [ ! -d node_modules ] && ! cmp -s package-lock.json "$MAIN/package-lock.json"; then
+	warn "package-lock.json weicht vom Haupt-Repo ab — für diesen Branch 'npm install' in diesem Worktree ausführen"
+fi
+
+# --- Portlage melden ---------------------------------------------------------
+# PUBLIC_SITE_URL ist auf https://localhost:4000 festgenagelt und baut die
+# Auth0-Callback-URL. Ein zweiter Dev-Server braucht deshalb mehr als nur
+# VITE_DEV_PORT — siehe docs/WORKTREES.md.
+if [ "$QUIET" -eq 0 ] && command -v lsof >/dev/null 2>&1 && lsof -ti:4000 >/dev/null 2>&1; then
+	say "worktree-setup: Port 4000 ist belegt — anderer Dev-Server läuft (siehe docs/WORKTREES.md)"
+fi
+
+[ "$DID_SOMETHING" -eq 1 ] || say "worktree-setup: nichts zu tun, Worktree ist eingerichtet"


### PR DESCRIPTION
## Warum

Frische Worktrees waren ohne Handarbeit nicht benutzbar — und die Handarbeit, die passierte, war teils die falsche: fünf Worktrees trugen ein eigenes `node_modules` von je ~800 MB, während zwei ohne eines einwandfrei liefen.

Ich habe deshalb gemessen, was ein Worktree wirklich braucht, statt es zu vermuten.

| Schritt | Nötig? | Beleg |
| --- | --- | --- |
| `.env`-Symlink | **ja** | sonst keine DB, kein Auth0 |
| `svelte-kit sync` | **ja** | `npm run type-check` bricht ohne `.svelte-kit/tsconfig.json` mit TS5083 ab (`check`/`build`/`dev` syncen selbst) |
| `uploads/`-Symlink | **ja** | `UPLOAD_PATH` ist relativ, die DB aber geteilt → Medien-Datensätze zeigen auf lokal fehlende Dateien |
| `npm install` | **nein** | Node löst `node_modules` aus dem Haupt-Repo auf, da Worktrees unter `<repo>/.claude/worktrees/` liegen. In einem Worktree ganz ohne eigenes `node_modules` liefen `npm run lint`, `svelte-kit sync` und alle 2038 Unit-Tests durch |
| `npx husky` | **nein** | `core.hooksPath` löst gegen das Haupt-Repo auf (`git rev-parse --git-path hooks`); ein Commit mit kaputter Message wurde auch ohne lokales `.husky/_` von commitlint blockiert |
| TLS-Zertifikate | **nein** | `npm run dev` ruft `setup-dev-certs.mjs` selbst auf, die mkcert-CA ist systemweit |

## Was drin ist

- **`scripts/setup-worktree.sh`** — verlinkt `.env` und `uploads/`, erzeugt `.svelte-kit/`, warnt bei abweichendem Lockfile. Idempotent, im Haupt-Repo und außerhalb von git ein No-Op. Die Kommentare halten fest, was das Skript bewusst *nicht* tut.
- **`SessionStart`-Hook** in `.claude/settings.json` — führt es automatisch aus, damit niemand daran denken muss. Manueller Aufruf: `npm run worktree:setup`.
- **`docs/WORKTREES.md`** — Referenz mit Belegen, geteilten Ressourcen und Aufräum-Befehlen.
- **`CLAUDE.md`** — 15 Zeilen mit den drei häufigsten Stolperfallen; Details bleiben im Doc, damit das Kontext-Budget schlank bleibt (Zahlen in `.claude/README.md` nachgezogen).

## Für Reviewer

- **Port 4000 ist nicht beliebig.** `PUBLIC_SITE_URL` steht fest auf `https://localhost:4000` und baut daraus die Auth0-Callback-URL. Verifiziert: mit `VITE_DEV_PORT=4005` enthält der `/api/auth/login`-Redirect weiterhin `redirect_uri=…localhost:4000…`, der Login bricht also. Ein worktree-lokales `.env.local` überschreibt das (ebenfalls verifiziert), aber die URL muss in Auth0 als *Allowed Callback URL* hinterlegt sein. Deshalb bewusst nicht automatisiert.
- **Geteilter Zustand.** Alle Worktrees zeigen über den `.env`-Symlink auf dieselbe DB und dieselben Uploads — `db:push` und `media:cleanup-orphans` wirken auf alle. Steht als Warnung im Doc.
- **`.claude/settings.json` hat mehr Diff als nötig**: der Prettier-Hook hat die Datei von Spaces auf Tabs umgestellt. Inhaltlich neu ist nur der `SessionStart`-Block.
- Der Hook läuft bei *jeder* Session, auch im Haupt-Repo. Dort steigt das Skript nach zwei `git rev-parse`-Aufrufen aus.

## Verifikation

- Wegwerf-Worktree angelegt → `type-check` scheiterte mit TS5083 → Skript → `type-check` sauber (Exit 0)
- Idempotenz, `--quiet`, No-Op im Haupt-Repo und außerhalb von git geprüft
- `npm run lint` (0 Fehler), Prettier auf allen geänderten Dateien, `bash -n`
- Nebenbei ~3,3 GB freigeräumt: vier Worktrees mit identischem Lockfile entlastet, einer mit echten Versionsabweichungen bewusst unangetastet

**Kein Test:** reine Konfiguration und Shell-Tooling ohne App-Logik — dokumentierte Ausnahme nach `.claude/rules/testing.md`. Stattdessen die oben genannte End-to-End-Verifikation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)