### PR TITLE
chore(build): update repo references after GitHub rename to ostsee-tiere

### DIFF
--- a/.claude/rules/docker.md
+++ b/.claude/rules/docker.md
@@ -151,7 +151,7 @@ Production-Promotion, nicht beim Build. Details: `docs/RELEASE_PIPELINE.md`
 ```yaml
 services:
   app:
-    image: ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}
+    image: ghcr.io/jansinger/ostsee-tiere:${IMAGE_TAG:-production}
     ports:
       - '3000:3000'
     environment:

--- a/.env.docker
+++ b/.env.docker
@@ -118,7 +118,7 @@ IMAGE_TAG="production"
 
 # Überschreibt die komplette Image-Referenz und hat Vorrang vor IMAGE_TAG.
 # Einziger Weg, auf einen Digest zu pinnen (hängt mit `@` an, nicht mit `:`):
-# APP_IMAGE="ghcr.io/jansinger/ostsee-sichtung@sha256:..."
+# APP_IMAGE="ghcr.io/jansinger/ostsee-tiere@sha256:..."
 
 # Bind app to localhost only (use with reverse proxy)
 # APP_HOST="127.0.0.1"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ostsee-sichtung
+  IMAGE_NAME: ostsee-tiere
 
 permissions: {}
 
@@ -292,7 +292,7 @@ jobs:
           ## Support
 
           For issues and questions, visit:
-          https://github.com/jansinger/ostsee-sichtung/issues
+          https://github.com/jansinger/ostsee-tiere/issues
           EOF
 
           # Create tarball

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ostsee-sichtung
+  IMAGE_NAME: ostsee-tiere
 
 permissions: {}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ This will guide you through creating a conventional commit message step by step.
 
    ```bash
    git clone <repository-url>
-   cd ostsee-sichtung
+   cd ostsee-tiere
    ```
 
 2. **Install dependencies**

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ FROM node:24-alpine AS runtime
 # OCI Image Labels (placed in final stage for proper metadata)
 LABEL org.opencontainers.image.title="Ostsee-Tiere"
 LABEL org.opencontainers.image.description="Marine animal sighting reporting platform for the Baltic Sea"
-LABEL org.opencontainers.image.source="https://github.com/jansinger/ostsee-sichtung"
+LABEL org.opencontainers.image.source="https://github.com/jansinger/ostsee-tiere"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.vendor="Ostsee-Tiere Project"
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 # Ostsee-Tiere
 
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jansinger/ostsee-sichtung/ci.yml?style=flat-square&logo=github&label=CI)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/jansinger/ostsee-tiere/ci.yml?style=flat-square&logo=github&label=CI)
 ![Vercel](https://img.shields.io/badge/Deployed%20on-Vercel-black?style=flat-square&logo=vercel)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/m/jansinger/ostsee-sichtung?style=flat-square&logo=github)
-![GitHub last commit](https://img.shields.io/github/last-commit/jansinger/ostsee-sichtung?style=flat-square&logo=github)
-![GitHub issues](https://img.shields.io/github/issues/jansinger/ostsee-sichtung?style=flat-square&logo=github)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/jansinger/ostsee-sichtung?style=flat-square&logo=github)
-![GitHub](https://img.shields.io/github/license/jansinger/ostsee-sichtung?style=flat-square)
-![GitHub package.json version](https://img.shields.io/github/package-json/v/jansinger/ostsee-sichtung?style=flat-square&logo=npm)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/jansinger/ostsee-tiere?style=flat-square&logo=github)
+![GitHub last commit](https://img.shields.io/github/last-commit/jansinger/ostsee-tiere?style=flat-square&logo=github)
+![GitHub issues](https://img.shields.io/github/issues/jansinger/ostsee-tiere?style=flat-square&logo=github)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/jansinger/ostsee-tiere?style=flat-square&logo=github)
+![GitHub](https://img.shields.io/github/license/jansinger/ostsee-tiere?style=flat-square)
+![GitHub package.json version](https://img.shields.io/github/package-json/v/jansinger/ostsee-tiere?style=flat-square&logo=npm)
 
 **Ostsee-Tiere** ist eine moderne SvelteKit-WebApp zur Erfassung und Verwaltung von Meerestier-Sichtungen in der Ostsee. Die Anwendung ermöglicht es Bürgern, Forschern und Naturbeobachtern, ihre Sichtungen von Walen, Robben und anderen Meerestieren zu melden und der Wissenschaft zur Verfügung zu stellen.
 
@@ -48,8 +48,8 @@ Ostsee-Tiere bietet eine benutzerfreundliche Plattform zur wissenschaftlichen Er
 
 ```bash
 # Repository klonen
