### PR TITLE
fix(a11y): meet WCAG AA contrast and 44px targets in the shared layer

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -89,6 +89,17 @@ die betroffenen Zeilen in `app.css` sind entsprechend kommentiert (z. B.
 Wer einen Farbwert ändert, muss den Kontrast neu prüfen. Ein „etwas helleres Blau"
 kann die Barrierefreiheit brechen.
 
+`--color-error` ist dabei der empfindlichste Wert: er ist nicht nur Flächenfarbe,
+sondern über `btn btn-outline btn-error btn-sm` (die kanonische destruktive
+Variante, siehe `design-system.md`) auch **Textfarbe**. Mit dem ursprünglichen
+`oklch(0.55 0.18 25)` erreichte diese Beschriftung nur 4,46:1 auf `base-100` und
+3,69:1 auf `base-200`; seit `oklch(0.48 0.18 25)` sind es 6,05:1 bzw. 5,01:1.
+Abgesichert ist das durch `e2e/form-a11y.spec.ts` → „Accessibility — text-error
+auf Buttons". Die Messmechanik liegt in `e2e/helpers/contrast.ts` und wird auch
+vom Alert-Test benutzt — sie muss im Browser laufen, weil `oklch()` und
+`color-mix(in oklab, …)` erst nach dem Gamut-Mapping nach sRGB als Kontrastwert
+lesbar sind.
+
 ---
 
 ## Nur ein helles Theme

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -380,3 +380,92 @@ test.describe('Accessibility — text-error auf Buttons', () => {
 		).toBeGreaterThanOrEqual(4.5);
 	});
 });
+
+// ── Touch-Target der Hinweis-Buttons in der Feld-Pipeline ──────────────────
+
+/**
+ * Projekt-Mindestmaß ist 44×44 px (`design-system.md`, A11y-Mindestanforderungen)
+ * — das Formular wird an Deck einhändig auf dem Telefon ausgefüllt.
+ *
+ * Gemessen wird die **echte Trefferfläche**, nicht `getBoundingClientRect()`:
+ * Der Hinweis-Button steht inline in einer Label-Zeile, und die 44 px kommen
+ * über ein Pseudo-Element, damit die Zeilenhöhe (28 px) erhalten bleibt. Ein
+ * Test über die Box-Maße würde diese Lösung fälschlich durchfallen lassen und
+ * eine Lösung durchwinken, die zwar 44 px groß aussieht, aber daneben klickt.
+ * `elementFromPoint` prüft stattdessen, was der Browser an den Rändern des
+ * 44-px-Quadrats tatsächlich träfe.
+ */
+const MIN_TOUCH_TARGET = 44;
+
+async function probeHitArea(page: import('@playwright/test').Page, selector: string) {
+	return page.evaluate(
+		({ selector, size }: { selector: string; size: number }) => {
+			const buttons = Array.from(document.querySelectorAll<HTMLElement>(selector));
+			const half = size / 2 - 1; // 1 px Sicherheitsabstand zum Rand des Quadrats
+			return buttons.map((button) => {
+				// `elementFromPoint` arbeitet nur im sichtbaren Viewport — die Felder
+				// stehen weit unterhalb der Falz, also jeden Button erst zentrieren.
+				button.scrollIntoView({ block: 'center' });
+				const rect = button.getBoundingClientRect();
+				const cx = rect.left + rect.width / 2;
+				const cy = rect.top + rect.height / 2;
+				const points: Array<[string, number, number]> = [
+					['oben', cx, cy - half],
+					['unten', cx, cy + half],
+					['links', cx - half, cy],
+					['rechts', cx + half, cy]
+				];
+				const misses = points
+					.filter(([, x, y]) => {
+						const hit = document.elementFromPoint(x, y);
+						return !hit || !(hit === button || button.contains(hit));
+					})
+					.map(([edge]) => edge);
+				return {
+					label: (button.getAttribute('aria-label') ?? '').slice(0, 40),
+					box: `${Math.round(rect.width)}x${Math.round(rect.height)}`,
+					misses
+				};
+			});
+		},
+		{ selector, size: MIN_TOUCH_TARGET }
+	);
+}
+
+test.describe('Accessibility — Touch-Targets der Hinweis-Buttons', () => {
+	test('jeder Hinweis-Button in FieldRenderer ist 44×44 px treffbar', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Schritt 1 rendert vier davon — genug, um die geteilte Pipeline zu prüfen.
+		const buttons = page.locator('button[aria-label^="Hinweis:"]');
+		expect(await buttons.count()).toBeGreaterThan(0);
+
+		const probed = await probeHitArea(page, 'button[aria-label^="Hinweis:"]');
+		for (const { label, box, misses } of probed) {
+			expect(
+				misses,
+				`${label} (Box ${box}): ${MIN_TOUCH_TARGET}px-Quadrat nicht treffbar an ${misses.join(', ')}`
+			).toEqual([]);
+		}
+	});
+
+	test('die Label-Zeile bleibt kompakt (kein 44-px-Sprung)', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Gegenprobe zum Test darüber: Das vergrößerte Touch-Target darf die
+		// Label-Zeile nicht auf Buttonhöhe aufblasen — sonst reißt es das Label
+		// vom zugehörigen Feld weg. Gemessen vor der Änderung: 28 px.
+		const rowHeights = await page.evaluate(() =>
+			Array.from(document.querySelectorAll<HTMLElement>('button[aria-label^="Hinweis:"]')).map(
+				(button) => Math.round(button.closest('label, legend')!.getBoundingClientRect().height)
+			)
+		);
+
+		expect(rowHeights.length).toBeGreaterThan(0);
+		for (const height of rowHeights) {
+			expect(height, `Label-Zeile ist ${height}px hoch`).toBeLessThanOrEqual(32);
+		}
+	});
+});

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Locator } from '@playwright/test';
 import { FormPage } from './pages/FormPage';
 import { fillStep1, fillStep2, expectCurrentStep } from './helpers/form-helpers';
