### PR TITLE
feat(map): consistent species-group color coding for markers and legend

### DIFF
--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -2,7 +2,14 @@
 	import type { CountData } from '$lib/map/countManager';
 	import { getMapCountManager } from '$lib/map/mapContext';
 	import type { MapTranslations } from '$lib/map/mapUtils';
-	import { backgroundColors, speciesSymbols } from '$lib/map/styleUtils';
+	import {
+		clusterStyleSteps,
+		legendGroups,
+		speciesGroupStyles,
+		speciesSymbols,
+		MARKER_BACKGROUND_COLOR,
+		TOTFUND_RING_COLOR
+	} from '$lib/map/styleUtils';
 	import Icon from '$lib/components/Icon.svelte';
 
 	let { translations, counts } = $props<{
@@ -19,6 +26,20 @@
 	// Zustand der Sichtbarkeitsfilter
 	let speciesVisibility = $state<Record<string, boolean>>({});
 	let colorVisibility = $state<Record<string, boolean>>({});
+
+	// Anzahl-Filtergruppen in Anzeige-Reihenfolge (Totfund zuletzt) — aus styleUtils
+	const countGroups = $derived(
+		Object.entries(legendGroups).map(([key, group]) => ({
+			key,
+			label: key === 'ct0' ? String(translations.found_dead) : group.name
+		}))
+	);
+
+	// Farbschlüssel: Tiergruppen-Ringe plus Totfund-Ring (gleiche Swatch-Darstellung)
+	const ringLegendEntries = $derived([
+		...Object.values(speciesGroupStyles).map(({ label, color }) => ({ label, color })),
+		{ label: String(translations.found_dead), color: TOTFUND_RING_COLOR }
+	]);
 
 	// Toggle-Funktion für das Panel
 	function togglePanel() {
@@ -38,8 +59,8 @@
 				speciesVisibility[key] = true;
 			});
 