-git clone https://github.com/jansinger/ostsee-sichtung.git
-cd ostsee-sichtung
+git clone https://github.com/jansinger/ostsee-tiere.git
+cd ostsee-tiere
 
 # Konfigurieren
 cp .env.docker .env
@@ -83,8 +83,8 @@ docker compose -f docker-compose.production.yml --profile monitoring up -d
 
 ```bash
 # Repository klonen
-git clone https://github.com/jansinger/ostsee-sichtung.git
-cd ostsee-sichtung
+git clone https://github.com/jansinger/ostsee-tiere.git
+cd ostsee-tiere
 
 # Abhängigkeiten installieren
 npm install
@@ -172,7 +172,7 @@ Die Route ist bewusst **nur in `dev`** erreichbar (`+page.server.ts` wirft sonst
 ## Projektstruktur
 
 ```
-ostsee-sichtung/
+ostsee-tiere/
 ├── src/
 │   ├── lib/
 │   │   ├── components/     # UI-Komponenten (Form, Map, Media, Admin, Weather)
@@ -311,13 +311,13 @@ docker compose -f docker-compose.production.yml --profile monitoring up -d
 
 ```bash
 # Neueste Version ziehen
-docker pull ghcr.io/jansinger/ostsee-sichtung:latest
+docker pull ghcr.io/jansinger/ostsee-tiere:latest
 
 # Oder spezifische Version (siehe GitHub Releases)
-docker pull ghcr.io/jansinger/ostsee-sichtung:v1.0.0
+docker pull ghcr.io/jansinger/ostsee-tiere:v1.0.0
 
 # Mit Tag ausführen
-docker run -p 3000:3000 --env-file .env ghcr.io/jansinger/ostsee-sichtung:latest
+docker run -p 3000:3000 --env-file .env ghcr.io/jansinger/ostsee-tiere:latest
 ```
 
 ### Dokumentation

--- a/README.vercel.md
+++ b/README.vercel.md
@@ -38,7 +38,7 @@ LOG_LEVEL="info"
 ```bash
 # Clone and install dependencies
 git clone your-repo
-cd ostsee-sichtung
+cd ostsee-tiere
 npm install
 
 # Set up local environment

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -24,9 +24,9 @@ services:
     # APP_IMAGE überschreibt die komplette Referenz und ist der einzige Weg,
     # auf einen Digest zu pinnen — ein Digest hängt mit `@` statt `:` an und
     # passt deshalb nicht in IMAGE_TAG:
-    #   APP_IMAGE=ghcr.io/jansinger/ostsee-sichtung@sha256:...
+    #   APP_IMAGE=ghcr.io/jansinger/ostsee-tiere@sha256:...
     # Siehe docs/RELEASE_PIPELINE.md
-    image: ${APP_IMAGE:-ghcr.io/jansinger/ostsee-sichtung:${IMAGE_TAG:-production}}
+    image: ${APP_IMAGE:-ghcr.io/jansinger/ostsee-tiere:${IMAGE_TAG:-production}}
     container_name: ostsee-tiere-app
     restart: unless-stopped
     # SECURITY: Bind to localhost only if using reverse proxy

--- a/docs/DATABASE_MIGRATION.md
+++ b/docs/DATABASE_MIGRATION.md
@@ -63,8 +63,8 @@ The migration process involves:
 
 ```bash
 # Clone the repository (if not already done)
