### PR TITLE
feat(map): bottom-sheet-panels auf mobile und 320-px-seitenpanels am desktop (H6)

### DIFF
--- a/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
+++ b/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
@@ -210,49 +210,49 @@ Zoom-Buttons tragen englische Titles/Labels („Zoom in", „Zoom out") in anson
 
 Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 
-| Kriterium                                           | Status                                                 | Verweis |
-| --------------------------------------------------- | ------------------------------------------------------ | ------- |
-| **Navigation/Controls**                             |                                                        |         |
-| Zoom-Buttons sichtbar, ≥44 px                       | ❌ 19×19 px                                            | H4      |
-| Kein Verdecken relevanter Daten durch UI            | ❌ Panels über Datenfläche                             | H6      |
-| Zustand teilbar (URL)                               | ❌                                                     | M4      |
-| Home-/Ausgangsansicht                               | ❌                                                     | M5      |
-| „Locate me"                                         | ❌ implementiert, deaktiviert                          | N2      |
-| Basemap lenkt nicht ab                              | ⚠️ OpenSeaMap dominiert ab Z12                         | M3      |
-| **Marker/Cluster**                                  |                                                        |         |
-| Clustering mit Zählern                              | ✅                                                     | —       |
-| Cluster-Klick zoomt / ortsgleiche auffächerbar      | ✅ Liste statt Spiderfy                                | —       |
-| Cluster überlappen nicht                            | ❌                                                     | M2      |
-| ≤6 colorblind-sichere Farben, Farbe + zweiter Kanal | ⚠️ Anzahl-Farben ok, Artcodierung faktisch wirkungslos | M1      |
-| Selected-State des Markers                          | ❌                                                     | M6      |
-| **Popups/Details**                                  |                                                        |         |
-| Nur Identifikations-Kern + Weg zu Details           | ⚠️ kein Detail-Link                                    | M6      |
-| Escape + X, Fokusrückgabe                           | ❌ Escape fehlt, kein Fokus-Mgmt                       | H1/H5   |
-| Nur ein Popup zugleich                              | ✅                                                     | —       |
-| Popup konsistent mit Filterzustand                  | ❌ Stale Popup                                         | H1      |
-| **Filter/Legende**                                  |                                                        |         |
-| Wirkung sofort sichtbar                             | ✅                                                     | —       |
-| Ergebnisanzahl sichtbar                             | ⚠️ nur in Legende (sichtbar/gesamt), nicht am Suchfeld | H3      |
-| Aktive Filter als Chips + Reset                     | ❌                                                     | M4      |
-| Slider mit numerischem Fallback                     | ❌                                                     | M10     |
-| Legende konsistent mit Kartendarstellung            | ❌                                                     | M1      |
-| Ladeindikator bei Filteranwendung                   | ⚠️ vorhanden, aber fake-getimt bzw. überblockierend    | H3/M7   |
-| **Mobile/Touch**                                    |                                                        |         |
-| Kein Layout-Bruch auf 375 px                        | ❌ Panel > Viewport                                    | H6      |
-| Details als Bottom Sheet                            | ❌ Desktop-Popup auch mobil                            | H6      |
-| Touch-Targets ≥44 px                                | ❌                                                     | H4      |
-| Pinch/Drag + Button-Alternativen                    | ✅                                                     | —       |
-| **Performance/Laden**                               |                                                        |         |
-| Clustering statt DOM-Marker                         | ✅ Canvas + Cluster                                    | —       |
-| Request-Abbruch bei schnellen Wechseln              | ✅ AbortController                                     | —       |
-| Kein Layout-Shift                                   | ✅                                                     | —       |
-| **Accessibility**                                   |                                                        |         |
-| Karte fokussierbar, Tastatur-Pan/Zoom               | ✅ behoben 2026-07-29 (`tabindex="0"` + Fokusring)     | K3      |
-| Marker per Tastatur/SR erreichbar                   | ✅ über Listenansicht (Umschalter „Karte / Liste")     | K3      |
-| Datenalternative (Tabelle/Liste)                    | ✅ behoben 2026-07-29 (`SightingsListView`)            | K3      |
-| Korrekte ARIA-Semantik                              | ✅ behoben 2026-07-29 (region + inert + Fokus-Mgmt)    | H5      |
-| Einzeltasten-Shortcuts abschaltbar                  | ✅ behoben 2026-07-29 (nur bei Fokus in der Karte)     | H7      |
-| Kontraste in Panels/Popups                          | ⚠️ Beluga-Badge, sonst ok                              | M1      |
+| Kriterium                                           | Status                                                                               | Verweis |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ | ------- |
+| **Navigation/Controls**                             |                                                                                      |         |
+| Zoom-Buttons sichtbar, ≥44 px                       | ❌ 19×19 px                                                                          | H4      |
+| Kein Verdecken relevanter Daten durch UI            | ⚠️ Panels auf 320 px reduziert (2026-07-29), überlagern rechts weiterhin             | H6      |
+| Zustand teilbar (URL)                               | ❌                                                                                   | M4      |
+| Home-/Ausgangsansicht                               | ❌                                                                                   | M5      |
+| „Locate me"                                         | ❌ implementiert, deaktiviert                                                        | N2      |
+| Basemap lenkt nicht ab                              | ⚠️ OpenSeaMap dominiert ab Z12                                                       | M3      |
+| **Marker/Cluster**                                  |                                                                                      |         |
+| Clustering mit Zählern                              | ✅                                                                                   | —       |
+| Cluster-Klick zoomt / ortsgleiche auffächerbar      | ✅ Liste statt Spiderfy                                                              | —       |
+| Cluster überlappen nicht                            | ❌                                                                                   | M2      |
+| ≤6 colorblind-sichere Farben, Farbe + zweiter Kanal | ⚠️ Anzahl-Farben ok, Artcodierung faktisch wirkungslos                               | M1      |
+| Selected-State des Markers                          | ❌                                                                                   | M6      |
+| **Popups/Details**                                  |                                                                                      |         |
+| Nur Identifikations-Kern + Weg zu Details           | ⚠️ kein Detail-Link                                                                  | M6      |
+| Escape + X, Fokusrückgabe                           | ❌ Escape fehlt, kein Fokus-Mgmt                                                     | H1/H5   |
+| Nur ein Popup zugleich                              | ✅                                                                                   | —       |
+| Popup konsistent mit Filterzustand                  | ❌ Stale Popup                                                                       | H1      |
+| **Filter/Legende**                                  |                                                                                      |         |
+| Wirkung sofort sichtbar                             | ✅                                                                                   | —       |
+| Ergebnisanzahl sichtbar                             | ⚠️ nur in Legende (sichtbar/gesamt), nicht am Suchfeld                               | H3      |
+| Aktive Filter als Chips + Reset                     | ❌                                                                                   | M4      |
+| Slider mit numerischem Fallback                     | ❌                                                                                   | M10     |
+| Legende konsistent mit Kartendarstellung            | ❌                                                                                   | M1      |
+| Ladeindikator bei Filteranwendung                   | ⚠️ vorhanden, aber fake-getimt bzw. überblockierend                                  | H3/M7   |
+| **Mobile/Touch**                                    |                                                                                      |         |
+| Kein Layout-Bruch auf 375 px                        | ✅ behoben 2026-07-29 (Panels als Bottom-Sheet < md)                                 | H6      |
+| Details als Bottom Sheet                            | ⚠️ Filter/Legende als Bottom-Sheet (2026-07-29); Marker-Popup weiterhin Desktop-Stil | H6      |
+| Touch-Targets ≥44 px                                | ❌                                                                                   | H4      |
+| Pinch/Drag + Button-Alternativen                    | ✅                                                                                   | —       |
+| **Performance/Laden**                               |                                                                                      |         |
+| Clustering statt DOM-Marker                         | ✅ Canvas + Cluster                                                                  | —       |
+| Request-Abbruch bei schnellen Wechseln              | ✅ AbortController                                                                   | —       |
+| Kein Layout-Shift                                   | ✅                                                                                   | —       |
+| **Accessibility**                                   |                                                                                      |         |
+| Karte fokussierbar, Tastatur-Pan/Zoom               | ✅ behoben 2026-07-29 (`tabindex="0"` + Fokusring)                                   | K3      |
+| Marker per Tastatur/SR erreichbar                   | ✅ über Listenansicht (Umschalter „Karte / Liste")                                   | K3      |
+| Datenalternative (Tabelle/Liste)                    | ✅ behoben 2026-07-29 (`SightingsListView`)                                          | K3      |
+| Korrekte ARIA-Semantik                              | ✅ behoben 2026-07-29 (region + inert + Fokus-Mgmt)                                  | H5      |
+| Einzeltasten-Shortcuts abschaltbar                  | ✅ behoben 2026-07-29 (nur bei Fokus in der Karte)                                   | H7      |
+| Kontraste in Panels/Popups                          | ⚠️ Beluga-Badge, sonst ok                                                            | M1      |
 
 ---
 
@@ -276,7 +276,7 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 - M1: Einheitliches Marker-/Legenden-Codierungssystem (colorblind-safe, Legende aus gemeinsamen Konstanten).
 - M4: URL-State + Filter-Chips + Reset.
 - M7: Loading-Konzept (Vollbild nur initial).
-- H6: Mobile Bottom-Sheet für Filter/Legende.
+- H6: Mobile Bottom-Sheet für Filter/Legende. — **Umgesetzt 2026-07-29** (gemeinsame Wrapper-Komponente `MapPanel.svelte`: < md Bottom-Sheet mit Peek/Expanded-Zustand, Schließen per Button, ab md 320-px-Seitenpanel mit `h-[calc(100%-5rem)]`; Öffnen des einen Panels schließt das andere in `SightingsMapView.svelte`; solange ein Sheet offen ist, blendet Mobile die Toggle-Tabs aus, weil sie sonst den Sheet-Header verdecken).
 
 **Strategisch:**
 

--- a/e2e/map-panels.spec.ts
+++ b/e2e/map-panels.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Page } from '@playwright/test';
+import { MapPage } from './pages/MapPage';
+import { setupMapPage } from './fixtures/mapSetup';
+
+/**
+ * Befund H6: Panels als Bottom-Sheet auf Mobile, 320-px-Panels mit
+ * gegenseitigem Schließen auf Desktop.
+ */
+test.describe.serial('Map Panels (H6) — Desktop', () => {
+	let mapPage: MapPage;
+	let sharedPage: Page;
+
+	test.beforeAll(async ({ browser }) => {
+		sharedPage = await browser.newPage();
+		mapPage = await setupMapPage(sharedPage);
+	});
+
+	test.afterAll(async () => {
+		await sharedPage.close();
+	});
+
+	test('Öffnen der Legende schließt das Filter-Panel und umgekehrt (Exklusivität)', async () => {
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+
+		// Legende öffnen → Filter-Panel muss zugehen
+		await mapPage.openLegend();
+		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', false);
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
+
+		// Filter öffnen → Legende muss zugehen
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+		await expect(mapPage.getLegendPanel()).toHaveJSProperty('inert', true);
+		await expect(mapPage.getLegendToggle()).toHaveAttribute('aria-expanded', 'false');
+
+		// Aufräumen für den nächsten Test
+		await sharedPage.keyboard.press('Escape');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+	});
+
+	test('Offenes Filter-Panel ist 320px breit und ragt nicht unten aus dem Viewport', async () => {
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+
+		// Geometrie erst nach der 300ms-Transition stabil → poll
+		await expect
+			.poll(async () => mapPage.getFilterPanel().evaluate((el) => el.getBoundingClientRect().width))
+			.toBe(320);
+
+		const fitsViewport = await mapPage
+			.getFilterPanel()
+			.evaluate((el) => el.getBoundingClientRect().bottom <= window.innerHeight);
+		expect(fitsViewport).toBe(true);
+
+		await sharedPage.keyboard.press('Escape');
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+	});
+});
+
+test.describe.serial('Map Panels (H6) — Mobile Bottom-Sheet', () => {
+	let mapPage: MapPage;
+	let mobilePage: Page;
+
+	test.beforeAll(async ({ browser }) => {
+		mobilePage = await browser.newPage({ viewport: { width: 375, height: 667 } });
+		mapPage = await setupMapPage(mobilePage);
+	});
+
+	test.afterAll(async () => {
+		await mobilePage.close();
+	});
+
+	test('Filter-Panel öffnet als Bottom-Sheet im peek-Zustand', async () => {
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+		await expect(mapPage.getFilterPanel()).toHaveAttribute('data-sheet-state', 'peek');
+
+		// Bottom-Sheet-Geometrie: unten, volle Breite (poll wegen 300ms-Transition)
+		await expect
+			.poll(async () =>
+				mapPage.getFilterPanel().evaluate((el) => {
+					const rect = el.getBoundingClientRect();
+					return {
+						left: rect.left,
+						fullWidth: rect.width === window.innerWidth,
+						atBottom: Math.abs(rect.bottom - window.innerHeight) <= 2
+					};
+				})
+			)
+			.toEqual({ left: 0, fullWidth: true, atBottom: true });
+	});
+
+	test('Vergrößern-Button schaltet das Sheet auf expanded', async () => {
+		await mobilePage.getByRole('button', { name: 'Filter vergrößern' }).click();
+		await expect(mapPage.getFilterPanel()).toHaveAttribute('data-sheet-state', 'expanded');
+
+		// expanded-Sheet nimmt mehr als 70% der Viewport-Höhe ein
+		await expect
+			.poll(async () =>
+				mapPage
+					.getFilterPanel()
+					.evaluate((el) => el.getBoundingClientRect().height > window.innerHeight * 0.7)
+			)
+			.toBe(true);
+	});
+
+	test('Filter schließen macht das Panel inert', async () => {
+		await mapPage.closeFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', true);
+		await expect(mapPage.getFilterToggle()).toHaveAttribute('aria-expanded', 'false');
+	});
+});

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -19,6 +19,7 @@
 	import CheckCircle from '~icons/lucide/check-circle';
 	import ChevronDown from '~icons/lucide/chevron-down';
 	import ChevronRight from '~icons/lucide/chevron-right';
+	import ChevronUp from '~icons/lucide/chevron-up';
 	import CircleAlert from '~icons/lucide/circle-alert';
 	import CircleCheck from '~icons/lucide/circle-check';
 	import CircleHelp from '~icons/lucide/circle-help';
@@ -46,7 +47,7 @@
 	import Heart from '~icons/lucide/heart';
 	import Home from '~icons/lucide/home';
 	import Image from '~icons/lucide/image';
-import Images from '~icons/lucide/images';
+	import Images from '~icons/lucide/images';
 	import Info from '~icons/lucide/info';
 	import List from '~icons/lucide/list';
 	import Loader2 from '~icons/lucide/loader-2';
@@ -112,6 +113,7 @@ import Images from '~icons/lucide/images';
 		'lucide:x': X,
 		'lucide:chevron-down': ChevronDown,
 		'lucide:chevron-right': ChevronRight,
+		'lucide:chevron-up': ChevronUp,
 		'lucide:filter': Filter,
 		'lucide:download': Download,
 		'lucide:columns': Columns,

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { getDaysInYear } from '$lib/map/dateUtils';
-	import { focusPanelHeading, returnFocusToToggle } from '$lib/map/panelFocus';
+	import MapPanel from './MapPanel.svelte';
 
 	let {
 		years = [],
 		defaultYear,
 		yearCounts = {},
 		isLoading = false,
+		// H6: Parent blendet die Toggle-Tabs auf Mobile aus, solange ein Sheet offen ist
+		toggleHidden = false,
 		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
 		// den State steuern können statt über DOM-Queries.
 		isOpen = $bindable(false)
@@ -16,27 +18,10 @@
 		defaultYear?: number;
 		yearCounts?: Record<number, number>;
 		isLoading?: boolean;
+		toggleHidden?: boolean;
 		isOpen?: boolean;
 	}>();
 
-	// Element-Referenzen für das Fokus-Management (H5)
-	let panelEl = $state<HTMLDivElement>();
-	let toggleEl = $state<HTMLButtonElement>();
-	let headingEl = $state<HTMLHeadingElement>();
-
-	// H5: Fokus folgt dem Panel-Zustand — beim Öffnen auf die Überschrift,
-	// beim Schließen zurück zum Toggle. Läuft auch, wenn der Zustand von
-	// außen (Tastaturkürzel im Parent) geändert wird.
-	let wasOpen = false;
-	$effect(() => {
-		if (isOpen === wasOpen) return;
-		wasOpen = isOpen;
-		if (isOpen) {
-			focusPanelHeading(headingEl);
-		} else {
-			returnFocusToToggle(panelEl, toggleEl);
-		}
-	});
 	// Explizite User-Auswahl (undefined = noch keine manuelle Wahl getroffen)
 	let userSelectedYear: number | undefined = $state(undefined);
 	// Effektiv gewähltes Jahr: User-Auswahl hat Vorrang, sonst Prop-Default
@@ -47,173 +32,121 @@
 
 	let daysInYear = $derived(getDaysInYear(selectedYear));
 
-	// Toggle-Funktion für das Panel
-	function togglePanel() {
-		isOpen = !isOpen;
-	}
-
-	// Schließe Panel
-	function closePanel() {
-		isOpen = false;
-	}
-
 	function handleYearChange(e: Event) {
 		const year = parseInt((e.target as HTMLSelectElement).value, 10);
 		if (!isNaN(year)) userSelectedYear = year;
 	}
 </script>
 
-<!-- Toggle Button (always visible) -->
-<button
-	bind:this={toggleEl}
-	onclick={togglePanel}
-	class="glass text-base-content hover:bg-base-200 border-primary/20 fixed top-20 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
-	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
-	aria-label="Filter"
-	aria-expanded={isOpen}
-	aria-controls="filter-panel"
+<MapPanel
+	panelId="filter-panel"
+	titleId="filter-title"
+	title="Filter"
+	toggleText="FILTER"
+	icon="lucide:filter"
+	togglePositionClass="top-20"
+	accentBorderClass="border-primary/20"
+	{isLoading}
+	{toggleHidden}
+	bind:isOpen
 >
-	<Icon
-		icon={isLoading ? 'lucide:loader-2' : 'lucide:filter'}
-		class="mb-1 h-4 w-4 {isLoading ? 'animate-spin' : ''}"
-	/>
-	<div
-		class="text-xs whitespace-nowrap"
-		style="writing-mode: vertical-rl; text-orientation: mixed;"
-	>
-		FILTER
-	</div>
-</button>
+	<div class="space-y-4">
+		<div class="fieldset w-full">
+			<label for="year-select" class="label py-1">
+				<span class="text-sm font-medium">Jahr</span>
+				{#if isLoading}
+					<Icon icon="lucide:loader-2" class="text-primary ml-2 h-3 w-3 animate-spin" />
+				{/if}
+			</label>
+			<select
+				id="year-select"
+				class="select select-sm focus:select-primary w-full text-sm {isLoading ? 'loading' : ''}"
+				title="Wählen Sie das Jahr aus, für das Sichtungen angezeigt werden sollen"
+				onchange={handleYearChange}
+			>
+				{#each years.toReversed() as year (year)}
+					<option value={year} selected={year === selectedYear}>
+						{yearCounts[year] ? `${year} (${yearCounts[year]})` : year}
+					</option>
+				{/each}
+			</select>
+		</div>
 
-<!-- Panel Container: nicht-modales Seitenpanel (H5) — role="region" statt
-     Fake-Dialog; inert nimmt das geschlossene (nur verschobene) Panel samt
-     seiner 18 fokussierbaren Elemente aus Tab-Zyklus und Accessibility-Tree. -->
-<div
-	bind:this={panelEl}
-	id="filter-panel"
-	class="glass border-primary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
-	style="transform: translateX({isOpen ? '0px' : '100%'});"
-	role="region"
-	aria-labelledby="filter-title"
-	inert={!isOpen}
->
-	<div class="scroll-styled h-full overflow-y-auto">
-		<div class="p-4">
-			<div class="mb-3 flex items-center justify-between">
-				<!-- tabindex="-1": Fokusziel beim Öffnen des Panels (H5) -->
-				<h2 id="filter-title" tabindex="-1" bind:this={headingEl} class="text-lg font-bold">
-					Filter
-				</h2>
-				<button
-					onclick={closePanel}
-					class="btn btn-ghost btn-xs hover:bg-base-200"
-					aria-label="Filter schließen"
-				>
-					<Icon icon="lucide:square-x" class="h-4 w-4" />
-				</button>
+		<div class="fieldset w-full">
+			<label for="filter-input" class="label py-1">
+				<span class="text-sm font-medium">Suchen</span>
+			</label>
+			<div class="relative">
+				<input
+					id="filter-input"
+					type="text"
+					bind:value={searchValue}
+					placeholder="Fahrwasser, Schiffsname, Name…"
+					class="input input-sm focus:input-primary w-full pr-10"
+					title="Nach Fahrwasser, Seezeichen, Schiffsname oder Name filtern. Filtert automatisch beim Tippen."
+					aria-describedby="filter-help"
+				/>
+				{#if isLoading}
+					<div class="absolute top-1/2 right-3 -translate-y-1/2 transform">
+						<Icon icon="lucide:loader-2" class="text-primary h-4 w-4 animate-spin" />
+					</div>
+				{/if}
+			</div>
+			<!-- Hilfetext ist über aria-describedby verknüpft — bewusst kein zweites
+			     <label>, sonst würde er zusätzlich in den Accessible Name einfließen -->
+			<div class="label py-0">
+				<span id="filter-help" class="text-base-content/60 text-xs">
+					{isLoading ? 'Filter wird angewendet...' : 'Filtert automatisch beim Tippen'}
+				</span>
+			</div>
+		</div>
+
+		<div class="space-y-3">
+			<div class="label py-1">
+				<span class="text-sm font-medium">Zeitraum</span>
 			</div>
 
-			<div class="space-y-4">
-				<div class="fieldset w-full">
-					<label for="year-select" class="label py-1">
-						<span class="text-sm font-medium">Jahr</span>
-						{#if isLoading}
-							<Icon icon="lucide:loader-2" class="text-primary ml-2 h-3 w-3 animate-spin" />
-						{/if}
+			<div class="space-y-3">
+				<div>
+					<label class="label py-0" for="time-range-start">
+						<span class="text-xs">Start</span>
 					</label>
-					<select
-						id="year-select"
-						class="select select-sm focus:select-primary w-full text-sm {isLoading
-							? 'loading'
-							: ''}"
-						title="Wählen Sie das Jahr aus, für das Sichtungen angezeigt werden sollen"
-						onchange={handleYearChange}
-					>
-						{#each years.toReversed() as year (year)}
-							<option value={year} selected={year === selectedYear}>
-								{yearCounts[year] ? `${year} (${yearCounts[year]})` : year}
-							</option>
-						{/each}
-					</select>
+					<input
+						type="range"
+						id="time-range-start"
+						class="range range-primary range-xs"
+						min="0"
+						max={daysInYear - 1}
+						value="0"
+					/>
+					<div class="mt-1">
+						<div
+							id="time-start"
+							class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
+						></div>
+					</div>
 				</div>
 
-				<div class="fieldset w-full">
-					<label for="filter-input" class="label py-1">
-						<span class="text-sm font-medium">Suchen</span>
+				<div>
+					<label class="label py-0" for="time-range-end">
+						<span class="text-xs">Ende</span>
 					</label>
-					<div class="relative">
-						<input
-							id="filter-input"
-							type="text"
-							bind:value={searchValue}
-							placeholder="Fahrwasser, Schiffsname, Name…"
-							class="input input-sm focus:input-primary w-full pr-10"
-							title="Nach Fahrwasser, Seezeichen, Schiffsname oder Name filtern. Filtert automatisch beim Tippen."
-							aria-describedby="filter-help"
-						/>
-						{#if isLoading}
-							<div class="absolute top-1/2 right-3 -translate-y-1/2 transform">
-								<Icon icon="lucide:loader-2" class="text-primary h-4 w-4 animate-spin" />
-							</div>
-						{/if}
-					</div>
-					<label class="label py-0" for="filter-input">
-						<span id="filter-help" class="text-base-content/60 text-xs">
-							{isLoading ? 'Filter wird angewendet...' : 'Filtert automatisch beim Tippen'}
-						</span>
-					</label>
-				</div>
-
-				<div class="space-y-3">
-					<div class="label py-1">
-						<span class="text-sm font-medium">Zeitraum</span>
-					</div>
-
-					<div class="space-y-3">
-						<div>
-							<label class="label py-0" for="time-range-start">
-								<span class="text-xs">Start</span>
-							</label>
-							<input
-								type="range"
-								id="time-range-start"
-								class="range range-primary range-xs"
-								min="0"
-								max={daysInYear - 1}
-								value="0"
-							/>
-							<div class="mt-1">
-								<div
-									id="time-start"
-									class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
-								></div>
-							</div>
-						</div>
-
-						<div>
-							<label class="label py-0" for="time-range-end">
-								<span class="text-xs">Ende</span>
-							</label>
-							<input
-								type="range"
-								id="time-range-end"
-								class="range range-primary range-xs"
-								min="0"
-								max={daysInYear - 1}
-								value={daysInYear - 1}
-							/>
-							<div class="mt-1">
-								<div
-									id="time-end"
-									class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
-								></div>
-							</div>
-						</div>
+					<input
+						type="range"
+						id="time-range-end"
+						class="range range-primary range-xs"
+						min="0"
+						max={daysInYear - 1}
+						value={daysInYear - 1}
+					/>
+					<div class="mt-1">
+						<div
+							id="time-end"
+							class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
+						></div>
 					</div>
 				</div>
 			</div>
 		</div>
 	</div>
-</div>
-
-<!-- Scrollbar styles sind jetzt global in app.css definiert -->
+</MapPanel>

--- a/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
@@ -1,7 +1,12 @@
 import { render } from 'vitest-browser-svelte';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import FilterPanel from './FilterPanel.svelte';
+// H6: Das Browser-Test-Setup lädt src/app.css nicht — für die Layout-Assertions
+// (Bottom-Sheet-Geometrie, md:hidden, Touch-Targets) müssen die Tailwind-Styles
+// aber wirken. Der Import gilt dateiweit und ändert an den bestehenden
+// (rein DOM-/Fokus-basierten) Tests nichts.
+import '../../../../app.css';
 
 const YEARS = [2023, 2024, 2025];
 
@@ -151,5 +156,147 @@ describe('FilterPanel', () => {
 			expect(getSlider('time-range-start').getAttribute('max')).toBe('365');
 			expect(getSlider('time-range-end').getAttribute('max')).toBe('365');
 		});
+	});
+});
+
+// ─── Befund H6: Panels als Bottom-Sheet (Mobile) / 320-px-Panel (Desktop) ────
+
+/** Vergrößern-/Verkleinern-Button im Panel-Header (H6, nur Mobile sichtbar) */
+function getSheetToggleButton(): HTMLButtonElement {
+	const button = document.querySelector(
+		'#filter-panel [aria-label="Filter vergrößern"], #filter-panel [aria-label="Filter verkleinern"]'
+	);
+	if (!(button instanceof HTMLButtonElement)) {
+		throw new Error('Vergrößern-Button not found');
+	}
+	return button;
+}
+
+async function openPanel(): Promise<void> {
+	await page.getByRole('button', { name: /^Filter$/i }).click();
+}
+
+describe('FilterPanel als Bottom-Sheet (H6)', () => {
+	afterEach(async () => {
+		// Vitest-Default-Viewport wiederherstellen, damit Folge-Tests
+		// nicht auf einem mobilen Viewport laufen
+		await page.viewport(414, 896);
+	});
+
+	it('Panel trägt data-sheet-state="peek" initial, nach dem Öffnen und nach erneutem Öffnen', async () => {
+		await page.viewport(375, 667);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		const panel = getFilterPanel();
+		expect(panel.getAttribute('data-sheet-state')).toBe('peek');
+
+		await openPanel();
+		expect(panel.getAttribute('data-sheet-state')).toBe('peek');
+
+		// Vergrößern → expanded
+		getSheetToggleButton().click();
+		await vi.waitFor(() => {
+			expect(panel.getAttribute('data-sheet-state')).toBe('expanded');
+		});
+
+		// Schließen und erneut öffnen → wieder peek
+		getCloseButton().click();
+		await vi.waitFor(() => {
+			expect(panel.inert).toBe(true);
+		});
+		await openPanel();
+		await vi.waitFor(() => {
+			expect(panel.getAttribute('data-sheet-state')).toBe('peek');
+		});
+	});
+
+	it('Vergrößern-Button wechselt aria-label und aria-expanded mit dem Sheet-Zustand', async () => {
+		await page.viewport(375, 667);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await openPanel();
+
+		const button = getSheetToggleButton();
+		expect(button.getAttribute('aria-label')).toBe('Filter vergrößern');
+		expect(button.getAttribute('aria-expanded')).toBe('false');
+
+		button.click();
+		await vi.waitFor(() => {
+			expect(getSheetToggleButton().getAttribute('aria-label')).toBe('Filter verkleinern');
+			expect(getSheetToggleButton().getAttribute('aria-expanded')).toBe('true');
+		});
+	});
+
+	it('Vergrößern-Button ist auf Desktop-Viewports per CSS versteckt (md:hidden)', async () => {
+		await page.viewport(1024, 768);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await openPanel();
+
+		// Im DOM vorhanden, aber ≥768px nicht sichtbar
+		const button = getSheetToggleButton();
+		expect(getComputedStyle(button).display).toBe('none');
+		expect(button.offsetParent).toBeNull();
+	});
+
+	it('Mobile: offenes Panel liegt als Bottom-Sheet unten über die volle Breite (peek 30–60%)', async () => {
+		await page.viewport(375, 667);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await openPanel();
+
+		// transition-transform (300ms) abwarten — Geometrie erst nach der Animation stabil
+		await vi.waitFor(
+			() => {
+				const rect = getFilterPanel().getBoundingClientRect();
+				expect(rect.left).toBe(0);
+				expect(rect.width).toBe(window.innerWidth);
+				expect(Math.abs(rect.bottom - window.innerHeight)).toBeLessThanOrEqual(2);
+				expect(rect.height).toBeGreaterThanOrEqual(window.innerHeight * 0.3);
+				expect(rect.height).toBeLessThanOrEqual(window.innerHeight * 0.6);
+			},
+			{ timeout: 2000 }
+		);
+	});
+
+	it('Mobile: expanded-Sheet nimmt mehr als 70% der Viewport-Höhe ein', async () => {
+		await page.viewport(375, 667);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await openPanel();
+		getSheetToggleButton().click();
+
+		await vi.waitFor(
+			() => {
+				const rect = getFilterPanel().getBoundingClientRect();
+				expect(rect.height).toBeGreaterThan(window.innerHeight * 0.7);
+				expect(Math.abs(rect.bottom - window.innerHeight)).toBeLessThanOrEqual(2);
+			},
+			{ timeout: 2000 }
+		);
+	});
+
+	it('Desktop: offenes Panel ist 320px breit und ragt nicht unten aus dem Viewport', async () => {
+		await page.viewport(1024, 768);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await openPanel();
+
+		await vi.waitFor(
+			() => {
+				const rect = getFilterPanel().getBoundingClientRect();
+				expect(rect.width).toBe(320);
+				expect(rect.bottom).toBeLessThanOrEqual(window.innerHeight);
+			},
+			{ timeout: 2000 }
+		);
+	});
+
+	it('Toggle-Button hält das 44px-Touch-Target auf Mobile (WCAG 2.5.5)', async () => {
+		await page.viewport(375, 667);
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		const rect = getToggleButton().getBoundingClientRect();
+		expect(rect.width).toBeGreaterThanOrEqual(44);
 	});
 });

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -11,41 +11,25 @@
 		TOTFUND_RING_COLOR
 	} from '$lib/map/styleUtils';
 	import Icon from '$lib/components/Icon.svelte';
-	import { focusPanelHeading, returnFocusToToggle } from '$lib/map/panelFocus';
+	import MapPanel from './MapPanel.svelte';
 
 	let {
 		translations,
 		counts,
+		// H6: Parent blendet die Toggle-Tabs auf Mobile aus, solange ein Sheet offen ist
+		toggleHidden = false,
 		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
 		// den State steuern können statt über DOM-Queries.
 		isOpen = $bindable(false)
 	} = $props<{
 		translations: MapTranslations;
 		counts: CountData;
+		toggleHidden?: boolean;
 		isOpen?: boolean;
 	}>();
 
 	// CountManager via typisiertem Svelte Context (Symbol-Key, siehe mapContext.ts)
 	const countManager = getMapCountManager();
-
-	// Element-Referenzen für das Fokus-Management (H5)
-	let panelEl = $state<HTMLDivElement>();
-	let toggleEl = $state<HTMLButtonElement>();
-	let headingEl = $state<HTMLHeadingElement>();
-
-	// H5: Fokus folgt dem Panel-Zustand — beim Öffnen auf die Überschrift,
-	// beim Schließen zurück zum Toggle. Läuft auch, wenn der Zustand von
-	// außen (Tastaturkürzel im Parent) geändert wird.
-	let wasOpen = false;
-	$effect(() => {
-		if (isOpen === wasOpen) return;
-		wasOpen = isOpen;
-		if (isOpen) {
-			focusPanelHeading(headingEl);
-		} else {
-			returnFocusToToggle(panelEl, toggleEl);
-		}
-	});
 
 	// Zustand der Sichtbarkeitsfilter
 	let speciesVisibility = $state<Record<string, boolean>>({});
@@ -64,16 +48,6 @@
 		...Object.values(speciesGroupStyles).map(({ label, color }) => ({ label, color })),
 		{ label: String(translations.found_dead), color: TOTFUND_RING_COLOR }
 	]);
