### PR TITLE
feat(map): seamark layer toggle and ux review fixes (M2, M3, M6, M7)

### DIFF
--- a/e2e/map-filters.spec.ts
+++ b/e2e/map-filters.spec.ts
@@ -47,6 +47,35 @@ test.describe.serial('Map Filter Panel', () => {
 		}
 	});
 
+	test('Jahreswechsel zeigt keinen Vollbild-Loading-Overlay mehr (M7)', async () => {
+		// M7: Das modale Vollbild-Overlay ist dem Initial-Load vorbehalten —
+		// Filter-/Jahreswechsel zeigen nur den Inline-Spinner im Filter-Panel.
+		// API künstlich verzögern, damit der Ladezustand beobachtbar ist.
+		await sharedPage.route('**/api/map/sightings?*', async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 700));
+			await route.continue();
+		});
+
+		await mapPage.openFilter();
+		const yearSelect = mapPage.getYearSelect();
+		const options = yearSelect.locator('option');
+		const count = await options.count();
+		const targetYear = await options.nth(count > 1 ? count - 1 : 0).getAttribute('value');
+
+		if (targetYear) {
+			const responsePromise = mapPage.waitForSightingsResponse();
+			await mapPage.selectYear(targetYear);
+
+			// Während des laufenden Requests: kein Vollbild-Overlay
+			await expect(mapPage.getLoadingOverlay()).toBeHidden();
+
+			await responsePromise;
+		}
+
+		await sharedPage.unroute('**/api/map/sightings?*');
+		await mapPage.closeFilter();
+	});
+
 	test('Suchtext in Eingabefeld löst API-Call mit search-Parameter aus', async () => {
 		await mapPage.openFilter();
 

--- a/e2e/map-filters.spec.ts
+++ b/e2e/map-filters.spec.ts
@@ -58,9 +58,7 @@ test.describe.serial('Map Filter Panel', () => {
 
 		await mapPage.openFilter();
 		const yearSelect = mapPage.getYearSelect();
-		const options = yearSelect.locator('option');
-		const count = await options.count();
-		const targetYear = await options.nth(count > 1 ? count - 1 : 0).getAttribute('value');
+		const targetYear = await yearSelect.locator('option').last().getAttribute('value');
 
 		if (targetYear) {
 			const responsePromise = mapPage.waitForSightingsResponse();

--- a/e2e/map-filters.spec.ts
+++ b/e2e/map-filters.spec.ts
@@ -51,9 +51,12 @@ test.describe.serial('Map Filter Panel', () => {
 		// M7: Das modale Vollbild-Overlay ist dem Initial-Load vorbehalten —
 		// Filter-/Jahreswechsel zeigen nur den Inline-Spinner im Filter-Panel.
 		// API künstlich verzögern, damit der Ladezustand beobachtbar ist.
+		// route.fallback() statt continue(): setupMapPage mockt den Endpoint
+		// bereits (fulfill) — continue() würde am Mock vorbei zum echten Server
+		// gehen, der in CI keine Datenbank hat.
 		await sharedPage.route('**/api/map/sightings?*', async (route) => {
 			await new Promise((resolve) => setTimeout(resolve, 700));
-			await route.continue();
+			await route.fallback();
 		});
 
 		await mapPage.openFilter();

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -25,7 +25,10 @@
 		// der URL initialisieren und über die Filter-Chips zurücksetzen kann —
 		// Checkboxen hier und Chips dort bleiben so eine einzige Wahrheit.
 		speciesVisibility = $bindable({}),
-		colorVisibility = $bindable({})
+		colorVisibility = $bindable({}),
+		// M3: Seezeichen-Ebene (OpenSeaMap) umschaltbar — der Parent reicht die
+		// Sichtbarkeit an den Map-Controller weiter.
+		onSeamarkToggle = undefined
 	} = $props<{
 		translations: MapTranslations;
 		counts: CountData;
@@ -33,6 +36,7 @@
 		isOpen?: boolean;
 		speciesVisibility?: Record<string, boolean>;
 		colorVisibility?: Record<string, boolean>;
+		onSeamarkToggle?: (visible: boolean) => void;
 	}>();
 
 	// CountManager via typisiertem Svelte Context (Symbol-Key, siehe mapContext.ts)
@@ -77,6 +81,13 @@
 	function handleColorToggle(colorGroup: string, visible: boolean) {
 		colorVisibility[colorGroup] = visible;
 		countManager.setColorVisibility(colorGroup, visible);
+	}
+
+	// M3: Sichtbarkeit der Seezeichen-Ebene — Default an (wie bisher)
+	let seamarkVisible = $state(true);
+	function handleSeamarkToggle(visible: boolean) {
+		seamarkVisible = visible;
+		onSeamarkToggle?.(visible);
 	}
 </script>
 
@@ -205,6 +216,22 @@
 				/>
 			</div>
 		{/each}
+	</div>
+
+	<div class="divider">Kartenebenen</div>
+
+	<!-- M3: Seezeichen-Ebene (OpenSeaMap) umschaltbar — sie dominiert ab
+	     mittleren Zoomstufen und ist für die Kernaufgabe sekundär -->
+	<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
+		<Icon icon="lucide:anchor" class="text-base-content/70 h-4 w-4 shrink-0" aria-hidden="true" />
+		<span class="flex-1 text-sm">Seezeichen &amp; Tonnen (OpenSeaMap)</span>
+		<input
+			type="checkbox"
+			class="seamark-checkbox checkbox checkbox-sm"
+			checked={seamarkVisible}
+			onchange={(e) => handleSeamarkToggle((e.target as HTMLInputElement).checked)}
+			aria-label="Seezeichen-Ebene (OpenSeaMap) anzeigen/ausblenden"
+		/>
 	</div>
 
 	<div class="divider">Cluster</div>

--- a/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/LegendPanel.svelte.test.ts
@@ -206,6 +206,32 @@ describe('LegendPanel', () => {
 		expect(document.body.textContent).toContain('je dunkler');
 	});
 
+	it('bietet einen Seezeichen-Toggle (OpenSeaMap), Default an (M3)', async () => {
+		render(LegendPanel, { translations, counts });
+
+		await page.getByRole('button', { name: /^Legende$/i }).click();
+
+		const checkbox = document.querySelector('.seamark-checkbox');
+		if (!(checkbox instanceof HTMLInputElement)) {
+			throw new Error('Seamark checkbox not found');
+		}
+		expect(checkbox.checked).toBe(true);
+		expect(document.body.textContent).toContain('Seezeichen');
+	});
+
+	it('meldet das Ausblenden der Seezeichen-Ebene über onSeamarkToggle (M3)', async () => {
+		const onSeamarkToggle = vi.fn();
+		render(LegendPanel, { translations, counts, onSeamarkToggle });
+
+		await page.getByRole('button', { name: /^Legende$/i }).click();
+
+		const checkbox = document.querySelector('.seamark-checkbox') as HTMLInputElement;
+		checkbox.checked = false;
+		checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+
+		expect(onSeamarkToggle).toHaveBeenCalledWith(false);
+	});
+
 	it('meldet Species- und Farb-Toggles an den CountManager', async () => {
 		render(LegendPanel, { translations, counts });
 

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -52,7 +52,8 @@
 		overview: 'Übersichtskarte',
 		zoom_title: 'Kartenauschnitt auf alle Meldungen zoomen',
 		zoom: 'Alle Meldungen',
-		report_date: 'Sichtung vom ',
+		// M6: kein Trailing-Space — der Builder setzt das Datum mit eigenem Trenner
+		report_date: 'Sichtung vom',
 		language: 'de',
 		species: 'Tierart',
 		species_legend: 'Tierart [ sichtbar / gesamt ]',
@@ -148,7 +149,6 @@
 	});
 	let isLoadingData = $state(false);
 	let isInitialLoading = $state(true);
-	let loadingType = $state<'initial' | 'filter' | 'features'>('initial');
 	let errorMessage = $state<string | null>(null);
 
 	// M4/N6: Sichtbarkeits-States der Legende — hierher gehoben, damit
@@ -444,7 +444,6 @@
 				onLoading: (loading) => {
 					isLoadingData = loading;
 					if (loading) {
-						loadingType = 'features';
 						errorMessage = null;
 					} else if (!firstLoadComplete) {
 						firstLoadComplete = true;
@@ -749,19 +748,10 @@
 			id="info"
 			class="border-base-300 bg-base-100 pointer-events-none absolute z-10 hidden max-w-sm rounded border p-2 shadow-lg"
 		></div>
-		<!-- Bestehender Load-Overlay -->
-		<div
-			id="overlay-load"
-			class="bg-base-100/70 absolute top-0 left-0 z-20 flex hidden h-full w-full items-center justify-center"
-		>
-			<div class="loading loading-lg loading-spinner"></div>
-		</div>
-
-		<!-- Verbesserter Loading-Overlay -->
-		<LoadingOverlay
-			isVisible={isInitialLoading || isLoadingData}
-			type={isInitialLoading ? 'initial' : loadingType}
-		/>
+		<!-- M7: Vollbild-Overlay nur beim Initial-Load — Filter-/Jahreswechsel
+		     zeigen stattdessen den Inline-Spinner im Filter-Panel (isLoading-Prop),
+		     dessen Toggle-Tab auch bei geschlossenem Panel mitrotiert. -->
+		<LoadingOverlay isVisible={isInitialLoading} type="initial" />
 
 		<!-- Keine Sichtungen für das gewählte Jahr -->
 		{#if showNoResults}
@@ -890,6 +880,7 @@
 		bind:isOpen={legendOpen}
 		bind:speciesVisibility
 		bind:colorVisibility
+		onSeamarkToggle={(visible) => mapInstance?.setSeamarkVisibility(visible)}
 	/>
 
 	<!-- Tastatur-Hilfe Button -->

--- a/src/lib/map/clusterConfig.test.ts
+++ b/src/lib/map/clusterConfig.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+	CLUSTER_MIN_DISTANCE_RATIO,
+	clusterDistanceForZoom,
+	clusterMinDistanceFor
+} from './clusterConfig';
+
+/**
+ * Tests für die Cluster-Distanz-Konfiguration (Befund M2).
+ *
+ * Vorher erlaubte `minDistance: 10` bei `distance: 40-50` fast vollständige
+ * Überlappung der Cluster-Kreise bei niedrigen Zoomstufen. minDistance muss
+ * an die jeweilige distance gekoppelt sein (~60 %), damit Cluster lesbar
+ * getrennt bleiben.
+ */
+describe('clusterDistanceForZoom', () => {
+	it('liefert die bisherige Zoom-Staffel (50/40/30/20)', () => {
+		expect(clusterDistanceForZoom(5)).toBe(50);
+		expect(clusterDistanceForZoom(7.9)).toBe(50);
+		expect(clusterDistanceForZoom(8)).toBe(40);
+		expect(clusterDistanceForZoom(9.9)).toBe(40);
+		expect(clusterDistanceForZoom(10)).toBe(30);
+		expect(clusterDistanceForZoom(11.9)).toBe(30);
+		expect(clusterDistanceForZoom(12)).toBe(20);
+		expect(clusterDistanceForZoom(18)).toBe(20);
+	});
+});
+
+describe('clusterMinDistanceFor', () => {
+	it('koppelt minDistance an ~60 % der distance', () => {
+		expect(CLUSTER_MIN_DISTANCE_RATIO).toBeCloseTo(0.6);
+		expect(clusterMinDistanceFor(50)).toBe(30);
+		expect(clusterMinDistanceFor(40)).toBe(24);
+		expect(clusterMinDistanceFor(30)).toBe(18);
+		expect(clusterMinDistanceFor(20)).toBe(12);
+	});
+
+	it('verhindert die alte Fast-Überlappung (minDistance 10 bei distance 40+)', () => {
+		for (const zoom of [5, 8, 10, 12]) {
+			const distance = clusterDistanceForZoom(zoom);
+			expect(clusterMinDistanceFor(distance)).toBeGreaterThanOrEqual(distance * 0.5);
+		}
+	});
+});

--- a/src/lib/map/clusterConfig.ts
+++ b/src/lib/map/clusterConfig.ts
@@ -1,0 +1,23 @@
+/**
+ * Cluster-Distanz-Konfiguration für die Sichtungskarte (M2).
+ *
+ * `distance` steuert, ab welchem Pixel-Abstand Features zu einem Cluster
+ * zusammengefasst werden; `minDistance` hält fertige Cluster auf Abstand.
+ * Ein fixes `minDistance: 10` bei `distance: 40-50` ließ Cluster bei
+ * Zoom ≤ 8 fast deckungsgleich übereinander liegen — deshalb ist
+ * minDistance hier an ~60 % der jeweiligen distance gekoppelt.
+ */
+export const CLUSTER_MIN_DISTANCE_RATIO = 0.6;
+
+/** Cluster-Distanz je Zoomstufe — enger clustern, je weiter hineingezoomt ist. */
+export function clusterDistanceForZoom(zoom: number): number {
+	if (zoom < 8) return 50;
+	if (zoom < 10) return 40;
+	if (zoom < 12) return 30;
+	return 20;
+}
+
+/** Mindestabstand zwischen Clustern, gekoppelt an die aktuelle Distanz. */
+export function clusterMinDistanceFor(distance: number): number {
+	return Math.round(distance * CLUSTER_MIN_DISTANCE_RATIO);
+}

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -237,6 +237,132 @@
 	padding: 8px;
 }
 
+/* ===========================
+   Sichtungs-Popup (M6)
+   Klassen statt Inline-Hex-Styles — Farben aus den Theme-Tokens,
+   die Inhalte kommen aus src/lib/map/popupContent.ts.
+   =========================== */
+
+/* padding-top berücksichtigt den 44px hohen Schließen-Button, damit dieser
+   den Inhalt (Überschrift) nicht überlappt. */
+.ol-popup {
+	position: absolute;
+	background-color: var(--color-base-100);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+	padding: 44px 15px 15px 15px;
+	border-radius: 10px;
+	border: 1px solid var(--color-base-300);
+	bottom: 12px;
+	left: -50px;
+	min-width: 280px;
+	z-index: 1000;
+}
+
+/* Close button — Hit-Target min. 44x44px (WCAG 2.5.5), Symbol bleibt optisch klein */
+.ol-popup-closer {
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 44px;
+	height: 44px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border: none;
+	background: none;
+	font-size: 18px;
+	cursor: pointer;
+	color: var(--color-base-content);
+	opacity: 0.6;
+}
+
+.sighting-popup .popup-title {
+	margin: 0 0 10px 0;
+	color: var(--color-base-content);
+}
+
+.cluster-popup .popup-title {
+	margin: 0 0 8px 0;
+	font-size: 14px;
+	color: var(--color-base-content);
+}
+
+.popup-row {
+	margin-bottom: 8px;
+}
+
+.popup-row-dead {
+	color: var(--color-error);
+}
+
+.cluster-list {
+	list-style: none;
+	margin: 0;
+	padding: 0 4px 0 0;
+	max-height: 240px;
+	overflow-y: auto;
+}
+
+.cluster-list-item {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	padding: 8px;
+	margin-bottom: 4px;
+	border: 1px solid var(--color-base-300);
+	border-radius: 6px;
+	background: var(--color-base-200);
+	cursor: pointer;
+	text-align: left;
+	font-size: 13px;
+	transition: background 0.15s;
+}
+
+.cluster-list-item:hover,
+.cluster-list-item:focus-visible {
+	background: var(--color-base-300);
+	outline: 2px solid var(--color-primary);
+	outline-offset: -2px;
+}
+
+.cluster-item-species {
+	flex: 1;
+	font-weight: 500;
+}
+
+.cluster-item-count {
+	color: var(--color-base-content);
+	opacity: 0.7;
+	white-space: nowrap;
+}
+
+.cluster-item-date {
+	color: var(--color-base-content);
+	opacity: 0.7;
+	font-size: 11px;
+	white-space: nowrap;
+}
+
+.cluster-item-dead {
+	color: var(--color-error);
+	font-weight: 600;
+	margin-left: 4px;
+}
+
+.cluster-back-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	border: none;
+	background: none;
+	cursor: pointer;
+	color: var(--color-primary);
+	font-size: 12px;
+	padding: 0 0 8px 0;
+	font-weight: 500;
+}
+
 /* Map Container Wrapper */
 .map-container-wrapper {
 	position: relative;

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -26,24 +26,16 @@ import {
 	createFeatureStyle,
 	getFeatureColorGroup
 } from './styleUtils';
-import { sanitizeText } from '$lib/utils/sanitize';
+import { clusterDistanceForZoom, clusterMinDistanceFor } from './clusterConfig';
+import {
+	createClusterInfoText,
+	createClusterListContent,
+	createInfoText,
+	createSightingPopupContent,
+	type SightingPopupProperties as SightingProperties
+} from './popupContent';
 
 const logger = createLogger('map:optimized-controller');
-
-/**
- * Interface für die Eigenschaften einer Sichtung
- */
-interface SightingProperties {
-	ta: string | number; // Tierart
-	ct: number; // Anzahl
-	jt?: number; // Jungtiere
-	ts?: number; // Timestamp
-	tf?: boolean; // Totfund
-	shipname?: string;
-	waterway?: string;
-	name?: string;
-	firstname?: string;
-}
 
 /**
  * Optionen für die Map-Klasse
@@ -104,6 +96,8 @@ export class SichtungenMap {
 	private activeAbortController: AbortController | null = null;
 	private filterDebounceTimeout: number | null = null;
 	private clusterDistance: number = 40; // Reduziert für bessere Performance
+	// M3: Seezeichen-Ebene als Feld, damit die Legende sie umschalten kann
+	private seamarkLayer: TileLayer<XYZ>;
 
 	// Popup-related
 	private popup!: Overlay;
@@ -155,10 +149,11 @@ export class SichtungenMap {
 			}
 		});
 
-		// Optimierte Cluster-Konfiguration
+		// Optimierte Cluster-Konfiguration — minDistance an die Distanz gekoppelt,
+		// sonst überlappen Cluster bei niedrigen Zoomstufen fast vollständig (M2)
 		this.clusterSource = new Cluster({
 			distance: this.clusterDistance,
-			minDistance: 10, // Mindestabstand zwischen Features
+			minDistance: clusterMinDistanceFor(this.clusterDistance),
 			source: this.reportsSource
 		});
 
@@ -186,6 +181,29 @@ export class SichtungenMap {
 					return styles ?? [];
 				}
 			}
+		});
+
+		// OpenSeaMap-Seezeichen (Bojen, Tonnen, Leuchtfeuer) — per Legende
+		// ein-/ausblendbar (M3), Default an
+		this.seamarkLayer = new TileLayer({
+			source: new XYZ({
+				url: 'https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png',
+				attributions: '© <a href="http://www.openseamap.org/">OpenSeaMap</a> contributors',
+				maxZoom: 18,
+				minZoom: 1,
+				crossOrigin: 'anonymous',
+				// Handle tile loading errors gracefully
+				tileLoadFunction: (tile, src) => {
+					const img = (tile as unknown as { getImage(): HTMLImageElement }).getImage();
+					img.onerror = () => {
+						// If tile fails to load, log for debugging and hide it
+						logger.warn({ tileUrl: src }, 'OpenSeaMap tile failed to load');
+						img.style.display = 'none';
+					};
+					img.src = src;
+				}
+			}),
+			opacity: 0.8 // Slightly transparent to blend well with base map
 		});
 
 		// Erstelle Popup
@@ -224,27 +242,8 @@ export class SichtungenMap {
 						}
 					})
 				}),
-				// OpenSeaMap-Layer für maritime Informationen
-				new TileLayer({
-					source: new XYZ({
-						url: 'https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png',
-						attributions: '© <a href="http://www.openseamap.org/">OpenSeaMap</a> contributors',
-						maxZoom: 18,
-						minZoom: 1,
-						crossOrigin: 'anonymous',
-						// Handle tile loading errors gracefully
-						tileLoadFunction: (tile, src) => {
-							const img = (tile as unknown as { getImage(): HTMLImageElement }).getImage();
-							img.onerror = () => {
-								// If tile fails to load, log for debugging and hide it
-								logger.warn({ tileUrl: src }, 'OpenSeaMap tile failed to load');
-								img.style.display = 'none';
-							};
-							img.src = src;
-						}
-					}),
-					opacity: 0.8 // Slightly transparent to blend well with base map
-				}),
+				// OpenSeaMap-Layer für maritime Informationen (Toggle in der Legende, M3)
+				this.seamarkLayer,
 				// Sichtungen-Layer (nur einer!)
 				this.reportsLayer,
 				// GPS-Position Layer
@@ -298,60 +297,19 @@ export class SichtungenMap {
 	}
 
 	private createPopup(): void {
+		// M6: Darstellung komplett über CSS-Klassen aus mapStyles.css —
+		// keine Inline-Styles am Theme vorbei.
 		this.popupElement = document.createElement('div');
 		this.popupElement.className = 'ol-popup';
 		this.popupElement.innerHTML = `
-			<style>
-				.cluster-list-item {
-					display: flex; align-items: center; gap: 8px; width: 100%;
-					padding: 8px; margin-bottom: 4px; border: 1px solid #e5e7eb;
-					border-radius: 6px; background: #f9fafb; cursor: pointer;
-					text-align: left; font-size: 13px; transition: background 0.15s;
-				}
-				.cluster-list-item:hover, .cluster-list-item:focus-visible {
-					background: #e0f2fe; outline: 2px solid #2563eb; outline-offset: -2px;
-				}
-			</style>
 			<div class="ol-popup-content">
 				<button class="ol-popup-closer" type="button" aria-label="Popup schließen">×</button>
 				<div class="popup-body"></div>
 			</div>
 		`;
 
-		// Style the popup
-		// padding-top berücksichtigt den 44px hohen Schließen-Button, damit dieser
-		// den Inhalt (Überschrift) nicht überlappt.
-		this.popupElement.style.cssText = `
-			position: absolute;
-			background-color: white;
-			box-shadow: 0 1px 4px rgba(0,0,0,0.2);
-			padding: 44px 15px 15px 15px;
-			border-radius: 10px;
-			border: 1px solid #cccccc;
-			bottom: 12px;
-			left: -50px;
-			min-width: 280px;
-			z-index: 1000;
-		`;
-
-		// Close button — Hit-Target min. 44x44px (WCAG 2.5.5), Symbol bleibt optisch klein
 		const closer = this.popupElement.querySelector('.ol-popup-closer') as HTMLButtonElement;
 		closer.onclick = () => this.closePopup();
-		closer.style.cssText = `
-			position: absolute;
-			top: 0;
-			right: 0;
-			width: 44px;
-			height: 44px;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			border: none;
-			background: none;
-			font-size: 18px;
-			cursor: pointer;
-			color: #999;
-		`;
 
 		this.popup = new Overlay({
 			element: this.popupElement,
@@ -388,16 +346,16 @@ export class SichtungenMap {
 					const features = feature.get('features');
 					if (features && features.length > 1) {
 						// Cluster-Info erstellen
-						infoText = this.createClusterInfoText(features);
+						infoText = createClusterInfoText(this.getPropsList(features), this.translations);
 					} else if (features && features.length === 1) {
 						// Einzelnes Feature aus Cluster
 						const singleFeature = features[0];
 						const props = singleFeature.getProperties();
-						infoText = this.createInfoText(props as SightingProperties);
+						infoText = createInfoText(props as SightingProperties, this.translations);
 					} else {
 						// Normales einzelnes Feature
 						const props = feature.getProperties();
-						infoText = this.createInfoText(props as SightingProperties);
+						infoText = createInfoText(props as SightingProperties, this.translations);
 					}
 
 					// Zeige Info-Element
@@ -454,6 +412,11 @@ export class SichtungenMap {
 		}) as EventsKey;
 	}
 
+	/** Properties-Liste für die reinen Content-Builder aus popupContent.ts */
+	private getPropsList(features: Feature<Geometry>[]): SightingProperties[] {
+		return features.map((feature) => feature.getProperties() as SightingProperties);
+	}
+
 	private sortFeaturesByDate(features: Feature<Geometry>[]): Feature<Geometry>[] {
 		return [...features].sort((a, b) => {
 			const tsA = (a.getProperties() as SightingProperties).ts || 0;
@@ -469,89 +432,16 @@ export class SichtungenMap {
 		if (features && features.length > 1) {
 			// Cluster - zeige Liste aller Sichtungen
 			const sorted = this.sortFeaturesByDate(features);
-			contentDiv.innerHTML = this.createClusterListContent(sorted);
+			contentDiv.innerHTML = createClusterListContent(this.getPropsList(sorted), this.translations);
 			this.attachClusterListHandlers(contentDiv, sorted, coordinate);
 		} else {
 			// Einzelfeature
 			const singleFeature = features ? features[0] : feature;
 			const props = singleFeature.getProperties() as SightingProperties;
-			contentDiv.innerHTML = this.createSightingPopupContent(props);
+			contentDiv.innerHTML = createSightingPopupContent(props, this.translations);
 		}
 
 		this.popup.setPosition(coordinate);
-	}
-
-	private createSightingPopupContent(props: SightingProperties): string {
-		const speciesMap = this.translations.speciesMap;
-		const speciesName = sanitizeText(
-			speciesMap[props.ta.toString()] || `Unbekannte Art (${props.ta})`
-		);
-		// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum
-		// (bis zu ±1 Tag Abweichung von der Berlin-Anzeige).
-		const date = props.ts
-			? new Date(props.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
-			: 'Unbekannt';
-
-		let content = `
-			<div class="sighting-popup">
-				<h3 style="margin: 0 0 10px 0; color: #333;">${speciesName}</h3>
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.count)}:</strong> ${props.ct} Tier${props.ct > 1 ? 'e' : ''}
-				</div>
-		`;
-
-		if (props.jt && props.jt > 0) {
-			content += `
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.young)}:</strong> ${props.jt}
-				</div>
-			`;
-		}
-
-		if (props.tf) {
-			content += `
-				<div style="margin-bottom: 8px; color: #dc2626;">
-					<strong>${sanitizeText(this.translations.found_dead)}:</strong> Ja
-				</div>
-			`;
-		}
-
-		content += `
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.report_date)}:</strong> ${date}
-				</div>
-		`;
-
-		if (props.waterway) {
-			content += `
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.area)}:</strong> ${sanitizeText(props.waterway)}
-				</div>
-			`;
-		}
-
-		if (props.name || props.firstname) {
-			const fullName = [props.firstname, props.name]
-				.filter(Boolean)
-				.map((v) => sanitizeText(v!))
-				.join(' ');
-			content += `
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.name)}:</strong> ${fullName}
-				</div>
-			`;
-		}
-
-		if (props.shipname) {
-			content += `
-				<div style="margin-bottom: 8px;">
-					<strong>${sanitizeText(this.translations.ship)}:</strong> ${sanitizeText(props.shipname)}
-				</div>
-			`;
-		}
-
-		content += '</div>';
-		return content;
 	}
 
 	/**
@@ -563,53 +453,6 @@ export class SichtungenMap {
 			.map((f) => f.getGeometry()?.getExtent() as [number, number, number, number] | undefined)
 			.filter((ext): ext is [number, number, number, number] => ext !== undefined);
 		return areExtentsColocated(extents);
-	}
-
-	/**
-	 * Erstellt eine scrollbare Liste aller Sichtungen im Cluster.
-	 * Erwartet bereits sortierte Features (via sortFeaturesByDate).
-	 */
-	private createClusterListContent(features: Feature<Geometry>[]): string {
-		const count = features.length;
-
-		let items = '';
-		features.forEach((feature, index) => {
-			const props = feature.getProperties() as SightingProperties;
-			const speciesName = sanitizeText(
-				this.translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`
-			);
-			// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum.
-			const date = props.ts
-				? new Date(props.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
-				: 'Unbekannt';
-			const deadBadge = props.tf
-				? '<span style="color: #dc2626; font-weight: 600; margin-left: 4px;">&#x2020;</span>'
-				: '';
-
-			items += `
-				<li>
-					<button
-						type="button"
-						data-cluster-index="${index}"
-						class="cluster-list-item"
-						aria-label="${speciesName}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
-					>
-						<span style="flex: 1; font-weight: 500;">${speciesName}${deadBadge}</span>
-						<span style="color: #6b7280; white-space: nowrap;">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
-						<span style="color: #9ca3af; font-size: 11px; white-space: nowrap;">${date}</span>
-					</button>
-				</li>
-			`;
-		});
-
-		return `
-			<div class="cluster-popup">
-				<h3 style="margin: 0 0 8px 0; color: #333; font-size: 14px;">${count} Sichtungen an diesem Ort</h3>
-				<ul aria-label="${count} Sichtungen" style="list-style: none; margin: 0; padding: 0; max-height: 240px; overflow-y: auto; padding-right: 4px;">
-					${items}
-				</ul>
-			</div>
-		`;
 	}
 
 	/**
@@ -632,10 +475,10 @@ export class SichtungenMap {
 				// Zeige Detail-Ansicht mit Zurück-Button
 				contentDiv.innerHTML = `
 					<div>
-						<button type="button" class="cluster-back-btn" style="display: inline-flex; align-items: center; gap: 4px; border: none; background: none; cursor: pointer; color: #2563eb; font-size: 12px; padding: 0 0 8px 0; font-weight: 500;">
+						<button type="button" class="cluster-back-btn">
 							&#8592; Alle ${sortedFeatures.length} Sichtungen
 						</button>
-						${this.createSightingPopupContent(props)}
+						${createSightingPopupContent(props, this.translations)}
 					</div>
 				`;
 				this.popup.setPosition(coordinate);
@@ -644,7 +487,10 @@ export class SichtungenMap {
 				const backBtn = contentDiv.querySelector('.cluster-back-btn');
 				backBtn?.addEventListener('click', (e) => {
 					e.stopPropagation();
-					contentDiv.innerHTML = this.createClusterListContent(sortedFeatures);
+					contentDiv.innerHTML = createClusterListContent(
+						this.getPropsList(sortedFeatures),
+						this.translations
+					);
 					this.attachClusterListHandlers(contentDiv, sortedFeatures, coordinate);
 					this.popup.setPosition(coordinate);
 				});
@@ -673,18 +519,11 @@ export class SichtungenMap {
 	private updateClusterDistance(): void {
 		const zoom = this.map.getView().getZoom() || 7;
 
-		let distance: number;
-		if (zoom < 8) {
-			distance = 50;
-		} else if (zoom < 10) {
-			distance = 40;
-		} else if (zoom < 12) {
-			distance = 30;
-		} else {
-			distance = 20;
-		}
-
+		// M2: minDistance mitführen — sonst fällt es auf den Konstruktor-Wert
+		// zurück und Cluster überlappen bei niedrigen Zoomstufen erneut
+		const distance = clusterDistanceForZoom(zoom);
 		this.clusterSource.setDistance(distance);
+		this.clusterSource.setMinDistance(clusterMinDistanceFor(distance));
 	}
 
 	/**
@@ -796,6 +635,15 @@ export class SichtungenMap {
 
 	public getMap(): Map {
 		return this.map;
+	}
+
+	/** M3: Seezeichen-Ebene (OpenSeaMap) ein-/ausblenden — Toggle in der Legende. */
+	public setSeamarkVisibility(visible: boolean): void {
+		this.seamarkLayer.setVisible(visible);
+	}
+
+	public getSeamarkVisibility(): boolean {
+		return this.seamarkLayer.getVisible();
 	}
 
 	private createCustomControls(): Control[] {
@@ -1063,53 +911,6 @@ export class SichtungenMap {
 				timeZone: 'Europe/Berlin'
 			});
 		}
-	}
-
-	private createInfoText(properties: SightingProperties): string {
-		const species = sanitizeText(this.translations.speciesMap[properties.ta] || 'Unbekannte Art');
-		const count = properties.ct || 0;
-		// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum.
-		const date = properties.ts
-			? new Date(properties.ts * 1000).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
-			: 'Unbekanntes Datum';
-		const isDead = properties.tf ? ` (${sanitizeText(this.translations.found_dead)})` : '';
-		return `
-			<div class="p-2 text-sm">
-				<strong>${species}</strong><br>
-				${sanitizeText(this.translations.count)}: ${count}${isDead}<br>
-				${sanitizeText(this.translations.report_date)}${date}
-			</div>
-		`;
-	}
-
-	private createClusterInfoText(features: Feature<Geometry>[]): string {
-		const count = features.length;
-		const speciesCount: Record<string, number> = {};
-
-		// Zähle die verschiedenen Arten im Cluster
-		features.forEach((feature) => {
-			const properties = feature.getProperties() as SightingProperties;
-			const speciesKey = properties.ta.toString();
-			speciesCount[speciesKey] = (speciesCount[speciesKey] || 0) + 1;
-		});
-
-		// Erstelle eine Zusammenfassung der häufigsten Arten
-		const sortedSpecies = Object.entries(speciesCount)
-			.sort(([, a], [, b]) => b - a)
-			.slice(0, 3) // Zeige nur die 3 häufigsten Arten
-			.map(([speciesId, count]) => {
-				const speciesName = sanitizeText(
-					this.translations.speciesMap[speciesId] || 'Unbekannte Art'
-				);
-				return `${speciesName}: ${count}`;
-			});
-
-		return `
-			<div class="p-2 text-sm">
-				<strong>${count} Sichtungen</strong><br>
-				${sortedSpecies.join('<br>')}
-			</div>
-		`;
 	}
 
 	private positionInfoElement(

--- a/src/lib/map/popupContent.test.ts
+++ b/src/lib/map/popupContent.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import type { MapTranslations } from './mapUtils';
+import {
+	createClusterInfoText,
+	createClusterListContent,
+	createInfoText,
+	createSightingPopupContent,
+	type SightingPopupProperties
+} from './popupContent';
+
+/**
+ * Tests für die Popup-/Hover-Inhalte (Befund M6).
+ *
+ * Vorher: „Sichtung vom :" (Leerzeichen vor Doppelpunkt), redundantes
+ * „Anzahl Tiere: 3 Tiere", Fahrwasser nur im Popup (nicht im Hover) und
+ * durchgehend Inline-Hex-Styles am Theme vorbei.
+ */
+
+const translations: MapTranslations = {
+	overview: 'Übersichtskarte',
+	zoom_title: 'Zoom',
+	zoom: 'Zoom',
+	report_date: 'Sichtung vom',
+	language: 'de',
+	species: 'Tierart',
+	species_legend: 'Tierart',
+	position: 'Position',
+	count: 'Anzahl Tiere',
+	young: 'Davon Jungtiere',
+	ship: 'Schiffsname',
+	name: 'Name',
+	area: 'Fahrwasser',
+	latitude: 'Breite',
+	longitude: 'Länge',
+	found_dead: 'Totfund',
+	speciesMap: { '0': 'Schweinswal', '1': 'Kegelrobbe' }
+};
+
+// 2026-05-12 12:00 UTC → 12.05.2026 in Europe/Berlin
+const TS = Date.UTC(2026, 4, 12, 12) / 1000;
+
+const baseProps: SightingPopupProperties = {
+	ta: 0,
+	ct: 3,
+	ts: TS
+};
+
+describe('createSightingPopupContent', () => {
+	it('rendert Datum ohne Leerzeichen-Doppelpunkt-Fehler', () => {
+		const html = createSightingPopupContent(baseProps, translations);
+		expect(html).not.toContain(' :');
+		expect(html).toContain('Sichtung vom');
+		expect(html).toContain('12.05.2026');
+	});
+
+	it('zeigt die Anzahl ohne redundantes „Tiere"-Suffix hinter dem Label', () => {
+		const html = createSightingPopupContent(baseProps, translations);
+		expect(html).toContain('Anzahl Tiere');
+		expect(html).not.toMatch(/Anzahl Tiere:<\/strong>\s*3\s*Tiere/);
+	});
+
+	it('zeigt das Fahrwasser mit Label, wenn vorhanden', () => {
+		const html = createSightingPopupContent({ ...baseProps, waterway: 'Kadetrinne' }, translations);
+		expect(html).toContain('Fahrwasser');
+		expect(html).toContain('Kadetrinne');
+	});
+
+	it('nutzt CSS-Klassen statt Inline-Styles', () => {
+		const html = createSightingPopupContent(
+			{
+				...baseProps,
+				jt: 1,
+				tf: true,
+				waterway: 'Kadetrinne',
+				name: 'Muster',
+				shipname: 'MS Test'
+			},
+			translations
+		);
+		expect(html).not.toContain('style=');
+	});
+
+	it('sanitisiert eingebettetes Markup aus Nutzdaten', () => {
+		const html = createSightingPopupContent(
+			{ ...baseProps, waterway: '<script>alert(1)</script>Rinne' },
+			translations
+		);
+		expect(html).not.toContain('<script>');
+		expect(html).toContain('Rinne');
+	});
+});
+
+describe('createClusterListContent', () => {
+	it('listet Einträge ohne Inline-Styles und mit Datum', () => {
+		const html = createClusterListContent(
+			[baseProps, { ...baseProps, ta: 1, ct: 1, tf: true }],
+			translations
+		);
+		expect(html).toContain('2 Sichtungen an diesem Ort');
+		expect(html).toContain('12.05.2026');
+		expect(html).not.toContain('style=');
+		expect(html).toContain('cluster-list-item');
+	});
+});
+
+describe('createInfoText (Hover)', () => {
+	it('trennt Label und Datum mit Leerzeichen', () => {
+		const html = createInfoText(baseProps, translations);
+		expect(html).toContain('Sichtung vom 12.05.2026');
+	});
+
+	it('zeigt das Fahrwasser konsistent auch im Hover-Info', () => {
+		const html = createInfoText({ ...baseProps, waterway: 'Kadetrinne' }, translations);
+		expect(html).toContain('Fahrwasser: Kadetrinne');
+	});
+});
+
+describe('createClusterInfoText (Hover)', () => {
+	it('fasst die häufigsten Arten zusammen', () => {
+		const html = createClusterInfoText(
+			[baseProps, baseProps, { ...baseProps, ta: 1 }],
+			translations
+		);
+		expect(html).toContain('3 Sichtungen');
+		expect(html).toContain('Schweinswal: 2');
+		expect(html).toContain('Kegelrobbe: 1');
+	});
+});

--- a/src/lib/map/popupContent.ts
+++ b/src/lib/map/popupContent.ts
@@ -35,10 +35,13 @@ function formatSightingDate(ts: number | undefined, fallback: string): string {
 		: fallback;
 }
 
-function speciesName(props: SightingPopupProperties, translations: MapTranslations): string {
-	return sanitizeText(
-		translations.speciesMap[props.ta.toString()] || `Unbekannte Art (${props.ta})`
-	);
+/** Artname aus der speciesMap, sanitisiert; der Fallback-Text variiert je Kontext. */
+function speciesName(
+	props: SightingPopupProperties,
+	translations: MapTranslations,
+	fallback: string
+): string {
+	return sanitizeText(translations.speciesMap[props.ta.toString()] || fallback);
 }
 
 /** Detail-Inhalt für das Klick-Popup einer einzelnen Sichtung. */
@@ -50,7 +53,7 @@ export function createSightingPopupContent(
 
 	let content = `
 		<div class="sighting-popup">
-			<h3 class="popup-title">${speciesName(props, translations)}</h3>
+			<h3 class="popup-title">${speciesName(props, translations, `Unbekannte Art (${props.ta})`)}</h3>
 			<div class="popup-row">
 				<strong>${sanitizeText(translations.count)}:</strong> ${props.ct}
 			</div>
@@ -122,9 +125,10 @@ export function createClusterListContent(
 
 	let items = '';
 	propsList.forEach((props, index) => {
-		const name = sanitizeText(translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`);
+		const name = speciesName(props, translations, `Art ${props.ta}`);
 		const date = formatSightingDate(props.ts, 'Unbekannt');
 		const deadBadge = props.tf ? '<span class="cluster-item-dead">&#x2020;</span>' : '';
+		const tierWord = props.ct > 1 ? 'Tiere' : 'Tier';
 
 		items += `
 			<li>
@@ -132,10 +136,10 @@ export function createClusterListContent(
 					type="button"
 					data-cluster-index="${index}"
 					class="cluster-list-item"
-					aria-label="${name}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
+					aria-label="${name}, ${props.ct} ${tierWord}, ${date}"
 				>
 					<span class="cluster-item-species">${name}${deadBadge}</span>
-					<span class="cluster-item-count">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
+					<span class="cluster-item-count">${props.ct}&nbsp;${tierWord}</span>
 					<span class="cluster-item-date">${date}</span>
 				</button>
 			</li>
@@ -157,7 +161,7 @@ export function createInfoText(
 	props: SightingPopupProperties,
 	translations: MapTranslations
 ): string {
-	const species = sanitizeText(translations.speciesMap[props.ta] || 'Unbekannte Art');
+	const species = speciesName(props, translations, 'Unbekannte Art');
 	const count = props.ct || 0;
 	const date = formatSightingDate(props.ts, 'Unbekanntes Datum');
 	const isDead = props.tf ? ` (${sanitizeText(translations.found_dead)})` : '';

--- a/src/lib/map/popupContent.ts
+++ b/src/lib/map/popupContent.ts
@@ -1,0 +1,204 @@
+/**
+ * HTML-Inhalte für Popups und Hover-Infos der Sichtungskarte (M6).
+ *
+ * Reine String-Builder ohne DOM-/OpenLayers-Abhängigkeit, damit sie in
+ * Node-Unit-Tests prüfbar sind. Alle Nutzdaten laufen durch sanitizeText;
+ * die Darstellung kommt aus CSS-Klassen in mapStyles.css — keine
+ * Inline-Styles am Theme vorbei.
+ */
+import { sanitizeText } from '$lib/utils/sanitize';
+import type { MapTranslations } from './mapUtils';
+
+/** Feature-Properties einer Sichtung, wie sie im GeoJSON ankommen. */
+export interface SightingPopupProperties {
+	ta: string | number; // Tierart
+	ct: number; // Anzahl
+	jt?: number; // Jungtiere
+	ts?: number; // Timestamp (Unix-Sekunden)
+	tf?: boolean; // Totfund
+	shipname?: string;
+	waterway?: string;
+	name?: string;
+	firstname?: string;
+}
+
+// M5: timeZone explizit setzen, sonst bestimmt die Browser-Zone das Datum
+// (bis zu ±1 Tag Abweichung von der Berlin-Anzeige).
+function formatSightingDate(ts: number | undefined, fallback: string): string {
+	return ts
+		? new Date(ts * 1000).toLocaleDateString('de-DE', {
+				day: '2-digit',
+				month: '2-digit',
+				year: 'numeric',
+				timeZone: 'Europe/Berlin'
+			})
+		: fallback;
+}
+
+function speciesName(props: SightingPopupProperties, translations: MapTranslations): string {
+	return sanitizeText(
+		translations.speciesMap[props.ta.toString()] || `Unbekannte Art (${props.ta})`
+	);
+}
+
+/** Detail-Inhalt für das Klick-Popup einer einzelnen Sichtung. */
+export function createSightingPopupContent(
+	props: SightingPopupProperties,
+	translations: MapTranslations
+): string {
+	const date = formatSightingDate(props.ts, 'Unbekannt');
+
+	let content = `
+		<div class="sighting-popup">
+			<h3 class="popup-title">${speciesName(props, translations)}</h3>
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.count)}:</strong> ${props.ct}
+			</div>
+	`;
+
+	if (props.jt && props.jt > 0) {
+		content += `
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.young)}:</strong> ${props.jt}
+			</div>
+		`;
+	}
+
+	if (props.tf) {
+		content += `
+			<div class="popup-row popup-row-dead">
+				<strong>${sanitizeText(translations.found_dead)}:</strong> Ja
+			</div>
+		`;
+	}
+
+	content += `
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.report_date)}</strong> ${date}
+			</div>
+	`;
+
+	if (props.waterway) {
+		content += `
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.area)}:</strong> ${sanitizeText(props.waterway)}
+			</div>
+		`;
+	}
+
+	if (props.name || props.firstname) {
+		const fullName = [props.firstname, props.name]
+			.filter(Boolean)
+			.map((v) => sanitizeText(v!))
+			.join(' ');
+		content += `
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.name)}:</strong> ${fullName}
+			</div>
+		`;
+	}
+
+	if (props.shipname) {
+		content += `
+			<div class="popup-row">
+				<strong>${sanitizeText(translations.ship)}:</strong> ${sanitizeText(props.shipname)}
+			</div>
+		`;
+	}
+
+	content += '</div>';
+	return content;
+}
+
+/**
+ * Scrollbare Liste aller Sichtungen eines Clusters.
+ * Erwartet bereits sortierte Properties (via sortFeaturesByDate im Controller).
+ */
+export function createClusterListContent(
+	propsList: SightingPopupProperties[],
+	translations: MapTranslations
+): string {
+	const count = propsList.length;
+
+	let items = '';
+	propsList.forEach((props, index) => {
+		const name = sanitizeText(translations.speciesMap[props.ta.toString()] || `Art ${props.ta}`);
+		const date = formatSightingDate(props.ts, 'Unbekannt');
+		const deadBadge = props.tf ? '<span class="cluster-item-dead">&#x2020;</span>' : '';
+
+		items += `
+			<li>
+				<button
+					type="button"
+					data-cluster-index="${index}"
+					class="cluster-list-item"
+					aria-label="${name}, ${props.ct} Tier${props.ct > 1 ? 'e' : ''}, ${date}"
+				>
+					<span class="cluster-item-species">${name}${deadBadge}</span>
+					<span class="cluster-item-count">${props.ct}&nbsp;Tier${props.ct > 1 ? 'e' : ''}</span>
+					<span class="cluster-item-date">${date}</span>
+				</button>
+			</li>
+		`;
+	});
+
+	return `
+		<div class="cluster-popup">
+			<h3 class="popup-title">${count} Sichtungen an diesem Ort</h3>
+			<ul class="cluster-list" aria-label="${count} Sichtungen">
+				${items}
+			</ul>
+		</div>
+	`;
+}
+
+/** Kompakte Hover-Info einer einzelnen Sichtung. */
+export function createInfoText(
+	props: SightingPopupProperties,
+	translations: MapTranslations
+): string {
+	const species = sanitizeText(translations.speciesMap[props.ta] || 'Unbekannte Art');
+	const count = props.ct || 0;
+	const date = formatSightingDate(props.ts, 'Unbekanntes Datum');
+	const isDead = props.tf ? ` (${sanitizeText(translations.found_dead)})` : '';
+	// M6: Fahrwasser konsistent auch im Hover anzeigen, nicht nur im Popup
+	const waterway = props.waterway
+		? `<br>${sanitizeText(translations.area)}: ${sanitizeText(props.waterway)}`
+		: '';
+	return `
+		<div class="p-2 text-sm">
+			<strong>${species}</strong><br>
+			${sanitizeText(translations.count)}: ${count}${isDead}<br>
+			${sanitizeText(translations.report_date)} ${date}${waterway}
+		</div>
+	`;
+}
+
+/** Hover-Zusammenfassung eines Clusters (häufigste Arten). */
+export function createClusterInfoText(
+	propsList: SightingPopupProperties[],
+	translations: MapTranslations
+): string {
+	const count = propsList.length;
+	const speciesCount: Record<string, number> = {};
+
+	propsList.forEach((props) => {
+		const speciesKey = props.ta.toString();
+		speciesCount[speciesKey] = (speciesCount[speciesKey] || 0) + 1;
+	});
+
+	const sortedSpecies = Object.entries(speciesCount)
+		.sort(([, a], [, b]) => b - a)
+		.slice(0, 3) // Zeige nur die 3 häufigsten Arten
+		.map(([speciesId, speciesTotal]) => {
+			const name = sanitizeText(translations.speciesMap[speciesId] || 'Unbekannte Art');
+			return `${name}: ${speciesTotal}`;
+		});
+
+	return `
+		<div class="p-2 text-sm">
+			<strong>${count} Sichtungen</strong><br>
+			${sortedSpecies.join('<br>')}
+		</div>
+	`;
+}


### PR DESCRIPTION
## Zusammenfassung

Setzt die vier verbliebenen M-Befunde aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` um (K/H/Quick-Wins sowie M1/M4/M5/M8/M9 sind bereits gemerged, #593–#609):

- **M2 — Cluster-Überlappung:** `minDistance` ist jetzt an ~60 % der jeweiligen `distance` gekoppelt (neu: `src/lib/map/clusterConfig.ts`), statt fix 10 px bei distance 40–50. `updateClusterDistance()` führt beide Werte bei Zoomwechseln mit.
- **M3 — OpenSeaMap-Toggle:** Neue Sektion „Kartenebenen" in der Legende mit Checkbox „Seezeichen & Tonnen (OpenSeaMap)". Sichtbarkeit über `SichtungenMap.setSeamarkVisibility()`; Default an, Opacity unverändert 0.8.
- **M6 — Popup-Inhalt:** Popup-/Hover-Builder als pure Funktionen nach `src/lib/map/popupContent.ts` extrahiert. Behebt „Sichtung vom :" (Trailing-Space + Doppelpunkt) und „Anzahl Tiere: 3 Tiere"; Fahrwasser erscheint jetzt auch im Hover-Info; alle Inline-Hex-Styles durch Theme-Token-Klassen in `mapStyles.css` ersetzt (`--color-base-*`, `--color-error`, `--color-primary`).
- **M7 — Loading-Konzept:** Vollbild-Overlay nur noch beim Initial-Load (`isInitialLoading`); Filter-/Jahreswechsel zeigen den vorhandenen Inline-Spinner im FilterPanel (dessen Toggle-Tab rotiert auch bei geschlossenem Panel). Totes `#overlay-load` entfernt.

## Tests (Test-First)

- Neu: `clusterConfig.test.ts` (Zoom-Staffel + minDistance-Kopplung), `popupContent.test.ts` (Textfehler, Fahrwasser, keine Inline-Styles, Sanitizing)
- Erweitert: `LegendPanel.svelte.test.ts` (Seamark-Toggle Default/Callback), `e2e/map-filters.spec.ts` (M7: kein Vollbild-Overlay bei verzögertem Jahreswechsel-Request)
- `npm run test:quick` grün (2229 Tests), alle 36 Map-E2E-Tests grün, `svelte-check`/`lint` ohne neue Befunde
- Visuell verifiziert: Cluster-Trennung, Popup-Einzel- und Listenansicht, Seamark-Toggle an/aus (Leuchtfeuer-Sektoren erscheinen/verschwinden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)