### PR TITLE
docs: fix documentation that contradicts the code

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -242,7 +242,7 @@ src/
 │   ├── map/                 # OpenLayers Controller & Utilities
 │   ├── report/              # Sichtungsmeldung
 │   │   ├── components/      # Form Steps, Sections, Fields
-│   │   └── formOptions/     # Enum/Option Definitionen (16 Dateien)
+│   │   └── formOptions/     # Enum/Option Definitionen (17 Dateien)
 │   ├── server/
 │   │   ├── audit/           # Audit-Logging
 │   │   ├── auth/            # JWT/Auth0 Authentication
@@ -258,7 +258,8 @@ src/
 │   │   ├── storage/         # File Storage (Local, Vercel Blob)
 │   │   ├── templates/       # Email-Templates (Handlebars)
 │   │   ├── utils/           # Server-Utilities (z.B. getClientIp)
-│   │   └── validation/      # Request-Validierung, Magic Bytes
+│   │   ├── validation/      # Request-Validierung, Magic Bytes
+│   │   └── weather/         # Wetter-Stundenindex
 │   ├── services/            # Client-Services (configService, weatherService)
 │   ├── storage/             # Browser Storage (GDPR-aware)
 │   ├── stores/              # Svelte Stores (Toast, Config)

--- a/README.md
+++ b/README.md
@@ -177,28 +177,38 @@ ostsee-sichtung/
 │   │   ├── map/            # OpenLayers Karten-Funktionalitäten
 │   │   ├── report/         # Sichtungsmeldung-Komponenten und -Logik
 │   │   ├── server/         # Server-seitige Logik
+│   │   │   ├── audit/      # Audit-Logging
 │   │   │   ├── auth/       # Auth0 + JWT Authentifizierung
 │   │   │   ├── config/     # Access Control Konfiguration
+│   │   │   ├── datetime/   # Server-Datums-Utilities (UTC / Berliner Ortszeit)
 │   │   │   ├── db/         # Datenbankzugriff und Schema
 │   │   │   ├── export/     # Datenexport (CSV, JSON, KML, XML)
 │   │   │   ├── geo/        # PostGIS / Baltic Sea Validation
 │   │   │   ├── media/      # EXIF-Metadaten-Extraktion
 │   │   │   ├── middleware/  # DB-Check, Maintenance, Rate Limit, Security Headers
 │   │   │   ├── services/   # Email, Config Init, Weather
+│   │   │   ├── spam/       # Spam-Erkennung
 │   │   │   ├── storage/    # Datei-Speicher (Local, Vercel Blob)
 │   │   │   ├── templates/  # E-Mail HTML-Templates
-│   │   │   └── validation/ # Magic Bytes, Request Validation
+│   │   │   ├── utils/      # Server-Utilities (z. B. getClientIp)
+│   │   │   ├── validation/ # Magic Bytes, Request Validation
+│   │   │   └── weather/    # Wetter-Stundenindex
 │   │   ├── services/       # Client/Server Services (Config, Weather)
 │   │   ├── storage/        # Browser Storage (GDPR-aware)
 │   │   ├── stores/         # Svelte Stores
 │   │   ├── types/          # TypeScript Typen
 │   │   └── utils/          # Hilfsfunktionen
 │   └── routes/             # SvelteKit-Routen
-│       ├── api/            # API-Endpunkte
+│       ├── about/          # Über-Seite
 │       ├── admin/          # Admin-Interface
+│       ├── api/            # API-Endpunkte
+│       ├── docs/           # API-Dokumentation (Scalar)
+│       ├── health/         # Health-Check-Endpunkt
+│       ├── maintenance/    # Wartungsmodus-Seite
 │       ├── map/            # Karten-Visualisierung
 │       ├── rest_sichtungen/ # Legacy REST API (POST, antworten, inBaltic)
-│       └── sichtungen/     # Legacy Sichtungs-API (showreports)
+│       ├── sichtungen/     # Legacy Sichtungs-API (showreports)
+│       └── uploads/        # Ausgelieferte Uploads (Local Storage)
 ├── static/                 # Statische Assets
 ├── docs/                   # Dokumentation
 └── e2e/                    # End-to-End Tests (Playwright)

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -8,64 +8,26 @@ Generated on: [AUTO-GENERATED]
 
 | License Type | Count | Compatibility |
 |-------------|-------|---------------|
-| MIT | 119 | ✅ Fully Compatible |
-| BSD-2-Clause | 8 | ✅ Fully Compatible |
-| Apache-2.0 | 7 | ✅ Fully Compatible |
-| BSD-3-Clause | 5 | ✅ Fully Compatible |
-| ISC | 5 | ✅ Fully Compatible |
-| MIT-0 | 3 | ✅ Fully Compatible |
-| CC0-1.0 | 2 | ✅ Fully Compatible |
+| MIT | 87 | ✅ Fully Compatible |
+| BSD-2-Clause | 10 | ✅ Fully Compatible |
+| Apache-2.0 | 8 | ✅ Fully Compatible |
+| ISC | 7 | ✅ Fully Compatible |
+| BSD-3-Clause | 3 | ✅ Fully Compatible |
 | Unlicense | 2 | ✅ Fully Compatible |
-| (MPL-2.0 OR Apache-2.0) | 1 | ✅ Dual Licensed |
-| BlueOak-1.0.0 | 1 | ✅ Fully Compatible |
+| MIT-0 | 1 | ✅ Fully Compatible |
 | (MIT AND Zlib) | 1 | ⚠️ Multiple Licenses |
 | 0BSD | 1 | ✅ Fully Compatible |
 | (MIT OR CC0-1.0) | 1 | ✅ Dual Licensed |
+| CC0-1.0 | 1 | ✅ Fully Compatible |
 | MIT AND BSD-3-Clause | 1 | ⚠️ Multiple Licenses |
 
