### PR TITLE
feat(map): dual-range time slider with aria-valuetext and date inputs (M10)

### DIFF
--- a/e2e/map-time-slider.spec.ts
+++ b/e2e/map-time-slider.spec.ts
@@ -21,7 +21,8 @@ test.describe.serial('Map Time Slider', () => {
 		const endSlider = mapPage.getEndSlider();
 
 		await expect(startSlider).toHaveAttribute('min', '0');
-		await expect(startSlider).toHaveAttribute('value', '0');
+		// M10: value ist eine DOM-Property der Svelte-Komponente, kein HTML-Attribut
+		await expect(startSlider).toHaveValue('0');
 
 		await expect(endSlider).toHaveAttribute('min', '0');
 
@@ -100,5 +101,57 @@ test.describe.serial('Map Time Slider', () => {
 	test('Zeitraum-Anzeige-Elemente sind im DOM vorhanden', async () => {
 		await expect(mapPage.getTimeStartDisplay()).toBeAttached();
 		await expect(mapPage.getTimeEndDisplay()).toBeAttached();
+	});
+
+	// ─── M10: Dual-Range-Slider — ein Track, aria-valuetext, Datums-Felder ─────
+
+	test('Griffe tragen lesbares Datum als aria-valuetext (M10)', async () => {
+		// Stand nach den vorherigen Serial-Tests: Jahr 2024, Start 0, Ende 200
+		// (Clamp-Test) — für einen deterministischen Stand explizit neu setzen.
+		await mapPage.setSliderValue('time-range-start', 0);
+		await mapPage.setSliderValue('time-range-end', 270);
+		await mapPage.setSliderValue('time-range-start', 90);
+
+		// 2024 (Schaltjahr): Index 90 = 31. März, Index 270 = 27. September
+		await expect(mapPage.getStartSlider()).toHaveAttribute('aria-valuetext', '31. März');
+		await expect(mapPage.getEndSlider()).toHaveAttribute('aria-valuetext', '27. September');
+	});
+
+	test('Track zeigt einen gefüllten Bereich zwischen den Griffen (M10)', async () => {
+		const container = sharedPage.locator('[data-testid="dual-range"]');
+		await expect(container).toBeAttached();
+
+		const vars = await container.evaluate((el) => ({
+			start: el.style.getPropertyValue('--range-start'),
+			end: el.style.getPropertyValue('--range-end')
+		}));
+		// Stand aus dem vorherigen Test: 90/365 ≈ 24,7 %, 270/365 ≈ 74 %
+		expect(parseFloat(vars.start)).toBeCloseTo((90 / 365) * 100, 1);
+		expect(parseFloat(vars.end)).toBeCloseTo((270 / 365) * 100, 1);
+
+		await expect(sharedPage.locator('.dual-range-fill')).toBeVisible();
+	});
+
+	test('Datums-Eingabefelder sind synchron zum Slider und aufs Jahr geklemmt (M10)', async () => {
+		const startDate = mapPage.getStartDateInput();
+		const endDate = mapPage.getEndDateInput();
+
+		await expect(startDate).toHaveAttribute('min', '2024-01-01');
+		await expect(startDate).toHaveAttribute('max', '2024-12-31');
+		await expect(endDate).toHaveAttribute('min', '2024-01-01');
+		await expect(endDate).toHaveAttribute('max', '2024-12-31');
+
+		// Stand aus den vorherigen Tests: Start-Index 90 = 2024-03-31
+		await expect(startDate).toHaveValue('2024-03-31');
+	});
+
+	test('Datums-Eingabe setzt den Slider-Wert (M10)', async () => {
+		// 2024-07-04 = Index 185 im Schaltjahr (31+29+31+30+31+30+3 = Tag 186, 0-basiert 185)
+		await mapPage.getStartDateInput().fill('2024-07-04');
+
+		await expect(mapPage.getStartSlider()).toHaveValue('185');
+		await expect(mapPage.getStartSlider()).toHaveAttribute('aria-valuetext', '4. Juli');
+		// URL-Sync (M4) übernimmt das Datum aus dem Kartenfilter
+		await expect(sharedPage).toHaveURL(/from=2024-07-04/);
 	});
 });

--- a/e2e/pages/MapPage.ts
+++ b/e2e/pages/MapPage.ts
@@ -146,6 +146,15 @@ export class MapPage {
 		return this.page.locator('#time-end');
 	}
 
+	/** M10: Datums-Eingabefelder — gleichwertige Alternative zum Dual-Slider */
+	getStartDateInput(): Locator {
+		return this.page.locator('#time-date-start');
+	}
+
+	getEndDateInput(): Locator {
+		return this.page.locator('#time-date-end');
+	}
+
 	/**
 	 * Sets a range slider value and fires the input event so event handlers run.
 	 * Playwright's fill() does not reliably fire input events on range inputs.

--- a/src/lib/components/map/Panel/DualRangeSlider.svelte
+++ b/src/lib/components/map/Panel/DualRangeSlider.svelte
@@ -92,6 +92,10 @@
 		}
 		rangeEl.value = String(clamp(day, min, max));
 		rangeEl.dispatchEvent(new Event('input', { bubbles: true }));
+		// Rückschreiben aus dem tatsächlichen (ggf. auf den anderen Griff
+		// geklemmten) Wert: ändert die Klemmung den State nicht, würde Svelte
+		// das Feld sonst auf dem getippten Datum stehen lassen.
+		input.value = isoDateFromDayOfYear(year, Number(rangeEl.value));
 	}
 
 	function onStartDateChange(event: Event): void {
@@ -155,7 +159,7 @@
 				type="date"
 				id="time-date-start"
 				class="input input-sm focus:input-primary w-full"
-				min={isoDateFromDayOfYear(year, 0)}
+				min={isoDateFromDayOfYear(year, min)}
 				max={isoDateFromDayOfYear(year, max)}
 				value={isoDateFromDayOfYear(year, startValue)}
 				onchange={onStartDateChange}
@@ -169,7 +173,7 @@
 				type="date"
 				id="time-date-end"
 				class="input input-sm focus:input-primary w-full"
-				min={isoDateFromDayOfYear(year, 0)}
+				min={isoDateFromDayOfYear(year, min)}
 				max={isoDateFromDayOfYear(year, max)}
 				value={isoDateFromDayOfYear(year, endValue)}
 				onchange={onEndDateChange}

--- a/src/lib/components/map/Panel/DualRangeSlider.svelte
+++ b/src/lib/components/map/Panel/DualRangeSlider.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+	import { formatDayOfYearLong, isoDateFromDayOfYear } from '$lib/map/dateUtils';
+	import { dayOfYearFromIsoDate } from '$lib/map/urlFilterState';
+
+	/**
+	 * M10: Echter Dual-Range-Slider für den Zeitfilter der Sichtungskarte —
+	 * ein Track, zwei Griffe, gefüllter Bereich dazwischen, plus zwei
+	 * Datums-Eingabefelder als gleichwertige Alternative (Baymard: Dual-Slider
+	 * werden ohne numerischen Fallback häufig missverstanden).
+	 *
+	 * DOM-Verträge nach außen (bewusst unverändert zum alten Aufbau):
+	 * - IDs `time-range-start`/`time-range-end`: timeSliderManager hängt hier
+	 *   seine input-Listener an (Clamping + setFilter), applyUrlFilters und
+	 *   reset() schreiben value/max direkt und dispatchen input-Events.
+	 * - `#time-start`/`#time-end`: der Map-Controller schreibt die formatierte
+	 *   Auswahl per innerText hinein (updateTimeRange).
+	 *
+	 * Die Komponente klemmt Start ≤ Ende selbst (identisch zum Manager), damit
+	 * ihr State unabhängig von der Listener-Reihenfolge konsistent bleibt —
+	 * der Manager clampt danach denselben Wert als No-op.
+	 */
+	let { min = 0, max, year } = $props<{ min?: number; max: number; year: number }>();
+
+	let startEl: HTMLInputElement | undefined = $state();
+	let endEl: HTMLInputElement | undefined = $state();
+
+	// Bewusst nur Startwerte: danach halten die input-Handler den State synchron.
+	// svelte-ignore state_referenced_locally
+	let startValue = $state(min);
+	// svelte-ignore state_referenced_locally
+	let endValue = $state(max);
+
+	// Jahreswechsel: der Browser klemmt die value-Property selbst, sobald das
+	// max-Attribut schrumpft — den geklemmten DOM-Stand in den State übernehmen.
+	// (timeSliderManager.reset() dispatcht zusätzlich input-Events; dieser
+	// Effect deckt den Fall ab, dass die Komponente ohne Manager läuft.)
+	$effect(() => {
+		void max;
+		if (startEl) startValue = Number(startEl.value);
+		if (endEl) endValue = Number(endEl.value);
+	});
+
+	const span = $derived(Math.max(max - min, 1));
+	const startPct = $derived(((startValue - min) / span) * 100);
+	const endPct = $derived(((endValue - min) / span) * 100);
+
+	// Liegen beide Griffe übereinander, muss der bewegliche greifbar sein:
+	// rechts gedrängt → Start liegt oben (kann nach links), sonst Ende.
+	const startOnTop = $derived(startValue > (min + max) / 2);
+
+	function clamp(value: number, lower: number, upper: number): number {
+		return Math.min(Math.max(value, lower), upper);
+	}
+
+	/** Klemmen statt Verschieben: Start darf gleich Ende sein (einzelner Tag). */
+	function onStartInput(): void {
+		if (!startEl || !endEl) return;
+		const end = Number(endEl.value);
+		let value = Number(startEl.value);
+		if (value > end) {
+			value = end;
+			startEl.value = String(value);
+		}
+		startValue = value;
+		endValue = end;
+	}
+
+	function onEndInput(): void {
+		if (!startEl || !endEl) return;
+		const start = Number(startEl.value);
+		let value = Number(endEl.value);
+		if (value < start) {
+			value = start;
+			endEl.value = String(value);
+		}
+		startValue = start;
+		endValue = value;
+	}
+
+	/**
+	 * Datums-Eingabe → Slider: über denselben Pfad wie die Slider-Bedienung
+	 * (value setzen + input-Event), damit der timeSliderManager Clamping und
+	 * setFilter übernimmt. Ungültige oder jahres-fremde Daten werden verworfen;
+	 * das Feld springt auf den aktuellen Wert zurück.
+	 */
+	function applyDateInput(input: HTMLInputElement, rangeEl: HTMLInputElement | undefined): void {
+		if (!rangeEl) return;
+		const day = input.value ? dayOfYearFromIsoDate(input.value, year) : null;
+		if (day === null) {
+			input.value = isoDateFromDayOfYear(year, Number(rangeEl.value));
+			return;
+		}
+		rangeEl.value = String(clamp(day, min, max));
+		rangeEl.dispatchEvent(new Event('input', { bubbles: true }));
+	}
+
+	function onStartDateChange(event: Event): void {
+		applyDateInput(event.currentTarget as HTMLInputElement, startEl);
+	}
+
+	function onEndDateChange(event: Event): void {
+		applyDateInput(event.currentTarget as HTMLInputElement, endEl);
+	}
+</script>
+
+<div class="space-y-2" role="group" aria-label="Zeitraum wählen">
+	<div
+		class="dual-range"
+		data-testid="dual-range"
+		style="--range-start:{startPct}%; --range-end:{endPct}%"
+	>
+		<div class="dual-range-track" aria-hidden="true">
+			<div class="dual-range-fill"></div>
+		</div>
+		<input
+			type="range"
+			id="time-range-start"
+			bind:this={startEl}
+			class="dual-range-input"
+			class:dual-range-input-top={startOnTop}
+			{min}
+			{max}
+			value={startValue}
+			aria-label="Zeitraum Start"
+			aria-valuetext={formatDayOfYearLong(year, startValue)}
+			oninput={onStartInput}
+		/>
+		<input
+			type="range"
+			id="time-range-end"
+			bind:this={endEl}
+			class="dual-range-input"
+			class:dual-range-input-top={!startOnTop}
+			{min}
+			{max}
+			value={endValue}
+			aria-label="Zeitraum Ende"
+			aria-valuetext={formatDayOfYearLong(year, endValue)}
+			oninput={onEndInput}
+		/>
+	</div>
+
+	<!-- Vom Map-Controller (updateTimeRange) per innerText befüllt -->
+	<div class="text-base-content/70 flex justify-between text-xs" aria-hidden="true">
+		<span id="time-start" class="bg-base-200 rounded px-2 py-1 font-medium"></span>
+		<span id="time-end" class="bg-base-200 rounded px-2 py-1 font-medium"></span>
+	</div>
+
+	<div class="grid grid-cols-2 gap-2">
+		<div>
+			<label class="label py-0" for="time-date-start">
+				<span class="text-xs">Start</span>
+			</label>
+			<input
+				type="date"
+				id="time-date-start"
+				class="input input-sm focus:input-primary w-full"
+				min={isoDateFromDayOfYear(year, 0)}
+				max={isoDateFromDayOfYear(year, max)}
+				value={isoDateFromDayOfYear(year, startValue)}
+				onchange={onStartDateChange}
+			/>
+		</div>
+		<div>
+			<label class="label py-0" for="time-date-end">
+				<span class="text-xs">Ende</span>
+			</label>
+			<input
+				type="date"
+				id="time-date-end"
+				class="input input-sm focus:input-primary w-full"
+				min={isoDateFromDayOfYear(year, 0)}
+				max={isoDateFromDayOfYear(year, max)}
+				value={isoDateFromDayOfYear(year, endValue)}
+				onchange={onEndDateChange}
+			/>
+		</div>
+	</div>
+</div>
+
+<style>
+	/* 44px hoch: die Griffe füllen die volle Höhe als Touch-Target (WCAG 2.5.5) */
+	.dual-range {
+		position: relative;
+		height: 2.75rem;
+	}
+
+	.dual-range-track {
+		position: absolute;
+		top: 50%;
+		right: 0;
+		left: 0;
+		height: 0.5rem;
+		transform: translateY(-50%);
+		overflow: hidden;
+		border-radius: 9999px;
+		background-color: var(--color-base-300);
+	}
+
+	/* Gefüllter Bereich zwischen den Griffen — zeigt den gewählten Zeitraum */
+	.dual-range-fill {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: var(--range-start);
+		width: calc(var(--range-end) - var(--range-start));
+		background-color: var(--color-primary);
+	}
+
+	/* Zwei überlagerte native Inputs: nur die Griffe nehmen Pointer-Events an */
+	.dual-range-input {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		width: 100%;
+		height: 100%;
+		margin: 0;
+		appearance: none;
+		-webkit-appearance: none;
+		background: transparent;
+		pointer-events: none;
+	}
+
+	.dual-range-input-top {
+		z-index: 3;
+	}
+
+	/* Griff: 44px Hit-Area (transparenter Rand), 24px sichtbarer Kreis */
+	.dual-range-input::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		appearance: none;
+		pointer-events: auto;
+		width: 44px;
+		height: 44px;
+		border: 10px solid transparent;
+		border-radius: 50%;
+		background-color: var(--color-primary);
+		background-clip: content-box;
+		cursor: pointer;
+	}
+
+	.dual-range-input::-moz-range-thumb {
+		pointer-events: auto;
+		box-sizing: border-box;
+		width: 44px;
+		height: 44px;
+		border: 10px solid transparent;
+		border-radius: 50%;
+		background-color: var(--color-primary);
+		background-clip: content-box;
+		cursor: pointer;
+	}
+
+	.dual-range-input::-moz-range-track {
+		background: transparent;
+	}
+
+	/* Sichtbarer Fokusring am Griff (Fokus-Regel aus app.css greift hier nicht,
+	   weil das Input selbst unsichtbar ist) */
+	.dual-range-input:focus-visible {
+		outline: none;
+	}
+
+	.dual-range-input:focus-visible::-webkit-slider-thumb {
+		outline: 3px solid var(--color-primary);
+		outline-offset: -4px;
+	}
+
+	.dual-range-input:focus-visible::-moz-range-thumb {
+		outline: 3px solid var(--color-primary);
+		outline-offset: -4px;
+	}
+</style>

--- a/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
+++ b/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
@@ -170,6 +170,26 @@ describe('DualRangeSlider', () => {
 		});
 	});
 
