### PR TITLE
feat(map): gps location control aktivieren (UX-Review N2)

### DIFF
--- a/e2e/map-location-control.spec.ts
+++ b/e2e/map-location-control.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+import { MAP_TEST_TIMEOUTS } from './config/testTimeouts';
+import { setupMapPage } from './fixtures/mapSetup';
+
+/**
+ * N2: GPS-Standort-Control auf der Sichtungskarte.
+ * Beide Berechtigungspfade werden getestet: erteilte Freigabe (context
+ * permissions + gemockte Position) und verweigerte Freigabe (Playwright
+ * verweigert Geolocation ohne grant automatisch).
+ */
+test.describe('Map Location Control', () => {
+	test.describe('mit erteilter Berechtigung', () => {
+		test.use({
+			permissions: ['geolocation'],
+			// Kieler Förde — innerhalb der Ostsee-Bounding-Box
+			geolocation: { latitude: 54.3233, longitude: 10.1228 }
+		});
+
+		test('Button startet und stoppt das Tracking (aria-pressed)', async ({ page }) => {
+			await setupMapPage(page);
+
+			const startButton = page.getByRole('button', { name: 'GPS-Position anzeigen' });
+			await expect(startButton).toBeVisible();
+			await expect(startButton).toHaveAttribute('aria-pressed', 'false');
+
+			await startButton.click();
+
+			const stopButton = page.getByRole('button', { name: 'GPS-Tracking stoppen' });
+			await expect(stopButton).toHaveAttribute('aria-pressed', 'true');
+
+			await stopButton.click();
+			await expect(page.getByRole('button', { name: 'GPS-Position anzeigen' })).toHaveAttribute(
+				'aria-pressed',
+				'false'
+			);
+		});
+
+		test('Tracking zeigt keine Fehlermeldung', async ({ page }) => {
+			const mapPage = await setupMapPage(page);
+
+			await page.getByRole('button', { name: 'GPS-Position anzeigen' }).click();
+			await expect(page.getByRole('button', { name: 'GPS-Tracking stoppen' })).toHaveAttribute(
+				'aria-pressed',
+				'true'
+			);
+			await expect(mapPage.getErrorAlert()).toBeHidden();
+		});
+	});
+
+	test.describe('mit verweigerter Berechtigung', () => {
+		test('zeigt Fehlermeldung und setzt den Button zurück', async ({ page }) => {
+			const mapPage = await setupMapPage(page);
+
+			const button = page.getByRole('button', { name: 'GPS-Position anzeigen' });
+			await button.click();
+
+			// Playwright verweigert Geolocation ohne grantPermissions → Fehlerpfad
+			await expect(mapPage.getErrorAlert()).toBeVisible({
+				timeout: MAP_TEST_TIMEOUTS.defaultUi
+			});
+			await expect(mapPage.getErrorAlert()).toContainText('Standortfreigabe');
+
+			// Button-Zustand wird zurückgesetzt, kein hängendes „Tracking aktiv"
+			await expect(page.getByRole('button', { name: 'GPS-Position anzeigen' })).toHaveAttribute(
+				'aria-pressed',
+				'false'
+			);
+		});
+
+		test('Fehlermeldung lässt sich schließen', async ({ page }) => {
+			const mapPage = await setupMapPage(page);
+
+			await page.getByRole('button', { name: 'GPS-Position anzeigen' }).click();
+			await expect(mapPage.getErrorAlert()).toBeVisible({
+				timeout: MAP_TEST_TIMEOUTS.defaultUi
+			});
+
+			await mapPage.getDismissErrorButton().click();
+			await expect(mapPage.getErrorAlert()).toBeHidden();
+		});
+	});
+});

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -438,7 +438,9 @@
 				sliderRangeId: 'slider-range',
 				timeStartId: 'time-start',
 				timeEndId: 'time-end',
