### PR TITLE
feat(map): url-sync der kartenfilter und entfernbare filter-chips (M4, N6)

### DIFF
--- a/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
+++ b/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
@@ -161,6 +161,8 @@ Ab Zoom ~12 fluten Seezeichen, Ankerplätze, Bojen (magenta/blau/gelb) die Karte
 
 Jahr, Suche, Zeitraum, Arten-Toggles und Kartenausschnitt sind nicht in der URL → gefilterte Ansichten sind **nicht teilbar/bookmarkbar**, Reload verwirft alles. Es gibt keinen „Filter zurücksetzen"-Button und keine sichtbaren aktiven Filter (Chips), sobald das Panel zu ist — die Karte kann kommentarlos „leer" wirken, wenn ein vergessener Suchbegriff/Slider aktiv ist (der Hinweis-State existiert nur beim Totalausfall aller Marker). **Empfehlung:** Query-Params (`?year=&q=&from=&to=`) + `replaceState`; Chips über der Karte mit Einzel-Entfernen + „Alle zurücksetzen".
 
+**Umgesetzt 2026-07-29** (bis auf den Kartenausschnitt): Query-Params `year`, `q`, `from`, `to`, `hs` (ausgeblendete Arten), `hc` (ausgeblendete Anzahl-Gruppen) werden beim Laden angewendet und per `replaceState` synchron gehalten (`urlFilterState.ts` mit Unit-Tests, `SightingsMapView.svelte`); aktive Filter erscheinen als einzeln entfernbare Chips über der Karte plus „Alle Filter zurücksetzen" (stellt Default-Jahr, leere Suche, vollen Zeitraum und alle Sichtbarkeiten wieder her). Der Kartenausschnitt (Center/Zoom) bleibt bewusst außen vor.
+
 ### M5 — Kein Weg zurück zur Ausgangsansicht; „Z"-Control kryptisch
 
 Nach Pan/Zoom (oder dem Welt-Zoom aus K2) gibt es keinen Home-Button; das einzige Extent-Control zeigt nur den Buchstaben „Z". **Empfehlung:** Home-Control (Ostsee-Extent) mit Icon + Tooltip; „Z" durch Icon (z. B. `lucide:maximize`) ersetzen.
@@ -201,7 +203,7 @@ Zoom-Buttons tragen englische Titles/Labels („Zoom in", „Zoom out") in anson
 - **N3:** `createClusterStyle` (`styleUtils.ts:386`) wird nirgends verwendet (Duplikat der Controller-Logik ohne Filterunterstützung).
 - **N4:** Jahresliste ist auf 10 Jahre begrenzt (`getAvailableYears(10)`), obwohl Daten bis 2007 zurückreichen — ältere Jahrgänge sind unerreichbar.
 - **N5:** Sichtungen an Land (im Test: Marker bei Hamburg-Zentrum und südlich von Hamburg) — Hinweis auf fehlende Plausibilitätsprüfung im Altbestand; auf der Karte wirken sie wie Fehler.
-- **N6:** Titel-Chip „Sichtungskarte 2026" aktualisiert korrekt bei Jahreswechsel (gut), kommuniziert aber nicht aktive Such-/Zeitfilter (siehe M4).
+- **N6:** Titel-Chip „Sichtungskarte 2026" aktualisiert korrekt bei Jahreswechsel (gut), kommuniziert aber nicht aktive Such-/Zeitfilter (siehe M4). — **Behoben 2026-07-29** über die Filter-Chips aus M4.
 - **N7:** Der Hilfe-„?"-Button unten links bleibt bestehen — gut sichtbar, aber sein Modal erwähnt die automatische Suche nicht und listet Escape nur für „Dialoge".
 
 ---
@@ -215,7 +217,7 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 | **Navigation/Controls**                             |                                                                                      |         |
 | Zoom-Buttons sichtbar, ≥44 px                       | ❌ 19×19 px                                                                          | H4      |
 | Kein Verdecken relevanter Daten durch UI            | ⚠️ Panels auf 320 px reduziert (2026-07-29), überlagern rechts weiterhin             | H6      |
-| Zustand teilbar (URL)                               | ❌                                                                                   | M4      |
+| Zustand teilbar (URL)                               | ⚠️ Filter in URL (2026-07-29), Kartenausschnitt weiterhin nicht                      | M4      |
 | Home-/Ausgangsansicht                               | ❌                                                                                   | M5      |
 | „Locate me"                                         | ❌ implementiert, deaktiviert                                                        | N2      |
 | Basemap lenkt nicht ab                              | ⚠️ OpenSeaMap dominiert ab Z12                                                       | M3      |
@@ -233,7 +235,7 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 | **Filter/Legende**                                  |                                                                                      |         |
 | Wirkung sofort sichtbar                             | ✅                                                                                   | —       |
 | Ergebnisanzahl sichtbar                             | ⚠️ nur in Legende (sichtbar/gesamt), nicht am Suchfeld                               | H3      |
-| Aktive Filter als Chips + Reset                     | ❌                                                                                   | M4      |
+| Aktive Filter als Chips + Reset                     | ✅ behoben 2026-07-29 (Chips über der Karte + „Alle zurücksetzen")                   | M4      |
 | Slider mit numerischem Fallback                     | ❌                                                                                   | M10     |
 | Legende konsistent mit Kartendarstellung            | ❌                                                                                   | M1      |
 | Ladeindikator bei Filteranwendung                   | ⚠️ vorhanden, aber fake-getimt bzw. überblockierend                                  | H3/M7   |
@@ -274,7 +276,7 @@ Bewertung: ✅ erfüllt · ⚠️ teilweise · ❌ nicht erfüllt
 - K3: `tabindex` + Fokusring + Skip-Link; Listen-/Tabellenansicht der gefilterten Sichtungen. — **Umgesetzt 2026-07-29** (`SightingsMapView.svelte`, `SightingsListView.svelte`, `listViewUtils.ts`).
 - H5: ARIA-Sanierung der Panels (inert, region, Fokus-Management). — **Umgesetzt 2026-07-29** (`FilterPanel.svelte`, `LegendPanel.svelte`, `LoadingOverlay.svelte`, `panelFocus.ts`; inkl. H7: Shortcuts nur bei Fokus in der Karten-Region, Panel-Steuerung über `bind:isOpen` statt DOM-Queries).
 - M1: Einheitliches Marker-/Legenden-Codierungssystem (colorblind-safe, Legende aus gemeinsamen Konstanten).
-- M4: URL-State + Filter-Chips + Reset.
+- M4: URL-State + Filter-Chips + Reset. — **Umgesetzt 2026-07-29** (`urlFilterState.ts` + Tests, `SightingsMapView.svelte`, `FilterPanel.svelte`, `LegendPanel.svelte`, `optimizedMapController.ts`; Kartenausschnitt weiterhin nicht in der URL).
 - M7: Loading-Konzept (Vollbild nur initial).
 - H6: Mobile Bottom-Sheet für Filter/Legende. — **Umgesetzt 2026-07-29** (gemeinsame Wrapper-Komponente `MapPanel.svelte`: < md Bottom-Sheet mit Peek/Expanded-Zustand, Schließen per Button, ab md 320-px-Seitenpanel mit `h-[calc(100%-5rem)]`; Öffnen des einen Panels schließt das andere in `SightingsMapView.svelte`; solange ein Sheet offen ist, blendet Mobile die Toggle-Tabs aus, weil sie sonst den Sheet-Header verdecken).
 

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -8,6 +8,9 @@
 		defaultYear,
 		yearCounts = {},
 		isLoading = false,
+		// M4: Suchbegriff aus der URL wiederhergestellt — nur Anzeige-Startwert,
+		// der zugehörige Daten-Fetch läuft über initialSearchTerm des Controllers.
+		initialSearch = '',
 		// H6: Parent blendet die Toggle-Tabs auf Mobile aus, solange ein Sheet offen ist
 		toggleHidden = false,
 		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
@@ -18,6 +21,7 @@
 		defaultYear?: number;
 		yearCounts?: Record<number, number>;
 		isLoading?: boolean;
+		initialSearch?: string;
 		toggleHidden?: boolean;
 		isOpen?: boolean;
 	}>();