+	it('stellt das Datums-Feld auch dann zurück, wenn die Klemmung den Wert nicht ändert', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		// Start == Ende (Tag 100) — die Klemmung eines späteren Datums ergibt
+		// wieder 100, der State ändert sich also nicht. Das Feld darf trotzdem
+		// nicht auf dem getippten Datum stehen bleiben.
+		setRangeValue('time-range-end', 100);
+		setRangeValue('time-range-start', 100);
+
+		const startDate = getDateInput('time-date-start');
+		startDate.value = '2025-12-01';
+		startDate.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').value).toBe('100');
+			// Tag 100 in 2025 = 11. April
+			expect(getDateInput('time-date-start').value).toBe('2025-04-11');
+		});
+	});
+
 	it('enthält die Anzeige-Elemente #time-start und #time-end (Controller-Vertrag)', () => {
 		render(DualRangeSlider, { max: 364, year: 2025 });
 

--- a/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
+++ b/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
@@ -197,13 +197,14 @@ describe('DualRangeSlider', () => {
 		expect(document.querySelector('#time-end')).not.toBeNull();
 	});
 
-	it('übernimmt einen externen Reset (beide Werte + Events, z. B. Jahreswechsel QW4)', async () => {
+	it('übernimmt einen externen Reset (beide Werte + ein Event, z. B. Jahreswechsel QW4)', async () => {
 		render(DualRangeSlider, { max: 364, year: 2025 });
 
 		setRangeValue('time-range-start', 100);
 		setRangeValue('time-range-end', 200);
 
-		// timeSliderManager.reset(): max/value direkt setzen, dann Events
+		// timeSliderManager.reset(): max/value direkt setzen, dann EIN Event —
+		// die Handler lesen beide Slider, ein Event synct den ganzen State.
 		const start = getRange('time-range-start');
 		const end = getRange('time-range-end');
 		start.max = '365';
@@ -211,7 +212,6 @@ describe('DualRangeSlider', () => {
 		start.value = '0';
 		end.value = '365';
 		start.dispatchEvent(new Event('input', { bubbles: true }));
-		end.dispatchEvent(new Event('input', { bubbles: true }));
 
 		await vi.waitFor(() => {
 			expect(getRange('time-range-start').value).toBe('0');

--- a/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
+++ b/src/lib/components/map/Panel/DualRangeSlider.svelte.test.ts
@@ -1,0 +1,202 @@
+// M10: Echter Dual-Range-Slider — ein Track, zwei Griffe, gefüllter Bereich.
+// Die Komponente behält die DOM-Verträge des alten Doppel-Slider-Aufbaus:
+// IDs time-range-start/time-range-end, Wert-Änderungen via value + input-Event
+// (timeSliderManager, applyUrlFilters), Anzeige-Elemente #time-start/#time-end.
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import DualRangeSlider from './DualRangeSlider.svelte';
+
+function getRange(id: string): HTMLInputElement {
+	const input = document.querySelector(`#${id}`);
+	if (!(input instanceof HTMLInputElement)) {
+		throw new Error(`Range input ${id} not found`);
+	}
+	return input;
+}
+
+function getDateInput(id: string): HTMLInputElement {
+	const input = document.querySelector(`#${id}`);
+	if (!(input instanceof HTMLInputElement)) {
+		throw new Error(`Date input ${id} not found`);
+	}
+	return input;
+}
+
+/** Simuliert den externen Schreibpfad (Manager/applyUrlFilters): value + input-Event */
+function setRangeValue(id: string, value: number): void {
+	const input = getRange(id);
+	input.value = String(value);
+	input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('DualRangeSlider', () => {
+	it('rendert beide Griffe mit korrekten min/max und Startwerten (volles Jahr)', () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const start = getRange('time-range-start');
+		const end = getRange('time-range-end');
+
+		expect(start.min).toBe('0');
+		expect(start.max).toBe('364');
+		expect(start.value).toBe('0');
+		expect(end.min).toBe('0');
+		expect(end.max).toBe('364');
+		expect(end.value).toBe('364');
+	});
+
+	it('trägt lesbares Datum als aria-valuetext auf beiden Griffen', () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		expect(getRange('time-range-start').getAttribute('aria-valuetext')).toBe('1. Januar');
+		expect(getRange('time-range-end').getAttribute('aria-valuetext')).toBe('31. Dezember');
+	});
+
+	it('aktualisiert aria-valuetext live bei Wert-Änderung („186" → „6. Juli")', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		setRangeValue('time-range-start', 186);
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').getAttribute('aria-valuetext')).toBe('6. Juli');
+		});
+	});
+
+	it('klemmt Start auf Ende, wenn Start über Ende hinausgezogen wird', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		setRangeValue('time-range-end', 100);
+		setRangeValue('time-range-start', 200);
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').value).toBe('100');
+			expect(getRange('time-range-end').value).toBe('100');
+		});
+	});
+
+	it('klemmt Ende auf Start, wenn Ende unter Start gezogen wird', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		setRangeValue('time-range-start', 200);
+		setRangeValue('time-range-end', 50);
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-end').value).toBe('200');
+		});
+	});
+
+	it('setzt die Füll-Variablen des Tracks aus den Griff-Positionen', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const container = document.querySelector('[data-testid="dual-range"]');
+		if (!(container instanceof HTMLElement)) throw new Error('Container not found');
+
+		expect(container.style.getPropertyValue('--range-start').trim()).toBe('0%');
+		expect(container.style.getPropertyValue('--range-end').trim()).toBe('100%');
+
+		setRangeValue('time-range-start', 91);
+		await vi.waitFor(() => {
+			expect(container.style.getPropertyValue('--range-start').trim()).toBe('25%');
+		});
+	});
+
+	it('hält das 44-px-Touch-Target der Griff-Flächen', () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const rect = getRange('time-range-start').getBoundingClientRect();
+		expect(rect.height).toBeGreaterThanOrEqual(44);
+	});
+
+	it('zeigt Datums-Eingabefelder, auf das gewählte Jahr geklemmt und synchron zum Slider', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const startDate = getDateInput('time-date-start');
+		const endDate = getDateInput('time-date-end');
+
+		expect(startDate.min).toBe('2025-01-01');
+		expect(startDate.max).toBe('2025-12-31');
+		expect(endDate.min).toBe('2025-01-01');
+		expect(endDate.max).toBe('2025-12-31');
+		expect(startDate.value).toBe('2025-01-01');
+		expect(endDate.value).toBe('2025-12-31');
+
+		setRangeValue('time-range-start', 186);
+		await vi.waitFor(() => {
+			expect(getDateInput('time-date-start').value).toBe('2025-07-06');
+		});
+	});
+
+	it('Datums-Eingabe setzt den Slider-Wert und feuert ein input-Event (Manager-Pfad)', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const start = getRange('time-range-start');
+		const inputEvents: string[] = [];
+		start.addEventListener('input', () => inputEvents.push(start.value));
+
+		const startDate = getDateInput('time-date-start');
+		startDate.value = '2025-07-06';
+		startDate.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(start.value).toBe('186');
+			expect(inputEvents).toContain('186');
+			expect(start.getAttribute('aria-valuetext')).toBe('6. Juli');
+		});
+	});
+
+	it('verwirft ein Datum außerhalb des Jahres und stellt den alten Wert wieder her', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		const startDate = getDateInput('time-date-start');
+		startDate.value = '2024-05-01';
+		startDate.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').value).toBe('0');
+			expect(getDateInput('time-date-start').value).toBe('2025-01-01');
+		});
+	});
+
+	it('Datums-Eingabe über dem Ende wird auf das Ende geklemmt', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		setRangeValue('time-range-end', 100);
+
+		const startDate = getDateInput('time-date-start');
+		startDate.value = '2025-12-01';
+		startDate.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').value).toBe('100');
+		});
+	});
+
+	it('enthält die Anzeige-Elemente #time-start und #time-end (Controller-Vertrag)', () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		expect(document.querySelector('#time-start')).not.toBeNull();
+		expect(document.querySelector('#time-end')).not.toBeNull();
+	});
+
+	it('übernimmt einen externen Reset (beide Werte + Events, z. B. Jahreswechsel QW4)', async () => {
+		render(DualRangeSlider, { max: 364, year: 2025 });
+
+		setRangeValue('time-range-start', 100);
+		setRangeValue('time-range-end', 200);
+
+		// timeSliderManager.reset(): max/value direkt setzen, dann Events
+		const start = getRange('time-range-start');
+		const end = getRange('time-range-end');
+		start.max = '365';
+		end.max = '365';
+		start.value = '0';
+		end.value = '365';
+		start.dispatchEvent(new Event('input', { bubbles: true }));
+		end.dispatchEvent(new Event('input', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(getRange('time-range-start').value).toBe('0');
+			expect(getRange('time-range-end').value).toBe('365');
+			expect(getRange('time-range-start').getAttribute('aria-valuetext')).toBe('1. Januar');
+		});
+	});
+});

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { getDaysInYear } from '$lib/map/dateUtils';
+	import DualRangeSlider from './DualRangeSlider.svelte';
 	import MapPanel from './MapPanel.svelte';
 
 	let {
@@ -108,52 +109,15 @@
 			</div>
 		</div>
 
-		<div class="space-y-3">
+		<div class="space-y-2">
 			<div class="label py-1">
 				<span class="text-sm font-medium">Zeitraum</span>
 			</div>
 
-			<div class="space-y-3">
-				<div>
-					<label class="label py-0" for="time-range-start">
-						<span class="text-xs">Start</span>
-					</label>
-					<input
-						type="range"
-						id="time-range-start"
-						class="range range-primary range-xs"
-						min="0"
-						max={daysInYear - 1}
-						value="0"
-					/>
-					<div class="mt-1">
-						<div
-							id="time-start"
-							class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
-						></div>
-					</div>
-				</div>
-
-				<div>
-					<label class="label py-0" for="time-range-end">
-						<span class="text-xs">Ende</span>
-					</label>
-					<input
-						type="range"
-						id="time-range-end"
-						class="range range-primary range-xs"
-						min="0"
-						max={daysInYear - 1}
-						value={daysInYear - 1}
-					/>
-					<div class="mt-1">
-						<div
-							id="time-end"
-							class="bg-base-200 rounded px-2 py-1 text-center text-xs font-medium"
-						></div>
-					</div>
-				</div>
-			</div>
+			<!-- M10: Ein Track, zwei Griffe, gefüllter Bereich; Datums-Felder als
+			     gleichwertige Alternative. DOM-Verträge (IDs, input-Events) bleiben
+			     erhalten — timeSliderManager und applyUrlFilters greifen direkt zu. -->
+			<DualRangeSlider max={daysInYear - 1} year={selectedYear} />
 		</div>
 	</div>
 </MapPanel>

--- a/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
@@ -157,6 +157,26 @@ describe('FilterPanel', () => {
 			expect(getSlider('time-range-end').getAttribute('max')).toBe('365');
 		});
 	});
