### PR TITLE
fix(ci): gate production behind staging and propagate build failures

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -144,10 +144,14 @@ sudo chown -R 1001:1001 ./uploads
 
 ## Docker Compose Production
 
+Image-Zeiger: `staging` = jedes neue Release (ungeprüft), `production` = nach
+Freigabe, `vX.Y.Z` = unveränderlich. `latest` bewegt sich erst bei der
+Production-Promotion, nicht beim Build. Details: `docs/RELEASE_PIPELINE.md`
+
 ```yaml
 services:
   app:
-    image: ghcr.io/jansinger/ostsee-sichtung:latest
+    image: ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}
     ports:
       - '3000:3000'
     environment:
@@ -245,5 +249,5 @@ server {
 
 - Keine Secrets in Dockerfile
 - Keine Build-Args für Secrets
-- Kein `latest` Tag in Production
+- Kein `staging` Tag in Production (Prod folgt `production` oder `vX.Y.Z`)
 - Keine Root-User im Container

--- a/.env.docker
+++ b/.env.docker
@@ -116,6 +116,10 @@ ENABLE_ANALYTICS="false"
 # IMAGE_TAG="v2.1.0"
 IMAGE_TAG="production"
 
+# Überschreibt die komplette Image-Referenz und hat Vorrang vor IMAGE_TAG.
+# Einziger Weg, auf einen Digest zu pinnen (hängt mit `@` an, nicht mit `:`):
+# APP_IMAGE="ghcr.io/jansinger/ostsee-sichtung@sha256:..."
+
 # Bind app to localhost only (use with reverse proxy)
 # APP_HOST="127.0.0.1"
 APP_HOST="0.0.0.0"

--- a/.env.docker
+++ b/.env.docker
@@ -109,9 +109,12 @@ ENABLE_ANALYTICS="false"
 # ============================================
 # Production Settings
 # ============================================
-# Pin to specific version tag for reproducible deployments
+# Welchem Image-Zeiger folgt dieser Stack? (docs/RELEASE_PIPELINE.md)
+#   production - freigegebener Stand, bewegt nur durch promote-production.yml
+#   staging    - jedes neue Release, ungeprüft (nur Staging-Host)
+#   vX.Y.Z     - feste Version, empfohlen für reproduzierbare Deployments
 # IMAGE_TAG="v2.1.0"
-IMAGE_TAG="latest"
+IMAGE_TAG="production"
 
 # Bind app to localhost only (use with reverse proxy)
 # APP_HOST="127.0.0.1"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,16 +1,27 @@
 name: Docker Publish
 
 on:
-  # Triggered by release-please after release creation
-  repository_dispatch:
-    types: [release-created]
-  # Manual trigger with version input
+  # Called by release-please.yml as part of the release run. Failures surface
+  # in that run instead of getting lost in a separate, fire-and-forget one.
+  workflow_call:
+    inputs:
+      version:
+        description: 'Release tag to build (e.g., v2.5.6)'
+        required: true
+        type: string
+      sha:
+        description: 'Commit SHA to build from'
+        required: true
+        type: string
+  # Rebuild an existing tag without cutting a new release — base image CVE,
+  # transient GHCR failure, retry of a broken build.
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to build (e.g., v1.31.6)'
         required: true
-  # Also trigger on tags for backwards compatibility
+  # Manually pushed tags. Release-please tags do NOT reach this trigger:
+  # pushes made with GITHUB_TOKEN never start a workflow run.
   push:
     tags:
       - 'v*'
@@ -32,19 +43,41 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
 
     steps:
+      # github.event_name ist bei workflow_call das Event des AUFRUFERS (also
+      # `push`, wenn release-please durch einen main-Push lief) — es taugt hier
+      # nicht zur Unterscheidung. inputs.version ist nur bei workflow_call
+      # gesetzt und ist deshalb das verlässliche Signal.
       - name: Determine version
         id: version
+        env:
+          CALL_VERSION: ${{ inputs.version }}
+          CALL_SHA: ${{ inputs.sha }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            echo "version=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.event.client_payload.sha }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [ -n "${CALL_VERSION}" ]; then
+            VERSION="${CALL_VERSION}"
+            SHA="${CALL_SHA}"
+          elif [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            VERSION="${DISPATCH_TAG}"
+            SHA="${GIT_SHA}"
           else
-            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            VERSION="${REF_NAME}"
+            SHA="${GIT_SHA}"
           fi
+
+          if [ -z "${VERSION}" ] || [ -z "${SHA}" ]; then
+            echo "::error::Version oder SHA konnte nicht bestimmt werden (version='${VERSION}' sha='${SHA}')."
+            exit 1
+          fi
+
+          {
+            echo "version=${VERSION}"
+            echo "sha=${SHA}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log build info
         run: |
@@ -143,25 +176,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Beim Build entstehen NUR die unveränderlichen Versions-Tags plus der
+      # bewegliche `staging`-Zeiger. Die Production-Zeiger (`production`,
+      # `latest`, MAJOR, MINOR) setzt ausschließlich promote-production.yml —
+      # sonst stünde das frisch gebaute Image sofort auf dem Prod-Host und das
+      # Staging würde nichts absichern. Siehe docs/RELEASE_PIPELINE.md.
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           # Remove 'v' prefix for semver tags
           SEMVER="${VERSION#v}"
-          MAJOR="${SEMVER%%.*}"
-          MINOR="${SEMVER%.*}"
 
           echo "Creating manifest for version: $VERSION"
-          echo "Tags: $VERSION, $SEMVER, $MINOR, $MAJOR, latest"
+          echo "Tags: $VERSION, $SEMVER, staging"
 
-          # Create all tags
           docker buildx imagetools create \
             -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${VERSION} \
             -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${SEMVER} \
-            -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${MINOR} \
-            -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${MAJOR} \
-            -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest \
+            -t ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:staging \
             $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Inspect image

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -159,9 +159,11 @@ jobs:
             echo "| Bewegte Tags | \`production\`, \`latest\`, \`${{ steps.version.outputs.minor }}\`, \`${{ steps.version.outputs.major }}\` |"
             echo "| Freigegeben von | @${{ github.actor }} |"
             echo
-            echo "Der Prod-Host zieht beim nächsten Pull-Lauf. Digest-genau pinnen:"
+            echo "Der Prod-Host zieht beim nächsten Pull-Lauf. Fest pinnen (.env):"
             echo
             echo '```bash'