@@ -28,7 +32,10 @@
 	let selectedYear = $derived(
 		userSelectedYear ?? defaultYear ?? years.at(-1) ?? new Date().getFullYear()
 	);
-	let searchValue = $state('');
+	// Bewusst nur der Startwert: danach ist das Eingabefeld (bind:value)
+	// die Quelle der Wahrheit.
+	// svelte-ignore state_referenced_locally
+	let searchValue = $state(initialSearch);
 
 	let daysInYear = $derived(getDaysInYear(selectedYear));
 

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -20,20 +20,23 @@
 		toggleHidden = false,
 		// H5: bindable, damit Tastaturkürzel im Parent das Panel direkt über
 		// den State steuern können statt über DOM-Queries.
-		isOpen = $bindable(false)
+		isOpen = $bindable(false),
+		// M4/N6: Sichtbarkeits-States sind bindable, damit der Parent sie aus
+		// der URL initialisieren und über die Filter-Chips zurücksetzen kann —
+		// Checkboxen hier und Chips dort bleiben so eine einzige Wahrheit.
+		speciesVisibility = $bindable({}),
+		colorVisibility = $bindable({})
 	} = $props<{
 		translations: MapTranslations;
 		counts: CountData;
 		toggleHidden?: boolean;
 		isOpen?: boolean;
+		speciesVisibility?: Record<string, boolean>;
+		colorVisibility?: Record<string, boolean>;
 	}>();
 
 	// CountManager via typisiertem Svelte Context (Symbol-Key, siehe mapContext.ts)
 	const countManager = getMapCountManager();
-
-	// Zustand der Sichtbarkeitsfilter
-	let speciesVisibility = $state<Record<string, boolean>>({});
-	let colorVisibility = $state<Record<string, boolean>>({});
 
 	// Anzahl-Filtergruppen in Anzeige-Reihenfolge (Totfund zuletzt) — aus styleUtils
 	const countGroups = $derived(
@@ -49,17 +52,17 @@
 		{ label: String(translations.found_dead), color: TOTFUND_RING_COLOR }
 	]);
 
-	// Initialisiere Visibility-States (alle sichtbar)
+	// Initialisiere Visibility-States (alle sichtbar). Nur fehlende Keys
+	// auffüllen — bereits gesetzte Werte (z. B. aus der URL wiederhergestellte
+	// ausgeblendete Arten, M4) dürfen nicht überschrieben werden.
 	$effect(() => {
 		if (translations && translations.speciesMap) {
-			// Initialisiere alle Arten als sichtbar
 			Object.keys(translations.speciesMap).forEach((key) => {
-				speciesVisibility[key] = true;
+				if (!(key in speciesVisibility)) speciesVisibility[key] = true;
 			});
 
-			// Initialisiere alle Anzahl-Gruppen als sichtbar
 			Object.keys(legendGroups).forEach((colorGroup) => {
-				colorVisibility[colorGroup] = true;
+				if (!(colorGroup in colorVisibility)) colorVisibility[colorGroup] = true;
 			});
 		}
 	});

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -337,7 +337,8 @@
 		const query = serializeMapFilterParams(state);
 		const search = query ? `?${query}` : '';
 		if (window.location.search === search) return;
-		replaceState(`${window.location.pathname}${search}`, page.state);
+		// Hash beibehalten — z. B. #map-skip-target nach Nutzung des Skip-Links.
+		replaceState(`${window.location.pathname}${search}${window.location.hash}`, page.state);
 	}
 
 	// --- N6: Aktionen der Filter-Chips -------------------------------------

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -15,6 +15,16 @@
 	} from '$lib/utils/date/defaultYear';
 	import { setMapCountManager } from '$lib/map/mapContext';
 	import { toListEntries, type SightingListProperties } from '$lib/map/listViewUtils';
+	import { legendGroups } from '$lib/map/styleUtils';
+	import {
+		buildFilterUrlState,
+		dayOfYearFromIsoDate,
+		parseMapFilterParams,
+		serializeMapFilterParams,
+		type MapFilterUrlState
+	} from '$lib/map/urlFilterState';
+	import { page } from '$app/state';
+	import { replaceState } from '$app/navigation';
 	import 'ol/ol.css';
 	import LoadingOverlay from './LoadingOverlay.svelte';
 	import FilterPanel from './Panel/FilterPanel.svelte';
@@ -79,15 +89,30 @@
 		colorCounts: {}
 	});
 
-	// Verfügbare Jahre für den Filter (10 Jahre zurück)
+	// M4: Filterzustand aus der URL — einmalig beim Initialisieren gelesen.
+	// Danach ist der Map-Controller die Quelle der Wahrheit, die URL folgt
+	// per replaceState (siehe syncFiltersToUrl). Die Route läuft mit ssr=false,
+	// window/page.url sind hier also verfügbar.
+	const urlFilterState = parseMapFilterParams(page.url.searchParams);
+
+	// Verfügbare Jahre für den Filter (10 Jahre zurück); ein per URL geteiltes
+	// älteres Jahr wird ergänzt, damit das Dropdown es anzeigen kann.
 	const years = getAvailableYears(10);
+	if (urlFilterState.year !== undefined && !years.includes(urlFilterState.year)) {
+		years.push(urlFilterState.year);
+		years.sort((a, b) => a - b);
+	}
 	// Bisheriges Fallback-Jahr, synchron verfügbar für den allerersten Render
 	// (bevor GET /api/map/sightings/years geladen ist). Als Konstante erfasst,
 	// damit die beiden $state-Deklarationen unten nicht voneinander abhängen.
 	const initialFallbackYear = getDefaultSightingYear();
 	// Default-Jahr: wird aktualisiert, sobald die verfügbaren Jahre geladen
-	// sind (QW2b). Bei fehlgeschlagenem Request bleibt der Fallback.
-	let defaultYear = $state(initialFallbackYear);
+	// sind (QW2b). Bei fehlgeschlagenem Request bleibt der Fallback. Ein Jahr
+	// aus der URL hat Vorrang — es speist das Jahres-Dropdown im FilterPanel.
+	let defaultYear = $state(urlFilterState.year ?? initialFallbackYear);
+	// Jahr, auf das „Filter zurücksetzen" führt (QW2b-Default, unabhängig von
+	// der URL) — Referenz dafür, ob das angezeigte Jahr als Filter-Chip zählt.
+	let apiDefaultYear = $state(initialFallbackYear);
 	// Rohdaten der verfügbaren Jahre (Antwort von GET /api/map/sightings/years)
 	let availableYearsData = $state<YearWithCount[]>([]);
 	// Sichtungsanzahl je Jahr für die Jahres-Dropdown-Beschriftung ("2025 (817)")
@@ -127,6 +152,26 @@
 	let isInitialLoading = $state(true);
 	let loadingType = $state<'initial' | 'filter' | 'features'>('initial');
 	let errorMessage = $state<string | null>(null);
