### PR TITLE
feat(ui): field mode for the sighting form (PR 3/4)

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -143,15 +143,16 @@ Anders als bei `warning` und `secondary` — wo der Wechsel von Weiß auf `base-
 
 ## Deckkraft-Untergrenze für Text ist /60
 
-`base-content` mit Deckkraft, gemessen:
+`base-content` mit Deckkraft, im Browser gemessen (nicht aus den oklch-Werten
+gerechnet — die Differenz beträgt hier bis zu 0,08):
 
 | Stufe | base-100    | base-200    | base-300    |
 | ----- | ----------- | ----------- | ----------- |
-| /80   | 9,87 ✅     | 8,69 ✅     | 7,56 ✅     |
-| /70   | 6,96 ✅     | 6,35 ✅     | 5,72 ✅     |
-| /60   | 4,92 ✅     | 4,61 ✅     | **4,27 ❌** |
-| /50   | **3,55 ❌** | **3,39 ❌** | **3,22 ❌** |
-| /40   | **2,63 ❌** | **2,55 ❌** | **2,46 ❌** |
+| /80   | 9,82 ✅     | 8,62 ✅     | 7,46 ✅     |
+| /70   | 7,04 ✅     | 6,41 ✅     | 5,74 ✅     |
+| /60   | 4,94 ✅     | 4,62 ✅     | **4,26 ❌** |
+| /50   | **3,54 ❌** | **3,39 ❌** | **3,23 ❌** |
+| /40   | **2,64 ❌** | **2,56 ❌** | **2,46 ❌** |
 
 **Regel:** `/60` ist die Untergrenze für Text, und nur auf `base-100` und `base-200`. `/40` und `/50` (bzw. `opacity-40`/`opacity-50`) sind ausschließlich für dekorative Flächen — nie für Zeichen, die gelesen werden müssen.
 
@@ -239,6 +240,37 @@ Der Alert-Text steht in `base-content`, nicht in der Statusfarbe (WCAG 1.4.3, Me
 - Destruktive Aktionen (Löschen, Zurücksetzen) einheitlich in **einer** Variante über das ganze Formular — im Sichtungsformular `btn btn-outline btn-error btn-sm`. Nicht an einer Stelle `btn-warning`, an anderer `btn-ghost text-error`. Destruktives immer mit Bestätigung. (Das früher nötige `min-h-11` entfällt: die 44px kommen seit der Touch-Target-Regel aus `app.css`, siehe „Feldmodus und Touch-Targets".)
 - Gleiche Aktion = gleiche Variante = gleiches Icon, egal in welcher Komponente sie auftaucht.
 - Ein Button, der nichts bewirkt, gehört entfernt — nicht dekorativ stehen gelassen.
+
+---
+
+## Gesperrte Schaltflächen tragen `aria-disabled`, nicht `disabled`
+
+Eine Schaltfläche, die gerade nicht ausgeführt werden darf, wird über
+`aria-disabled="true"` gesperrt und bleibt fokussierbar. `disabled` nimmt sie aus
+der Tab-Reihenfolge, und der Browser verwirft dabei den Fokus — wer per Tastatur
+arbeitet, verliert seine Position, und zwar ausgerechnet während einer laufenden
+Aktion. Die eigentliche Sperre übernimmt ein Wächter in der Handler-Funktion.
+
+Begründet und angewendet in `PositionPanel.svelte` („Mein aktueller Standort"
+während der Ortung), `FormSteps.svelte` und `StepProgressCompact.svelte` (noch
+nicht erreichbare Schritte). Nebeneffekt, der das Muster zusätzlich trägt: der
+`title` mit der Begründung („Bitte füllen Sie zuerst die vorherigen Schritte
+aus") ist an einem `disabled`-Element per Tastatur nicht erreichbar.
+
+**Konsequenz für Tests — leicht zu übersehen:** Playwright wertet
+`aria-disabled="true"` selbst als „nicht bedienbar" und klickt gar nicht erst.
+Ein Test, der die Sperre prüfen will, läuft ohne `force: true` in einen Timeout
+und bestätigt am Ende nur Playwrights eigene Actionability-Prüfung — die Sperre
+der Anwendung wird dabei nie erreicht.
+
+```ts
+await expect(letzter).toHaveAttribute('aria-disabled', 'true');
+await letzter.click({ force: true }); // ohne force: Timeout, App-Sperre ungeprüft
+await expect(ersterSchritt).toHaveAttribute('aria-current', 'step');
+```
+
+Beispiel: `e2e/form-field-mode.spec.ts` → „Vorwärts bleibt gesperrt, solange der
+Schritt unvollständig ist".
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,8 @@ jobs:
                 e2e/form-a11y.spec.ts \
                 e2e/form-position.spec.ts \
                 e2e/form-position-photo.spec.ts \
-                e2e/form-autosave.spec.ts
+                e2e/form-autosave.spec.ts \
+                e2e/form-field-mode.spec.ts
               ;;
             map)
               npm run test:e2e -- e2e/map-*.spec.ts

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -70,7 +70,14 @@ nachzumessen, dokumentiert eine Vermutung.
 bessere Wahl, `base-content` misst 4,22 bzw. 4,31. Die Lightness von
 `--status-info-surface` und `--status-success-surface` darf deshalb nie erhöht
 werden (Regel in `.claude/rules/design-system.md`). Auf `base-200` ist
-`text-info-strong` mit 4,53 der knappste Vordergrundwert.
+`text-accent-strong` mit 4,57 der knappste Vordergrundwert.
+
+`text-info-strong` lag dort ursprünglich bei 4,53 und ist mit PR 3 auf
+`oklch(0.46 …)` gesenkt worden (4,66). Grund war nicht der Wert selbst, sondern
+seine Empfindlichkeit: die 8-Bit-Quantisierung nach sRGB kostete diesen Farbton
+bei `L = 0.465` **0,043** Kontrast, die vier Nachbarn nur 0,005–0,012. Wer einen
+`-strong`-Wert ändert, misst deshalb den quantisierten Wert nach, nicht den
+gerechneten — Begründung steht an der Zeile in `src/css/tokens.css`.
 
 **Regel:** `text-`, `fill-`, `stroke-` → immer `-strong`. `bg-`, `btn-`,
 `badge-`, `alert-` → nie `-strong`.
@@ -188,6 +195,35 @@ Ziel trägt das Label", inklusive Umschalter auf den Feldmodus.
 `min-h-11` an der Aufrufstelle ist damit überflüssig und `btn-xs` nicht mehr
 gefährlich. Ausnahme über `.target-exempt` — nur für Ziele, die nachweislich
 nicht mit dem Finger bedient werden.
+
+### Feldmodus aktivieren
+
+Der Modus hängt an genau einem Attribut am `<html>`-Element. Es gibt drei Wege
+dorthin, je nachdem, wie lange er halten soll:
+
+| Zweck                        | Weg                                                                    | Reichweite                  |
+| ---------------------------- | ---------------------------------------------------------------------- | --------------------------- |
+| Dauerhaft für ein Deployment | in `src/app.html` `data-density="field"` an das `<html>` hängen        | die ganze Auslieferung      |
+| Kurz ansehen oder nachmessen | `/styleguide` → Umschalter „Feldmodus"                                 | solange die Seite offen ist |
+| Einmalig prüfen, ohne Neubau | DevTools-Konsole: `document.documentElement.dataset.density = 'field'` | bis zum nächsten Laden      |
+
+Der Normalzustand ist die **Abwesenheit** des Attributs — es gibt bewusst
+keinen Selektor für `comfortable`. Wer `[data-density='comfortable']` stylt,
+bricht damit zwei Dinge auf einmal: den „Attribut weg = Normalfall"-Vertrag und
+den Hydrations-Check in `e2e/design-tokens.spec.ts`, der die Anwesenheit des
+Attributs als Signal benutzt (dort kommentiert).
+
+Was der Modus ändert, steht vollständig in `src/css/tokens.css` unter
+`[data-density='field']`: `--target-min` 44 → 56px, `--target-gap` 16 → 24px,
+`--text-support` 13 → 14px. Keine Komponente fragt den Modus ab. Eine
+Komponente, die ihn abfragen müsste, ist ein Hinweis darauf, dass ihr ein Token
+fehlt — nicht darauf, dass sie eine Fallunterscheidung braucht.
+
+**Keine Bedienung in der App.** Es gibt absichtlich keinen Umschalter im
+Formular: Der Modus ist eine Betriebsentscheidung für ein Gerät („dieses Tablet
+liegt an Deck"), keine Nutzerpräferenz pro Sitzung. Ein Schalter im Formular
+wäre ein weiteres Bedienelement in genau dem Bildschirmbereich, den der Modus
+freiräumen soll.
 
 ---
 

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -48,8 +48,8 @@ die als Fläche funktioniert, funktioniert als Vordergrund nicht.
 
 | Farbe       | Fläche (`bg-*`) | weiß darauf | Vordergrund (`text-*-strong`) | auf base-100 | auf base-200 |
 | ----------- | --------------- | ----------- | ----------------------------- | ------------ | ------------ |
-| `primary`   | `#004062`       | 11,00 ✅    | `text-primary` genügt         | 9,22 ✅      | 7,66 ✅      |
-| `info`      | `#007daa`       | 4,65 ✅     | `#00648f`                     | 5,48 ✅      | 4,53 ✅      |
+| `primary`   | `#004062`       | 11,00 ✅    | `text-primary` genügt         | 9,24 ✅      | 7,65 ✅      |
+| `info`      | `#007daa`       | 4,65 ✅     | `#00628d`                     | 5,63 ✅      | 4,66 ✅      |
 | `success`   | `#1c882d`       | 4,56 ✅     | `#006d09`                     | 5,53 ✅      | 4,57 ✅      |
 | `warning`   | `#bb8500`       | 3,26 ❌ †   | `#865100`                     | 5,53 ✅      | 4,58 ✅      |
 | `error`     | `#ac1922`       | 7,20 ✅     | `text-error` genügt           | 6,05 ✅      | 5,01 ✅      |
@@ -90,12 +90,12 @@ gehören nur auf `base-100` und `base-200` — dieselbe Regel, die für
 
 | Token         | Stufe | base-100 | base-200 | base-300 | Verwendung                      |
 | ------------- | ----- | -------- | -------- | -------- | ------------------------------- |
-| `--fg-strong` | 100 % | 16,53 ✅ | 13,72 ✅ | 11,3 ✅  | Fließtext                       |
-| `--fg-muted`  | 70 %  | 6,96 ✅  | 6,35 ✅  | 5,72 ✅  | Sekundärtext, Hilfetext         |
-| `--fg-subtle` | 60 %  | 4,94 ✅  | 4,62 ✅  | 4,27 ❌  | Untergrenze, nicht auf base-300 |
+| `--fg-strong` | 100 % | 16,50 ✅ | 13,66 ✅ | 11,26 ✅ | Fließtext                       |
+| `--fg-muted`  | 70 %  | 7,04 ✅  | 6,41 ✅  | 5,74 ✅  | Sekundärtext, Hilfetext         |
+| `--fg-subtle` | 60 %  | 4,94 ✅  | 4,62 ✅  | 4,26 ❌  | Untergrenze, nicht auf base-300 |
 