-				enableLocationControl: false,
+				// N2: GPS-Standort-Control aktiv — Positionsdaten bleiben rein
+				// lokal im Browser (kein Request mit Koordinaten).
+				enableLocationControl: true,
 				initialYear,
 				initialSearchTerm: urlFilterState.query ?? '',
 				onLoading: (loading) => {
@@ -463,6 +465,11 @@
 					errorMessage = 'Fehler beim Laden der Kartendaten. Bitte versuchen Sie es erneut.';
 					isLoadingData = false;
 					isInitialLoading = false;
+				},
+				// N2: Geolocation-Fehler (z. B. verweigerte Berechtigung) im
+				// bestehenden Fehler-Toast anzeigen statt stumm zu scheitern.
+				onGeolocationError: (message) => {
+					errorMessage = message;
 				}
 			});
 

--- a/src/lib/map/controls/LocationControl.svelte.test.ts
+++ b/src/lib/map/controls/LocationControl.svelte.test.ts
@@ -1,0 +1,90 @@
+/**
+ * DOM-Tests für die LocationControl (N2) — laufen im Browser-Projekt, weil das
+ * Control echte DOM-Elemente baut (ol/control braucht document).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { MapController } from '$lib/map/optimizedMapController';
+import { LocationControl } from './LocationControl';
+
+/** Minimaler MapController-Fake: Tracking-Zustand + Listener wie der echte Controller. */
+function createControllerFake() {
+	let tracking = false;
+	const listeners: ((isTracking: boolean) => void)[] = [];
+	const controller: MapController = {
+		toggleGeolocation: vi.fn(() => {
+			tracking = !tracking;
+			listeners.forEach((cb) => cb(tracking));
+		}),
+		zoomAllFeatures: vi.fn(),
+		onTrackingChange: (cb) => listeners.push(cb)
+	};
+	return {
+		controller,
+		/** Simuliert einen Geolocation-Fehler: Controller stoppt und benachrichtigt. */
+		emitTrackingStopped() {
+			tracking = false;
+			listeners.forEach((cb) => cb(false));
+		}
+	};
+}
+
+function getButton(control: LocationControl): HTMLButtonElement {
+	// `element` ist in den OL-Typings protected, zur Laufzeit aber zugänglich —
+	// für den DOM-Test reicht der lesende Zugriff.
+	const element = (control as unknown as { element: HTMLElement }).element;
+	const button = element.querySelector('button');
+	if (!button) throw new Error('LocationControl rendert keinen Button');
+	return button;
+}
+
+describe('LocationControl', () => {
+	it('rendert einen type=button mit deutschem Label und aria-pressed=false', () => {
+		const { controller } = createControllerFake();
+		const control = new LocationControl(controller);
+		const button = getButton(control);
+
+		expect(button.type).toBe('button');
+		expect(button.getAttribute('aria-label')).toBe('GPS-Position anzeigen');
+		expect(button.title).toBe('GPS-Position anzeigen');
+		expect(button.getAttribute('aria-pressed')).toBe('false');
+	});
+
+	it('nutzt ein Inline-SVG-Icon mit aria-hidden statt Emoji', () => {
+		const { controller } = createControllerFake();
+		const control = new LocationControl(controller);
+		const button = getButton(control);
+
+		const svg = button.querySelector('svg');
+		expect(svg).not.toBeNull();
+		expect(svg?.getAttribute('aria-hidden')).toBe('true');
+		expect(button.textContent).not.toContain('📍');
+	});
+
+	it('wechselt beim Klick auf aria-pressed=true und Stopp-Label', () => {
+		const { controller } = createControllerFake();
+		const control = new LocationControl(controller);
+		const button = getButton(control);
+
+		button.click();
+
+		expect(controller.toggleGeolocation).toHaveBeenCalledOnce();
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+		expect(button.getAttribute('aria-label')).toBe('GPS-Tracking stoppen');
+		expect(button.title).toBe('GPS-Tracking stoppen');
+	});
+
+	it('setzt den Zustand zurück, wenn der Controller das Tracking stoppt (Fehlerpfad)', () => {
+		const fake = createControllerFake();
+		const control = new LocationControl(fake.controller);
+		const button = getButton(control);
+
+		button.click();
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+
+		// z. B. verweigerte Berechtigung: Controller stoppt Tracking von sich aus
+		fake.emitTrackingStopped();
+
+		expect(button.getAttribute('aria-pressed')).toBe('false');
+		expect(button.getAttribute('aria-label')).toBe('GPS-Position anzeigen');
+	});
+});

