### PR TITLE
fix(map): korrekte ARIA-Semantik der Karten-Panels und WCAG-konforme Tastaturkürzel (H5, H7)

### DIFF
--- a/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
+++ b/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
@@ -250,8 +250,8 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 | Karte fokussierbar, Tastatur-Pan/Zoom               | ✅ behoben 2026-07-29 (`tabindex="0"` + Fokusring)     | K3      |
 | Marker per Tastatur/SR erreichbar                   | ✅ über Listenansicht (Umschalter „Karte / Liste")     | K3      |
 | Datenalternative (Tabelle/Liste)                    | ✅ behoben 2026-07-29 (`SightingsListView`)            | K3      |
-| Korrekte ARIA-Semantik                              | ❌                                                     | H5      |
-| Einzeltasten-Shortcuts abschaltbar                  | ❌                                                     | H7      |
+| Korrekte ARIA-Semantik                              | ✅ behoben 2026-07-29 (region + inert + Fokus-Mgmt)    | H5      |
+| Einzeltasten-Shortcuts abschaltbar                  | ✅ behoben 2026-07-29 (nur bei Fokus in der Karte)     | H7      |
 | Kontraste in Panels/Popups                          | ⚠️ Beluga-Badge, sonst ok                              | M1      |
 
 ---
@@ -272,7 +272,7 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 **Mittelfristig:**
 
 - K3: `tabindex` + Fokusring + Skip-Link; Listen-/Tabellenansicht der gefilterten Sichtungen. — **Umgesetzt 2026-07-29** (`SightingsMapView.svelte`, `SightingsListView.svelte`, `listViewUtils.ts`).
-- H5: ARIA-Sanierung der Panels (inert, region, Fokus-Management).
+- H5: ARIA-Sanierung der Panels (inert, region, Fokus-Management). — **Umgesetzt 2026-07-29** (`FilterPanel.svelte`, `LegendPanel.svelte`, `LoadingOverlay.svelte`, `panelFocus.ts`; inkl. H7: Shortcuts nur bei Fokus in der Karten-Region, Panel-Steuerung über `bind:isOpen` statt DOM-Queries).
 - M1: Einheitliches Marker-/Legenden-Codierungssystem (colorblind-safe, Legende aus gemeinsamen Konstanten).
 - M4: URL-State + Filter-Chips + Reset.
 - M7: Loading-Konzept (Vollbild nur initial).

--- a/e2e/map-accessibility.spec.ts
+++ b/e2e/map-accessibility.spec.ts
@@ -25,8 +25,9 @@ test.describe.serial('Map Accessibility', () => {
 		expect(label).toMatch(/Sichtungskarte/i);
 	});
 
-	test('Tastatur-Shortcut H öffnet Hilfe-Modal', async () => {
-		await sharedPage.locator('body').click();
+	test('Tastatur-Shortcut H öffnet Hilfe-Modal (bei fokussierter Karte)', async () => {
+		// H7: Zeichen-Shortcuts wirken nur bei Fokus in der Karten-Region
+		await mapPage.getMapContainer().focus();
 		await sharedPage.keyboard.press('h');
 
 		const dialog = sharedPage.getByRole('dialog', { name: /tastaturkürzel/i });
@@ -36,7 +37,7 @@ test.describe.serial('Map Accessibility', () => {
 	});
 
 	test('Tastatur-Shortcut ? öffnet Hilfe-Modal', async () => {
-		await sharedPage.locator('body').click();
+		await mapPage.getMapContainer().focus();
 		await sharedPage.keyboard.press('?');
 
 		const dialog = sharedPage.getByRole('dialog', { name: /tastaturkürzel/i });
@@ -46,7 +47,7 @@ test.describe.serial('Map Accessibility', () => {
 	});
 
 	test('Escape schließt Hilfe-Modal', async () => {
-		await sharedPage.locator('body').click();
+		await mapPage.getMapContainer().focus();
 		await sharedPage.keyboard.press('h');
 		const dialog = sharedPage.getByRole('dialog', { name: /tastaturkürzel/i });
 		await expect(dialog).toBeVisible({ timeout: MAP_TEST_TIMEOUTS.keyboardModal });
@@ -57,20 +58,80 @@ test.describe.serial('Map Accessibility', () => {
 
 	test('ESC schließt offenes Filter-Panel', async () => {
 		await mapPage.openFilter();
-		await expect(mapPage.getFilterPanel()).toHaveAttribute('aria-hidden', 'false');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
 
-		await sharedPage.locator('body').click();
 		await sharedPage.keyboard.press('Escape');
-		await expect(mapPage.getFilterPanel()).toHaveAttribute('aria-hidden', 'true');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
 	});
 
 	test('ESC schließt offene Legende', async () => {
 		await mapPage.openLegend();
-		await expect(mapPage.getLegendPanel()).toHaveAttribute('aria-hidden', 'false');
+		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', false);
 
-		await sharedPage.locator('body').click();
 		await sharedPage.keyboard.press('Escape');
-		await expect(mapPage.getLegendPanel()).toHaveAttribute('aria-hidden', 'true');
+		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', true);
+	});
+
+	// ─── Befund H5: ARIA-Semantik der Seitenpanels ─────────────────────────────
+
+	test('Panels sind nicht-modale Regionen, Toggles tragen aria-expanded/aria-controls', async () => {
+		// Nicht-modales Seitenpanel: role="region" statt Fake-Dialog
+		await expect(mapPage.getFilterPanel()).toHaveAttribute('role', 'region');
+		await expect(mapPage.getFilterPanel()).not.toHaveAttribute('aria-modal', 'true');
+		await expect(mapPage.getLegendPanel()).toHaveAttribute('role', 'region');
+		await expect(mapPage.getLegendPanel()).not.toHaveAttribute('aria-modal', 'true');
+
+		// Zustand hängt am Toggle-Button, nicht an aria-hidden am Panel
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-controls', 'filter-panel');
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'true');
+		await sharedPage.keyboard.press('Escape');
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	test('Geschlossene Panels sind inert — kein Element im Tab-Zyklus (WCAG 4.1.2)', async () => {
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+
+		// Fokusversuch auf ein Element im geschlossenen Panel darf nicht greifen
+		const focusable = await mapPage.getYearSelect().evaluate((el) => {
+			(el as HTMLSelectElement).focus();
+			return document.activeElement === el;
+		});
+		expect(focusable).toBe(false);
+	});
+
+	test('Fokus wandert beim Öffnen ins Panel und beim Schließen zurück zum Toggle', async () => {
+		await mapPage.openFilter();
+		await expect
+			.poll(async () => sharedPage.evaluate(() => document.activeElement?.id))
+			.toBe('filter-title');
+
+		await mapPage.closeFilter();
+		const toggleFocused = await mapPage
+			.getFilterToggle()
+			.evaluate((el) => document.activeElement === el);
+		expect(toggleFocused).toBe(true);
+	});
+
+	// ─── Befund H7: Einzeltasten-Shortcuts nur bei Fokus in der Karte ──────────
+
+	test('F-Shortcut wirkt nicht, wenn der Fokus außerhalb der Karte liegt (WCAG 2.1.4)', async () => {
+		// Fokus auf ein Element außerhalb der Karten-Region legen
+		await sharedPage.getByRole('button', { name: /Tastatur-Hilfe anzeigen/i }).focus();
+		await sharedPage.keyboard.press('f');
+
+		// Panel bleibt zu — der Shortcut darf hier nicht feuern
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	test('F-Shortcut öffnet das Filter-Panel bei fokussierter Karte', async () => {
+		await mapPage.getMapContainer().focus();
+		await sharedPage.keyboard.press('f');
+
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'true');
+		await sharedPage.keyboard.press('Escape');
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
 	});
 
 	// ─── Befund K3: Barrierefreie Sichtungskarte ───────────────────────────────

--- a/e2e/map-accessibility.spec.ts
+++ b/e2e/map-accessibility.spec.ts
@@ -64,6 +64,17 @@ test.describe.serial('Map Accessibility', () => {
 		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
 	});
 
+	test('ESC schließt das Filter-Panel auch bei Fokus im Suchfeld', async () => {
+		// Escape wirkt global — der Input-Guard des Keyboard-Handlers darf
+		// Escape nicht verschlucken (Copilot-Review PR #601)
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+		await mapPage.getFilterInput().focus();
+
+		await sharedPage.keyboard.press('Escape');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+	});
+
 	test('ESC schließt offene Legende', async () => {
 		await mapPage.openLegend();
 		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', false);

--- a/e2e/map-filters.spec.ts
+++ b/e2e/map-filters.spec.ts
@@ -16,10 +16,10 @@ test.describe.serial('Map Filter Panel', () => {
 	});
 
 	test('Tastatur-Shortcut F öffnet Filter-Panel', async () => {
-		// Focus the page body to ensure keyboard events are received
-		await sharedPage.locator('body').click();
+		// H7: Zeichen-Shortcuts wirken nur bei Fokus in der Karten-Region
+		await mapPage.getMapContainer().focus();
 		await sharedPage.keyboard.press('f');
-		await expect(mapPage.getFilterPanel()).toHaveAttribute('aria-hidden', 'false');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
 		await mapPage.closeFilter();
 	});
 

--- a/e2e/map-lazy-loading.spec.ts
+++ b/e2e/map-lazy-loading.spec.ts
@@ -27,27 +27,34 @@ test.describe('Map Page', () => {
 
 	// Skip in CI: Route interception for lazy-loaded chunks doesn't work reliably
 	// in production builds where chunk names are hashed differently
-	(isCI ? test.skip : test)('shows loading state with accessible dialog', async ({ page }) => {
-		await page.route('**/SightingsMapView*.js', async (route) => {
-			await new Promise((resolve) => setTimeout(resolve, 1000));
-			await route.continue();
-		});
+	(isCI ? test.skip : test)(
+		'shows loading state with accessible status message',
+		async ({ page }) => {
+			await page.route('**/SightingsMapView*.js', async (route) => {
+				await new Promise((resolve) => setTimeout(resolve, 1000));
+				await route.continue();
+			});
 
-		const mapPage = new MapPage(page);
-		await mapPage.goto();
+			const mapPage = new MapPage(page);
+			await mapPage.goto();
 
-		const loadingDialog = mapPage.getLoadingOverlay();
-		const isDialogVisible = await loadingDialog.isVisible().catch(() => false);
+			const loadingStatus = mapPage.getLoadingOverlay();
+			const isStatusVisible = await loadingStatus.isVisible().catch(() => false);
 
-		if (isDialogVisible) {
-			await expect(loadingDialog).toHaveAttribute('aria-modal', 'true');
-			await expect(loadingDialog).toHaveAttribute('aria-labelledby', 'loading-title');
-			await expect(page.locator('#loading-title')).toContainText(/wird/i);
-			await expect(loadingDialog).toBeHidden({ timeout: MAP_TEST_TIMEOUTS.overlayHide });
+			if (isStatusVisible) {
+				// H5: Ladezustand ist eine Statusmeldung in einer polite-Live-Region,
+				// kein Dialog
+				await expect(loadingStatus).toContainText(/wird/i);
+				const liveRegion = page.locator('[role="status"][aria-live="polite"]', {
+					has: loadingStatus
+				});
+				await expect(liveRegion).toHaveCount(1);
+				await expect(loadingStatus).toBeHidden({ timeout: MAP_TEST_TIMEOUTS.overlayHide });
+			}
+
+			await expect(page.locator('body')).toBeVisible();
 		}
-
-		await expect(page.locator('body')).toBeVisible();
-	});
+	);
 
 	// Skip in CI: Route interception for lazy-loaded chunks doesn't work reliably
 	// in production builds where chunk names are hashed differently

--- a/e2e/map-legend.spec.ts
+++ b/e2e/map-legend.spec.ts
@@ -10,10 +10,10 @@ test.describe('Map Legend Panel', () => {
 	});
 
 	test('Tastatur-Shortcut L öffnet Legende-Panel', async ({ page }) => {
-		// Focus the page body to ensure keyboard events are received
-		await page.locator('body').click();
+		// H7: Zeichen-Shortcuts wirken nur bei Fokus in der Karten-Region
+		await mapPage.getMapContainer().focus();
 		await page.keyboard.press('l');
-		await expect(mapPage.getLegendPanel()).toHaveAttribute('aria-hidden', 'false');
+		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', false);
 		await expect(mapPage.getColorCheckboxes().first()).toBeVisible();
 	});
 });

--- a/e2e/pages/MapPage.ts
+++ b/e2e/pages/MapPage.ts
@@ -36,13 +36,13 @@ export class MapPage {
 
 	private async waitForLoadOnce() {
 		// Phase 1: Wait for the filter toggle button to appear — proves SightingsMapView is mounted
-		const filterToggle = this.page.getByRole('button', { name: /filter öffnen/i });
+		const filterToggle = this.getFilterToggle();
 		await filterToggle.waitFor({ state: 'visible', timeout: MAP_TEST_TIMEOUTS.componentMount });
 
 		// Phase 2: Wait for SichtungsMapView's own loading overlay to clear (1.5s init timeout).
 		// Use count() for an instant DOM check rather than a timed probe — if the overlay is
 		// already gone (Svelte {#if} removed it), count() returns 0 immediately with no delay.
-		const loadingOverlay = this.page.locator('[aria-labelledby="loading-title"]');
+		const loadingOverlay = this.getLoadingOverlay();
 		if ((await loadingOverlay.count()) > 0) {
 			await loadingOverlay.waitFor({ state: 'hidden', timeout: MAP_TEST_TIMEOUTS.overlayHide });
 		}
@@ -50,8 +50,13 @@ export class MapPage {
 
 	// ─── Filter Panel ──────────────────────────────────────────────────────────
 
+	/** Toggle-Button des Filter-Panels (statisches Label, Zustand via aria-expanded) */
+	getFilterToggle(): Locator {
+		return this.page.getByRole('button', { name: /^filter$/i });
+	}
+
 	async openFilter() {
-		await this.page.getByRole('button', { name: /filter öffnen/i }).click();
+		await this.getFilterToggle().click();
 	}
 
 	async closeFilter() {
@@ -88,8 +93,13 @@ export class MapPage {
 
 	// ─── Legend Panel ──────────────────────────────────────────────────────────
 
+	/** Toggle-Button des Legende-Panels (statisches Label, Zustand via aria-expanded) */
+	getLegendToggle(): Locator {
+		return this.page.getByRole('button', { name: /^legende$/i });
+	}
+
 	async openLegend() {
-		await this.page.getByRole('button', { name: /legende öffnen/i }).click();
+		await this.getLegendToggle().click();
 	}
 
 	async closeLegend() {
@@ -150,7 +160,9 @@ export class MapPage {
 	// ─── Loading & Errors ──────────────────────────────────────────────────────
 
 	getLoadingOverlay(): Locator {
-		return this.page.locator('[aria-labelledby="loading-title"]');
+		// H5: LoadingOverlay ist eine role="status"-Live-Region; der sichtbare
+		// Inhalt trägt eine Test-ID, weil der Wrapper dauerhaft im DOM bleibt.
+		return this.page.getByTestId('map-loading-content');
 	}
 
 	getErrorAlert(): Locator {

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -49,7 +49,11 @@
 					<div
 						class="bg-primary/10 mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full"
 					>
-						<Icon icon={iconMap[loadingType]} class="text-primary h-8 w-8 animate-spin" />
+						<Icon
+							icon={iconMap[loadingType]}
+							class="text-primary h-8 w-8 animate-spin"
+							aria-hidden="true"
+						/>
 					</div>
 					<h3 class="text-base-content text-lg font-semibold">
 						{displayMessage}

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -26,54 +26,60 @@
 	const displayMessage = $derived(messageMap[loadingType]);
 </script>
 
-{#if isVisible}
-	<!-- Backdrop -->
-	<div
-		class="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-all duration-300"
-		style="animation: fadeIn 0.3s ease-out"
-		role="dialog"
-		aria-modal="true"
-		aria-labelledby="loading-title"
-	></div>
-
-	<!-- Loading Content -->
-	<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+<!-- H5: Der Ladezustand ist kein Dialog, sondern eine Statusmeldung. Die
+     Live-Region bleibt dauerhaft im DOM, damit Screenreader schon die erste
+     Statusänderung ansagen; der Inhalt wird nur bei Sichtbarkeit gerendert. -->
+<div role="status" aria-live="polite">
+	{#if isVisible}
+		<!-- Backdrop (rein visuell) -->
 		<div
-			class="bg-base-100 mx-auto w-full max-w-sm scale-100 transform rounded-2xl p-8 shadow-2xl transition-all duration-300"
-			style="animation: bounceIn 0.4s ease-out"
-		>
-			<!-- Header -->
-			<div class="mb-6 text-center">
-				<div
-					class="bg-primary/10 mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full"
-				>
-					<Icon icon={iconMap[loadingType]} class="text-primary h-8 w-8 animate-spin" />
-				</div>
-				<h3 id="loading-title" class="text-base-content text-lg font-semibold">
-					{displayMessage}
-				</h3>
-			</div>
+			class="fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-all duration-300"
+			style="animation: fadeIn 0.3s ease-out"
+		></div>
 
-			<!-- Indeterminate Loading Dots -->
-			<div class="mb-2 flex items-center justify-center space-x-2">
-				<div class="bg-primary h-2 w-2 animate-bounce rounded-full"></div>
-				<div
-					class="bg-primary h-2 w-2 animate-bounce rounded-full"
-					style="animation-delay: 0.1s"
-				></div>
-				<div
-					class="bg-primary h-2 w-2 animate-bounce rounded-full"
-					style="animation-delay: 0.2s"
-				></div>
-			</div>
-
-			{#if type === 'initial'}
-				<div class="text-base-content/60 mt-4 text-center text-sm">
-					<p>Verwenden Sie <kbd class="kbd kbd-xs">H</kbd> für Tastaturkürzel</p>
+		<!-- Loading Content -->
+		<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+			<div
+				data-testid="map-loading-content"
+				class="bg-base-100 mx-auto w-full max-w-sm scale-100 transform rounded-2xl p-8 shadow-2xl transition-all duration-300"
+				style="animation: bounceIn 0.4s ease-out"
+			>
+				<!-- Header -->
+				<div class="mb-6 text-center">
+					<div
+						class="bg-primary/10 mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full"
+					>
+						<Icon icon={iconMap[loadingType]} class="text-primary h-8 w-8 animate-spin" />
+					</div>
+					<h3 class="text-base-content text-lg font-semibold">
+						{displayMessage}
+					</h3>
 				</div>
-			{/if}
+
+				<!-- Indeterminate Loading Dots -->
+				<div class="mb-2 flex items-center justify-center space-x-2">
+					<div class="bg-primary h-2 w-2 animate-bounce rounded-full"></div>
+					<div
+						class="bg-primary h-2 w-2 animate-bounce rounded-full"
+						style="animation-delay: 0.1s"
+					></div>
+					<div
+						class="bg-primary h-2 w-2 animate-bounce rounded-full"
+						style="animation-delay: 0.2s"
+					></div>
+				</div>
+
+				{#if type === 'initial'}
+					<div class="text-base-content/60 mt-4 text-center text-sm">
+						<!-- H7: Kürzel wirken nur bei fokussierter Karte (WCAG 2.1.4) -->
+						<p>
+							Tastaturkürzel: Karte fokussieren, dann <kbd class="kbd kbd-xs">H</kbd> drücken
+						</p>
+					</div>
+				{/if}
+			</div>
 		</div>
-	</div>
-{/if}
+	{/if}
+</div>
 
 <!-- Animations sind jetzt global in app.css definiert -->

--- a/src/lib/components/map/LoadingOverlay.svelte.test.ts
+++ b/src/lib/components/map/LoadingOverlay.svelte.test.ts
@@ -2,36 +2,50 @@ import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
 import LoadingOverlay from './LoadingOverlay.svelte';
 
-function getDialog(): HTMLElement {
-	const dialog = document.querySelector('[aria-labelledby="loading-title"]');
-	if (!(dialog instanceof HTMLElement)) {
-		throw new Error('Loading dialog not found');
+/**
+ * Tests für LoadingOverlay (Befund H5): Der Ladezustand ist kein Dialog,
+ * sondern eine Statusmeldung — role="status" + aria-live="polite" auf einer
+ * dauerhaft vorhandenen Live-Region. Das frühere role="dialog"/aria-modal
+ * saß auf dem leeren Backdrop-Div, und aria-labelledby zeigte in einen
+ * anderen Teilbaum.
+ */
+
+function getStatusRegion(): HTMLElement {
+	const status = document.querySelector('[role="status"]');
+	if (!(status instanceof HTMLElement)) {
+		throw new Error('Status-Live-Region nicht gefunden');
 	}
-	return dialog;
+	return status;
 }
 
 describe('LoadingOverlay', () => {
-	it('rendert nichts wenn isVisible false ist', () => {
+	it('Live-Region existiert schon vor dem Sichtbarwerden (sonst verpassen Screenreader die erste Meldung)', () => {
 		render(LoadingOverlay, { isVisible: false, type: 'initial' });
 
-		expect(document.querySelector('[aria-labelledby="loading-title"]')).toBeNull();
+		const status = getStatusRegion();
+		expect(status.getAttribute('aria-live')).toBe('polite');
+		expect(status.textContent?.trim()).toBe('');
 	});
 
-	it('rendert Dialog mit ARIA-Attributen und Initial-Hinweis', () => {
+	it('zeigt Statusmeldung und Initial-Hinweis innerhalb der Live-Region', () => {
 		render(LoadingOverlay, { isVisible: true, type: 'initial' });
 
-		const dialog = getDialog();
-		expect(dialog.getAttribute('role')).toBe('dialog');
-		expect(dialog.getAttribute('aria-modal')).toBe('true');
-		expect(dialog.getAttribute('aria-labelledby')).toBe('loading-title');
-		expect(document.body.textContent).toContain('Karte wird initialisiert...');
-		expect(document.body.textContent).toContain('Verwenden Sie H für Tastaturkürzel');
+		const status = getStatusRegion();
+		expect(status.textContent).toContain('Karte wird initialisiert...');
+		expect(status.textContent).toContain('Tastaturkürzel');
+	});
+
+	it('enthält keine Dialog-/Modal-Attribute mehr', () => {
+		render(LoadingOverlay, { isVisible: true, type: 'initial' });
+
+		expect(document.querySelector('[role="dialog"]')).toBeNull();
+		expect(document.querySelector('[aria-modal]')).toBeNull();
 	});
 
 	it('zeigt den passenden Text für Filter-Ladevorgänge', () => {
 		render(LoadingOverlay, { isVisible: true, type: 'filter' });
 
 		expect(document.body.textContent).toContain('Filter werden angewendet...');
-		expect(document.body.textContent).not.toContain('Verwenden Sie H für Tastaturkürzel');
+		expect(document.body.textContent).not.toContain('Tastaturkürzel');
 	});
 });

--- a/src/lib/components/map/LoadingOverlay.svelte.test.ts
+++ b/src/lib/components/map/LoadingOverlay.svelte.test.ts
@@ -42,6 +42,14 @@ describe('LoadingOverlay', () => {
 		expect(document.querySelector('[aria-modal]')).toBeNull();
 	});
 
+	it('dekoratives Spinner-Icon ist aria-hidden (wird in der Live-Region nicht mit angesagt)', () => {
+		render(LoadingOverlay, { isVisible: true, type: 'filter' });
+
+		const svg = document.querySelector('[role="status"] svg');
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute('aria-hidden')).toBe('true');
+	});
+
 	it('zeigt den passenden Text für Filter-Ladevorgänge', () => {
 		render(LoadingOverlay, { isVisible: true, type: 'filter' });
 

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -1,21 +1,42 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { getDaysInYear } from '$lib/map/dateUtils';
+	import { focusPanelHeading, returnFocusToToggle } from '$lib/map/panelFocus';
 
 	let {
 		years = [],
 		defaultYear,
 		yearCounts = {},
-		isLoading = false
+		isLoading = false,
+		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
+		// den State steuern können statt über DOM-Queries.
+		isOpen = $bindable(false)
 	} = $props<{
 		years?: number[];
 		defaultYear?: number;
 		yearCounts?: Record<number, number>;
 		isLoading?: boolean;
+		isOpen?: boolean;
 	}>();
 
-	// Reactive state für Panel-Sichtbarkeit (Svelte 5 runes)
-	let isOpen = $state(false);
+	// Element-Referenzen für das Fokus-Management (H5)
+	let panelEl = $state<HTMLDivElement>();
+	let toggleEl = $state<HTMLButtonElement>();
+	let headingEl = $state<HTMLHeadingElement>();
+
+	// H5: Fokus folgt dem Panel-Zustand — beim Öffnen auf die Überschrift,
+	// beim Schließen zurück zum Toggle. Läuft auch, wenn der Zustand von
+	// außen (Tastaturkürzel im Parent) geändert wird.
+	let wasOpen = false;
+	$effect(() => {
+		if (isOpen === wasOpen) return;
+		wasOpen = isOpen;
+		if (isOpen) {
+			focusPanelHeading(headingEl);
+		} else {
+			returnFocusToToggle(panelEl, toggleEl);
+		}
+	});
 	// Explizite User-Auswahl (undefined = noch keine manuelle Wahl getroffen)
 	let userSelectedYear: number | undefined = $state(undefined);
 	// Effektiv gewähltes Jahr: User-Auswahl hat Vorrang, sonst Prop-Default
@@ -44,10 +65,13 @@
 
 <!-- Toggle Button (always visible) -->
 <button
+	bind:this={toggleEl}
 	onclick={togglePanel}
 	class="glass text-base-content hover:bg-base-200 border-primary/20 fixed top-20 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
 	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
-	aria-label="Filter {isOpen ? 'schließen' : 'öffnen'}"
+	aria-label="Filter"
+	aria-expanded={isOpen}
+	aria-controls="filter-panel"
 >
 	<Icon
 		icon={isLoading ? 'lucide:loader-2' : 'lucide:filter'}
@@ -61,19 +85,25 @@
 	</div>
 </button>
 
-<!-- Panel Container -->
+<!-- Panel Container: nicht-modales Seitenpanel (H5) — role="region" statt
+     Fake-Dialog; inert nimmt das geschlossene (nur verschobene) Panel samt
+     seiner 18 fokussierbaren Elemente aus Tab-Zyklus und Accessibility-Tree. -->
 <div
+	bind:this={panelEl}
+	id="filter-panel"
 	class="glass border-primary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
 	style="transform: translateX({isOpen ? '0px' : '100%'});"
-	role="dialog"
-	aria-modal="true"
+	role="region"
 	aria-labelledby="filter-title"
-	aria-hidden={!isOpen}
+	inert={!isOpen}
 >
 	<div class="scroll-styled h-full overflow-y-auto">
 		<div class="p-4">
 			<div class="mb-3 flex items-center justify-between">
-				<h2 id="filter-title" class="text-lg font-bold">Filter</h2>
+				<!-- tabindex="-1": Fokusziel beim Öffnen des Panels (H5) -->
+				<h2 id="filter-title" tabindex="-1" bind:this={headingEl} class="text-lg font-bold">
+					Filter
+				</h2>
 				<button
 					onclick={closePanel}
 					class="btn btn-ghost btn-xs hover:bg-base-200"

--- a/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
@@ -6,17 +6,23 @@ import FilterPanel from './FilterPanel.svelte';
 const YEARS = [2023, 2024, 2025];
 
 function getFilterPanel(): HTMLElement {
-	const panel = document.querySelector('[aria-labelledby="filter-title"]');
+	const panel = document.querySelector('#filter-panel');
 	if (!(panel instanceof HTMLElement)) {
 		throw new Error('Filter panel not found');
 	}
 	return panel;
 }
 
+function getToggleButton(): HTMLButtonElement {
+	const button = document.querySelector('button[aria-controls="filter-panel"]');
+	if (!(button instanceof HTMLButtonElement)) {
+		throw new Error('Filter toggle button not found');
+	}
+	return button;
+}
+
 function getCloseButton(): HTMLButtonElement {
-	const button = document.querySelector(
-		'[aria-labelledby="filter-title"] [aria-label="Filter schließen"]'
-	);
+	const button = document.querySelector('#filter-panel [aria-label="Filter schließen"]');
 	if (!(button instanceof HTMLButtonElement)) {
 		throw new Error('Filter close button not found');
 	}
@@ -48,47 +54,85 @@ function getSlider(id: string): HTMLInputElement {
 }
 
 describe('FilterPanel', () => {
-	it('öffnet und schließt das Panel über die Buttons', async () => {
+	it('öffnet und schließt das Panel über die Buttons (inert im geschlossenen Zustand)', async () => {
 		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
 
-		const toggleButton = page.getByRole('button', { name: /Filter öffnen/i });
 		const panel = getFilterPanel();
 
-		expect(panel.getAttribute('aria-hidden')).toBe('true');
-		await toggleButton.click();
+		// H5: Geschlossenes Panel ist inert — kein Element im Tab-Zyklus
+		expect(panel.inert).toBe(true);
+
+		await page.getByRole('button', { name: /^Filter$/i }).click();
 		await vi.waitFor(() => {
-			expect(panel.getAttribute('aria-hidden')).toBe('false');
+			expect(panel.inert).toBe(false);
 		});
 
 		getCloseButton().click();
 		await vi.waitFor(() => {
-			expect(panel.getAttribute('aria-hidden')).toBe('true');
+			expect(panel.inert).toBe(true);
+		});
+	});
+
+	it('Toggle-Button trägt aria-expanded und aria-controls (H5)', async () => {
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		const toggle = getToggleButton();
+		expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+		await page.getByRole('button', { name: /^Filter$/i }).click();
+		await vi.waitFor(() => {
+			expect(toggle.getAttribute('aria-expanded')).toBe('true');
+		});
+	});
+
+	it('Elemente im geschlossenen Panel sind nicht fokussierbar (WCAG 4.1.2)', async () => {
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		const yearSelect = getYearSelect();
+		yearSelect.focus();
+		expect(document.activeElement).not.toBe(yearSelect);
+	});
+
+	it('beim Öffnen wandert der Fokus auf die Panel-Überschrift, beim Schließen zurück zum Toggle', async () => {
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await page.getByRole('button', { name: /^Filter$/i }).click();
+		const heading = document.querySelector('#filter-title');
+		await vi.waitFor(() => {
+			expect(document.activeElement).toBe(heading);
+		});
+
+		await page.getByRole('button', { name: 'Filter schließen' }).click();
+		await vi.waitFor(() => {
+			expect(document.activeElement).toBe(getToggleButton());
 		});
 	});
 
 	it('behält Suchtext beim Schließen und erneuten Öffnen', async () => {
 		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
 
-		await page.getByRole('button', { name: /Filter öffnen/i }).click();
+		await page.getByRole('button', { name: /^Filter$/i }).click();
 		const searchInput = getSearchInput();
 		searchInput.value = 'Seehund';
 		searchInput.dispatchEvent(new Event('input', { bubbles: true }));
 
 		getCloseButton().click();
-		await page.getByRole('button', { name: /Filter öffnen/i }).click();
+		await page.getByRole('button', { name: /^Filter$/i }).click();
 
 		await vi.waitFor(() => {
 			expect(getSearchInput().value).toBe('Seehund');
 		});
 	});
 
-	it('zeigt Jahresoptionen und korrekte ARIA-Attribute', async () => {
+	it('zeigt Jahresoptionen und korrekte ARIA-Attribute (region statt dialog)', async () => {
 		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
 
-		await page.getByRole('button', { name: /Filter öffnen/i }).click();
+		await page.getByRole('button', { name: /^Filter$/i }).click();
 
+		// H5: Nicht-modales Seitenpanel — role="region", kein aria-modal
 		const panel = getFilterPanel();
-		expect(panel.getAttribute('aria-modal')).toBe('true');
+		expect(panel.getAttribute('role')).toBe('region');
+		expect(panel.hasAttribute('aria-modal')).toBe(false);
 		expect(panel.getAttribute('aria-labelledby')).toBe('filter-title');
 
 		const options = getYearSelect().querySelectorAll('option');
@@ -98,7 +142,7 @@ describe('FilterPanel', () => {
 	it('passt Slider-Maximum bei Schaltjahr an', async () => {
 		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
 
-		await page.getByRole('button', { name: /Filter öffnen/i }).click();
+		await page.getByRole('button', { name: /^Filter$/i }).click();
 		const yearSelect = getYearSelect();
 		yearSelect.value = '2024';
 		yearSelect.dispatchEvent(new Event('change', { bubbles: true }));

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -11,17 +11,41 @@
 		TOTFUND_RING_COLOR
 	} from '$lib/map/styleUtils';
 	import Icon from '$lib/components/Icon.svelte';
+	import { focusPanelHeading, returnFocusToToggle } from '$lib/map/panelFocus';
 
-	let { translations, counts } = $props<{
+	let {
+		translations,
+		counts,
+		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
+		// den State steuern können statt über DOM-Queries.
+		isOpen = $bindable(false)
+	} = $props<{
 		translations: MapTranslations;
 		counts: CountData;
+		isOpen?: boolean;
 	}>();
 
 	// CountManager via typisiertem Svelte Context (Symbol-Key, siehe mapContext.ts)
 	const countManager = getMapCountManager();
 
-	// Reactive state für Panel-Sichtbarkeit (Svelte 5 runes)
-	let isOpen = $state(false);
+	// Element-Referenzen für das Fokus-Management (H5)
+	let panelEl = $state<HTMLDivElement>();
+	let toggleEl = $state<HTMLButtonElement>();
+	let headingEl = $state<HTMLHeadingElement>();
+
+	// H5: Fokus folgt dem Panel-Zustand — beim Öffnen auf die Überschrift,
+	// beim Schließen zurück zum Toggle. Läuft auch, wenn der Zustand von
+	// außen (Tastaturkürzel im Parent) geändert wird.
+	let wasOpen = false;
+	$effect(() => {
+		if (isOpen === wasOpen) return;
+		wasOpen = isOpen;
+		if (isOpen) {
+			focusPanelHeading(headingEl);
+		} else {
+			returnFocusToToggle(panelEl, toggleEl);
+		}
+	});
 
 	// Zustand der Sichtbarkeitsfilter
 	let speciesVisibility = $state<Record<string, boolean>>({});
@@ -81,10 +105,13 @@
 
 <!-- Toggle Button (always visible) -->
 <button
+	bind:this={toggleEl}
 	onclick={togglePanel}
 	class="glass text-base-content hover:bg-base-200 border-secondary/20 fixed top-52 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
 	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
-	aria-label="Legende {isOpen ? 'schließen' : 'öffnen'}"
+	aria-label="Legende"
+	aria-expanded={isOpen}
+	aria-controls="legend-panel"
 >
 	<Icon icon="lucide:list" class="mb-1 h-4 w-4" />
 	<div
@@ -95,19 +122,25 @@
 	</div>
 </button>
 
-<!-- Panel Container -->
+<!-- Panel Container: nicht-modales Seitenpanel (H5) — role="region" statt
+     Fake-Dialog; inert nimmt das geschlossene (nur verschobene) Panel samt
+     seiner fokussierbaren Elemente aus Tab-Zyklus und Accessibility-Tree. -->
 <div
+	bind:this={panelEl}
+	id="legend-panel"
 	class="glass border-secondary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
 	style="transform: translateX({isOpen ? '0px' : '100%'});"
-	role="dialog"
-	aria-modal="true"
+	role="region"
 	aria-labelledby="legend-title"
-	aria-hidden={!isOpen}
+	inert={!isOpen}
 >
 	<div class="scroll-styled h-full overflow-y-auto">
 		<div class="p-6">
 			<div class="mb-4 flex items-center justify-between">
-				<h2 id="legend-title" class="text-xl font-bold">Legende</h2>
+				<!-- tabindex="-1": Fokusziel beim Öffnen des Panels (H5) -->
+				<h2 id="legend-title" tabindex="-1" bind:this={headingEl} class="text-xl font-bold">
+					Legende
+				</h2>
 				<button
 					onclick={closePanel}
 					class="btn btn-ghost btn-sm hover:bg-base-200"

--- a/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
@@ -95,30 +95,48 @@ describe('LegendPanel', () => {
 		vi.clearAllMocks();
 	});
 
-	it('öffnet und schließt das Panel über die Buttons', async () => {
+	it('öffnet und schließt das Panel über die Buttons (inert im geschlossenen Zustand)', async () => {
 		render(LegendPanel, { translations, counts });
 
+		// H5: Geschlossenes Panel ist inert — kein Element im Tab-Zyklus
 		const panel = getLegendPanel();
-		expect(panel.getAttribute('aria-hidden')).toBe('true');
+		expect(panel.inert).toBe(true);
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 		await vi.waitFor(() => {
-			expect(panel.getAttribute('aria-hidden')).toBe('false');
+			expect(panel.inert).toBe(false);
 		});
 
 		getCloseButton().click();
 		await vi.waitFor(() => {
-			expect(panel.getAttribute('aria-hidden')).toBe('true');
+			expect(panel.inert).toBe(true);
+		});
+	});
+
+	it('Toggle-Button trägt aria-expanded und aria-controls (H5)', async () => {
+		render(LegendPanel, { translations, counts });
+
+		const toggle = document.querySelector('button[aria-controls="legend-panel"]');
+		if (!(toggle instanceof HTMLButtonElement)) {
+			throw new Error('Legend toggle button not found');
+		}
+		expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+		await page.getByRole('button', { name: /^Legende$/i }).click();
+		await vi.waitFor(() => {
+			expect(toggle.getAttribute('aria-expanded')).toBe('true');
 		});
 	});
 
 	it('rendert Arten-, Farbgruppen- und Zählerdaten', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
+		// H5: Nicht-modales Seitenpanel — role="region", kein aria-modal
 		const panel = getLegendPanel();
-		expect(panel.getAttribute('aria-modal')).toBe('true');
+		expect(panel.getAttribute('role')).toBe('region');
+		expect(panel.hasAttribute('aria-modal')).toBe(false);
 		expect(panel.getAttribute('aria-labelledby')).toBe('legend-title');
 
 		expect(document.querySelectorAll('.species-checkbox')).toHaveLength(4);
@@ -131,7 +149,7 @@ describe('LegendPanel', () => {
 	it('zeigt Gruppen-Badges aus den styleUtils-Konstanten (Kegelrobbe → Robbe)', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		const sealRow = document.querySelector('[data-species-row="1"]');
 		expect(sealRow?.textContent).toContain('Robbe');
@@ -140,7 +158,7 @@ describe('LegendPanel', () => {
 	it('weist Unbekannte Walart nicht als Großwal aus (M8)', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		const unknownRow = document.querySelector('[data-species-row="8"]');
 		expect(unknownRow?.textContent).not.toContain('Großwal');
@@ -150,7 +168,7 @@ describe('LegendPanel', () => {
 	it('graut Arten ohne Sichtungen (0/0) aus, Checkbox bleibt bedienbar', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		const unknownRow = document.querySelector('[data-species-row="8"]');
 		expect(unknownRow?.querySelector('.grayscale')).not.toBeNull();
@@ -170,7 +188,7 @@ describe('LegendPanel', () => {
 			counts
 		});
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		const row = document.querySelector('[data-species-row="99"]');
 		const swatch = row?.querySelector('div[style*="border"]');
@@ -182,7 +200,7 @@ describe('LegendPanel', () => {
 	it('erklärt die Cluster-Farbskala', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		expect(document.body.textContent).toContain('Cluster');
 		expect(document.body.textContent).toContain('je dunkler');
@@ -191,7 +209,7 @@ describe('LegendPanel', () => {
 	it('meldet Species- und Farb-Toggles an den CountManager', async () => {
 		render(LegendPanel, { translations, counts });
 
-		await page.getByRole('button', { name: /Legende öffnen/i }).click();
+		await page.getByRole('button', { name: /^Legende$/i }).click();
 
 		const speciesCheckbox = getSpeciesCheckbox('0');
 		speciesCheckbox.checked = false;

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -109,6 +109,11 @@
 	// zur Karte und zeigt dieselbe gefilterte Datenmenge.
 	let viewMode = $state<'map' | 'list'>('map');
 	let showKeyboardHelp = $state(false);
+	// H5: Panel-Zustände leben hier und werden per bind:isOpen an die Panels
+	// gereicht — Tastaturkürzel schalten den State direkt statt DOM-Buttons
+	// per querySelector zu klicken.
+	let filterOpen = $state(false);
+	let legendOpen = $state(false);
 	let isLoadingData = $state(false);
 	let isInitialLoading = $state(true);
 	let loadingType = $state<'initial' | 'filter' | 'features'>('initial');
@@ -355,6 +360,36 @@
 				return;
 			}
 
+			// Escape ist kein Zeichen-Shortcut (WCAG 2.1.4 greift nicht) und
+			// wirkt deshalb weiterhin global.
+			// QW3: Kaskade Popup → Hilfe-Modal → Filter-Panel → Legende.
+			// Jede Stufe schließt nur genau eine Ebene pro Tastendruck.
+			if (event.key === 'Escape') {
+				if (mapInstance?.closePopup()) {
+					return;
+				}
+				if (showKeyboardHelp) {
+					showKeyboardHelp = false;
+					return;
+				}
+				if (filterOpen) {
+					filterOpen = false;
+					return;
+				}
+				if (legendOpen) {
+					legendOpen = false;
+				}
+				return;
+			}
+
+			// H7 (WCAG 2.1.4): Einzeltasten-Shortcuts nur, wenn der Fokus in
+			// der Karten-Region liegt — sonst lösen Spracheingabe oder
+			// beiläufiges Tippen sie versehentlich aus.
+			const mapElement = document.getElementById(mapContainerId);
+			if (!(event.target instanceof Node) || !mapElement?.contains(event.target)) {
+				return;
+			}
+
 			switch (event.key) {
 				case 'h':
 				case 'H':
@@ -363,59 +398,20 @@
 					showKeyboardHelp = !showKeyboardHelp;
 					break;
 				case 'f':
-				case 'F': {
+				case 'F':
 					event.preventDefault();
-					// Toggle Filter Panel
-					const filterButton = document.querySelector(
-						'[aria-label*="Filter"]'
-					) as HTMLButtonElement;
-					filterButton?.click();
+					filterOpen = !filterOpen;
 					break;
-				}
 				case 'l':
-				case 'L': {
+				case 'L':
 					event.preventDefault();
-					// Toggle Legende Panel
-					const legendButton = document.querySelector(
-						'[aria-label*="Legende"]'
-					) as HTMLButtonElement;
-					legendButton?.click();
+					legendOpen = !legendOpen;
 					break;
-				}
 				case 'z':
-				case 'Z': {
+				case 'Z':
 					event.preventDefault();
-					// Zoom auf alle Meldungen
-					const zoomButton = document.querySelector(
-						'.zoom-all-control button'
-					) as HTMLButtonElement;
-					zoomButton?.click();
+					mapInstance?.zoomAllFeatures();
 					break;
-				}
-				case 'Escape': {
-					// QW3: Kaskade Popup → Hilfe-Modal → Filter-Panel → Legende.
-					// Jede Stufe schließt nur genau eine Ebene pro Tastendruck.
-					if (mapInstance?.closePopup()) {
-						break;
-					}
-					if (showKeyboardHelp) {
-						showKeyboardHelp = false;
-						break;
-					}
-					// Schließe offene Panels in der Priorität: Filter → Legende
-					const filterPanel = document.querySelector('[aria-labelledby="filter-title"]');
-					const legendPanel = document.querySelector('[aria-labelledby="legend-title"]');
-					if (filterPanel?.getAttribute('aria-hidden') === 'false') {
-						filterPanel
-							.querySelector<HTMLButtonElement>('[aria-label="Filter schließen"]')
-							?.click();
-					} else if (legendPanel?.getAttribute('aria-hidden') === 'false') {
-						legendPanel
-							.querySelector<HTMLButtonElement>('[aria-label="Legende schließen"]')
-							?.click();
-					}
-					break;
-				}
 			}
 		};
 		document.addEventListener('keydown', keyboardHandler);
@@ -593,10 +589,16 @@
 	</div>
 
 	<!-- Filter-Panel Komponente -->
-	<FilterPanel {years} {defaultYear} {yearCounts} isLoading={isLoadingData} />
+	<FilterPanel
+		{years}
+		{defaultYear}
+		{yearCounts}
+		isLoading={isLoadingData}
+		bind:isOpen={filterOpen}
+	/>
 
 	<!-- Legende-Panel Komponente -->
-	<LegendPanel {translations} {counts} />
+	<LegendPanel {translations} {counts} bind:isOpen={legendOpen} />
 
 	<!-- Tastatur-Hilfe Button -->
 	<button
@@ -671,6 +673,10 @@
 				</div>
 
 				<div class="text-base-content/60 mt-6 space-y-1 text-xs">
+					<p class="flex items-center gap-2">
+						<Icon icon="lucide:info" width="14" height="14" class="text-primary" />
+						Die Buchstaben-Kürzel wirken, solange der Fokus auf der Karte liegt
+					</p>
 					<p class="flex items-center gap-2">
 						<Icon icon="lucide:navigation" width="14" height="14" class="text-primary" />
 						Karte mit Tab fokussieren, dann mit den Pfeiltasten verschieben und mit + / − zoomen

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -350,18 +350,9 @@
 	 */
 	function setupKeyboardNavigation() {
 		keyboardHandler = (event) => {
-			// Nur aktiv wenn kein Input-Element fokussiert ist
-			if (
-				event.target instanceof HTMLInputElement ||
-				event.target instanceof HTMLSelectElement ||
-				event.target instanceof HTMLTextAreaElement ||
-				(event.target instanceof HTMLElement && event.target.isContentEditable)
-			) {
-				return;
-			}
-
 			// Escape ist kein Zeichen-Shortcut (WCAG 2.1.4 greift nicht) und
-			// wirkt deshalb weiterhin global.
+			// wirkt global — auch bei Fokus im Suchfeld, deshalb VOR dem
+			// Input-Guard behandelt.
 			// QW3: Kaskade Popup → Hilfe-Modal → Filter-Panel → Legende.
 			// Jede Stufe schließt nur genau eine Ebene pro Tastendruck.
 			if (event.key === 'Escape') {
@@ -379,6 +370,17 @@
 				if (legendOpen) {
 					legendOpen = false;
 				}
+				return;
+			}
+
+			// Zeichen-Shortcuts: nicht aktiv, wenn ein Eingabe-Element
+			// fokussiert ist
+			if (
+				event.target instanceof HTMLInputElement ||
+				event.target instanceof HTMLSelectElement ||
+				event.target instanceof HTMLTextAreaElement ||
+				(event.target instanceof HTMLElement && event.target.isContentEditable)
+			) {
 				return;
 			}
 
@@ -674,19 +676,19 @@
 
 				<div class="text-base-content/60 mt-6 space-y-1 text-xs">
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:info" width="14" height="14" class="text-primary" />
+						<Icon icon="lucide:info" width="14" height="14" class="text-primary" aria-hidden="true" />
 						Die Buchstaben-Kürzel wirken, solange der Fokus auf der Karte liegt
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:navigation" width="14" height="14" class="text-primary" />
+						<Icon icon="lucide:navigation" width="14" height="14" class="text-primary" aria-hidden="true" />
 						Karte mit Tab fokussieren, dann mit den Pfeiltasten verschieben und mit + / − zoomen
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:list" width="14" height="14" class="text-primary" />
+						<Icon icon="lucide:list" width="14" height="14" class="text-primary" aria-hidden="true" />
 						Der Umschalter „Karte / Liste" zeigt alle Sichtungen als Tabelle
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:mouse-pointer" width="14" height="14" class="text-primary" />
+						<Icon icon="lucide:mouse-pointer" width="14" height="14" class="text-primary" aria-hidden="true" />
 						Klicken Sie auf Marker für Details
 					</p>
 				</div>

--- a/src/lib/map/panelFocus.ts
+++ b/src/lib/map/panelFocus.ts
@@ -16,8 +16,9 @@ export function focusPanelHeading(heading: HTMLElement | undefined): void {
 /**
  * Gibt den Fokus an den Toggle-Button zurück — aber nur, wenn er beim
  * Schließen im Panel lag oder durch das `inert`-Attribut bereits auf
- * `<body>` zurückgefallen ist. Lag der Fokus woanders (z. B. auf der Karte
- * beim Schließen per Tastaturkürzel), wird er nicht gestohlen.
+ * `<body>`/`<html>` zurückgefallen ist (Browser unterscheiden sich hier).
+ * Lag der Fokus woanders (z. B. auf der Karte beim Schließen per
+ * Tastaturkürzel), wird er nicht gestohlen.
  */
 export function returnFocusToToggle(
 	panel: HTMLElement | undefined,
@@ -25,7 +26,12 @@ export function returnFocusToToggle(
 ): void {
 	void tick().then(() => {
 		const active = document.activeElement;
-		if (active === null || active === document.body || (panel?.contains(active) ?? false)) {
+		if (
+			active === null ||
+			active === document.body ||
+			active === document.documentElement ||
+			(panel?.contains(active) ?? false)
+		) {
 			toggle?.focus();
 		}
 	});

--- a/src/lib/map/panelFocus.ts
+++ b/src/lib/map/panelFocus.ts
@@ -1,0 +1,32 @@
+/**
+ * Fokus-Management für die nicht-modalen Seitenpanels der Sichtungskarte (H5).
+ *
+ * Beim Öffnen wandert der Fokus auf die Panel-Überschrift (Screenreader sagen
+ * damit den Kontext an), beim Schließen kehrt er zum Toggle-Button zurück.
+ * Beide Funktionen warten einen Tick, damit `inert` am Panel bereits im DOM
+ * angekommen ist, bevor der Fokus gesetzt wird.
+ */
+import { tick } from 'svelte';
+
+/** Setzt den Fokus nach dem nächsten DOM-Update auf die Panel-Überschrift. */
+export function focusPanelHeading(heading: HTMLElement | undefined): void {
+	void tick().then(() => heading?.focus());
+}
+
+/**
+ * Gibt den Fokus an den Toggle-Button zurück — aber nur, wenn er beim
+ * Schließen im Panel lag oder durch das `inert`-Attribut bereits auf
+ * `<body>` zurückgefallen ist. Lag der Fokus woanders (z. B. auf der Karte
+ * beim Schließen per Tastaturkürzel), wird er nicht gestohlen.
+ */
+export function returnFocusToToggle(
+	panel: HTMLElement | undefined,
+	toggle: HTMLElement | undefined
+): void {
+	void tick().then(() => {
+		const active = document.activeElement;
+		if (active === null || active === document.body || (panel?.contains(active) ?? false)) {
+			toggle?.focus();
+		}
+	});
+}


### PR DESCRIPTION
## Zusammenfassung

Behebt die Befunde **H5** (fehlerhafte ARIA-Semantik in Panels und Overlays) und **H7** (globale Einzeltasten-Shortcuts) aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md`.

### H5 — ARIA-Sanierung

- **FilterPanel/LegendPanel:** `role="dialog"` + `aria-modal="true"` auf den nicht-modalen Seitenpanels ersetzt durch `role="region"`; die Toggle-Buttons tragen jetzt ein statisches Label plus `aria-expanded`/`aria-controls`.
- **Tab-Zyklus:** Geschlossene Panels (nur per `translateX` verschoben) sind jetzt `inert` — die vorher 18 fokussierbaren Elemente hinter `aria-hidden` sind aus Tab-Reihenfolge und Accessibility-Tree entfernt (WCAG 4.1.2).
- **Fokus-Management** (neues Modul `src/lib/map/panelFocus.ts`): Beim Öffnen wandert der Fokus auf die Panel-Überschrift (`tabindex="-1"`), beim Schließen zurück zum Toggle-Button — nur wenn der Fokus im Panel lag, damit er beim Schließen per Shortcut nicht gestohlen wird.
- **LoadingOverlay:** `role="dialog"`/`aria-modal` saß auf dem leeren Backdrop-Div, `aria-labelledby` zeigte in einen fremden Teilbaum → jetzt dauerhaft im DOM stehende `role="status"`-Live-Region mit `aria-live="polite"` (Screenreader verpassen so die erste Statusänderung nicht).

### H7 — Einzeltasten-Shortcuts (WCAG 2.1.4)

- H/F/L/Z/? feuern nur noch, wenn der Fokus in der Karten-Region (`#map`) liegt — beiläufiges Tippen oder Spracheingabe löst sie nicht mehr aus. Escape ist kein Zeichen-Shortcut und wirkt weiterhin global (Kaskade Popup → Hilfe → Filter → Legende).
- Hilfe-Modal und Lade-Hinweis erklären die Fokus-Bedingung.

### Refactoring (Review-Empfehlung)

- Tastaturkürzel steuern die Panels über `bind:isOpen`-State statt `document.querySelector('[aria-label*="Filter"]').click()`; „Z" ruft `mapInstance.zoomAllFeatures()` direkt auf.

## Tests (Test-First)

- Komponententests der drei Komponenten auf die Soll-Semantik umgeschrieben und erweitert (inert, `aria-expanded`, Fokus-Wanderung, Status-Live-Region): **20/20 grün** (vitest-browser-svelte, echtes Chromium)
- Neue E2E-Tests: „F-Shortcut wirkt nicht bei Fokus außerhalb der Karte", „Fokus kehrt zum Toggle zurück", „Geschlossene Panels sind inert"; bestehende Specs von `aria-hidden` auf `inert`/`aria-expanded` umgestellt — **alle 38 Karten-E2E-Tests grün**
- `npm run test:quick` (ESLint, TypeScript, svelte-check, 2102 Server-Unit-Tests): grün
- Projekt-Code-Review (`/review`): 0 Anti-Patterns, keine kritischen Befunde

## Doku

- Statustabelle und Roadmap in `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` aktualisiert (H5/H7 → ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)