-git clone https://github.com/jansinger/ostsee-sichtung.git
-cd ostsee-sichtung
+git clone https://github.com/jansinger/ostsee-tiere.git
+cd ostsee-tiere
 
 # Install dependencies
 npm install
@@ -516,8 +516,8 @@ psql $DATABASE_POSTGRES_URL -c "SELECT 1;"
 
 ### Getting Help
 
-- **Issues**: https://github.com/jansinger/ostsee-sichtung/issues
-- **Documentation**: https://github.com/jansinger/ostsee-sichtung/tree/main/docs
+- **Issues**: https://github.com/jansinger/ostsee-tiere/issues
+- **Documentation**: https://github.com/jansinger/ostsee-tiere/tree/main/docs
 
 ---
 

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -120,7 +120,7 @@ sudo chown 1001:1001 uploads
 chmod 600 .env
 
 # 8. Pull and start container
-docker pull ghcr.io/jansinger/ostsee-sichtung:production
+docker pull ghcr.io/jansinger/ostsee-tiere:production
 
 docker run -d \
   --name ostsee-tiere \
@@ -128,7 +128,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:production
+  ghcr.io/jansinger/ostsee-tiere:production
 
 # 9. Database schema is migrated automatically on container startup.
 #    Requirement for external databases: PostGIS must be enabled once
@@ -161,15 +161,15 @@ For development or testing with PostgreSQL running inside Docker.
 mkdir -p ostsee-tiere && cd ostsee-tiere
 
 # 2. Download required files
-curl -O https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/docker-compose.production.yml
-curl -O https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/.env.docker
+curl -O https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/docker-compose.production.yml
+curl -O https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/.env.docker
 
 # 3. (Optional) Download monitoring config
 mkdir -p monitoring/grafana/provisioning/datasources monitoring/grafana/provisioning/dashboards monitoring/grafana/dashboards
-curl -o monitoring/prometheus.yml https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/monitoring/prometheus.yml
-curl -o monitoring/grafana/provisioning/datasources/prometheus.yml https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/monitoring/grafana/provisioning/datasources/prometheus.yml
-curl -o monitoring/grafana/provisioning/dashboards/default.yml https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/monitoring/grafana/provisioning/dashboards/default.yml
-curl -o monitoring/grafana/dashboards/ostsee-tiere-overview.json https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/monitoring/grafana/dashboards/ostsee-tiere-overview.json
+curl -o monitoring/prometheus.yml https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/monitoring/prometheus.yml
+curl -o monitoring/grafana/provisioning/datasources/prometheus.yml https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/monitoring/grafana/provisioning/datasources/prometheus.yml
+curl -o monitoring/grafana/provisioning/dashboards/default.yml https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/monitoring/grafana/provisioning/dashboards/default.yml
+curl -o monitoring/grafana/dashboards/ostsee-tiere-overview.json https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/monitoring/grafana/dashboards/ostsee-tiere-overview.json
 
 # 4. Configure environment
 cp .env.docker .env
@@ -226,8 +226,8 @@ Access the application at: http://localhost:3000
 
 ```bash
 # Clone repository
-git clone https://github.com/jansinger/ostsee-sichtung.git
-cd ostsee-sichtung
+git clone https://github.com/jansinger/ostsee-tiere.git
+cd ostsee-tiere
 
 # Configure
 cp .env.docker .env
@@ -283,7 +283,7 @@ See [Local Development Testing](#local-development-testing-with-rancher-desktop)
 
 ```bash
 # Pull image
-docker pull ghcr.io/jansinger/ostsee-sichtung:production
+docker pull ghcr.io/jansinger/ostsee-tiere:production
 
 # Create uploads directory
 mkdir -p ./uploads