-
-	// Toggle-Funktion für das Panel
-	function togglePanel() {
-		isOpen = !isOpen;
-	}
-
-	// Schließe Panel
-	function closePanel() {
-		isOpen = false;
-	}
 
 	// Initialisiere Visibility-States (alle sichtbar)
 	$effect(() => {
@@ -103,189 +77,149 @@
 	}
 </script>
 
-<!-- Toggle Button (always visible) -->
-<button
-	bind:this={toggleEl}
-	onclick={togglePanel}
-	class="glass text-base-content hover:bg-base-200 border-secondary/20 fixed top-52 right-0 z-50 flex h-32 w-8 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 sm:w-12 md:w-8"
-	style="transform: translateX({isOpen ? 'calc(-1 * min(400px, 100vw))' : '0px'});"
-	aria-label="Legende"
-	aria-expanded={isOpen}
-	aria-controls="legend-panel"
+<MapPanel
+	panelId="legend-panel"
+	titleId="legend-title"
+	title="Legende"
+	toggleText="LEGENDE"
+	icon="lucide:list"
+	togglePositionClass="top-52"
+	accentBorderClass="border-secondary/20"
+	{toggleHidden}
+	bind:isOpen
 >
-	<Icon icon="lucide:list" class="mb-1 h-4 w-4" />
-	<div
-		class="text-xs whitespace-nowrap"
-		style="writing-mode: vertical-rl; text-orientation: mixed;"
-	>
-		LEGENDE
-	</div>
-</button>
-
-<!-- Panel Container: nicht-modales Seitenpanel (H5) — role="region" statt
-     Fake-Dialog; inert nimmt das geschlossene (nur verschobene) Panel samt
-     seiner fokussierbaren Elemente aus Tab-Zyklus und Accessibility-Tree. -->
-<div
-	bind:this={panelEl}
-	id="legend-panel"
-	class="glass border-secondary/20 fixed top-20 right-0 z-40 h-full w-100 max-w-[100vw] overflow-hidden border-l-2 pr-8 shadow-2xl backdrop-blur-sm transition-transform duration-300 ease-in-out"
-	style="transform: translateX({isOpen ? '0px' : '100%'});"
-	role="region"
-	aria-labelledby="legend-title"
-	inert={!isOpen}
->
-	<div class="scroll-styled h-full overflow-y-auto">
-		<div class="p-6">
-			<div class="mb-4 flex items-center justify-between">
-				<!-- tabindex="-1": Fokusziel beim Öffnen des Panels (H5) -->
-				<h2 id="legend-title" tabindex="-1" bind:this={headingEl} class="text-xl font-bold">
-					Legende
-				</h2>
-				<button
-					onclick={closePanel}
-					class="btn btn-ghost btn-sm hover:bg-base-200"
-					aria-label="Legende schließen"
-				>
-					<Icon icon="lucide:square-x" class="h-4 w-4" />
-				</button>
-			</div>
-
-			<!-- Info-Box: wie die Marker codiert sind -->
-			<div class="bg-base-300/50 mb-4 rounded-lg p-3 text-sm">
-				<div class="flex items-start gap-2">
-					<Icon icon="lucide:info" class="text-info mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-					<div>
-						<strong>So lesen Sie die Karte:</strong> Die Ringfarbe zeigt die Tiergruppe, das Symbol die
-						Gruppe als zweites Merkmal. Ab zwei Tieren steht die Anzahl unter dem Marker. Ein schwarzer
-						Ring bedeutet Totfund. Deaktivieren Sie Checkboxen, um Arten oder Gruppengrößen auszublenden
-						— die Zahlen zeigen sichtbare/gesamt Sichtungen.
-					</div>
-				</div>
-			</div>
-
-			<!-- Tiergruppen-Farbschlüssel -->
-			<div class="mb-4 flex flex-wrap gap-3">
-				{#each ringLegendEntries as entry (entry.label)}
-					<span class="flex items-center gap-1.5 text-xs">
-						<span
-							class="inline-block h-4 w-4 rounded-full"
-							style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {entry.color};"
-							aria-hidden="true"
-						></span>
-						{entry.label}
-					</span>
-				{/each}
-			</div>
-
-			<div class="divider">{translations.species_legend}</div>
-
-			<div class="mb-6 space-y-3">
-				{#each Object.entries(translations.speciesMap) as [key, value] (key)}
-					{@const symbol = speciesSymbols[key]}
-					{@const total = counts.speciesCounts[key]?.total || 0}
-					<div
-						class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors"
-						data-species-row={key}
-					>
-						<!-- 0/0-Arten ausgrauen: visuelle Teile abschwächen, Checkbox bleibt bedienbar -->
-						<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-40 grayscale' : ''}">
-							<div
-								class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
-								style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol
-									? symbol.baseColor
-									: speciesGroupStyles.unbekannt.color};"
-							>
-								{#if symbol}
-									<span class="text-base" title={String(value)}>{symbol.symbol}</span>
-								{:else}
-									<div class="bg-base-content/40 h-4 w-4 rounded-full"></div>
-								{/if}
-							</div>
-
-							<div class="flex items-center gap-2">
-								<span class="text-sm font-medium">{value}</span>
-								{#if symbol}
-									<span
-										class="text-base-content rounded-full border-2 px-2 py-0.5 text-xs font-medium"
-										style="border-color: {symbol.baseColor};"
-									>
-										{speciesGroupStyles[symbol.category].label}
-									</span>
-								{/if}
-							</div>
-						</div>
-
-						<div class="flex items-center gap-2">
-							<span class="text-base-content/70 font-mono text-xs">
-								{counts.speciesCounts[key]?.visible || 0}/{total}
-							</span>
-							<input
-								type="checkbox"
-								class="species-checkbox checkbox checkbox-sm"
-								value={key}
-								checked={speciesVisibility[key] ?? true}
-								onchange={(e) => handleSpeciesToggle(key, (e.target as HTMLInputElement).checked)}
-								aria-label="Sichtbarkeit für {value} umschalten. Aktuell {counts.speciesCounts[key]
-									?.visible || 0} von {total} Sichtungen sichtbar."
-							/>
-						</div>
-					</div>
-				{/each}
-			</div>
-
-			<div class="divider">{translations.count}</div>
-
-			<div class="space-y-3">
-				{#each countGroups as group (group.key)}
-					<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
-						{#if group.key === 'ct0'}
-							<span
-								class="h-5 w-5 shrink-0 rounded-full shadow-sm"
-								style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {TOTFUND_RING_COLOR};"
-								aria-hidden="true"
-							></span>
-						{:else}
-							<span
-								class="text-base-content/70 w-5 shrink-0 text-center font-mono text-xs"
-								aria-hidden="true">#</span
-							>
-						{/if}
-						<span class="flex-1 text-sm">{group.label}</span>
-						<span class="text-base-content/70 font-mono text-xs"
-							>{counts.colorCounts[group.key] || 0}</span
-						>
-						<input
-							type="checkbox"
-							class="color-checkbox checkbox checkbox-sm"
-							value={group.key}
-							checked={colorVisibility[group.key] ?? true}
-							onchange={(e) => handleColorToggle(group.key, (e.target as HTMLInputElement).checked)}
-							aria-label="Sichtungen der Gruppe {group.label} anzeigen/ausblenden"
-						/>
-					</div>
-				{/each}
-			</div>
-
-			<div class="divider">Cluster</div>
-
-			<!-- Cluster-Farbskala erklären (M1) — aus derselben Konstante wie die Karte -->
-			<div class="mb-8">
-				<div class="mb-2 flex items-center gap-1" aria-hidden="true">
-					{#each clusterStyleSteps as step (step.color)}
-						<span
-							class="inline-flex items-center justify-center rounded-full text-[10px] font-bold text-white"
-							style="background-color: {step.color}; width: {step.radius}px; height: {step.radius}px;"
-						></span>
-					{/each}
-				</div>
-				<p class="text-base-content/80 text-sm">
-					Blaue Kreise fassen mehrere Sichtungen an nahe beieinanderliegenden Orten zusammen. Die
-					Zahl nennt die Anzahl der Sichtungen; je dunkler und größer der Kreis, desto mehr sind es.
-					Beim Hineinzoomen teilt sich ein Cluster in einzelne Marker auf.
-				</p>
+	<!-- Info-Box: wie die Marker codiert sind -->
+	<div class="bg-base-300/50 mb-4 rounded-lg p-3 text-sm">
+		<div class="flex items-start gap-2">
+			<Icon icon="lucide:info" class="text-info mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+			<div>
+				<strong>So lesen Sie die Karte:</strong> Die Ringfarbe zeigt die Tiergruppe, das Symbol die Gruppe
+				als zweites Merkmal. Ab zwei Tieren steht die Anzahl unter dem Marker. Ein schwarzer Ring bedeutet
+				Totfund. Deaktivieren Sie Checkboxen, um Arten oder Gruppengrößen auszublenden — die Zahlen zeigen
+				sichtbare/gesamt Sichtungen.
 			</div>
 		</div>
 	</div>
-</div>
 
-<!-- Scrollbar styles sind jetzt global in app.css definiert -->
+	<!-- Tiergruppen-Farbschlüssel -->
+	<div class="mb-4 flex flex-wrap gap-3">
+		{#each ringLegendEntries as entry (entry.label)}
+			<span class="flex items-center gap-1.5 text-xs">
+				<span
+					class="inline-block h-4 w-4 rounded-full"
+					style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {entry.color};"
+					aria-hidden="true"
+				></span>
+				{entry.label}
+			</span>
+		{/each}
+	</div>
+
+	<div class="divider">{translations.species_legend}</div>
+
+	<div class="mb-6 space-y-3">
+		{#each Object.entries(translations.speciesMap) as [key, value] (key)}
+			{@const symbol = speciesSymbols[key]}
+			{@const total = counts.speciesCounts[key]?.total || 0}
+			<div
+				class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors"
+				data-species-row={key}
+			>
+				<!-- 0/0-Arten ausgrauen: visuelle Teile abschwächen, Checkbox bleibt bedienbar -->
+				<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-40 grayscale' : ''}">
+					<div
+						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
+						style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol
+							? symbol.baseColor
+							: speciesGroupStyles.unbekannt.color};"
+					>
+						{#if symbol}
+							<span class="text-base" title={String(value)}>{symbol.symbol}</span>
+						{:else}
+							<div class="bg-base-content/40 h-4 w-4 rounded-full"></div>
+						{/if}
+					</div>
+
+					<div class="flex items-center gap-2">
+						<span class="text-sm font-medium">{value}</span>
+						{#if symbol}
+							<span
+								class="text-base-content rounded-full border-2 px-2 py-0.5 text-xs font-medium"
+								style="border-color: {symbol.baseColor};"
+							>
+								{speciesGroupStyles[symbol.category].label}
+							</span>
+						{/if}
+					</div>
+				</div>
+
+				<div class="flex items-center gap-2">
+					<span class="text-base-content/70 font-mono text-xs">
+						{counts.speciesCounts[key]?.visible || 0}/{total}
+					</span>
+					<input
+						type="checkbox"
+						class="species-checkbox checkbox checkbox-sm"
+						value={key}
+						checked={speciesVisibility[key] ?? true}
+						onchange={(e) => handleSpeciesToggle(key, (e.target as HTMLInputElement).checked)}
+						aria-label="Sichtbarkeit für {value} umschalten. Aktuell {counts.speciesCounts[key]
+							?.visible || 0} von {total} Sichtungen sichtbar."
+					/>
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<div class="divider">{translations.count}</div>
+
+	<div class="space-y-3">
+		{#each countGroups as group (group.key)}
+			<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
+				{#if group.key === 'ct0'}
+					<span
+						class="h-5 w-5 shrink-0 rounded-full shadow-sm"
+						style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {TOTFUND_RING_COLOR};"
+						aria-hidden="true"
+					></span>
+				{:else}
+					<span
+						class="text-base-content/70 w-5 shrink-0 text-center font-mono text-xs"
+						aria-hidden="true">#</span
+					>
+				{/if}
+				<span class="flex-1 text-sm">{group.label}</span>
+				<span class="text-base-content/70 font-mono text-xs"
+					>{counts.colorCounts[group.key] || 0}</span
+				>
+				<input
+					type="checkbox"
+					class="color-checkbox checkbox checkbox-sm"
+					value={group.key}
+					checked={colorVisibility[group.key] ?? true}
+					onchange={(e) => handleColorToggle(group.key, (e.target as HTMLInputElement).checked)}
+					aria-label="Sichtungen der Gruppe {group.label} anzeigen/ausblenden"
+				/>
+			</div>
+		{/each}
+	</div>
+
+	<div class="divider">Cluster</div>
+
+	<!-- Cluster-Farbskala erklären (M1) — aus derselben Konstante wie die Karte -->
+	<div class="mb-8">
+		<div class="mb-2 flex items-center gap-1" aria-hidden="true">
+			{#each clusterStyleSteps as step (step.color)}
+				<span
+					class="inline-block rounded-full"
+					style="background-color: {step.color}; width: {step.radius}px; height: {step.radius}px;"
+				></span>
+			{/each}
+		</div>
+		<p class="text-base-content/80 text-sm">
+			Blaue Kreise fassen mehrere Sichtungen an nahe beieinanderliegenden Orten zusammen. Die Zahl
+			nennt die Anzahl der Sichtungen; je dunkler und größer der Kreis, desto mehr sind es. Beim
+			Hineinzoomen teilt sich ein Cluster in einzelne Marker auf.
+		</p>
+	</div>
+</MapPanel>

--- a/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
@@ -1,5 +1,5 @@
 import { render } from 'vitest-browser-svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { CountData } from '$lib/map/countManager';
 import type { MapTranslations } from '$lib/map/mapUtils';
@@ -221,5 +221,36 @@ describe('LegendPanel', () => {
 
 		expect(mockCountManager.setSpeciesVisibility).toHaveBeenCalledWith('0', false);
 		expect(mockCountManager.setColorVisibility).toHaveBeenCalledWith('ct1', false);
+	});
+});
+
+// ─── Befund H6: Legende als Bottom-Sheet (geteilte Panel-Komponente) ─────────
+
+describe('LegendPanel als Bottom-Sheet (H6)', () => {
+	afterEach(async () => {
+		// Vitest-Default-Viewport wiederherstellen
+		await page.viewport(414, 896);
+	});
+
+	it('offenes Panel trägt data-sheet-state="peek", der Vergrößern-Button schaltet auf expanded', async () => {
+		await page.viewport(375, 667);
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /^Legende$/i }).click();
+
+		const panel = getLegendPanel();
+		await vi.waitFor(() => {
+			expect(panel.getAttribute('data-sheet-state')).toBe('peek');
+		});
+
+		const expandButton = document.querySelector('#legend-panel [aria-label="Legende vergrößern"]');
+		if (!(expandButton instanceof HTMLButtonElement)) {
+			throw new Error('Vergrößern-Button not found');
+		}
+
+		expandButton.click();
+		await vi.waitFor(() => {
+			expect(panel.getAttribute('data-sheet-state')).toBe('expanded');
+		});
 	});
 });

--- a/src/lib/components/map/Panel/MapPanel.svelte
+++ b/src/lib/components/map/Panel/MapPanel.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import Icon from '$lib/components/Icon.svelte';
+	import { focusPanelHeading, returnFocusToToggle } from '$lib/map/panelFocus';
+
+	let {
+		panelId,
+		titleId,
+		title,
+		toggleText,
+		icon,
+		togglePositionClass,
+		accentBorderClass,
+		isLoading = false,
+		// H6: Auf Mobile verdecken die fixen Toggle-Tabs den Sheet-Header —
+		// der Parent blendet deshalb beide Tabs aus, solange ein Sheet offen ist.
+		toggleHidden = false,
+		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
+		// den State steuern können statt über DOM-Queries.
+		isOpen = $bindable(false),
+		children
+	} = $props<{
+		panelId: string;
+		titleId: string;
+		title: string;
+		toggleText: string;
+		icon: string;
+		togglePositionClass: string;
+		accentBorderClass: string;
+		isLoading?: boolean;
+		toggleHidden?: boolean;
+		isOpen?: boolean;
+		children: Snippet;
+	}>();
+
+	// Element-Referenzen für das Fokus-Management (H5)
+	let panelEl = $state<HTMLDivElement>();
+	let toggleEl = $state<HTMLButtonElement>();
+	let headingEl = $state<HTMLHeadingElement>();
+
+	// H6: Unterhalb von md ist das Panel ein Bottom-Sheet mit zwei Höhen —
+	// Peek (Karte bleibt sichtbar) und Expanded. Auf md+ ohne Wirkung.
+	let sheetExpanded = $state(false);
+
+	// H5: Fokus folgt dem Panel-Zustand — beim Öffnen auf die Überschrift,
+	// beim Schließen zurück zum Toggle. Läuft auch, wenn der Zustand von
+	// außen (Tastaturkürzel im Parent) geändert wird.
+	let wasOpen = false;
+	$effect(() => {
+		if (isOpen === wasOpen) return;
+		wasOpen = isOpen;
+		if (isOpen) {
+			focusPanelHeading(headingEl);
+		} else {
+			// H6: Sheet startet beim nächsten Öffnen wieder im Peek-Zustand
+			sheetExpanded = false;
+			returnFocusToToggle(panelEl, toggleEl);
+		}
+	});
+
+	function togglePanel() {
+		isOpen = !isOpen;
+	}
+
+	function closePanel() {
+		isOpen = false;
+	}
+</script>
+
+<!-- Toggle Button (always visible) — H6: auf Mobile 44px breit (Touch-Target)
+     und ortsfest; nur auf md+ wandert er mit dem Panel nach links. -->
+<button
+	bind:this={toggleEl}
+	onclick={togglePanel}
+	class="glass text-base-content hover:bg-base-200 {accentBorderClass} {togglePositionClass} fixed right-0 z-50 flex h-32 w-11 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 md:w-8 {isOpen
+		? 'md:-translate-x-80'
+		: ''} {toggleHidden ? 'max-md:hidden' : ''}"
+	aria-label={title}
+	aria-expanded={isOpen}
+	aria-controls={panelId}
+>
+	<Icon
+		icon={isLoading ? 'lucide:loader-2' : icon}
+		class="mb-1 h-4 w-4 {isLoading ? 'animate-spin' : ''}"
+	/>
+	<div
+		class="text-xs whitespace-nowrap"
+		style="writing-mode: vertical-rl; text-orientation: mixed;"
+	>
+		{toggleText}
+	</div>
+</button>
+
+<!-- Panel Container: nicht-modales Seitenpanel (H5) — role="region" statt
+     Fake-Dialog; inert nimmt das geschlossene (nur verschobene) Panel samt
+     seiner fokussierbaren Elemente aus Tab-Zyklus und Accessibility-Tree.
+     H6: < md als Bottom-Sheet (Peek/Expanded), ab md als 320px-Seitenpanel,
+     dessen Höhe den top-20-Versatz berücksichtigt. -->
+<div
+	bind:this={panelEl}
+	id={panelId}
+	data-sheet-state={sheetExpanded ? 'expanded' : 'peek'}
+	class="glass {accentBorderClass} fixed z-40 overflow-hidden shadow-2xl backdrop-blur-sm transition-[transform,height] duration-300 ease-in-out max-md:inset-x-0 max-md:bottom-0 max-md:rounded-t-2xl max-md:border-t-2 md:top-20 md:right-0 md:h-[calc(100%-5rem)] md:w-80 md:border-l-2 {sheetExpanded
+		? 'max-md:h-[85dvh]'
+		: 'max-md:h-[45dvh]'} {isOpen
+		? 'translate-x-0 translate-y-0'
+		: 'max-md:translate-y-full md:translate-x-full'}"
+	role="region"
+	aria-labelledby={titleId}
+	inert={!isOpen}
+>
+	<div class="flex h-full flex-col">
+		<!-- Drag-Handle-Optik des Bottom-Sheets (nur Mobile, rein dekorativ) -->
+		<div class="flex justify-center pt-2 md:hidden" aria-hidden="true">
+			<div class="bg-base-content/20 h-1.5 w-10 rounded-full"></div>
+		</div>
+
+		<div class="flex shrink-0 items-center justify-between gap-2 px-4 pt-2 md:pt-4">
+			<!-- tabindex="-1": Fokusziel beim Öffnen des Panels (H5) -->
+			<h2 id={titleId} tabindex="-1" bind:this={headingEl} class="text-lg font-bold">
+				{title}
+			</h2>
+			<div class="flex items-center gap-1">
+				<!-- H6: Peek/Expanded-Umschalter des Bottom-Sheets (nur < md) -->
+				<button
+					onclick={() => (sheetExpanded = !sheetExpanded)}
+					class="btn btn-ghost btn-sm hover:bg-base-200 min-h-11 min-w-11 md:hidden"
+					aria-expanded={sheetExpanded}
+					aria-label={sheetExpanded ? `${title} verkleinern` : `${title} vergrößern`}
+				>
+					<Icon
+						icon={sheetExpanded ? 'lucide:chevron-down' : 'lucide:chevron-up'}
+						class="h-4 w-4"
+					/>
+				</button>
+				<button
+					onclick={closePanel}
+					class="btn btn-ghost btn-sm hover:bg-base-200 min-h-11 min-w-11"
+					aria-label="{title} schließen"
+				>
+					<Icon icon="lucide:square-x" class="h-4 w-4" />
+				</button>
+			</div>
+		</div>
+
+		<div class="scroll-styled min-h-0 flex-1 overflow-y-auto px-4 pb-4">
+			{@render children()}
+		</div>
+	</div>
+</div>

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -114,6 +114,15 @@
 	// per querySelector zu klicken.
 	let filterOpen = $state(false);
 	let legendOpen = $state(false);
+
+	// H6: Es ist immer nur ein Panel offen — beide liegen an derselben Position
+	// (Desktop rechts, Mobile als Bottom-Sheet) und würden sich sonst überlagern.
+	$effect(() => {
+		if (filterOpen) legendOpen = false;
+	});
+	$effect(() => {
+		if (legendOpen) filterOpen = false;
+	});
 	let isLoadingData = $state(false);
 	let isInitialLoading = $state(true);
 	let loadingType = $state<'initial' | 'filter' | 'features'>('initial');
@@ -590,17 +599,24 @@
 		</div>
 	</div>
 
-	<!-- Filter-Panel Komponente -->
+	<!-- Filter-Panel Komponente — toggleHidden: solange ein Bottom-Sheet offen
+	     ist, verdecken die fixen Tabs auf Mobile sonst dessen Header (H6) -->
 	<FilterPanel
 		{years}
 		{defaultYear}
 		{yearCounts}
 		isLoading={isLoadingData}
+		toggleHidden={filterOpen || legendOpen}
 		bind:isOpen={filterOpen}
 	/>
 
 	<!-- Legende-Panel Komponente -->
-	<LegendPanel {translations} {counts} bind:isOpen={legendOpen} />
+	<LegendPanel
+		{translations}
+		{counts}
+		toggleHidden={filterOpen || legendOpen}
+		bind:isOpen={legendOpen}
+	/>
 
 	<!-- Tastatur-Hilfe Button -->
 	<button
@@ -676,19 +692,43 @@
 
 				<div class="text-base-content/60 mt-6 space-y-1 text-xs">
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:info" width="14" height="14" class="text-primary" aria-hidden="true" />
+						<Icon
+							icon="lucide:info"
+							width="14"
+							height="14"
+							class="text-primary"
+							aria-hidden="true"
+						/>
 						Die Buchstaben-Kürzel wirken, solange der Fokus auf der Karte liegt
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:navigation" width="14" height="14" class="text-primary" aria-hidden="true" />
+						<Icon
+							icon="lucide:navigation"
+							width="14"
+							height="14"
+							class="text-primary"
+							aria-hidden="true"
+						/>
 						Karte mit Tab fokussieren, dann mit den Pfeiltasten verschieben und mit + / − zoomen
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:list" width="14" height="14" class="text-primary" aria-hidden="true" />
+						<Icon
+							icon="lucide:list"
+							width="14"
+							height="14"
+							class="text-primary"
+							aria-hidden="true"
+						/>
 						Der Umschalter „Karte / Liste" zeigt alle Sichtungen als Tabelle
 					</p>
 					<p class="flex items-center gap-2">
-						<Icon icon="lucide:mouse-pointer" width="14" height="14" class="text-primary" aria-hidden="true" />
+						<Icon
+							icon="lucide:mouse-pointer"
+							width="14"
+							height="14"
+							class="text-primary"
+							aria-hidden="true"
+						/>
 						Klicken Sie auf Marker für Details
 					</p>
 				</div>


### PR DESCRIPTION
## Zusammenfassung

Setzt Befund **H6 (Vollausbau)** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` um: Die fixen 400-px-Seitenpanels (Filter/Legende) waren auf Mobilgeräten defekt (Panel > Viewport, Toggle wanderte ins Layout) und überlagerten sich am Desktop an identischer Position.

- **Neue gemeinsame Wrapper-Komponente `MapPanel.svelte`** (Toggle-Tab + Panel-Container + Fokus-Management aus H5) — Filter-/LegendPanel liefern nur noch Inhalt, die bisherige Shell-Duplikation entfällt.
- **Mobile (< md):** Panel als Bottom-Sheet mit Peek- (45 dvh) und Expanded-Zustand (85 dvh), Umschalten per Vergrößern-Button (`aria-expanded`, `data-sheet-state`), Schließen per Button (nicht nur Swipe). Toggle-Tabs 44 px breit (Touch-Target) und ausgeblendet, solange ein Sheet offen ist — sie verdeckten sonst dessen Header (Playwright-Fund).
- **Desktop (≥ md):** Panelbreite 320 px statt 400 px; Höhe `h-[calc(100%-5rem)]` statt `top-20 + h-full` (der untere Rand lag bisher 5 rem außerhalb des Viewports).
- **Exklusivität:** Öffnen des einen Panels schließt das andere (zwei `$effect`s in `SightingsMapView.svelte`) — auch über die Tastaturkürzel F/L.
- ARIA-Semantik und Fokus-Management aus H5 (region, `inert`, Fokus rein/raus) bleiben unverändert; Review-Doku und Checkliste nachgezogen.

## Test-First

Alle neuen Tests entstanden vor der Implementierung (RED → GREEN):

- 8 neue Browser-Komponententests (`FilterPanel`/`LegendPanel.svelte.test.ts`): Sheet-Zustände, Vergrößern-Button, Bottom-Sheet- und Desktop-Geometrie per `page.viewport`, 44-px-Touch-Target
- Neue `e2e/map-panels.spec.ts`: Exklusivität, 320-px-Breite + Viewport-Höhe, Mobile-Bottom-Sheet-Ablauf (375×667)

## Verifikation

- [x] Panel-Komponententests 24/24, gesamte Client-Suite 132/132
- [x] `e2e/map-panels.spec.ts` 5/5 und alle 39 bestehenden Karten-E2E-Tests grün
- [x] `npm run test:quick` (Lint 0 Fehler, tsc, svelte-check, 2102 Unit-Tests)
- [x] Projekt-Review (`/review`) ohne kritische Befunde; zwei kosmetische Fixes direkt eingearbeitet
- [x] Visuell verifiziert (Screenshots Desktop 1280 px / Mobile 375 px, Peek + Expanded + Legende)

🤖 Generated with [Claude Code](https://claude.com/claude-code)