+
+	// M4/N6: Sichtbarkeits-States der Legende — hierher gehoben, damit
+	// URL-Initialisierung und Filter-Chips dieselben Checkbox-Zustände
+	// steuern wie das LegendPanel (bind: an dessen Props).
+	let speciesVisibility = $state<Record<string, boolean>>({});
+	let colorVisibility = $state<Record<string, boolean>>({});
+
+	// N6: aktuell aktive Filter für die Chips — nach jedem Count-Update aus
+	// dem Controller-Zustand neu abgeleitet (Default-Werte sind weggelassen).
+	let activeFilters = $state<MapFilterUrlState>({});
+	let hasActiveFilters = $derived(
+		activeFilters.year !== undefined ||
+			activeFilters.query !== undefined ||
+			activeFilters.from !== undefined ||
+			(activeFilters.hiddenSpecies?.length ?? 0) > 0 ||
+			(activeFilters.hiddenColors?.length ?? 0) > 0
+	);
+	// URL-Schreiben erst nach applyUrlFilters() freischalten — die Zwischen-
+	// stände des Initial-Loads würden die geteilten Params sonst wegkürzen.
+	let urlSyncEnabled = false;
 
 	// Aktuell angezeigtes Jahr für den Titel
 	let currentDisplayedYear = $state(initialFallbackYear);
@@ -218,6 +263,148 @@
 		yearSelect.dispatchEvent(new Event('change', { bubbles: true }));
 	}
 