--- a/src/lib/map/controls/LocationControl.ts
+++ b/src/lib/map/controls/LocationControl.ts
@@ -1,18 +1,20 @@
 import { Control } from 'ol/control';
 import type { MapController } from '$lib/map/optimizedMapController';
+import { locationButtonState } from './locationControlState';
 
 /**
- * Control für GPS-Standortbestimmung
+ * Control für GPS-Standortbestimmung (N2)
  */
+// Locate-Icon (Lucide "locate"), 20x20, currentColor — analog ZoomAllControl.
+const LOCATE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="2" x2="5" y1="12" y2="12"/><line x1="19" x2="22" y1="12" y2="12"/><line x1="12" x2="12" y1="2" y2="5"/><line x1="12" x2="12" y1="19" y2="22"/><circle cx="12" cy="12" r="7"/></svg>`;
+
 export class LocationControl extends Control {
-	private mapInstance: MapController;
 	private button: HTMLButtonElement;
 
 	constructor(mapInstance: MapController) {
 		const button = document.createElement('button');
-		button.innerHTML = '📍';
-		button.title = 'GPS-Position anzeigen';
-		button.setAttribute('aria-label', 'GPS-Position anzeigen');
+		button.type = 'button';
+		button.innerHTML = LOCATE_ICON_SVG;
 
 		const element = document.createElement('div');
 		element.className = 'location-control ol-unselectable ol-control';
@@ -22,28 +24,22 @@ export class LocationControl extends Control {
 			element: element
 		});
 
-		this.mapInstance = mapInstance;
 		this.button = button;
+		this.applyState(false);
 
 		button.addEventListener('click', () => {
-			this.toggleLocation();
+			mapInstance.toggleGeolocation();
 		});
+
+		// Button-Zustand kommt ausschließlich vom Controller: so setzt auch ein
+		// Geolocation-Fehler (z. B. verweigerte Berechtigung) den Toggle zurück.
+		mapInstance.onTrackingChange((isTracking) => this.applyState(isTracking));
 	}
 
-	private toggleLocation(): void {
-		const isTracking = this.mapInstance.toggleGeolocation();
-
-		// Aktualisiere Button-Erscheinungsbild
-		if (isTracking) {
-			this.button.style.backgroundColor = '#3b82f6';
-			this.button.style.color = 'white';
-			this.button.title = 'GPS-Tracking stoppen';
-			this.button.setAttribute('aria-label', 'GPS-Tracking stoppen');
-		} else {
-			this.button.style.backgroundColor = 'rgba(255, 255, 255, 0.9)';
-			this.button.style.color = '#444';
-			this.button.title = 'GPS-Position anzeigen';
-			this.button.setAttribute('aria-label', 'GPS-Position anzeigen');
-		}
+	private applyState(isTracking: boolean): void {
+		const state = locationButtonState(isTracking);
+		this.button.setAttribute('aria-pressed', String(state.pressed));
+		this.button.title = state.label;
+		this.button.setAttribute('aria-label', state.label);
 	}
 }

--- a/src/lib/map/controls/locationControlState.test.ts
+++ b/src/lib/map/controls/locationControlState.test.ts
@@ -29,8 +29,11 @@ describe('geolocationErrorMessage', () => {
 		expect(message).toContain('verweigert');
 	});
 
-	it('meldet bei POSITION_UNAVAILABLE (2) eine nicht ermittelbare Position', () => {
-		expect(geolocationErrorMessage(2)).toContain('konnte nicht ermittelt werden');
+	it('meldet bei POSITION_UNAVAILABLE (2) eine nicht verfügbare Position', () => {
+		const message = geolocationErrorMessage(2);
+		expect(message).toContain('derzeit nicht verfügbar');
+		// Abgrenzung zum Default-Text für unbekannte Codes
+		expect(message).not.toBe(geolocationErrorMessage(undefined));
 	});
 
 	it('meldet bei TIMEOUT (3) eine Zeitüberschreitung', () => {

--- a/src/lib/map/controls/locationControlState.test.ts
+++ b/src/lib/map/controls/locationControlState.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+	LOCATION_LABEL_IDLE,
+	LOCATION_LABEL_TRACKING,
+	geolocationErrorMessage,
+	locationButtonState
+} from './locationControlState';
+
+describe('locationButtonState', () => {
+	it('liefert im Ruhezustand aria-pressed=false und das Start-Label', () => {
+		const state = locationButtonState(false);
+		expect(state.pressed).toBe(false);
+		expect(state.label).toBe(LOCATION_LABEL_IDLE);
+		expect(state.label).toBe('GPS-Position anzeigen');
+	});
+
+	it('liefert beim Tracking aria-pressed=true und das Stopp-Label', () => {
+		const state = locationButtonState(true);
+		expect(state.pressed).toBe(true);
+		expect(state.label).toBe(LOCATION_LABEL_TRACKING);
+		expect(state.label).toBe('GPS-Tracking stoppen');
+	});
+});
+
+describe('geolocationErrorMessage', () => {
+	it('erklärt bei PERMISSION_DENIED (1) die Standortfreigabe', () => {
+		const message = geolocationErrorMessage(1);
+		expect(message).toContain('Standortfreigabe');
+		expect(message).toContain('verweigert');
+	});
+
+	it('meldet bei POSITION_UNAVAILABLE (2) eine nicht ermittelbare Position', () => {
+		expect(geolocationErrorMessage(2)).toContain('konnte nicht ermittelt werden');
+	});
+
+	it('meldet bei TIMEOUT (3) eine Zeitüberschreitung', () => {
+		expect(geolocationErrorMessage(3)).toContain('Zeitüberschreitung');
+	});
+
+	it('fällt bei unbekanntem oder fehlendem Code auf eine generische Meldung zurück', () => {
+		expect(geolocationErrorMessage(undefined)).toContain('konnte nicht ermittelt werden');
+		expect(geolocationErrorMessage(99)).toContain('konnte nicht ermittelt werden');
+	});
+
+	it('liefert immer eine deutschsprachige, nicht-leere Meldung', () => {
+		for (const code of [1, 2, 3, undefined]) {
+			const message = geolocationErrorMessage(code);
+			expect(message.length).toBeGreaterThan(10);
+		}
+	});
+});

--- a/src/lib/map/controls/locationControlState.ts
+++ b/src/lib/map/controls/locationControlState.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure Zustands- und Fehlerlogik der LocationControl (N2) — vom DOM getrennt,
+ * damit sie ohne OpenLayers/Browser testbar ist.
+ */
+
+export const LOCATION_LABEL_IDLE = 'GPS-Position anzeigen';
+export const LOCATION_LABEL_TRACKING = 'GPS-Tracking stoppen';
+
+export interface LocationButtonState {
+	/** Wert für aria-pressed — der Button ist ein Toggle. */
+	pressed: boolean;
+	/** Gemeinsames title/aria-label des Buttons. */
+	label: string;
+}
+
+export function locationButtonState(isTracking: boolean): LocationButtonState {
+	return isTracking
+		? { pressed: true, label: LOCATION_LABEL_TRACKING }
+		: { pressed: false, label: LOCATION_LABEL_IDLE };
+}
+
+/**
+ * Übersetzt GeolocationPositionError-Codes (1 = PERMISSION_DENIED,
+ * 2 = POSITION_UNAVAILABLE, 3 = TIMEOUT) in verständliche deutsche Meldungen.
+ */
+export function geolocationErrorMessage(code?: number): string {
+	switch (code) {
+		case 1:
+			return 'Die Standortfreigabe wurde verweigert. Bitte erlauben Sie den Standortzugriff in Ihren Browser-Einstellungen.';
+		case 3:
+			return 'Zeitüberschreitung bei der Standortbestimmung. Bitte versuchen Sie es erneut.';
+		default:
+			return 'Ihre Position konnte nicht ermittelt werden. Bitte versuchen Sie es später erneut.';
+	}
+}

--- a/src/lib/map/controls/locationControlState.ts
+++ b/src/lib/map/controls/locationControlState.ts
@@ -27,6 +27,8 @@ export function geolocationErrorMessage(code?: number): string {
 	switch (code) {
 		case 1:
 			return 'Die Standortfreigabe wurde verweigert. Bitte erlauben Sie den Standortzugriff in Ihren Browser-Einstellungen.';
+		case 2:
+			return 'Ihre Position ist derzeit nicht verfügbar. Bitte versuchen Sie es später erneut.';
 		case 3:
 			return 'Zeitüberschreitung bei der Standortbestimmung. Bitte versuchen Sie es erneut.';
 		default:

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -127,11 +127,23 @@
 	display: flex !important;
 	align-items: center !important;
 	justify-content: center !important;
-	transition: all 0.2s ease;
+	/* Keine transition hier: Chromium wendet !important-Wechsel (aria-pressed)
+	   bei `transition: all` nicht an — der Aktiv-Zustand bliebe unsichtbar. */
 }
 
 .location-control button:hover {
 	background-color: rgba(255, 255, 255, 1) !important;
+}
+
+/* N2: Aktives Tracking — Zustand hängt am aria-pressed-Attribut (ein Zustand,
+   eine Quelle), Farben aus dem Theme (Buttons sind DOM, kein Canvas). */
+.location-control button[aria-pressed='true'] {
+	background-color: var(--color-primary) !important;
+	color: var(--color-primary-content) !important;
+}
+
+.location-control button[aria-pressed='true']:hover {
+	background-color: var(--color-primary) !important;
 }
 
 /* GPS Control */

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -16,6 +16,7 @@ import Cluster from 'ol/source/Cluster';
 import VectorSource from 'ol/source/Vector';
 import { Circle, Fill, Stroke, Style } from 'ol/style';
 import { LocationControl } from './controls/LocationControl.js';
+import { geolocationErrorMessage } from './controls/locationControlState.js';
 import { ZoomAllControl } from './controls/ZoomAllControl.js';
 import { getDefaultSightingYear } from '$lib/utils/date/defaultYear';
 import { clampExtentToBaltic, type Extent } from './extentUtils';
@@ -63,6 +64,11 @@ export interface MapOptions {
 	initialSearchTerm?: string;
 	onLoading?: (isLoading: boolean) => void;
 	onError?: (error: Error) => void;
+	/**
+	 * N2: Geolocation-Fehler (verweigerte Berechtigung, Timeout, …) — erhält
+	 * eine bereits nutzerverständliche deutsche Meldung für die Toast-Anzeige.
+	 */
+	onGeolocationError?: (message: string) => void;
 }
 
 /**
@@ -70,8 +76,14 @@ export interface MapOptions {
  * Controls nutzen dieses Interface statt des konkreten SichtungenMap-Typs.
  */
 export interface MapController {
-	toggleGeolocation(): boolean;
+	toggleGeolocation(): void;
 	zoomAllFeatures(): void;
+	/**
+	 * N2: Registriert einen Listener für Tracking-Zustandswechsel — feuert auch,
+	 * wenn der Controller das Tracking selbst stoppt (Geolocation-Fehler), damit
+	 * die LocationControl ihren Toggle-Zustand zurücksetzen kann.
+	 */
+	onTrackingChange(callback: (isTracking: boolean) => void): void;
 }
 
 /**
@@ -110,6 +122,9 @@ export class SichtungenMap {
 	private locationSource!: VectorSource<Feature<Geometry>>;
 	private locationLayer!: VectorLayer<VectorSource<Feature<Geometry>>>;
 	private isTracking: boolean = false;
+	private trackingChangeCallbacks: ((isTracking: boolean) => void)[] = [];
+	// N2: Nur beim ersten Positionsfix pro Tracking-Sitzung zentrieren
+	private hasCenteredOnFirstFix: boolean = false;
 
 	constructor(options: MapOptions) {
 		this.translations = options.translations;
@@ -695,6 +710,9 @@ export class SichtungenMap {
 	}
 
 	private initializeGeolocation(): void {
+		// Datenschutz: Die Positionsdaten bleiben rein lokal im Browser — sie
+		// werden ausschließlich im locationLayer gerendert; es wird kein Request
+		// mit Koordinaten an den Server oder Dritte ausgelöst.
 		this.geolocation = new Geolocation({
 			trackingOptions: {
 				enableHighAccuracy: true
@@ -706,12 +724,20 @@ export class SichtungenMap {
 			this.geolocation.on('change:position', () => {
 				const coordinates = this.geolocation.getPosition();
 				if (coordinates) {
-					this.locationSource.clear();
-					const positionFeature = new Feature({
-						geometry: new OlPoint(coordinates),
-						type: 'location'
-					});
-					this.locationSource.addFeature(positionFeature);
+					this.replaceLocationFeature('location', new OlPoint(coordinates));
+
+					// N2: Beim ersten Fix einer Tracking-Sitzung auf die Position
+					// zentrieren — danach nicht mehr (kein Auto-Follow), damit der
+					// Nutzer die Karte frei verschieben kann.
+					if (!this.hasCenteredOnFirstFix) {
+						this.hasCenteredOnFirstFix = true;
+						const view = this.map.getView();
+						view.animate({
+							center: coordinates,
+							zoom: Math.max(view.getZoom() ?? 0, 10),
+							duration: 800
+						});
+					}
 				}
 			}) as EventsKey
 		);
@@ -720,15 +746,35 @@ export class SichtungenMap {
 			this.geolocation.on('change:accuracyGeometry', () => {
 				const accuracy = this.geolocation.getAccuracyGeometry();
 				if (accuracy) {
-					this.locationSource.clear();
-					const accuracyFeature = new Feature({
-						geometry: accuracy,
-						type: 'accuracy'
-					});
-					this.locationSource.addFeature(accuracyFeature);
+					this.replaceLocationFeature('accuracy', accuracy);
 				}
 			}) as EventsKey
 		);
+
+		// N2: Fehlerpfad — verweigerte Berechtigung, Timeout etc. Tracking
+		// stoppen (setzt via onTrackingChange auch die LocationControl zurück)
+		// und eine verständliche Meldung an die View geben.
+		this.geolocationKeys.push(
+			this.geolocation.on('error', (event) => {
+				logger.warn({ code: event.code, message: event.message }, 'Geolocation error');
+				this.stopTracking();
+				this.options.onGeolocationError?.(geolocationErrorMessage(event.code));
+			}) as EventsKey
+		);
+	}
+
+	/**
+	 * Ersetzt genau das Feature des angegebenen Typs im Location-Layer.
+	 * Positions- und Genauigkeits-Feature dürfen sich nicht gegenseitig
+	 * löschen — ein pauschales clear() ließ sonst immer nur das zuletzt
+	 * aktualisierte Feature übrig.
+	 */
+	private replaceLocationFeature(type: 'location' | 'accuracy', geometry: Geometry): void {
+		this.locationSource
+			.getFeatures()
+			.filter((feature) => feature.get('type') === type)
+			.forEach((feature) => this.locationSource.removeFeature(feature));
+		this.locationSource.addFeature(new Feature({ geometry, type }));
 	}
 
 	private applyFilter(searchTerm: string): void {
@@ -751,13 +797,24 @@ export class SichtungenMap {
 
 	public startTracking(): void {
 		this.isTracking = true;
+		this.hasCenteredOnFirstFix = false;
 		this.geolocation.setTracking(true);
+		this.notifyTrackingChange();
 	}
 
 	public stopTracking(): void {
 		this.isTracking = false;
 		this.geolocation.setTracking(false);
 		this.locationSource.clear();
+		this.notifyTrackingChange();
+	}
+
+	public onTrackingChange(callback: (isTracking: boolean) => void): void {
+		this.trackingChangeCallbacks.push(callback);
+	}
+
+	private notifyTrackingChange(): void {
+		this.trackingChangeCallbacks.forEach((callback) => callback(this.isTracking));
 	}
 
 	public isCurrentlyTracking(): boolean {
@@ -783,13 +840,11 @@ export class SichtungenMap {
 		});
 	}
 
-	public toggleGeolocation(): boolean {
+	public toggleGeolocation(): void {
 		if (this.isTracking) {
 			this.stopTracking();
-			return false;
 		} else {
 			this.startTracking();
-			return true;
 		}
 	}
 
@@ -817,6 +872,7 @@ export class SichtungenMap {
 		this.geolocationKeys.forEach((k) => unByKey(k));
 		this.geolocationKeys = [];
 		this.geolocation.dispose();
+		this.trackingChangeCallbacks = [];
 
 		// View resolution listener entfernen
 		if (this.viewResolutionKey) {


### PR DESCRIPTION
## Zusammenfassung

Setzt **Befund N2** aus `docs/UX_REVIEW_SICHTUNGSKARTE_2026-07-28.md` um: Die vollständig implementierte, aber nie eingebundene GPS-Standortanzeige (`LocationControl` + Geolocation-Tracking im Controller) ist jetzt auf der Sichtungskarte aktiv — auf A11y-Standard gebracht, mit Fehlerpfad und Erst-Fix-Zentrierung.

### Änderungen

- **Aktivierung:** `enableLocationControl: true` in `SightingsMapView.svelte`; CSS-Offsets (44×44-px-Spalte links) waren bereits korrekt, ergänzt wurde nur der Aktiv-Stil.
- **A11y (analog ZoomAllControl aus #593):** `aria-pressed` als Toggle-Zustand mit **einer** Zustandsquelle (neuer `onTrackingChange`-Callback des Controllers), deutsches `title`/`aria-label` („GPS-Position anzeigen" / „GPS-Tracking stoppen"), Lucide-`locate`-Inline-SVG (currentColor, `aria-hidden`) statt 📍-Emoji, Aktiv-Stil über Theme-Tokens `--color-primary`/`--color-primary-content` (Vollton, handgeprüftes AA-Paar).
- **Fehlerpfad:** `geolocation.on('error')` stoppt das Tracking, setzt den Button zurück und zeigt je Fehlercode eine verständliche deutsche Meldung im bestehenden Fehler-Toast. Die pure Zustands-/Fehlerlogik ist nach `locationControlState.ts` extrahiert und einzeln getestet.
- **Erst-Fix-Zentrierung:** Beim ersten Positionsfix pro Tracking-Sitzung `view.animate` auf die Position (Zoom mind. 10) — kein Auto-Follow bei weiteren Updates.
- **Datenschutz:** Positionsdaten bleiben rein lokal im Browser (kein Request mit Koordinaten) — im Code kommentiert.

### Nebenbei behobene Altbugs

- Positions- und Genauigkeits-Feature löschten sich gegenseitig (`clear()` auf der ganzen Source in beiden Listenern) → typbezogenes Ersetzen.
- `transition: all 0.2s` am Button maskierte in Chromium den per `!important` umgeschalteten Aktiv-Zustand dauerhaft → Transition entfernt, Ursache im CSS kommentiert.
- `MapController.toggleGeolocation()` gibt `void` statt `boolean` zurück (Rückgabewert war nach dem Umbau tote API; Zustand fließt über `onTrackingChange`).

### Tests (Test-First)

| Ebene | Datei | Abdeckung |
| --- | --- | --- |
| Unit (Node) | `locationControlState.test.ts` | Button-Zustand, Fehlercode → Meldung (7 Tests) |
| Browser-DOM | `LocationControl.svelte.test.ts` | aria-pressed-Toggle, SVG/aria-hidden, Fehler-Reset (4 Tests) |
| E2E | `map-location-control.spec.ts` | Berechtigung erteilt (Tracking an/aus) und verweigert (Toast + Button-Reset), beide Pfade (4 Tests) |

Verifikation: 2.248 Server-Unit-Tests, 153 Client-Tests, 34 bestehende Karten-E2E-Tests, Type-Check, Lint, Svelte-Check — alles grün. Zusätzlich im echten Browser verifiziert (Platzierung, Aktiv-Stil, Toggle-Verhalten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)