-**Total Dependencies**: 157
+**Total Dependencies**: 123
 
 ## Detailed License Information
 
-### MIT (119 packages)
+### MIT (87 packages)
 
 **Compatibility**: ✅ Fully Compatible
-
-- **@acemir/cssom@0.9.31**
-  - Repository: https://github.com/acemir/CSSOM
-  - Publisher: Nikita Vasilyev
-
-- **@asamuzakjp/css-color@5.0.1**
-  - Repository: https://github.com/asamuzaK/cssColor
-  - Publisher: asamuzaK
-
-- **@asamuzakjp/dom-selector@6.8.1**
-  - Repository: https://github.com/asamuzaK/domSelector
-  - Publisher: asamuzaK
-
-- **@asamuzakjp/nwsapi@2.3.9**
-  - Repository: https://github.com/dperini/nwsapi
-  - Publisher: Diego Perini
-
-- **@bramus/specificity@2.4.2**
-  - Repository: https://github.com/bramus/specificity
-  - Publisher: Bramus Van Damme
-
-- **@csstools/css-calc@3.1.1**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **@csstools/css-color-parser@4.0.2**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **@csstools/css-parser-algorithms@4.0.0**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **@csstools/css-tokenizer@4.0.0**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **@exodus/bytes@1.15.0**
-  - Repository: https://github.com/ExodusOSS/bytes
-  - Publisher: Exodus Movement, Inc.
 
 - **@noble/hashes@2.0.1**
   - Repository: https://github.com/paulmillr/noble-hashes
@@ -87,42 +49,26 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/mxxii/selderee
   - Publisher: KillyMXI
 
-- **@turf/boolean-point-in-polygon@7.3.4**
+- **@turf/boolean-point-in-polygon@7.3.5**
   - Repository: https://github.com/Turfjs/turf
   - Publisher: Turf Authors
 
-- **@turf/helpers@7.3.4**
+- **@turf/helpers@7.3.5**
   - Repository: https://github.com/Turfjs/turf
   - Publisher: Turf Authors
 
-- **@turf/invariant@7.3.4**
+- **@turf/invariant@7.3.5**
   - Repository: https://github.com/Turfjs/turf
   - Publisher: Turf Authors
 
 - **@types/geojson@7946.0.16**
   - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-- **@types/jsonwebtoken@9.0.10**
-  - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-- **@types/ms@2.1.0**
-  - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-- **@types/node@25.4.0**
-  - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-
 - **@types/rbush@4.0.0**
   - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-- **@types/trusted-types@2.0.7**
-  - Repository: https://github.com/DefinitelyTyped/DefinitelyTyped
-
-- **@zarrita/storage@0.1.4**
+- **@zarrita/storage@0.2.0**
   - Repository: https://github.com/manzt/zarrita.js
-
-- **agent-base@7.1.4**
-  - Repository: https://github.com/TooTallNate/proxy-agents
-  - Publisher: Nathan Rajlich
 
 - **async-retry@1.3.3**
   - Repository: https://github.com/vercel/async-retry
@@ -131,47 +77,40 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/davidmarkclements/atomic-sleep
   - Publisher: David Mark Clements
 
-- **bidi-js@1.0.3**
-  - Repository: https://github.com/lojjic/bidi-js
-  - Publisher: Jason Johnston
-
 - **bignumber.js@9.3.1**
   - Repository: https://github.com/MikeMcl/bignumber.js
   - Publisher: Michael Mclaughlin
 
-- **css-tree@3.2.1**
-  - Repository: https://github.com/csstree/csstree
-  - Publisher: Roman Dvornov
+- **cross-spawn@7.0.6**
+  - Repository: https://github.com/moxystudio/node-cross-spawn
+  - Publisher: André Cruz
 
-- **cssstyle@6.2.0**
-  - Repository: https://github.com/jsdom/cssstyle
-
-- **data-urls@7.0.0**
-  - Repository: https://github.com/jsdom/data-urls
-  - Publisher: Domenic Denicola
-
-- **debug@4.4.3**
-  - Repository: https://github.com/debug-js/debug
-  - Publisher: Josh Junon
-
-- **decimal.js@10.6.0**
-  - Repository: https://github.com/MikeMcl/decimal.js
-  - Publisher: Michael Mclaughlin
+- **dayjs@1.11.20**
+  - Repository: https://github.com/iamkun/dayjs
+  - Publisher: iamkun
 
 - **deepmerge@4.3.1**
   - Repository: https://github.com/TehShrike/deepmerge
 
-- **dequal@2.0.3**
-  - Repository: https://github.com/lukeed/dequal
-  - Publisher: Luke Edwards
-
 - **dom-serializer@2.0.0**
+  - Repository: https://github.com/cheeriojs/dom-serializer
+  - Publisher: Felix Boehm
+
+- **dom-serializer@3.1.1**
   - Repository: https://github.com/cheeriojs/dom-serializer
   - Publisher: Felix Boehm
 
 - **error-causes@3.0.2**
   - Repository: https://github.com/paralleldrive/error-causes
   - Publisher: Eric Elliott
+
+- **escape-string-regexp@4.0.0**
+  - Repository: https://github.com/sindresorhus/escape-string-regexp
+  - Publisher: Sindre Sorhus
+
+- **execa@5.1.1**
+  - Repository: https://github.com/sindresorhus/execa
+  - Publisher: Sindre Sorhus
 
 - **exifr@7.1.3**
   - Repository: https://github.com/MikeKovarik/exifr
@@ -181,33 +120,29 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/101arrowz/fflate
   - Publisher: Arjun Barrett
 
-- **geotiff@3.0.4**
+- **geotiff@3.0.5**
   - Repository: https://github.com/geotiffjs/geotiff.js
   - Publisher: Fabian Schindler
 
