### PR TITLE
docs(docs): sync position docs with the merged single-panel state

### DIFF
--- a/docs/MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md
+++ b/docs/MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md
@@ -454,24 +454,32 @@ keinen Reload. Eine gehaltene Referenz überlebt Schritt 1 bis 4 problemlos.
 
 Und die Größen sind kleiner als gedacht:
 
-| Grenze                            | Wert            | Fundstelle                                        |
-| --------------------------------- | --------------- | ------------------------------------------------- |
-| Client-Konfiguration (DB-Default) | 10 MB           | `configService.ts:25`, `configInitializer.ts:258` |
-| Server, **anonym**                | **5 MB** (hart) | `api/files/upload/+server.ts`                     |
-| Server, angemeldet                | 50 MB           | ebd.                                              |
-| GPS-Foto Schritt 1                | 10 MB, 1 Datei  | `UPLOAD_LIMITS.PHOTO_GPS_MAX_SIZE`                |
-| Erlaubte Videoformate             | nur `video/mp4` | `configService.ts:26`                             |
+> **Stand 2026-07-29 korrigiert.** Die ursprüngliche Fassung dieses Abschnitts
+> nannte 5 MB für anonyme Melder und einen offenen Client/Server-Widerspruch.
+> Beides ist überholt (siehe unten) — die Argumentation gegen A2 ändert das
+> nicht, die Größenordnung bleibt klein.
 
-Für Bürgerinnen und Bürger — der Normalfall, anonym — liegt die reale Grenze
-also bei **5 MB**, auch für Videos. Die 50 MB aus
-`FILE_VALIDATION_PRESETS.MEDIA` greifen nur für angemeldete Nutzer.
+| Grenze                              | Wert                       | Fundstelle                                             |
+| ----------------------------------- | -------------------------- | ------------------------------------------------------ |
+| **Anonym** — Client **und** Server  | **10 MB**, nur Bildformate | `src/lib/constants/uploadDefaults.ts`                  |
+| Angemeldet (Laufzeit-Konfiguration) | 10 MB (DB-Default)         | `configService.ts:25`, `configInitializer.ts:258`      |
+| Angemeldet, Server-Obergrenze       | 50 MB                      | `api/files/upload/+server.ts`                          |
+| GPS-Foto Schritt 1                  | 10 MB, 1 Datei             | `PositionPanel.svelte` (Bilder, `maxFiles={1}`)        |
+| Videoformate                        | nur `video/mp4`            | `configService.ts:26` — **nur für angemeldete Nutzer** |
 
-**Nebenbefund (eigener Bug, unabhängig vom Einwilligungsthema):** Client und
-Server widersprechen sich. Die Dropzone akzeptiert nach DB-Konfiguration 10 MB,
-der Server lehnt oberhalb 5 MB mit 413 ab. Eine 6-MB-Datei kommt also durch die
-Client-Validierung und scheitert danach. Heute fällt das sofort als Fehler-Toast
-auf; bei verzögertem Upload würde es erst beim Absenden auffallen. Sollte in
-jedem Fall behoben werden.
+Für Bürgerinnen und Bürger — der Normalfall, anonym — liegt die reale Grenze bei
+**10 MB**, und **Videos gibt es dort gar nicht**: `/api/config/upload` liefert
+nicht authentifizierten Nutzern `PUBLIC_UPLOAD_ALLOWED_TYPES` (jpeg/png/gif/webp).
+Die 50 MB aus `FILE_VALIDATION_PRESETS.MEDIA` greifen nur für angemeldete Nutzer.
+
+**Nebenbefund — behoben, nicht mehr offen.** Die ursprüngliche Fassung notierte
+hier einen Client/Server-Widerspruch: Dropzone 10 MB, Server 413 oberhalb 5 MB.
+Beide Seiten ziehen inzwischen aus derselben Konstante
+(`ANONYMOUS_UPLOAD_MAX_SIZE_BYTES = PUBLIC_UPLOAD_MAX_FILE_SIZE_BYTES`,
+`src/lib/constants/uploadDefaults.ts`); die gemeinsame Quelle kam mit #567, die
+serverseitige Angleichung mit #589. Gegen ein erneutes Auseinanderlaufen steht
+`src/lib/constants/uploadLimitConsistency.test.ts`, dessen Doc-Kommentar
+ausdrücklich auf diesen Abschnitt zurückverweist.
 
 ### 9.2 Die drei Risiken, die gegen A2 sprechen
 

--- a/docs/MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md
+++ b/docs/MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md
@@ -72,9 +72,10 @@ legt sofort eine Zeile in `sichtungen_files` an
 (`saveUploadedFile`, `src/lib/server/db/sightingFilesRepository.ts:18`) — mit
 `sightingId = null`.
 
-Die Dropzone in `sections/PositionAndTime.svelte` (Schritt 1) und die in
-`sections/Media.svelte` (Schritt 3) schreiben beide in dasselbe
-`$form.uploadedFiles`. `mediaConsent` wird erst in Schritt 3 gezeigt.
+Die Dropzone in `form/position/PositionPanel.svelte` (Schritt 1; bis #590 in
+`sections/PositionAndTime.svelte`) und die in `sections/Media.svelte` (Schritt 3)
+schreiben beide in dasselbe `$form.uploadedFiles`. `mediaConsent` wird erst in
+Schritt 3 gezeigt.
 
 ### B5 — EXIF-Auswertung braucht den Upload gar nicht _(neu, entscheidend)_
 