-            echo "IMAGE_TAG=${TAG}   # oder: ${IMAGE}@${DIGEST}"
+            echo "IMAGE_TAG=${TAG}"
+            echo "# oder digest-genau — APP_IMAGE hat Vorrang vor IMAGE_TAG:"
+            echo "APP_IMAGE=${IMAGE}@${DIGEST}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,0 +1,167 @@
+name: Promote to Production
+
+# Schiebt eine bereits gebaute und auf Staging verifizierte Release-Version nach
+# Production — durch UMHÄNGEN der Image-Tags, nicht durch einen Rebuild. Das auf
+# Production laufende Image ist damit bitgleich mit dem, das auf Staging getestet
+# wurde (identischer Digest).
+#
+# Ablauf: docker-publish.yml baut beim Release `vX.Y.Z` + `X.Y.Z` + `staging`.
+# Der Staging-Host folgt `staging` automatisch. Dieser Workflow setzt nach
+# manueller Freigabe `production`, `latest`, `X.Y` und `X` auf denselben Digest;
+# der Prod-Host folgt `production`.
+#
+# Details: docs/RELEASE_PIPELINE.md
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release-Version, die nach Production soll (z. B. v2.5.6)'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ostsee-sichtung
+
+permissions: {}
+
+jobs:
+  promote:
+    name: Promote ${{ inputs.version }} to Production
+    runs-on: ubuntu-latest
+    # Das Approval-Gate. Required Reviewers werden am Environment `Production`
+    # in den Repo-Settings konfiguriert — existiert die Environment nicht, legt
+    # GitHub sie beim ersten Lauf OHNE Schutzregeln an und der Job läuft still
+    # ohne Rückfrage durch. Namen sind case-insensitiv.
+    environment:
+      name: Production
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: promote-production
+      cancel-in-progress: false
+
+    steps:
+      - name: Validate version input
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$INPUT_VERSION" | grep -Eq '^v?[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$INPUT_VERSION' ist keine gültige Release-Version (erwartet: vX.Y.Z)."
+            exit 1
+          fi
+
+          SEMVER="${INPUT_VERSION#v}"
+          {
+            echo "tag=v${SEMVER}"
+            echo "semver=${SEMVER}"
+            echo "minor=${SEMVER%.*}"
+            echo "major=${SEMVER%%.*}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # Stellt sicher, dass wirklich das getestete Artefakt weitergereicht wird:
+      # existiert der Versions-Tag nicht, wurde er nie gebaut — dann bricht die
+      # Promotion ab, statt einen falschen Zeiger zu setzen.
+      - name: Verify release image exists
+        id: source
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! docker buildx imagetools inspect "${IMAGE}:${TAG}" >/dev/null 2>&1; then
+            echo "::error::${IMAGE}:${TAG} existiert nicht in der Registry. Wurde das Release gebaut?"
+            exit 1
+          fi
+
+          DIGEST=$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{json .Manifest}}' | jq -r '.digest')
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+          echo "Promoting ${IMAGE}:${TAG} (${DIGEST})"
+
+      # Warnt, wenn der Staging-Zeiger nicht auf dieser Version steht — dann
+      # wurde entweder etwas anderes getestet oder inzwischen ein neueres
+      # Release gebaut. Kein harter Abbruch: eine bewusste Re-Promotion einer
+      # älteren Version (Rollback) muss möglich bleiben.
+      - name: Check staging pointer
+        continue-on-error: true
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          EXPECTED: ${{ steps.source.outputs.digest }}
+        run: |
+          set -euo pipefail
+          STAGING=$(docker buildx imagetools inspect "${IMAGE}:staging" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest' || echo '')
+          if [ -z "$STAGING" ]; then
+            echo "::warning::Kein staging-Tag gefunden — Promotion nicht gegen Staging abgeglichen."
+          elif [ "$STAGING" != "$EXPECTED" ]; then
+            echo "::warning::staging zeigt auf ${STAGING}, promotet wird aber ${EXPECTED}. Rollback oder veraltete Auswahl?"
+          else
+            echo "staging und Promotion-Ziel sind identisch (${EXPECTED})."
+          fi
+
+      - name: Move production tags
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.version.outputs.tag }}
+          MINOR: ${{ steps.version.outputs.minor }}
+          MAJOR: ${{ steps.version.outputs.major }}
+        run: |
+          set -euo pipefail
+          # imagetools create kopiert die Manifest-Liste — Multi-Arch bleibt
+          # erhalten und der Digest ist identisch mit dem der Quelle.
+          docker buildx imagetools create \
+            -t "${IMAGE}:production" \
+            -t "${IMAGE}:latest" \
+            -t "${IMAGE}:${MINOR}" \
+            -t "${IMAGE}:${MAJOR}" \
+            "${IMAGE}:${TAG}"
+
+      - name: Verify production pointer
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          EXPECTED: ${{ steps.source.outputs.digest }}
+        run: |
+          set -euo pipefail
+          ACTUAL=$(docker buildx imagetools inspect "${IMAGE}:production" --format '{{json .Manifest}}' | jq -r '.digest')
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::production zeigt auf ${ACTUAL}, erwartet war ${EXPECTED}."
+            exit 1
+          fi
+          echo "production == ${ACTUAL}"
+
+      - name: Job summary
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ steps.version.outputs.tag }}
+          DIGEST: ${{ steps.source.outputs.digest }}
+        run: |
+          {
+            echo "## Production-Promotion: ${TAG}"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Image | \`${IMAGE}\` |"
+            echo "| Version | \`${TAG}\` |"
+            echo "| Digest | \`${DIGEST}\` |"
+            echo "| Bewegte Tags | \`production\`, \`latest\`, \`${{ steps.version.outputs.minor }}\`, \`${{ steps.version.outputs.major }}\` |"
+            echo "| Freigegeben von | @${{ github.actor }} |"
+            echo
+            echo "Der Prod-Host zieht beim nächsten Pull-Lauf. Digest-genau pinnen:"
+            echo
+            echo '```bash'
+            echo "IMAGE_TAG=${TAG}   # oder: ${IMAGE}@${DIGEST}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,26 +39,48 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.sha }}
           fetch-depth: 0
+          fetch-tags: true
 
-      - name: Update release branch
+      # Fast-forward statt Force-Push: `release` soll den Release-Tag immer nur
+      # nach VORNE bewegen. Ein Force-Push würde einen Direkt-Hotfix auf
+      # `release` stillschweigend verwerfen — der --ff-only-Merge bricht in dem
+      # Fall laut ab, und die Divergenz wird sichtbar statt vernichtet.
+      - name: Fast-forward release branch to tag
+        env:
+          TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Force push the release tag commit to the release branch
-          git push origin HEAD:release --force-with-lease
+          if git ls-remote --exit-code --heads origin release >/dev/null 2>&1; then
+            git fetch --force origin release:refs/remotes/origin/release
+            git checkout -B release refs/remotes/origin/release
+            git merge --ff-only "$TAG"
+          else
+            echo "Branch 'release' existiert noch nicht — wird aus $TAG erzeugt."
+            git checkout -B release "$TAG"
+          fi
 
-          echo "Updated release branch to ${{ needs.release-please.outputs.tag_name }}"
+          git push origin release
+          echo "Updated release branch to $TAG"
 
-  # Trigger Docker build after release
-  trigger-docker-build:
-    runs-on: ubuntu-latest
-    needs: release-please
+  # Docker-Build als aufgerufener Workflow, nicht per repository_dispatch:
+  # dadurch schlägt DIESER Release-Lauf fehl, wenn der Build scheitert. Beim
+  # Dispatch blieb der Release-Lauf grün und der Fehler nur im separaten Run
+  # sichtbar.
+  #
+  # Die Permissions müssen hier stehen: ein aufgerufener Workflow bekommt nie
+  # mehr Rechte als der aufrufende Job. Ohne packages/security-events bricht
+  # der Push nach GHCR bzw. der Trivy-Upload ab — erst mitten im Build.
+  docker-publish:
+    needs: [release-please, update-release-branch]
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-
-    steps:
-      - name: Trigger Docker publish workflow
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          event-type: release-created
-          client-payload: '{"tag": "${{ needs.release-please.outputs.tag_name }}", "sha": "${{ needs.release-please.outputs.sha }}"}'
+    permissions:
+      contents: write # Release-Assets ans GitHub Release hängen
+      packages: write # Push nach GHCR
+      security-events: write # Trivy-SARIF nach GitHub Security
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}
+      sha: ${{ needs.release-please.outputs.sha }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,10 +132,11 @@ Durchgesetzt via `commitlint.config.mjs`.
 Automatisiert über **release-please**: Commits auf `main` werden analysiert, ein Release-PR wird erstellt, bei Merge folgen Tag, GitHub Release, Branch `release` und Docker Build.
 
 Das Release-Image geht **nicht** direkt nach Production. Es bekommt beim Bau nur
-`vX.Y.Z` und den `staging`-Zeiger; der Staging-Host zieht automatisch. Erst der
-manuelle Workflow **Promote to Production** (mit Approval am Environment
-`production`) hängt `production`/`latest` auf denselben Digest um — es wird dabei
-nichts neu gebaut. Ablauf, Host-Setup und Rollback: `docs/RELEASE_PIPELINE.md`
+`vX.Y.Z`, `X.Y.Z` und den `staging`-Zeiger; der Staging-Host zieht automatisch.
+Erst der manuelle Workflow **Promote to Production** (mit Approval am Environment
+`Production`) hängt `production`, `latest`, `X.Y` und `X` auf denselben Digest um
+— es wird dabei nichts neu gebaut. Ablauf, Host-Setup und Rollback:
+`docs/RELEASE_PIPELINE.md`
 
 **Wichtig:** Keine manuellen Releases oder Tags. Nicht auf den `release` Branch pushen.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,13 @@ Durchgesetzt via `commitlint.config.mjs`.
 
 ## Release-Prozess
 
-Automatisiert über **release-please**: Commits auf `main` werden analysiert, ein Release-PR wird erstellt, bei Merge folgen Tag, GitHub Release und Docker Build.
+Automatisiert über **release-please**: Commits auf `main` werden analysiert, ein Release-PR wird erstellt, bei Merge folgen Tag, GitHub Release, Branch `release` und Docker Build.
+
+Das Release-Image geht **nicht** direkt nach Production. Es bekommt beim Bau nur
+`vX.Y.Z` und den `staging`-Zeiger; der Staging-Host zieht automatisch. Erst der
+manuelle Workflow **Promote to Production** (mit Approval am Environment
+`production`) hängt `production`/`latest` auf denselben Digest um — es wird dabei
+nichts neu gebaut. Ablauf, Host-Setup und Rollback: `docs/RELEASE_PIPELINE.md`
 
 **Wichtig:** Keine manuellen Releases oder Tags. Nicht auf den `release` Branch pushen.
 
@@ -143,6 +149,7 @@ Automatisiert über **release-please**: Commits auf `main` werden analysiert, ei
 | `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen                         |
 | `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)                          |
 | `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                                           |
+| `docs/RELEASE_PIPELINE.md`         | Release → Staging → Production, Image-Tags, Promotion, Rollback |
 | `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                        |
 | `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                            |
 | `docs/ENVIRONMENT.md`              | Umgebungsvariablen, inkl. Zeitzonen-Konvention (Abschnitt `TZ`) |

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ docker run -p 3000:3000 --env-file .env ghcr.io/jansinger/ostsee-sichtung:latest
 
 - 📘 [Docker Deployment Guide](docs/DOCKER_DEPLOYMENT.md) - Vollständige Deployment-Anleitung
 - 📗 [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) - Schnellanleitung für Production
+- 🚦 [Release-Pipeline](docs/RELEASE_PIPELINE.md) - Release → Staging → Production, Image-Tags, Rollback
 - 📙 [Environment Variables Reference](docs/ENVIRONMENT.md) - Alle Umgebungsvariablen
 - 📕 [Database Migration Guide](docs/DATABASE_MIGRATION.md) - Migration von bestehenden Installationen
 - 📒 [Design Guide](docs/DESIGN_GUIDE.md) - UI/UX Best Practices

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -15,9 +15,15 @@ services:
   # Application Service
   # ============================================
   app:
-    # Pin to specific version in production! Use :latest only for testing
-    # Example: ghcr.io/jansinger/ostsee-sichtung:v2.1.0
-    image: ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-latest}
+    # IMAGE_TAG steuert, welchem Zeiger dieser Stack folgt:
+    #   production  - freigegebener Stand (Default; wird nur von
+    #                 promote-production.yml bewegt)
+    #   staging     - jedes neue Release, ungeprüft (Staging-Host)
+    #   vX.Y.Z      - feste Version, empfohlen für Prod-Stacks
+    # Maximale Genauigkeit per Digest:
+    #   ghcr.io/jansinger/ostsee-sichtung@sha256:...
+    # Siehe docs/RELEASE_PIPELINE.md
+    image: ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}
     container_name: ostsee-tiere-app
     restart: unless-stopped
     # SECURITY: Bind to localhost only if using reverse proxy

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -20,15 +20,18 @@ services:
     #                 promote-production.yml bewegt)
     #   staging     - jedes neue Release, ungeprüft (Staging-Host)
     #   vX.Y.Z      - feste Version, empfohlen für Prod-Stacks
-    # Maximale Genauigkeit per Digest:
-    #   ghcr.io/jansinger/ostsee-sichtung@sha256:...
+    #
+    # APP_IMAGE überschreibt die komplette Referenz und ist der einzige Weg,
+    # auf einen Digest zu pinnen — ein Digest hängt mit `@` statt `:` an und
+    # passt deshalb nicht in IMAGE_TAG:
+    #   APP_IMAGE=ghcr.io/jansinger/ostsee-sichtung@sha256:...
     # Siehe docs/RELEASE_PIPELINE.md
-    image: ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}
+    image: ${APP_IMAGE:-ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}}
     container_name: ostsee-tiere-app
     restart: unless-stopped
     # SECURITY: Bind to localhost only if using reverse proxy
     ports:
-      - "${APP_HOST:-0.0.0.0}:${APP_PORT:-3000}:3000"
+      - '${APP_HOST:-0.0.0.0}:${APP_PORT:-3000}:3000'
     environment:
       # Node.js Configuration
       NODE_ENV: production
@@ -120,15 +123,15 @@ services:
       - ostsee-network
 
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
 
     labels:
-      - "com.ostsee-tiere.service=app"
-      - "com.ostsee-tiere.version=${VERSION:-latest}"
+      - 'com.ostsee-tiere.service=app'
+      - 'com.ostsee-tiere.version=${VERSION:-latest}'
 
     # Security hardening
     security_opt:
@@ -142,8 +145,8 @@ services:
     logging:
       driver: json-file
       options:
-        max-size: "10m"
-        max-file: "5"
+        max-size: '10m'
+        max-file: '5'
 
     # Resource limits (adjust based on server capacity)
     # Note: Requires Docker Compose with --compatibility flag or Docker Swarm mode
@@ -151,11 +154,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "${APP_CPU_LIMIT:-2}"
-          memory: "${APP_MEMORY_LIMIT:-2G}"
+          cpus: '${APP_CPU_LIMIT:-2}'
+          memory: '${APP_MEMORY_LIMIT:-2G}'
         reservations:
-          cpus: "0.5"
-          memory: "512M"
+          cpus: '0.5'
+          memory: '512M'
 
   # ============================================
   # PostgreSQL with PostGIS
@@ -168,13 +171,13 @@ services:
     # SECURITY: Only expose to localhost, not publicly!
     # For external access, use SSH tunnel or reverse proxy
     ports:
-      - "127.0.0.1:${DB_PORT:-5432}:5432"
+      - '127.0.0.1:${DB_PORT:-5432}:5432'
     environment:
       # Database initialization (must match DATABASE_POSTGRES_URL in app)
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${PGPASSWORD}
       POSTGRES_DB: ostsee
-      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=en_US.UTF-8"
+      POSTGRES_INITDB_ARGS: '-E UTF8 --locale=en_US.UTF-8'
       # Performance tuning (optional overrides)
       POSTGRES_SHARED_BUFFERS: ${POSTGRES_SHARED_BUFFERS:-256MB}
       POSTGRES_EFFECTIVE_CACHE_SIZE: ${POSTGRES_EFFECTIVE_CACHE_SIZE:-1GB}
@@ -191,14 +194,14 @@ services:
       - ostsee-network
 
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d ostsee"]
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d ostsee']
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
 
     labels:
-      - "com.ostsee-tiere.service=database"
+      - 'com.ostsee-tiere.service=database'
 
     # Security hardening
     security_opt:
@@ -208,8 +211,8 @@ services:
     logging:
       driver: json-file
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: '10m'
+        max-file: '3'
 
   # ============================================
   # Prometheus (Monitoring)
@@ -219,7 +222,7 @@ services:
     container_name: ostsee-tiere-prometheus
     restart: unless-stopped
     ports:
-      - "127.0.0.1:${PROMETHEUS_PORT:-9090}:9090"
+      - '127.0.0.1:${PROMETHEUS_PORT:-9090}:9090'
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -232,12 +235,12 @@ services:
     networks:
       - ostsee-network
     labels:
-      - "com.ostsee-tiere.service=monitoring"
+      - 'com.ostsee-tiere.service=monitoring'
     logging:
       driver: json-file
       options:
-        max-size: "5m"
-        max-file: "3"
+        max-size: '5m'
+        max-file: '3'
     profiles:
       - monitoring
 
@@ -249,7 +252,7 @@ services:
     container_name: ostsee-tiere-grafana
     restart: unless-stopped
     ports:
-      - "127.0.0.1:${GRAFANA_PORT:-3001}:3000"
+      - '127.0.0.1:${GRAFANA_PORT:-3001}:3000'
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
@@ -264,12 +267,12 @@ services:
     networks:
       - ostsee-network
     labels:
-      - "com.ostsee-tiere.service=visualization"
+      - 'com.ostsee-tiere.service=visualization'
     logging:
       driver: json-file
       options:
-        max-size: "5m"
-        max-file: "3"
+        max-size: '5m'
+        max-file: '3'
     profiles:
       - monitoring
 
@@ -281,7 +284,7 @@ services:
     container_name: ostsee-tiere-node-exporter
     restart: unless-stopped
     ports:
-      - "127.0.0.1:${NODE_EXPORTER_PORT:-9100}:9100"
+      - '127.0.0.1:${NODE_EXPORTER_PORT:-9100}:9100'
     command:
       - '--path.procfs=/host/proc'
       - '--path.sysfs=/host/sys'
@@ -293,12 +296,12 @@ services:
     networks:
       - ostsee-network
     labels:
-      - "com.ostsee-tiere.service=metrics"
+      - 'com.ostsee-tiere.service=metrics'
     logging:
       driver: json-file
       options:
-        max-size: "5m"
-        max-file: "3"
+        max-size: '5m'
+        max-file: '3'
     profiles:
       - monitoring
 
@@ -310,37 +313,37 @@ volumes:
   uploads:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=uploads"
+      - 'com.ostsee-tiere.volume=uploads'
 
   # Application logs
   logs:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=logs"
+      - 'com.ostsee-tiere.volume=logs'
 
   # PostgreSQL data
   pgdata:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=database"
+      - 'com.ostsee-tiere.volume=database'
 
   # Database backups
   db-backups:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=backups"
+      - 'com.ostsee-tiere.volume=backups'
 
   # Prometheus metrics data
   prometheus-data:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=metrics"
+      - 'com.ostsee-tiere.volume=metrics'
 
   # Grafana dashboards and configuration
   grafana-data:
     driver: local
     labels:
-      - "com.ostsee-tiere.volume=dashboards"
+      - 'com.ostsee-tiere.volume=dashboards'
 
 # ============================================
 # Networks
@@ -349,4 +352,4 @@ networks:
   ostsee-network:
     driver: bridge
     labels:
-      - "com.ostsee-tiere.network=main"
+      - 'com.ostsee-tiere.network=main'

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -120,7 +120,7 @@ sudo chown 1001:1001 uploads
 chmod 600 .env
 
 # 8. Pull and start container
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+docker pull ghcr.io/jansinger/ostsee-sichtung:production
 
 docker run -d \
   --name ostsee-tiere \
@@ -128,7 +128,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:latest
+  ghcr.io/jansinger/ostsee-sichtung:production
 
 # 9. Database schema is migrated automatically on container startup.
 #    Requirement for external databases: PostGIS must be enabled once
@@ -283,7 +283,7 @@ See [Local Development Testing](#local-development-testing-with-rancher-desktop)
 
 ```bash
 # Pull image
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+docker pull ghcr.io/jansinger/ostsee-sichtung:production
 
 # Create uploads directory
 mkdir -p ./uploads