-- **handlebars@4.7.8**
+- **get-stream@6.0.1**
+  - Repository: https://github.com/sindresorhus/get-stream
+  - Publisher: Sindre Sorhus
+
+- **handlebars@4.7.9**
   - Repository: https://github.com/handlebars-lang/handlebars.js
   - Publisher: Yehuda Katz
-
-- **html-encoding-sniffer@6.0.0**
-  - Repository: https://github.com/jsdom/html-encoding-sniffer
-  - Publisher: Domenic Denicola
 
 - **html-to-text@9.0.5**
   - Repository: https://github.com/html-to-text/node-html-to-text
   - Publisher: Malte Legenhausen
 
-- **htmlparser2@8.0.2**
+- **htmlparser2@12.0.0**
   - Repository: https://github.com/fb55/htmlparser2
   - Publisher: Felix Boehm
 
-- **http-proxy-agent@7.0.2**
-  - Repository: https://github.com/TooTallNate/proxy-agents
-  - Publisher: Nathan Rajlich
-
-- **https-proxy-agent@7.0.6**
-  - Repository: https://github.com/TooTallNate/proxy-agents
-  - Publisher: Nathan Rajlich
+- **htmlparser2@8.0.2**
+  - Repository: https://github.com/fb55/htmlparser2
+  - Publisher: Felix Boehm
 
 - **is-buffer@2.0.5**
   - Repository: https://github.com/feross/is-buffer
@@ -216,89 +151,52 @@ Generated on: [AUTO-GENERATED]
 - **is-node-process@1.2.0**
   - Repository: https://github.com/mswjs/is-node-process
 
-- **is-potential-custom-element-name@1.0.1**
-  - Repository: https://github.com/mathiasbynens/is-potential-custom-element-name
-  - Publisher: Mathias Bynens
+- **is-plain-object@5.0.0**
+  - Repository: https://github.com/jonschlinkert/is-plain-object
+  - Publisher: Jon Schlinkert
 
-- **isomorphic-dompurify@3.1.0**
-  - Repository: https://github.com/kkomelin/isomorphic-dompurify
+- **is-stream@2.0.1**
+  - Repository: https://github.com/sindresorhus/is-stream
+  - Publisher: Sindre Sorhus
 
-- **jose@6.2.1**
+- **jose@5.10.0**
   - Repository: https://github.com/panva/jose
   - Publisher: Filip Skokan
 
-- **jsdom@28.1.0**
-  - Repository: https://github.com/jsdom/jsdom
+- **jose@6.2.4**
+  - Repository: https://github.com/panva/jose
+  - Publisher: Filip Skokan
 
-- **jsonwebtoken@9.0.3**
-  - Repository: https://github.com/auth0/node-jsonwebtoken
-  - Publisher: auth0
-
-- **jwa@2.0.1**
-  - Repository: https://github.com/brianloveswords/node-jwa
-  - Publisher: Brian J. Brennan
-
-- **jwks-rsa@4.0.1**
-  - Repository: https://github.com/auth0/node-jwks-rsa
-  - Publisher: Auth0
-
-- **jws@4.0.1**
-  - Repository: https://github.com/brianloveswords/node-jws
-  - Publisher: Brian J Brennan
+- **launder@1.7.1**
+  - Repository: https://github.com/apostrophecms/apostrophe
+  - Publisher: Apostrophe Technologies, Inc.
 
 - **leac@0.6.0**
   - Repository: https://github.com/mxxii/leac
   - Publisher: KillyMXI
 
-- **limiter@1.1.5**
-  - Repository: https://github.com/jhurliman/node-rate-limiter
-  - Publisher: John Hurliman
+- **merge-stream@2.0.0**
+  - Repository: https://github.com/grncdr/merge-stream
+  - Publisher: Stephen Sugden
 
-- **lodash.clonedeep@4.5.0**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.includes@4.3.0**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.isboolean@3.0.3**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.isinteger@4.0.4**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.isnumber@3.0.3**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.isplainobject@4.0.6**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.isstring@4.0.1**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lodash.once@4.1.1**
-  - Repository: https://github.com/lodash/lodash
-  - Publisher: John-David Dalton
-
-- **lru-memoizer@3.0.0**
-  - Repository: https://github.com/jfromaniello/lru-memoizer
-  - Publisher: José F. Romaniello
+- **mimic-fn@2.1.0**
+  - Repository: https://github.com/sindresorhus/mimic-fn
+  - Publisher: Sindre Sorhus
 
 - **minimist@1.2.8**
   - Repository: https://github.com/minimistjs/minimist
   - Publisher: James Halliday
 
-- **ms@2.1.3**
-  - Repository: https://github.com/vercel/ms
+- **nanoid@3.3.12**
+  - Repository: https://github.com/ai/nanoid
+  - Publisher: Andrey Sitnik
 
 - **neo-async@2.6.2**
   - Repository: https://github.com/suguru03/neo-async
+
+- **npm-run-path@4.0.1**
+  - Repository: https://github.com/sindresorhus/npm-run-path
+  - Publisher: Sindre Sorhus
 
 - **numcodecs@0.3.2**
   - Repository: https://github.com/manzt/numcodecs.js
@@ -308,17 +206,29 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/mcollina/on-exit-or-gc
   - Publisher: Matteo Collina
 
+- **onetime@5.1.2**
+  - Repository: https://github.com/sindresorhus/onetime
+  - Publisher: Sindre Sorhus
+
+- **os-paths@4.4.0**
+  - Repository: https://github.com/rivy/js.os-paths
+  - Publisher: Roy Ivy III
+
 - **parse-headers@2.0.6**
   - Repository: https://github.com/kesla/parse-headers
   - Publisher: David Björklund
 
-- **parse5@8.0.0**
-  - Repository: https://github.com/inikulin/parse5
-  - Publisher: Ivan Nikulin
+- **parse-srcset@1.0.2**
+  - Repository: https://github.com/albell/parse-srcset
+  - Publisher: Alex Bell
 
 - **parseley@0.12.1**
   - Repository: https://github.com/mxxii/parseley
   - Publisher: KillyMXI
