### PR TITLE
feat(map): jahres-dropdown aus dem years-endpoint speisen (N4)

### DIFF
--- a/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
+++ b/docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md
@@ -201,7 +201,7 @@ Zoom-Buttons tragen englische Titles/Labels („Zoom in", „Zoom out") in anson
 - **N1:** `MapPanelManager.initializePanels()` ist funktionsloser Platzhalter (`panelManager.ts:15-29`); `updateTimeFilter()` im Controller ebenso (`optimizedMapController.ts:853-859`). Tote Pfade entfernen.
 - **N2:** `LocationControl`/Geolocation ist vollständig implementiert, aber deaktiviert (`enableLocationControl: false`, `SightingsMapView.svelte:131`) — entweder aktivieren („Mein Standort" ist Standard bei Sichtungskarten) oder Code entfernen.
 - **N3:** `createClusterStyle` (`styleUtils.ts:386`) wird nirgends verwendet (Duplikat der Controller-Logik ohne Filterunterstützung).
-- **N4:** Jahresliste ist auf 10 Jahre begrenzt (`getAvailableYears(10)`), obwohl Daten bis 2007 zurückreichen — ältere Jahrgänge sind unerreichbar.
+- **N4:** Jahresliste ist auf 10 Jahre begrenzt (`getAvailableYears(10)`), obwohl Daten bis 2007 zurückreichen — ältere Jahrgänge sind unerreichbar. — **Behoben 2026-07-29:** Dropdown speist sich aus `GET /api/map/sightings/years` (`deriveSelectableYears`, absteigend); aktuelles Kalenderjahr und URL-Jahr bleiben immer wählbar, bei leerem Endpoint greift der 11-Jahre-Fallback.
 - **N5:** Sichtungen an Land (im Test: Marker bei Hamburg-Zentrum und südlich von Hamburg) — Hinweis auf fehlende Plausibilitätsprüfung im Altbestand; auf der Karte wirken sie wie Fehler.
 - **N6:** Titel-Chip „Sichtungskarte 2026" aktualisiert korrekt bei Jahreswechsel (gut), kommuniziert aber nicht aktive Such-/Zeitfilter (siehe M4). — **Behoben 2026-07-29** über die Filter-Chips aus M4.
 - **N7:** Der Hilfe-„?"-Button unten links bleibt bestehen — gut sichtbar, aber sein Modal erwähnt die automatische Suche nicht und listet Escape nur für „Dialoge".

--- a/src/lib/components/map/Panel/FilterPanel.svelte
+++ b/src/lib/components/map/Panel/FilterPanel.svelte
@@ -29,9 +29,10 @@
 
 	// Explizite User-Auswahl (undefined = noch keine manuelle Wahl getroffen)
 	let userSelectedYear: number | undefined = $state(undefined);
-	// Effektiv gewähltes Jahr: User-Auswahl hat Vorrang, sonst Prop-Default
+	// Effektiv gewähltes Jahr: User-Auswahl hat Vorrang, sonst Prop-Default,
+	// sonst das neueste Jahr der absteigend sortierten Liste (N4)
 	let selectedYear = $derived(
-		userSelectedYear ?? defaultYear ?? years.at(-1) ?? new Date().getFullYear()
+		userSelectedYear ?? defaultYear ?? years[0] ?? new Date().getFullYear()
 	);
 	// Bewusst nur der Startwert: danach ist das Eingabefeld (bind:value)
 	// die Quelle der Wahrheit.
@@ -72,7 +73,7 @@
 				title="Wählen Sie das Jahr aus, für das Sichtungen angezeigt werden sollen"
 				onchange={handleYearChange}
 			>
-				{#each years.toReversed() as year (year)}
+				{#each years as year (year)}
 					<option value={year} selected={year === selectedYear}>
 						{yearCounts[year] ? `${year} (${yearCounts[year]})` : year}
 					</option>

--- a/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
+++ b/src/lib/components/map/Panel/FilterPanel.svelte.test.ts
@@ -144,6 +144,17 @@ describe('FilterPanel', () => {
 		expect(options.length).toBe(3);
 	});
 
+	// N4: Die years-Prop kommt bereits absteigend sortiert aus deriveSelectableYears —
+	// das Dropdown übernimmt die Reihenfolge unverändert (neuestes Jahr zuerst).
+	it('rendert die Jahresoptionen in Prop-Reihenfolge (absteigend, neuestes zuerst)', async () => {
+		render(FilterPanel, { years: [2026, 2025, 2008], defaultYear: 2025 });
+
+		await page.getByRole('button', { name: /^Filter$/i }).click();
+
+		const options = Array.from(getYearSelect().querySelectorAll('option'));
+		expect(options.map((option) => option.value)).toEqual(['2026', '2025', '2008']);
+	});
+
 	it('passt Slider-Maximum bei Schaltjahr an', async () => {
 		render(FilterPanel, { years: YEARS, defaultYear: 2025 });
 

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -7,7 +7,7 @@
 	import { MapTimeSliderManager } from '$lib/map/timeSliderManager';
 	import { speciesLabels } from '$lib/report/formOptions/species';
 	import {
-		getAvailableYears,
+		deriveSelectableYears,
 		getDefaultSightingYear,
 		pickDefaultYear,
 		type YearWithCount
@@ -94,13 +94,6 @@
 	// window/page.url sind hier also verfügbar.
 	const urlFilterState = parseMapFilterParams(page.url.searchParams);
 
-	// Verfügbare Jahre für den Filter (10 Jahre zurück); ein per URL geteiltes
-	// älteres Jahr wird ergänzt, damit das Dropdown es anzeigen kann.
-	const years = getAvailableYears(10);
-	if (urlFilterState.year !== undefined && !years.includes(urlFilterState.year)) {
-		years.push(urlFilterState.year);
-		years.sort((a, b) => a - b);
-	}
 	// Bisheriges Fallback-Jahr, synchron verfügbar für den allerersten Render
 	// (bevor GET /api/map/sightings/years geladen ist). Als Konstante erfasst,
 	// damit die beiden $state-Deklarationen unten nicht voneinander abhängen.
@@ -114,6 +107,13 @@
 	let apiDefaultYear = $state(initialFallbackYear);
 	// Rohdaten der verfügbaren Jahre (Antwort von GET /api/map/sightings/years)
 	let availableYearsData = $state<YearWithCount[]>([]);
+	// N4: Wählbare Jahre für das Filter-Dropdown — alle Jahre mit Daten aus dem
+	// Endpoint (vor dem Laden bzw. bei Fehlschlag: Fallback auf die letzten
+	// 11 Kalenderjahre), vereint mit dem aktuellen Jahr und einem URL-Jahr (M4).
+	const currentCalendarYear = new Date().getFullYear();
+	let years = $derived(
+		deriveSelectableYears(availableYearsData, currentCalendarYear, urlFilterState.year)
+	);
 	// Sichtungsanzahl je Jahr für die Jahres-Dropdown-Beschriftung ("2025 (817)")
 	let yearCounts = $derived(
 		Object.fromEntries(availableYearsData.map((entry) => [entry.year, entry.count]))

--- a/src/lib/utils/date/defaultYear.test.ts
+++ b/src/lib/utils/date/defaultYear.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
 	getDefaultSightingYear,
 	isInTransitionPeriod,
-	getAvailableYears,
+	deriveSelectableYears,
 	pickDefaultYear
 } from './defaultYear';
 
@@ -97,38 +97,59 @@ describe('defaultYear utilities', () => {
 		});
 	});
 
-	describe('getAvailableYears', () => {
-		beforeEach(() => {
-			vi.useFakeTimers();
-			vi.setSystemTime(new Date('2024-06-15'));
+	// N4: Das Jahres-Dropdown speist sich aus GET /api/map/sightings/years —
+	// alle Jahre mit Daten, nicht nur die letzten 10.
+	describe('deriveSelectableYears', () => {
+		it('liefert alle Jahre mit Daten absteigend, vereint mit dem aktuellen Kalenderjahr', () => {
+			const available = [
+				{ year: 2007, count: 5 },
+				{ year: 2025, count: 817 },
+				{ year: 2010, count: 3 }
+			];
+			expect(deriveSelectableYears(available, 2026)).toEqual([2026, 2025, 2010, 2007]);
 		});
 
-		afterEach(() => {
-			vi.useRealTimers();
+		it('schließt Jahre ohne Sichtungen (count 0) aus', () => {
+			const available = [
+				{ year: 2024, count: 0 },
+				{ year: 2023, count: 5 }
+			];
+			expect(deriveSelectableYears(available, 2026)).toEqual([2026, 2023]);
 		});
 
-		it('should return 11 years by default (current + 10 previous)', () => {
-			const years = getAvailableYears();
-			expect(years).toHaveLength(11);
-			expect(years[0]).toBe(2024);
-			expect(years[10]).toBe(2014);
+		it('dupliziert das aktuelle Kalenderjahr nicht, wenn es bereits Daten hat', () => {
+			expect(deriveSelectableYears([{ year: 2026, count: 10 }], 2026)).toEqual([2026]);
 		});
 
-		it('should return correct number of years when specified', () => {
-			const years = getAvailableYears(5);
-			expect(years).toHaveLength(6);
-			expect(years[0]).toBe(2024);
-			expect(years[5]).toBe(2019);
+		it('fällt bei leerer Endpoint-Antwort auf die letzten 11 Kalenderjahre zurück', () => {
+			expect(deriveSelectableYears([], 2026)).toEqual([
+				2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016
+			]);
 		});
 
-		it('should return years in descending order', () => {
-			const years = getAvailableYears(3);
-			expect(years).toEqual([2024, 2023, 2022, 2021]);
+		it('fällt zurück, wenn kein einziges Jahr Daten hat (nur count 0)', () => {
+			expect(deriveSelectableYears([{ year: 2025, count: 0 }], 2026)).toEqual([
+				2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016
+			]);
 		});
 
-		it('should handle 0 years back', () => {
-			const years = getAvailableYears(0);
-			expect(years).toEqual([2024]);
+		it('ergänzt ein URL-Jahr (M4, ?year=…), das nicht in der Endpoint-Liste steht', () => {
+			const available = [{ year: 2025, count: 10 }];
+			expect(deriveSelectableYears(available, 2026, 2008)).toEqual([2026, 2025, 2008]);
+		});
+
+		it('dupliziert ein URL-Jahr nicht, das die Endpoint-Liste bereits enthält', () => {
+			const available = [
+				{ year: 2008, count: 4 },
+				{ year: 2025, count: 10 }
+			];
+			expect(deriveSelectableYears(available, 2026, 2008)).toEqual([2026, 2025, 2008]);
+		});
+
+		it('ergänzt das URL-Jahr auch im Fallback-Fall (geteilte URL bei leerer DB)', () => {
+			expect(deriveSelectableYears([], 2026, 2008)).toEqual([
+				2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2008
+			]);
 		});
 	});
 

--- a/src/lib/utils/date/defaultYear.ts
+++ b/src/lib/utils/date/defaultYear.ts
@@ -36,30 +36,45 @@ export function isInTransitionPeriod(): boolean {
 }
 
 /**
- * Gibt eine Liste von Jahren für Auswahlfelder zurück.
- * Beginnt mit dem aktuellen Jahr und geht die angegebene Anzahl Jahre zurück.
- *
- * @param yearsBack Anzahl der Jahre, die zurück gegangen werden soll (Standard: 10)
- * @returns Array von Jahren in absteigender Reihenfolge
- */
-export function getAvailableYears(yearsBack: number = 10): number[] {
-	const currentYear = new Date().getFullYear();
-	const years: number[] = [];
-
-	for (let i = 0; i <= yearsBack; i++) {
-		years.push(currentYear - i);
-	}
-
-	return years;
-}
-
-/**
  * Ein Jahr mit der Anzahl an Sichtungen darin (z. B. Antwort von
  * `GET /api/map/sightings/years`).
  */
 export interface YearWithCount {
 	year: number;
 	count: number;
+}
+
+/**
+ * Leitet die im Jahres-Dropdown wählbaren Jahre ab (N4).
+ *
+ * Reine Funktion (kein Fetch, kein Datum) — testbar ohne Fake-Timer.
+ * - Basis sind alle Jahre mit `count > 0` aus `GET /api/map/sightings/years`.
+ * - Liefert der Endpoint nichts Brauchbares (Fehler, leere Dev-DB), greift der
+ *   bisherige Fallback: die letzten 11 Kalenderjahre ab `currentYear`.
+ * - `currentYear` ist immer wählbar, auch ohne Daten — sonst käme man nach der
+ *   ersten Freigabe des Jahres ohne Seiten-Reload nicht dorthin.
+ * - `extraYear` (Jahr aus einer geteilten URL, M4) wird ergänzt, falls es fehlt.
+ *
+ * @param availableYears Jahre mit Sichtungsanzahl, beliebige Reihenfolge
+ * @param currentYear Aktuelles Kalenderjahr
+ * @param extraYear Zusätzlich wählbares Jahr (z. B. `?year=…` aus der URL)
+ * @returns Wählbare Jahre, absteigend sortiert und ohne Duplikate
+ */
+export function deriveSelectableYears(
+	availableYears: YearWithCount[],
+	currentYear: number,
+	extraYear?: number
+): number[] {
+	const withData = availableYears.filter((entry) => entry.count > 0).map((entry) => entry.year);
+	const fallback = Array.from({ length: 11 }, (_, index) => currentYear - index);
+
+	const years = new Set(withData.length > 0 ? withData : fallback);
+	years.add(currentYear);
+	if (extraYear !== undefined) {
+		years.add(extraYear);
+	}
+
+	return [...years].sort((a, b) => b - a);
 }
 
 /**


### PR DESCRIPTION
## Zusammenfassung

Befund **N4** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md`: Das Jahres-Dropdown der Sichtungskarte war statisch auf die letzten 10 Kalenderjahre begrenzt (`getAvailableYears(10)`), obwohl freigegebene Daten bis ~2007 zurückreichen — ältere Jahrgänge waren unerreichbar.

- **Neue pure Funktion `deriveSelectableYears`** (`src/lib/utils/date/defaultYear.ts`): alle Jahre mit `count > 0` aus `GET /api/map/sightings/years`, absteigend sortiert, vereint mit dem aktuellen Kalenderjahr (bleibt vor der ersten Freigabe des Jahres wählbar) und einem URL-Jahr aus geteilten Links (M4). Fallback bei Endpoint-Fehler/leerer DB: die bisherigen 11 Kalenderjahre.
- **`SightingsMapView`**: `years` ist jetzt `$derived` aus `availableYearsData` — das Dropdown aktualisiert sich reaktiv nach dem Laden des Endpoints; die Zähler-Beschriftung („2025 (652)") kommt weiter aus `yearCounts`.
- **`FilterPanel`**: rendert die Prop-Reihenfolge direkt (neuestes Jahr zuerst) statt `toReversed()` — vorher kippte die Reihenfolge, je nachdem ob ein URL-Jahr ergänzt war; letzter Fallback `years.at(-1)` → `years[0]`.
- **`getAvailableYears` entfernt** — nach der Umstellung projektweit ohne Aufrufer.
- Review-Report: N4 als behoben markiert.

## Tests

- 8 neue Unit-Tests für `deriveSelectableYears` (Ableitung, count-0-Ausschluss, Fallback, URL-Jahr mit/ohne Endpoint-Treffer — deckt den M4-Fall `?year=2008` ab), TDD RED→GREEN.
- Neuer Browser-Test: Dropdown übernimmt die absteigende Prop-Reihenfolge.
- `npm run test:quick` grün (2245 Tests inkl. lint/type-check/svelte-check), FilterPanel-Browser-Tests 16/16.
- Live gegen die lokale DB verifiziert: `/map?year=2008` zeigt 19 absteigende Optionen (2026 … „2009 (2)", 2008 aus der URL ergänzt und vorselektiert); Wechsel auf 2009 lädt Daten und synct Titel-Chip + URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)