@@ -302,7 +302,7 @@ docker run -d \
   -e JWKS_URL="https://your-tenant.auth0.com/.well-known/jwks.json" \
   -e API_AUDIENCE="your-api-audience" \
   -e PUBLIC_SITE_URL="https://your-domain.com" \
-  ghcr.io/jansinger/ostsee-sichtung:production
+  ghcr.io/jansinger/ostsee-tiere:production
 
 # Alternative: Use named volume instead of bind mount
 # -v ostsee-uploads:/app/uploads
@@ -514,7 +514,7 @@ cp .env /opt/ostsee-tiere/.env
 chmod 600 /opt/ostsee-tiere/.env
 
 # Pull latest image
-docker pull ghcr.io/jansinger/ostsee-sichtung:production
+docker pull ghcr.io/jansinger/ostsee-tiere:production
 
 # Run container (bind to localhost only - use reverse proxy for external access)
 docker run -d \
@@ -523,7 +523,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:production
+  ghcr.io/jansinger/ostsee-tiere:production
 
 # Database schema is migrated automatically on startup
 # (PostGIS must be enabled once on external databases beforehand)
@@ -643,7 +643,7 @@ ExecStart=/usr/bin/docker run --rm \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:production
+  ghcr.io/jansinger/ostsee-tiere:production
 ExecStop=/usr/bin/docker stop ostsee-tiere
 
 [Install]
@@ -667,7 +667,7 @@ sudo systemctl start ostsee-tiere
 /usr/local/bin/backup-db.sh
 
 # Pull new image
-docker pull ghcr.io/jansinger/ostsee-sichtung:production
+docker pull ghcr.io/jansinger/ostsee-tiere:production
 
 # Restart (with systemd)
 sudo systemctl restart ostsee-tiere
@@ -681,7 +681,7 @@ docker run -d \
   -p 127.0.0.1:3000:3000 \
   -v /opt/ostsee-tiere/uploads:/app/uploads \
   --env-file /opt/ostsee-tiere/.env \
-  ghcr.io/jansinger/ostsee-sichtung:production
+  ghcr.io/jansinger/ostsee-tiere:production
 
 # Clean up old images
 docker image prune -f
@@ -1118,7 +1118,7 @@ services:
 > Full pipeline reference including host-side pull setup and rollback:
 > [RELEASE_PIPELINE.md](./RELEASE_PIPELINE.md)
 