+
+- **path-key@3.1.1**
+  - Repository: https://github.com/sindresorhus/path-key
+  - Publisher: Sindre Sorhus
 
 - **peberminta@0.9.0**
   - Repository: https://github.com/mxxii/peberminta
@@ -340,6 +250,10 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/rowanwins/point-in-polygon-hao
   - Publisher: Rowan Winsemius
 
+- **postcss@8.5.18**
+  - Repository: https://github.com/postcss/postcss
+  - Publisher: Andrey Sitnik
+
 - **process-warning@5.0.0**
   - Repository: https://github.com/fastify/process-warning
   - Publisher: Tomas Della Vedova
@@ -348,13 +262,9 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/jquense/expr
   - Publisher: @monasticpanic Jason Quense
 
-- **protocol-buffers-schema@3.6.0**
+- **protocol-buffers-schema@3.6.1**
   - Repository: https://github.com/mafintosh/protocol-buffers-schema
   - Publisher: Mathias Buus
-
-- **punycode@2.3.1**
-  - Repository: https://github.com/mathiasbynens/punycode.js
-  - Publisher: Mathias Bynens
 
 - **quick-format-unescaped@4.0.4**
   - Repository: https://github.com/davidmarkclements/quick-format
@@ -375,10 +285,6 @@ Generated on: [AUTO-GENERATED]
 - **reference-spec-reader@0.2.0**
   - Publisher: manzt
 
-- **require-from-string@2.0.2**
-  - Repository: https://github.com/floatdrop/require-from-string
-  - Publisher: Vsevolod Strukchinsky
-
 - **resolve-protobuf-schema@2.1.0**
   - Repository: https://github.com/mafintosh/resolve-protobuf-schema
   - Publisher: Mathias Buus
@@ -387,29 +293,33 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/tim-kos/node-retry
   - Publisher: Tim Koschützki
 
-- **safe-buffer@5.2.1**
-  - Repository: https://github.com/feross/safe-buffer
-  - Publisher: Feross Aboukhadijeh
-
 - **safe-stable-stringify@2.5.0**
   - Repository: https://github.com/BridgeAR/safe-stable-stringify
   - Publisher: Ruben Bridgewater
+
+- **sanitize-html@2.17.6**
+  - Repository: https://github.com/apostrophecms/apostrophe
+  - Publisher: Apostrophe Technologies, Inc.
 
 - **selderee@0.11.0**
   - Repository: https://github.com/mxxii/selderee
   - Publisher: KillyMXI
 
+- **shebang-command@2.0.0**
+  - Repository: https://github.com/kevva/shebang-command
+  - Publisher: Kevin Mårtensson
+
+- **shebang-regex@3.0.0**
+  - Repository: https://github.com/sindresorhus/shebang-regex
+  - Publisher: Sindre Sorhus
+
 - **sonic-boom@4.2.1**
   - Repository: https://github.com/pinojs/sonic-boom
   - Publisher: Matteo Collina
 
-- **svelte-forms-lib@2.0.1**
-  - Repository: https://github.com/tjinauyeung/svelte-forms-lib
-  - Publisher: Tjin Au Yeung
-
-- **symbol-tree@3.2.4**
-  - Repository: https://github.com/jsdom/js-symbol-tree
-  - Publisher: Joris van der Wel
+- **strip-final-newline@2.0.0**
+  - Repository: https://github.com/sindresorhus/strip-final-newline
+  - Publisher: Sindre Sorhus
 
 - **thread-stream@4.0.0**
   - Repository: https://github.com/mcollina/thread-stream
@@ -422,78 +332,48 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/jquense/tiny-case
   - Publisher: Jason Quense
 
-- **tldts-core@7.0.25**
-  - Repository: https://github.com/remusao/tldts
-  - Publisher: Rémi Berson
-
-- **tldts@7.0.25**
-  - Repository: https://github.com/remusao/tldts
-  - Publisher: Rémi Berson
-
 - **toposort@2.0.2**
   - Repository: https://github.com/marcelklehr/toposort
   - Publisher: Marcel Klehr
 
-- **tr46@6.0.0**
-  - Repository: https://github.com/jsdom/tr46
-  - Publisher: Sebastian Mayr
-
-- **undici-types@7.18.2**
+- **undici@6.27.0**
   - Repository: https://github.com/nodejs/undici
 
-- **undici@6.23.0**
-  - Repository: https://github.com/nodejs/undici
-
-- **undici@7.22.0**
-  - Repository: https://github.com/nodejs/undici
-
-- **unzipit@1.4.3**
+- **unzipit@2.0.0**
   - Repository: https://github.com/greggman/unzipit
-
-- **uzip-module@1.0.3**
-  - Repository: https://github.com/greggman/uzip-module
-
-- **w3c-xmlserializer@5.0.0**
-  - Repository: https://github.com/jsdom/w3c-xmlserializer
-
-- **whatwg-mimetype@5.0.0**
-  - Repository: https://github.com/jsdom/whatwg-mimetype
-  - Publisher: Domenic Denicola
-
-- **whatwg-url@16.0.1**
-  - Repository: https://github.com/jsdom/whatwg-url
-  - Publisher: Sebastian Mayr
 
 - **wordwrap@1.0.0**
   - Repository: https://github.com/substack/node-wordwrap
   - Publisher: James Halliday
 
-- **xmlchars@2.2.0**
-  - Repository: https://github.com/lddubeau/xmlchars
-  - Publisher: Louis-Dominique Dubeau
+- **xdg-app-paths@5.5.1**
+  - Repository: https://github.com/rivy/js.xdg-app-paths
+  - Publisher: Roy Ivy III
+
+- **xdg-portable@7.3.0**
+  - Repository: https://github.com/rivy/js.xdg-portable
+  - Publisher: Roy Ivy III
 
 - **yup@1.7.1**
   - Repository: https://github.com/jquense/yup
   - Publisher: @monasticpanic Jason Quense
 