+
+	// M10: Datums-Eingabefelder als gleichwertige Alternative zum Dual-Slider —
+	// ihre min/max-Klemmung folgt dem gewählten Jahr.
+	it('klemmt die Datums-Eingabefelder auf das gewählte Jahr', async () => {
+		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
+
+		await page.getByRole('button', { name: /^Filter$/i }).click();
+
+		expect(getSlider('time-date-start').min).toBe('2025-01-01');
+		expect(getSlider('time-date-end').max).toBe('2025-12-31');
+
+		const yearSelect = getYearSelect();
+		yearSelect.value = '2024';
+		yearSelect.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await vi.waitFor(() => {
+			expect(getSlider('time-date-start').min).toBe('2024-01-01');
+			expect(getSlider('time-date-end').max).toBe('2024-12-31');
+		});
+	});
 });
 
 // ─── Befund H6: Panels als Bottom-Sheet (Mobile) / 320-px-Panel (Desktop) ────

--- a/src/lib/map/dateUtils.test.ts
+++ b/src/lib/map/dateUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getDaysInYear, isLeapYear } from './dateUtils';
+import {
+	dateFromDayOfYear,
+	formatDayOfYearLong,
+	getDaysInYear,
+	isLeapYear,
+	isoDateFromDayOfYear
+} from './dateUtils';
 
 describe('isLeapYear', () => {
 	it('erkennt normales Jahr als kein Schaltjahr', () => {
@@ -20,6 +26,55 @@ describe('isLeapYear', () => {
 
 	it('erkennt 2028 als Schaltjahr', () => {
 		expect(isLeapYear(2028)).toBe(true);
+	});
+});
+
+describe('dateFromDayOfYear', () => {
+	it('gibt den 1. Januar für Tag-Index 0 zurück', () => {
+		const date = dateFromDayOfYear(2025, 0);
+		expect(date.getFullYear()).toBe(2025);
+		expect(date.getMonth()).toBe(0);
+		expect(date.getDate()).toBe(1);
+	});
+
+	it('gibt den 31. Dezember für den letzten Tag-Index zurück', () => {
+		const date = dateFromDayOfYear(2025, 364);
+		expect(date.getMonth()).toBe(11);
+		expect(date.getDate()).toBe(31);
+	});
+
+	it('berücksichtigt den Schalttag (Tag 59 = 29. Februar 2024)', () => {
+		const date = dateFromDayOfYear(2024, 59);
+		expect(date.getMonth()).toBe(1);
+		expect(date.getDate()).toBe(29);
+	});
+});
+
+describe('isoDateFromDayOfYear', () => {
+	it('formatiert Tag-Index 0 als YYYY-01-01', () => {
+		expect(isoDateFromDayOfYear(2025, 0)).toBe('2025-01-01');
+	});
+
+	it('formatiert Tag-Index 186 in 2025 als 6. Juli', () => {
+		expect(isoDateFromDayOfYear(2025, 186)).toBe('2025-07-06');
+	});
+
+	it('formatiert den letzten Tag eines Schaltjahres', () => {
+		expect(isoDateFromDayOfYear(2024, 365)).toBe('2024-12-31');
+	});
+});
+
+describe('formatDayOfYearLong', () => {
+	it('formatiert Tag-Index 186 in 2025 als „6. Juli" (M10: aria-valuetext)', () => {
+		expect(formatDayOfYearLong(2025, 186)).toBe('6. Juli');
+	});
+
+	it('formatiert Tag-Index 0 als „1. Januar"', () => {
+		expect(formatDayOfYearLong(2025, 0)).toBe('1. Januar');
+	});
+
+	it('formatiert den Schalttag als „29. Februar"', () => {
+		expect(formatDayOfYearLong(2024, 59)).toBe('29. Februar');
 	});
 });
 

--- a/src/lib/map/dateUtils.ts
+++ b/src/lib/map/dateUtils.ts
@@ -12,3 +12,30 @@ export function getDaysInYear(year: number): number {
 export function isLeapYear(year: number): boolean {
 	return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }
+
+/**
+ * Lokales Datum für einen 0-basierten Tag-Index innerhalb eines Jahres
+ * (Tag 0 = 1. Januar). Kalender-Arithmetik über den Date-Konstruktor —
+ * robust gegenüber Sommerzeit-Umstellungen.
+ */
+export function dateFromDayOfYear(year: number, dayIndex: number): Date {
+	return new Date(year, 0, 1 + dayIndex);
+}
+
+/** ISO-Datum (YYYY-MM-DD, lokale Zeit) eines 0-basierten Tag-Index. */
+export function isoDateFromDayOfYear(year: number, dayIndex: number): string {
+	const date = dateFromDayOfYear(year, dayIndex);
+	const pad = (value: number): string => String(value).padStart(2, '0');
+	return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * Lesbares deutsches Datum („6. Juli") eines 0-basierten Tag-Index —
+ * für aria-valuetext der Slider-Griffe (M10).
+ */
+export function formatDayOfYearLong(year: number, dayIndex: number): string {
+	return dateFromDayOfYear(year, dayIndex).toLocaleDateString('de-DE', {
+		day: 'numeric',
+		month: 'long'
+	});
+}

--- a/src/lib/map/timeSliderManager.test.ts
+++ b/src/lib/map/timeSliderManager.test.ts
@@ -90,25 +90,25 @@ describe('MapTimeSliderManager', () => {
 		});
 
 		// M10: Die DualRangeSlider-Komponente hält ihren State über input-Events
-		// synchron. reset() muss die Events deshalb nach dem Setzen der Werte
+		// synchron. reset() muss deshalb nach dem Setzen der Werte ein Event
 		// dispatchen — sonst zeigen Füllbereich und Datums-Eingabefelder nach
-		// Jahreswechsel (QW4) oder Chip-Reset die alte Auswahl.
-		it('dispatcht input-Events auf beiden Slidern (Komponenten-Sync, M10)', () => {
+		// Jahreswechsel (QW4) oder Chip-Reset die alte Auswahl. Ein einzelnes
+		// Event genügt: Komponente und updateTimeFilter lesen beide Slider.
+		it('dispatcht genau ein input-Event nach dem Setzen beider Werte (M10)', () => {
 			const manager = new MapTimeSliderManager();
 			manager.initialize(createMockMapInstance());
 
-			const startInputs: string[] = [];
-			const endInputs: string[] = [];
-			startSlider.addEventListener('input', () => startInputs.push(startSlider.value));
-			endSlider.addEventListener('input', () => endInputs.push(endSlider.value));
+			const seen: Array<[string, string]> = [];
+			startSlider.addEventListener('input', () => seen.push([startSlider.value, endSlider.value]));
+			endSlider.addEventListener('input', () => seen.push([startSlider.value, endSlider.value]));
 
 			manager.reset(366);
 
-			expect(startInputs).toEqual(['0']);
-			expect(endInputs).toEqual(['365']);
+			// Genau ein Event, und beide Werte sind zu dem Zeitpunkt schon gesetzt
+			expect(seen).toEqual([['0', '365']]);
 		});
 
-		it('propagiert nach reset() den vollen Jahresbereich an setFilter', () => {
+		it('propagiert nach reset() den vollen Jahresbereich an setFilter (einmal)', () => {
 			const mapInstance = createMockMapInstance();
 			const manager = new MapTimeSliderManager();
 			manager.initialize(mapInstance);
@@ -116,9 +116,10 @@ describe('MapTimeSliderManager', () => {
 			manager.reset(366);
 
 			// getDisplayedYear liefert 2024 (Schaltjahr): Tag 0 = 1. Januar,
-			// Tag 365 = 31. Dezember, Ende des Tages.
+			// Tag 365 = 31. Dezember, Ende des Tages. Nur ein setFilter-Aufruf —
+			// doppeltes Filtern + URL-Sync wäre redundante Arbeit.
 			const setFilter = vi.mocked(mapInstance.setFilter);
-			expect(setFilter).toHaveBeenCalled();
+			expect(setFilter).toHaveBeenCalledOnce();
 			const [start, end] = setFilter.mock.calls.at(-1)!;
 			expect(start).toBe(new Date(2024, 0, 1).getTime());
 			expect(end).toBe(new Date(2024, 11, 31, 23, 59, 59, 999).getTime());

--- a/src/lib/map/timeSliderManager.test.ts
+++ b/src/lib/map/timeSliderManager.test.ts
@@ -18,6 +18,12 @@ class FakeRangeInput {
 	dispatch(type: string): void {
 		(this.listeners[type] ?? []).forEach((handler) => handler());
 	}
+
+	// M10: reset() dispatcht echte input-Events — der Stub braucht die DOM-API.
+	dispatchEvent(event: { type: string }): boolean {
+		this.dispatch(event.type);
+		return true;
+	}
 }
 
 function createMockMapInstance(): SichtungenMap {
@@ -81,6 +87,49 @@ describe('MapTimeSliderManager', () => {
 			const manager = new MapTimeSliderManager();
 
 			expect(() => manager.reset(366)).not.toThrow();
+		});
+
+		// M10: Die DualRangeSlider-Komponente hält ihren State über input-Events
+		// synchron. reset() muss die Events deshalb nach dem Setzen der Werte
+		// dispatchen — sonst zeigen Füllbereich und Datums-Eingabefelder nach
+		// Jahreswechsel (QW4) oder Chip-Reset die alte Auswahl.
+		it('dispatcht input-Events auf beiden Slidern (Komponenten-Sync, M10)', () => {
+			const manager = new MapTimeSliderManager();
+			manager.initialize(createMockMapInstance());
+
+			const startInputs: string[] = [];
+			const endInputs: string[] = [];
+			startSlider.addEventListener('input', () => startInputs.push(startSlider.value));
+			endSlider.addEventListener('input', () => endInputs.push(endSlider.value));
+
+			manager.reset(366);
+
+			expect(startInputs).toEqual(['0']);
+			expect(endInputs).toEqual(['365']);
+		});
+
+		it('propagiert nach reset() den vollen Jahresbereich an setFilter', () => {
+			const mapInstance = createMockMapInstance();
+			const manager = new MapTimeSliderManager();
+			manager.initialize(mapInstance);
+
+			manager.reset(366);
+
+			// getDisplayedYear liefert 2024 (Schaltjahr): Tag 0 = 1. Januar,
+			// Tag 365 = 31. Dezember, Ende des Tages.
+			const setFilter = vi.mocked(mapInstance.setFilter);
+			expect(setFilter).toHaveBeenCalled();
+			const [start, end] = setFilter.mock.calls.at(-1)!;
+			expect(start).toBe(new Date(2024, 0, 1).getTime());
+			expect(end).toBe(new Date(2024, 11, 31, 23, 59, 59, 999).getTime());
+		});
+
+		it('wirft nicht, wenn reset() vor initialize() läuft (keine Listener)', () => {
+			const manager = new MapTimeSliderManager();
+
+			expect(() => manager.reset(365)).not.toThrow();
+			expect(startSlider.value).toBe('0');
+			expect(endSlider.value).toBe('364');
 		});
 	});
 

--- a/src/lib/map/timeSliderManager.ts
+++ b/src/lib/map/timeSliderManager.ts
@@ -74,14 +74,14 @@ export class MapTimeSliderManager implements TimeSliderManager {
 		startSlider.value = '0';
 		endSlider.value = maxValue;
 
-		// M10: input-Events dispatchen, damit die DualRangeSlider-Komponente
+		// M10: ein input-Event dispatchen, damit die DualRangeSlider-Komponente
 		// (Füllbereich, aria-valuetext, Datums-Eingabefelder) den neuen Zustand
-		// übernimmt. Beide Werte sind zu diesem Zeitpunkt bereits konsistent
-		// gesetzt — das Clamping in initialize() ist ein No-op. Der dadurch
-		// ausgelöste setFilter()-Aufruf setzt denselben vollen Jahresbereich,
-		// den setYear() im Controller bereits gesetzt hat.
+		// übernimmt. Ein einzelnes Event genügt, weil Komponente und
+		// updateTimeFilter() beide Slider-Werte lesen — beide sind zu diesem
+		// Zeitpunkt bereits konsistent gesetzt, das Clamping ist ein No-op.
+		// Der ausgelöste setFilter()-Aufruf setzt denselben vollen
+		// Jahresbereich, den setYear() im Controller bereits gesetzt hat.
 		startSlider.dispatchEvent(new Event('input', { bubbles: true }));
-		endSlider.dispatchEvent(new Event('input', { bubbles: true }));
 	}
 
 	/**

--- a/src/lib/map/timeSliderManager.ts
+++ b/src/lib/map/timeSliderManager.ts
@@ -73,6 +73,15 @@ export class MapTimeSliderManager implements TimeSliderManager {
 		endSlider.max = maxValue;
 		startSlider.value = '0';
 		endSlider.value = maxValue;
+
+		// M10: input-Events dispatchen, damit die DualRangeSlider-Komponente
+		// (Füllbereich, aria-valuetext, Datums-Eingabefelder) den neuen Zustand
+		// übernimmt. Beide Werte sind zu diesem Zeitpunkt bereits konsistent
+		// gesetzt — das Clamping in initialize() ist ein No-op. Der dadurch
+		// ausgelöste setFilter()-Aufruf setzt denselben vollen Jahresbereich,
+		// den setYear() im Controller bereits gesetzt hat.
+		startSlider.dispatchEvent(new Event('input', { bubbles: true }));
+		endSlider.dispatchEvent(new Event('input', { bubbles: true }));
 	}
 
 	/**


### PR DESCRIPTION
## Zusammenfassung

Setzt **Befund M10** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` um: Der Zeitfilter der Sichtungskarte bestand aus zwei getrennten Range-Slidern — der „Ende"-Track wirkte bei 31.12. komplett gefüllt statt den gewählten *Bereich* zu zeigen, Screenreader hörten nackte Tag-Indizes („186"), und es gab keinen numerischen Fallback (Baymard: Dual-Slider werden von >50 % missverstanden).

### Änderungen

- **Neue Komponente `DualRangeSlider.svelte`** — echter Dual-Range-Slider ohne neue Dependency: zwei überlagerte native Range-Inputs auf einem gemeinsamen Track, gefüllter `primary`-Bereich zwischen den Griffen, 44-px-Touch-Targets (transparenter Rand, 24-px-Kreis sichtbar), eigener Fokusring am Griff. Farben ausschließlich aus Theme-Tokens.
- **`aria-valuetext` mit lesbarem Datum** („6. Juli" statt „186") auf beiden Griffen, live aktualisiert.
- **Zwei Datums-Eingabefelder** (`input type=date`, auf das gewählte Jahr geklemmt) als gleichwertige Alternative, beidseitig synchron mit dem Slider.
- **`timeSliderManager.reset()` dispatcht jetzt `input`-Events**, damit Füllbereich, aria-valuetext und Datums-Felder Jahreswechsel (QW4) und Chip-Resets übernehmen. Der dadurch ausgelöste `setFilter()`-Aufruf setzt denselben vollen Jahresbereich, den `setYear()` bereits gesetzt hat.
- **Neue Datums-Helfer** `dateFromDayOfYear`/`isoDateFromDayOfYear`/`formatDayOfYearLong` in `dateUtils.ts`.

### Erhaltene Verträge

- IDs `time-range-start`/`time-range-end` + Wert-Änderung via `value` + `input`-Event → `timeSliderManager` (Klemmen, `setFilter(startMs, endMs)` als Senke), `applyUrlFilters` (M4) und die Filter-Chips (N6) arbeiten unverändert
- `#time-start`/`#time-end` werden weiter vom Map-Controller per `innerText` befüllt
- Start == Ende (einzelner Tag) bleibt erlaubt; die Komponente klemmt zusätzlich selbst, damit ihr State unabhängig von der Listener-Reihenfolge konsistent ist

### Review

`/review` (projektspezifische Anti-Pattern-Checks + /simplify) und Design-System-Check durchgeführt; der einzige echte Befund (stale Datums-Feld nach No-op-Klemmung bei Start == Ende) ist mit eigenem Testfall gefixt. Svelte-MCP-Autofixer: keine Issues.

## Tests

- **Test-first:** 14 neue Browser-Komponenten-Tests (`DualRangeSlider.svelte.test.ts`), erweiterte Unit-Tests für `timeSliderManager` (Event-Dispatch in `reset()`) und `dateUtils`, neuer FilterPanel-Test (Jahres-Klemmung der Datums-Felder)
- **E2E:** `map-time-slider.spec.ts` um 4 M10-Fälle erweitert (aria-valuetext, Track-Füllung, Datums-Feld-Sync, Datums-Eingabe inkl. `from=`-URL-Param); alle Karten-Specs grün (10 + 27 + 11)
- `npm run test:quick` grün (Lint 0 Fehler, tsc, svelte-check 0 Fehler, 2229 Server-Unit-Tests); alle 2375 Unit-Tests (Server + Browser) grün
- Visuell im Browser verifiziert: Drag des Start-Griffs → Füllung folgt, Endpunkt-Anzeigen, Datums-Felder, Filter-Chip und URL-Sync korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)