-**Image Repository:** [`ghcr.io/jansinger/ostsee-sichtung`](https://github.com/jansinger/ostsee-sichtung/pkgs/container/ostsee-sichtung)
+**Image Repository:** [`ghcr.io/jansinger/ostsee-tiere`](https://github.com/jansinger/ostsee-tiere/pkgs/container/ostsee-tiere)
 
 ### The release chain
 
@@ -1168,7 +1168,7 @@ reproducible deployments, pin `IMAGE_TAG` to an explicit `vX.Y.Z`, or set
 ```bash
 IMAGE_TAG=v2.5.6
 # or, digest-exact (APP_IMAGE takes precedence over IMAGE_TAG):
-APP_IMAGE=ghcr.io/jansinger/ostsee-sichtung@sha256:...
+APP_IMAGE=ghcr.io/jansinger/ostsee-tiere@sha256:...
 ```
 
 ### Verification and scanning
@@ -1186,11 +1186,11 @@ Every build additionally produces:
 Verify what a tag currently resolves to:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/jansinger/ostsee-sichtung:production \
+docker buildx imagetools inspect ghcr.io/jansinger/ostsee-tiere:production \
   --format '{{json .Manifest}}' | jq -r '.digest'
 ```
 
-Workflow runs: <https://github.com/jansinger/ostsee-sichtung/actions>
+Workflow runs: <https://github.com/jansinger/ostsee-tiere/actions>
 
 ---
 
@@ -1339,7 +1339,7 @@ Note: PostgreSQL must be configured to accept connections from Docker
 Starting Ostsee-Tiere Release Container
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Runtime:   rancher
-Image:     ghcr.io/jansinger/ostsee-sichtung:latest
+Image:     ghcr.io/jansinger/ostsee-tiere:latest
 Port:      http://localhost:3000
 Database:  postgresql://ostsee_app:***@192.168.68.51:5432/ostsee
 Uploads:   /path/to/project/uploads
@@ -1663,11 +1663,11 @@ Images are automatically scanned with Trivy during CI/CD. Check results:
 
 ```bash
 # View scan results in GitHub Actions
-# https://github.com/jansinger/ostsee-sichtung/actions
+# https://github.com/jansinger/ostsee-tiere/actions
 
 # Or scan locally
 docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
-  aquasec/trivy image ghcr.io/jansinger/ostsee-sichtung:production
+  aquasec/trivy image ghcr.io/jansinger/ostsee-tiere:production
 ```
 
 ---
@@ -1688,7 +1688,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
   "containerDefinitions": [
     {
       "name": "app",
-      "image": "ghcr.io/jansinger/ostsee-sichtung:production",
+      "image": "ghcr.io/jansinger/ostsee-tiere:production",
       "portMappings": [{"containerPort": 3000, "protocol": "tcp"}],
       "environment": [...],
       "secrets": [
@@ -1703,7 +1703,7 @@ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
 
 ```bash
 gcloud run deploy ostsee-tiere \
-  --image ghcr.io/jansinger/ostsee-sichtung:production \
+  --image ghcr.io/jansinger/ostsee-tiere:production \
   --platform managed \
   --region europe-west1 \
   --allow-unauthenticated \
@@ -1717,7 +1717,7 @@ gcloud run deploy ostsee-tiere \
 az container create \
   --resource-group ostsee-tiere-rg \
   --name ostsee-tiere-app \
-  --image ghcr.io/jansinger/ostsee-sichtung:production \
+  --image ghcr.io/jansinger/ostsee-tiere:production \
   --cpu 2 --memory 4 \
   --ports 3000 \
   --environment-variables \
@@ -1777,14 +1777,14 @@ docker volume prune -f
 
 ### Getting Help
 
-- **Issues**: https://github.com/jansinger/ostsee-sichtung/issues
-- **Discussions**: https://github.com/jansinger/ostsee-sichtung/discussions
-- **Documentation**: https://github.com/jansinger/ostsee-sichtung/tree/main/docs
+- **Issues**: https://github.com/jansinger/ostsee-tiere/issues
+- **Discussions**: https://github.com/jansinger/ostsee-tiere/discussions
+- **Documentation**: https://github.com/jansinger/ostsee-tiere/tree/main/docs
 
 ### Reporting Security Issues
 
 Please report security vulnerabilities via GitHub Security Advisories:
-https://github.com/jansinger/ostsee-sichtung/security/advisories
+https://github.com/jansinger/ostsee-tiere/security/advisories
 
 **Do NOT create public GitHub issues for security vulnerabilities.**
 

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -75,10 +75,10 @@ mkdir -p uploads
 
 ```bash
 # Nur die benötigten Dateien herunterladen
-curl -fsSL https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/docker-compose.production.yml \
+curl -fsSL https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/docker-compose.production.yml \
   -o docker-compose.yml
 
-curl -fsSL https://raw.githubusercontent.com/jansinger/ostsee-sichtung/main/.env.docker \
+curl -fsSL https://raw.githubusercontent.com/jansinger/ostsee-tiere/main/.env.docker \
   -o .env.example
 ```
 

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -143,7 +143,7 @@ RUNNING=$(docker inspect --format '{{.Image}}' \
 
 docker compose pull --quiet
 PULLED=$(docker image inspect --format '{{.Id}}' \
-  ghcr.io/jansinger/ostsee-sichtung:production)
+  ghcr.io/jansinger/ostsee-tiere:production)
 
 if [ "$RUNNING" = "$PULLED" ]; then
   exit 0

--- a/run-release.sh
+++ b/run-release.sh
@@ -23,7 +23,7 @@
 set -e
 
 CONTAINER_NAME="ostsee-tiere-release"
-IMAGE_BASE="ghcr.io/jansinger/ostsee-sichtung"
+IMAGE_BASE="ghcr.io/jansinger/ostsee-tiere"
 VERSION="${1:-latest}"
 PORT="${PORT:-3000}"
 SSL_PORT="${SSL_PORT:-3443}"

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -17,7 +17,7 @@
 		<nav>
 			<div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
 				<a
-					href="https://github.com/jansinger/ostsee-sichtung"
+					href="https://github.com/jansinger/ostsee-tiere"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="btn btn-ghost btn-xs sm:btn-sm text-xs sm:text-sm"

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -441,7 +441,7 @@ SOFTWARE.</pre>
 					</div>
 					<div class="card-actions mt-4">
 						<a
-							href="https://github.com/jansinger/ostsee-sichtung"
+							href="https://github.com/jansinger/ostsee-tiere"
 							target="_blank"
 							rel="noopener noreferrer"
 							class="btn btn-outline btn-sm"
@@ -514,7 +514,7 @@ SOFTWARE.</pre>
 					</p>
 					<div class="flex flex-wrap gap-3">
 						<a
-							href="https://github.com/jansinger/ostsee-sichtung/issues/new"
+							href="https://github.com/jansinger/ostsee-tiere/issues/new"
 							target="_blank"
 							rel="noopener noreferrer"
 							class="btn btn-outline btn-sm"
@@ -530,7 +530,7 @@ SOFTWARE.</pre>
 							Issue erstellen
 						</a>
 						<a
-							href="https://github.com/jansinger/ostsee-sichtung/issues"
+							href="https://github.com/jansinger/ostsee-tiere/issues"
 							target="_blank"
 							rel="noopener noreferrer"
 							class="btn btn-ghost btn-sm"


### PR DESCRIPTION
## Summary
- The GitHub repository `jansinger/ostsee-sichtung` was renamed to `jansinger/ostsee-tiere`. This updates the local git remote and all hardcoded references so the codebase, CI, and produced Docker images match the new name.
- Updated GHCR image name (`IMAGE_NAME`) in `docker-publish.yml` and `promote-production.yml`, plus the image reference in `docker-compose.production.yml`, `Dockerfile` (`org.opencontainers.image.source` label), `run-release.sh`, and `.env.docker`.
- Updated repo URLs in `README.md`, `README.vercel.md`, `CONTRIBUTING.md`, `docs/DATABASE_MIGRATION.md`, `docs/DOCKER_DEPLOYMENT.md`, `docs/PRODUCTION_DEPLOYMENT.md`, `docs/RELEASE_PIPELINE.md`, `.claude/rules/docker.md`.
- Updated public-facing GitHub links in `src/lib/components/PublicFooter.svelte` and `src/routes/about/+page.svelte`.
- `CHANGELOG.md` intentionally left untouched — it's release-please generated and its historical links still resolve fine via GitHub's redirect.

## Why
Keeps the repo self-consistent with the new GitHub name, and ensures the next release publishes its image under `ghcr.io/jansinger/ostsee-tiere` instead of the stale `ostsee-sichtung` path.

## Reviewer notes
- Docker-image path change is a breaking change for anything pulling the old `ghcr.io/jansinger/ostsee-sichtung` image tag. After merge + next release, the production host's `APP_IMAGE`/compose config needs to be updated to point at the new image path.
- No test/behavior changes — this is a pure rename/reference update.

## Test plan
- [x] `npm run lint` / `type-check` ran clean via pre-commit hook (2 pre-existing unrelated warnings)
- [ ] Confirm next CI release build publishes to `ghcr.io/jansinger/ostsee-tiere`
- [ ] Update production host's `APP_IMAGE` env once the new image is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)