-			// Initialisiere alle Farb-Gruppen als sichtbar
-			['ct0', 'ct1', 'ct2', 'ct6', 'ct11', 'ct15'].forEach((colorGroup) => {
+			// Initialisiere alle Anzahl-Gruppen als sichtbar
+			Object.keys(legendGroups).forEach((colorGroup) => {
 				colorVisibility[colorGroup] = true;
 			});
 		}
@@ -96,51 +117,66 @@
 				</button>
 			</div>
 
-			<div class="divider">{translations.species_legend}</div>
-
-			<!-- Info-Box über die Bedienung -->
+			<!-- Info-Box: wie die Marker codiert sind -->
 			<div class="bg-base-300/50 mb-4 rounded-lg p-3 text-sm">
 				<div class="flex items-start gap-2">
-					<span class="text-info">ℹ️</span>
+					<Icon icon="lucide:info" class="text-info mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
 					<div>
-						<strong>Verwendung:</strong> Deaktivieren Sie Checkboxen, um bestimmte Arten oder Gruppengrößen
-						auszublenden. Die Zahlen zeigen sichtbare/gesamt Sichtungen an.
+						<strong>So lesen Sie die Karte:</strong> Die Ringfarbe zeigt die Tiergruppe, das Symbol die
+						Gruppe als zweites Merkmal. Ab zwei Tieren steht die Anzahl unter dem Marker. Ein schwarzer
+						Ring bedeutet Totfund. Deaktivieren Sie Checkboxen, um Arten oder Gruppengrößen auszublenden
+						— die Zahlen zeigen sichtbare/gesamt Sichtungen.
 					</div>
 				</div>
 			</div>
 
+			<!-- Tiergruppen-Farbschlüssel -->
+			<div class="mb-4 flex flex-wrap gap-3">
+				{#each ringLegendEntries as entry (entry.label)}
+					<span class="flex items-center gap-1.5 text-xs">
+						<span
+							class="inline-block h-4 w-4 rounded-full"
+							style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {entry.color};"
+							aria-hidden="true"
+						></span>
+						{entry.label}
+					</span>
+				{/each}
+			</div>
+
+			<div class="divider">{translations.species_legend}</div>
+
 			<div class="mb-6 space-y-3">
 				{#each Object.entries(translations.speciesMap) as [key, value] (key)}
 					{@const symbol = speciesSymbols[key]}
-					<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-						<div
-							class="flex h-8 w-8 items-center justify-center rounded-full border shadow-sm"
-							style="background-color: {symbol
-								? backgroundColors[symbol.category] + 'CC'
-								: '#F0F0F0'}; border-color: {symbol ? symbol.baseColor : '#333'};"
-						>
-							{#if symbol}
-								<span class="text-xl" style="color: {symbol.baseColor};" title={String(value)}>
-									{symbol.symbol}
-								</span>
-							{:else}
-								<div class="bg-base-content/40 h-4 w-4 rounded-full"></div>
-							{/if}
-						</div>
+					{@const total = counts.speciesCounts[key]?.total || 0}
+					<div
+						class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors"
+						data-species-row={key}
+					>
+						<!-- 0/0-Arten ausgrauen: visuelle Teile abschwächen, Checkbox bleibt bedienbar -->
+						<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-40 grayscale' : ''}">
+							<div
+								class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
+								style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol
+									? symbol.baseColor
+									: TOTFUND_RING_COLOR};"
+							>
+								{#if symbol}
+									<span class="text-base" title={String(value)}>{symbol.symbol}</span>
+								{:else}
+									<div class="bg-base-content/40 h-4 w-4 rounded-full"></div>
+								{/if}
+							</div>
 
-						<div class="flex-1">
 							<div class="flex items-center gap-2">
 								<span class="text-sm font-medium">{value}</span>
 								{#if symbol}
 									<span
-										class="rounded-full px-2 py-1 text-xs font-medium text-white"
-										style="background-color: {symbol.baseColor};"
+										class="text-base-content rounded-full border-2 px-2 py-0.5 text-xs font-medium"
+										style="border-color: {symbol.baseColor};"
 									>
-										{symbol.category === 'kleinwal'
-											? 'Kleinwal'
-											: symbol.category === 'grosswal'
-												? 'Großwal'
-												: 'Robbe'}
+										{speciesGroupStyles[symbol.category].label}
 									</span>
 								{/if}
 							</div>
@@ -148,7 +184,7 @@
 
 						<div class="flex items-center gap-2">
 							<span class="text-base-content/70 font-mono text-xs">
-								{counts.speciesCounts[key]?.visible || 0}/{counts.speciesCounts[key]?.total || 0}
+								{counts.speciesCounts[key]?.visible || 0}/{total}
 							</span>
 							<input
 								type="checkbox"
@@ -157,7 +193,7 @@
 								checked={speciesVisibility[key] ?? true}
 								onchange={(e) => handleSpeciesToggle(key, (e.target as HTMLInputElement).checked)}
 								aria-label="Sichtbarkeit für {value} umschalten. Aktuell {counts.speciesCounts[key]
-									?.visible || 0} von {counts.speciesCounts[key]?.total || 0} Sichtungen sichtbar."
+									?.visible || 0} von {total} Sichtungen sichtbar."
 							/>
 						</div>
 					</div>
@@ -167,96 +203,53 @@
 			<div class="divider">{translations.count}</div>
 
 			<div class="space-y-3">
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border shadow-sm" style="background-color: #FFD700;"></div>
-					<span class="flex-1 text-sm">1</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct1'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct1"
-						checked={colorVisibility['ct1'] ?? true}
-						onchange={(e) => handleColorToggle('ct1', (e.target as HTMLInputElement).checked)}
-						aria-label="Sichtungen mit 1 Tier anzeigen/ausblenden"
-					/>
+				{#each countGroups as group (group.key)}
+					<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
+						{#if group.key === 'ct0'}
+							<span
+								class="h-5 w-5 shrink-0 rounded-full shadow-sm"
+								style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {TOTFUND_RING_COLOR};"
+								aria-hidden="true"
+							></span>
+						{:else}
+							<span
+								class="text-base-content/70 w-5 shrink-0 text-center font-mono text-xs"
+								aria-hidden="true">#</span
+							>
+						{/if}
+						<span class="flex-1 text-sm">{group.label}</span>
+						<span class="text-base-content/70 font-mono text-xs"
+							>{counts.colorCounts[group.key] || 0}</span
+						>
+						<input
+							type="checkbox"
+							class="color-checkbox checkbox checkbox-sm"
+							value={group.key}
+							checked={colorVisibility[group.key] ?? true}
+							onchange={(e) => handleColorToggle(group.key, (e.target as HTMLInputElement).checked)}
+							aria-label="Sichtungen der Gruppe {group.label} anzeigen/ausblenden"
+						/>
+					</div>
+				{/each}
+			</div>
+
+			<div class="divider">Cluster</div>
+
+			<!-- Cluster-Farbskala erklären (M1) — aus derselben Konstante wie die Karte -->
+			<div class="mb-8">
+				<div class="mb-2 flex items-center gap-1" aria-hidden="true">
+					{#each clusterStyleSteps as step (step.color)}
+						<span
+							class="inline-flex items-center justify-center rounded-full text-[10px] font-bold text-white"
+							style="background-color: {step.color}; width: {step.radius}px; height: {step.radius}px;"
+						></span>
+					{/each}
 				</div>
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border shadow-sm" style="background-color: #FF8C00;"></div>
-					<span class="flex-1 text-sm">2-5</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct2'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct2"
-						checked={colorVisibility['ct2'] ?? true}
-						onchange={(e) => handleColorToggle('ct2', (e.target as HTMLInputElement).checked)}
-						aria-label="Sichtungen mit 2-5 Tieren anzeigen/ausblenden"
-					/>
-				</div>
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border shadow-sm" style="background-color: #DC143C;"></div>
-					<span class="flex-1 text-sm">6-10</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct6'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct6"
-						checked={colorVisibility['ct6'] ?? true}
-						onchange={(e) => handleColorToggle('ct6', (e.target as HTMLInputElement).checked)}
-						aria-label="Sichtungen mit 6-10 Tieren anzeigen/ausblenden"
-					/>
-				</div>
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border shadow-sm" style="background-color: #8B008B;"></div>
-					<span class="flex-1 text-sm">11-15</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct11'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct11"
-						checked={colorVisibility['ct11'] ?? true}
-						onchange={(e) => handleColorToggle('ct11', (e.target as HTMLInputElement).checked)}
-						aria-label="Sichtungen mit 11-15 Tieren anzeigen/ausblenden"
-					/>
-				</div>
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border shadow-sm" style="background-color: #0066CC;"></div>
-					<span class="flex-1 text-sm">&gt; 15</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct15'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct15"
-						checked={colorVisibility['ct15'] ?? true}
-						onchange={(e) => handleColorToggle('ct15', (e.target as HTMLInputElement).checked)}
-						aria-label="Sichtungen mit mehr als 15 Tieren anzeigen/ausblenden"
-					/>
-				</div>
-				<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-					<div class="h-5 w-5 rounded border bg-black shadow-sm"></div>
-					<span class="flex-1 text-sm">{translations.found_dead}</span>
-					<span class="text-base-content/70 font-mono text-xs"
-						>{counts.colorCounts['ct0'] || 0}</span
-					>
-					<input
-						type="checkbox"
-						class="color-checkbox checkbox checkbox-sm"
-						value="ct0"
-						checked={colorVisibility['ct0'] ?? true}
-						onchange={(e) => handleColorToggle('ct0', (e.target as HTMLInputElement).checked)}
-						aria-label="Totfunde anzeigen/ausblenden"
-					/>
-				</div>
+				<p class="text-base-content/80 text-sm">
+					Blaue Kreise fassen mehrere Sichtungen an nahe beieinanderliegenden Orten zusammen. Die
+					Zahl nennt die Anzahl der Sichtungen; je dunkler und größer der Kreis, desto mehr sind es.
+					Beim Hineinzoomen teilt sich ein Cluster in einzelne Marker auf.
+				</p>
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -160,7 +160,7 @@
 								class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
 								style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol
 									? symbol.baseColor
-									: TOTFUND_RING_COLOR};"
+									: speciesGroupStyles.unbekannt.color};"
 							>
 								{#if symbol}
 									<span class="text-base" title={String(value)}>{symbol.symbol}</span>

--- a/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
@@ -161,6 +161,24 @@ describe('LegendPanel', () => {
 		expect(unknownRow?.querySelector('.species-checkbox')).not.toBeNull();
 	});
 
+	it('unbekannte Tierart-IDs bekommen den neutralen grauen Ring, nicht Totfund-Schwarz', async () => {
+		render(LegendPanel, {
+			translations: {
+				...translations,
+				speciesMap: { ...translations.speciesMap, '99': 'Zukünftige Art' }
+			},
+			counts
+		});
+
+		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+
+		const row = document.querySelector('[data-species-row="99"]');
+		const swatch = row?.querySelector('div[style*="border"]');
+		// Browser normalisiert Hex zu rgb(): #767676 = rgb(118, 118, 118)
+		expect(swatch?.getAttribute('style')).toContain('rgb(118, 118, 118)');
+		expect(swatch?.getAttribute('style')).not.toContain('rgb(0, 0, 0)');
+	});
+
 	it('erklärt die Cluster-Farbskala', async () => {
 		render(LegendPanel, { translations, counts });
 

--- a/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
@@ -34,7 +34,8 @@ const translations: MapTranslations = {
 	speciesMap: {
 		'0': 'Schweinswal',
 		'1': 'Kegelrobbe',
-		'2': 'Seehund'
+		'2': 'Seehund',
+		'8': 'Unbekannte Walart'
 	}
 };
 
@@ -42,7 +43,8 @@ const counts: CountData = {
 	speciesCounts: {
 		'0': { visible: 3, total: 5 },
 		'1': { visible: 1, total: 2 },
-		'2': { visible: 0, total: 1 }
+		'2': { visible: 0, total: 1 },
+		'8': { visible: 0, total: 0 }
 	},
 	colorCounts: {
 		ct0: 1,
@@ -119,11 +121,53 @@ describe('LegendPanel', () => {
 		expect(panel.getAttribute('aria-modal')).toBe('true');
 		expect(panel.getAttribute('aria-labelledby')).toBe('legend-title');
 
-		expect(document.querySelectorAll('.species-checkbox')).toHaveLength(3);
+		expect(document.querySelectorAll('.species-checkbox')).toHaveLength(4);
 		expect(document.querySelectorAll('.color-checkbox')).toHaveLength(6);
 		expect(document.body.textContent).toContain('Schweinswal');
 		expect(document.body.textContent).toContain('3/5');
 		expect(document.body.textContent).toContain('Totfund');
+	});
+
+	it('zeigt Gruppen-Badges aus den styleUtils-Konstanten (Kegelrobbe → Robbe)', async () => {
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+
+		const sealRow = document.querySelector('[data-species-row="1"]');
+		expect(sealRow?.textContent).toContain('Robbe');
+	});
+
+	it('weist Unbekannte Walart nicht als Großwal aus (M8)', async () => {
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+
+		const unknownRow = document.querySelector('[data-species-row="8"]');
+		expect(unknownRow?.textContent).not.toContain('Großwal');
+		expect(unknownRow?.textContent).toContain('Art unbestimmt');
+	});
+
+	it('graut Arten ohne Sichtungen (0/0) aus, Checkbox bleibt bedienbar', async () => {
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+
+		const unknownRow = document.querySelector('[data-species-row="8"]');
+		expect(unknownRow?.querySelector('.grayscale')).not.toBeNull();
+		// Art mit Sichtungen ist nicht ausgegraut
+		const porpoiseRow = document.querySelector('[data-species-row="0"]');
+		expect(porpoiseRow?.querySelector('.grayscale')).toBeNull();
+		// Checkbox der 0/0-Art bleibt vorhanden und aktivierbar
+		expect(unknownRow?.querySelector('.species-checkbox')).not.toBeNull();
+	});
+
+	it('erklärt die Cluster-Farbskala', async () => {
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+
+		expect(document.body.textContent).toContain('Cluster');
+		expect(document.body.textContent).toContain('je dunkler');
 	});
 
 	it('meldet Species- und Farb-Toggles an den CountManager', async () => {

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -14,13 +14,18 @@ import { fromLonLat } from 'ol/proj';
 import { OSM, XYZ } from 'ol/source';
 import Cluster from 'ol/source/Cluster';
 import VectorSource from 'ol/source/Vector';
-import { Circle, Fill, Stroke, Style, Text } from 'ol/style';
+import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { LocationControl } from './controls/LocationControl.js';
 import { ZoomAllControl } from './controls/ZoomAllControl.js';
 import { getDefaultSightingYear } from '$lib/utils/date/defaultYear';
 import { clampExtentToBaltic, type Extent } from './extentUtils';
 import { areExtentsColocated, type MapTranslations } from './mapUtils';
-import { clearStyleCache, createFeatureStyle, getFeatureColorGroup } from './styleUtils';
+import {
+	clearStyleCache,
+	createClusterStyle,
+	createFeatureStyle,
+	getFeatureColorGroup
+} from './styleUtils';
 import { sanitizeText } from '$lib/utils/sanitize';
 
 const logger = createLogger('map:optimized-controller');
@@ -165,14 +170,14 @@ export class SichtungenMap {
 				} else {
 					const singleFeature = features ? features[0] : feature;
 					// Verwende die originale Style-Funktion mit den aktuellen Filtern
-					const style = createFeatureStyle(
+					const styles = createFeatureStyle(
 						singleFeature as Feature<Geometry>,
 						this.hiddenSpecies,
 						this.hiddenColors,
 						this.timeFilter
 					);
-					// Return empty array if style is null to make feature invisible
-					return style ? [style] : [];
+					// Return empty array if styles are null to make feature invisible
+					return styles ?? [];
 				}
 			}
 		});
@@ -1170,60 +1175,7 @@ export class SichtungenMap {
 			return null;
 		}
 
-		// Erstelle Cluster-Style basierend auf der Anzahl sichtbarer Features
-		const size = visibleCount;
-
-		// Bestimme Cluster-Größe und Farbe basierend auf Anzahl der sichtbaren Features
-		let radius = 15;
-		let fontSize = 12;
-		let color = '#3399CC';
-
-		if (size < 5) {
-			radius = 18;
-			fontSize = 12;
-			color = '#51C2D5';
-		} else if (size < 10) {
-			radius = 22;
-			fontSize = 13;
-			color = '#3399CC';
-		} else if (size < 25) {
-			radius = 26;
-			fontSize = 14;
-			color = '#2E7D99';
-		} else if (size < 50) {
-			radius = 30;
-			fontSize = 15;
-			color = '#1E5266';
-		} else {
-			radius = 35;
-			fontSize = 16;
-			color = '#0F2933';
-		}
-
-		return new Style({
-			image: new Circle({
-				radius: radius,
-				fill: new Fill({
-					color: color + 'E6' // 90% Transparenz
-				}),
-				stroke: new Stroke({
-					color: color,
-					width: 2
-				})
-			}),
-			text: new Text({
-				text: size.toString(),
-				font: `bold ${fontSize}px Arial, sans-serif`,
-				fill: new Fill({
-					color: '#FFFFFF'
-				}),
-				stroke: new Stroke({
-					color: color,
-					width: 1
-				}),
-				textAlign: 'center',
-				textBaseline: 'middle'
-			})
-		});
+		// Gemeinsame Cluster-Skala aus styleUtils — identisch mit der Legende
+		return createClusterStyle(visibleCount);
 	}
 }

--- a/src/lib/map/styleUtils.test.ts
+++ b/src/lib/map/styleUtils.test.ts
@@ -1,55 +1,147 @@
-// ol/style wird auf Modulebene instanziiert (new Stroke(), new Fill() in legendGroups).
+// ol/style wird auf Modulebene instanziiert (new Stroke(), new Fill()).
 // Mock muss vor dem Import aktiv sein — vi.mock() wird von Vitest automatisch gehoisted.
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('ol/style', () => {
 	class Stroke {
-		private color: string;
+		private opts: { color?: string; width?: number };
 		constructor(opts?: { color?: string; width?: number }) {
-			this.color = opts?.color ?? 'black';
+			this.opts = opts ?? {};
 		}
 		getColor() {
-			return this.color;
+			return this.opts.color ?? 'black';
 		}
 	}
 	class Fill {
-		private color: string;
+		private opts: { color?: string };
 		constructor(opts?: { color?: string }) {
-			this.color = opts?.color ?? '#000';
+			this.opts = opts ?? {};
 		}
 		getColor() {
-			return this.color;
+			return this.opts.color ?? '#000';
+		}
+	}
+	class Circle {
+		private opts: { stroke?: Stroke; fill?: Fill; radius?: number };
+		constructor(opts?: { stroke?: Stroke; fill?: Fill; radius?: number }) {
+			this.opts = opts ?? {};
+		}
+		getStroke() {
+			return this.opts.stroke;
+		}
+		getFill() {
+			return this.opts.fill;
+		}
+	}
+	class Text {
+		private opts: { text?: string };
+		constructor(opts?: { text?: string }) {
+			this.opts = opts ?? {};
+		}
+		getText() {
+			return this.opts.text;
 		}
 	}
 	class Style {
-		constructor(_opts?: unknown) {}
-	}
-	class Circle {
-		constructor(_opts?: unknown) {}
+		private opts: { image?: unknown; text?: Text };
+		constructor(opts?: { image?: unknown; text?: Text }) {
+			this.opts = opts ?? {};
+		}
+		getImage() {
+			return this.opts.image;
+		}
+		getText() {
+			return this.opts.text;
+		}
 	}
 	class RegularShape {
-		constructor(_opts?: unknown) {}
-	}
-	class Text {
 		constructor(_opts?: unknown) {}
 	}
 	return { Stroke, Fill, Style, Circle, RegularShape, Text };
 });
 
+import type { Feature } from 'ol';
+import type { Geometry } from 'ol/geom';
 import {
-	backgroundColors,
 	clearStyleCache,
+	clusterStyleSteps,
 	createClusterStyle,
+	createFeatureStyle,
+	getClusterStyleStep,
 	getFeatureColorGroup,
 	isBetween,
 	legendGroups,
-	speciesSymbols
+	MARKER_BACKGROUND_COLOR,
+	speciesGroupStyles,
+	speciesSymbols,
+	TOTFUND_RING_COLOR
 } from './styleUtils';
-import type { SightingProperties } from './styleUtils';
-import type { Feature } from 'ol';
-import type { Geometry } from 'ol/geom';
+import type { SightingProperties, SpeciesCategory } from './styleUtils';
+
+/**
+ * WCAG-Kontrastverhältnis zweier Hex-Farben (z. B. '#0072B2' vs '#FFFFFF').
+ */
+function contrastRatio(hexA: string, hexB: string): number {
+	const luminance = (hex: string): number => {
+		const channels = [1, 3, 5].map((i) => {
+			const c = parseInt(hex.slice(i, i + 2), 16) / 255;
+			return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+		});
+		return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+	};
+	const [l1, l2] = [luminance(hexA), luminance(hexB)].sort((a, b) => b - a);
+	return (l1! + 0.05) / (l2! + 0.05);
+}
+
+/** Minimaler Feature-Mock für createFeatureStyle */
+function mockFeature(props: Partial<SightingProperties>): Feature<Geometry> {
+	const properties = { ta: 0, ct: 1, tf: false, ts: 1000, ...props };
+	const stored: Record<string, unknown> = {};
+	return {
+		getProperties: () => properties,
+		set: (key: string, value: unknown) => {
+			stored[key] = value;
+		},
+		get: (key: string) => stored[key]
+	} as unknown as Feature<Geometry>;
+}
+
+const NO_FILTER = { lower: 0, upper: Number.MAX_SAFE_INTEGER };
 
 describe('styleUtils', () => {
+	describe('speciesGroupStyles (Farbe = Artgruppe, M1)', () => {
+		const categories: SpeciesCategory[] = ['kleinwal', 'grosswal', 'robbe', 'unbekannt'];
+
+		it('definiert alle vier Artgruppen mit Label, Farbe und Symbol', () => {
+			for (const category of categories) {
+				const group = speciesGroupStyles[category];
+				expect(group, `Gruppe ${category} fehlt`).toBeDefined();
+				expect(group.label).toBeTruthy();
+				expect(group.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+				expect(group.symbol).toBeTruthy();
+			}
+		});
+
+		it('alle Gruppenfarben sind paarweise verschieden', () => {
+			const colors = categories.map((c) => speciesGroupStyles[c].color);
+			expect(new Set(colors).size).toBe(colors.length);
+		});
+
+		it('jede Gruppenfarbe hat ≥ 3:1 Kontrast auf dem weißen Marker (WCAG 1.4.11)', () => {
+			for (const category of categories) {
+				const ratio = contrastRatio(speciesGroupStyles[category].color, MARKER_BACKGROUND_COLOR);
+				expect(ratio, `${category}: ${ratio.toFixed(2)}`).toBeGreaterThanOrEqual(3);
+			}
+		});
+
+		it('Totfund-Ring ist Schwarz und von allen Gruppenfarben unterscheidbar', () => {
+			expect(TOTFUND_RING_COLOR).toBe('#000000');
+			for (const category of categories) {
+				expect(speciesGroupStyles[category].color).not.toBe(TOTFUND_RING_COLOR);
+			}
+		});
+	});
+
 	describe('speciesSymbols', () => {
 		it('hat Einträge für alle 11 Tierarten (0–10)', () => {
 			for (let i = 0; i <= 10; i++) {
@@ -62,40 +154,47 @@ describe('styleUtils', () => {
 				expect(entry.symbol, `symbol fehlt für ${id}`).toBeTruthy();
 				expect(entry.baseColor, `baseColor fehlt für ${id}`).toMatch(/^#[0-9A-Fa-f]{6}$/);
 				expect(entry.size, `size fehlt für ${id}`).toBeGreaterThan(0);
-				expect(['kleinwal', 'grosswal', 'robbe'], `ungültige category für ${id}`).toContain(
-					entry.category
-				);
+				expect(
+					['kleinwal', 'grosswal', 'robbe', 'unbekannt'],
+					`ungültige category für ${id}`
+				).toContain(entry.category);
 			}
 		});
 
-		it('Schweinswal (0) ist Kleinwal', () => {
+		it('Farbe und Symbol jeder Art stammen aus ihrer Gruppendefinition (eine Quelle für Karte + Legende)', () => {
+			for (const [id, entry] of Object.entries(speciesSymbols)) {
+				const group = speciesGroupStyles[entry.category];
+				expect(entry.baseColor, `baseColor von ${id} weicht von Gruppe ab`).toBe(group.color);
+				expect(entry.symbol, `symbol von ${id} weicht von Gruppe ab`).toBe(group.symbol);
+			}
+		});
+
+		it('Kleinwale: Schweinswal (0), Delphin (3), Beluga (4)', () => {
 			expect(speciesSymbols['0']!.category).toBe('kleinwal');
+			expect(speciesSymbols['3']!.category).toBe('kleinwal');
+			expect(speciesSymbols['4']!.category).toBe('kleinwal');
 		});
 
-		it('Kegelrobbe (1) ist Robbe', () => {
-			expect(speciesSymbols['1']!.category).toBe('robbe');
-		});
-
-		it('Buckelwal (7) ist Großwal', () => {
+		it('Großwale: Zwergwal (5), Finnwal (6), Buckelwal (7)', () => {
+			expect(speciesSymbols['5']!.category).toBe('grosswal');
+			expect(speciesSymbols['6']!.category).toBe('grosswal');
 			expect(speciesSymbols['7']!.category).toBe('grosswal');
 		});
-	});
 
-	describe('backgroundColors', () => {
-		it('hat Hintergrundfarben für alle drei Kategorien', () => {
-			expect(backgroundColors['kleinwal']).toBeDefined();
-			expect(backgroundColors['grosswal']).toBeDefined();
-			expect(backgroundColors['robbe']).toBeDefined();
+		it('Unbekannte Walart (8) wird NICHT als Großwal ausgewiesen (M8)', () => {
+			expect(speciesSymbols['8']!.category).toBe('unbekannt');
+			expect(speciesGroupStyles['unbekannt'].label).not.toBe('Großwal');
 		});
 
-		it('alle Farben sind gültige Hex-Codes', () => {
-			for (const [, color] of Object.entries(backgroundColors)) {
-				expect(color).toMatch(/^#[0-9A-Fa-f]{6}$/);
-			}
+		it('Robben: Kegelrobbe (1), Seehund (2), Ringelrobbe (9), Unbekannte Robbenart (10)', () => {
+			expect(speciesSymbols['1']!.category).toBe('robbe');
+			expect(speciesSymbols['2']!.category).toBe('robbe');
+			expect(speciesSymbols['9']!.category).toBe('robbe');
+			expect(speciesSymbols['10']!.category).toBe('robbe');
 		});
 	});
 
-	describe('legendGroups', () => {
+	describe('legendGroups (Anzahl-Filtergruppen)', () => {
 		it('enthält alle erwarteten Gruppen', () => {
 			expect(legendGroups['ct0']).toBeDefined();
 			expect(legendGroups['ct1']).toBeDefined();
@@ -158,11 +257,8 @@ describe('styleUtils', () => {
 			expect(getFeatureColorGroup({ ta: 0, ct: 1, tf: false, ts: 0 })).toBe('ct1');
 		});
 
-		it('gibt ct2 zurück für ct = 2', () => {
+		it('gibt ct2 zurück für ct = 2 und ct = 5', () => {
 			expect(getFeatureColorGroup({ ta: 0, ct: 2, tf: false, ts: 0 })).toBe('ct2');
-		});
-
-		it('gibt ct2 zurück für ct = 5', () => {
 			expect(getFeatureColorGroup({ ta: 0, ct: 5, tf: false, ts: 0 })).toBe('ct2');
 		});
 
@@ -177,11 +273,103 @@ describe('styleUtils', () => {
 		it('gibt ct15 zurück für ct = 16', () => {
 			expect(getFeatureColorGroup({ ta: 0, ct: 16, tf: false, ts: 0 })).toBe('ct15');
 		});
+	});
 
-		it('gibt ct1 als Fallback zurück (Grenzfall: kein Match)', () => {
-			// Alle realistischen Werte matchen. Testet dass die Funktion einen Default zurückgibt.
-			// ct=1, tf=false → ct1
-			expect(getFeatureColorGroup({ ta: 5, ct: 1, tf: false, ts: 0 })).toBe('ct1');
+	describe('createFeatureStyle (Ring = Gruppenfarbe, Anzahl = Zahl)', () => {
+		it('gibt null zurück, wenn die Art ausgeblendet ist', () => {
+			const feature = mockFeature({ ta: 0 });
+			expect(createFeatureStyle(feature, { '0': true }, {}, NO_FILTER)).toBeNull();
+		});
+
+		it('gibt null zurück, wenn die Anzahl-Gruppe ausgeblendet ist', () => {
+			const feature = mockFeature({ ta: 0, ct: 3 });
+			expect(createFeatureStyle(feature, {}, { ct2: true }, NO_FILTER)).toBeNull();
+		});
+
+		it('gibt null zurück, wenn der Zeitstempel außerhalb des Zeitfilters liegt', () => {
+			const feature = mockFeature({ ta: 0, ts: 1 });
+			expect(createFeatureStyle(feature, {}, {}, { lower: 5000, upper: 9000 })).toBeNull();
+		});
+
+		it('Einzeltier (ct=1): nur Marker-Style ohne Zahl', () => {
+			clearStyleCache();
+			const styles = createFeatureStyle(mockFeature({ ta: 0, ct: 1 }), {}, {}, NO_FILTER);
+			expect(styles).toHaveLength(1);
+		});
+
+		it('Gruppe (ct=7): Marker-Style plus Anzahl-Text "7"', () => {
+			clearStyleCache();
+			const styles = createFeatureStyle(mockFeature({ ta: 0, ct: 7 }), {}, {}, NO_FILTER);
+			expect(styles).toHaveLength(2);
+			const countText = (styles![1] as unknown as { getText(): { getText(): string } }).getText();
+			expect(countText.getText()).toBe('7');
+		});
+
+		it('Ringfarbe entspricht der Gruppenfarbe der Art (Robbe)', () => {
+			clearStyleCache();
+			const styles = createFeatureStyle(mockFeature({ ta: 1, ct: 2 }), {}, {}, NO_FILTER);
+			const image = (
+				styles![0] as unknown as { getImage(): { getStroke(): { getColor(): string } } }
+			).getImage();
+			expect(image.getStroke().getColor()).toBe(speciesGroupStyles['robbe'].color);
+		});
+
+		it('Totfund: Ring ist schwarz, unabhängig von der Art', () => {
+			clearStyleCache();
+			const styles = createFeatureStyle(mockFeature({ ta: 1, ct: 1, tf: true }), {}, {}, NO_FILTER);
+			const image = (
+				styles![0] as unknown as { getImage(): { getStroke(): { getColor(): string } } }
+			).getImage();
+			expect(image.getStroke().getColor()).toBe(TOTFUND_RING_COLOR);
+		});
+	});
+
+	describe('clusterStyleSteps (Cluster-Skala, eine Quelle für Karte + Legende)', () => {
+		it('Schwellen steigen monoton, letzte Stufe ist offen (upTo === null)', () => {
+			expect(clusterStyleSteps.length).toBeGreaterThanOrEqual(3);
+			for (let i = 1; i < clusterStyleSteps.length; i++) {
+				const prev = clusterStyleSteps[i - 1]!;
+				const curr = clusterStyleSteps[i]!;
+				if (curr.upTo !== null) {
+					expect(prev.upTo).not.toBeNull();
+					expect(curr.upTo).toBeGreaterThan(prev.upTo!);
+				}
+				expect(curr.radius).toBeGreaterThan(prev.radius);
+			}
+			expect(clusterStyleSteps[clusterStyleSteps.length - 1]!.upTo).toBeNull();
+		});
+
+		it('weiße Zahl hat ≥ 4,5:1 Kontrast auf jeder Cluster-Farbe (WCAG 1.4.3)', () => {
+			for (const step of clusterStyleSteps) {
+				const ratio = contrastRatio(step.color, '#FFFFFF');
+				expect(ratio, `${step.color}: ${ratio.toFixed(2)}`).toBeGreaterThanOrEqual(4.5);
+			}
+		});
+
+		it('getClusterStyleStep wählt die richtige Stufe', () => {
+			expect(getClusterStyleStep(2)).toBe(clusterStyleSteps[0]);
+			expect(getClusterStyleStep(10_000)).toBe(clusterStyleSteps[clusterStyleSteps.length - 1]);
+			// Grenzwert: upTo ist inklusiv
+			const first = clusterStyleSteps[0]!;
+			expect(getClusterStyleStep(first.upTo!)).toBe(first);
+			expect(getClusterStyleStep(first.upTo! + 1)).toBe(clusterStyleSteps[1]);
+		});
+	});
+
+	describe('createClusterStyle', () => {
+		it('zeigt die Anzahl als Text und nutzt die Farbe der passenden Stufe', () => {
+			clearStyleCache();
+			const style = createClusterStyle(3);
+			const text = (style as unknown as { getText(): { getText(): string } }).getText();
+			expect(text.getText()).toBe('3');
+		});
+
+		it('cached Styles pro Größe', () => {
+			clearStyleCache();
+			const style1 = createClusterStyle(2);
+			expect(createClusterStyle(2)).toBe(style1);
+			clearStyleCache();
+			expect(createClusterStyle(2)).not.toBe(style1);
 		});
 	});
 
@@ -204,26 +392,6 @@ describe('styleUtils', () => {
 	});
 
 	describe('clearStyleCache', () => {
-		it('leert den Style-Cache — createClusterStyle erstellt danach neues Objekt', () => {
-			// Minimaler Mock für ein Cluster-Feature (2 Features → Schlüssel "cluster_2")
-			const mockFeature = {
-				get: (key: string) => (key === 'features' ? [{}, {}] : undefined)
-			} as unknown as Feature<Geometry>;
-
-			// Ersten Style erzeugen und cachen
-			const style1 = createClusterStyle(mockFeature);
-			// Zweiter Aufruf: kommt aus dem Cache (gleiches Objekt)
-			const style1Cached = createClusterStyle(mockFeature);
-			expect(style1).toBe(style1Cached);
-
-			// Cache leeren
-			clearStyleCache();
-
-			// Dritter Aufruf: Cache ist leer → neues Objekt
-			const style2 = createClusterStyle(mockFeature);
-			expect(style2).not.toBe(style1);
-		});
-
 		it('kann mehrfach aufgerufen werden ohne Fehler', () => {
 			expect(() => {
 				clearStyleCache();

--- a/src/lib/map/styleUtils.test.ts
+++ b/src/lib/map/styleUtils.test.ts
@@ -314,6 +314,21 @@ describe('styleUtils', () => {
 			expect(image.getStroke().getColor()).toBe(speciesGroupStyles['robbe'].color);
 		});
 
+		it('teilt den Marker-Basisstyle zwischen unterschiedlichen Anzahlen (Cache)', () => {
+			clearStyleCache();
+			const styles3 = createFeatureStyle(mockFeature({ ta: 0, ct: 3 }), {}, {}, NO_FILTER);
+			const styles9 = createFeatureStyle(mockFeature({ ta: 0, ct: 9 }), {}, {}, NO_FILTER);
+			// Ring+Emoji hängen nur von Art und Totfund ab — gleiche Style-Instanz
+			expect(styles3![0]).toBe(styles9![0]);
+		});
+
+		it('teilt den Anzahl-Textstyle zwischen unterschiedlichen Arten (Cache)', () => {
+			clearStyleCache();
+			const porpoise = createFeatureStyle(mockFeature({ ta: 0, ct: 4 }), {}, {}, NO_FILTER);
+			const seal = createFeatureStyle(mockFeature({ ta: 1, ct: 4 }), {}, {}, NO_FILTER);
+			expect(porpoise![1]).toBe(seal![1]);
+		});
+
 		it('Totfund: Ring ist schwarz, unabhängig von der Art', () => {
 			clearStyleCache();
 			const styles = createFeatureStyle(mockFeature({ ta: 1, ct: 1, tf: true }), {}, {}, NO_FILTER);

--- a/src/lib/map/styleUtils.ts
+++ b/src/lib/map/styleUtils.ts
@@ -1,4 +1,4 @@
-import { Stroke, Fill, Style, Circle, RegularShape, Text } from 'ol/style';
+import { Stroke, Fill, Style, Circle, Text } from 'ol/style';
 import type { Feature } from 'ol';
 import type { Geometry } from 'ol/geom';
 
@@ -22,18 +22,17 @@ export interface SightingProperties {
 }
 
 /**
- * Definition einer Legendengruppe
+ * Definition einer Anzahl-Filtergruppe (Legende „Anzahl")
  */
 export interface LegendGroup {
 	name: string;
-	fill: Fill;
 	match: (properties: SightingProperties) => boolean;
 }
 
 /**
  * Stil-Cache für schnelleren Zugriff
  */
-const styleCache: Record<string, Style> = {};
+const styleCache: Record<string, Style | Style[]> = {};
 
 /**
  * Leert den Style-Cache (für dispose/cleanup)
@@ -42,153 +41,103 @@ export function clearStyleCache(): void {
 	Object.keys(styleCache).forEach((k) => delete styleCache[k]);
 }
 
-/**
- * Grundeinstellungen für alle Stile
- */
-const defaultStroke = new Stroke({ color: 'black', width: 2 });
 const defaultRadius = 8;
 
 /**
- * Verbesserte Symbol-Definitionen für Tierarten
+ * Codierungssystem der Karte (UX-Review M1):
+ * - Ringfarbe des Markers = Artgruppe (farbfehlsicht-sichere Okabe-Ito/Wong-Palette)
+ * - Emoji-Symbol = zweiter, redundanter Kanal für die Artgruppe
+ * - Anzahl der Tiere = Zahl unter dem Marker (ab 2 Tieren)
+ * - Schwarzer Ring = Totfund (Zustands-Kanal, überschreibt die Gruppenfarbe)
+ * Legende (LegendPanel.svelte) rendert aus genau diesen Konstanten.
+ */
+export type SpeciesCategory = 'kleinwal' | 'grosswal' | 'robbe' | 'unbekannt';
+
+export interface SpeciesGroupStyle {
+	label: string; // Badge-/Legendentext der Gruppe
+	color: string; // Ring- und Akzentfarbe (≥ 3:1 auf Weiß, WCAG 1.4.11)
+	symbol: string; // Emoji als zweiter Kanal
+}
+
+export const speciesGroupStyles: Record<SpeciesCategory, SpeciesGroupStyle> = {
+	kleinwal: { label: 'Kleinwal', color: '#0072B2', symbol: '🐬' }, // Wong-Blau
+	grosswal: { label: 'Großwal', color: '#009E73', symbol: '🐋' }, // Wong-Grün
+	robbe: { label: 'Robbe', color: '#D55E00', symbol: '🦭' }, // Wong-Vermillion
+	// „Unbekannte Walart" (M8): weder Klein- noch Großwal zuordenbar → neutrale Gruppe
+	unbekannt: { label: 'Art unbestimmt', color: '#767676', symbol: '❓' }
+};
+
+/** Hintergrund des Markerkreises — Bezugsfläche für die 3:1-Kontrastprüfung der Ringe */
+export const MARKER_BACKGROUND_COLOR = '#FFFFFF';
+
+/** Totfund überschreibt die Gruppenfarbe des Rings */
+export const TOTFUND_RING_COLOR = '#000000';
+
+/**
+ * Symbol-Definition einer Tierart — Farbe und Symbol kommen immer aus der Gruppe
  */
 export interface SpeciesSymbol {
-	symbol: string; // Unicode-Symbol
-	baseColor: string; // Grundfarbe der Tiergruppe
+	symbol: string; // Unicode-Symbol (identisch mit der Gruppe)
+	baseColor: string; // Gruppenfarbe (identisch mit speciesGroupStyles[category].color)
 	size: number; // Relative Größe
-	category: 'kleinwal' | 'grosswal' | 'robbe';
+	category: SpeciesCategory;
+}
+
+function speciesEntry(category: SpeciesCategory, size = 1.0): SpeciesSymbol {
+	const group = speciesGroupStyles[category];
+	return { symbol: group.symbol, baseColor: group.color, size, category };
 }
 
 /**
- * Mapping von Tierarten zu verbesserten Symbolen
+ * Mapping von Tierarten-IDs zu Gruppen-Symbolik
  */
 export const speciesSymbols: Record<string, SpeciesSymbol> = {
-	'0': {
-		// Schweinswal
-		symbol: '🐋',
-		baseColor: '#4A90E2', // Blau für Kleinwale
-		size: 1.0,
-		category: 'kleinwal'
-	},
-	'1': {
-		// Kegelrobbe
-		symbol: '🦭',
-		baseColor: '#8B4513', // Braun für Robben
-		size: 1.1,
-		category: 'robbe'
-	},
-	'2': {
-		// Seehund
-		symbol: '🦭',
-		baseColor: '#CD853F', // Helles Braun für Seehunde
-		size: 1.0,
-		category: 'robbe'
-	},
-	'3': {
-		// Delphin
-		symbol: '🐬',
-		baseColor: '#00CED1', // Türkis für Delphine
-		size: 1.0,
-		category: 'kleinwal'
-	},
-	'4': {
-		// Beluga
-		symbol: '🐋',
-		baseColor: '#F0F8FF', // Weiß für Beluga
-		size: 1.2,
-		category: 'kleinwal'
-	},
-	'5': {
-		// Zwergwal
-		symbol: '🐳',
-		baseColor: '#2F4F4F', // Dunkelgrau für Großwale
-		size: 1.3,
-		category: 'grosswal'
-	},
-	'6': {
-		// Finnwal
-		symbol: '🐋',
-		baseColor: '#1C1C1C', // Schwarz für Finnwal
-		size: 1.5,
-		category: 'grosswal'
-	},
-	'7': {
-		// Buckelwal
-		symbol: '🐳',
-		baseColor: '#36454F', // Charcoal für Buckelwal
-		size: 1.4,
-		category: 'grosswal'
-	},
-	'8': {
-		// Unbekannte Walart
-		symbol: '❓',
-		baseColor: '#696969', // Grau für unbekannt
-		size: 1.2,
-		category: 'grosswal'
-	},
-	'9': {
-		// Ringelrobbe
-		symbol: '🦭',
-		baseColor: '#A0522D', // Sienna für Ringelrobbe
-		size: 0.9,
-		category: 'robbe'
-	},
-	'10': {
-		// Unbekannte Robbenart
-		symbol: '❓',
-		baseColor: '#8B4513', // Braun für unbekannte Robbe
-		size: 1.0,
-		category: 'robbe'
-	}
+	'0': speciesEntry('kleinwal'), // Schweinswal
+	'1': speciesEntry('robbe'), // Kegelrobbe
+	'2': speciesEntry('robbe'), // Seehund
+	'3': speciesEntry('kleinwal'), // Delphin
+	'4': speciesEntry('kleinwal'), // Beluga
+	'5': speciesEntry('grosswal', 1.15), // Zwergwal
+	'6': speciesEntry('grosswal', 1.15), // Finnwal
+	'7': speciesEntry('grosswal', 1.15), // Buckelwal
+	'8': speciesEntry('unbekannt'), // Unbekannte Walart
+	'9': speciesEntry('robbe'), // Ringelrobbe
+	'10': speciesEntry('robbe') // Unbekannte Robbenart
 };
 
 /**
- * Hintergrundfarben für bessere Sichtbarkeit der Symbole
- */
-export const backgroundColors: Record<string, string> = {
-	kleinwal: '#E6F3FF', // Helles Blau
-	grosswal: '#F0F0F0', // Hellgrau
-	robbe: '#F5E6D3' // Beige
-};
-
-/**
- * Barrierefreie Farbgruppen für die Anzahl der Tiere
- * Farben wurden für Farbenblindheit (Deuteranopie/Protanopie) optimiert
+ * Anzahl-Filtergruppen: reine Filterlogik (Legende, countManager, hiddenColors).
+ * Die Anzahl wird auf der Karte als Zahl dargestellt, nicht mehr als Farbe.
  */
 export const legendGroups: Record<string, LegendGroup> = {
 	ct1: {
 		name: '1',
-		fill: new Fill({ color: '#FFD700' }), // Goldgelb - gut sichtbar
 		match: (val) => !val.tf && val.ct === 1
 	},
 	ct2: {
 		name: '2-5',
-		fill: new Fill({ color: '#FF8C00' }), // Dunkles Orange - unterscheidbar
 		match: (val) => !val.tf && val.ct >= 2 && val.ct <= 5
 	},
 	ct6: {
 		name: '6-10',
-		fill: new Fill({ color: '#DC143C' }), // Crimson Rot - hoher Kontrast
 		match: (val) => !val.tf && val.ct >= 6 && val.ct <= 10
 	},
 	ct11: {
 		name: '11-15',
-		fill: new Fill({ color: '#8B008B' }), // Dunkles Magenta - unterscheidbar
 		match: (val) => !val.tf && val.ct >= 11 && val.ct <= 15
 	},
 	ct15: {
 		name: '> 15',
-		fill: new Fill({ color: '#0066CC' }), // Starkes Blau - farbenblind-freundlich
 		match: (val) => !val.tf && val.ct > 15
 	},
 	ct0: {
 		name: 'Totfund',
-		fill: new Fill({ color: '#000000' }), // Schwarz für maximalen Kontrast
 		match: (val) => val.tf || val.ct === 0
 	}
 };
 
 /**
- * Bestimmt die Farbgruppe eines Features basierend auf seinen Eigenschaften
+ * Bestimmt die Anzahl-Gruppe eines Features basierend auf seinen Eigenschaften
  */
 export function getFeatureColorGroup(properties: SightingProperties): string {
 	for (const [key, group] of Object.entries(legendGroups)) {
@@ -202,142 +151,60 @@ export function getFeatureColorGroup(properties: SightingProperties): string {
 }
 
 /**
- * Erstellt einen verbesserten Unicode-basierten Style für ein Feature
+ * Erstellt die Marker-Styles: weißer Kreis mit Gruppenfarben-Ring und Emoji,
+ * darunter die Anzahl als Zahl (ab 2 Tieren).
  */
-function createUnicodeSymbolStyle(speciesId: string, colorGroup: string): Style {
-	const speciesSymbol = speciesSymbols[speciesId];
-	if (!speciesSymbol) {
-		// Fallback für unbekannte Arten
-		return createFallbackGeometricStyle(speciesId, colorGroup);
-	}
+function createMarkerStyles(speciesId: string, count: number, isDead: boolean): Style[] {
+	const speciesSymbol = speciesSymbols[speciesId] ?? speciesEntry('unbekannt');
+	const ringColor = isDead ? TOTFUND_RING_COLOR : speciesSymbol.baseColor;
 
-	// Berechne die finale Größe basierend auf der Tierart
 	const fontSize = Math.round(defaultRadius * 2.5 * speciesSymbol.size);
+	const radius = fontSize / 2 + 4;
 
-	// Bestimme die Farbe basierend auf der Count-Gruppe
-	const countColor = (legendGroups[colorGroup]?.fill.getColor() as string) || '#333333';
-
-	// Erstelle Hintergrund-Style für bessere Sichtbarkeit
-	const backgroundColor = backgroundColors[speciesSymbol.category] || '#FFFFFF';
-
-	return new Style({
-		// Hintergrundkreis für bessere Sichtbarkeit
-		image: new Circle({
-			radius: fontSize / 2 + 4,
-			fill: new Fill({ color: backgroundColor + 'CC' }), // 80% Transparenz
-			stroke: new Stroke({
-				color: countColor,
-				width: 2
-			})
-		}),
-		// Unicode-Text-Symbol
-		text: new Text({
-			text: speciesSymbol.symbol,
-			font: `${fontSize}px Arial, sans-serif`,
-			fill: new Fill({ color: countColor }),
-			stroke: new Stroke({
-				color: '#FFFFFF',
-				width: 1
+	const styles = [
+		new Style({
+			image: new Circle({
+				radius,
+				fill: new Fill({ color: MARKER_BACKGROUND_COLOR + 'E6' }), // 90% Deckung
+				stroke: new Stroke({ color: ringColor, width: 3 })
 			}),
-			offsetY: 0,
-			textAlign: 'center',
-			textBaseline: 'middle'
+			text: new Text({
+				text: speciesSymbol.symbol,
+				font: `${fontSize}px Arial, sans-serif`,
+				textAlign: 'center',
+				textBaseline: 'middle'
+			})
 		})
-	});
-}
+	];
 
-/**
- * Fallback: Erstellt geometrische Formen für Browser ohne Unicode-Support
- */
-function createFallbackGeometricStyle(speciesId: string, colorGroup: string): Style {
-	// Verwende die ursprüngliche geometrische Form-Logik als Fallback
-	let points = 4;
-	let angle = Math.PI / 4;
-	let radius2: number | undefined = undefined;
-
-	switch (speciesId) {
-		case '0': // Schweinswal (Kreis)
-			return new Style({
-				image: new Circle({
-					radius: defaultRadius,
-					fill: legendGroups[colorGroup]?.fill || new Fill({ color: '#333333' }),
-					stroke: defaultStroke
+	if (count > 1) {
+		styles.push(
+			new Style({
+				text: new Text({
+					text: count.toString(),
+					font: 'bold 12px Arial, sans-serif',
+					offsetY: radius + 9,
+					fill: new Fill({ color: '#1A1A1A' }),
+					stroke: new Stroke({ color: '#FFFFFF', width: 3 }),
+					textAlign: 'center',
+					textBaseline: 'middle'
 				})
-			});
-		case '1': // Kegelrobbe (Quadrat)
-			points = 4;
-			angle = Math.PI / 4;
-			break;
-		case '2': // Seehund (Dreieck)
-			points = 3;
-			angle = 0;
-			break;
-		case '3': // Delphin (Dreieck links)
-			points = 3;
-			angle = Math.PI / 6;
-			break;
-		case '4': // Beluga (Dreieck rechts)
-			points = 3;
-			angle = Math.PI / 2;
-			break;
-		case '5': // Zwergwal (Stern)
-			points = 5;
-			angle = 0;
-			radius2 = 2;
-			break;
-		case '6': // Finnwal (Kreuz)
-			points = 4;
-			angle = 0;
-			radius2 = 2;
-			break;
-		case '7': // Buckelwal (X)
-			points = 4;
-			angle = Math.PI / 4;
-			radius2 = 2;
-			break;
-		case '8': // Unbekannte Walart (Fünfeck)
-			points = 5;
-			angle = 0;
-			break;
-		case '9': // Ringelrobbe (Sechseck)
-			points = 6;
-			angle = 0;
-			break;
-		case '10': // Unbekannte Robbenart (Achteck)
-			points = 8;
-			angle = 0;
-			break;
-		default:
-			points = 4;
-			angle = Math.PI / 4;
+			})
+		);
 	}
 
-	const shapeOptions = {
-		points: points,
-		radius: defaultRadius,
-		fill: legendGroups[colorGroup]?.fill || new Fill({ color: '#333333' }),
-		stroke: defaultStroke,
-		angle: angle
-	};
-
-	if (radius2 !== undefined) {
-		Object.assign(shapeOptions, { radius2 });
-	}
-
-	return new Style({
-		image: new RegularShape(shapeOptions)
-	});
+	return styles;
 }
 
 /**
- * Erzeugt einen verbesserten Style für ein Feature basierend auf seiner Art und Anzahl
+ * Erzeugt die Styles für ein Feature basierend auf Art, Anzahl und Totfund-Status
  */
 export function createFeatureStyle(
 	feature: Feature<Geometry>,
 	hiddenSpecies: Record<string, boolean>,
 	hiddenColors: Record<string, boolean>,
 	timeFilter: { lower: number; upper: number }
-): Style | null {
+): Style[] | null {
 	const properties = feature.getProperties() as SightingProperties;
 	const speciesId = (properties.speciesKey as string) || properties.ta.toString();
 	const colorGroup = getFeatureColorGroup(properties);
@@ -355,99 +222,78 @@ export function createFeatureStyle(
 	feature.set('stcVisibility', true);
 	feature.set('stcGroup', colorGroup);
 
-	// Cache-Key aus Art und Farbgruppe
-	const key = `unicode_${speciesId}#${colorGroup}`;
+	// Totfund-Regel kommt aus legendGroups.ct0 — colorGroup ist bereits berechnet
+	const isDead = colorGroup === 'ct0';
+	const key = `marker_${speciesId}#${properties.ct}#${isDead}`;
 
-	// Aus dem Cache zurückgeben, falls vorhanden
 	if (styleCache[key]) {
-		return styleCache[key];
+		return styleCache[key] as Style[];
 	}
 
-	// Versuche zuerst Unicode-Symbole zu verwenden
-	let style: Style;
+	const styles = createMarkerStyles(speciesId, properties.ct, isDead);
+	styleCache[key] = styles;
 
-	try {
-		style = createUnicodeSymbolStyle(speciesId, colorGroup);
-	} catch (error) {
-		// Fallback auf geometrische Formen bei Fehlern
-		console.warn('Unicode-Symbole nicht verfügbar, verwende geometrische Formen:', error);
-		style = createFallbackGeometricStyle(speciesId, colorGroup);
-	}
-
-	// Style im Cache speichern
-	styleCache[key] = style;
-
-	return style;
+	return styles;
 }
 
 /**
- * Erstellt einen Style für geclusterte Features
+ * Cluster-Farbskala: hell → dunkel = wenige → viele Sichtungen.
+ * Alle Farben halten ≥ 4,5:1 für die weiße Anzahl (WCAG 1.4.3) und
+ * kollidieren nicht mit den Gruppenfarben der Einzelmarker.
+ * Die Legende erklärt diese Skala aus derselben Konstante (M1).
  */
-export function createClusterStyle(feature: Feature<Geometry>): Style {
-	const features = feature.get('features');
-	const size = features ? features.length : 0;
+export interface ClusterStyleStep {
+	upTo: number | null; // inklusive Obergrenze, null = offene letzte Stufe
+	color: string;
+	radius: number;
+	fontSize: number;
+}
 
-	// Cache-Key für Cluster-Styles
+export const clusterStyleSteps: ClusterStyleStep[] = [
+	{ upTo: 4, color: '#2E7D99', radius: 18, fontSize: 12 },
+	{ upTo: 9, color: '#25647F', radius: 22, fontSize: 13 },
+	{ upTo: 24, color: '#1E5266', radius: 26, fontSize: 14 },
+	{ upTo: 49, color: '#16404F', radius: 30, fontSize: 15 },
+	{ upTo: null, color: '#0F2933', radius: 35, fontSize: 16 }
+];
+
+/**
+ * Wählt die Cluster-Stufe für eine Anzahl von Sichtungen
+ */
+export function getClusterStyleStep(size: number): ClusterStyleStep {
+	return (
+		clusterStyleSteps.find((step) => step.upTo !== null && size <= step.upTo) ??
+		clusterStyleSteps[clusterStyleSteps.length - 1]!
+	);
+}
+
+/**
+ * Erstellt einen Style für ein Cluster mit der angegebenen Anzahl sichtbarer Sichtungen
+ */
+export function createClusterStyle(size: number): Style {
 	const clusterKey = `cluster_${size}`;
 
 	if (styleCache[clusterKey]) {
-		return styleCache[clusterKey];
+		return styleCache[clusterKey] as Style;
 	}
 
-	// Bestimme Cluster-Größe und Farbe basierend auf Anzahl der Features
-	let radius = 15;
-	let fontSize = 12;
-	let color = '#3399CC';
-
-	if (size < 5) {
-		radius = 18;
-		fontSize = 12;
-		color = '#51C2D5';
-	} else if (size < 10) {
-		radius = 22;
-		fontSize = 13;
-		color = '#3399CC';
-	} else if (size < 25) {
-		radius = 26;
-		fontSize = 14;
-		color = '#2E7D99';
-	} else if (size < 50) {
-		radius = 30;
-		fontSize = 15;
-		color = '#1E5266';
-	} else {
-		radius = 35;
-		fontSize = 16;
-		color = '#0F2933';
-	}
+	const step = getClusterStyleStep(size);
 
 	const style = new Style({
 		image: new Circle({
-			radius: radius,
-			fill: new Fill({
-				color: color + 'E6' // 90% Transparenz
-			}),
-			stroke: new Stroke({
-				color: color,
-				width: 2
-			})
+			radius: step.radius,
+			fill: new Fill({ color: step.color + 'E6' }), // 90% Deckung
+			stroke: new Stroke({ color: '#FFFFFF', width: 2 })
 		}),
 		text: new Text({
 			text: size.toString(),
-			font: `bold ${fontSize}px Arial, sans-serif`,
-			fill: new Fill({
-				color: '#FFFFFF'
-			}),
-			stroke: new Stroke({
-				color: color,
-				width: 1
-			}),
+			font: `bold ${step.fontSize}px Arial, sans-serif`,
+			fill: new Fill({ color: '#FFFFFF' }),
 			textAlign: 'center',
 			textBaseline: 'middle'
 		})
 	});
 
-	// Style im Cache speichern
 	styleCache[clusterKey] = style;
 
 	return style;

--- a/src/lib/map/styleUtils.ts
+++ b/src/lib/map/styleUtils.ts
@@ -150,50 +150,72 @@ export function getFeatureColorGroup(properties: SightingProperties): string {
 	return 'ct1';
 }
 
+/** Schriftgröße des Emoji-Symbols einer Art */
+function markerFontSize(speciesSymbol: SpeciesSymbol): number {
+	return Math.round(defaultRadius * 2.5 * speciesSymbol.size);
+}
+
+/** Radius des Markerkreises einer Art (auch Bezug für den Anzahl-Offset) */
+function markerRadius(speciesSymbol: SpeciesSymbol): number {
+	return markerFontSize(speciesSymbol) / 2 + 4;
+}
+
 /**
- * Erstellt die Marker-Styles: weißer Kreis mit Gruppenfarben-Ring und Emoji,
- * darunter die Anzahl als Zahl (ab 2 Tieren).
+ * Marker-Basisstyle (weißer Kreis, Gruppenfarben-Ring, Emoji) — hängt nur von
+ * Art und Totfund-Status ab und wird deshalb unabhängig von der Anzahl gecacht.
  */
-function createMarkerStyles(speciesId: string, count: number, isDead: boolean): Style[] {
-	const speciesSymbol = speciesSymbols[speciesId] ?? speciesEntry('unbekannt');
-	const ringColor = isDead ? TOTFUND_RING_COLOR : speciesSymbol.baseColor;
-
-	const fontSize = Math.round(defaultRadius * 2.5 * speciesSymbol.size);
-	const radius = fontSize / 2 + 4;
-
-	const styles = [
-		new Style({
-			image: new Circle({
-				radius,
-				fill: new Fill({ color: MARKER_BACKGROUND_COLOR + 'E6' }), // 90% Deckung
-				stroke: new Stroke({ color: ringColor, width: 3 })
-			}),
-			text: new Text({
-				text: speciesSymbol.symbol,
-				font: `${fontSize}px Arial, sans-serif`,
-				textAlign: 'center',
-				textBaseline: 'middle'
-			})
-		})
-	];
-
-	if (count > 1) {
-		styles.push(
-			new Style({
-				text: new Text({
-					text: count.toString(),
-					font: 'bold 12px Arial, sans-serif',
-					offsetY: radius + 9,
-					fill: new Fill({ color: '#1A1A1A' }),
-					stroke: new Stroke({ color: '#FFFFFF', width: 3 }),
-					textAlign: 'center',
-					textBaseline: 'middle'
-				})
-			})
-		);
+function getMarkerBaseStyle(speciesId: string, isDead: boolean): Style {
+	const key = `markerBase_${speciesId}#${isDead}`;
+	if (styleCache[key]) {
+		return styleCache[key] as Style;
 	}
 
-	return styles;
+	const speciesSymbol = speciesSymbols[speciesId] ?? speciesEntry('unbekannt');
+	const ringColor = isDead ? TOTFUND_RING_COLOR : speciesSymbol.baseColor;
+	const fontSize = markerFontSize(speciesSymbol);
+
+	const style = new Style({
+		image: new Circle({
+			radius: markerRadius(speciesSymbol),
+			fill: new Fill({ color: MARKER_BACKGROUND_COLOR + 'E6' }), // 90% Deckung
+			stroke: new Stroke({ color: ringColor, width: 3 })
+		}),
+		text: new Text({
+			text: speciesSymbol.symbol,
+			font: `${fontSize}px Arial, sans-serif`,
+			textAlign: 'center',
+			textBaseline: 'middle'
+		})
+	});
+
+	styleCache[key] = style;
+	return style;
+}
+
+/**
+ * Anzahl-Textstyle unter dem Marker — hängt nur von Anzahl und Offset ab
+ * und wird artenübergreifend geteilt.
+ */
+function getCountTextStyle(count: number, offsetY: number): Style {
+	const key = `countText_${count}#${offsetY}`;
+	if (styleCache[key]) {
+		return styleCache[key] as Style;
+	}
+
+	const style = new Style({
+		text: new Text({
+			text: count.toString(),
+			font: 'bold 12px Arial, sans-serif',
+			offsetY,
+			fill: new Fill({ color: '#1A1A1A' }),
+			stroke: new Stroke({ color: '#FFFFFF', width: 3 }),
+			textAlign: 'center',
+			textBaseline: 'middle'
+		})
+	});
+
+	styleCache[key] = style;
+	return style;
 }
 
 /**
@@ -230,7 +252,14 @@ export function createFeatureStyle(
 		return styleCache[key] as Style[];
 	}
 
-	const styles = createMarkerStyles(speciesId, properties.ct, isDead);
+	// Basis- und Anzahl-Style werden separat gecacht und hier nur kombiniert —
+	// so entsteht pro Anzahl kein neuer Ring/Emoji-Style
+	const speciesSymbol = speciesSymbols[speciesId] ?? speciesEntry('unbekannt');
+	const base = getMarkerBaseStyle(speciesId, isDead);
+	const styles =
+		properties.ct > 1
+			? [base, getCountTextStyle(properties.ct, markerRadius(speciesSymbol) + 9)]
+			: [base];
 	styleCache[key] = styles;
 
 	return styles;

--- a/src/lib/types/map.ts
+++ b/src/lib/types/map.ts
@@ -3,7 +3,6 @@
  */
 
 import type { Map } from 'ol';
-import type { Fill } from 'ol/style';
 
 /**
  * Translation interface for map labels
@@ -168,11 +167,10 @@ export interface PanelManager {
 }
 
 /**
- * Legend group definition
+ * Legend group definition (count filter groups — no color anymore, see styleUtils.ts)
  */
 export interface LegendGroup {
 	name: string;
-	fill: Fill;
 	match: (properties: SightingProperties) => boolean;
 }
 
@@ -180,8 +178,8 @@ export interface LegendGroup {
  * Species symbol definition
  */
 export interface SpeciesSymbol {
-	symbol: string; // Unicode symbol
-	baseColor: string; // Base color of animal group
+	symbol: string; // Unicode symbol (identical to the group symbol)
+	baseColor: string; // Group color (identical to speciesGroupStyles[category].color)
 	size: number; // Relative size
-	category: 'kleinwal' | 'grosswal' | 'robbe';
+	category: 'kleinwal' | 'grosswal' | 'robbe' | 'unbekannt';
 }


### PR DESCRIPTION
## Zusammenfassung

Setzt die Befunde **M1** und **M8** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` um: Karte und Legende sprechen jetzt dieselbe visuelle Sprache und rendern aus denselben exportierten Konstanten.

### Neues Codierungssystem (M1)

- **Ringfarbe = Artgruppe** in farbfehlsicht-sicherer Okabe-Ito/Wong-Palette: Kleinwal `#0072B2` (Blau), Großwal `#009E73` (Grün), Robbe `#D55E00` (Vermillion), Art unbestimmt `#767676` (Grau)
- **Emoji pro Gruppe** (🐬/🐋/🦭/❓) als redundanter zweiter Kanal
- **Anzahl als Zahl unter dem Marker** (ab 2 Tieren) statt als Farbcode
- **Schwarzer Ring = Totfund** (Zustands-Kanal, überschreibt die Gruppenfarbe)
- Die Anzahl-Gruppen (ct1–ct15) bleiben als reine Filter erhalten — ohne Farbsemantik

### Eine Quelle für Karte und Legende

- `styleUtils.ts` exportiert `speciesGroupStyles`, `clusterStyleSteps`, `MARKER_BACKGROUND_COLOR`, `TOTFUND_RING_COLOR`
- `LegendPanel.svelte` rendert Farbschlüssel, Badges, Anzahl-Filter und Cluster-Skala ausschließlich daraus — keine Inline-Hex-Duplikate mehr
- Cluster-Farbskala wird in einem neuen Legenden-Abschnitt erklärt; die zwei hellsten Stufen wurden abgedunkelt, damit die weiße Zahl überall ≥ 4,5:1 hält
- Toter Code `createClusterStyle(feature)` entfernt; der Controller nutzt jetzt das gemeinsame `createClusterStyle(size)` statt einer eigenen Farbrampe

### Detailbefunde (M8 u. a.)

- Beluga-Kontrastfehler (Weiß auf `#F0F8FF`) per Design behoben: Badges sind Outline mit `text-base-content`
- Arten mit 0/0 Sichtungen werden ausgegraut (Checkbox bleibt bedienbar)
- „Unbekannte Walart" trägt das Badge **„Art unbestimmt"** statt „Großwal"

## Tests & Verifikation

- Test-first: neue Unit-Tests inkl. echter WCAG-Kontrastberechnung (Ringe ≥ 3:1 auf Weiß, Cluster ≥ 4,5:1 für weiße Zahl) und Konsistenzprüfung Art ↔ Gruppe
- `npm run test:quick`: 2081 Tests grün; `LegendPanel.svelte.test.ts` (Browser): 7/7 grün
- Visuell am laufenden Dev-Server verifiziert (Karte gezoomt, Legende oben/unten)
- `/review` mit Anti-Pattern-Checks + /simplify durchgeführt: 0 Anti-Pattern, 2 Vereinfachungen eingearbeitet

🤖 Generated with [Claude Code](https://claude.com/claude-code)