-`/50` (3,39) und `/40` (2,55) sind **dekorativ**. Nie für Zeichen, die gelesen
-werden müssen.
+`/50` (3,54 / 3,39 / 3,23) und `/40` (2,64 / 2,56 / 2,46) sind **dekorativ**.
+Nie für Zeichen, die gelesen werden müssen.
 
 ---
 

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -149,7 +149,17 @@ test.describe('Styleguide — Bedienung', () => {
 	   der Hydration tut nichts, weil `onclick` dann noch nicht am Element
 	   hängt. `networkidle` plus ein hydrationsabhängiges Element ist dasselbe
 	   Muster wie in `FormPage.goto()`; hier dient `data-density` als Signal:
-	   das Attribut entsteht erst durch den `$effect` der Seite. */
+	   das Attribut entsteht erst durch den `$effect` der Seite.
+
+	   Damit trägt `data-density` hier zwei Bedeutungen gleichzeitig: den
+	   Dichte-Zustand und — über seine bloße Anwesenheit — das Hydrations-Signal.
+	   Solange `tokens.css` nur `[data-density='field']` kennt, ist das
+	   folgenlos, weil „comfortable" ein reiner Marker ohne Wirkung ist. Sobald
+	   jemand `[data-density='comfortable']` stylt oder das Attribut in
+	   `app.html` vorbelegt, koppelt dieser `beforeEach` an etwas, das er nie
+	   prüfen wollte: er wartet dann auf einen Zustand, den schon das SSR-HTML
+	   mitbringt, und klickt wieder gegen einen toten Button. In dem Fall
+	   braucht die Hydration ein eigenes Signal — nicht dieses Attribut. */
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/styleguide');
 		await page.waitForLoadState('networkidle');

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -18,7 +18,7 @@ test.describe('FormSteps — Step-Indikator', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		const activeStep = page.locator('[aria-current="step"]');
+		const activeStep = page.locator('[aria-current="step"]:visible');
 		await expect(activeStep).toBeVisible();
 		await expect(activeStep).toHaveAttribute('aria-label', /Position & Zeit/i);
 	});
@@ -129,8 +129,13 @@ test.describe('Accessibility — Keyboard Navigation', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		// Navigation should have aria-label
-		const nav = page.locator('nav[aria-label="Formular-Schritte"]');
+		/* Navigation should have aria-label.
+		   `:visible` ist hier nicht Kosmetik: Seit PR 3 gibt es ZWEI Navigationen
+		   mit diesem Label — den ausgeschriebenen Stepper ab `md` und den
+		   kompakten im ortsfesten Balken darunter. CSS blendet immer genau eine
+		   aus, Screenreader-Nutzende treffen also nie beide. Ohne den Filter
+		   wäre das ein Strict-Mode-Verstoß und kein echter Befund. */
+		const nav = page.locator('nav[aria-label="Formular-Schritte"]:visible');
 		await expect(nav).toBeVisible();
 
 		// Buttons should have aria-labels

--- a/e2e/form-autosave.spec.ts
+++ b/e2e/form-autosave.spec.ts
@@ -20,7 +20,7 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		// Reload page
 		await page.reload();
 		await page.waitForLoadState('networkidle');
-		await page.locator('[aria-current="step"]').waitFor({ state: 'visible' });
+		await page.locator('[aria-current="step"]:visible').waitFor({ state: 'visible' });
 
 		// Step 2 should be restored
 		await expectCurrentStep(page, /Sichtungsdetails/i);
@@ -40,7 +40,7 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		// Reload
 		await page.reload();
 		await page.waitForLoadState('networkidle');
-		await page.locator('[aria-current="step"]').waitFor({ state: 'visible' });
+		await page.locator('[aria-current="step"]:visible').waitFor({ state: 'visible' });
 
 		// Date should still be filled
 		const dateInput = page.locator('[data-testid="field-sightingDate"]');
@@ -95,7 +95,7 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		// Reload to verify storage was cleared
 		await page.reload();
 		await page.waitForLoadState('networkidle');
-		await page.locator('[aria-current="step"]').waitFor({ state: 'visible' });
+		await page.locator('[aria-current="step"]:visible').waitFor({ state: 'visible' });
 
 		// Should start fresh on Step 1 with no restore toast
 		await expectCurrentStep(page, /Position & Zeit/i);

--- a/e2e/form-field-mode.spec.ts
+++ b/e2e/form-field-mode.spec.ts
@@ -59,27 +59,75 @@ test.describe('Feldmodus — ortsfeste Schritt-Navigation', () => {
 		expect(geometrie.zIndex).toBe('30'); // --layer-nav
 	});
 
-	/* Der Grund, warum `.form-step-nav` am Wrapper hängt und nicht am <nav>:
-	   ein Alert außerhalb des stickyen Elements scrollt weg, während der Balken
-	   stehen bleibt — die Begründung für ein nicht reagierendes „Weiter" wäre
-	   dann genau im falschen Moment aus dem Bild. */
-	test('Der Inline-Alert wandert mit dem Balken mit', async ({ page }) => {
+	/* Der Alert steht bewusst NICHT im stickyen Container.
+
+	   Erst dort hineingenommen (dann wandert er mit), dann wieder heraus: bei
+	   fünf gleichzeitig verletzten Regeln in Schritt 1 machte die <ul> den
+	   Balken 390px hoch — 46 % eines 844px-Bildschirms, dauerhaft. Was im
+	   Balken bleiben muss, ist die Zahl und ein Weg zurück zum Feld. */
+	test('Der volle Alert steht im Fluss, nicht im Balken', async ({ page }) => {
 		await gotoStep(page, 0);
 		await page.getByRole('button', { name: 'Nächster Schritt' }).click();
 
-		const alert = page.locator('.form-step-nav .alert[role="alert"]');
-		await expect(alert).toBeVisible();
+		const alert = page.locator('.alert[role="alert"]').filter({ hasText: /Fahrwasser|Position/i });
+		await expect(alert.first()).toBeVisible();
+		expect(
+			await page.locator('.form-step-nav .alert[role="alert"]').count(),
+			'Der Alert gehört nicht in den ortsfesten Balken'
+		).toBe(0);
+	});
 
-		// Mitten im Dokument stehen bleiben — der Alert muss im Bild bleiben
-		await page.evaluate(() => window.scrollTo(0, 300));
+	test('Der Balken zeigt die Fehlerzahl und springt zum ersten Feld', async ({ page }) => {
+		await gotoStep(page, 0);
+		await page.getByRole('button', { name: 'Nächster Schritt' }).click();
+
+		const sprung = page.locator('.form-step-nav').getByRole('button', { name: /fehlerhaften/i });
+		await expect(sprung).toBeVisible();
+		await expect(sprung).toContainText(/\d+ Fehler/);
+
+		await sprung.click();
+		/* scrollToFirstError bringt das erste Feld der fieldOrder ins Bild —
+		   geprüft wird die Wirkung, nicht der Aufruf. */
 		await expect
 			.poll(() =>
-				alert.evaluate((el) => {
-					const r = el.getBoundingClientRect();
-					return r.top >= 0 && r.bottom <= window.innerHeight;
+				page.evaluate(() => {
+					const feld = document.querySelector('[data-field="waterway"], [data-testid="field-waterway"]');
+					if (!feld) return null;
+					const r = feld.getBoundingClientRect();
+					return r.top >= 0 && r.top <= window.innerHeight;
 				})
 			)
 			.toBe(true);
+	});
+
+	/* Der eigentliche Regressionsschutz für die Höhe: Der Balken darf auch im
+	   schlimmsten Fehlerfall nicht wieder zum halben Bildschirm werden. */
+	test('Der Balken bleibt auch bei fünf Fehlern kompakt', async ({ page }) => {
+		await page.addInitScript(() => {
+			sessionStorage.setItem('sichtungen_current_step', '0');
+			sessionStorage.setItem(
+				'sichtungen_form_data',
+				JSON.stringify({
+					hasPosition: true,
+					latitude: 10,
+					longitude: 0,
+					waterway: 'x'.repeat(300),
+					sightingDate: '2099-01-01',
+					sightingTime: ''
+				})
+			);
+		});
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+		await page.getByRole('button', { name: 'Nächster Schritt' }).click();
+		await expect(
+			page.locator('.form-step-nav').getByRole('button', { name: /fehlerhaften/i })
+		).toBeVisible();
+
+		const hoehe = await page
+			.locator('.form-step-nav')
+			.evaluate((el) => el.getBoundingClientRect().height);
+		expect(hoehe, 'Der Balken frisst wieder den halben Bildschirm').toBeLessThanOrEqual(130);
 	});
 
 	test('Am Dokumentende verdeckt der Balken keinen Inhalt', async ({ page }) => {
@@ -101,8 +149,8 @@ test.describe('Feldmodus — ortsfeste Schritt-Navigation', () => {
 		const padding = await page.evaluate(
 			() => getComputedStyle(document.documentElement).scrollPaddingBottom
 		);
-		// 8.5rem = 136px, mindestens die gemessene Balkenhöhe von 132px
-		expect(parseFloat(padding)).toBeGreaterThanOrEqual(132);
+		// 7.5rem = 120px — die gemessene Balkenhöhe im Normalfall
+		expect(parseFloat(padding)).toBeGreaterThanOrEqual(120);
 	});
 });
 

--- a/e2e/form-field-mode.spec.ts
+++ b/e2e/form-field-mode.spec.ts
@@ -1,0 +1,241 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * form-field-mode.spec.ts — Feldmodus und Breakpoint-Vertrag des Formulars
+ *
+ * Warum im Browser und nicht als Unit-Test: Alle drei Zusagen dieses PRs sind
+ * Layout-Zusagen, die erst eine Engine einlöst — `position: sticky` gegen den
+ * Viewport, `md:hidden` gegen eine Media Query, `--text-support` gegen die
+ * Kaskade aus @theme und [data-density]. Über die CSS-Quelle wäre keine davon
+ * prüfbar; über einen Snapshot wären sie prüfbar, aber nicht lesbar.
+ *
+ * Die Breite ist deshalb hier kein Detail, sondern der Testfall: 390px steht
+ * für das Telefon an Deck, 800px für das Tablet. Der Vertrag aus
+ * design-system.md sagt, dass `md` (768px) die Grenze ist — 800 liegt knapp
+ * darüber und würde eine versehentlich stehengebliebene `sm:`-Umschaltung
+ * (640px) nicht von einer korrekten `md:` unterscheiden. Dafür gibt es den
+ * dritten Fall bei 700px: dort MUSS noch das kompakte Layout stehen.
+ */
+
+const PHONE = { width: 390, height: 844 };
+const BETWEEN = { width: 700, height: 844 }; // zwischen sm (640) und md (768)
+const TABLET = { width: 800, height: 844 };
+
+/** Setzt den Schritt vor dem ersten Rendern — CURRENT_STEP liegt im sessionStorage. */
+async function gotoStep(page: Page, step: number): Promise<void> {
+	await page.addInitScript((s) => {
+		sessionStorage.setItem('sichtungen_current_step', String(s));
+	}, step);
+	await page.goto('/');
+	await page.waitForLoadState('networkidle');
+}
+
+const compactStepper = (page: Page) =>
+	page.locator('.form-step-nav nav[aria-label="Formular-Schritte"]');
+const fullStepper = (page: Page) =>
+	page
+		.locator('nav[aria-label="Formular-Schritte"]')
+		.filter({ hasNot: page.locator('ol li span') });
+
+test.describe('Feldmodus — ortsfeste Schritt-Navigation', () => {
+	test.use({ viewport: PHONE });
+
+	test('Der Balken steht unten, ohne dass man scrollen muss', async ({ page }) => {
+		await gotoStep(page, 0);
+		const bar = page.locator('.form-step-nav');
+
+		const geometrie = await bar.evaluate((el) => ({
+			position: getComputedStyle(el).position,
+			unten: Math.round(el.getBoundingClientRect().bottom),
+			viewport: window.innerHeight,
+			// Der Balken muss ÜBER dem Karteninhalt liegen, nicht darunter
+			zIndex: getComputedStyle(el).zIndex
+		}));
+
+		expect(geometrie.position).toBe('sticky');
+		expect(geometrie.unten).toBe(geometrie.viewport);
+		expect(geometrie.zIndex).toBe('30'); // --layer-nav
+	});
+
+	/* Der Grund, warum `.form-step-nav` am Wrapper hängt und nicht am <nav>:
+	   ein Alert außerhalb des stickyen Elements scrollt weg, während der Balken
+	   stehen bleibt — die Begründung für ein nicht reagierendes „Weiter" wäre
+	   dann genau im falschen Moment aus dem Bild. */
+	test('Der Inline-Alert wandert mit dem Balken mit', async ({ page }) => {
+		await gotoStep(page, 0);
+		await page.getByRole('button', { name: 'Nächster Schritt' }).click();
+
+		const alert = page.locator('.form-step-nav .alert[role="alert"]');
+		await expect(alert).toBeVisible();
+
+		// Mitten im Dokument stehen bleiben — der Alert muss im Bild bleiben
+		await page.evaluate(() => window.scrollTo(0, 300));
+		await expect
+			.poll(() =>
+				alert.evaluate((el) => {
+					const r = el.getBoundingClientRect();
+					return r.top >= 0 && r.bottom <= window.innerHeight;
+				})
+			)
+			.toBe(true);
+	});
+
+	test('Am Dokumentende verdeckt der Balken keinen Inhalt', async ({ page }) => {
+		await gotoStep(page, 0);
+		await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+		const ueberlappung = await page.evaluate(() => {
+			const bar = document.querySelector('.form-step-nav');
+			const davor = bar?.previousElementSibling;
+			if (!bar || !davor) return null;
+			return davor.getBoundingClientRect().bottom - bar.getBoundingClientRect().top;
+		});
+
+		expect(ueberlappung, 'Der Balken überlappt am Ende das Element darüber').toBeLessThanOrEqual(0);
+	});
+
+	test('scroll-padding hält Felder aus dem Balken heraus', async ({ page }) => {
+		await gotoStep(page, 0);
+		const padding = await page.evaluate(
+			() => getComputedStyle(document.documentElement).scrollPaddingBottom
+		);
+		// 8.5rem = 136px, mindestens die gemessene Balkenhöhe von 132px
+		expect(parseFloat(padding)).toBeGreaterThanOrEqual(132);
+	});
+});
+
+test.describe('Kompakter Schritt-Stepper', () => {
+	test.use({ viewport: PHONE });
+
+	test('aria-current="step" steht genau einmal, am aktuellen Schritt', async ({ page }) => {
+		await gotoStep(page, 2);
+		const buttons = compactStepper(page).getByRole('button');
+
+		await expect(buttons).toHaveCount(4);
+		await expect(buttons.nth(2)).toHaveAttribute('aria-current', 'step');
+		for (const index of [0, 1, 3]) {
+			await expect(buttons.nth(index)).not.toHaveAttribute('aria-current', 'step');
+		}
+	});
+
+	test('Klick-Navigation bleibt erhalten — zurück ist immer erlaubt', async ({ page }) => {
+		await gotoStep(page, 2);
+		await compactStepper(page).getByRole('button').first().click();
+
+		await expect(compactStepper(page).getByRole('button').first()).toHaveAttribute(
+			'aria-current',
+			'step'
+		);
+		await expect(page.getByRole('heading', { name: 'Position & Zeit' })).toBeVisible();
+	});
+
+	test('Vorwärts bleibt gesperrt, solange der Schritt unvollständig ist', async ({ page }) => {
+		await gotoStep(page, 0);
+		const letzter = compactStepper(page).getByRole('button').last();
+
+		await expect(letzter).toHaveAttribute('aria-disabled', 'true');
+		/* `force`, weil Playwright `aria-disabled="true"` selbst als „nicht
+		   bedienbar" wertet und gar nicht erst klickt. Ohne das Flag würde der
+		   Test die Sperre der Anwendung nie erreichen und nur Playwrights
+		   eigene Actionability-Prüfung bestätigen. Das Element ist bewusst
+		   nicht `disabled`: ein deaktivierter Button ist nicht fokussierbar und
+		   sein `title` („Bitte füllen Sie zuerst …") wäre per Tastatur nicht
+		   erreichbar — dasselbe Muster wie im ausgeschriebenen Stepper. */
+		await letzter.click({ force: true });
+		await expect(compactStepper(page).getByRole('button').first()).toHaveAttribute(
+			'aria-current',
+			'step'
+		);
+	});
+
+	test('Jedes Segment ist ein 44-px-Ziel — im Feldmodus 56', async ({ page }) => {
+		await gotoStep(page, 0);
+		const erstes = compactStepper(page).getByRole('button').first();
+		expect((await erstes.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+
+		await page.evaluate(() => (document.documentElement.dataset.density = 'field'));
+		await expect.poll(async () => (await erstes.boundingBox())?.height).toBeGreaterThanOrEqual(56);
+	});
+});
+
+test.describe('Breakpoint-Vertrag — md, nicht sm', () => {
+	test('bei 700px gilt noch das kompakte Layout', async ({ page }) => {
+		await page.setViewportSize(BETWEEN);
+		await gotoStep(page, 0);
+
+		await expect(compactStepper(page)).toBeVisible();
+		await expect(page.locator('.form-step-nav')).toHaveCSS('position', 'sticky');
+	});
+
+	test('bei 800px übernimmt der ausgeschriebene Stepper', async ({ page }) => {
+		await page.setViewportSize(TABLET);
+		await gotoStep(page, 0);
+
+		await expect(compactStepper(page)).toBeHidden();
+		await expect(fullStepper(page)).toBeVisible();
+		await expect(page.locator('.form-step-nav')).toHaveCSS('position', 'static');
+	});
+
+	/* Der eigentliche Regressionsschutz: Eine zurückgebliebene `sm:`-Umschaltung
+	   fiele bei 390 und 800 nicht auf, weil beide Breiten auf derselben Seite
+	   der 640px-Grenze liegen wie der md-Vertrag es vorsieht. Sichtbar wird sie
+	   nur dazwischen. Geprüft am Datum/Uhrzeit-Raster, das früher bei `sm`
+	   zweispaltig wurde. */
+	test('kein Formular-Element schaltet zwischen 640 und 768px um', async ({ page }) => {
+		await gotoStep(page, 0);
+
+		const messen = async (width: number) => {
+			await page.setViewportSize({ width, height: 844 });
+			await page.waitForTimeout(150);
+			return page.evaluate(() =>
+				[...document.querySelectorAll('#form-content [class*="grid-cols"]')].map(
+					(el) => getComputedStyle(el).gridTemplateColumns.split(' ').length
+				)
+			);
+		};
+
+		expect(await messen(639), 'Spaltenzahl kippt zwischen 639px und 767px').toEqual(
+			await messen(767)
+		);
+	});
+});
+
+test.describe('Hilfetexte im Feld', () => {
+	test.use({ viewport: PHONE });
+
+	/* 13px statt 12px, /70 statt /60 — beides steht in design-system.md
+	   („Sekundärtext gehört auf /70, nicht auf /60") und ist genau der Text,
+	   der bei Sonnenlicht an Deck als erstes unlesbar wird. */
+	test('Hilfetext ist text-support und wächst im Feldmodus auf 14px', async ({ page }) => {
+		await gotoStep(page, 0);
+		const hilfetext = page.locator('#form-content [id$="-help"]').first();
+		await expect(hilfetext).toBeVisible();
+
+		const normal = await hilfetext.evaluate((el) =>
+			parseFloat(getComputedStyle(el.querySelector('span') ?? el).fontSize)
+		);
+		expect(normal).toBeCloseTo(13, 0);
+
+		await page.evaluate(() => (document.documentElement.dataset.density = 'field'));
+		await expect
+			.poll(() =>
+				hilfetext.evaluate((el) =>
+					parseFloat(getComputedStyle(el.querySelector('span') ?? el).fontSize)
+				)
+			)
+			.toBeCloseTo(14, 0);
+	});
+
+	test('kein Hilfetext unter Deckkraft /70', async ({ page }) => {
+		await gotoStep(page, 0);
+		const zuBlass = await page.evaluate(() => {
+			const cls = (el: Element) => el.getAttribute('class') ?? '';
+			const verboten = /(^|\s)text-base-content\/(40|50|60)(\s|$)/;
+			return [...document.querySelectorAll('#form-content [class]')]
+				.filter((el) => verboten.test(cls(el)) && (el.textContent ?? '').trim().length > 0)
+				.map((el) => `${el.tagName.toLowerCase()}.${cls(el)}`)
+				.slice(0, 10);
+		});
+		expect(zuBlass, 'Hilfetext gehört auf /70 (design-system.md)').toEqual([]);
+	});
+});

--- a/e2e/form-field-mode.spec.ts
+++ b/e2e/form-field-mode.spec.ts
@@ -32,10 +32,12 @@ async function gotoStep(page: Page, step: number): Promise<void> {
 
 const compactStepper = (page: Page) =>
 	page.locator('.form-step-nav nav[aria-label="Formular-Schritte"]');
+/* Beide Stepper tragen dasselbe `aria-label` — sie sind dieselbe Navigation in
+   zwei Darstellungen, und wer die Seite bedient, trifft immer nur eine davon.
+   Auseinandergehalten werden sie deshalb an ihrer Umgebung: der kompakte liegt
+   im `.form-step-nav`-Balken, der ausgeschriebene bringt `.step-button` mit. */
 const fullStepper = (page: Page) =>
-	page
-		.locator('nav[aria-label="Formular-Schritte"]')
-		.filter({ hasNot: page.locator('ol li span') });
+	page.locator('nav[aria-label="Formular-Schritte"]').filter({ has: page.locator('.step-button') });
 
 test.describe('Feldmodus — ortsfeste Schritt-Navigation', () => {
 	test.use({ viewport: PHONE });

--- a/e2e/helpers/form-helpers.ts
+++ b/e2e/helpers/form-helpers.ts
@@ -44,7 +44,7 @@ export async function fillStep4(formPage: FormPage) {
 
 /** Wait for the active step indicator to show a specific step name */
 export async function expectCurrentStep(page: Page, pattern: RegExp) {
-	await expect(page.locator('[aria-current="step"]')).toHaveAttribute('aria-label', pattern, {
+	await expect(page.locator('[aria-current="step"]:visible')).toHaveAttribute('aria-label', pattern, {
 		timeout: 5000
 	});
 }

--- a/e2e/pages/FormPage.ts
+++ b/e2e/pages/FormPage.ts
@@ -8,10 +8,21 @@ import type { Page, Locator } from '@playwright/test';
  * elements by FieldRenderer.svelte (not on a wrapper div). Use `[data-testid="field-X"]`
  * directly to target the field.
  *
+ * Note on the active step: since PR 3 the step state stands TWICE in the DOM —
+ * the written out stepper (`FormSteps.svelte`, `md` and up) and the compact one
+ * in the fixed bar (`StepProgressCompact.svelte`, below `md`). Both carry
+ * `aria-current="step"`; CSS hides one of them, so assistive technology and the
+ * user only ever meet one. A bare `[aria-current="step"]` therefore matches two
+ * elements and trips Playwright's strict mode — every access goes through
+ * ACTIVE_STEP, which adds `:visible` and thus means "the active step at THIS
+ * viewport width".
+ *
  * Note on navigation: Step indicator buttons allow direct navigation.
  * Backward: always allowed. Forward: only if all intermediate steps are valid.
  * Steps with unmet validation are disabled. Primary navigation via clickNext() / clickPrevious().
  */
+const ACTIVE_STEP = '[aria-current="step"]:visible';
+
 export class FormPage {
 	constructor(private page: Page) {}
 
@@ -20,7 +31,7 @@ export class FormPage {
 		// Wait for Svelte to fully hydrate before interacting with form elements
 		await this.page.waitForLoadState('networkidle');
 		// Ensure the step indicator (Svelte component) is rendered and interactive
-		await this.page.locator('[aria-current="step"]').waitFor({ state: 'visible' });
+		await this.page.locator(ACTIVE_STEP).waitFor({ state: 'visible' });
 	}
 
 	// ── Step Navigation ──────────────────────────────────────────────────────
@@ -116,7 +127,7 @@ export class FormPage {
 	// ── Status Queries ────────────────────────────────────────────────────────
 
 	async getCurrentStep(): Promise<string> {
-		return (await this.page.locator('[aria-current="step"]').getAttribute('aria-label')) ?? '';
+		return (await this.page.locator(ACTIVE_STEP).getAttribute('aria-label')) ?? '';
 	}
 
 	async isNextDisabled(): Promise<boolean> {
@@ -137,6 +148,6 @@ export class FormPage {
 	}
 
 	getActiveStepButton(): Locator {
-		return this.page.locator('[aria-current="step"]');
+		return this.page.locator(ACTIVE_STEP);
 	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -444,6 +444,13 @@ label:has(> .toggle) {
 		position: sticky;
 		bottom: 0;
 		z-index: var(--layer-nav);
+		/* Oben --space-2 statt --space-3: die erste Zeile ist die
+		   Fortschrittsanzeige, deren Schaltflächen 44px hoch sind, während die
+		   Linie darin nur 6px zeichnet. Über der Linie liegen dadurch schon 19px
+		   Leerraum aus dem Ziel selbst — zusammen mit 8px Polsterung sind das
+		   27px, mehr als die 16px, die eine Zeile mit sichtbarem Inhalt bräuchte.
+		   Unten bleibt --space-3, dort grenzt die Schaltflächenzeile direkt an. */
+		padding-top: var(--space-2);
 		padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
 		box-shadow: 0 -4px 16px color-mix(in oklab, var(--color-neutral) 14%, transparent);
 	}
@@ -452,13 +459,13 @@ label:has(> .toggle) {
 	   `scrollIntoView` und vom Fokus-Scroll des Browsers sonst genau hinter den
 	   Balken geschoben — man tippt ins Feld und sieht es nicht mehr. Betrifft
 	   auch `scrollToFirstError` nach einem gescheiterten „Weiter".
-	   Der Wert deckt den Balken im Normalfall ab (132px gemessen bei 390px
-	   Breite: Fortschrittszeile + Schaltflächen + Innenabstand). Mit
-	   eingeblendetem Inline-Alert ist der Balken höher — dann ist es eine
-	   Näherung, keine Garantie. Das ist vertretbar, weil in dem Zustand die
-	   Fehlermeldung im Bild wichtiger ist als das Feld darunter. */
+	   Der Wert entspricht der gemessenen Balkenhöhe bei 390px Breite: 120px aus
+	   Fortschrittszeile, Schaltflächenzeile und Innenabstand. Im Feldmodus sind
+	   es 144px — dort ist es also eine Näherung. Bewusst nicht auf das Maximum
+	   gesetzt: der Wert gilt auch oberhalb `md` nicht, und ein zu großer Wert
+	   schiebt fokussierte Felder unnötig weit nach oben. */
 	html {
-		scroll-padding-bottom: calc(8.5rem + env(safe-area-inset-bottom, 0px));
+		scroll-padding-bottom: calc(7.5rem + env(safe-area-inset-bottom, 0px));
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -447,6 +447,19 @@ label:has(> .toggle) {
 		padding-bottom: calc(var(--space-3) + env(safe-area-inset-bottom, 0px));
 		box-shadow: 0 -4px 16px color-mix(in oklab, var(--color-neutral) 14%, transparent);
 	}
+
+	/* Gegenstück zum Balken: Ein Feld am unteren Ende des Schritts wird von
+	   `scrollIntoView` und vom Fokus-Scroll des Browsers sonst genau hinter den
+	   Balken geschoben — man tippt ins Feld und sieht es nicht mehr. Betrifft
+	   auch `scrollToFirstError` nach einem gescheiterten „Weiter".
+	   Der Wert deckt den Balken im Normalfall ab (132px gemessen bei 390px
+	   Breite: Fortschrittszeile + Schaltflächen + Innenabstand). Mit
+	   eingeblendetem Inline-Alert ist der Balken höher — dann ist es eine
+	   Näherung, keine Garantie. Das ist vertretbar, weil in dem Zustand die
+	   Fehlermeldung im Bild wichtiger ist als das Feld darunter. */
+	html {
+		scroll-padding-bottom: calc(8.5rem + env(safe-area-inset-bottom, 0px));
+	}
 }
 
 /* ===== Accessibility ===== */

--- a/src/app.html
+++ b/src/app.html
@@ -1,4 +1,21 @@
 <!doctype html>
+<!--
+  Feldmodus: `data-density="field"` an das <html> unten hängen — mehr braucht es
+  nicht. `[data-density='field']` in src/css/tokens.css hebt dann --target-min
+  auf 56px, --target-gap auf 24px und --text-support auf 14px; keine Komponente
+  kennt den Modus, alle lesen nur die Tokens. Anleitung und Grenzen:
+  docs/DESIGN_SYSTEM.md, Abschnitt „Feldmodus aktivieren".
+
+  Das Attribut steht hier bewusst NICHT mit dem Normalwert „comfortable"
+  vorbelegt, obwohl das symmetrischer aussähe. Zwei Gründe:
+  1. Es gibt keinen Selektor für „comfortable" — der Normalfall ist die
+     Abwesenheit des Attributs. Ein vorbelegter Wert wäre Zierde, die man beim
+     Umschalten überschreiben statt setzen müsste.
+  2. /styleguide schreibt das Attribut beim Mounten und löscht es beim
+     Verlassen wieder. Stünde hier ein Startwert, wäre er danach weg — und
+     e2e/design-tokens.spec.ts benutzt genau die Abwesenheit als Signal dafür,
+     dass die Seite hydriert ist (dort ausführlich kommentiert).
+-->
 <html lang="de" data-theme="meeresmuseum">
 	<head>
 		<meta charset="utf-8" />

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -34,7 +34,13 @@
 	               auf base-100/200 ≥ 4,5:1 erreicht. Hue und Chroma sind
 	               gegenüber -surface unverändert. */
 	--status-info-surface: oklch(0.55 0.12 230); /*    #007daa */
-	--status-info-strong: oklch(0.465 0.12 230); /*    #00648f  5,51 / 4,58 */
+	/* L bewusst 0.46 und nicht 0.465 wie die Nachbarn: dieser Ton rundet
+	   ungünstig gegen base-200 (#d1d8df). Die 8-Bit-Quantisierung nach sRGB
+	   kostet ihn bei 0.465 ganze 0,043 Kontrast (4,578 gerechnet → 4,535
+	   gemessen) und lässt damit nur 0,03 über der 4,5-Schwelle. Die anderen
+	   vier -strong-Werte verlieren an derselben Stelle nur 0,005–0,012.
+	   Bei 0.46 sind es 4,672 → 4,662, also 0,16 Puffer. */
+	--status-info-strong: oklch(0.46 0.12 230); /*     #00628d  5,63 / 4,66 */
 	--status-success-surface: oklch(0.55 0.16 145); /* #1c882d */
 	--status-success-strong: oklch(0.46 0.16 145); /*  #006d09  5,53 / 4,59 */
 	--status-warning-surface: oklch(0.65 0.16 85); /*  #bb8500 */

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -32,7 +32,19 @@
 	   *-surface = Flächenfarbe (Button, Badge, Alert-Tint)
 	   *-strong  = Vordergrundfarbe (Text, Icon, Zahl) — L ≈ 0.47, damit sie
 	               auf base-100/200 ≥ 4,5:1 erreicht. Hue und Chroma sind
-	               gegenüber -surface unverändert. */
+	               gegenüber -surface unverändert.
+
+	   Die Zahlenpaare hinter den -strong-Zeilen sind base-100 / base-200 und
+	   sind im Browser GEMESSEN, nicht gerechnet: erst nach dem Gamut-Mapping
+	   nach sRGB und der 8-Bit-Quantisierung steht der Wert fest, den ein Auge
+	   tatsächlich sieht. Die Differenz ist nicht immer vernachlässigbar — siehe
+	   den Kommentar an --status-info-strong, wo sie 0,043 beträgt.
+
+	   Maßgeblich ist deshalb nicht dieser Kommentar, sondern
+	   e2e/design-tokens.spec.ts: der Test misst dieselben Kombinationen unter
+	   /styleguide im echten Browser und ist die Instanz, die Rot oder Grün
+	   sagt. Wer hier eine Zahl ändert, ohne sie dort nachzumessen, schreibt
+	   eine Vermutung auf. */
 	--status-info-surface: oklch(0.55 0.12 230); /*    #007daa */
 	/* L bewusst 0.46 und nicht 0.465 wie die Nachbarn: dieser Ton rundet
 	   ungünstig gegen base-200 (#d1d8df). Die 8-Bit-Quantisierung nach sRGB
@@ -42,14 +54,14 @@
 	   Bei 0.46 sind es 4,672 → 4,662, also 0,16 Puffer. */
 	--status-info-strong: oklch(0.46 0.12 230); /*     #00628d  5,63 / 4,66 */
 	--status-success-surface: oklch(0.55 0.16 145); /* #1c882d */
-	--status-success-strong: oklch(0.46 0.16 145); /*  #006d09  5,53 / 4,59 */
+	--status-success-strong: oklch(0.46 0.16 145); /*  #006d09  5,53 / 4,57 */
 	--status-warning-surface: oklch(0.65 0.16 85); /*  #bb8500 */
-	--status-warning-strong: oklch(0.48 0.16 85); /*   #865100  5,52 / 4,58 */
+	--status-warning-strong: oklch(0.48 0.16 85); /*   #865100  5,53 / 4,58 */
 	--status-error-surface: oklch(
 		0.48 0.18 25
 	); /*    #ac1922  — ist bereits
-	     beides: Fläche (weiß darauf 7,19) und Vordergrund (6,04 / 5,01). */
-	--status-accent-strong: oklch(0.475 0.047 215); /* #3c636d  5,51 / 4,57 */
+	     beides: Fläche (weiß darauf 7,20) und Vordergrund (6,05 / 5,01). */
+	--status-accent-strong: oklch(0.475 0.047 215); /* #3c636d  5,52 / 4,57 */
 
 	/* ── Ebene 2: semantische Tokens ────────────────────────────────────── */
 
@@ -59,6 +71,8 @@
 	--color-info-strong: var(--status-info-strong);
 	--color-success-strong: var(--status-success-strong);
 	--color-warning-strong: var(--status-warning-strong);
+	/* Als einzige -strong-Farbe kein eigenes Primitiv, sondern das Marken-Grau
+	   --brand-sea-400 (#42626a). Gemessen 5,54 / 4,58. */
 	--color-secondary-strong: var(--brand-sea-400);
 	--color-accent-strong: var(--status-accent-strong);
 
@@ -80,11 +94,12 @@
 	--text-support-lh: 1.5;
 
 	/* Deckkraft-Stufen von base-content. /60 ist die Untergrenze für Text
-	   und gilt nur auf base-100 und base-200 (auf base-300: 4,27 → zu wenig).
-	   /50 (3,39) und /40 (2,55) sind ausschließlich dekorativ. */
+	   und gilt nur auf base-100 und base-200 (auf base-300: 4,26 → zu wenig).
+	   /50 (3,39) und /40 (2,56) sind ausschließlich dekorativ.
+	   Zahlen wie oben gemessen, nicht gerechnet — base-100 / 200 / 300. */
 	--fg-strong: 1;
-	--fg-muted: 0.7; /*   6,96 / 6,35 / 5,72 */
-	--fg-subtle: 0.6; /*  4,92 / 4,61 / 4,27 ← nur base-100 + base-200 */
+	--fg-muted: 0.7; /*   7,04 / 6,41 / 5,74 */
+	--fg-subtle: 0.6; /*  4,94 / 4,62 / 4,26 ← nur base-100 + base-200 */
 
 	/* Abstände — 4-px-Raster, fünf Stufen */
 	--space-1: 0.25rem; /*  4px — Icon zu Text */

--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -194,7 +194,7 @@
 				{/if}
 			</div>
 
-			<div class="grid gap-3 {multiple ? 'sm:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1'}">
+			<div class="grid gap-3 {multiple ? 'md:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1'}">
 				{#each files as file, index (file.name + index)}
 					<div class="card bg-base-100 shadow-sm">
 						<div class="card-body p-3">
@@ -217,7 +217,7 @@
 									<h4 class="truncate text-sm font-medium" title={file.name}>
 										{file.name}
 									</h4>
-									<p class="text-base-content/60 text-xs">
+									<p class="text-base-content/70 text-support">
 										{(file.size / (1024 * 1024)).toFixed(2)} MB
 									</p>
 								</div>
@@ -297,10 +297,10 @@
 				<!-- Ein Steuerelement überall, nur der Hinweis ist responsiv: Ziehen gibt
 				     es auf einem Telefon nicht, der Satz beschriebe dort eine unmögliche
 				     Handlung. -->
-				<p class="text-base-content/60 mt-1 text-xs {actionLabel ? 'hidden sm:inline' : ''}">
+				<p class="text-base-content/70 text-support mt-1 {actionLabel ? 'hidden md:inline' : ''}">
 					{emptyText}
 				</p>
-				<p class="text-base-content/40 mt-1 text-xs">
+				<p class="text-base-content/70 text-support mt-1">
 					{subtitle}{additionalText ? ` - ${additionalText}` : ''}
 				</p>
 			</div>

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -183,7 +183,7 @@
 								<Icon icon="lucide:chart-pie" width="16" class="text-success" />
 								Ihre Daten machen den Unterschied
 							</h4>
-							<div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+							<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
 								<div class="bg-success/10 border-success/20 rounded-lg border p-4 text-center">
 									<div class="text-success mb-2 text-2xl font-bold">
 										{#if loading}

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -224,11 +224,11 @@
 <Form {...formProps} bind:context={formContext}>
 	{#if isNotIFrame}
 		<!-- Form Title -->
-		<div class="mb-4 text-center sm:mb-8">
-			<h1 class="text-base-content mb-2 text-2xl font-bold sm:text-3xl lg:text-4xl">
+		<div class="mb-4 text-center md:mb-8">
+			<h1 class="text-base-content mb-2 text-2xl font-bold md:text-3xl lg:text-4xl">
 				Meerestier-Sichtung melden
 			</h1>
-			<p class="text-base-content/70 px-2 text-sm sm:text-lg">
+			<p class="text-base-content/70 px-2 text-sm md:text-lg">
 				Helfen Sie der Forschung mit Ihrer Wal- oder Robbensichtung
 			</p>
 		</div>

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -149,7 +149,7 @@
 		{/if}
 
 		<!-- Action Buttons -->
-		<div class="flex flex-col justify-center gap-4 sm:flex-row">
+		<div class="flex flex-col justify-center gap-4 md:flex-row">
 			<button onclick={handleNewReport} class="btn btn-primary btn-lg">
 				Weitere Sichtung melden
 			</button>
@@ -166,7 +166,7 @@
 				<div class="card-body text-center">
 					<h3 class="mb-4 text-lg font-semibold">Interessiert an mehr?</h3>
 
-					<div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+					<div class="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
 						<a href="/map" class="btn btn-outline btn-sm flex items-center gap-2">
 							<Icon icon="lucide:map" width="16" height="16" />
 							Alle Sichtungen auf der Karte

--- a/src/lib/report/components/form/FormActions.svelte
+++ b/src/lib/report/components/form/FormActions.svelte
@@ -32,10 +32,10 @@
 </script>
 
 <!-- Form Actions -->
-<div class="mx-auto mt-8 flex justify-center sm:justify-start">
+<div class="mx-auto mt-8 flex justify-center md:justify-start">
 	<button
 		type="button"
-		class="btn btn-outline btn-error btn-sm min-h-11 w-full sm:w-auto"
+		class="btn btn-outline btn-error btn-sm min-h-11 w-full md:w-auto"
 		onclick={handleReset}
 		disabled={$isSubmitting}
 	>

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -32,7 +32,15 @@
   circle). Navigation is a real <button> for proper keyboard/AT support;
   aria-current marks the active step (WAI stepper pattern).
 -->
-<nav class="mb-8" aria-label="Formular-Schritte">
+<!--
+  Ab `md`. Unterhalb davon zeigt `StepProgressCompact.svelte` denselben Zustand
+  im ortsfesten Balken unten — der Stepper hier wäre dort doppelt: er kostet
+  oben Platz und ist beim Bedienen der Navigation längst aus dem Bild.
+  Ausgeblendet statt umgebaut, weil beide Varianten dieselbe Regel
+  (`canNavigateToStep`) und dasselbe `aria-current` benutzen; es gibt keinen
+  Zustand, der nur in einer der beiden existiert.
+-->
+<nav class="mb-8 hidden md:block" aria-label="Formular-Schritte">
 	<ul class="steps steps-horizontal w-full">
 		{#each steps as step, index (step.id)}
 			{@const navigable = canNavigateTo(index)}
@@ -42,7 +50,7 @@
 			>
 				<button
 					type="button"
-					class="step-button px-1 text-xs sm:text-sm"
+					class="text-support step-button px-1"
 					class:cursor-not-allowed={!navigable}
 					aria-disabled={!navigable ? 'true' : 'false'}
 					aria-label={step.title}

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -61,6 +61,16 @@
 	// All error messages of the current step, for inline display
 	const stepErrorMessages = $derived(getStepAlertMessages(stepValidation.errors));
 
+	// Zahl für die kompakte Anzeige im Balken. Dieselbe Quelle wie die
+	// ausgeschriebene Liste — getErrorCount zählt bereits, was showValidationError
+	// für seine Toast-Meldung benutzt.
+	const stepErrorCount = $derived(getErrorCount(stepValidation.errors));
+
+	/** Springt zum ersten fehlerhaften Feld — gleiche Reihenfolge wie nach „Weiter". */
+	function jumpToFirstError(): void {
+		scrollToFirstError(stepValidation.errors, stepFieldOrders[currentStep] ?? []);
+	}
+
 	const isLastStep = $derived(currentStep >= totalSteps - 1);
 	const isFirstStep = $derived(currentStep <= 0);
 
@@ -180,42 +190,54 @@
 </script>
 
 <!--
+  Der volle Alert steht im Fluss, NICHT im ortsfesten Balken.
+
+  Er dort hineinzunehmen war der naheliegende Reflex — `position: sticky` wirkt
+  nur auf das Element mit der Klasse, ein Alert davor scrollt also weg. Gemessen
+  ist das aber die schlechtere Wahl: Schritt 1 kann fünf Regeln gleichzeitig
+  verletzen (Breitengrad, Längengrad, Fahrwasser-Länge, Zukunftsdatum,
+  Uhrzeitformat), und die <ul> darunter machte den Balken bei 390×844 dann
+  390px hoch — 46 % des Bildschirms, dauerhaft im Weg.
+
+  Der Alert muss auch gar nicht stehen bleiben: Er wird in dem Moment gelesen,
+  in dem er entsteht, und direkt danach springt `scrollToFirstError` zum ersten
+  fehlerhaften Feld, wo das Feld seinen Fehler selbst trägt (`FieldRenderer`,
+  `role="alert"`). Was im Balken bleiben muss, ist nur die Tatsache „hier sind
+  noch N Fehler" plus ein Weg zurück dorthin — das leistet die kompakte
+  Schaltfläche unten mit einer Zeile Höhe statt fünf.
+-->
+{#if showStepAlert && stepErrorMessages.length > 0}
+	<div class="alert alert-warning mb-2" role="alert">
+		<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
+		{#if stepErrorMessages.length === 1}
+			<span>{stepErrorMessages[0]?.message}</span>
+		{:else}
+			<ul class="list-inside list-disc">
+				{#each stepErrorMessages as { field, message } (field)}
+					<li>{message}</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+{/if}
+
+<!--
   Unterhalb `md` ist dieser Block der ortsfeste Balken am unteren Rand
   (`.form-step-nav`, Regel in app.css inkl. `env(safe-area-inset-bottom)`).
 
-  Die Klasse trägt der Wrapper und NICHT das <nav> darin — obwohl das <nav> das
-  eigentliche Bedienelement ist. Grund: `position: sticky` wirkt nur auf das
-  Element, das die Klasse trägt. Läge der Inline-Alert wie zuvor als Geschwister
-  DAVOR, würde er beim Scrollen weglaufen, während der Balken stehen bleibt —
-  „Weiter" reagiert dann sichtbar nicht, und die Begründung dafür steht
-  irgendwo weiter oben außerhalb des Bildes. Alert, Fortschritt und Schaltflächen
-  gehören deshalb in denselben stickyen Container.
-
-  Der Container ist bewusst kein zweites <nav>: die Navigations-Landmark bleibt
-  das innere <nav>, der Wrapper ist reines Layout.
+  Die Klasse trägt der Wrapper und nicht das <nav> darin: der Balken ist mehr
+  als die Navigations-Landmark — er trägt auch den Fortschritt und den
+  Fehler-Sprung. Das <nav> bleibt die Landmark, der Wrapper ist reines Layout.
 -->
 <div class="form-step-nav bg-base-200 rounded-lg p-4">
-	<!-- Inline validation error above navigation — only after a failed "Weiter"-attempt -->
-	{#if showStepAlert && stepErrorMessages.length > 0}
-		<div class="alert alert-warning mb-3" role="alert">
-			<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
-			{#if stepErrorMessages.length === 1}
-				<span>{stepErrorMessages[0]?.message}</span>
-			{:else}
-				<ul class="list-inside list-disc">
-					{#each stepErrorMessages as { field, message } (field)}
-						<li>{message}</li>
-					{/each}
-				</ul>
-			{/if}
-		</div>
-	{/if}
-
 	<!-- Fortschritt im Balken — nur unterhalb `md`, oberhalb zeigt ihn FormSteps -->
 	<StepProgressCompact steps={formStepsConfig} bind:currentStep />
 
 	<!-- Navigation UI -->
-	<nav class="mt-3 flex items-center justify-between md:mt-0" aria-label="Formular Navigation">
+	<nav
+		class="mt-2 flex items-center justify-between gap-2 md:mt-0"
+		aria-label="Formular Navigation"
+	>
 		<button
 			type="button"
 			onclick={previousStep}
@@ -225,6 +247,30 @@
 		>
 			← Zurück
 		</button>
+
+		<!--
+			Kompakte Fehleranzeige — ersetzt im Balken die ausgeschriebene Liste.
+			Nur unterhalb `md`: darüber ist der Balken nicht ortsfest, der volle
+			Alert steht also ohnehin sichtbar direkt darüber und diese Schaltfläche
+			wäre eine zweite Anzeige derselben Sache.
+
+			„Fehler" ist im Deutschen im Singular und Plural gleich, der sichtbare
+			Text braucht deshalb keine Fallunterscheidung — der Accessible Name
+			schon, sonst liest der Screenreader „Zu den 1 fehlerhaften Feldern".
+		-->
+		{#if showStepAlert && stepErrorCount > 0}
+			<button
+				type="button"
+				onclick={jumpToFirstError}
+				class="btn btn-ghost btn-sm text-error gap-1 md:hidden"
+				aria-label={stepErrorCount === 1
+					? 'Zum fehlerhaften Feld springen'
+					: `Zu den ${stepErrorCount} fehlerhaften Feldern springen`}
+			>
+				<Icon icon="lucide:triangle-alert" width="16" class="shrink-0" aria-hidden="true" />
+				{stepErrorCount} Fehler
+			</button>
+		{/if}
 
 		<button
 			type="button"

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
+	import StepProgressCompact from './StepProgressCompact.svelte';
 	import { validateStep } from '$lib/form/validation/stepValidation';
 	import { createLogger } from '$lib/logger';
 	import { getFormContext } from '$lib/report/formContext';
@@ -178,47 +179,64 @@
 	}
 </script>
 
-<!-- Inline validation error above navigation — only after a failed "Weiter"-attempt -->
-{#if showStepAlert && stepErrorMessages.length > 0}
-	<div class="alert alert-warning mb-2" role="alert">
-		<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
-		{#if stepErrorMessages.length === 1}
-			<span>{stepErrorMessages[0]?.message}</span>
-		{:else}
-			<ul class="list-inside list-disc">
-				{#each stepErrorMessages as { field, message } (field)}
-					<li>{message}</li>
-				{/each}
-			</ul>
-		{/if}
-	</div>
-{/if}
+<!--
+  Unterhalb `md` ist dieser Block der ortsfeste Balken am unteren Rand
+  (`.form-step-nav`, Regel in app.css inkl. `env(safe-area-inset-bottom)`).
 
-<!-- Navigation UI -->
-<nav
-	class="bg-base-200 flex items-center justify-between rounded-lg p-4"
-	aria-label="Formular Navigation"
->
-	<button
-		type="button"
-		onclick={previousStep}
-		disabled={isFirstStep || $isSubmitting}
-		class="btn btn-outline"
-		aria-label="Vorheriger Schritt"
-	>
-		← Zurück
-	</button>
+  Die Klasse trägt der Wrapper und NICHT das <nav> darin — obwohl das <nav> das
+  eigentliche Bedienelement ist. Grund: `position: sticky` wirkt nur auf das
+  Element, das die Klasse trägt. Läge der Inline-Alert wie zuvor als Geschwister
+  DAVOR, würde er beim Scrollen weglaufen, während der Balken stehen bleibt —
+  „Weiter" reagiert dann sichtbar nicht, und die Begründung dafür steht
+  irgendwo weiter oben außerhalb des Bildes. Alert, Fortschritt und Schaltflächen
+  gehören deshalb in denselben stickyen Container.
 
-	<button
-		type="button"
-		onclick={nextStep}
-		disabled={$isSubmitting}
-		class="btn btn-primary"
-		aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
-	>
-		{#if $isSubmitting}
-			<span class="loading loading-spinner loading-sm"></span>
-		{/if}
-		{isLastStep ? 'Absenden' : 'Weiter →'}
-	</button>
-</nav>
+  Der Container ist bewusst kein zweites <nav>: die Navigations-Landmark bleibt
+  das innere <nav>, der Wrapper ist reines Layout.
+-->
+<div class="form-step-nav bg-base-200 rounded-lg p-4">
+	<!-- Inline validation error above navigation — only after a failed "Weiter"-attempt -->
+	{#if showStepAlert && stepErrorMessages.length > 0}
+		<div class="alert alert-warning mb-3" role="alert">
+			<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
+			{#if stepErrorMessages.length === 1}
+				<span>{stepErrorMessages[0]?.message}</span>
+			{:else}
+				<ul class="list-inside list-disc">
+					{#each stepErrorMessages as { field, message } (field)}
+						<li>{message}</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Fortschritt im Balken — nur unterhalb `md`, oberhalb zeigt ihn FormSteps -->
+	<StepProgressCompact steps={formStepsConfig} bind:currentStep />
+
+	<!-- Navigation UI -->
+	<nav class="mt-3 flex items-center justify-between md:mt-0" aria-label="Formular Navigation">
+		<button
+			type="button"
+			onclick={previousStep}
+			disabled={isFirstStep || $isSubmitting}
+			class="btn btn-outline"
+			aria-label="Vorheriger Schritt"
+		>
+			← Zurück
+		</button>
+
+		<button
+			type="button"
+			onclick={nextStep}
+			disabled={$isSubmitting}
+			class="btn btn-primary"
+			aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
+		>
+			{#if $isSubmitting}
+				<span class="loading loading-spinner loading-sm"></span>
+			{/if}
+			{isLastStep ? 'Absenden' : 'Weiter →'}
+		</button>
+	</nav>
+</div>

--- a/src/lib/report/components/form/StepProgressCompact.svelte
+++ b/src/lib/report/components/form/StepProgressCompact.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { canNavigateToStep } from '$lib/form/validation/stepNavigation';
+	import { getFormContext } from '$lib/report/formContext';
+	import type { FormStep } from '$lib/report/types';
+
+	/**
+	 * Kompakte Fortschrittsanzeige für den ortsfesten Balken unterhalb `md`.
+	 *
+	 * Der ausgeschriebene Stepper aus `FormSteps.svelte` steht am Seitenkopf und
+	 * ist dort ab `md` sichtbar. Auf dem Telefon ist er zweimal im Weg: er kostet
+	 * oben Platz und ist beim Bedienen der Navigation unten aus dem Bild. Diese
+	 * Variante zeigt denselben Zustand im Balken, in dem auch „Zurück"/„Weiter"
+	 * liegen — vier Segmente statt vier Beschriftungen.
+	 *
+	 * Was dabei erhalten bleiben MUSS und deshalb hier steht statt in einer
+	 * reinen CSS-Lösung:
+	 *  - Klick-Navigation über dieselbe Regel wie oben (`canNavigateToStep`,
+	 *    kein zweites Regelwerk),
+	 *  - `aria-current="step"` am aktiven Schritt (WAI-Stepper-Muster),
+	 *  - ein 44-px-Ziel pro Segment (`--target-min`, im Feldmodus 56px).
+	 *
+	 * Die Segmente sind Dekoration, die Ansage trägt der Text „Schritt X von Y"
+	 * plus das `aria-label` je Schaltfläche. Deshalb ist die Farbdifferenz der
+	 * Segmente nicht der einzige Kanal — sie darf unter 3:1 liegen, ohne dass
+	 * Information verloren geht (WCAG 1.4.11 greift nur für Elemente, die den
+	 * Zustand allein tragen).
+	 */
+	let { steps, currentStep = $bindable(0) }: { steps: FormStep[]; currentStep?: number } = $props();
+
+	const { form } = getFormContext();
+
+	function canNavigateTo(targetIndex: number): boolean {
+		return canNavigateToStep(currentStep, targetIndex, $form);
+	}
+
+	function handleStepClick(index: number): void {
+		if (canNavigateTo(index)) {
+			currentStep = index;
+		}
+	}
+</script>
+
+<nav class="flex items-center gap-3 md:hidden" aria-label="Formular-Schritte">
+	<p class="text-support text-base-content/70 shrink-0">
+		Schritt {currentStep + 1} von {steps.length}
+	</p>
+	<ol class="flex flex-1 gap-1">
+		{#each steps as step, index (step.id)}
+			{@const navigable = canNavigateTo(index)}
+			<li class="flex-1">
+				<button
+					type="button"
+					class="flex min-h-[var(--target-min)] w-full items-center px-0.5"
+					class:cursor-not-allowed={!navigable}
+					aria-current={currentStep === index ? 'step' : undefined}
+					aria-disabled={!navigable ? 'true' : 'false'}
+					aria-label="Schritt {index + 1}: {step.title}"
+					title={navigable
+						? step.description
+						: 'Bitte füllen Sie zuerst die vorherigen Schritte aus'}
+					onclick={() => handleStepClick(index)}
+				>
+					<span
+						class="h-1.5 w-full rounded-full {currentStep >= index
+							? 'bg-primary'
+							: 'bg-base-content/20'}"
+						class:opacity-50={!navigable && index > currentStep}
+					></span>
+				</button>
+			</li>
+		{/each}
+	</ol>
+</nav>

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -529,7 +529,7 @@
 				</button>
 			</div>
 
-			<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+			<div class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
 				<!-- Uploaded files -->
 				{#each mediaFiles as mediaFile (mediaFile.uid)}
 					<!-- Media File Card -->

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -287,7 +287,7 @@
 					class="btn btn-ghost btn-sm btn-circle -my-2.5 min-h-11 min-w-11"
 					aria-label={`Hinweis: ${metaValues.valueText}`}
 				>
-					<Icon icon="lucide:info" width="14" class="text-base-content/60" />
+					<Icon icon="lucide:info" width="14" class="text-base-content/70" />
 				</button>
 			</span>
 		{/if}
@@ -341,7 +341,7 @@
 	<!-- Help Text -->
 	{#if metaValues.helpText}
 		<div id={helpId} class="mt-1 text-left">
-			<span class="text-base-content/60 text-xs leading-relaxed">
+			<span class="text-base-content/70 text-support leading-relaxed">
 				{metaValues.helpText}
 			</span>
 		</div>
@@ -350,7 +350,7 @@
 	<!-- Error Message -->
 	{#if error}
 		<div id={errorId} class="mt-1 text-left" role="alert" aria-live="polite">
-			<span class="text-error flex items-center gap-1 text-xs font-medium">
+			<span class="text-error text-support flex items-center gap-1 font-medium">
 				<Icon icon="lucide:triangle-alert" width="14" class="text-error flex-shrink-0" />
 				{error}
 			</span>

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -176,7 +176,7 @@
 										{#if species.images.length > 0}
 											<div
 												class="grid grid-cols-1 gap-3"
-												class:sm:grid-cols-2={species.images.length > 1}
+												class:md:grid-cols-2={species.images.length > 1}
 											>
 												{#each species.images as image (image.src)}
 													<div class="text-center">

--- a/src/lib/report/components/form/position/LocationDescription.svelte
+++ b/src/lib/report/components/form/position/LocationDescription.svelte
@@ -49,7 +49,7 @@
 			: 'Kein GPS? Beschreiben Sie das Seegebiet'}
 	</summary>
 	<div class="collapse-content">
-		<p class="text-base-content/70 mb-3 text-xs">
+		<p class="text-base-content/70 text-support mb-3">
 			Viele Fotos enthalten keine GPS-Daten, und nicht jede Position lässt sich auf der Karte
 			wiederfinden — das ist kein Problem. Eine kurze Beschreibung des Fahrwassers genügt uns, auch
 			ungefähre Angaben sind wertvoll.

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -200,8 +200,8 @@
 	}
 </script>
 
-<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-	<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
+	<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
 		<Icon aria-hidden="true" icon="lucide:map-pin" width="20" class="text-primary" />
 		Positionsangabe
 	</h3>
@@ -212,7 +212,7 @@
 	<!-- Hero: Foto mit GPS. Tint-Fläche trägt bewusst text-base-content,
 	     NICHT text-primary-content (weiß auf hellblau ≈ 1,3:1). -->
 	<div
-		class="border-primary bg-primary/5 text-base-content rounded-lg border-2 p-4 sm:p-6"
+		class="border-primary bg-primary/5 text-base-content rounded-lg border-2 p-4 md:p-6"
 		data-testid="photo-position-card"
 	>
 		<h4 class="mb-1 flex items-center gap-2 font-semibold">
@@ -302,7 +302,7 @@
 		</div>
 	</div>
 
-	<div class="divider text-base-content/60 mt-6 mb-3 text-xs">oder Position selbst setzen</div>
+	<div class="divider text-base-content/70 text-support mt-6 mb-3">oder Position selbst setzen</div>
 
 	<!-- Eigener Button statt des OpenLayers-GPS-Controls: Die Karte startet
 	     zugeklappt, im Startzustand gäbe es sonst gar keinen sichtbaren
@@ -310,7 +310,7 @@
 	     Hand — beides ist im Karten-Control nicht erreichbar. -->
 	<button
 		type="button"
-		class="btn btn-outline min-h-11 w-full sm:w-auto"
+		class="btn btn-outline min-h-11 w-full md:w-auto"
 		onclick={useCurrentPosition}
 		aria-disabled={locating}
 		data-testid="use-current-position"
@@ -324,7 +324,7 @@
 		     damit er auch angesagt wird und nicht nur zu sehen ist. -->
 		{locating ? 'Standort wird ermittelt …' : 'Mein aktueller Standort'}
 	</button>
-	<p class="text-base-content/60 mt-1 mb-3 text-xs">
+	<p class="text-base-content/70 text-support mt-1 mb-3">
 		Übernimmt den Standort Ihres Geräts — sinnvoll, wenn Sie die Sichtung direkt vor Ort melden.
 	</p>
 

--- a/src/lib/report/components/sections/PositionAndTime.svelte
+++ b/src/lib/report/components/sections/PositionAndTime.svelte
@@ -8,8 +8,8 @@
 	<PositionPanel />
 
 	<!-- Date and Time Section (always visible) -->
-	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
+		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
 			<Icon aria-hidden="true" icon="lucide:calendar" width="20" class="text-primary" />
 			Datum und Uhrzeit
 		</h3>

--- a/src/lib/report/components/steps/Step1LocationTime.svelte
+++ b/src/lib/report/components/steps/Step1LocationTime.svelte
@@ -5,14 +5,14 @@
 
 <div class="space-y-8">
 	<!-- Step Header -->
-	<div class="space-y-2 text-center px-2 sm:px-0">
+	<div class="space-y-2 text-center px-2 md:px-0">
 		<div class="flex justify-center">
-			<div class="bg-primary/20 flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-full">
-				<Icon icon="lucide:map-pin" width="20" class="text-primary sm:w-6 sm:h-6" />
+			<div class="bg-primary/20 flex h-10 w-10 md:h-12 md:w-12 items-center justify-center rounded-full">
+				<Icon icon="lucide:map-pin" width="20" class="text-primary md:w-6 md:h-6" />
 			</div>
 		</div>
-		<h2 class="text-base-content text-xl sm:text-2xl font-bold">Position & Zeit</h2>
-		<p class="text-base-content/70 mx-auto max-w-2xl text-sm sm:text-base">
+		<h2 class="text-base-content text-xl md:text-2xl font-bold">Position & Zeit</h2>
+		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
 			Wo und wann haben Sie die Sichtung gemacht? <strong
 				>GPS-Koordinaten sind am wertvollsten</strong
 			>
@@ -20,7 +20,7 @@
 			für die Wissenschaft!
 		</p>
 		<div class="flex justify-center">
-			<div class="badge badge-outline badge-primary text-center min-h-fit h-auto py-2 px-3 whitespace-normal text-xs sm:text-sm sm:whitespace-nowrap max-w-xs sm:max-w-none">
+			<div class="badge badge-outline badge-primary text-center min-h-fit h-auto py-2 px-3 whitespace-normal text-xs md:text-sm md:whitespace-nowrap max-w-xs md:max-w-none">
 				Schritt 1 von 4 - Grunddaten (erforderlich)
 			</div>
 		</div>

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte
@@ -6,20 +6,20 @@
 
 <div class="space-y-8">
 	<!-- Step Header -->
-	<div class="space-y-2 text-center px-2 sm:px-0">
+	<div class="space-y-2 text-center px-2 md:px-0">
 		<div class="flex justify-center">
-			<div class="bg-primary/20 flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-full">
-				<Icon icon="lucide:binoculars" width="20" class="text-primary sm:w-6 sm:h-6" />
+			<div class="bg-primary/20 flex h-10 w-10 md:h-12 md:w-12 items-center justify-center rounded-full">
+				<Icon icon="lucide:binoculars" width="20" class="text-primary md:w-6 md:h-6" />
 			</div>
 		</div>
-		<h2 class="text-base-content text-xl sm:text-2xl font-bold">Sichtungsdetails</h2>
-		<p class="text-base-content/70 max-w-2xl mx-auto text-sm sm:text-base">
+		<h2 class="text-base-content text-xl md:text-2xl font-bold">Sichtungsdetails</h2>
+		<p class="text-base-content/70 max-w-2xl mx-auto text-sm md:text-base">
 			Was haben Sie genau beobachtet? <strong>Tierart und Anzahl</strong> sind besonders wichtig. 
 			Bei Unsicherheit wählen Sie "Unbekannt" - auch geschätzte Angaben sind wertvoll für die 
 			Populationsforschung!
 		</p>
 		<div class="flex justify-center">
-			<div class="badge badge-outline badge-primary text-center min-h-fit h-auto py-2 px-3 whitespace-normal text-xs sm:text-sm sm:whitespace-nowrap max-w-xs sm:max-w-none">
+			<div class="badge badge-outline badge-primary text-center min-h-fit h-auto py-2 px-3 whitespace-normal text-xs md:text-sm md:whitespace-nowrap max-w-xs md:max-w-none">
 				Schritt 2 von 4 - Beobachtung (erforderlich)
 			</div>
 		</div>

--- a/src/lib/report/components/steps/Step3Observations.svelte
+++ b/src/lib/report/components/steps/Step3Observations.svelte
@@ -41,23 +41,23 @@
 
 <div class="space-y-8">
 	<!-- Step Header -->
-	<div class="space-y-4 px-2 text-center sm:px-0">
+	<div class="space-y-4 px-2 text-center md:px-0">
 		<div class="flex justify-center">
 			<div
-				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full sm:h-12 sm:w-12"
+				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>
-				<Icon icon="lucide:activity" width="20" class="text-primary sm:h-6 sm:w-6" />
+				<Icon icon="lucide:activity" width="20" class="text-primary md:h-6 md:w-6" />
 			</div>
 		</div>
-		<h2 class="text-base-content text-xl font-bold sm:text-2xl">Zusätzliche Beobachtungen</h2>
-		<p class="text-base-content/70 mx-auto max-w-2xl text-sm sm:text-base">
+		<h2 class="text-base-content text-xl font-bold md:text-2xl">Zusätzliche Beobachtungen</h2>
+		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
 			Diese Details sind <strong>optional, aber extrem wertvoll</strong> für die Forschung!
 			Verhaltensinformationen, Umweltbedingungen und <strong>Fotos/Videos</strong> helfen bei der Artbestimmung
 			und dem Verständnis der Meerestiere.
 		</p>
 		<div class="flex items-center justify-center gap-4">
 			<div
-				class="badge badge-outline badge-primary h-auto min-h-fit max-w-xs px-3 py-2 text-center text-xs whitespace-normal sm:max-w-none sm:text-sm sm:whitespace-nowrap"
+				class="badge badge-outline badge-primary h-auto min-h-fit max-w-xs px-3 py-2 text-center text-xs whitespace-normal md:max-w-none md:text-sm md:whitespace-nowrap"
 			>
 				Schritt 3 von 4 - Optional, aber sehr hilfreich
 			</div>

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -28,23 +28,23 @@
 
 <div class="space-y-8">
 	<!-- Step Header -->
-	<div class="space-y-2 px-2 text-center sm:px-0">
+	<div class="space-y-2 px-2 text-center md:px-0">
 		<div class="flex justify-center">
 			<div
-				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full sm:h-12 sm:w-12"
+				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>
-				<Icon icon="lucide:user" width="20" class="text-primary sm:h-6 sm:w-6" />
+				<Icon icon="lucide:user" width="20" class="text-primary md:h-6 md:w-6" />
 			</div>
 		</div>
-		<h2 class="text-base-content text-xl font-bold sm:text-2xl">Kontaktdaten & Abschluss</h2>
-		<p class="text-base-content/70 mx-auto max-w-2xl text-sm sm:text-base">
+		<h2 class="text-base-content text-xl font-bold md:text-2xl">Kontaktdaten & Abschluss</h2>
+		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
 			Ihre <strong>E-Mail-Adresse</strong> ist erforderlich für die Bestätigung. Kontaktdaten
 			ermöglichen wichtige Rückfragen zur Datenqualität. <strong>Datenschutz:</strong> Ihre persönlichen
 			Daten werden nie öffentlich angezeigt!
 		</p>
 		<div class="flex justify-center">
 			<div
-				class="badge badge-outline badge-primary h-auto min-h-fit max-w-xs px-3 py-2 text-center text-xs whitespace-normal sm:max-w-none sm:text-sm sm:whitespace-nowrap"
+				class="badge badge-outline badge-primary h-auto min-h-fit max-w-xs px-3 py-2 text-center text-xs whitespace-normal md:max-w-none md:text-sm md:whitespace-nowrap"
 			>
 				Schritt 4 von 4 - Fast geschafft!
 			</div>
@@ -52,8 +52,8 @@
 	</div>
 
 	<!-- Personal Contact Information -->
-	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-		<h3 class="mb-3 flex gap-2 text-base font-semibold sm:text-lg">
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
+		<h3 class="mb-3 flex gap-2 text-base font-semibold md:text-lg">
 			<Icon icon="lucide:user" width="20" class="text-primary" />
 			Ihre Kontaktdaten
 		</h3>
@@ -128,8 +128,8 @@
 	</div>
 
 	<!-- Boat Information Section -->
-	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
+		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
 			<Icon icon="lucide:anchor" width="20" class="text-primary" />
 			Boot-/Schiffsinformationen
 		</h3>
@@ -146,8 +146,8 @@
 	</div>
 
 	<!-- Additional Information Section -->
-	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold sm:text-lg">
+	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
+		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
 			<Icon icon="lucide:message-square" width="20" class="text-primary" />
 			Zusätzliche Informationen
 		</h3>
@@ -156,8 +156,8 @@
 	</div>
 
 	<!-- Privacy and Consent Section -->
-	<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 sm:p-4">
-		<h3 class="mb-3 flex gap-2 text-base font-semibold sm:text-lg">
+	<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 md:p-4">
+		<h3 class="mb-3 flex gap-2 text-base font-semibold md:text-lg">
 			<Icon icon="lucide:lock" width="20" class="text-primary" />
 			Datenschutz und Einverständnis
 		</h3>


### PR DESCRIPTION
PR 3 von 4 der Design-System-Reihe. Das Meldeformular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, einhändig, teils mit Handschuhen. Dieser PR richtet es darauf aus und setzt nebenbei den Breakpoint-Vertrag durch, den `design-system.md` seit PR 1 festschreibt.

Enthält außerdem zwei Nachträge zu PR 2 (#615), als eigener erster Commit.

---

## Nachtrag zu PR 2: `--status-info-strong`

Der Wert stand wie seine vier Nachbarn auf `oklch(0.465 …)`, maß auf `base-200` aber nur **4,53** — 0,03 über der Schwelle. Nachgemessen im Browser gegen die echten `/styleguide`-Elemente:

| Wert | gerechnet | gemessen (8-Bit sRGB) | Verlust |
| ---- | --------- | --------------------- | ------- |
| `0.465` | 4,578 | **4,535** | 0,043 |
| `0.46` | 4,672 | **4,662** | 0,011 |
| die anderen vier `-strong` | — | — | 0,005–0,012 |

Der Ton ist also nicht knapp, sondern **empfindlich**: er verliert an der Quantisierung nach sRGB das Vierfache seiner Nachbarn. Neuer Wert `oklch(0.46 0.12 230)` = `#00628d`, 5,63 / 4,66. Die Begründung steht an der Zeile in `src/css/tokens.css`, damit sie beim nächsten „etwas freundlicheres Blau" mitgelesen wird.

`docs/DESIGN_SYSTEM.md` sagte „`text-info-strong` mit 4,53 der knappste Vordergrundwert" — das ist jetzt `text-accent-strong` mit 4,57.

Zweiter Nachtrag: Kommentar am `beforeEach` in `e2e/design-tokens.spec.ts`. `data-density` trägt dort zwei Bedeutungen gleichzeitig — Dichte-Zustand und, über seine bloße Anwesenheit, das Hydrations-Signal. Folgenlos, solange `tokens.css` nur `[data-density='field']` kennt; eine Falle, sobald jemand `comfortable` styled oder das Attribut vorbelegt.

---

## Feldmodus

### 1. Ortsfester Balken unterhalb `md`

Die Primäraktion lag am Ende eines bis zu 2.400px langen Schritts. Die Schritt-Navigation wird unterhalb `md` zum Balken am unteren Rand (`.form-step-nav`, CSS lag seit PR 1 bereit, inkl. `env(safe-area-inset-bottom)`).

**Die Klasse sitzt am Wrapper, nicht am `<nav>`**, weil der Balken mehr trägt als die Navigations-Landmark: Fortschritt und Fehler-Sprung gehören dazu. Das `<nav>` bleibt die Landmark.

> **Der Inline-Alert lag zwischenzeitlich mit im Balken** — `position: sticky` wirkt nur auf das Element mit der Klasse, ein Alert davor scrollt also weg. Die Review-Runde hat das zurückgedreht; die Begründung und die Messwerte stehen unten unter „Nachtrag → 2".

Gemessen bei 390×844:

- am Dokumentende Überlappung mit dem Element darüber: **−8px** (verdeckt nichts) ✓
- Balkenhöhe **120px** normal, **144px** im Feldmodus (Werte und Herleitung unten)

Dazu `scroll-padding-bottom` am `html` innerhalb derselben Media Query: ohne das schiebt der Fokus-Scroll des Browsers ein Feld am unteren Ende hinter den Balken — man tippt hinein und sieht es nicht mehr. Betrifft auch `scrollToFirstError` nach einem gescheiterten „Weiter".

### 2. Kompakter Schritt-Stepper im Balken

Neu: `StepProgressCompact.svelte` — „Schritt X von Y" plus vier Segmente, unterhalb `md`. Der ausgeschriebene Stepper aus `FormSteps.svelte` ist jetzt `hidden md:block`.

Beide benutzen **dieselbe** Regel (`canNavigateToStep`) und dasselbe `aria-current="step"`; es gibt keinen Zustand, den nur eine der beiden Varianten kennt. Jedes Segment ist ein 44-px-Ziel (im Feldmodus 56px). Die Segmentfarbe ist bewusst nicht der einzige Kanal — Text und `aria-label` tragen den Zustand redundant.

### 3. Hilfetexte

`text-xs` → `text-support` (13px, im Feldmodus 14px), `/60` → `/70` in `FieldRenderer`, `PositionPanel`, `LocationDescription`, `UnifiedDropzone`. `design-system.md`: „Sekundärtext gehört auf /70 … Hilfetexte werden im Feld gelesen, bei Sonnenlicht an Deck."

Dabei aufgefallen und mitkorrigiert: der Untertitel in `UnifiedDropzone` stand auf `/40` — unter der Lesbarkeitsgrenze, die das Design System für Text setzt.

### 4. `data-density` schaltbar und dokumentiert

`src/app.html` erklärt am `<html>`, dass `data-density="field"` genügt; `docs/DESIGN_SYSTEM.md` bekommt den Abschnitt „Feldmodus aktivieren" mit drei Wegen (Deployment / `/styleguide`-Umschalter / DevTools).

**Das Attribut wird bewusst NICHT mit `comfortable` vorbelegt**, obwohl das symmetrischer aussähe. Es gäbe zwei Schäden auf einmal: der Normalfall ist die *Abwesenheit* des Attributs (es gibt keinen Selektor für `comfortable`), und `/styleguide` löscht es beim Verlassen wieder — ein Startwert wäre danach weg. Genau die Falle, die der Nachtrag oben beschreibt.

Ebenfalls dokumentiert: Es gibt absichtlich keinen Umschalter im Formular. Der Modus ist eine Betriebsentscheidung für ein Gerät („dieses Tablet liegt an Deck"), keine Nutzerpräferenz pro Sitzung — und ein Schalter wäre ein weiteres Bedienelement in genau dem Bereich, den der Modus freiräumen soll.

### 5. Breakpoint-Vertrag: `sm:` → `md:`

Alle Layout-Umschaltungen im Formular ziehen von `sm` (640px) auf `md` (768px), 13 Dateien. Vorher war ein 700-px-Tablet für das Formular „Desktop" und für die Navigation „Mobil".

Keine Kollisionen: die vorhandenen `md:`-Klassen in vier der Dateien sind durchweg `md:grid-cols-*` auf anderen Elementen. `FormSteps`' `text-xs sm:text-sm` wurde toter Code, sobald der Stepper nur noch ab `md` erscheint — jetzt `text-support`.

---

## Für das Review

**Die Umstellung aus Punkt 5 ist bei 390px und 800px unsichtbar.** Beide Breiten liegen auf derselben Seite der 640-px-Grenze wie `md` es vorsieht; sichtbar wird der Unterschied ausschließlich zwischen 640 und 767. Wer das nachsehen will, nimmt ~700px. Der Test macht es genauso: er vergleicht die Spaltenzahl aller Raster bei 639px gegen 767px.

`e2e/form-field-mode.spec.ts`, 15 Tests: Balken-Geometrie und `z-index`, Alert im Fluss statt im Balken, Fehlerzahl-Sprung, Höhengrenze im Fünf-Fehler-Fall, keine Überlappung am Dokumentende, `scroll-padding`, `aria-current` genau einmal, Klick-Navigation rückwärts, Vorwärtssperre, 44/56-px-Ziele, `md`-Vertrag bei 700/800, Hilfetextgröße normal und im Feldmodus, DOM-Scan gegen `/40`–`/60` bei Text.

Ein Detail dort ist erwähnenswert: Playwright klickt `aria-disabled="true"` gar nicht erst — der Test hätte die Sperre der Anwendung nie erreicht und nur Playwrights eigene Actionability-Prüfung bestätigt. Steht jetzt mit `force: true` und Begründung drin. Die Schaltflächen sind bewusst nicht `disabled`: ein deaktivierter Button ist nicht fokussierbar, sein `title` („Bitte füllen Sie zuerst …") wäre per Tastatur nicht erreichbar.

## Grün

Stand der ersten Runde; die aktuellen Zahlen stehen unten am Ende des Nachtrags.

---

# Nachtrag: Review-Runde

Vier Punkte aus dem Review, dazu die Messwerte, die sie ausgelöst oder widerlegt haben.

## 1. Alle Kontrastzahlen sind jetzt gemessen

Die Kommentare in `tokens.css` trugen Werte aus einer Fließkomma-Rechnung. Alle fünf `-strong`-Paare gegen `/styleguide` nachgemessen — die Vorgabe aus dem Review hat sich bis auf ≤ 0,005 bestätigt:

| Token | base-100 | base-200 |
| ----- | -------- | -------- |
| `info-strong` (0.46) | 5,63 | 4,66 |
| `success-strong` | 5,53 | 4,57 |
| `warning-strong` | 5,53 | 4,58 |
| `secondary-strong` | 5,54 | 4,58 |
| `accent-strong` | 5,52 | 4,57 |

Am Block steht jetzt, dass die Zahlen gemessen und nicht gerechnet sind und dass `e2e/design-tokens.spec.ts` die maßgebliche Instanz ist.

**Dieselbe Fließkomma-Herkunft steckte an drei weiteren Stellen**, alle nachgemessen und korrigiert:

- Die Deckkraft-Tabelle in `.claude/rules/design-system.md` und `docs/DESIGN_SYSTEM.md`. Die größte Abweichung lag bei `/80` mit **0,10** (9,87 dokumentiert, 9,82 gemessen), `/70` mit 0,08. Für die Regelgrenze `/60` ändert sich nichts (4,94 / 4,62 / 4,26 — `base-300` bleibt unter AA).
- Die Rollen-Tabelle in `docs/DESIGN_SYSTEM.md` zeigte für `info` noch den Vor-PR-3-Wert (`#00648f`, 5,48 / 4,53).
- `--fg-muted` / `--fg-subtle` in `tokens.css` selbst.

Die Flächenwerte (`weiß darauf`, `*-content`) haben sich dagegen alle bestätigt: `info` 4,65, `success` 4,56, `error` 7,20, `secondary` 6,18, `accent` 8,45.

## 2. Der Alert verlässt den Balken wieder

Der Einwand stimmt, und der Messwert fällt schärfer aus als geschätzt. Schritt 1 kann **fünf** Regeln gleichzeitig verletzen — Breitengrad, Längengrad, Fahrwasser-Länge, Zukunftsdatum, Uhrzeitformat:

| | Balkenhöhe bei 390×844 | Anteil am Bildschirm |
| --- | --- | --- |
| vorher (volle `<ul>` im Balken) | **390px** | 46 % |
| nachher (kompakte Anzeige) | **120px** | 14 % |

Im Balken steht jetzt eine Schaltfläche „5 Fehler" mit Warndreieck, die `scrollToFirstError` mit der bestehenden `fieldOrder` aufruft. Der volle Alert bleibt im Fluss an seiner Stelle.

Zwei Details:

- „Fehler" ist im Deutschen in Singular und Plural gleich — der sichtbare Text braucht keine Fallunterscheidung, der Accessible Name schon, sonst liest ein Screenreader „Zu den 1 fehlerhaften Feldern springen".
- Die Schaltfläche ist `md:hidden`. Oberhalb `md` ist der Balken nicht ortsfest, der volle Alert steht also ohnehin sichtbar direkt darüber; beides gleichzeitig wäre dieselbe Aussage zweimal.

Abgesichert durch drei Tests, darunter eine harte Höhengrenze (`≤ 130px`) im Fünf-Fehler-Fall.

## 3. Balkenhöhe — was die zwei Hebel wirklich hergeben

**Gemessen, beide Dichten, 390×844:**

| Zustand | normal | Feldmodus (`data-density="field"`) |
| ------- | ------ | ---------------------------------- |
| vor dieser Runde | 132px (16 %) | 152px (18 %) |
| **jetzt** | **120px (14 %)** | **144px (17 %)** |

Der 44-px-Test hält in beiden Dichten (Segmentziel 44px bzw. 56px, gemessen).

**Der Polsterungs-Hebel gibt null her:** Tailwinds `p-4` **ist** `--space-3` — beides `1rem`. Die Umstellung wäre eine Umbenennung ohne Wirkung gewesen. Was etwas hergab, ist die **obere** Polsterung, jetzt `--space-2`: die Fortschrittszeile besteht aus 44px hohen Zielen, in denen nur eine 6px-Linie gezeichnet wird — über der Linie liegen dadurch bereits 19px Leerraum aus dem Ziel selbst.

**Die 4px-Linie trägt die Klick-Navigation nicht.** Vier Segmente brauchen vier 44-px-Ziele; die als 4px hohe Linie zu bekommen ginge nur über Trefferflächen, die entweder die Schaltflächenzeile darunter oder den Seiteninhalt darüber überlappen — im ersten Fall stiehlt der Fortschritt Klicks von „Weiter". Damit greift der im Review vorgesehene Rückfall: Segmente bleiben.

**Der Zielwert ~88px ist erreichbar, aber nicht umsonst.** Ohne Fortschrittszeile misst der Balken 84px (96px im Feldmodus) — gemessen, nicht geschätzt. Der Preis ist die Klick-Navigation unterhalb `md`, und die gab es vor diesem PR: der ausgeschriebene Stepper stand auf dem Telefon am Seitenkopf. Das wäre also keine Vereinfachung, sondern eine Rücknahme. Eine Variante ohne diesen Preis gäbe es — Label und Linie als **eine** Schaltfläche, die eine Schritt-Auswahl aufklappt (Balken 76px, alle Ziele ≥ 44px) — das ist aber ein eigener Entwurf mit einem zusätzlichen Tipp-Schritt und gehört nicht beiläufig in diesen PR. Sag Bescheid, wenn das die gewünschte Richtung ist.

## 4. Zwei Regeln in `design-system.md`

- **`aria-disabled` statt `disabled`**, mit der Begründung aus `PositionPanel.svelte` (Fokus geht bei `disabled` verloren, und der `title` mit der Begründung ist per Tastatur nicht erreichbar) und der Test-Konsequenz: Playwright klickt solche Schaltflächen von sich aus nicht, ein Test ohne `force: true` läuft in einen Timeout und prüft am Ende nur Playwrights eigene Actionability. Beispiel verlinkt.
- **`--color-info` / `--color-success` dürfen nie heller werden** — stand bereits seit PR 1 drin, Werte in dieser Runde nachgemessen und bestätigt (4,65 bzw. 4,56 mit weißem Text).

## Warum der Breakpoint-Test 639 gegen 767 misst

Der `md`-Vertrag verschiebt Umschaltpunkte von 640px auf 768px. Bei den Review-Breiten 390px und 800px ist davon **nichts** zu sehen: beide liegen außerhalb des Bandes, in dem sich alt und neu unterscheiden. Ein Test bei diesen Breiten wäre grün geblieben, auch wenn jede einzelne `sm:`-Klasse stehengeblieben wäre.

Sichtbar wird der Unterschied ausschließlich zwischen 640 und 767. Der Test vergleicht deshalb die Spaltenzahl aller Raster im Formular bei **639px gegen 767px** und verlangt Gleichheit — eine übersehene `sm:`-Umschaltung kippt dort und nirgendwo sonst. Die 700px-Aufnahme in der Konversation zeigt denselben Punkt für das Auge.

## Grün nach dieser Runde

- `npm run test:quick`: 2.252 Unit-Tests ✓
- `form`-Shard inkl. `form-field-mode.spec.ts` (jetzt 15 Tests): 71 ✓
- `smoke`-Shard: 47 ✓ · `map`-Shard: 53 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