@@ -396,7 +397,7 @@ machen. Das Projekt schreibt Test-First vor (`.claude/rules/testing.md`).
 | B-I      | `schema.ts`, `mapFormToSighting.ts`, `drizzle/` (via `db:generate`), `field-mapping.ts`, `AdminSightingView.svelte`, `csvExport.ts` |
 | B-III    | `sightingSchema.ts:1182` (+ `sightingSchemaClaims.test.ts` beachten)                                                                |
 | A2       | `MediaFile.ts`, `DropzoneEnhanced.svelte`, `ModernReportForm.svelte`, `api/sightings/+server.ts`, `sightingFilesRepository.ts`      |
-| A1       | `PositionAndTime.svelte`, `Media.svelte`, `sightingSchema.ts`                                                                       |
+| A1       | `form/position/PositionPanel.svelte` (seit #590; vorher `PositionAndTime.svelte`), `Media.svelte`, `sightingSchema.ts`              |
 | Cleanup  | neues Skript unter `scripts/`, `sightingFilesRepository.ts`                                                                         |
 
 **Testabdeckung, die zuerst rot sein muss**
@@ -453,13 +454,13 @@ keinen Reload. Eine gehaltene Referenz überlebt Schritt 1 bis 4 problemlos.
 
 Und die Größen sind kleiner als gedacht:
 
-| Grenze | Wert | Fundstelle |
-|--------|------|------------|
-| Client-Konfiguration (DB-Default) | 10 MB | `configService.ts:25`, `configInitializer.ts:258` |
-| Server, **anonym** | **5 MB** (hart) | `api/files/upload/+server.ts` |
-| Server, angemeldet | 50 MB | ebd. |
-| GPS-Foto Schritt 1 | 10 MB, 1 Datei | `UPLOAD_LIMITS.PHOTO_GPS_MAX_SIZE` |
-| Erlaubte Videoformate | nur `video/mp4` | `configService.ts:26` |
+| Grenze                            | Wert            | Fundstelle                                        |
+| --------------------------------- | --------------- | ------------------------------------------------- |
+| Client-Konfiguration (DB-Default) | 10 MB           | `configService.ts:25`, `configInitializer.ts:258` |
+| Server, **anonym**                | **5 MB** (hart) | `api/files/upload/+server.ts`                     |
+| Server, angemeldet                | 50 MB           | ebd.                                              |
+| GPS-Foto Schritt 1                | 10 MB, 1 Datei  | `UPLOAD_LIMITS.PHOTO_GPS_MAX_SIZE`                |
+| Erlaubte Videoformate             | nur `video/mp4` | `configService.ts:26`                             |
 
 Für Bürgerinnen und Bürger — der Normalfall, anonym — liegt die reale Grenze
 also bei **5 MB**, auch für Videos. Die 50 MB aus

--- a/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
+++ b/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
@@ -241,7 +241,7 @@ mehr:
 | Damals                                                    | Heute                                                                                                      |
 | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `sections/positionMethod.ts` (+ `positionMethod.test.ts`) | gelöscht                                                                                                   |
-| `sections/PositionAndTime.svelte:14, 39–48`               | Datei auf 18 Zeilen reine Komposition geschrumpft (`<PositionPanel />` + Datum/Uhrzeit-Sektion)            |
+| `sections/PositionAndTime.svelte:14, 39–48`               | Datei auf 21 Zeilen reine Komposition geschrumpft (`<PositionPanel />` + Datum/Uhrzeit-Sektion)            |
 | Radiogruppe / Kacheln der Methodenwahl                    | entfallen; stattdessen `form/position/PositionPanel.svelte` und `form/position/LocationDescription.svelte` |
 
 Damit sind auch die beiden Stellen weiter oben überholt, die die

--- a/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
+++ b/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
@@ -227,7 +227,7 @@ Weiterhin bewusst offen: nur Light-Theme (Produktentscheidung), `boatDrive` kann
 ### Nachtrag: U10 ist gegenstandslos (2026-07-29)
 
 **U10 ist nicht behoben — die Frage stellt sich nicht mehr.** Mit
-[#590](https://github.com/jansinger/ostsee-sichtung/pull/590) (Commit `a7cbb2e`)
+[#590](https://github.com/jansinger/ostsee-tiere/pull/590) (Commit `a7cbb2e`)
 ist die Positionsmethoden-Wahl **ersatzlos entfallen**. Es gibt kein „Foto mit
 GPS / Karte / Beschreibung" mehr, sondern genau ein Positions-Panel, in dem alle
 Wege gleichzeitig erreichbar sind. Ohne Modus gibt es weder einen Zustand, der

--- a/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
+++ b/docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md
@@ -58,7 +58,7 @@ Folgen (live verifiziert):
 | U7  | **Doppelte Labels bei Toggles/Checkboxen:** Label erscheint zweimal („Handelt es sich um einen Totfund?" ×2, „Einverständnis zur Mediennutzung" ×2) — FieldRenderer rendert das Label, BaseToggle/BaseCheckbox wiederholen es.                                                                                                                                | FieldRenderer.svelte:237–272 + 291–293                                               |
 | U8  | **Copy-Fehler / inkonsistente Sprache:** „Handel**tete** es sich um **L**ebende Tiere…" (Tippfehler); „Reaktion auf **Ihr Boot**" auch bei Land-Sichtung; Medien-Sektion bewirbt „Fotos/**Videos**", akzeptiert aber nur Bildformate (JPG/PNG/GIF/WEBP); „max 10MB" vs. 30-MB-Cap im GPS-Upload-Code.                                                         | sightingSchema (isDead helpText), Behavior/Media-Sections, PositionAndTime.svelte:32 |
 | U9  | **Scroll/Fokus nach Schrittwechsel landet unterhalb des Step-Headers** (Badge „Schritt X von 4" und Überschrift werden übersprungen; live mehrfach mitten im Formular gelandet).                                                                                                                                                                              | StepNavigation.svelte:41–51 (`#form-content` beginnt unter dem Header)               |
-| U10 | **Positionsmethode nicht persistiert:** Nach Reload steht die Auswahl wieder auf „Foto mit GPS", auch wenn der Nutzer Karte/Beschreibung gewählt hatte; Methodenwechsel setzt bereits gesetzte Koordinaten nicht zurück.                                                                                                                                      | PositionAndTime.svelte:14, 39–48                                                     |
+| U10 | **Positionsmethode nicht persistiert:** Nach Reload steht die Auswahl wieder auf „Foto mit GPS", auch wenn der Nutzer Karte/Beschreibung gewählt hatte; Methodenwechsel setzt bereits gesetzte Koordinaten nicht zurück. — **Gegenstandslos seit #590:** es gibt keine Positionsmethode mehr (siehe Nachtrag 2026-07-29).                                     | Damals `PositionAndTime.svelte:14, 39–48` — Code existiert nicht mehr                |
 | U11 | **Fehlermeldungs-Stil inkonsistent:** teils freundlich-deutsch („Wie viele Tiere haben Sie gesehen?"), teils technisch-englisch (U3), teils Feldname-Präfix („GPS-Position: Breitengrad ist erforderlich").                                                                                                                                                   | sightingSchema.ts passim                                                             |
 
 ---
@@ -201,7 +201,7 @@ Stand nach der Nacharbeit: 1685 Unit-Tests, 74 Browser-Komponententests, 86 E2E-
 | **U4** toter Abbrechen-Button                | Entfernt (`goto('/')` auf der eigenen Seite war nachweislich wirkungslos, auch im iFrame-Modus).                                                                                                                  |
 | **U5** doppeltes „Kontaktdaten löschen"      | Konsolidiert in `src/lib/report/clearContactData.ts`, nur noch in Schritt 4 (fachlicher Kontext), ein Text, ein Toast.                                                                                            |
 | **U9** Scrollziel beim Schrittwechsel        | `scrollToStepHeader()` in `fieldNavigation.ts` — der Kopf des neuen Schritts (Icon/Überschrift/Badge) ist jetzt sichtbar.                                                                                         |
-| **U10** Positionsmethode nicht persistiert   | `positionMethod.ts`: Methode wird beim Mount aus dem Formularzustand abgeleitet (Koordinaten → Karte, Fahrwasser → Beschreibung, sonst Foto).                                                                     |
+| **U10** Positionsmethode nicht persistiert   | _(damals)_ `positionMethod.ts`: Methode wird beim Mount aus dem Formularzustand abgeleitet (Koordinaten → Karte, Fahrwasser → Beschreibung, sonst Foto). **Überholt durch #590 — siehe Nachtrag 2026-07-29.**     |
 | **U11/U8** erfundene Statistiken in Tooltips | Vier unbelegte Zahlen („73 % der Sichtungen morgens", „5x mehr Tiere", „40 % durch Nordwind", „60 % mit Elektromotor") entfernt und durch nachprüfbare Aussagen ersetzt. Belegte Zahlen können mit Quelle zurück. |
 | **D3** Button-Hierarchie                     | Eine Primäraktion pro Bereich; destruktive Aktionen einheitlich `btn-outline btn-error` mit 44 px Touch-Target; „Zurück" von Vollton auf `btn-outline`.                                                           |
 | **D5** Step-4-Markup                         | Sections liegen nicht mehr im zentrierten Header; alle `text-left`-Gegensteuerungen entfallen.                                                                                                                    |
@@ -223,3 +223,32 @@ Weiterhin bewusst offen: nur Light-Theme (Produktentscheidung), `boatDrive` kann
 2. **K3 + D1:** Totfund-Kontrast, tote Animationsklassen.
 3. **U1/U2 + U3:** Fehler-Timing & Bootsantrieb-Konditionallogik.
 4. Doku-Rest: `.claude/README.md`-Zeile, `DESIGN_GUIDE.md` ersetzen, Design-System-Rule + A11y-Check ergänzen.
+
+### Nachtrag: U10 ist gegenstandslos (2026-07-29)
+
+**U10 ist nicht behoben — die Frage stellt sich nicht mehr.** Mit
+[#590](https://github.com/jansinger/ostsee-sichtung/pull/590) (Commit `a7cbb2e`)
+ist die Positionsmethoden-Wahl **ersatzlos entfallen**. Es gibt kein „Foto mit
+GPS / Karte / Beschreibung" mehr, sondern genau ein Positions-Panel, in dem alle
+Wege gleichzeitig erreichbar sind. Ohne Modus gibt es weder einen Zustand, der
+über einen Reload zu persistieren wäre, noch einen Methodenwechsel, der
+Koordinaten zurücksetzen müsste — der stille Datenverlust im damaligen
+`selectMethod('manual')` ist damit ebenfalls weg.
+
+Die im obigen Text und in der Restliste genannten Fundstellen existieren so nicht
+mehr:
+
+| Damals                                                    | Heute                                                                                                      |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `sections/positionMethod.ts` (+ `positionMethod.test.ts`) | gelöscht                                                                                                   |
+| `sections/PositionAndTime.svelte:14, 39–48`               | Datei auf 18 Zeilen reine Komposition geschrumpft (`<PositionPanel />` + Datum/Uhrzeit-Sektion)            |
+| Radiogruppe / Kacheln der Methodenwahl                    | entfallen; stattdessen `form/position/PositionPanel.svelte` und `form/position/LocationDescription.svelte` |
+
+Damit sind auch die beiden Stellen weiter oben überholt, die die
+Methodenwahl als Stärke führen („Gesamteindruck", „Was gut funktioniert") — die
+Begründung dafür steht in `docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md`
+(Abschnitt „Problem"): Das Datenmodell ist binär, nicht ternär, und der dritte
+Tab bot kein Feld, das der Fallback-Block nicht ohnehin schon zeigte.
+
+Der Ist-Zustand samt der Abweichungen zwischen Spec und Umsetzung steht in
+`docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md`.

--- a/docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md
+++ b/docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md
@@ -1,8 +1,153 @@
 # Positionsangabe in Schritt 1 — Design
 
 **Datum:** 2026-07-28
-**Status:** Freigegeben (nach Review vom 2026-07-28)
-**Betrifft:** `src/lib/report/components/sections/PositionAndTime.svelte` und Umfeld
+**Status:** **Umgesetzt in #590** (Commit `a7cbb2e`, 2026-07-29) — mit dokumentierten
+Abweichungen, siehe nächster Abschnitt. Vorher: Freigegeben (Review vom 2026-07-28).
+**Betrifft:** `src/lib/report/components/form/position/` (neu),
+`src/lib/report/components/sections/PositionAndTime.svelte` (auf Komposition geschrumpft)
+und Umfeld
+
+---
+
+## Umsetzung — Abweichungen von dieser Spec
+
+Der Rest dieses Dokuments ist die Spec **vor** der Umsetzung und bleibt als
+Entwurfsstand stehen. Wo der gebaute Stand abweicht, gilt die Umsetzung — die
+Gründe stehen hier. An den betroffenen Stellen weiter unten steht jeweils ein
+kurzer Verweis hierher.
+
+### 1. Ortsbeschreibung: Klappzustand ist Startwert, nicht laufende Regel
+
+**Spec:** Der Beschreibungsblock klappt in Zustand B zu (`descriptionCollapsed`
+als fortlaufend ausgewertete Regel).
+
+**Gebaut:** `LocationDescription.svelte` ist genau **ein** `<details>`. Sein
+Startzustand wird **einmalig beim Mounten** aus `descriptionCollapsed` bestimmt
+(bewusst über `get(form)` statt `$form`, damit daraus keine reaktive Abhängigkeit
+wird); danach gehört er dem Nutzer.
+
+**Warum:** Ein reaktiv gebundener Zustand hing an genau den beiden Feldern
+(`waterway`/`seaMark`), die im Block liegen. Das erste `change` im gerade
+getippten Feld kippte den Zustand, Svelte riss den Teilbaum ab, das fokussierte
+Input wurde ersetzt und `document.activeElement` fiel auf `<body>` zurück — der
+nächste Tab begann wieder oben auf der Seite. Die Felder stehen deshalb jetzt
+genau einmal im Markup, in einem Container, der nie ausgetauscht wird. Auch kein
+`bind:open`, damit `PositionPanel.focusDescription()` die Disclosure imperativ
+aufklappen kann, ohne dass ein gebundener Zustand zurückschreibt.
+
+**Die gebaute Variante ist die bessere.** `descriptionCollapsed` existiert
+unverändert weiter und ist weiter getestet — nur seine Rolle ist eine andere.
+
+**Folge, die mitgebaut werden musste:** Der Block ist damit zuklappbar, während
+`waterway` noch Pflicht ist. `scrollToFirstError` fokussierte aber ein Feld, das
+in einem geschlossenen `<details>` per `content-visibility: hidden` unerreichbar
+ist — der `.focus()`-Aufruf tat still nichts. Der Vorfahren-`<details>`-Lauf
+liegt deshalb jetzt in `openAncestorDetails()` (`$lib/utils/fieldNavigation.ts`)
+und wird von beiden Aufrufern benutzt; jedes Feld hinter einer Disclosure bekommt
+so einen funktionierenden Fehlersprung, nicht nur `waterway`.
+
+### 2. Karte: `mapExpanded` heißt anders und ist nicht sticky
+
+**Spec:** `mapExpanded(hasCoordinates, wasEverExpanded)` — „einmal offen, bleibt
+offen".
+
+**Gebaut:** `shouldOpenMapOnCoordinateChange(hasCoordinates, hadCoordinates)` —
+true nur auf der **steigenden Flanke**, also genau dann, wenn eine Position neu
+entsteht. Die Disclosure selbst liegt an `bind:open={mapOpen}`.
+
+**Warum:** `hasCoordinates || wasEverExpanded` hätte `open` erzwungen und dem
+Nutzer das Zuklappen der Karte dauerhaft unmöglich gemacht. Der Zweck der
+Sticky-Regel — kein springendes Layout, „Foto wieder entfernt → Karte bleibt
+offen" — ist erfüllt: Nichts schließt die Karte automatisch. Sie bleibt offen,
+weil sie niemand zumacht, nicht weil sie festgehalten wird.
+
+### 3. `PhotoStatus` hat einen vierten Wert: `analyzing`
+
+**Spec:** `'none' | 'position-applied' | 'no-gps'`.
+
+**Gebaut:** zusätzlich `'analyzing'`, entschieden über ein zweites strukturelles
+Prädikat `isAnalyzed()`; `MediaFile` trägt dafür ein `analyzed`-Flag.
+
+**Warum:** Die `MediaFile` liegt beim Drop **synchron** im Store, `hasPosition()`
+liest aber `exifData`, das bis zum Auflösen der Metadaten-Promise `undefined`
+bleibt. Ohne den vierten Zustand meldete das Panel für **jedes** frische Foto
+zuerst „keine GPS-Daten" — auch für solche mit GPS — und nahm die Behauptung
+Sekundenbruchteile später zurück. Mit `role="status"` am Block sagt ein
+Screenreader sie inzwischen an.
+
+### 4. Neu: `shouldWarnAboutMissingGps(status, coordinatesPresent)`
+
+Nicht in der Spec vorgesehen. `photoStatus` urteilt allein über die
+`MediaFile`-Instanzen, die Koordinaten kommen aus einer zweiten, unabhängigen
+Quelle (`$form`, über `sessionStorage` reloadfest). Beide können auseinander
+laufen: Eine nach einem Reload aus `$form.uploadedFiles` neu gebaute Datei ohne
+`exifData` meldet `hasPosition() === false`, während die Koordinaten längst
+wieder da sind. Sichtbar war das als grüne Ostsee-Bestätigung **neben** gelber
+„keine GPS-Daten"-Warnung — deren Ausweg „Auf Karte wählen" die korrekte Position
+überschrieben hätte.
+
+### 5. `DropzoneEnhanced.svelte` bleibt **nicht** unverändert
+
+**Spec:** „bleibt unverändert. Der Foto-Zustand lässt sich von außen ableiten."
+
+**Gebaut:** Die Annahme hielt nur für die Koordinaten. Vier Dinge waren von außen
+nicht ableitbar und mussten in die Komponente:
+
+- **Abschluss der Auswertung** (`analyzed` / `isAnalyzed()`) — siehe Punkt 3.
+- **Herkunft einer Datei** (`isFromPositionStep`, über `positionFileOrigin.ts`
+  als uid-Menge in `sessionStorage` reloadfest). Ohne sie entschieden die Fotos
+  aus Schritt 3 mit darüber, was Schritt 1 über „dieses Foto" behauptet — und der
+  einzige Ausweg „Neu auswählen" löschte serverseitig **alle** Medien über alle
+  Schritte. Bewusst nicht in `$form.uploadedFiles`: das ist Teil des Yup-Schemas
+  und reist zum Server.
+- **Aufnahmezeit eines Fotos ohne GPS** (`exifDateTimeApply.ts`). Der Schreibvorgang
+  hing an `hasPosition()`; die Karte zeigte „Aufnahmezeit: …", im Formular stand
+  weiter der Schema-Default. Nutzer sahen das richtige Datum und hörten auf, das
+  Feld zu prüfen.
+- **Vier neue Props:** `showNoGpsWarning`, `showPositionMap`,
+  `onExifDateTimeApplied` (plus `actionLabel` an `UnifiedDropzone`) — siehe
+  Punkt 7.
+
+### 6. `LocationInput`: mehr als nur `collapsibleCoordinates`
+
+Die Koordinatenlogik ist wie vorgesehen unangetastet. Das Umfeld nicht:
+
+- `enableGPS={!collapsibleCoordinates}` — das OpenLayers-GPS-Control saß zusätzlich
+  zum Panel-Button in der Karte. Zwei Bedienelemente für dieselbe Aktion
+  widersprechen `.claude/rules/design-system.md`; im Meldeformular gewinnt der
+  Panel-Button (Fehlerpfad, erreichbar bei zugeklappter Karte, Beschriftung statt
+  „📍"), in der Admin-Maske bleibt das Control die einzige GPS-Möglichkeit.
+  `watchPosition` (Dauertracking) fällt damit weg — für eine Sichtung, die einen
+  Zeitpunkt festhält, ist das ein Fix, kein Verlust.
+- `hasPosition` wird an `OLMap` durchgereicht, damit vor der ersten Wahl **kein**
+  Marker auf `defaultCenter` 54.5/13.5 sitzt; `OLMap` bekam zusätzlich
+  Tippen-zum-Setzen und einen Hinweis, der keinen GPS-Button mehr nennt, den es
+  hier nicht gibt.
+
+### 7. Zustand A/B: „Koordinaten eingeben" liegt **in** der Karten-Disclosure
+
+Die ASCII-Skizzen zeigen zwei gleichrangige Disclosures auf Panel-Ebene. Gebaut
+ist die Koordinaten-Disclosure (`data-testid="coordinate-fields"`) **innerhalb**
+von `LocationInput` — und `LocationInput` wird erst gemountet, wenn die
+Karten-Disclosure offen ist (für die Mehrheit, die die Karte nie aufklappt,
+entsteht so keine OpenLayers-Instanz und es werden keine Kacheln geladen). Preis:
+Die Koordinatenfelder sind im Startzustand zwei Klicks entfernt statt einem.
+
+### Nachträglich doch umgesetzt (keine Abweichung)
+
+- **Primärbutton im Hero.** Über das neue Prop `actionLabel` an
+  `UnifiedDropzone`: Die gestrichelte Fläche bleibt Drop-Ziel, der Button wird
+  Klick-Ziel (GitHub-/Figma-Muster) — keine verschachtelte Interaktion, kein
+  doppelt geöffneter Dateidialog.
+- **Kompakte Zeile in Zustand B.** Über `showPositionMap={false}`. Ohne sie
+  rendert die Foto-Karte eine 300-px-Lesekarte, während die Panel-Disclosure
+  ~200 px darunter eine zweite, interaktive Karte mit demselben Marker
+  aufklappt — rund 600 px doppelte Karte auf 375 px Breite.
+- **„Datum und Uhrzeit konnten übernommen werden" (Zustand C)** steht wieder da,
+  aber gegated auf die Meldung `onExifDateTimeApplied` aus `DropzoneEnhanced` —
+  **nicht** auf `$form.sightingDate`. Letzteres ist durch den Schema-Default
+  `berlinToday()` ab Formular-Initialisierung immer gefüllt, die Bedingung wäre
+  konstant wahr.
 
 ---
 
@@ -113,6 +258,12 @@ selbst setzen) statt Methode ↔ Fallback.
 Die Karte klappt automatisch auf, sobald eine Position existiert — damit ist die
 EXIF-Position erstmals sichtbar und korrigierbar. Einmal geöffnet, bleibt sie
 offen.
+
+> **Abweichungen (#590):** Die Karte klappt nur auf, wenn eine Position **neu**
+> entsteht, und der Nutzer darf sie danach zuklappen (Punkt 2). „▸ Koordinaten
+> eingeben" liegt nicht neben der Karte, sondern in ihrer Disclosure (Punkt 7).
+> Die kompakte Bestätigungszeile ist umgesetzt — dafür rendert die Foto-Karte
+> hier keine eigene zweite Karte mehr (`showPositionMap={false}`).
 
 ### Zustand C — Foto ohne GPS-Daten
 
@@ -228,6 +379,10 @@ Widerspruch, sondern gewollt — beim Umsetzen aber leicht als einer zu lesen.
 ableiten: `mediaStore` liegt bereits im Form-Context (`Form.svelte:40-50`), und
 `MediaFile` bietet `hasPosition()`, `exifData` und `timestamp`.
 
+> **Abweichung (#590), Punkt 5:** Das hat nicht gehalten. `DropzoneEnhanced` hat
+> vier Props und drei neue Nachbarmodule bekommen; `LocationInput` und `OLMap`
+> haben mehr geändert als das eine Prop (Punkt 6).
+
 ### Reine Logik in `positionPanelState.ts`
 
 ```ts
@@ -238,12 +393,26 @@ mapExpanded(hasCoordinates, wasEverExpanded): boolean
 descriptionCollapsed(hasCoordinates, waterway, seaMark): boolean
 ```
 
+> **Abweichung (#590), Punkte 2–4.** Gebaut ist:
+>
+> ```ts
+> type PhotoStatus = 'none' | 'analyzing' | 'position-applied' | 'no-gps';
+>
+> photoStatus(mediaFiles): PhotoStatus
+> shouldWarnAboutMissingGps(status, coordinatesPresent): boolean
+> shouldOpenMapOnCoordinateChange(hasCoordinates, hadCoordinates): boolean
+> descriptionCollapsed(hasCoordinates, waterway, seaMark): boolean
+> ```
+
 `descriptionCollapsed` fängt eine echte Falle ab: Wer erst das Seegebiet
 beschreibt und _danach_ ein Foto mit GPS hochlädt, dem darf der Block nicht
 zuklappen und den eingegebenen Text verstecken.
 
 **Regel:** zuklappen nur, wenn Koordinaten vorliegen **und** beide Felder leer
 sind. Sonst bleibt der Block offen, nur ohne Pflicht-Stern.
+
+> **Abweichung (#590), Punkt 1:** Die Regel gilt, aber nur als **Startwert** beim
+> Mounten. Danach gehört der Klappzustand dem Nutzer.
 
 `mapExpanded` ist sticky, und zwar unabhängig davon, **warum** die Karte
 aufgegangen ist: Sobald sie einmal offen war — durch Nutzerklick _oder_ durch das
@@ -252,6 +421,11 @@ Koordinaten später wieder entfallen. Der zweite Parameter heißt daher besser
 `wasEverExpanded`. Das vermeidet springendes Layout und stellt sicher, dass die
 Fehler- und Randfall-Tabelle („Foto wieder entfernt → Karte bleibt offen") auch
 für den Nutzer gilt, der die Karte nie selbst angeklickt hat.
+
+> **Abweichung (#590), Punkt 2:** Nicht sticky umgesetzt, sondern als steigende
+> Flanke — sonst könnte der Nutzer die Karte nie wieder zuklappen. Der
+> beschriebene Effekt („Foto wieder entfernt → Karte bleibt offen") gilt
+> trotzdem: Nichts schließt sie automatisch.
 
 ---
 
@@ -293,12 +467,31 @@ ist. Diese Logik ist korrekt und vorsichtig und bleibt unangetastet.
 | Nutzer klappt die Karte wieder zu, obwohl Koordinaten gesetzt sind | `VerifyLocation` bleibt sichtbar — es liegt **außerhalb** der Karten-Disclosure. Sonst verschwände die Ostsee-Prüfung genau dann, wenn sie noch gilt                                                                         |
 | GPS-Button, Sichtung aber an einem anderen Tag gemacht             | Der Button übernimmt den aktuellen Gerätestandort. Abgefedert nur über das Label „Mein aktueller Standort" (siehe „Texte und bewusste Nicht-Entscheidungen"); eine Datumsprüfung ist optional und nicht Teil dieser Änderung |
 
-### Offener Punkt
+### Offener Punkt — **erledigt in #590**
 
 Der GPS-Button stammt aus einem OpenLayers-Control (`OLMap.svelte:80-86`). Ein
 Fehlerpfad für „Standortfreigabe abgelehnt" oder fehlendes HTTPS ist dort nicht
 erkennbar behandelt. Da der Button im neuen Layout prominenter wird, ist das beim
 Umsetzen zu prüfen und gegebenenfalls um einen Hinweis zu ergänzen.
+
+**Umsetzung:** Der Panel-Button benutzt das Control gar nicht mehr, sondern
+`form/position/geolocation.ts` mit injizierter `Geolocation`-Instanz.
+`describeGeolocationError` übersetzt die Codes 1–3 in Sätze, die im Panel als
+`alert alert-warning` erscheinen. Dazu kamen zwei Fälle, die die Spec nicht auf
+dem Schirm hatte:
+
+- **Nie beantworteter Berechtigungsdialog.** Die `timeout`-Option der API läuft
+  laut Spezifikation erst ab der Antwort auf den Dialog — ohne Antwort kommt
+  überhaupt kein Callback und die Promise wurde nie erfüllt. Ein eigener Wächter
+  (`GEOLOCATION_WATCHDOG_MS` = 30 s, bewusst deutlich größer als die
+  API-Frist `GEOLOCATION_TIMEOUT_MS` = 10 s, weil die beiden Uhren zu
+  verschiedenen Zeitpunkten starten) löst den Fall auf.
+- **`getCurrentPosition` wirft synchron** statt den Fehler-Callback zu rufen,
+  etwa außerhalb eines Secure Context. Im Promise-Executor hätte das die Promise
+  abgelehnt, die der Aufrufer ohne `try` awaitet — der Button wäre dauerhaft im
+  Ladezustand stehen geblieben.
+
+Das In-Karten-Control bleibt in der Admin-Maske (Punkt 6).
 
 ---
 
@@ -345,6 +538,13 @@ das meistgenutzte Bedienelement des Schritts. Behebung gehört in diese Änderun
 sofern sie ohne Nebenwirkung auf die Medien-Sektion in Schritt 3 möglich ist —
 sonst als eigener Vorgang.
 
+**Erledigt in #590** — und zwar an **vier** Stellen, nicht zwei: Die Datei trägt
+beide Dropzone-Layouts, die Spec hatte nur die zwei aus dem Positions-Schritt
+gesehen. Alle vier laufen jetzt auf `btn-sm` + `min-h-11` (bzw. zusätzlich
+`min-w-11` für die runde Variante) und wurden im Browser nachgemessen: 108×44,
+108×44, 92×44 und 44×44 bei 375 px und 1280 px, ohne horizontalen Überlauf. Die
+Zeile mit dem `text-nowrap`-Koordinaten-Badge brauchte dafür `flex-wrap gap-2`.
+
 ---
 
 ## Tests
@@ -354,6 +554,14 @@ Test-first gemäß `.claude/rules/testing.md`.
 **Neu (Node):** `positionPanelState.test.ts` — `photoStatus`, `mapExpanded`
 (inklusive Sticky-Verhalten), `descriptionCollapsed` inklusive des Falls „Text
 bereits eingegeben".
+
+> **Abweichung (#590):** statt `mapExpanded` deckt der Test
+> `shouldOpenMapOnCoordinateChange` (steigende Flanke) und
+> `shouldWarnAboutMissingGps` ab, dazu den neuen `analyzing`-Zustand von
+> `photoStatus`. Dazugekommen sind außerdem `geolocation.test.ts`,
+> `LocationDescription.svelte.test.ts`, `LocationInput.svelte.test.ts`,
+> `DropzoneEnhanced.svelte.test.ts`, `exifDateTimeApply.test.ts`,
+> `positionFileOrigin.test.ts` und `MediaFile.test.ts`.
 
 **Entfällt:** `positionMethod.test.ts`.
 

--- a/docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md
+++ b/docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md
@@ -380,8 +380,9 @@ ableiten: `mediaStore` liegt bereits im Form-Context (`Form.svelte:40-50`), und
 `MediaFile` bietet `hasPosition()`, `exifData` und `timestamp`.
 
 > **Abweichung (#590), Punkt 5:** Das hat nicht gehalten. `DropzoneEnhanced` hat
-> vier Props und drei neue Nachbarmodule bekommen; `LocationInput` und `OLMap`
-> haben mehr geändert als das eine Prop (Punkt 6).
+> vier neue Props und zwei neue Nachbarmodule bekommen (`exifDateTimeApply.ts`,
+> `positionFileOrigin.ts`), dazu ein erweitertes `MediaFile`; `LocationInput` und
+> `OLMap` haben mehr geändert als das eine Prop (Punkt 6).
 
 ### Reine Logik in `positionPanelState.ts`
 
@@ -572,6 +573,12 @@ und `method-photo`; diese Selektoren existieren nicht mehr. Neu abzudecken:
 - Beschreibungsblock beim Laden offen, `waterway` als Pflichtfeld
 - Kartenbereich initial zugeklappt
 - `waterway` und `seaMark` ohne jeden Moduswechsel erreichbar
+
+> **Umgesetzt in #590:** Alle vier Punkte sind abgedeckt; statt der alten
+> Selektoren assertet der Test jetzt ihre **Abwesenheit** (`toHaveCount(0)` auf
+> `#method-*`). Dazu kam `e2e/form-position-photo.spec.ts` — bis dahin enthielt
+> `e2e/` kein einziges `setInputFiles`, der Datei-Upload war E2E vollständig
+> ungetestet.
 
 **Neue Fixtures — liegen vor.** In `e2e/` gab es bisher **kein einziges**
 `setInputFiles`; der Datei-Upload war E2E vollständig ungetestet. Die drei


### PR DESCRIPTION
Nach dem Merge von #590 (`a7cbb2e`) beschrieben drei Dokumente noch die entfallene Positionsmethoden-Wahl. Reine Doku-Arbeit — kein Produktivcode, keine Tests, kein `app.css`.

## 1. `docs/UX_POSITIONSANGABE_SCHRITT1_2026-07-28.md`

Die Spec, auf der #590 beruht, stand weiter auf „Freigegeben". Status jetzt: **„Umgesetzt in #590, mit dokumentierten Abweichungen"**, gefolgt von einem Abschnitt, der jede Abweichung samt Begründung nennt. Der Spec-Text bleibt als Entwurfsstand stehen; an den irreführenden Stellen steht ein kurzer Verweis in diesen Abschnitt.

Vollständig gegen den gemergten Stand geprüft. Verbliebene Abweichungen:

| # | Abweichung | Grund |
|---|---|---|
| 1 | Ortsbeschreibung: `descriptionCollapsed` ist **Startwert beim Mounten**, keine laufende Regel | Reaktiv gebunden hing der Zustand an genau den Feldern im Block — das erste `change` riss den Teilbaum ab, `document.activeElement` fiel auf `<body>`. Gebaute Variante ist die bessere. Folge: `openAncestorDetails()` in `fieldNavigation.ts`, damit der Fehlersprung hinter Disclosures funktioniert |
| 2 | `mapExpanded` heißt `shouldOpenMapOnCoordinateChange` und ist **nicht sticky**, sondern steigende Flanke | `hasCoordinates \|\| wasEverExpanded` hätte `open` erzwungen und das Zuklappen unmöglich gemacht. Der Effekt („Foto entfernt → Karte bleibt offen") gilt trotzdem |
| 3 | `PhotoStatus` hat einen vierten Wert `analyzing` | `MediaFile` liegt beim Drop synchron im Store, `exifData` erst nach der Metadaten-Promise — sonst „keine GPS-Daten" für **jedes** frische Foto, mit `role="status"` angesagt |
| 4 | Neu: `shouldWarnAboutMissingGps(status, coordinatesPresent)` | Koordinaten und `MediaFile`-Instanzen sind zwei unabhängige Quellen; nach Reload standen grüne Ostsee-Bestätigung und gelbe GPS-Warnung nebeneinander, deren Ausweg die korrekte Position überschrieben hätte |
| 5 | `DropzoneEnhanced.svelte` blieb **nicht** unverändert | Von außen nicht ableitbar: Abschluss der Auswertung, Herkunft einer Datei (`positionFileOrigin.ts`), Aufnahmezeit eines Fotos ohne GPS (`exifDateTimeApply.ts`), dazu vier neue Props |
| 6 | `LocationInput`: mehr als `collapsibleCoordinates` | `enableGPS={!collapsibleCoordinates}` (zwei Controls für dieselbe Aktion), `hasPosition` an `OLMap` gegen den Phantom-Marker auf 54.5/13.5 |
| 7 | „Koordinaten eingeben" liegt **in** der Karten-Disclosure, nicht daneben | `LocationInput` besitzt den Collapse und wird erst gemountet, wenn die Karte offen ist. Preis: zwei Klicks statt einem |

**Nachträglich doch umgesetzt** (keine Abweichung, aber vermerkt, damit es niemand neu herleitet): Primärbutton im Hero (`actionLabel` an `UnifiedDropzone`), kompakte Zeile in Zustand B (`showPositionMap={false}`), und der Satz „Datum und Uhrzeit konnten übernommen werden" — gegated auf `onExifDateTimeApplied`, nicht auf `$form.sightingDate` (Schema-Default `berlinToday()` wäre konstant wahr).

**Offene Punkte der Spec als erledigt markiert:** der Geolocation-Fehlerpfad (eigenes `geolocation.ts` statt OL-Control, inkl. der zwei Fälle, die die Spec nicht sah: nie beantworteter Dialog, synchroner Wurf) und die `btn-xs`-Touch-Targets (vier Stellen statt der vermuteten zwei, im Browser nachgemessen).

## 2. `docs/UX_DESIGN_REVIEW_SICHTUNGSFORMULAR_2026-07-24.md`

Befund **U10** nannte `positionMethod.ts` als Lösung und zitierte `PositionAndTime.svelte:14, 39–48`. Beides existiert nicht mehr. **U10 ist nicht behoben, sondern gegenstandslos:** ohne Methode gibt es keinen Zustand zu persistieren und keinen Methodenwechsel, der Koordinaten verwerfen könnte. Als datierter Nachtrag ergänzt, plus Marker an den zwei Zeilen, die eine aktuelle Aussage machten.

## 3. Gegenprobe auf weitere Drift

- `grep -rn "positionMethod\|derivePositionMethod" docs/ .claude/`: verbliebene Treffer liegen ausschließlich im „Problem"-Teil der Spec (korrekte Beschreibung des Vorzustands) und in den neu markierten Zeilen.
- `.claude/rules/forms.md` und `docs/DESIGN_GUIDE.md`: **keine Drift** — beide zeigen nicht auf die alte Struktur.
- `.claude/rules/design-system.md` und `.claude/rules/browser-storage.md`: in #590 bereits nachgezogen, nicht angefasst.
- **Zusätzlich gefunden:** `docs/MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md` zeigte für die Schritt-1-Dropzone (Fließtext und Arbeitspunkt A1) noch auf `sections/PositionAndTime.svelte`. Pfad auf `form/position/PositionPanel.svelte` korrigiert — ein Arbeitspunkt, der auf die falsche Datei zeigt, schickt den nächsten Bearbeiter ins Leere.

## Verifikation

`npm run test:quick` grün: ESLint 0 Fehler (2 bekannte `no-explicit-any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`, keine Regression), `tsc --noEmit` sauber, `svelte-check` sauber, **141 Test-Dateien / 2068 Unit-Tests bestanden**.

Hinweis: Prettier hat beim Speichern eine unbeteiligte Tabelle in `MEDIENEINWILLIGUNG_ANALYSE_2026-07-28.md` neu ausgerichtet (reine Whitespace-Änderung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)