+	/**
+	 * Wendet den beim Start aus der URL gelesenen Filterzustand an (M4).
+	 * Läuft einmalig nach dem ersten Daten-Load (siehe onLoading-Callback).
+	 * Jahr und Suchbegriff sind zu dem Zeitpunkt bereits über initialYear/
+	 * initialSearchTerm des Controllers aktiv — hier fehlen noch Zeitraum
+	 * und Sichtbarkeiten.
+	 */
+	function applyUrlFilters(): void {
+		if (!mapInstance) return;
+		const year = mapInstance.getDisplayedYear();
+
+		// Ausgeblendete Arten/Farbgruppen — nur bekannte Keys übernehmen,
+		// damit Tippfehler aus geteilten URLs nicht dauerhaft mitgeschleppt werden.
+		for (const id of urlFilterState.hiddenSpecies ?? []) {
+			if (id in speciesLabels) {
+				speciesVisibility[id] = false;
+				countManager.setSpeciesVisibility(id, false);
+			}
+		}
+		for (const key of urlFilterState.hiddenColors ?? []) {
+			if (key in legendGroups) {
+				colorVisibility[key] = false;
+				countManager.setColorVisibility(key, false);
+			}
+		}
+
+		// Zeitraum: über denselben Pfad wie die Slider-Bedienung (DOM-Werte
+		// setzen + input-Event), damit Slider-Stellung und Datenfilter nicht
+		// auseinanderlaufen. Daten aus einem anderen Jahr liefern null und
+		// werden ignoriert.
+		const startDay = urlFilterState.from ? dayOfYearFromIsoDate(urlFilterState.from, year) : null;
+		const endDay = urlFilterState.to ? dayOfYearFromIsoDate(urlFilterState.to, year) : null;
+		if (startDay === null && endDay === null) return;
+
+		const startSlider = document.getElementById('time-range-start') as HTMLInputElement | null;
+		const endSlider = document.getElementById('time-range-end') as HTMLInputElement | null;
+		if (!startSlider || !endSlider) return;
+
+		// max explizit setzen — das reaktive max-Attribut des FilterPanels ist
+		// zu diesem Zeitpunkt möglicherweise noch nicht auf das Jahr geflusht.
+		const maxValue = (getDaysInYear(year) - 1).toString();
+		startSlider.max = maxValue;
+		endSlider.max = maxValue;
+		if (endDay !== null) endSlider.value = endDay.toString();
+		if (startDay !== null) startSlider.value = startDay.toString();
+		// Beide Werte sind gesetzt, bevor Events feuern — der Clamping-Code im
+		// TimeSliderManager sieht damit bereits das konsistente Paar.
+		endSlider.dispatchEvent(new Event('input', { bubbles: true }));
+		startSlider.dispatchEvent(new Event('input', { bubbles: true }));
+	}
+
+	/** Liest den aktuellen Filterzustand aus dem Controller (Defaults weggelassen). */
+	function readCurrentFilterState(): MapFilterUrlState {
+		if (!mapInstance) return {};
+		const hidden = mapInstance.getHidden();
+		return buildFilterUrlState({
+			year: mapInstance.getDisplayedYear(),
+			defaultYear: apiDefaultYear,
+			searchTerm: mapInstance.getSearchTerm(),
+			timeFilter: mapInstance.getTimeFilter(),
+			hiddenSpecies: hidden.species,
+			hiddenColors: hidden.colors
+		});
+	}
+
+	/**
+	 * M4: Spiegelt den Filterzustand per replaceState in die URL — keine
+	 * Navigation, kein History-Eintrag, damit Zurück nicht durch jede
+	 * Filteränderung läuft.
+	 */
+	function syncFiltersToUrl(state: MapFilterUrlState): void {
+		const query = serializeMapFilterParams(state);
+		const search = query ? `?${query}` : '';
+		if (window.location.search === search) return;
+		replaceState(`${window.location.pathname}${search}`, page.state);
+	}
+
+	// --- N6: Aktionen der Filter-Chips -------------------------------------
+
+	/** Leert die Suche über denselben Pfad wie das Suchfeld (input-Event). */
+	function clearSearchFilter(): void {
+		const input = document.getElementById('filter-input') as HTMLInputElement | null;
+		if (!input) return;
+		input.value = '';
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+	}
+
+	/** Stellt den vollen Jahres-Zeitraum wieder her (Slider + Datenfilter). */
+	function resetTimeFilter(): void {
+		if (!mapInstance) return;
+		const year = mapInstance.getDisplayedYear();
+		timeSliderManager?.reset(getDaysInYear(year));
+		mapInstance.setFilter(
+			new Date(year, 0, 1).getTime(),
+			new Date(year, 11, 31, 23, 59, 59, 999).getTime()
+		);
+	}
+
+	function showSpecies(speciesId: string): void {
+		speciesVisibility[speciesId] = true;
+		countManager.setSpeciesVisibility(speciesId, true);
+	}
+
+	function showColorGroup(colorGroup: string): void {
+		colorVisibility[colorGroup] = true;
+		countManager.setColorVisibility(colorGroup, true);
+	}
+
+	/**
+	 * N6: Stellt Default-Jahr, leere Suche, vollen Zeitraum und alle
+	 * Sichtbarkeiten wieder her.
+	 */
+	function resetAllFilters(): void {
+		clearSearchFilter();
+		resetTimeFilter();
+		// Kopien iterieren: die Handler stoßen Count-Updates an, die
+		// activeFilters während der Iteration neu zuweisen.
+		[...(activeFilters.hiddenSpecies ?? [])].forEach(showSpecies);
+		[...(activeFilters.hiddenColors ?? [])].forEach(showColorGroup);
+		if (mapInstance && mapInstance.getDisplayedYear() !== apiDefaultYear) {
+			switchToYear(apiDefaultYear);
+		}
+	}
+
+	/** Chip-Beschriftung einer Art — speciesLabels ist über SpeciesEnum indiziert. */
+	function speciesLabel(speciesId: string): string {
+		const labels: Record<string, string> = speciesLabels;
+		return labels[speciesId] ?? `Art ${speciesId}`;
+	}
+
+	/** Chip-Beschriftung einer Anzahl-Gruppe (analog zum LegendPanel). */
+	function colorGroupLabel(colorGroup: string): string {
+		if (colorGroup === 'ct0') return String(translations.found_dead);
+		return `Anzahl ${legendGroups[colorGroup]?.name ?? colorGroup}`;
+	}
+
+	/** ISO-Datum (YYYY-MM-DD) → kompakte deutsche Anzeige „TT.MM." */
+	function formatChipDate(iso: string): string {
+		const [, month, day] = iso.split('-');
+		return `${day}.${month}.`;
+	}
+
 	// Modern $effect for map initialization and cleanup
 	$effect(() => {
 		// Check if we have the required DOM element
@@ -232,9 +419,12 @@
 		void (async () => {
 			// QW2b: Verfügbare Jahre vor Karteninitialisierung laden, damit die
 			// Karte direkt mit einem Jahr startet, das tatsächlich Daten hat.
-			const initialYear = await loadAvailableYears();
+			// M4: Ein Jahr aus der URL hat Vorrang vor dem ermittelten Default.
+			const loadedDefaultYear = await loadAvailableYears();
 			if (cancelled) return;
 
+			apiDefaultYear = loadedDefaultYear;
+			const initialYear = urlFilterState.year ?? loadedDefaultYear;
 			defaultYear = initialYear;
 
 			// Initialisiere Manager
@@ -252,6 +442,7 @@
 				timeEndId: 'time-end',
 				enableLocationControl: false,
 				initialYear,
+				initialSearchTerm: urlFilterState.query ?? '',
 				onLoading: (loading) => {
 					isLoadingData = loading;
 					if (loading) {
@@ -259,6 +450,12 @@
 						errorMessage = null;
 					} else if (!firstLoadComplete) {
 						firstLoadComplete = true;
+						// M4: URL-Filter erst nach dem ersten Load anwenden —
+						// setYear() setzt den timeFilter nach dem Fetch auf das
+						// volle Jahr zurück und würde einen früher gesetzten
+						// URL-Zeitraum wieder verwerfen.
+						applyUrlFilters();
+						urlSyncEnabled = true;
 						countManager.updateCounts();
 						currentDisplayedYear = mapInstance!.getDisplayedYear();
 						isInitialLoading = false;
@@ -278,6 +475,10 @@
 			countManager.onCountsUpdated((newCounts) => {
 				counts = newCounts;
 				featureCount = countMapInstance.getFeatures().length;
+				// M4/N6: Der CountManager feuert nach jeder Filter-, Zeitraum-
+				// und Jahresänderung — derselbe Trigger hält Chips und URL synchron.
+				activeFilters = readCurrentFilterState();
+				if (urlSyncEnabled) syncFiltersToUrl(activeFilters);
 			});
 
 			// Initialisiere andere Manager
@@ -448,6 +649,80 @@
 		</h1>
 	{/if}
 
+	<!-- N6: Aktive Filter als einzeln entfernbare Chips über der Karte —
+	     sichtbar auch bei geschlossenen Panels. Klick auf einen Chip entfernt
+	     genau diesen Filter; „Alle zurücksetzen" stellt den Grundzustand her. -->
+	{#if hasActiveFilters}
+		<div
+			class="absolute top-16 left-1/2 z-30 flex w-max max-w-[92vw] -translate-x-1/2 flex-wrap items-center justify-center gap-2"
+			role="group"
+			aria-label="Aktive Filter"
+		>
+			{#if activeFilters.year !== undefined}
+				<button
+					type="button"
+					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					onclick={() => switchToYear(apiDefaultYear)}
+					aria-label="Filter Jahr {activeFilters.year} entfernen und zum Standard-Jahr {apiDefaultYear} wechseln"
+				>
+					Jahr {activeFilters.year}
+					<Icon icon="lucide:x" width="14" height="14" aria-hidden="true" />
+				</button>
+			{/if}
+			{#if activeFilters.query !== undefined}
+				<button
+					type="button"
+					class="btn btn-sm bg-base-100 min-h-11 max-w-56 gap-1 shadow-lg"
+					onclick={clearSearchFilter}
+					aria-label="Suchfilter {activeFilters.query} entfernen"
+				>
+					<span class="truncate">Suche „{activeFilters.query}"</span>
+					<Icon icon="lucide:x" width="14" height="14" class="shrink-0" aria-hidden="true" />
+				</button>
+			{/if}
+			{#if activeFilters.from !== undefined && activeFilters.to !== undefined}
+				<button
+					type="button"
+					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					onclick={resetTimeFilter}
+					aria-label="Zeitraum-Filter entfernen und volles Jahr anzeigen"
+				>
+					Zeitraum {formatChipDate(activeFilters.from)}–{formatChipDate(activeFilters.to)}
+					<Icon icon="lucide:x" width="14" height="14" aria-hidden="true" />
+				</button>
+			{/if}
+			{#each activeFilters.hiddenSpecies ?? [] as speciesId (speciesId)}
+				<button
+					type="button"
+					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					onclick={() => showSpecies(speciesId)}
+					aria-label="{speciesLabel(speciesId)} wieder anzeigen"
+				>
+					Ohne {speciesLabel(speciesId)}
+					<Icon icon="lucide:x" width="14" height="14" aria-hidden="true" />
+				</button>
+			{/each}
+			{#each activeFilters.hiddenColors ?? [] as colorGroup (colorGroup)}
+				<button
+					type="button"
+					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					onclick={() => showColorGroup(colorGroup)}
+					aria-label="Gruppe {colorGroupLabel(colorGroup)} wieder anzeigen"
+				>
+					Ohne {colorGroupLabel(colorGroup)}
+					<Icon icon="lucide:x" width="14" height="14" aria-hidden="true" />
+				</button>
+			{/each}
+			<button
+				type="button"
+				class="btn btn-outline btn-sm bg-base-100 min-h-11 shadow-lg"
+				onclick={resetAllFilters}
+			>
+				Alle Filter zurücksetzen
+			</button>
+		</div>
+	{/if}
+
 	<!-- Vollbild-Karte -->
 	<div class="relative h-full w-full">
 		<!--
@@ -606,6 +881,7 @@
 		{defaultYear}
 		{yearCounts}
 		isLoading={isLoadingData}
+		initialSearch={urlFilterState.query ?? ''}
 		toggleHidden={filterOpen || legendOpen}
 		bind:isOpen={filterOpen}
 	/>
@@ -616,6 +892,8 @@
 		{counts}
 		toggleHidden={filterOpen || legendOpen}
 		bind:isOpen={legendOpen}
+		bind:speciesVisibility
+		bind:colorVisibility
 	/>
 
 	<!-- Tastatur-Hilfe Button -->

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -63,6 +63,12 @@ export interface MapOptions {
 	 * verfügbaren Jahre vom Server geladen sind.
 	 */
 	initialYear?: number;
+	/**
+	 * Startet die Karte mit einem bereits gesetzten Suchbegriff (M4: aus der
+	 * URL wiederhergestellt) — fließt in den ersten Daten-Fetch ein, statt
+	 * nach dem Initial-Load einen zweiten Request auszulösen.
+	 */
+	initialSearchTerm?: string;
 	onLoading?: (isLoading: boolean) => void;
 	onError?: (error: Error) => void;
 }
@@ -192,6 +198,7 @@ export class SichtungenMap {
 
 		// Initialize the timeFilter with sensible defaults (zeige das ganze Jahr)
 		this.displayedYear = options.initialYear ?? getDefaultSightingYear();
+		this.searchTerm = options.initialSearchTerm ?? '';
 		const yearStart = new Date(this.displayedYear, 0, 1).getTime();
 		const yearEnd = new Date(this.displayedYear, 11, 31, 23, 59, 59).getTime();
 		this.timeFilter = {
@@ -997,6 +1004,10 @@ export class SichtungenMap {
 
 	public getTimeFilter(): { lower: number; upper: number } {
 		return this.timeFilter;
+	}
+
+	public getSearchTerm(): string {
+		return this.searchTerm;
 	}
 
 	public getFeatures(): Feature<Geometry>[] {

--- a/src/lib/map/urlFilterState.test.ts
+++ b/src/lib/map/urlFilterState.test.ts
@@ -124,6 +124,12 @@ describe('parseMapFilterParams', () => {
 			});
 		});
 
+		it('trimmt Whitespace um Einträge (handbearbeitete URLs)', () => {
+			expect(parseMapFilterParams(params({ hs: '1, 2 ,3' }))).toEqual({
+				hiddenSpecies: ['1', '2', '3']
+			});
+		});
+
 		it('ignoriert hs wenn kein gültiger Eintrag übrig bleibt', () => {
 			expect(parseMapFilterParams(params({ hs: 'abc,,x' }))).toEqual({});
 		});
@@ -145,6 +151,12 @@ describe('parseMapFilterParams', () => {
 		it('entfernt Duplikate', () => {
 			expect(parseMapFilterParams(params({ hc: 'ct1,ct1,ct2' }))).toEqual({
 				hiddenColors: ['ct1', 'ct2']
+			});
+		});
+
+		it('trimmt Whitespace um Einträge (handbearbeitete URLs)', () => {
+			expect(parseMapFilterParams(params({ hc: ' ct0 , ct1' }))).toEqual({
+				hiddenColors: ['ct0', 'ct1']
 			});
 		});
 

--- a/src/lib/map/urlFilterState.test.ts
+++ b/src/lib/map/urlFilterState.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from 'vitest';
+import {
+	buildFilterUrlState,
+	dayOfYearFromIsoDate,
+	isFullYearRange,
+	isoDateFromTimestamp,
+	parseMapFilterParams,
+	serializeMapFilterParams,
+	type MapFilterUrlState
+} from '$lib/map/urlFilterState';
+
+/**
+ * Tests für den URL-Query-Param-Sync der Sichtungskarten-Filter
+ * (Befund M4/N6 aus docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md).
+ *
+ * Vertrag: Query-Params `year`, `q`, `from`, `to`, `hs`, `hc`.
+ * Ungültige Werte werden feldweise ignoriert; Default-Werte werden
+ * beim Serialisieren weggelassen. Alle Zeitstempel sind lokale Zeit
+ * (die Slider/der Controller arbeiten in der Browser-Zeitzone).
+ */
+
+/** Baut URLSearchParams aus einem Record — kompakter als Query-Strings im Test. */
+function params(entries: Record<string, string>): URLSearchParams {
+	return new URLSearchParams(entries);
+}
+
+describe('parseMapFilterParams', () => {
+	it('gibt leeren Zustand für leere Params zurück', () => {
+		expect(parseMapFilterParams(new URLSearchParams())).toEqual({});
+	});
+
+	describe('year', () => {
+		it('liest gültiges Jahr als Zahl', () => {
+			expect(parseMapFilterParams(params({ year: '2025' }))).toEqual({ year: 2025 });
+		});
+
+		it('akzeptiert die Bereichsgrenzen 2000 und 2100', () => {
+			expect(parseMapFilterParams(params({ year: '2000' }))).toEqual({ year: 2000 });
+			expect(parseMapFilterParams(params({ year: '2100' }))).toEqual({ year: 2100 });
+		});
+
+		it('ignoriert nicht-numerisches Jahr', () => {
+			expect(parseMapFilterParams(params({ year: 'abc' }))).toEqual({});
+		});
+
+		it('ignoriert Jahr unterhalb des Bereichs', () => {
+			expect(parseMapFilterParams(params({ year: '1899' }))).toEqual({});
+		});
+
+		it('ignoriert Jahr oberhalb des Bereichs', () => {
+			expect(parseMapFilterParams(params({ year: '99999' }))).toEqual({});
+		});
+	});
+
+	describe('q', () => {
+		it('liest Suchbegriff getrimmt', () => {
+			expect(parseMapFilterParams(params({ q: '  Schweinswal  ' }))).toEqual({
+				query: 'Schweinswal'
+			});
+		});
+
+		it('ignoriert leeren Suchbegriff', () => {
+			expect(parseMapFilterParams(params({ q: '' }))).toEqual({});
+		});
+
+		it('ignoriert Suchbegriff aus nur Whitespace', () => {
+			expect(parseMapFilterParams(params({ q: '   ' }))).toEqual({});
+		});
+	});
+
+	describe('from/to', () => {
+		it('liest gültige ISO-Daten', () => {
+			expect(parseMapFilterParams(params({ from: '2025-03-01', to: '2025-09-30' }))).toEqual({
+				from: '2025-03-01',
+				to: '2025-09-30'
+			});
+		});
+
+		it('akzeptiert from ohne to', () => {
+			expect(parseMapFilterParams(params({ from: '2025-03-01' }))).toEqual({
+				from: '2025-03-01'
+			});
+		});
+
+		it('akzeptiert to ohne from', () => {
+			expect(parseMapFilterParams(params({ to: '2025-09-30' }))).toEqual({ to: '2025-09-30' });
+		});
+
+		it('ignoriert unmögliches Kalenderdatum (2025-02-30)', () => {
+			expect(parseMapFilterParams(params({ from: '2025-02-30' }))).toEqual({});
+		});
+
+		it('ignoriert ungültigen Monat (2025-13-01)', () => {
+			expect(parseMapFilterParams(params({ to: '2025-13-01' }))).toEqual({});
+		});
+
+		it('ignoriert Werte im falschen Format', () => {
+			expect(parseMapFilterParams(params({ from: 'kein-datum' }))).toEqual({});
+		});
+
+		it('ignoriert ungültiges from unabhängig von gültigem to', () => {
+			expect(parseMapFilterParams(params({ from: 'kein-datum', to: '2025-09-30' }))).toEqual({
+				to: '2025-09-30'
+			});
+		});
+	});
+
+	describe('hs (ausgeblendete Arten)', () => {
+		it('splittet kommaseparierte Arten-IDs', () => {
+			expect(parseMapFilterParams(params({ hs: '0,2,5' }))).toEqual({
+				hiddenSpecies: ['0', '2', '5']
+			});
+		});
+
+		it('behält nur rein numerische Einträge', () => {
+			expect(parseMapFilterParams(params({ hs: '1,abc,2,ct3' }))).toEqual({
+				hiddenSpecies: ['1', '2']
+			});
+		});
+
+		it('entfernt Duplikate', () => {
+			expect(parseMapFilterParams(params({ hs: '1,2,1' }))).toEqual({
+				hiddenSpecies: ['1', '2']
+			});
+		});
+
+		it('ignoriert hs wenn kein gültiger Eintrag übrig bleibt', () => {
+			expect(parseMapFilterParams(params({ hs: 'abc,,x' }))).toEqual({});
+		});
+	});
+
+	describe('hc (ausgeblendete Farbgruppen)', () => {
+		it('splittet kommaseparierte Farbgruppen-Keys', () => {
+			expect(parseMapFilterParams(params({ hc: 'ct0,ct1' }))).toEqual({
+				hiddenColors: ['ct0', 'ct1']
+			});
+		});
+
+		it('behält nur Einträge im Muster ct<Zahl>', () => {
+			expect(parseMapFilterParams(params({ hc: 'ct0,foo,3,ct12' }))).toEqual({
+				hiddenColors: ['ct0', 'ct12']
+			});
+		});
+
+		it('entfernt Duplikate', () => {
+			expect(parseMapFilterParams(params({ hc: 'ct1,ct1,ct2' }))).toEqual({
+				hiddenColors: ['ct1', 'ct2']
+			});
+		});
+
+		it('ignoriert hc wenn kein gültiger Eintrag übrig bleibt', () => {
+			expect(parseMapFilterParams(params({ hc: 'foo,bar' }))).toEqual({});
+		});
+	});
+
+	it('ignoriert ungültige Felder einzeln und behält gültige', () => {
+		const result = parseMapFilterParams(
+			params({ year: 'abc', q: 'Robbe', from: '2025-02-30', hs: '3', hc: 'nope' })
+		);
+
+		expect(result).toEqual({ query: 'Robbe', hiddenSpecies: ['3'] });
+	});
+});
+
+describe('serializeMapFilterParams', () => {
+	it('gibt leeren String für leeren Zustand zurück', () => {
+		expect(serializeMapFilterParams({})).toBe('');
+	});
+
+	it('serialisiert einzelne Felder', () => {
+		expect(serializeMapFilterParams({ year: 2024 })).toBe('year=2024');
+		expect(serializeMapFilterParams({ query: 'Robbe' })).toBe('q=Robbe');
+		expect(serializeMapFilterParams({ from: '2025-03-01' })).toBe('from=2025-03-01');
+	});
+
+	it('hat kein führendes Fragezeichen', () => {
+		expect(serializeMapFilterParams({ year: 2024 })).not.toMatch(/^\?/);
+	});
+
+	it('hält die Feld-Reihenfolge year, q, from, to, hs, hc ein', () => {
+		const result = serializeMapFilterParams({
+			hiddenColors: ['ct0'],
+			hiddenSpecies: ['1'],
+			to: '2025-09-30',
+			from: '2025-03-01',
+			query: 'Wal',
+			year: 2024
+		});
+
+		const keys = [...new URLSearchParams(result).keys()];
+		expect(keys).toEqual(['year', 'q', 'from', 'to', 'hs', 'hc']);
+	});
+
+	it('serialisiert Arrays kommasepariert als ein Param', () => {
+		const result = serializeMapFilterParams({
+			hiddenSpecies: ['0', '2', '5'],
+			hiddenColors: ['ct0', 'ct1']
+		});
+
+		// Komma darf URL-encodiert sein (%2C) — deshalb Roundtrip statt String-Vergleich
+		const parsed = new URLSearchParams(result);
+		expect(parsed.get('hs')).toBe('0,2,5');
+		expect(parsed.get('hc')).toBe('ct0,ct1');
+	});
+
+	it('lässt nicht gesetzte Felder weg', () => {
+		const result = serializeMapFilterParams({ year: 2024, hiddenSpecies: ['1'] });
+
+		const parsed = new URLSearchParams(result);
+		expect(parsed.has('q')).toBe(false);
+		expect(parsed.has('from')).toBe(false);
+		expect(parsed.has('to')).toBe(false);
+		expect(parsed.has('hc')).toBe(false);
+	});
+
+	it('roundtrip: parse(serialize(state)) ergibt den Zustand zurück', () => {
+		const state: MapFilterUrlState = {
+			year: 2024,
+			query: 'Kegelrobbe Rügen',
+			from: '2024-03-01',
+			to: '2024-10-15',
+			hiddenSpecies: ['0', '3'],
+			hiddenColors: ['ct1', 'ct2']
+		};
+
+		const roundtripped = parseMapFilterParams(new URLSearchParams(serializeMapFilterParams(state)));
+
+		expect(roundtripped).toEqual(state);
+	});
+});
+
+describe('buildFilterUrlState', () => {
+	function makeInput(
+		overrides: Partial<Parameters<typeof buildFilterUrlState>[0]> = {}
+	): Parameters<typeof buildFilterUrlState>[0] {
+		return {
+			year: 2025,
+			defaultYear: 2025,
+			searchTerm: '',
+			timeFilter: {
+				lower: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(),
+				upper: new Date(2025, 11, 31, 23, 59, 59, 0).getTime()
+			},
+			hiddenSpecies: {},
+			hiddenColors: {},
+			...overrides
+		};
+	}
+
+	it('liefert leeren Zustand für Default-Werte', () => {
+		expect(buildFilterUrlState(makeInput())).toEqual({});
+	});
+
+	it('setzt year nur wenn es vom Default abweicht', () => {
+		expect(
+			buildFilterUrlState(
+				makeInput({
+					year: 2024,
+					timeFilter: {
+						lower: new Date(2024, 0, 1, 0, 0, 0, 0).getTime(),
+						upper: new Date(2024, 11, 31, 23, 59, 59, 0).getTime()
+					}
+				})
+			)
+		).toEqual({ year: 2024 });
+	});
+
+	it('lässt year beim Default-Jahr weg', () => {
+		const result = buildFilterUrlState(makeInput({ year: 2025, searchTerm: 'Wal' }));
+
+		expect(result.year).toBeUndefined();
+	});
+
+	it('setzt query nur bei nicht-leerem getrimmtem Suchbegriff', () => {
+		expect(buildFilterUrlState(makeInput({ searchTerm: '  Schweinswal ' }))).toEqual({
+			query: 'Schweinswal'
+		});
+		expect(buildFilterUrlState(makeInput({ searchTerm: '   ' }))).toEqual({});
+	});
+
+	it('lässt from/to bei vollem Jahresbereich weg', () => {
+		const result = buildFilterUrlState(makeInput());
+
+		expect(result.from).toBeUndefined();
+		expect(result.to).toBeUndefined();
+	});
+
+	it('setzt from und to bei eingeschränktem Zeitfilter', () => {
+		const result = buildFilterUrlState(
+			makeInput({
+				timeFilter: {
+					lower: new Date(2025, 2, 1, 0, 0, 0, 0).getTime(),
+					upper: new Date(2025, 8, 30, 23, 59, 59, 0).getTime()
+				}
+			})
+		);
+
+		expect(result.from).toBe('2025-03-01');
+		expect(result.to).toBe('2025-09-30');
+	});
+
+	it('sortiert hiddenSpecies numerisch aufsteigend', () => {
+		const result = buildFilterUrlState(
+			makeInput({ hiddenSpecies: { '10': true, '2': true, '1': true } })
+		);
+
+		expect(result.hiddenSpecies).toEqual(['1', '2', '10']);
+	});
+
+	it('übernimmt nur Arten mit Wert true', () => {
+		const result = buildFilterUrlState(
+			makeInput({ hiddenSpecies: { '0': false, '3': true, '5': false } })
+		);
+
+		expect(result.hiddenSpecies).toEqual(['3']);
+	});
+
+	it('lässt hiddenSpecies weg wenn nichts ausgeblendet ist', () => {
+		const result = buildFilterUrlState(makeInput({ hiddenSpecies: { '0': false } }));
+
+		expect(result.hiddenSpecies).toBeUndefined();
+	});
+
+	it('sortiert hiddenColors alphabetisch', () => {
+		const result = buildFilterUrlState(
+			makeInput({ hiddenColors: { ct2: true, ct0: true, ct1: true } })
+		);
+
+		expect(result.hiddenColors).toEqual(['ct0', 'ct1', 'ct2']);
+	});
+
+	it('lässt hiddenColors weg wenn nichts ausgeblendet ist', () => {
+		const result = buildFilterUrlState(makeInput({ hiddenColors: { ct0: false } }));
+
+		expect(result.hiddenColors).toBeUndefined();
+	});
+});
+
+describe('dayOfYearFromIsoDate', () => {
+	it('gibt 0 für den 1. Januar zurück', () => {
+		expect(dayOfYearFromIsoDate('2025-01-01', 2025)).toBe(0);
+	});
+
+	it('gibt 364 für den 31. Dezember eines normalen Jahres zurück', () => {
+		expect(dayOfYearFromIsoDate('2025-12-31', 2025)).toBe(364);
+	});
+
+	it('gibt 365 für den 31. Dezember eines Schaltjahres zurück', () => {
+		expect(dayOfYearFromIsoDate('2024-12-31', 2024)).toBe(365);
+	});
+
+	it('rechnet über die DST-Grenze hinweg exakt (15. Juli → 195)', () => {
+		// 31+28+31+30+31+30+14 = 195; die Sommerzeit-Umstellung Ende März
+		// darf das Ergebnis nicht um einen Tag verschieben.
+		expect(dayOfYearFromIsoDate('2025-07-15', 2025)).toBe(195);
+	});
+
+	it('gibt null für ein Datum aus einem anderen Jahr zurück', () => {
+		expect(dayOfYearFromIsoDate('2024-06-01', 2025)).toBeNull();
+	});
+
+	it('gibt null für ein unmögliches Kalenderdatum zurück', () => {
+		expect(dayOfYearFromIsoDate('2025-02-30', 2025)).toBeNull();
+	});
+
+	it('gibt null für ungültiges Format zurück', () => {
+		expect(dayOfYearFromIsoDate('foo', 2025)).toBeNull();
+	});
+});
+
+describe('isoDateFromTimestamp', () => {
+	it('formatiert lokalen Zeitstempel als YYYY-MM-DD', () => {
+		expect(isoDateFromTimestamp(new Date(2025, 6, 15).getTime())).toBe('2025-07-15');
+	});
+
+	it('polstert einstellige Monate und Tage mit Nullen', () => {
+		expect(isoDateFromTimestamp(new Date(2025, 0, 5).getTime())).toBe('2025-01-05');
+	});
+});
+
+describe('isFullYearRange', () => {
+	it('erkennt volles Jahr mit upper 23:59:59.000', () => {
+		const timeFilter = {
+			lower: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(),
+			upper: new Date(2025, 11, 31, 23, 59, 59, 0).getTime()
+		};
+
+		expect(isFullYearRange(timeFilter, 2025)).toBe(true);
+	});
+
+	it('erkennt volles Jahr mit upper 23:59:59.999', () => {
+		const timeFilter = {
+			lower: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(),
+			upper: new Date(2025, 11, 31, 23, 59, 59, 999).getTime()
+		};
+
+		expect(isFullYearRange(timeFilter, 2025)).toBe(true);
+	});
+
+	it('ist false wenn lower erst am 2. Januar beginnt', () => {
+		const timeFilter = {
+			lower: new Date(2025, 0, 2, 0, 0, 0, 0).getTime(),
+			upper: new Date(2025, 11, 31, 23, 59, 59, 0).getTime()
+		};
+
+		expect(isFullYearRange(timeFilter, 2025)).toBe(false);
+	});
+
+	it('ist false wenn upper schon am 30. Dezember endet', () => {
+		const timeFilter = {
+			lower: new Date(2025, 0, 1, 0, 0, 0, 0).getTime(),
+			upper: new Date(2025, 11, 30, 23, 59, 59, 0).getTime()
+		};
+
+		expect(isFullYearRange(timeFilter, 2025)).toBe(false);
+	});
+});

--- a/src/lib/map/urlFilterState.ts
+++ b/src/lib/map/urlFilterState.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure Funktionen für den URL-Query-Param-Sync der Sichtungskarten-Filter
+ * (Befund M4/N6 aus docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md).
+ *
+ * Query-Params: `year`, `q`, `from`, `to`, `hs` (ausgeblendete Arten-IDs,
+ * kommasepariert), `hc` (ausgeblendete Farbgruppen, kommasepariert).
+ *
+ * Alle Zeitstempel sind lokale Zeit — Zeitslider und Map-Controller arbeiten
+ * in der Browser-Zeitzone (`new Date(year, 0, 1)` usw.), daher darf hier
+ * nichts über UTC laufen.
+ */
+
+export interface MapFilterUrlState {
+	year?: number;
+	query?: string;
+	from?: string; // ISO-Datum YYYY-MM-DD (lokale Zeit)
+	to?: string; // ISO-Datum YYYY-MM-DD (lokale Zeit)
+	hiddenSpecies?: string[]; // numerische Arten-IDs
+	hiddenColors?: string[]; // Farbgruppen-Keys wie 'ct0', 'ct1'
+}
+
+/** Plausibilitätsbereich für das Jahr — außerhalb ist es ein Tippfehler/Angriff. */
+const YEAR_MIN = 2000;
+const YEAR_MAX = 2100;
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+const SPECIES_ID_PATTERN = /^\d+$/;
+const COLOR_GROUP_PATTERN = /^ct\d+$/;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Parst ein ISO-Datum (YYYY-MM-DD) als lokales Datum. `null` bei falschem
+ * Format oder unmöglichem Kalenderdatum (Date-Rollover wie 2025-02-30 → 2. März
+ * wird über den Rückvergleich der Datumsteile erkannt).
+ */
+function parseIsoDate(iso: string): Date | null {
+	const match = ISO_DATE_PATTERN.exec(iso);
+	if (!match) return null;
+
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const date = new Date(year, month - 1, day);
+
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+		return null;
+	}
+	return date;
+}
+
+/** Splittet einen kommaseparierten Listen-Param, validiert und dedupliziert. */
+function parseListParam(raw: string | null, pattern: RegExp): string[] {
+	if (!raw) return [];
+	return [...new Set(raw.split(',').filter((entry) => pattern.test(entry)))];
+}
+
+/**
+ * Liest den Filterzustand aus URL-Query-Params.
+ * Ungültige Werte werden feldweise ignoriert — das Feld fehlt dann im Ergebnis.
+ */
+export function parseMapFilterParams(params: URLSearchParams): MapFilterUrlState {
+	const state: MapFilterUrlState = {};
+
+	const yearRaw = params.get('year');
+	if (yearRaw && /^\d{4}$/.test(yearRaw)) {
+		const year = Number(yearRaw);
+		if (year >= YEAR_MIN && year <= YEAR_MAX) state.year = year;
+	}
+
+	const query = params.get('q')?.trim();
+	if (query) state.query = query;
+
+	const from = params.get('from');
+	if (from && parseIsoDate(from)) state.from = from;
+
+	const to = params.get('to');
+	if (to && parseIsoDate(to)) state.to = to;
+
+	const hiddenSpecies = parseListParam(params.get('hs'), SPECIES_ID_PATTERN);
+	if (hiddenSpecies.length > 0) state.hiddenSpecies = hiddenSpecies;
+
+	const hiddenColors = parseListParam(params.get('hc'), COLOR_GROUP_PATTERN);
+	if (hiddenColors.length > 0) state.hiddenColors = hiddenColors;
+
+	return state;
+}
+
+/**
+ * Serialisiert den Zustand als Query-String ohne führendes '?'.
+ * Leerer Zustand → ''. Feld-Reihenfolge: year, q, from, to, hs, hc.
+ */
+export function serializeMapFilterParams(state: MapFilterUrlState): string {
+	const params = new URLSearchParams();
+
+	if (state.year !== undefined) params.set('year', String(state.year));
+	if (state.query) params.set('q', state.query);
+	if (state.from) params.set('from', state.from);
+	if (state.to) params.set('to', state.to);
+	if (state.hiddenSpecies && state.hiddenSpecies.length > 0) {
+		params.set('hs', state.hiddenSpecies.join(','));
+	}
+	if (state.hiddenColors && state.hiddenColors.length > 0) {
+		params.set('hc', state.hiddenColors.join(','));
+	}
+
+	return params.toString();
+}
+
+/**
+ * Baut den URL-Zustand aus dem rohen Controller-Zustand.
+ * Default-Werte (Default-Jahr, leere Suche, voller Jahresbereich, nichts
+ * ausgeblendet) werden weggelassen, damit die URL im Grundzustand leer bleibt.
+ */
+export function buildFilterUrlState(input: {
+	year: number;
+	defaultYear: number;
+	searchTerm: string;
+	timeFilter: { lower: number; upper: number };
+	hiddenSpecies: Record<string, boolean>;
+	hiddenColors: Record<string, boolean>;
+}): MapFilterUrlState {
+	const state: MapFilterUrlState = {};
+
+	if (input.year !== input.defaultYear) state.year = input.year;
+
+	const query = input.searchTerm.trim();
+	if (query) state.query = query;
+
+	if (!isFullYearRange(input.timeFilter, input.year)) {
+		state.from = isoDateFromTimestamp(input.timeFilter.lower);
+		state.to = isoDateFromTimestamp(input.timeFilter.upper);
+	}
+
+	const hiddenSpecies = Object.keys(input.hiddenSpecies)
+		.filter((key) => input.hiddenSpecies[key])
+		.sort((a, b) => Number(a) - Number(b));
+	if (hiddenSpecies.length > 0) state.hiddenSpecies = hiddenSpecies;
+
+	const hiddenColors = Object.keys(input.hiddenColors)
+		.filter((key) => input.hiddenColors[key])
+		.sort();
+	if (hiddenColors.length > 0) state.hiddenColors = hiddenColors;
+
+	return state;
+}
+
+/**
+ * Tag-Index (0-basiert) eines ISO-Datums innerhalb von `year`.
+ * `null` bei ungültigem Format, unmöglichem Kalenderdatum oder anderem Jahr.
+ * `Math.round` gleicht die fehlende Stunde über die Sommerzeit-Grenze aus.
+ */
+export function dayOfYearFromIsoDate(iso: string, year: number): number | null {
+	const date = parseIsoDate(iso);
+	if (!date || date.getFullYear() !== year) return null;
+
+	const janFirst = new Date(year, 0, 1);
+	return Math.round((date.getTime() - janFirst.getTime()) / MS_PER_DAY);
+}
+
+/** Lokales Datum eines Unix-ms-Timestamps als YYYY-MM-DD. */
+export function isoDateFromTimestamp(ts: number): string {
+	const date = new Date(ts);
+	const pad = (value: number): string => String(value).padStart(2, '0');
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * Prüft, ob der Zeitfilter das komplette Jahr abdeckt. `upper` wird mit
+ * Sekunden-Genauigkeit verglichen: der Controller setzt 23:59:59.000, der
+ * Slider-Endanschlag 23:59:59.999 — beide zählen als volles Jahr.
+ */
+export function isFullYearRange(
+	timeFilter: { lower: number; upper: number },
+	year: number
+): boolean {
+	const yearStart = new Date(year, 0, 1, 0, 0, 0, 0).getTime();
+	const yearEnd = new Date(year, 11, 31, 23, 59, 59, 0).getTime();
+	return timeFilter.lower <= yearStart && timeFilter.upper >= yearEnd;
+}

--- a/src/lib/map/urlFilterState.ts
+++ b/src/lib/map/urlFilterState.ts
@@ -49,10 +49,21 @@ function parseIsoDate(iso: string): Date | null {
 	return date;
 }
 
-/** Splittet einen kommaseparierten Listen-Param, validiert und dedupliziert. */
+/**
+ * Splittet einen kommaseparierten Listen-Param, validiert und dedupliziert.
+ * Einträge werden vorher getrimmt — handbearbeitete URLs enthalten gern
+ * Leerzeichen nach den Kommas (`hs=1, 2`).
+ */
 function parseListParam(raw: string | null, pattern: RegExp): string[] {
 	if (!raw) return [];
-	return [...new Set(raw.split(',').filter((entry) => pattern.test(entry)))];
+	return [
+		...new Set(
+			raw
+				.split(',')
+				.map((entry) => entry.trim())
+				.filter((entry) => pattern.test(entry))
+		)
+	];
 }
 
 /**


### PR DESCRIPTION
## Zusammenfassung

Befunde **M4** und **N6** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md`: Die Filter der Sichtungskarte (`/map`) stehen jetzt in der URL und aktive Filter sind als entfernbare Chips sichtbar.

- **URL-Sync (M4):** Query-Params `year`, `q`, `from`, `to`, `hs` (ausgeblendete Arten), `hc` (ausgeblendete Anzahl-Gruppen) werden beim Laden angewendet und per `replaceState` synchron gehalten — gefilterte Ansichten sind teilbar/bookmarkbar, Reload verwirft nichts mehr. Default-Werte tauchen nicht in der URL auf; ungültige Werte werden feldweise ignoriert.
- **Filter-Chips (N6):** Aktive Filter erscheinen als einzeln entfernbare Chips über der Karte (DaisyUI-Buttons, 44-px-Touch-Targets, `aria-label`s) plus „Alle Filter zurücksetzen" (Default-Jahr, leere Suche, voller Zeitraum, alle Sichtbarkeiten).
- **Bewusst außen vor:** Kartenausschnitt (Center/Zoom) — im Report als verbleibendes ⚠️ dokumentiert.

## Umsetzung

- Neues pures Modul `src/lib/map/urlFilterState.ts` (Test-First, **56 Unit-Tests**): Parsen/Serialisieren/Tag-Index-Umrechnung, DST-sicher, Whitelist-Validierung gegen kaputte geteilte URLs.
- Jahr + Suche fließen über `initialYear`/`initialSearchTerm` direkt in den ersten Fetch (kein Doppel-Request); Zeitraum + Sichtbarkeiten werden nach dem ersten Load angewendet (`setYear()` würde den timeFilter sonst wieder auf das volle Jahr zurücksetzen).
- URL folgt dem Controller-Zustand aus dem `onCountsUpdated`-Callback; Guard verhindert, dass Zwischenstände des Initial-Loads geteilte Params wegkürzen.
- LegendPanel-Sichtbarkeiten als `$bindable` zum Parent gehoben — Chips und Legende-Checkboxen teilen einen Zustand.

## Tests & Verifikation

- `npm run test:quick` grün (Lint, tsc, svelte-check, 2158 Unit-Tests, davon 56 neu)
- Projekt-Review (`/review`): 0 kritische Befunde, 0 Warnungen, A11y-Checkliste bestanden
- Playwright-E2E-Verifikation gegen den Dev-Server: 14/14 Prüfungen bestanden (URL → Zustand inkl. Slider-Positionen und Legende-Checkbox, Chip-Entfernen, Reset → leere URL, Jahreswechsel → URL; Desktop 1280 px + Mobile 375 px ohne Overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)