### PR TITLE
fix(build): keep vite dep-optimizer cache valid across dev restarts

### DIFF
--- a/src/tools/vite-stable-dep-hash.test.ts
+++ b/src/tools/vite-stable-dep-hash.test.ts
@@ -1,0 +1,87 @@
+import type { ResolvedConfig } from 'vite';
+import { describe, expect, it } from 'vitest';
+import { stableDepHash } from './vite-stable-dep-hash';
+
+/**
+ * Baut ein minimales ResolvedConfig-Stub mit den beiden Feldern, die Vite in
+ * den Dep-Optimizer-Hash einrechnet.
+ */
+function configWith(external: unknown, noExternal: unknown = [], envName = 'ssr'): ResolvedConfig {
+	return {
+		environments: {
+			[envName]: { resolve: { external, noExternal } }
+		}
+	} as unknown as ResolvedConfig;
+}
+
+/** Ruft den configResolved-Hook des Plugins auf. */
+function applyPlugin(config: ResolvedConfig): void {
+	const hook = stableDepHash().configResolved;
+	if (typeof hook !== 'function') throw new Error('configResolved ist kein Hook');
+	hook.call({} as never, config);
+}
+
+/** Liest ein Environment aus — `noUncheckedIndexedAccess` erzwingt die Prüfung. */
+function resolveOf(config: ResolvedConfig, envName = 'ssr') {
+	const environment = config.environments[envName];
+	if (!environment) throw new Error(`Environment "${envName}" fehlt im Stub`);
+	return environment.resolve;
+}
+
+describe('stableDepHash', () => {
+	it('sortiert resolve.external, damit der Config-Hash stabil bleibt', () => {
+		const config = configWith(['local-pkg', '@antfu/install-pkg', 'cookie']);
+
+		applyPlugin(config);
+
+		expect(resolveOf(config).external).toEqual(['@antfu/install-pkg', 'cookie', 'local-pkg']);
+	});
+
+	it('sortiert resolve.noExternal', () => {
+		const config = configWith([], ['unplugin-icons', 'esm-env', 'svelte']);
+
+		applyPlugin(config);
+
+		expect(resolveOf(config).noExternal).toEqual(['esm-env', 'svelte', 'unplugin-icons']);
+	});
+
+	it('erzeugt aus unterschiedlichen Reihenfolgen dasselbe Ergebnis', () => {
+		// Das ist die eigentliche Eigenschaft: SvelteKit/Vite füllen resolve.external
+		// über parallele Auflösung, die Reihenfolge schwankt zwischen Starts.
+		const a = configWith(['local-pkg', '@antfu/install-pkg', 'unplugin']);
+		const b = configWith(['unplugin', 'local-pkg', '@antfu/install-pkg']);
+
+		applyPlugin(a);
+		applyPlugin(b);
+
+		expect(resolveOf(a).external).toEqual(resolveOf(b).external);
+	});
+
+	it('erfasst alle Environments, nicht nur ssr', () => {
+		const config = configWith(['b', 'a'], ['d', 'c'], 'client');
+
+		applyPlugin(config);
+
+		expect(resolveOf(config, 'client').external).toEqual(['a', 'b']);
+		expect(resolveOf(config, 'client').noExternal).toEqual(['c', 'd']);
+	});
+
+	it('lässt nicht-Array-Werte unangetastet', () => {
+		// resolve.noExternal darf laut Vite-Typen auch true sein.
+		const config = configWith(true, true);
+
+		expect(() => applyPlugin(config)).not.toThrow();
+		expect(resolveOf(config).external).toBe(true);
+		expect(resolveOf(config).noExternal).toBe(true);
+	});
+
+	it('sortiert RegExp-Einträge deterministisch mit', () => {
+		const a = configWith([], [/^svelte\//, 'esm-env']);
+		const b = configWith([], ['esm-env', /^svelte\//]);
+
+		applyPlugin(a);
+		applyPlugin(b);
+
+		expect(String(resolveOf(a).noExternal)).toBe(String(resolveOf(b).noExternal));
+	});
+});

--- a/src/tools/vite-stable-dep-hash.test.ts
+++ b/src/tools/vite-stable-dep-hash.test.ts
@@ -29,6 +29,10 @@ function resolveOf(config: ResolvedConfig, envName = 'ssr') {
 }
 
 describe('stableDepHash', () => {
+	it('läuft als post-Plugin, damit spätere configResolved-Hooks nicht mehr umsortieren', () => {
+		expect(stableDepHash().enforce).toBe('post');
+	});
+
 	it('sortiert resolve.external, damit der Config-Hash stabil bleibt', () => {
 		const config = configWith(['local-pkg', '@antfu/install-pkg', 'cookie']);
 

--- a/src/tools/vite-stable-dep-hash.ts
+++ b/src/tools/vite-stable-dep-hash.ts
@@ -1,0 +1,35 @@
+/**
+ * Hält Vites Dep-Optimizer-Cache über Dev-Starts hinweg gültig.
+ *
+ * Vite bildet den Cache-Key (`configHash` in den `_metadata.json` unter
+ * `node_modules/.vite/deps` bzw. `deps_ssr`)
+ * unter anderem über `resolve.external` und `resolve.noExternal`. SvelteKit,
+ * vite-plugin-svelte und unplugin-icons füllen diese Listen über parallele
+ * Auflösung — die Reihenfolge schwankt daher zwischen zwei identischen Starts.
+ * Vite sieht einen anderen Hash, meldet
+ * „Re-optimizing dependencies because vite config has changed" und bündelt die
+ * Dependencies bei *jedem* `npm run dev` neu.
+ *
+ * Beide Listen werden als Any-Match ausgewertet (`createIsConfiguredAsExternal`),
+ * die Reihenfolge ist also bedeutungslos — Sortieren ändert das Verhalten nicht,
+ * macht den Hash aber deterministisch.
+ *
+ * Gemessen (siehe PR-Beschreibung): `ready` 1.6–2.7 s → ~0.6 s, keine
+ * Re-Optimierung mehr ab dem zweiten Start.
+ */
+import type { Plugin } from 'vite';
+
+export function stableDepHash(): Plugin {
+	return {
+		name: 'ostsee:stable-dep-hash',
+		// Muss vor der Initialisierung des Dep-Optimizers laufen — configResolved
+		// ist der letzte Hook davor.
+		configResolved(config) {
+			for (const environment of Object.values(config.environments)) {
+				const { resolve } = environment;
+				if (Array.isArray(resolve.external)) resolve.external.sort();
+				if (Array.isArray(resolve.noExternal)) resolve.noExternal.sort();
+			}
+		}
+	};
+}

--- a/src/tools/vite-stable-dep-hash.ts
+++ b/src/tools/vite-stable-dep-hash.ts
@@ -22,8 +22,17 @@ import type { Plugin } from 'vite';
 export function stableDepHash(): Plugin {
 	return {
 		name: 'ostsee:stable-dep-hash',
-		// Muss vor der Initialisierung des Dep-Optimizers laufen — configResolved
-		// ist der letzte Hook davor.
+		/**
+		 * `configResolved` ist der letzte Hook vor der Initialisierung des
+		 * Dep-Optimizers. `enforce: 'post'` sorgt dafür, dass die Sortierung nach
+		 * den `configResolved`-Hooks aller anderen Plugins läuft — sonst könnte ein
+		 * Plugin danach noch anhängen und die Reihenfolge erneut kippen.
+		 *
+		 * Gemessen ist das aktuell nicht nötig (die Listen stehen schon vor dem
+		 * ersten `configResolved` fest, kein Plugin mutiert sie danach). Es macht
+		 * die Garantie aber strukturell statt zufällig und kostet nichts.
+		 */
+		enforce: 'post',
 		configResolved(config) {
 			for (const environment of Object.values(config.environments)) {
 				const { resolve } = environment;

--- a/vite.config.ci.ts
+++ b/vite.config.ci.ts
@@ -28,7 +28,6 @@ export default defineConfig({
 		'process.env.SKIP_DB_CHECK': JSON.stringify('true')
 	},
 	plugins: [
-		stableDepHash(),
 		tailwindcss(),
 		Icons({
 			compiler: 'svelte',
@@ -39,8 +38,10 @@ export default defineConfig({
 				props.height = props.height || '20';
 			}
 		}),
-		sveltekit()
+		sveltekit(),
 		// No basicSsl plugin for CI to avoid HTTPS certificate issues
+		// Zuletzt: sortiert resolve.external/noExternal nach allen anderen Plugins.
+		stableDepHash()
 	],
 	server: {
 		host: '0.0.0.0',

--- a/vite.config.ci.ts
+++ b/vite.config.ci.ts
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
+import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 /**
  * In Git-Worktrees liegt das installierte node_modules außerhalb des
@@ -27,6 +28,7 @@ export default defineConfig({
 		'process.env.SKIP_DB_CHECK': JSON.stringify('true')
 	},
 	plugins: [
+		stableDepHash(),
 		tailwindcss(),
 		Icons({
 			compiler: 'svelte',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
+import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 const certFile = fileURLToPath(new URL('./certs/localhost.pem', import.meta.url));
 const keyFile = fileURLToPath(new URL('./certs/localhost-key.pem', import.meta.url));
@@ -26,6 +27,7 @@ const devCert =
 
 export default defineConfig({
 	plugins: [
+		stableDepHash(),
 		tailwindcss(),
 		sveltekit(),
 		Icons({
@@ -53,6 +55,17 @@ export default defineConfig({
 		...(devCert ? { https: devCert } : {}),
 		hmr: {
 			overlay: true
+		},
+		/**
+		 * Git-Worktrees liegen unter `.claude/worktrees/` *innerhalb* des Repo-Roots.
+		 * Aktuell hält Vite sie ohnehin heraus (es beobachtet nur Dateien aus dem
+		 * Modulgraph), und alle übrigen Tools schließen sie über `.gitignore` aus.
+		 * Der Eintrag hier ist die Absicherung: Fällt die `.gitignore`-Zeile weg,
+		 * beobachtet der Watcher sonst still ein Vielfaches an Dateien.
+		 * Vite ergänzt seine Defaults (`**\/node_modules/**`, `**\/.git/**`).
+		 */
+		watch: {
+			ignored: ['**/.claude/worktrees/**', '**/.worktrees/**']
 		},
 		// Warmup critical modules for faster initial page load
 		warmup: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,6 @@ const devCert =
 
 export default defineConfig({
 	plugins: [
-		stableDepHash(),
 		tailwindcss(),
 		sveltekit(),
 		Icons({
@@ -47,7 +46,9 @@ export default defineConfig({
 						domains: ['localhost', '*.local.dev'],
 						certDir: './certs/basic-ssl'
 					})
-				])
+				]),
+		// Zuletzt: sortiert resolve.external/noExternal nach allen anderen Plugins.
+		stableDepHash()
 	],
 	server: {
 		host: 'localhost',


### PR DESCRIPTION
## Ausgangspunkt

Gemeldet war: `npm run dev` im Hauptverzeichnis ist sehr langsam, weil Vite (und ggf. andere Tools) alle Worktrees mitparsen.

**Die Annahme hält nicht.** Kein Tool in der Kette scannt die Worktrees — alles einzeln nachgemessen:

| Tool | Dateien gesamt | davon aus Worktrees |
|---|---|---|
| Vite-8-Watcher (`server.watcher.getWatched()`) | 903 Verzeichnisse | **0** |
| Tailwind-4-Oxide-Scanner | 669 | **0** |
| ESLint | 543 | **0** |
| Prettier | — | **0** (mit Probe-Datei verifiziert) |
| `tsconfig.json` | `include: ../src/**` | **0** |

Grund: die zwei `.gitignore`-Zeilen `.claude/worktrees/` und `.worktrees`. Tailwind, ESLint (über `includeIgnoreFile`) und Prettier respektieren sie, und Vite 8 beobachtet ohnehin nur Dateien aus dem Modulgraph statt des Root-Baums.

## Was wirklich gebremst hat

Vite hat den Dep-Optimizer-Cache bei **jedem** `npm run dev` verworfen:

```
[vite] (ssr) Re-optimizing dependencies because vite config has changed
```

… obwohl sich an der Config nichts geändert hatte. Eingegrenzt durch Diffen zweier `resolveConfig`-Läufe: `resolve.external` kam in wechselnder Reihenfolge zurück (`@antfu/install-pkg`, `local-pkg`, `@scalar/client-side-rendering` tauschten die Plätze). SvelteKit, vite-plugin-svelte und unplugin-icons füllen die Liste über parallele Auflösung. Vite rechnet `resolve` in den `configHash` des Dep-Optimizers ein — eine umsortierte Liste invalidiert also den Cache, und esbuild bündelt bei jedem Start alle Dependencies neu.

`resolve.external` und `resolve.noExternal` werden beide als Any-Match ausgewertet (`createIsConfiguredAsExternal`), ihre Reihenfolge ist bedeutungslos. Das neue Plugin sortiert sie in `configResolved` — das Auflösungsverhalten bleibt identisch, der Hash wird deterministisch.

## Messwerte

Je 3–4 Läufe, gleiche Maschine:

| | vorher | nachher |
|---|---|---|
| `ready in` | 1612–2684 ms | **589–673 ms** |
| Re-Optimierung pro Start | jedes Mal | **0** (ab 2. Start) |
| Start → erste Seite | 4,74 s Ø (bis 5,18 s) | **4,51 s Ø, stabil** |

Zur ehrlichen Einordnung: der Ende-zu-Ende-Gewinn ist mit ~0,2 s klein — der SSR-Transform dominiert und verschiebt sich nur aus dem Startup in den ersten Request. Der eigentliche Gewinn ist, dass die wiederholte Neubündelung und die Ausreißer wegfallen. Warme Renders lagen mit 20–37 ms nie im Problembereich.

## Änderungen

- **`src/tools/vite-stable-dep-hash.ts`** (neu) — Plugin, das `resolve.external`/`noExternal` in `configResolved` sortiert. Liegt in `src/tools/`, weil dort bereits Tooling mit ko-lokalisierten Tests wohnt und es damit von vitest, tsconfig und ESLint erfasst wird.
- **`src/tools/vite-stable-dep-hash.test.ts`** (neu) — 6 Unit-Tests, test-first geschrieben (RED verifiziert, dann GREEN). Deckt ab: Sortierung beider Listen, Determinismus über unterschiedliche Eingabereihenfolgen, alle Environments statt nur `ssr`, Nicht-Array-Werte (`true`) unangetastet, RegExp-Einträge.
- **`vite.config.ts`** — Plugin eingehängt; zusätzlich `server.watch.ignored` für die Worktree-Verzeichnisse.
- **`vite.config.ci.ts`** — Plugin eingehängt, damit lokale E2E-Läufe denselben Effekt haben.

Der `watch.ignored`-Eintrag ist ausdrücklich **Absicherung, kein Fix**: aktuell greift er nicht, weil Vite die Worktrees ohnehin nicht beobachtet. Fällt aber die `.gitignore`-Zeile weg, würde der Watcher still ~13.000 Extra-Dateien aufnehmen.

## Verifikation

- `npm run test:quick` grün — 151 Test-Dateien, 2258 Tests, dazu lint + type-check + svelte-check.
- 4 Dev-Neustarts in Folge: Lauf 1 optimiert einmalig neu (erwartet, die Config hat sich ja tatsächlich geändert), Läufe 2–4 melden **0** Re-Optimierungen.
- `resolve.external` liefert jetzt reproduzierbar alphabetische Reihenfolge.
- Watcher-Probe nach der Änderung: weiterhin 0 Worktree-Verzeichnisse.
- Seite im Browser geprüft: `h1` „Meerestier-Sichtung melden", Formular sichtbar, keine HTTP-Fehler, warme Renders 20–24 ms.

## Für Reviewer

Die Sortierung mutiert die Arrays in-place. Das ist bewusst — Vite liest sie danach für den Hash, und beide Listen sind semantisch Mengen, keine Sequenzen. Falls Vite/SvelteKit die Reihenfolge upstream irgendwann stabilisieren, kann das Plugin ersatzlos entfallen.

Nicht Teil dieses PRs, aber beim Messen aufgefallen: 10 von 12 Worktrees haben ein eigenes `node_modules` (zusammen 3,9 GB), entgegen der Regel in `docs/WORKTREES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)