@@ -302,7 +302,7 @@ docker run -d \
   -e JWKS_URL="https://your-tenant.auth0.com/.well-known/jwks.json" \
   -e API_AUDIENCE="your-api-audience" \
   -e PUBLIC_SITE_URL="https://your-domain.com" \
-  ghcr.io/jansinger/ostsee-sichtung:latest
+  ghcr.io/jansinger/ostsee-sichtung:production
 
 # Alternative: Use named volume instead of bind mount
 # -v ostsee-uploads:/app/uploads
@@ -514,7 +514,7 @@ cp .env /opt/ostsee-tiere/.env
 chmod 600 /opt/ostsee-tiere/.env
 
 # Pull latest image
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+docker pull ghcr.io/jansinger/ostsee-sichtung:production
 
 # Run container (bind to localhost only - use reverse proxy for external access)
 docker run -d \
@@ -523,7 +523,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:latest
+  ghcr.io/jansinger/ostsee-sichtung:production
 
 # Database schema is migrated automatically on startup
 # (PostGIS must be enabled once on external databases beforehand)
@@ -643,7 +643,7 @@ ExecStart=/usr/bin/docker run --rm \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:latest
+  ghcr.io/jansinger/ostsee-sichtung:production
 ExecStop=/usr/bin/docker stop ostsee-tiere
 
 [Install]