-import { measureContrast } from './helpers/contrast';
+import { formatRatio, measureContrast } from './helpers/contrast';
 
 // ── Phase 5A: FormSteps Indicator ──────────────────────────────────────────
 
@@ -301,7 +301,7 @@ test.describe('Accessibility — Alert-Kontrast', () => {
 
 		expect(measured).toHaveLength(ALERT_VARIANTS.length);
 		for (const { name, ratio } of measured) {
-			expect(ratio, `${name}: gemessen ${ratio}:1`).toBeGreaterThanOrEqual(4.5);
+			expect(ratio, `${name}: gemessen ${formatRatio(ratio)}:1`).toBeGreaterThanOrEqual(4.5);
 		}
 	});
 });
@@ -343,7 +343,7 @@ test.describe('Accessibility — text-error auf Buttons', () => {
 		]);
 
 		for (const { name, ratio } of measured) {
-			expect(ratio, `${name}: gemessen ${ratio}:1`).toBeGreaterThanOrEqual(4.5);
+			expect(ratio, `${name}: gemessen ${formatRatio(ratio)}:1`).toBeGreaterThanOrEqual(4.5);
 		}
 	});
 
@@ -372,11 +372,11 @@ test.describe('Accessibility — text-error auf Buttons', () => {
 
 		expect(
 			onBase100.ratio,
-			`${onBase100.name}: ${onBase100.foreground} auf ${onBase100.background} = ${onBase100.ratio}:1`
+			`${onBase100.name}: ${onBase100.foreground} auf ${onBase100.background} = ${formatRatio(onBase100.ratio)}:1`
 		).toBeGreaterThanOrEqual(4.5);
 		expect(
 			onBase200.ratio,
-			`${onBase200.name}: ${onBase200.foreground} auf ${onBase200.background} = ${onBase200.ratio}:1`
+			`${onBase200.name}: ${onBase200.foreground} auf ${onBase200.background} = ${formatRatio(onBase200.ratio)}:1`
 		).toBeGreaterThanOrEqual(4.5);
 	});
 });
