### PR TITLE
fix(test): allow serving main-repo node_modules to browser tests in worktrees

### DIFF
--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -39,6 +39,28 @@ in zwei Fällen:
   Worktree** (das lokale `node_modules` verdeckt das des Haupt-Repos)
 - der Worktree liegt außerhalb des Repo-Baums — dann greift die Auflösung nach oben nicht
 
+## Browser-Tests: `server.fs.allow` muss das echte `node_modules` freigeben
+
+Die `*.svelte.test.ts`-Tests (`npm run test:unit:client`) laufen über einen
+Vite-Dev-Server, der Module an den Headless-Browser ausliefert. Im Worktree liegt das
+aufgelöste `node_modules` im Haupt-Repo — **außerhalb** des Worktree-Roots — und Vites
+`server.fs.allow` blockte die Auslieferung: alle Browser-Tests scheiterten mit
+„Failed to fetch dynamically imported module …/node_modules/vitest-browser-svelte/…".
+
+Behoben in [`vite.config.ci.ts`](../vite.config.ci.ts) (wird von den Client-Tests via
+`vitest.config.ts` extended): Das reale `node_modules` wird über
+`createRequire(import.meta.url).resolve('vite/package.json')` ermittelt und zusammen
+mit `searchForWorkspaceRoot(process.cwd())` in `server.fs.allow` eingetragen —
+`fs.allow` ersetzt Vites Default (Workspace-Root), deshalb müssen beide Einträge rein.
+
+Zwei Stolperfallen für künftige Änderungen an dieser Stelle:
+
+- Ein bloßer Existenz-Check per Verzeichnis-Aufstieg findet das **falsche**
+  Verzeichnis: Vite legt im Worktree ein Cache-Stub `node_modules/.vite` ohne Pakete
+  an. Deshalb Nodes eigene Paketauflösung nutzen.
+- Verifiziert am 2026-07-29: `npx vitest run --project client src/lib/components/map/Panel/`
+  läuft mit dieser Config im Worktree **und** im Haupt-Repo grün.
+
 ## Was von selbst funktioniert
 
 | Thema           | Warum kein Setup nötig                                                                                                                                                      |

--- a/vite.config.ci.ts
+++ b/vite.config.ci.ts
@@ -4,8 +4,22 @@
  */
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
+import { createRequire } from 'node:module';
+import path from 'node:path';
 import Icons from 'unplugin-icons/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, searchForWorkspaceRoot } from 'vite';
+
+/**
+ * In Git-Worktrees liegt das installierte node_modules außerhalb des
+ * Worktree-Roots (Node löst es per Verzeichnis-Aufstieg aus dem Haupt-Repo
+ * auf). Vites server.fs.allow blockt dann die Auslieferung z. B. von
+ * vitest-browser-svelte an die Browser-Tests. Deshalb das reale
+ * node_modules über Nodes eigene Auflösung ermitteln — ein bloßer
+ * Existenz-Check reicht nicht, weil Vite im Worktree ein Cache-Stub
+ * (node_modules/.vite) ohne Pakete anlegt.
+ */
+const require = createRequire(import.meta.url);
+const nodeModulesDir = path.dirname(path.dirname(require.resolve('vite/package.json')));
 
 export default defineConfig({
 	// Set environment variable to skip database check in CI/E2E tests
@@ -31,7 +45,11 @@ export default defineConfig({
 		port: 4000,
 		strictPort: true,
 		// Disable HMR overlay for CI
-		hmr: false
+		hmr: false,
+		fs: {
+			// fs.allow ersetzt Vites Default (Workspace-Root) — daher beides angeben
+			allow: [searchForWorkspaceRoot(process.cwd()), nodeModulesDir]
+		}
 	},
 	optimizeDeps: {
 		// Pre-bundle these dependencies to avoid CommonJS issues


### PR DESCRIPTION
## Was geändert wurde

- **`vite.config.ci.ts`**: `server.fs.allow` gibt jetzt zusätzlich zum Workspace-Root (`searchForWorkspaceRoot`) das real aufgelöste `node_modules`-Verzeichnis frei. Es wird ohne hartkodierten Pfad über Nodes eigene Paketauflösung ermittelt (`createRequire(import.meta.url).resolve('vite/package.json')`).
- **`docs/WORKTREES.md`**: Neuer Abschnitt zu Ursache, Lösung und Stolperfallen.

## Warum

In Git-Worktrees unter `.claude/worktrees/` löst Node `node_modules` per Verzeichnis-Aufstieg aus dem Haupt-Repo auf — das liegt **außerhalb** des Worktree-Roots. Vites `server.fs.allow` blockte deshalb die Auslieferung von `vitest-browser-svelte` an den Headless-Browser, und **alle** `*.svelte.test.ts`-Suites (`npm run test:unit:client`) scheiterten mit „Failed to fetch dynamically imported module".

## Für Reviewer

- `fs.allow` **ersetzt** Vites Default (Workspace-Root) — daher müssen beide Einträge in die Liste.
- Ein bloßer Existenz-Check per Verzeichnis-Aufstieg findet das falsche Verzeichnis: Vite legt im Worktree ein leeres Cache-Stub `node_modules/.vite` an. Deshalb die `createRequire`-Auflösung (in der Doku als Warnung festgehalten).
- Kein Unit-Test: Konfigurationsänderung ohne Business-Logik (dokumentierte Ausnahme in `.claude/rules/testing.md`).

## Verifikation

- Worktree: `npx vitest run --project client src/lib/components/map/Panel/` → 24/24 grün; volle Client-Suite `npm run test:unit:client` → **132/132 grün**
- Haupt-Repo: Config temporär übernommen, Panel-Tests → 24/24 grün (danach Originalzustand wiederhergestellt)
- `eslint vite.config.ci.ts` und `npm run type-check` ohne Befund

🤖 Generated with [Claude Code](https://claude.com/claude-code)