@@ -657,9 +657,17 @@ sudo systemctl start ostsee-tiere
 
 ### Update Process
 
+> The `production` tag only advances after a release has been promoted (see
+> [CI/CD and Release Process](#cicd-and-release-process)). Pulling it therefore
+> never picks up an unverified build. **Back up the database first** — schema
+> migrations run automatically on container start and cannot be rolled back.
+
 ```bash
+# Back up before updating (see Backup & Restore below)
+/usr/local/bin/backup-db.sh
+
 # Pull new image
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+docker pull ghcr.io/jansinger/ostsee-sichtung:production
 
 # Restart (with systemd)
 sudo systemctl restart ostsee-tiere
@@ -673,7 +681,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:latest
+  ghcr.io/jansinger/ostsee-sichtung:production
 
 # Clean up old images
 docker image prune -f
@@ -1107,62 +1115,75 @@ services:
 
 ## CI/CD and Release Process
 
-### Automated Docker Image Publishing
-
-Docker images are automatically built and published to GitHub Container Registry (GHCR) via GitHub Actions when:
-
-- A new version tag is pushed (e.g., `v1.31.2`)
-- A release is published
-- The workflow is manually triggered
+> Full pipeline reference including host-side pull setup and rollback:
+> [RELEASE_PIPELINE.md](./RELEASE_PIPELINE.md)
 
 **Image Repository:** [`ghcr.io/jansinger/ostsee-sichtung`](https://github.com/jansinger/ostsee-sichtung/pkgs/container/ostsee-sichtung)
 
-**Available Tags:**
+### The release chain
 
-- `latest` - Latest stable release
-- `vX.Y.Z` - Specific version (e.g., `v1.31.3`)
-- `main` - Latest build from main branch
+Releases are driven by **release-please**. Never push tags by hand.
 
-### Retry Mechanism for Transient Errors
+1. Commits land on `main` → release-please maintains an open release PR.
+2. Merging that PR creates tag `vX.Y.Z` and the GitHub Release, fast-forwards
+   the `release` branch, and calls
+   [`docker-publish.yml`](../.github/workflows/docker-publish.yml) via
+   `workflow_call` — all within the same workflow run.
+3. `docker-publish.yml` builds `linux/amd64` and `linux/arm64` on separate
+   runners, pushes both by digest, merges them into one manifest list, and tags
+   it `vX.Y.Z`, `X.Y.Z` and `staging`.
+4. After manual verification on staging,
+   [`promote-production.yml`](../.github/workflows/promote-production.yml) is
+   triggered by hand and gated by the `Production` environment. It moves
+   `production`, `latest`, `X.Y` and `X` onto the digest that was already
+   built — **no rebuild happens**.
 
-The Docker Release workflow includes automatic retry logic to handle transient registry errors (such as 502 Bad Gateway):
+> Why a call rather than its own trigger: tags and pushes created with
+> `GITHUB_TOKEN` do not start workflow runs, so `on: push: tags: ['v*']` would
+> never fire for a release-please tag. Calling the workflow also puts the build
+> in the same `needs` chain — a failed build turns the release run red instead
+> of failing silently in a separate run.
+>
+> The `push: tags` trigger in `docker-publish.yml` remains for tags pushed by
+> hand, as does `workflow_dispatch` for rebuilding an existing tag.
 
-**Retry Strategy:**
+### Available tags
 
-- **Maximum Attempts**: 3
-- **Wait Between Retries**:
-  - First retry: 60 seconds
-  - Second retry: 120 seconds (exponential backoff)
-- **Behavior**: Each failed push attempt is automatically retried with increasing wait times
+| Tag                  | Set by                   | Meaning                                                        |
+| -------------------- | ------------------------ | -------------------------------------------------------------- |
+| `vX.Y.Z`, `X.Y.Z`    | `docker-publish.yml`     | Immutable. Always resolves to the same digest.                 |
+| `staging`            | `docker-publish.yml`     | Newest release, **unverified**. Staging host follows this tag. |
+| `production`         | `promote-production.yml` | Approved for production. Production hosts follow this tag.     |
+| `latest`, `X.Y`, `X` | `promote-production.yml` | Convenience pointers to the current production release.        |
 
-**Why This Matters:**
-GitHub Container Registry (GHCR) may occasionally experience temporary unavailability or rate limiting, especially during:
+There is no `main` tag — nothing is published from branch builds.
 
-- Multi-platform builds (linux/amd64, linux/arm64)
-- Large layer uploads
-- High GitHub Actions usage periods
+**`latest` no longer moves at build time.** It advances only when a release is
+promoted to production. A host tracking `latest` therefore stays on the last
+approved release instead of picking up every fresh build. For fully
+reproducible deployments, pin `IMAGE_TAG` to an explicit `vX.Y.Z` or to a
+digest.
 
-The retry mechanism ensures that transient infrastructure issues don't block your releases. The workflow will:
+### Verification and scanning
 
-1. ✅ Succeed on first attempt (most common case)
-2. ⚠️ Retry after 60 seconds if first attempt fails
-3. ⚠️ Retry after 120 seconds if second attempt fails
-4. ❌ Only fail permanently after all 3 attempts are exhausted
+Every build additionally produces:
 
-**Monitoring:**
-Check the workflow logs at: https://github.com/jansinger/ostsee-sichtung/actions/workflows/docker-release.yml
+- **Trivy scan** (CRITICAL/HIGH) uploaded to GitHub Security as SARIF, plus a
+  JSON artifact retained for 90 days
+- **Image digest artifact** (`image-digest.txt`) with the manifest digest,
+  platform list and a ready-to-use pull command
+- **Release assets** attached to the GitHub Release:
+  `docker-compose.production.yml`, `.env.example`, the digest file and a
+  deployment tarball
 
-Each retry attempt is clearly logged with attempt numbers and wait times.
+Verify what a tag currently resolves to:
 
-### Image Verification
+```bash
+docker buildx imagetools inspect ghcr.io/jansinger/ostsee-sichtung:production \
+  --format '{{json .Manifest}}' | jq -r '.digest'
+```
 
-After a successful push, the workflow generates:
-
-- **Image Digest**: Cryptographic hash of the image
-- **Image Tags**: All applied tags (version, latest, etc.)
-- **Pull Command**: Ready-to-use command with digest for verification
-
-Download these details from GitHub Actions artifacts (retention: 90 days).
+Workflow runs: <https://github.com/jansinger/ostsee-sichtung/actions>
 
 ---
 
@@ -1615,9 +1636,15 @@ services:
 
 ### 5. Regular Updates
 
+Track the `production` tag so hosts only ever receive promoted releases, and
+back up before every update — migrations run on container start.
+
 ```bash
-# Pull latest image
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+# Back up first
+/usr/local/bin/backup-db.sh
+
+# Pull the promoted image (IMAGE_TAG=production in .env)
+docker compose -f docker-compose.production.yml pull
 
 # Recreate containers
 docker compose -f docker-compose.production.yml up -d
@@ -1633,7 +1660,7 @@ Images are automatically scanned with Trivy during CI/CD. Check results:
 
 # Or scan locally
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-  aquasec/trivy image ghcr.io/jansinger/ostsee-sichtung:latest
+  aquasec/trivy image ghcr.io/jansinger/ostsee-sichtung:production
 ```
 
 ---
@@ -1654,7 +1681,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
   "containerDefinitions": [
     {
       "name": "app",
-      "image": "ghcr.io/jansinger/ostsee-sichtung:latest",
+      "image": "ghcr.io/jansinger/ostsee-sichtung:production",
       "portMappings": [{"containerPort": 3000, "protocol": "tcp"}],
       "environment": [...],
       "secrets": [
@@ -1669,7 +1696,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
 
 ```bash
 gcloud run deploy ostsee-tiere \
-  --image ghcr.io/jansinger/ostsee-sichtung:latest \
+  --image ghcr.io/jansinger/ostsee-sichtung:production \
   --platform managed \
   --region europe-west1 \
   --allow-unauthenticated \
@@ -1683,7 +1710,7 @@ gcloud run deploy ostsee-tiere \
 az container create \
   --resource-group ostsee-tiere-rg \
   --name ostsee-tiere-app \
-  --image ghcr.io/jansinger/ostsee-sichtung:latest \
+  --image ghcr.io/jansinger/ostsee-sichtung:production \
   --cpu 2 --memory 4 \
   --ports 3000 \
   --environment-variables \

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -1161,8 +1161,15 @@ There is no `main` tag — nothing is published from branch builds.
 **`latest` no longer moves at build time.** It advances only when a release is
 promoted to production. A host tracking `latest` therefore stays on the last
 approved release instead of picking up every fresh build. For fully
-reproducible deployments, pin `IMAGE_TAG` to an explicit `vX.Y.Z` or to a
-digest.
+reproducible deployments, pin `IMAGE_TAG` to an explicit `vX.Y.Z`, or set
+`APP_IMAGE` to a full digest reference — a digest attaches with `@` instead of
+`:` and therefore cannot go into `IMAGE_TAG`:
+
+```bash
+IMAGE_TAG=v2.5.6
+# or, digest-exact (APP_IMAGE takes precedence over IMAGE_TAG):
+APP_IMAGE=ghcr.io/jansinger/ostsee-sichtung@sha256:...
+```
 
 ### Verification and scanning
 

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -124,8 +124,9 @@ API_AUDIENCE="deine-api-audience"
 # Anwendung
 PUBLIC_SITE_URL="https://deine-domain.de"
 
-# WICHTIG: Für Production spezifische Version pinnen!
-IMAGE_TAG="v2.2.3"  # Nicht "latest" in Production!
+# Welchem Image-Zeiger folgt der Stack? Siehe RELEASE_PIPELINE.md
+# "production" = freigegebener Stand, "vX.Y.Z" = feste Version (am sichersten)
+IMAGE_TAG="v2.2.3"  # Nicht "staging" in Production!
 
 # App nur über Reverse Proxy erreichbar machen
 APP_HOST="127.0.0.1"
@@ -458,19 +459,24 @@ Unbegrenzt — kein automatisches Löschen. Manuelles Löschen via SQL wenn nöt
 
 ## 10. Updates durchführen
 
+> Ein neues Release landet **nicht** automatisch hier. Es geht zuerst auf
+> Staging (Tag `staging`); erst nach der Freigabe über den Workflow
+> _Promote to Production_ wandert der Zeiger `production` mit. Der komplette
+> Ablauf inkl. Rollback steht in [RELEASE_PIPELINE.md](./RELEASE_PIPELINE.md).
+
 ### Standard-Update
 
 ```bash
 cd /opt/ostsee-tiere
 
-# Backup erstellen
+# Backup erstellen — die Schema-Migrationen des neuen Release laufen beim
+# Container-Start automatisch und sind nicht rückrollbar
 ./backup.sh
 
 # Neues Image herunterladen
 docker compose pull
 
 # Container neu starten (Zero-Downtime mit Health Checks)
-# Schema-Migrationen des neuen Release laufen dabei automatisch
 docker compose up -d
 
 # Logs prüfen (inkl. Migrations-Ausgabe)
@@ -480,8 +486,8 @@ docker compose logs -f app
 ### Update auf spezifische Version
 
 ```bash
-# In .env oder docker-compose.yml:
-# image: ghcr.io/jansinger/ostsee-sichtung:v2.1.0
+# In .env:
+# IMAGE_TAG="v2.1.0"
 
 docker compose pull
 docker compose up -d

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -1,0 +1,219 @@
+# Release-Pipeline
+
+Vom Commit auf `main` bis zum Container auf Production. Leitprinzip: **einmal
+bauen, Artefakt weiterreichen.** Das Image, das auf Production läuft, ist
+bitgleich mit dem, das auf Staging getestet wurde — Promotion hängt nur Tags um,
+sie baut nichts neu.
+
+---
+
+## Überblick
+
+```mermaid
+flowchart TD
+    A[Push auf main] -->|ci.yml| B[Lint, Types, Unit, E2E]
+    B --> C[Release-Please-PR sammelt Commits]
+    C -->|PR gemerged| D[release-please.yml]
+    D --> E[Tag vX.Y.Z + GitHub Release]
+    D --> F[Branch release ff-only auf Tag]
+    D -->|workflow_call| G[docker-publish.yml]
+    G --> H["Image: vX.Y.Z, X.Y.Z, staging"]
+    H --> I[Staging-Host zieht staging]
+    I --> J{Manuelle Prüfung}
+    J -->|Freigabe| K[promote-production.yml + Approval]
+    K --> L["Tags production, latest, X.Y, X → gleicher Digest"]
+    L --> M[Prod-Host zieht production]
+```
+
+---
+
+## Image-Tags
+
+| Tag                  | Wird gesetzt von                       | Bedeutung                                                       |
+| -------------------- | -------------------------------------- | --------------------------------------------------------------- |
+| `vX.Y.Z`, `X.Y.Z`    | `docker-publish.yml` beim Release      | Unveränderlich. Zeigt für immer auf denselben Digest.           |
+| `staging`            | `docker-publish.yml` beim Release      | Neuestes Release, **ungeprüft**. Staging-Host folgt diesem Tag. |
+| `production`         | `promote-production.yml` nach Freigabe | Freigegebener Stand. Prod-Host folgt diesem Tag.                |
+| `latest`, `X.Y`, `X` | `promote-production.yml` nach Freigabe | Bequemlichkeits-Zeiger auf den Production-Stand.                |
+
+**Wichtig:** `latest` bewegt sich seit dieser Pipeline **nicht mehr beim Build**,
+sondern erst bei der Production-Freigabe. Vorher stand jedes frische Release
+sofort auf `latest` — ein Host, der `latest` zieht, hätte das Staging damit
+komplett übersprungen.
+
+---
+
+## Die vier Stufen
+
+### 1. Push auf `main`
+
+`ci.yml` läuft. Es wird kein Image gebaut und nichts deployt. Für lokale
+Entwicklung `npm run dev`.
+
+### 2. Release-PR mergen
+
+`release-please.yml` erledigt drei Dinge:
+
+- Tag `vX.Y.Z` + GitHub Release + `CHANGELOG.md`
+- Branch `release` per `git merge --ff-only` auf den Tag (Fast-Forward, kein
+  Force-Push — ein Direkt-Commit auf `release` lässt den Job laut fehlschlagen,
+  statt still überschrieben zu werden)
+- Aufruf von `docker-publish.yml` per `workflow_call` (Job `docker-publish`)
+
+> Warum ein Aufruf und kein eigener Trigger: Tags und Pushes, die mit
+> `GITHUB_TOKEN` entstehen, starten **keine** Workflow-Läufe. Ein
+> `on: push: tags: ['v*']` in `docker-publish.yml` feuert für ein
+> release-please-Tag also nie. Über `workflow_call` hängt der Build zusätzlich
+> in derselben `needs`-Kette — schlägt er fehl, ist der Release-Lauf rot statt
+> grün mit stillem Fehler nebenan.
+>
+> Der `push: tags`-Trigger in `docker-publish.yml` bleibt trotzdem bestehen —
+> er greift für von Hand gepushte Tags.
+
+### 3. Build + Staging
+
+`docker-publish.yml` baut Multi-Arch (amd64 + arm64), pusht nach GHCR, scannt
+mit Trivy und hängt die Deployment-Assets ans Release. Danach steht `staging`
+auf dem neuen Digest, und der Staging-Host zieht beim nächsten Lauf.
+
+### 4. Production-Freigabe
+
+Manuell: **Actions → Promote to Production → Run workflow**, Version eintragen
+(`v2.5.6`). Der Job hängt am GitHub-Environment `Production` und wartet auf die
+Freigabe der dort hinterlegten Reviewer.
+
+Der Workflow prüft, dass der Versions-Tag existiert, warnt wenn `staging` auf
+etwas anderes zeigt (Rollback bleibt trotzdem möglich), hängt die
+Production-Tags um und verifiziert danach, dass `production` wirklich auf dem
+erwarteten Digest steht.
+
+---
+
+## Host-Setup (pull-basiert)
+
+Beide Hosts holen sich das Image selbst ab. GitHub Actions braucht **keinen**
+Zugriff auf die Server, es bewegt nur Tags in der Registry — keine SSH-Keys als
+Repo-Secrets, keine offenen Ports für CI.
+
+Beide Stacks nutzen dieselbe `docker-compose.production.yml`. Der Unterschied
+liegt allein in `.env`.
+
+### Staging (hawking)
+
+```bash
+# /opt/ostsee-staging/.env
+IMAGE_TAG=staging
+COMPOSE_PROJECT_NAME=ostsee-staging
+ORIGIN=https://staging.ostsee-tiere.example.com
+```
+
+Update-Lauf, z. B. als systemd-Timer alle 5 Minuten:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/ostsee-staging
+docker compose pull --quiet
+docker compose up -d
+docker image prune -f --filter "until=168h"
+```
+
+### Production (Hetzner)
+
+```bash
+# /opt/ostsee-tiere/.env
+IMAGE_TAG=production
+COMPOSE_PROJECT_NAME=ostsee-tiere
+ORIGIN=https://ostsee-tiere.example.com
+```
+
+Auf Production **vor** dem Update sichern — die Schema-Migrationen des neuen
+Release laufen beim Container-Start automatisch und sind nicht rückrollbar:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/ostsee-tiere
+
+# Image-ID des laufenden Containers. `.Image` ist am Container die ID des
+# Images, mit dem er gestartet wurde — NICHT .RepoDigests, das gibt es nur
+# am Image-Objekt und wäre hier leer.
+RUNNING=$(docker inspect --format '{{.Image}}' \
+  "$(docker compose ps -q app)" 2>/dev/null || echo none)
+
+docker compose pull --quiet
+PULLED=$(docker image inspect --format '{{.Id}}' \
+  ghcr.io/jansinger/ostsee-sichtung:production)
+
+if [ "$RUNNING" = "$PULLED" ]; then
+  exit 0
+fi
+
+# backup.sh wird beim Server-Setup angelegt, siehe
+# PRODUCTION_DEPLOYMENT.md Abschnitt 8 (Backup einrichten).
+/opt/ostsee-tiere/backup.sh
+docker compose up -d
+```
+
+Ein Timer alle 5 Minuten reicht; der ID-Vergleich macht die Läufe dazwischen zu
+No-ops. Wer den Moment lieber selbst bestimmt, lässt den Timer weg und ruft das
+Skript nach der Freigabe von Hand auf.
+
+---
+
+## Zwei Dinge, die getrennt sein müssen
+
+**Datenbanken.** Staging und Production brauchen jeweils eine eigene DB.
+Migrationen laufen beim Container-Start — bei geteilter DB migriert das
+Staging-Deploy die Produktion, und die Freigabe sichert nichts mehr ab.
+
+**Upload-Verzeichnisse.** Jeder Stack braucht sein eigenes `uploads/`-Volume.
+Medien liegen seit dem 28.07.2026 auf Platte statt in Vercel Blob; ein geteiltes
+Volume würde Staging-Testdaten in den Prod-Bestand schreiben.
+
+---
+
+## Rollback
+
+Da alle Versions-Tags unveränderlich sind, ist der Rückweg dieselbe Aktion mit
+einer älteren Version:
+
+**Actions → Promote to Production → Run workflow → `v2.5.5`**
+
+Der Workflow warnt, dass `staging` auf etwas Neueres zeigt, und macht trotzdem
+weiter. Der Prod-Host zieht beim nächsten Lauf zurück.
+
+**Grenze:** Das rollt den _Code_ zurück, nicht das _Schema_. Enthielt das
+fehlerhafte Release eine destruktive Migration, muss die DB aus dem Backup
+zurückgeholt werden, das `backup.sh` vor dem Update gezogen hat. Deshalb steht
+der Backup-Schritt im Prod-Skript vor `docker compose up -d`.
+
+---
+
+## Einmaliges Setup
+
+- [x] GitHub-Environment `Production` mit _Required reviewers_ — vorhanden
+      (Stand 29.07.2026: Reviewer `jansinger`). Referenziert der Workflow eine
+      nicht existierende Environment, legt GitHub sie beim ersten Lauf **ohne**
+      Schutzregeln an und die Promotion läuft still ohne Rückfrage durch.
+- [ ] `promote-production.yml` muss auf `main` liegen, sonst taucht
+      _Run workflow_ nicht in der Actions-UI auf (`workflow_dispatch` wird nur
+      vom Default-Branch gelesen)
+- [ ] Staging-Host: Stack unter `/opt/ostsee-staging` mit `IMAGE_TAG=staging`,
+      eigener DB und eigenem `uploads`-Volume
+- [ ] Prod-Host: `IMAGE_TAG` in der bestehenden `.env` auf `production` setzen
+      (bisheriger Default war `latest`)
+- [ ] Beide Hosts: `docker login ghcr.io` mit einem Read-Token, falls das
+      Package privat ist
+- [ ] Pull-Timer auf beiden Hosts einrichten
+
+---
+
+## Verwandte Dokumente
+
+| Dokument                                               | Inhalt                                   |
+| ------------------------------------------------------ | ---------------------------------------- |
+| [PRODUCTION_DEPLOYMENT.md](./PRODUCTION_DEPLOYMENT.md) | Server einrichten, Reverse Proxy, Backup |
+| [DOCKER_DEPLOYMENT.md](./DOCKER_DEPLOYMENT.md)         | Vollständige Docker-Referenz             |
+| [ENVIRONMENT.md](./ENVIRONMENT.md)                     | Umgebungsvariablen                       |
+| [DATABASE_MIGRATION.md](./DATABASE_MIGRATION.md)       | Schema-Migrationen                       |

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -202,6 +202,7 @@ der Backup-Schritt im Prod-Skript vor `docker compose up -d`.
 - [ ] Staging-Host: Stack unter `/opt/ostsee-staging` mit `IMAGE_TAG=staging`,
       eigener DB und eigenem `uploads`-Volume
 - [ ] Prod-Host: `IMAGE_TAG` in der bestehenden `.env` auf `production` setzen
+      (oder digest-genau per `APP_IMAGE=…@sha256:…`, das Vorrang hat)
       (bisheriger Default war `latest`)
 - [ ] Beide Hosts: `docker login ghcr.io` mit einem Read-Token, falls das
       Package privat ist


### PR DESCRIPTION
## Warum

Das Release-Image ging bisher **direkt nach Production**: `docker-publish.yml` setzte `latest` bereits beim Build, und `docker-compose.production.yml` defaultete auf `latest`. Ein Host, der zieht, übersprang das Staging damit vollständig — die Trennung existierte nur auf dem Papier.

Zweitens war der Docker-Build per `repository_dispatch` vom Release-Lauf abgekoppelt: schlug er fehl, blieb der Release-Please-Run grün und der Fehler nur im separaten Run sichtbar.

Hintergrund: Production zieht künftig auf Docker (hawking = Staging, Hetzner = Prod), pull-basiert. GitHub Actions braucht keinen Zugriff auf die Server, es bewegt nur Tags in GHCR.

## Was sich ändert

**Build-Zeit → nur `vX.Y.Z`, `X.Y.Z`, `staging`.** Die Production-Zeiger (`production`, `latest`, `X.Y`, `X`) bewegt ausschließlich der neue Workflow `promote-production.yml`. Der wartet am Environment `Production` auf Freigabe und hängt die **bereits gebaute** Manifest-Liste per `imagetools create` um — kein Rebuild, Prod läuft bitgleich mit dem, was auf Staging getestet wurde. Rollback ist derselbe Workflow mit einer älteren Version.

**`docker-publish.yml` wird per `workflow_call` eingebunden** statt per `repository_dispatch` und hängt damit in der `needs`-Kette des Release-Laufs. `workflow_dispatch` und `push: tags` bleiben erhalten, damit ein bestehender Tag ohne neues Release neu gebaut werden kann.

**`release` wird per `merge --ff-only` aktualisiert** statt per Force-Push — ein Direkt-Commit auf dem Branch lässt den Job jetzt laut fehlschlagen, statt still überschrieben zu werden.

## Worauf beim Review achten

**Die Version-Ermittlung in `prepare` musste umgebaut werden.** Bei `workflow_call` ist `github.event_name` das Event des *Aufrufers* — also `push`, wenn release-please durch einen main-Push lief. Die alte Verzweigung wäre still in den Tag-Zweig gelaufen und hätte `main` statt `v2.5.6` als Version gebaut. Unterschieden wird jetzt über `inputs.version`, das nur bei `workflow_call` gesetzt ist.

**Die Permissions stehen am aufrufenden Job**, nicht Top-Level. Ein aufgerufener Workflow bekommt nie mehr Rechte als der Aufrufer; ohne `packages: write` / `security-events: write` bräche der GHCR-Push bzw. der Trivy-Upload erst mitten im Build ab. Am Job statt Top-Level, damit der `release-please`-Job selbst kein GHCR-Schreibrecht bekommt.

## Dokumentation

`docs/RELEASE_PIPELINE.md` ist neu (Tag-Semantik, Host-Setup, Rollback, Setup-Checkliste).

Der CI/CD-Abschnitt in `DOCKER_DEPLOYMENT.md` beschrieb einen **Retry-Mechanismus mit 3 Versuchen und Backoff, den es nie gab**, einen `main`-Tag, der nie existierte, und verlinkte auf das nicht existierende `docker-release.yml`. Ersetzt durch die reale Kette. Produktionsbezogene Beispiele (Quick Start, systemd, AWS ECS, Cloud Run, Azure, Trivy) von `:latest` auf `:production` gezogen; die `run-release.sh`-Beispielausgabe und das lokal gebaute `ostsee-tiere:latest` blieben korrekterweise stehen.

Der Backup-Schritt steht in beiden Update-Anleitungen jetzt **vor** dem Pull — Migrationen laufen beim Container-Start und sind nicht rückrollbar.

## Verifikation

- Version-Ermittlung für alle vier Trigger-Zweige lokal durchgespielt (`workflow_call`, `workflow_dispatch`, Tag-Push, Dispatch ohne Tag → sauberer Abbruch)
- Digest-Vergleich im Host-Skript gegen einen laufenden Container geprüft: `.Image` am Container und `.Id` am Image liefern denselben SHA. Die erste Fassung nutzte `.RepoDigests` am Container — das Feld existiert dort nicht (`map has no entry for key`) und wäre mit `|| echo none` still zu `none` geworden: **jeder Timer-Lauf hätte Backup + Neustart auf Prod ausgelöst.**
- `docker compose config` rendert `image: ghcr.io/jansinger/ostsee-sichtung:production`
- YAML aller Workflows geparst, Prettier grün
- Environment `Production` existiert bereits mit `required_reviewers` (verifiziert via API); Namen sind case-insensitiv

**Kein Test:** reine CI-Konfiguration und Dokumentation.

## Nach dem Merge

`promote-production.yml` muss auf `main` liegen, bevor *Run workflow* in der Actions-UI erscheint. Dieser PR ist bewusst `fix(...)` und nicht `ci(...)`, damit release-please einen Release-PR öffnet und die Kette einmal komplett durchlaufen kann, bevor der Stand auf Prod geht.

Offen auf Betriebsseite: Staging-Stack auf hawking (eigene DB, eigenes `uploads`-Volume), `IMAGE_TAG` auf dem Prod-Host von `latest` auf `production`, Pull-Timer auf beiden Hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)