@@ -387,13 +387,15 @@ test.describe('Accessibility — text-error auf Buttons', () => {
  * Projekt-Mindestmaß ist 44×44 px (`design-system.md`, A11y-Mindestanforderungen)
  * — das Formular wird an Deck einhändig auf dem Telefon ausgefüllt.
  *
- * Gemessen wird die **echte Trefferfläche**, nicht `getBoundingClientRect()`:
- * Der Hinweis-Button steht inline in einer Label-Zeile, und die 44 px kommen
- * über ein Pseudo-Element, damit die Zeilenhöhe (28 px) erhalten bleibt. Ein
- * Test über die Box-Maße würde diese Lösung fälschlich durchfallen lassen und
- * eine Lösung durchwinken, die zwar 44 px groß aussieht, aber daneben klickt.
- * `elementFromPoint` prüft stattdessen, was der Browser an den Rändern des
- * 44-px-Quadrats tatsächlich träfe.
+ * Gemessen wird die **echte Trefferfläche**, nicht `getBoundingClientRect()`.
+ * Der Hinweis-Button steht inline in einer Label-Zeile: Er ist über
+ * `min-h-11 min-w-11` echte 44×44 px groß, ragt durch `-my-2.5` aber oben und
+ * unten aus der 28 px hohen Zeile heraus (`FieldRenderer.svelte`). Ein Test
+ * über die Box-Maße prüfte nur, wie groß das Element sich *nennt* — er würde
+ * eine Lösung durchwinken, die 44 px misst, deren Ränder aber von einem
+ * Nachbarn überdeckt sind oder ins Leere klicken. `elementFromPoint` prüft
+ * stattdessen, was der Browser an den Rändern des 44-px-Quadrats tatsächlich
+ * träfe, und bleibt damit gültig, wenn die 44 px später anders erzeugt werden.
  */
 const MIN_TOUCH_TARGET = 44;
 

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Locator } from '@playwright/test';
 import { FormPage } from './pages/FormPage';
 import { fillStep1, fillStep2, expectCurrentStep } from './helpers/form-helpers';
+import { measureContrast } from './helpers/contrast';
 
 // ── Phase 5A: FormSteps Indicator ──────────────────────────────────────────
 
@@ -274,13 +275,9 @@ test.describe('Accessibility — Fokus-Indikator', () => {
  * .alert-error` aus `src/app.css` gegen einen Rückfall auf die Statusfarbe als
  * Textfarbe.
  *
- * Warum im echten Browser und nicht über die CSS-Quelle: Die beteiligten Werte
- * sind `oklch()`-Tokens, die per `color-mix(in oklab, …)` zu Hintergrund und
- * Rahmen verrechnet werden. Ein Kontrastwert lässt sich daraus nur ableiten,
- * wenn die Browser-Engine die Farben tatsächlich auflöst — inklusive
- * Gamut-Mapping nach sRGB. Der Canvas-Umweg unten erzwingt genau diese
- * Auflösung: `fillStyle` akzeptiert den serialisierten Computed Value,
- * `getImageData` liefert die echten sRGB-Bytes zurück.
+ * Warum im echten Browser und nicht über die CSS-Quelle: siehe die Erklärung in
+ * `helpers/contrast.ts` — `oklch()` und `color-mix(in oklab, …)` werden erst
+ * nach dem Gamut-Mapping nach sRGB als Kontrastwert lesbar.
  *
  * Der Fehler, den dieser Test verhindert, hatte alle vier Varianten zwischen
  * 2,45:1 und 3,84:1 gehalten (WCAG 1.4.3 verlangt 4,5:1 für Fließtext) — die
@@ -288,63 +285,98 @@ test.describe('Accessibility — Fokus-Indikator', () => {
  */
 const ALERT_VARIANTS = ['alert-info', 'alert-success', 'alert-warning', 'alert-error'] as const;
 
-async function measureAlertContrast(page: import('@playwright/test').Page) {
-	return page.evaluate(
-		(variants: readonly string[]) => {
-			const canvas = document.createElement('canvas');
-			canvas.width = 1;
-			canvas.height = 1;
-			const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
-
-			/** Serialisierte CSS-Farbe (oklab/color-mix/oklch) → sRGB-Bytes. */
-			function toRgb(cssColor: string): [number, number, number] {
-				ctx.clearRect(0, 0, 1, 1);
-				ctx.fillStyle = '#000000';
-				ctx.fillStyle = cssColor;
-				ctx.fillRect(0, 0, 1, 1);
-				const d = ctx.getImageData(0, 0, 1, 1).data;
-				return [d[0], d[1], d[2]];
-			}
-
-			function luminance([r, g, b]: [number, number, number]): number {
-				const lin = [r, g, b]
-					.map((v) => v / 255)
-					.map((v) => (v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
-				return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
-			}
-
-			return variants.map((variant) => {
-				const probe = document.createElement('div');
-				probe.className = `alert ${variant}`;
-				probe.style.cssText = 'position:fixed;top:0;left:0;visibility:hidden;pointer-events:none';
-				probe.innerHTML = '<span>Kontrastprobe</span>';
-				document.body.appendChild(probe);
-
-				const style = getComputedStyle(probe);
-				const fg = toRgb(style.color);
-				const bg = toRgb(style.backgroundColor);
-				probe.remove();
-
-				const l1 = luminance(fg);
-				const l2 = luminance(bg);
-				const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
-				return { variant, ratio: Math.round(ratio * 100) / 100 };
-			});
-		},
-		[...ALERT_VARIANTS] as string[]
-	);
-}
-
 test.describe('Accessibility — Alert-Kontrast', () => {
 	test('alle vier Alert-Varianten erreichen WCAG AA (4,5:1)', async ({ page }) => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		const measured = await measureAlertContrast(page);
+		const measured = await measureContrast(
+			page,
+			ALERT_VARIANTS.map((variant) => ({
+				name: variant,
+				className: `alert ${variant}`,
+				backdrop: 'var(--color-base-100)'
+			}))
+		);
 
 		expect(measured).toHaveLength(ALERT_VARIANTS.length);
-		for (const { variant, ratio } of measured) {
-			expect(ratio, `${variant}: gemessen ${ratio}:1`).toBeGreaterThanOrEqual(4.5);
+		for (const { name, ratio } of measured) {
+			expect(ratio, `${name}: gemessen ${ratio}:1`).toBeGreaterThanOrEqual(4.5);
 		}
+	});
+});
+
+// ── Kontrast von `text-error` als Button-Beschriftung ──────────────────────
+
+/**
+ * Schützt `--color-error` aus `src/app.css` gegen eine Aufhellung.
+ *
+ * Die kanonische destruktive Variante des Projekts ist
+ * `btn btn-outline btn-error btn-sm min-h-11` (`design-system.md`,
+ * Button-Hierarchie) — „Formular zurücksetzen", „Kontaktdaten löschen" und jeder
+ * Entfernen-Button lösen zu dieser Farbe auf. `btn-sm` setzt `--fontsize: .75rem`
+ * bei Gewicht 600; das ist **kein** „large text", die 3:1-Ausnahme aus WCAG 1.4.3
+ * greift also nicht.
+ *
+ * Gemessen wird auf beiden Flächen, auf denen der Button real vorkommt:
+ * `base-100` (Karten-Inhalt) und `base-200` (Seitenhintergrund). Mit dem alten
+ * `oklch(0.55 0.18 25)` lagen die Werte bei 4,46:1 bzw. 3,69:1 — beide unter AA.
+ */
+const DESTRUCTIVE_BUTTON_CLASS = 'btn btn-outline btn-error btn-sm min-h-11';
+
+test.describe('Accessibility — text-error auf Buttons', () => {
+	test('destruktiver Button erreicht WCAG AA auf base-100 und base-200', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		const measured = await measureContrast(page, [
+			{
+				name: 'btn-outline btn-error auf base-100',
+				className: DESTRUCTIVE_BUTTON_CLASS,
+				backdrop: 'var(--color-base-100)'
+			},
+			{
+				name: 'btn-outline btn-error auf base-200',
+				className: DESTRUCTIVE_BUTTON_CLASS,
+				backdrop: 'var(--color-base-200)'
+			}
+		]);
+
+		for (const { name, ratio } of measured) {
+			expect(ratio, `${name}: gemessen ${ratio}:1`).toBeGreaterThanOrEqual(4.5);
+		}
+	});
+
+	test('der echte „Formular zurücksetzen"-Button erreicht WCAG AA', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Nicht nur eine Probe mit denselben Klassen: dieser Teil bemerkt auch,
+		// wenn die Aufrufstelle in `FormActions.svelte` auf eine andere Variante
+		// wechselt.
+		const reset = page.getByRole('button', { name: /Formular zurücksetzen/i });
+		await expect(reset).toBeVisible();
+
+		const [onBase100, onBase200] = await measureContrast(page, [
+			{
+				name: 'Formular zurücksetzen auf base-100',
+				selector: 'button.btn-error',
+				backdrop: 'var(--color-base-100)'
+			},
+			{
+				name: 'Formular zurücksetzen auf base-200',
+				selector: 'button.btn-error',
+				backdrop: 'var(--color-base-200)'
+			}
+		]);
+
+		expect(
+			onBase100.ratio,
+			`${onBase100.name}: ${onBase100.foreground} auf ${onBase100.background} = ${onBase100.ratio}:1`
+		).toBeGreaterThanOrEqual(4.5);
+		expect(
+			onBase200.ratio,
+			`${onBase200.name}: ${onBase200.foreground} auf ${onBase200.background} = ${onBase200.ratio}:1`
+		).toBeGreaterThanOrEqual(4.5);
 	});
 });

--- a/e2e/helpers/contrast.ts
+++ b/e2e/helpers/contrast.ts
@@ -26,11 +26,26 @@ export interface ContrastProbe {
 
 export interface ContrastResult {
 	name: string;
-	/** Kontrastverhältnis Vordergrund : Hintergrund, auf 2 Nachkommastellen. */
+	/**
+	 * Kontrastverhältnis Vordergrund : Hintergrund — **ungerundet**.
+	 *
+	 * Bewusst nicht gerundet: Der Wert wird direkt gegen die WCAG-Schwelle
+	 * verglichen. Bei zwei Nachkommastellen bestünde ein echtes 4,4951 als
+	 * 4,50 — und dieser Test existiert gerade dafür, ein Abdriften Richtung
+	 * Schwelle zu bemerken. Gerundet wird erst in der Fehlermeldung.
+	 */
 	ratio: number;
 	/** Serialisierte sRGB-Werte — hilfreich, wenn eine Messung überrascht. */
 	foreground: string;
 	background: string;
+}
+
+/**
+ * Rundet ein Kontrastverhältnis für die Ausgabe — nur für Fehlermeldungen.
+ * Verglichen wird immer der ungerundete Wert aus `ContrastResult.ratio`.
+ */
+export function formatRatio(ratio: number): string {
+	return ratio.toFixed(2);
 }
 
 export async function measureContrast(
@@ -104,7 +119,7 @@ export async function measureContrast(
 			const l2 = luminance(bg);
 			return {
 				name: item.name,
-				ratio: Math.round(((Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)) * 100) / 100,
+				ratio: (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05),
 				foreground: `rgb(${fg.join(', ')})`,
 				background: `rgb(${bg.join(', ')})`
 			};

--- a/e2e/helpers/contrast.ts
+++ b/e2e/helpers/contrast.ts
@@ -1,0 +1,113 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * WCAG-Kontrastmessung im echten Browser.
+ *
+ * Warum nicht über die CSS-Quelle: Die Theme-Farben in `src/app.css` stehen in
+ * `oklch()` und werden teils per `color-mix(in oklab, …)` verrechnet. Ein
+ * Kontrastwert lässt sich daraus erst ableiten, wenn die Browser-Engine sie
+ * auflöst — inklusive Gamut-Mapping nach sRGB. Der Canvas-Umweg unten erzwingt
+ * genau diese Auflösung: `fillStyle` akzeptiert den serialisierten Computed
+ * Value, `getImageData` liefert die echten sRGB-Bytes zurück.
+ *
+ * Transparente Elementhintergründe (z. B. `btn-outline`) werden über `backdrop`
+ * komponiert, damit auch Textfarben auf durchsichtigen Flächen korrekt messen.
+ */
+export interface ContrastProbe {
+	/** Beschriftung für die Fehlermeldung. */
+	name: string;
+	/** Klassen des zu messenden Elements. Ignoriert, wenn `selector` gesetzt ist. */
+	className?: string;
+	/** Statt eines Probe-Elements ein echtes Element aus der Seite messen. */
+	selector?: string;
+	/** CSS-Farbe der Fläche, auf der das Element liegt (z. B. `var(--color-base-200)`). */
+	backdrop: string;
+}
+
+export interface ContrastResult {
+	name: string;
+	/** Kontrastverhältnis Vordergrund : Hintergrund, auf 2 Nachkommastellen. */
+	ratio: number;
+	/** Serialisierte sRGB-Werte — hilfreich, wenn eine Messung überrascht. */
+	foreground: string;
+	background: string;
+}
+
+export async function measureContrast(
+	page: Page,
+	probes: ContrastProbe[]
+): Promise<ContrastResult[]> {
+	return page.evaluate((items: ContrastProbe[]) => {
+		const canvas = document.createElement('canvas');
+		canvas.width = 1;
+		canvas.height = 1;
+		const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
+
+		/** Beliebige CSS-Farbe → serialisierter Computed Value. */
+		function resolve(cssColor: string): string {
+			const probe = document.createElement('span');
+			probe.style.cssText = `position:fixed;top:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;color:${cssColor}`;
+			document.body.appendChild(probe);
+			const value = getComputedStyle(probe).color;
+			probe.remove();
+			return value;
+		}
+
+		/** Serialisierte CSS-Farbe → sRGB-Bytes, ggf. über einen Backdrop komponiert. */
+		function toRgb(cssColor: string, backdrop?: string): [number, number, number] {
+			ctx.clearRect(0, 0, 1, 1);
+			ctx.fillStyle = '#000000';
+			if (backdrop) {
+				ctx.fillStyle = backdrop;
+				ctx.fillRect(0, 0, 1, 1);
+				ctx.fillStyle = '#000000';
+			}
+			ctx.fillStyle = cssColor;
+			ctx.fillRect(0, 0, 1, 1);
+			const d = ctx.getImageData(0, 0, 1, 1).data;
+			return [d[0], d[1], d[2]];
+		}
+
+		function luminance([r, g, b]: [number, number, number]): number {
+			const lin = [r, g, b]
+				.map((v) => v / 255)
+				.map((v) => (v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4));
+			return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+		}
+
+		return items.map((item) => {
+			const backdrop = resolve(item.backdrop);
+
+			let element: Element | null = null;
+			let temporary: HTMLElement | null = null;
+			if (item.selector) {
+				element = document.querySelector(item.selector);
+				if (!element) {
+					throw new Error(`Kontrastmessung: Element "${item.selector}" nicht gefunden`);
+				}
+			} else {
+				temporary = document.createElement('div');
+				temporary.className = item.className ?? '';
+				temporary.style.cssText =
+					'position:fixed;top:0;left:0;visibility:hidden;pointer-events:none';
+				temporary.textContent = 'Kontrastprobe';
+				document.body.appendChild(temporary);
+				element = temporary;
+			}
+
+			const style = getComputedStyle(element);
+			const fg = toRgb(style.color, backdrop);
+			const bg = toRgb(style.backgroundColor, backdrop);
+			temporary?.remove();
+
+			const l1 = luminance(fg);
+			const l2 = luminance(bg);
+			return {
+				name: item.name,
+				ratio: Math.round(((Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)) * 100) / 100,
+				foreground: `rgb(${fg.join(', ')})`,
+				background: `rgb(${bg.join(', ')})`
+			};
+		});
+	}, probes);
+}

--- a/src/app.css
+++ b/src/app.css
@@ -55,7 +55,15 @@
 	--color-success-content: oklch(1 0 0);
 	--color-warning: oklch(0.65 0.16 85);
 	--color-warning-content: oklch(1 0 0);
-	--color-error: oklch(0.55 0.18 25);
+	/* Nur die Lightness gegenüber dem Ursprungswert 0.55 abgesenkt (Hue 25 und
+	   Chroma 0.18 unverändert): `text-error` ist die kanonische destruktive
+	   Button-Farbe und lag als Beschriftung bei 4,46:1 auf base-100 und 3,69:1
+	   auf base-200 — beides unter WCAG 1.4.3 (4,5:1; `btn-sm` ist mit .75rem
+	   kein „large text"). Im Browser gemessen ergibt 0.48 jetzt 6,05:1 auf
+	   base-100 und 5,01:1 auf base-200; weißer Text auf `bg-error`/`btn-error`
+	   steigt dabei von 5,31:1 auf 7,20:1. Abgesichert durch
+	   `e2e/form-a11y.spec.ts` → „Accessibility — text-error auf Buttons". */
+	--color-error: oklch(0.48 0.18 25);
 	--color-error-content: oklch(1 0 0);
 
 	/* ── DaisyUI v5 Layout Variablen ──────────────────────────────── */

--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -167,7 +167,16 @@
 </script>
 
 <div class="space-y-4 {className}">
-	<!-- File Preview Section (nur wenn showPreview und Dateien vorhanden) -->
+	<!-- File Preview Section (nur wenn showPreview und Dateien vorhanden)
+
+	     Hinweis zur Erreichbarkeit: In der App rendert dieser Block derzeit nie —
+	     einziger Consumer ist `DropzoneEnhanced.svelte`, und der setzt
+	     `showPreview={false}`. Der Prop-Default ist aber `true`, der nächste
+	     Consumer bekäme die Vorschau also sofort. Deshalb gelten hier dieselben
+	     Regeln wie nebenan: 44-px-Touch-Targets (`min-h-11`, design-system.md)
+	     und ausschließlich Theme-Tokens (`text-error-content` statt `text-white`,
+	     daisyui.md). Abgesichert durch `UnifiedDropzone.svelte.test.ts`
+	     → „Vorschau-Buttons — A11y und Theme-Tokens". -->
 	{#if showPreview && files.length > 0}
 		<div class="bg-base-200 rounded-lg p-4">
 			<div class="mb-4 flex items-center justify-between">
@@ -177,7 +186,7 @@
 				{#if multiple}
 					<button
 						type="button"
-						class="btn btn-ghost btn-xs text-error hover:bg-error hover:text-white"
+						class="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content min-h-11"
 						onclick={clearAll}
 					>
 						Alle löschen
@@ -193,10 +202,13 @@
 							<div class="flex items-start gap-3">
 								<!-- File Icon/Thumbnail -->
 								<div class="flex-shrink-0">
-									<div
-										class="bg-base-200 flex h-12 w-12 items-center justify-center rounded"
-									>
-										<Icon icon={getFileIconName(file.type)} width="24" height="24" class="text-primary" />
+									<div class="bg-base-200 flex h-12 w-12 items-center justify-center rounded">
+										<Icon
+											icon={getFileIconName(file.type)}
+											width="24"
+											height="24"
+											class="text-primary"
+										/>
 									</div>
 								</div>
 
@@ -213,7 +225,7 @@
 								<!-- Remove Button -->
 								<button
 									type="button"
-									class="btn btn-ghost btn-xs text-error"
+									class="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content min-h-11 min-w-11"
 									onclick={() => removeFile(file)}
 									aria-label="Datei entfernen"
 								>
@@ -269,7 +281,9 @@
 			<div class="flex flex-col items-center">
 				<Icon
 					icon="lucide:upload"
-					class="mb-2 h-8 w-8 transition-colors {isDragOver ? 'text-primary' : 'text-base-content/40'}"
+					class="mb-2 h-8 w-8 transition-colors {isDragOver
+						? 'text-primary'
+						: 'text-base-content/40'}"
 				/>
 				<p class="text-sm font-medium {isDragOver ? 'text-primary' : ''}">
 					{isDragOver ? `${multiple ? 'Dateien' : 'Datei'} hier ablegen!` : title}

--- a/src/lib/components/form/UnifiedDropzone.svelte.test.ts
+++ b/src/lib/components/form/UnifiedDropzone.svelte.test.ts
@@ -347,4 +347,61 @@ describe('UnifiedDropzone', () => {
 			});
 		});
 	});
+
+	/**
+	 * Die Vorschau ist in der App derzeit nicht erreichbar: einziger Consumer ist
+	 * `DropzoneEnhanced.svelte`, und der setzt `showPreview={false}`. Der Default
+	 * der Prop ist aber `true` — der nächste Consumer, der sie weglässt, bekäme
+	 * die Buttons sofort zu sehen. Deshalb gelten hier dieselben Regeln wie
+	 * nebenan in `DropzoneEnhanced`: 44 px Touch-Target
+	 * (`design-system.md`) und ausschließlich Theme-Tokens, kein `text-white`
+	 * (`daisyui.md`).
+	 */
+	describe('Vorschau-Buttons — A11y und Theme-Tokens', () => {
+		/**
+		 * Geprüft werden die Klassen, nicht die gerenderte Pixelhöhe: Das
+		 * Browser-Test-Setup lädt `src/app.css` nicht, es gibt im Test-DOM also
+		 * weder Tailwind- noch DaisyUI-Regeln — ein `getBoundingClientRect()`
+		 * misst hier die ungestylte Button-Höhe (21 px) und wäre aussagelos.
+		 * Die tatsächliche Pixelgröße im gebauten CSS deckt der E2E-Test
+		 * „Accessibility — Touch-Targets der Hinweis-Buttons" ab.
+		 */
+		it('Entfernen- und "Alle löschen"-Button tragen die 44-px-Klassen', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				files: [makeFile('a.jpg'), makeFile('b.jpg')],
+				showPreview: true,
+				multiple: true
+			});
+
+			const buttons = [
+				page.getByRole('button', { name: 'Alle löschen' }),
+				page.getByRole('button', { name: 'Datei entfernen' }).first()
+			];
+
+			for (const button of buttons) {
+				await expect.element(button).toBeVisible();
+				const className = (button.element() as HTMLElement).className;
+				expect(className, `unerwartete Größenklasse: ${className}`).toContain('min-h-11');
+				expect(className, `btn-xs unterschreitet 44 px: ${className}`).not.toContain('btn-xs');
+			}
+		});
+
+		it('verwendet keine rohen Farbklassen ausserhalb des Themes', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				files: [makeFile('a.jpg')],
+				showPreview: true,
+				multiple: true
+			});
+
+			await expect.element(page.getByRole('button', { name: 'Alle löschen' })).toBeVisible();
+
+			const rawColorClasses = Array.from(document.querySelectorAll<HTMLElement>('button'))
+				.map((button) => button.className)
+				.filter((className) => /(^|:)text-white\b|(^|:)bg-white\b|-gray-\d/.test(className));
+
+			expect(rawColorClasses).toEqual([]);
+		});
+	});
 });

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
@@ -103,10 +103,13 @@ describe('DropzoneEnhanced — Herkunft wiederhergestellter Dateien', () => {
 	it('trennt beide Herkünfte in einem gemeinsamen Store', async () => {
 		markPositionFile('position-uid');
 
-		const { mediaStore } = renderDropzone([uploadedFile('position-uid'), uploadedFile('media-uid')], {
-			maxFiles: 10,
-			enableGPSExtraction: false
-		});
+		const { mediaStore } = renderDropzone(
+			[uploadedFile('position-uid'), uploadedFile('media-uid')],
+			{
+				maxFiles: 10,
+				enableGPSExtraction: false
+			}
+		);
 
 		await expect.poll(() => mediaStore.mediaFiles.length).toBe(2);
 		const byUid = Object.fromEntries(
@@ -217,11 +220,9 @@ describe('DropzoneEnhanced — Karte in der Foto-Karte', () => {
 	}
 
 	it('zeigt ohne `showPositionMap` die kompakte Bestätigungszeile statt einer zweiten Karte', async () => {
-		renderDropzone(
-			[],
-			{ maxFiles: 1, enableGPSExtraction: true, showPositionMap: false },
-			[gpsMediaFile('gps-uid')]
-		);
+		renderDropzone([], { maxFiles: 1, enableGPSExtraction: true, showPositionMap: false }, [
+			gpsMediaFile('gps-uid')
+		]);
 
 		await expect
 			.poll(() => document.querySelectorAll('[data-testid="photo-position-summary"]').length)
@@ -253,8 +254,8 @@ describe('DropzoneEnhanced — sichtbarer Auslöser', () => {
 		});
 
 		const button = await vi.waitUntil(() =>
-			Array.from(document.querySelectorAll('button')).find(
-				(candidate) => candidate.textContent?.includes('Foto auswählen')
+			Array.from(document.querySelectorAll('button')).find((candidate) =>
+				candidate.textContent?.includes('Foto auswählen')
 			)
 		);
 		expect(button.className).toContain('btn-primary');

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -268,12 +268,23 @@
 			</span>
 		{/if}
 
-		<!-- Value Information Tooltip (fokussierbar für Tastatur/Touch) -->
+		<!-- Value Information Tooltip (fokussierbar für Tastatur/Touch)
+
+		     `min-h-11 min-w-11` hält das 44-px-Touch-Target (design-system.md),
+		     das `btn-xs` mit 24 px deutlich unterschritt. Das `-my-2.5` nimmt die
+		     zusätzlichen 2 × 10 px wieder aus dem Zeilenfluss heraus, damit die
+		     Label-Zeile bei 28 px bleibt und das Label nicht von seinem Feld
+		     weggedrückt wird — ohne den Negativ-Margin wächst sie auf 48 px.
+
+		     Damit das trägt, darf am Label/Legend kein `overflow-hidden` stehen:
+		     es klippt nicht nur den überstehenden Teil der Trefferfläche, sondern
+		     auch die Tooltip-Blase selbst. Horizontal hält `w-full` zusammen mit
+		     dem `overflow-wrap: break-word` der Caption-Span. -->
 		{#if metaValues.valueText}
 			<span class="tooltip tooltip-left ml-2 inline-block" data-tip={metaValues.valueText}>
 				<button
 					type="button"
-					class="btn btn-ghost btn-xs btn-circle"
+					class="btn btn-ghost btn-sm btn-circle -my-2.5 min-h-11 min-w-11"
 					aria-label={`Hinweis: ${metaValues.valueText}`}
 				>
 					<Icon icon="lucide:info" width="14" class="text-base-content/60" />
@@ -313,7 +324,7 @@
 	{#if isRadioGroup}
 		<!-- Radiogruppe: fieldset+legend statt label[for], das ins Leere zeigen würde -->
 		<fieldset class="w-full">
-			<legend class="label w-full overflow-hidden pb-1">{@render caption()}</legend>
+			<legend class="label w-full pb-1">{@render caption()}</legend>
 			{@render description()}
 			{@render fieldControl()}
 		</fieldset>
@@ -322,7 +333,7 @@
 		{@render description()}
 		{@render fieldControl()}
 	{:else}
-		<label for={fieldId} class="label w-full overflow-hidden pb-1">{@render caption()}</label>
+		<label for={fieldId} class="label w-full pb-1">{@render caption()}</label>
 		{@render description()}
 		{@render fieldControl()}
 	{/if}


### PR DESCRIPTION
## Warum dieser PR

Drei Barrierefreiheits-Befunde aus dem Design-System-Review zu #590. Sie standen dort bewusst nicht drin, weil jeder **quer zur gesamten App** liegt und nicht zum Positions-Panel gehört: ein Theme-Token, die geteilte Feld-Pipeline und eine geteilte Dropzone-Komponente.

Alle Kontrastwerte unten sind gemessen, nicht geschätzt — `oklch()` und `color-mix(in oklab, …)` lassen sich erst nach dem Gamut-Mapping nach sRGB als Kontrast lesen, deshalb über einen Browser-Roundtrip (`getComputedStyle` → Canvas), wie in `.claude/rules/daisyui.md` beschrieben.

## 1. `--color-error` war zu hell für Text

`text-error` als Button-Beschriftung erreichte **4,46:1** auf `base-100` und **3,69:1** auf `base-200` — WCAG AA verlangt 4,5:1, und `btn-sm` setzt 0,75 rem bei Gewicht 600, zählt also nicht als „large text".

Das trifft die **kanonische destruktive Variante** des Projekts (`btn btn-outline btn-error btn-sm min-h-11` laut `design-system.md`) und damit „Formular zurücksetzen", „Kontaktdaten löschen" und jeden Entfernen-Button.

`oklch(0.55 → 0.48 0.18 25)`, nur die Helligkeit:

| Kombination | vorher | nachher |
| --- | --- | --- |
| `text-error` auf `base-100` | 4,46:1 ✗ | **6,05:1** ✓ |
| `text-error` auf `base-200` | 3,69:1 ✗ | **5,01:1** ✓ |
| `text-error` auf `bg-error/10` | 3,87:1 ✗ | **5,12:1** ✓ |
| weiß auf `btn-error` | 5,31:1 | **7,20:1** |
| `alert-error` Text | 14,23:1 | 13,82:1 |
| `input-error` Rahmen | — | 6,05:1 (nötig: 3) |

Der Alert bleibt deutlich rot und von `alert-warning` unterscheidbar. Abgesichert durch eine neue Assertion in `e2e/form-a11y.spec.ts`, damit der Wert nicht unbemerkt zurückdriftet.

**Bekannter Rest:** auf `base-300` ergibt `text-error` 4,13:1. Es gibt keine solche Aufrufstelle — `base-300` wird durchweg als Rahmen oder Zeilen-Hover verwendet, `text-error` sitzt immer auf `base-100`. Nachgeprüft, nicht angenommen.

## 2. Die Hilfe-Buttons an den Feldern maßen 24×24 px

`FieldRenderer.svelte` — also in der geteilten `FormField`-Pipeline, damit auf **jedem** Schritt des Formulars, allein vier davon auf Schritt 1. Projekt-Minimum sind 44×44 px, ausdrücklich begründet damit, dass das Formular an Deck einhändig ausgefüllt wird. #590 hat die Dropzone-Buttons gehoben, diesen hier nie erreicht.

Ein naiver Größensprung hätte die Label-Zeile von 28 auf 48 px wachsen lassen. Gelöst mit `btn-sm min-h-11 min-w-11 -my-2.5`: die Trefferfläche ist echte 44×44 px, die Zeilenhöhe bleibt bei 28 px.

Dafür musste `overflow-hidden` vom Label weichen — **und das hatte schon vorher die Tooltip-Bubble abgeschnitten.** Ein Nebenfund, der ohne diesen Fix nicht aufgefallen wäre. Horizontale Containment bei 375 px und 1280 px gegengeprüft, kein Überlauf.

## 3. `UnifiedDropzone` trug noch das Muster, das nebenan aufgeräumt wurde

Zwei Buttons mit `btn-xs` (24 px) und `hover:text-white` — letzteres umgeht das Theme, korrekt wäre `text-error-content`. #590 hat genau dieses Muster in `DropzoneEnhanced` an vier Stellen behoben, hier aber nicht propagiert.

**Zur Erreichbarkeit:** beide sitzen im `showPreview`-Block, und der einzige Nicht-Test-Aufrufer (`DropzoneEnhanced.svelte:929`) übergibt hart `showPreview={false}` — der Code ist in der App also tot. Trotzdem korrigiert statt gelöscht: `UnifiedDropzone` ist eine geteilte Komponente, deren öffentliches Prop auf `true` steht und die acht Tests hat; ein Löschen würde das Default-Verhalten still ändern. Die Unerreichbarkeit ist im Kommentar vermerkt.

## Getestet

2068 Unit-Tests, 107 Browser-Komponententests, 102 E2E (1 übersprungen). `tsc --noEmit` und `svelte-check` fehlerfrei. Jeder Fix mit vorher fehlschlagendem Test (RED→GREEN).

**Nicht verifiziert:** die Admin-Oberfläche im eingeloggten Zustand (Auth0, kein Dev-Bypass) — dort wurden nur die exakten Klassenkombinationen nachgemessen.

Der erste Commit ist ein Formatierungs-Rest aus #590: ein Formatter lief dort, das Ergebnis landete aber nie in einem Commit, und `npm run lint` prüft kein Format. Rein Whitespace, separat gehalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