-- **zarrita@0.6.1**
+- **zarrita@0.7.1**
   - Repository: https://github.com/manzt/zarrita.js
 
-### MIT-0 (3 packages)
+- **zod@4.1.11**
+  - Repository: https://github.com/colinhacks/zod
+  - Publisher: Colin McDonnell
+
+### MIT-0 (1 package)
 
 **Compatibility**: ✅ Fully Compatible
 
-- **@csstools/color-helpers@6.0.2**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **@csstools/css-syntax-patches-for-csstree@1.1.0**
-  - Repository: https://github.com/csstools/postcss-plugins
-
-- **nodemailer@8.0.2**
+- **nodemailer@9.0.3**
   - Repository: https://github.com/nodemailer/nodemailer
   - Publisher: Andris Reinman
 
-### ISC (5 packages)
+### ISC (7 packages)
 
 **Compatibility**: ✅ Fully Compatible
 
@@ -501,29 +381,76 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/mapbox/earcut
   - Publisher: Vladimir Agafonkin
 
+- **isexe@2.0.0**
+  - Repository: https://github.com/isaacs/isexe
+  - Publisher: Isaac Z. Schlueter
+
+- **picocolors@1.1.1**
+  - Repository: https://github.com/alexeyraspopov/picocolors
+  - Publisher: Alexey Raspopov
+
 - **quickselect@3.0.0**
   - Repository: https://github.com/mourner/quickselect
   - Publisher: Vladimir Agafonkin
 
-- **saxes@6.0.0**
-  - Repository: https://github.com/lddubeau/saxes
-  - Publisher: Louis-Dominique Dubeau
-
-- **semver@7.7.4**
-  - Repository: https://github.com/npm/node-semver
-  - Publisher: GitHub Inc.
+- **signal-exit@3.0.7**
+  - Repository: https://github.com/tapjs/signal-exit
+  - Publisher: Ben Coe
 
 - **split2@4.2.0**
   - Repository: https://github.com/mcollina/split2
   - Publisher: Matteo Collina
 
-### BSD-3-Clause (5 packages)
+- **which@2.0.2**
+  - Repository: https://github.com/isaacs/node-which
+  - Publisher: Isaac Z. Schlueter
+
+### BSD-2-Clause (10 packages)
 
 **Compatibility**: ✅ Fully Compatible
 
-- **buffer-equal-constant-time@1.0.1**
-  - Repository: https://github.com/goinstant/buffer-equal-constant-time
-  - Publisher: GoInstant Inc., a salesforce.com company
+- **domelementtype@2.3.0**
+  - Repository: https://github.com/fb55/domelementtype
+  - Publisher: Felix Boehm
+
+- **domelementtype@3.0.0**
+  - Repository: https://github.com/fb55/domelementtype
+  - Publisher: Felix Boehm
+
+- **domhandler@5.0.3**
+  - Repository: https://github.com/fb55/domhandler
+  - Publisher: Felix Boehm
+
+- **domhandler@6.0.1**
+  - Repository: https://github.com/fb55/domhandler
+  - Publisher: Felix Boehm
+
+- **domutils@3.2.2**
+  - Repository: https://github.com/fb55/domutils
+  - Publisher: Felix Boehm
+
+- **domutils@4.0.2**
+  - Repository: https://github.com/fb55/domutils
+  - Publisher: Felix Boehm
+
+- **entities@4.5.0**
+  - Repository: https://github.com/fb55/entities
+  - Publisher: Felix Boehm
+
+- **entities@8.0.0**
+  - Repository: https://github.com/fb55/entities
+  - Publisher: Felix Boehm
+
+- **ol@10.9.0**
+  - Repository: https://github.com/openlayers/openlayers
+
+- **uglify-js@3.19.3**
+  - Repository: https://github.com/mishoo/UglifyJS
+  - Publisher: Mihai Bazon
+
+### BSD-3-Clause (3 packages)
+
+**Compatibility**: ✅ Fully Compatible
 
 - **pbf@4.0.1**
   - Repository: https://github.com/mapbox/pbf
@@ -537,63 +464,29 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/mozilla/source-map
   - Publisher: Nick Fitzgerald
 
-- **tough-cookie@6.0.0**
-  - Repository: https://github.com/salesforce/tough-cookie
-  - Publisher: Jeremy Stashewsky
-
-### BSD-2-Clause (8 packages)
+### Apache-2.0 (8 packages)
 
 **Compatibility**: ✅ Fully Compatible
 
-- **domelementtype@2.3.0**
-  - Repository: https://github.com/fb55/domelementtype
-  - Publisher: Felix Boehm
-
-- **domhandler@5.0.3**
-  - Repository: https://github.com/fb55/domhandler
-  - Publisher: Felix Boehm
-
-- **domutils@3.2.2**
-  - Repository: https://github.com/fb55/domutils
-  - Publisher: Felix Boehm
-
-- **entities@4.5.0**
-  - Repository: https://github.com/fb55/entities
-  - Publisher: Felix Boehm
-
-- **entities@6.0.1**
-  - Repository: https://github.com/fb55/entities
-  - Publisher: Felix Boehm
-
-- **ol@10.8.0**
-  - Repository: https://github.com/openlayers/openlayers
-
-- **uglify-js@3.19.3**
-  - Repository: https://github.com/mishoo/UglifyJS
-  - Publisher: Mihai Bazon
-
-- **webidl-conversions@8.0.1**
-  - Repository: https://github.com/jsdom/webidl-conversions
-  - Publisher: Domenic Denicola
-
-### Apache-2.0 (7 packages)
-
-**Compatibility**: ✅ Fully Compatible
-
-- **@opentelemetry/api@1.9.0**
-  - Repository: https://github.com/open-telemetry/opentelemetry-js
-  - Publisher: OpenTelemetry Authors
-
-- **@vercel/blob@2.3.1**
+- **@vercel/blob@2.6.1**
   - Repository: https://github.com/vercel/storage
 
-- **drizzle-orm@0.45.1**
+- **@vercel/cli-config@0.2.0**
+  - Repository: https://github.com/vercel/vercel
+
+- **@vercel/cli-exec@1.0.0**
+  - Repository: https://github.com/vercel/vercel
+
+- **@vercel/oidc@3.6.2**
+  - Repository: https://github.com/vercel/vercel
+
+- **drizzle-orm@0.45.2**
   - Repository: https://github.com/drizzle-team/drizzle-orm
   - Publisher: Drizzle Team
 
-- **ecdsa-sig-formatter@1.0.11**
-  - Repository: https://github.com/Brightspace/node-ecdsa-sig-formatter
-  - Publisher: D2L Corporation
+- **human-signals@2.1.0**
+  - Repository: https://github.com/ehmicky/human-signals
+  - Publisher: ehmicky
 
 - **lerc@3.0.0**
   - Repository: https://github.com/Esri/lerc
@@ -602,35 +495,11 @@ Generated on: [AUTO-GENERATED]
 - **web-worker@1.5.0**
   - Repository: https://github.com/developit/web-worker
 
-- **xml-name-validator@5.0.0**
-  - Repository: https://github.com/jsdom/xml-name-validator
-  - Publisher: Domenic Denicola
-
-### BlueOak-1.0.0 (1 package)
-
-**Compatibility**: ✅ Fully Compatible
-
-- **lru-cache@11.2.6**
-  - Repository: https://github.com/isaacs/node-lru-cache
-  - Publisher: Isaac Z. Schlueter
-
-### CC0-1.0 (2 packages)
-
-**Compatibility**: ✅ Fully Compatible
-
-- **mdn-data@2.27.1**
-  - Repository: https://github.com/mdn/data
-  - Publisher: Mozilla Developer Network
-
-- **xml-utils@1.10.2**
-  - Repository: https://github.com/DanielJDufour/xml-utils
-  - Publisher: Daniel J. Dufour
-
 ### Unlicense (2 packages)
 
 **Compatibility**: ✅ Fully Compatible
 
-- **postgres@3.4.8**
+- **postgres@3.4.9**
   - Repository: https://github.com/porsager/postgres
   - Publisher: Rasmus Porsager
 
@@ -646,13 +515,13 @@ Generated on: [AUTO-GENERATED]
   - Repository: https://github.com/Microsoft/tslib
   - Publisher: Microsoft Corp.
 
-### (MPL-2.0 OR Apache-2.0) (1 package)
+### CC0-1.0 (1 package)
 
-**Compatibility**: ✅ Dual Licensed
+**Compatibility**: ✅ Fully Compatible
 
-- **dompurify@3.3.3**
-  - Repository: https://github.com/cure53/DOMPurify
-  - Publisher: Dr.-Ing. Mario Heiderich, Cure53
+- **xml-utils@1.10.2**
+  - Repository: https://github.com/DanielJDufour/xml-utils
+  - Publisher: Daniel J. Dufour
 
 ### (MIT AND Zlib) (1 package)
 

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -3,21 +3,19 @@ THIRD-PARTY SOFTWARE NOTICES AND LICENSE TERMS
 
 This project uses the following third-party software components:
 
-MIT: 119 packages
-MIT-0: 3 packages
-Apache-2.0: 7 packages
-BSD-3-Clause: 5 packages
-BSD-2-Clause: 8 packages
-(MPL-2.0 OR Apache-2.0): 1 package
-ISC: 5 packages
-BlueOak-1.0.0: 1 package
-CC0-1.0: 2 packages
+MIT: 87 packages
+Apache-2.0: 8 packages
+BSD-2-Clause: 10 packages
+ISC: 7 packages
+MIT-0: 1 package
 (MIT AND Zlib): 1 package
+BSD-3-Clause: 3 packages
 Unlicense: 2 packages
 0BSD: 1 package
 (MIT OR CC0-1.0): 1 package
+CC0-1.0: 1 package
 MIT AND BSD-3-Clause: 1 package
 
-Total Dependencies: 157
+Total Dependencies: 123
 
 For detailed information, see THIRD-PARTY-NOTICES.md

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -14,6 +14,7 @@ Complete reference for all environment variables used in the Ostsee-Tiere platfo
 - [Logging & Debugging](#logging--debugging)
 - [Feature Flags](#feature-flags)
 - [Docker-Specific Variables](#docker-specific-variables)
+- [Build & Development Variables](#build--development-variables)
 - [Quick Reference](#quick-reference)
 
 ---
@@ -203,6 +204,28 @@ PUBLIC_SITE_URL=https://sightings.meeresmuseum.de
 
 ## Database Configuration
 
+### `DATABASE_URL`
+
+**Type**: `string` (Connection String)
+**Required**: No
+**Default**: none
+**Description**: Fallback connection string, only read when `DATABASE_POSTGRES_URL` is
+unset. The application itself always uses `DATABASE_POSTGRES_URL`; the fallback exists
+for the maintenance tool `src/tools/cleanup-orphaned-uploads.ts`, which accepts either
+name so it can run in environments that already provide the conventional
+`DATABASE_URL`. Neither name has a built-in default — the tool deletes files and
+therefore refuses to guess a target database.
+
+**Precedence**:
+
+```bash
+# DATABASE_POSTGRES_URL wins whenever both are set
+DATABASE_POSTGRES_URL=postgresql://user:pass@db:5432/ostsee
+DATABASE_URL=postgresql://user:pass@other:5432/ostsee   # ignored here
+```
+
+---
+
 ### `PGUSER`
 
 **Type**: `string`
@@ -283,6 +306,28 @@ PUBLIC_SITE_URL=https://sightings.meeresmuseum.de
 **Default**: `local`
 **Options**: `local` | `vercel-blob`
 **Description**: Storage backend for uploaded media files. Currently, only `local` and `vercel-blob` are supported for production use. The values `s3` and `gcs` may appear in code and types as reserved providers, but they are not implemented yet and must not be used in configuration.
+
+---
+
+### `VERCEL`
+
+**Type**: `string`
+**Required**: No (set automatically by the Vercel platform)
+**Default**: unset
+**Description**: Platform marker, not meant to be set by hand. When `STORAGE_PROVIDER`
+is empty and `VERCEL` holds any non-empty value, the storage factory
+(`src/lib/server/storage/factory.ts`) selects `vercel-blob`. Outside Vercel the factory
+falls back to `local`.
+
+**Resolution order** (first match wins):
+
+1. `STORAGE_PROVIDER` — explicit configuration
+2. `VERCEL` non-empty → `vercel-blob`
+3. SvelteKit `dev` flag → `local`
+4. fallback → `local`
+
+Setting `STORAGE_PROVIDER` explicitly overrides the `VERCEL` detection, which is the
+supported way to run a Vercel deployment against local storage or vice versa.
 
 ---
 
@@ -734,6 +779,45 @@ ALLOW_DESTRUCTIVE_MIGRATIONS=true
 **Description**: Grafana admin password.
 
 **Important**: Change this in production!
+
+---
+
+## Build & Development Variables
+
+These are read by the build and dev tooling rather than by the running application.
+
+### `USE_NODE_ADAPTER`
+
+**Type**: `boolean` (string comparison against `"true"`)
+**Required**: No
+**Default**: unset → Vercel adapter
+**Description**: Selects the SvelteKit adapter in `svelte.config.js`. Only the exact
+string `true` switches to `@sveltejs/adapter-node`; any other value keeps the Vercel
+adapter. The Docker image sets it (`Dockerfile`), so container builds always produce the
+Node build. Set it at **build** time — changing it for an already-built image has no
+effect.
+
+```bash
+# Node build (what the Dockerfile does)
+USE_NODE_ADAPTER=true npm run build
+```
+
+---
+
+### `VITE_DEV_PORT`
+
+**Type**: `number`
+**Required**: No
+**Default**: `4000`
+**Description**: Port for the Vite dev server (`vite.config.ts`). Changing it is only
+half the story: `PUBLIC_SITE_URL` builds the Auth0 callback URL and is pinned to port
+4000, so a dev server on another port still gets redirected back to 4000 after login
+unless the alternative URL is registered in Auth0. See
+[docs/WORKTREES.md](WORKTREES.md) for the full picture.
+
+```bash
+VITE_DEV_PORT=4005 npm run dev
+```
 
 ---
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -210,11 +210,26 @@ PUBLIC_SITE_URL=https://sightings.meeresmuseum.de
 **Required**: No
 **Default**: none
 **Description**: Fallback connection string, only read when `DATABASE_POSTGRES_URL` is
-unset. The application itself always uses `DATABASE_POSTGRES_URL`; the fallback exists
-for the maintenance tool `src/tools/cleanup-orphaned-uploads.ts`, which accepts either
-name so it can run in environments that already provide the conventional
-`DATABASE_URL`. Neither name has a built-in default — the tool deletes files and
-therefore refuses to guess a target database.
+unset. The application itself never reads it — `src/lib/server/db/index.ts`,
+`drizzle.config.ts`, `scripts/docker-migrate.ts` and `scripts/docker-entrypoint.sh` all
+require `DATABASE_POSTGRES_URL`. The fallback exists for part of the maintenance tooling
+in `src/tools/`, so those scripts also run in environments that already provide the
+conventional `DATABASE_URL`.
+
+**Which tools accept it**:
+
+| Tool                           | Behaviour when neither variable is set                             |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `cleanup-orphaned-uploads.ts`  | aborts — it deletes files and must never guess a target            |
+| `migrate-timestamps-to-utc.js` | aborts                                                             |
+| `fix-media-upload-flags.js`    | falls back to a hard-coded local dev connection (`localhost:5433`) |
+
+The remaining tools (`generate-reference-ids.ts`, `migrate-old-uploads.ts`) read
+`DATABASE_POSTGRES_URL` only and do **not** honour `DATABASE_URL`.
+
+Note the third row: `fix-media-upload-flags.js` is the one script that connects
+somewhere by default instead of failing. Set the variable explicitly before running it
+against anything other than the local dev database.
 
 **Precedence**:
 

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -28,7 +28,9 @@ Worktrees unter `<repo>/.claude/worktrees/` liegen, greifen sie automatisch auf
 `<repo>/node_modules` zu — inklusive `node_modules/.bin`, also auch `npm run …`.
 
 Verifiziert in einem Worktree ganz ohne eigenes `node_modules`: `npm run lint`,
-`npx svelte-kit sync` und `npm run test:unit` (2038 Tests) liefen durch.
+`npx svelte-kit sync` und `npm run test:unit` liefen durch (damals 2038 Tests — die
+Zahl wächst mit der Suite und ist hier nur Beleg dafür, dass die Suite vollständig
+lief, nicht der Sollwert).
 
 Eine eigene Installation kostet ~800 MB pro Worktree ohne Gegenwert. Nötig ist sie nur
 in zwei Fällen:

--- a/src/tools/generate-reference-ids.ts
+++ b/src/tools/generate-reference-ids.ts
@@ -12,7 +12,8 @@
  * 3. Update the sighting with the determined referenceId
  *
  * Prerequisites:
- * - DATABASE_URL environment variable must be set
+ * - DATABASE_POSTGRES_URL environment variable must be set (this tool does not
+ *   fall back to DATABASE_URL)
  * - Database connection must be available
  *
  * Usage:


### PR DESCRIPTION
Audit der Doku gegen den tatsächlichen Code-Stand, ausgelöst durch den Befund aus #602 (der `svelte-forms-lib`-Sweep aus #464 blieb auf `.claude/` und `CLAUDE.md` beschränkt).

## 1. THIRD-PARTY-NOTICES.md — der Generator ist in Ordnung, die Datei war nur alt

Die Datei wurde seit **2026-03-12** nicht neu erzeugt und listete daher noch Pakete, die längst keine Abhängigkeit mehr sind — u. a. `svelte-forms-lib@2.0.1` sowie die Teilbäume `jsonwebtoken`/`jwks-rsa` und `isomorphic-dompurify`/`jsdom`.

Die zweite Hypothese aus dem Auftrag (Generator liest die falsche Quelle) hat sich **nicht** bestätigt:

- `src/tools/generate-license-notices.js` ruft `license-checker --production --excludePrivatePackages` auf — korrekte Quelle.
- Gegenprobe: das regenerierte Ergebnis deckt sich **exakt** mit `npm ls --omit=dev --all` — 116 Pakete, keine Abweichung in beide Richtungen.

Deshalb wurde der Generator **nicht** angefasst, nur neu ausgeführt. Alle verbleibenden Lizenztypen liegen weiter innerhalb der `license:audit`-Allowlist, kein GPL/AGPL.

**Ursache, dass es auffiel:** CI regeneriert die Notices nie und vergleicht sie auch nicht — sie greift nur die `license-checker`-Summary nach GPL/AGPL ab. Es gibt also kein Drift-Gate (siehe „Offen" unten).

## 2. ENVIRONMENT.md — vier gelesene Variablen fehlten

Die Datei tritt als vollständige Referenz auf, ließ aber vier tatsächlich ausgewertete Variablen aus:

| Variable | Gelesen in |
| --- | --- |
| `DATABASE_URL` | `src/tools/cleanup-orphaned-uploads.ts` (Fallback, wenn `DATABASE_POSTGRES_URL` fehlt) |
| `VERCEL` | `src/lib/server/storage/factory.ts` (wählt `vercel-blob`, wenn `STORAGE_PROVIDER` leer ist) |
| `USE_NODE_ADAPTER` | `svelte.config.js`, gesetzt im `Dockerfile` |
| `VITE_DEV_PORT` | `vite.config.ts` — bisher nur in `WORKTREES.md` erwähnt |

Für die beiden Build-/Dev-Variablen gibt es einen neuen Abschnitt „Build & Development Variables" (inkl. ToC-Eintrag).

## 3. Struktur-Bäume

- `README.md`: `src/lib/server/` ohne `audit/`, `datetime/`, `spam/`, `utils/`, `weather/`; `src/routes/` ohne `about/`, `docs/`, `health/`, `maintenance/`, `uploads/`.
- `.claude/README.md`: `server/weather/` fehlte; `formOptions/` mit „16 Dateien" statt 17.

## 4. WORKTREES.md — Testzahl als Momentaufnahme markiert

„2038 Tests" belegte, dass die Suite in einem Worktree ohne eigenes `node_modules` durchlief; aktuell sind es 2102. Die Zahl wurde **nicht** stillschweigend hochgesetzt, sondern als zeitpunktbezogen gekennzeichnet — die umgebende Aussage protokolliert einen Verifikationslauf unter Bedingungen, die hier nicht reproduziert wurden.

## Geprüft und bewusst *nicht* geändert

Diese Kandidaten sahen veraltet aus, hielten der Prüfung am Code aber stand:

- `backup-db.sh` (DOCKER_DEPLOYMENT.md) — die Stelle fordert auf, die Datei *anzulegen*; sie soll nicht existieren.
- `tailwind.config.js` (`.claude/rules/daisyui.md`) — die Regel dokumentiert ausdrücklich, dass die Datei entfernt wurde und nicht neu angelegt werden darf.
- „Automatische Thumbnail-Generierung" (README) — stimmt: Canvas-basiert in `src/lib/utils/client/fileAnalysis.ts` (`drawImage` + `toDataURL`), client-seitig, deshalb ohne `sharp`.
- `JWKS_URL` / `API_AUDIENCE` — trotz Wegfall von `jwks-rsa` weiterhin gelesen (Auth läuft jetzt über `jose`).
- CONFIGURATION_USAGE.md — alle Methoden, Config-Keys und der 5-Minuten-Client-Cache stimmen mit `src/lib/services/configService.ts` überein.
- Zusätzlich ohne Befund: alle `npm run`-Skripte aus der Doku existieren; keine toten Markdown-Links; Rules-Tabelle und `paths`-Frontmatter in `.claude/README.md` stimmen; Port 4000, `BODY_SIZE_LIMIT`-Default (50 MB), Upload-Limits (10 MB anonym / 50 MB authentifiziert), Node-Engines, DaisyUI v5, Theme `meeresmuseum` und die Commit-Scopes sind korrekt.

Historische Review-Dokumente (`docs/UX_*`, `LAUNCH_REVIEW_*`, `TIMEZONE_REVIEW_*`, …) und `CHANGELOG.md` blieben unangetastet.

## Offen (bewusst nicht in diesem PR)

- **Kein Drift-Gate für THIRD-PARTY-NOTICES.** Genau deshalb blieb die Datei vier Monate stehen. Ein CI-Schritt, der `npm run generate:licenses` ausführt und auf ein leeres `git diff` prüft, würde das dauerhaft verhindern — das ändert aber CI-Verhalten und gehört nicht in einen Doku-PR.
- `commitlint.config.mjs` kennt zusätzlich den Scope `updated-dependencies` (Dependabot); `CLAUDE.md` listet ihn nicht. Da er nicht für Menschen gedacht ist, hier unverändert gelassen.

## Verifikation

`npm run test:quick` grün: 142 Test-Dateien, 2102 Tests, Lint nur mit den zwei bekannten `no-explicit-any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`, `tsc --noEmit` sauber. Kein Produktivcode geändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)