### PR TITLE
refactor(ui): return the last hardcoded areas to the design system (PR 4/4)

### DIFF
--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -259,26 +259,18 @@ test.describe('Styleguide — Bedienung', () => {
 	}
 });
 
-/* Bekannt rot bis PR 4 — läuft deshalb bewusst NICHT mit.
-   Die Gruppe scannt den Bestand und listet jede Aufrufstelle, die eine
-   Flächen-Statusfarbe als Vordergrund verwendet, Text unter Deckkraft /60
-   setzt oder eine Tailwind-Paletten-Farbe am Theme vorbei nutzt (Befunde F2,
-   F3 und F11 des Reviews — über 60 Stellen).
+/* Seit PR 4 aktiver Guard — vorher `describe.fixme`, weil der Bestand die
+   Befunde F2, F3 und F11 des Reviews an über 60 Stellen enthielt.
 
-   `describe.fixme` überspringt die Tests, sie erzeugen im normalen Lauf also
-   weder Rot noch Ausgabe — das ist hier der Zweck: CI bleibt grün, ohne dass
-   die Assertions aufgeweicht werden. Die Arbeitsliste holt man sich gezielt,
-   indem man `.fixme` temporär entfernt und nur diese Datei laufen lässt:
+   Die Gruppe scannt den ausgelieferten DOM und meldet jede Aufrufstelle, die
+   eine Flächen-Statusfarbe als Vordergrund verwendet, Text unter Deckkraft /60
+   setzt oder eine Tailwind-Paletten-Farbe am Theme vorbei nutzt.
 
-     npx playwright test e2e/design-tokens.spec.ts --reporter=list
-
-   Die Fehlermeldung jedes Tests enthält dann die gefundenen Aufrufstellen
-   (max. 20 pro Route). PR 4 arbeitet sie ab; danach fällt `.fixme` dauerhaft
-   weg und die Gruppe wird zum echten Guard.
-
-   Die Regex NICHT aufweichen, um die Gruppe grün zu bekommen: sie wäre genau
-   dann wertlos, wenn sie nur noch findet, was ohnehin konform ist. */
-test.describe.fixme('Design-Tokens — verbotene Kombinationen im DOM', () => {
+   Die Regex NICHT aufweichen, um die Gruppe grün zu halten: sie wäre genau
+   dann wertlos, wenn sie nur noch findet, was ohnehin konform ist. Eine neue
+   Fundstelle gehört an der Aufrufstelle behoben — `text-*-strong` statt
+   `text-*`, `/70` statt `/50`, Theme-Token statt Tailwind-Palette. */
+test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 	/* Ruhezustand-Scan. Hover-Zustände tauchen in getComputedStyle nicht auf
 	   und sind hier deshalb nicht prüfbar — dafür gilt die Regel in
 	   design-system.md („text-error nicht auf base-300"). */

--- a/src/lib/components/MaintenanceBanner.svelte
+++ b/src/lib/components/MaintenanceBanner.svelte
@@ -13,7 +13,7 @@
 		</div>
 		<div class="flex-1">
 			<h3 class="font-bold flex items-center gap-2">
-				<Icon icon="lucide:triangle-alert" width="20" height="20" class="text-warning" />
+				<Icon icon="lucide:triangle-alert" width="20" height="20" class="text-warning-strong" />
 				Wartungsmodus ist aktiv
 			</h3>
 			<div class="text-sm">

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -46,7 +46,7 @@
 				<span class="hidden sm:inline">Deutsches Meeresmuseum, Stralsund, Deutschland</span>
 				<span class="sm:hidden">Deutsches Meeresmuseum</span>
 			</p>
-			<p class="mt-1 text-xs opacity-50">
+			<p class="mt-1 text-xs opacity-70">
 				<span class="hidden sm:inline">Meldeplattform für Meerestiere in der Ostsee</span>
 				<span class="sm:hidden">Ostsee Sichtungen</span>
 			</p>

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -82,7 +82,7 @@
 		<div class="space-y-4">
 			<div class="card bg-base-200 p-4">
 				<!-- Technische Informationen -->
-				<div class="text-sm text-gray-600">
+				<div class="text-sm text-base-content/70">
 					<p>Datensatz ID: {sighting.id}</p>
 					<p>Gemeldet: {formatLocalDateTime(sighting.created)}</p>
 					<p>Verifiziert: <BooleanStatus value={sighting.verified} /></p>

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -353,7 +353,7 @@
 				class="text-primary mx-auto mb-4 animate-spin"
 			/>
 			<p class="text-base-content/70 text-lg">Daten werden geladen...</p>
-			<p class="text-base-content/50 text-sm">Bitte warten Sie einen Moment</p>
+			<p class="text-base-content/70 text-sm">Bitte warten Sie einen Moment</p>
 		</div>
 	</div>
 {:else}

--- a/src/lib/components/admin/BooleanStatus.svelte
+++ b/src/lib/components/admin/BooleanStatus.svelte
@@ -35,23 +35,36 @@
 		}
 	});
 
-	// Custom classes for better styling
-	const badgeClasses = $derived.by(() => {
-		const baseClasses = `badge badge-${size} inline-flex items-center gap-1 font-medium`;
-		if (isTrue) {
-			return `${baseClasses} bg-green-100 text-green-800 border-green-200`;
-		} else {
-			return `${baseClasses} bg-gray-100 text-gray-600 border-gray-200`;
-		}
-	});
+	/* Vollständige Klassennamen, kein `badge-${size}`: Tailwind 4 erkennt nur
+	   Strings, die als Ganzes im Quelltext stehen (daisyui.md). */
+	const SIZE_CLASS = {
+		xs: 'badge-xs',
+		sm: 'badge-sm',
+		md: 'badge-md',
+		lg: 'badge-lg'
+	} as const;
+
+	/* badge-success ist eine Vollton-Fläche — dort ist `*-content` korrekt und
+	   kommt aus DaisyUI selbst. badge-ghost trägt base-content auf base-200. */
+	const badgeClasses = $derived(
+		`badge ${SIZE_CLASS[size]} ${isTrue ? 'badge-success' : 'badge-ghost'} inline-flex items-center gap-1 font-medium`
+	);
 </script>
 
 <div class={badgeClasses}>
 	{#if showIcon}
 		{#if isTrue}
-			<Icon icon="lucide:circle-check" class="flex-shrink-0" style="width: {iconSize}px; height: {iconSize}px;" />
+			<Icon
+				icon="lucide:circle-check"
+				class="flex-shrink-0"
+				style="width: {iconSize}px; height: {iconSize}px;"
+			/>
 		{:else}
-			<Icon icon="lucide:circle-x" class="flex-shrink-0" style="width: {iconSize}px; height: {iconSize}px;" />
+			<Icon
+				icon="lucide:circle-x"
+				class="flex-shrink-0"
+				style="width: {iconSize}px; height: {iconSize}px;"
+			/>
 		{/if}
 	{/if}
 	<span>{isTrue ? trueLabel : falseLabel}</span>

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -261,7 +261,7 @@
 									<div class="min-w-0 flex-1">
 										<div class="font-medium">{info.name}</div>
 										<div class="text-base-content/70 mt-1 text-xs">{info.description}</div>
-										<div class="text-base-content/50 mt-1 text-xs">
+										<div class="text-base-content/70 mt-1 text-xs">
 											~{formatFileSize(estimateFileSize(format, totalRecords))}
 										</div>
 									</div>

--- a/src/lib/components/admin/weather/WeatherDataDisplay.svelte
+++ b/src/lib/components/admin/weather/WeatherDataDisplay.svelte
@@ -112,7 +112,7 @@
 		<div class="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
 			<div class="bg-base-100 rounded-lg p-3">
 				<h5 class="mb-2 flex items-center gap-2 font-medium">
-					<Icon icon="lucide:info" width="16" class="text-info" />
+					<Icon icon="lucide:info" width="16" class="text-info-strong" />
 					API-Wetterdaten
 				</h5>
 
@@ -121,7 +121,7 @@
 
 			<div class="bg-base-100 rounded-lg p-3">
 				<h5 class="mb-2 flex items-center gap-2 font-medium">
-					<Icon icon="lucide:map-pin" width="16" class="text-secondary" />
+					<Icon icon="lucide:map-pin" width="16" class="text-secondary-strong" />
 					Position & Zeit
 				</h5>
 
@@ -149,19 +149,19 @@
 		<!-- Zusätzliche Wetterdaten -->
 		<div class="border-base-300 mt-4 border-t pt-3">
 			<h5 class="mb-2 flex items-center gap-2 text-sm font-medium">
-				<Icon icon="lucide:cloud" width="16" class="text-info" />
+				<Icon icon="lucide:cloud" width="16" class="text-info-strong" />
 				Erweiterte Wetterdaten
 			</h5>
 			<div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
 				{#if weatherData.processed.humidity}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:cloud" width="14" class="text-info" />
+						<Icon icon="lucide:cloud" width="14" class="text-info-strong" />
 						<span>Luftfeuchtigkeit: {weatherData.processed.humidity}%</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.precipitation}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:cloud-rain" width="14" class="text-info" />
+						<Icon icon="lucide:cloud-rain" width="14" class="text-info-strong" />
 						<span>Niederschlag: {weatherData.raw_data.precipitation}mm</span>
 					</div>
 				{/if}
@@ -173,25 +173,25 @@
 				{/if}
 				{#if weatherData.raw_data.wave_height}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:waves" width="14" class="text-info" />
+						<Icon icon="lucide:waves" width="14" class="text-info-strong" />
 						<span>Wellenhöhe: {weatherData.raw_data.wave_height.toFixed(2)}m</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.wave_direction}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:wind" width="14" class="text-info" />
+						<Icon icon="lucide:wind" width="14" class="text-info-strong" />
 						<span>Wellenrichtung: {Math.round(weatherData.raw_data.wave_direction)}°</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.wave_period}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:gem" width="14" class="text-info" />
+						<Icon icon="lucide:gem" width="14" class="text-info-strong" />
 						<span>Wellenperiode: {weatherData.raw_data.wave_period.toFixed(1)}s</span>
 					</div>
 				{/if}
 				{#if weatherData.raw_data.sea_surface_temperature}
 					<div class="flex items-center gap-2">
-						<Icon icon="lucide:thermometer" width="14" class="text-info" />
+						<Icon icon="lucide:thermometer" width="14" class="text-info-strong" />
 						<span>Wassertemp: {weatherData.raw_data.sea_surface_temperature}°C</span>
 					</div>
 				{/if}
@@ -215,7 +215,7 @@
 						<div>Konfidenz: {Math.round(weatherData.quality.confidence * 100)}%</div>
 					</div>
 					{#if weatherData.quality.notes}
-						<div class="text-base-content/50 mt-2 text-xs">
+						<div class="text-base-content/70 mt-2 text-xs">
 							Hinweis: {weatherData.quality.notes}
 						</div>
 					{/if}
@@ -237,6 +237,9 @@
 {:else}
 	<div class="no-weather-data border-base-300 bg-base-50 mt-4 rounded-lg border p-4">
 		<div class="text-base-content/70 text-center">
+			<!-- opacity-50 ist hier zulässig: rein dekoratives Leerzustands-Icon ohne
+			     Textinhalt. Die /60-Untergrenze aus design-system.md gilt für Zeichen,
+			     die gelesen werden müssen — die Aussage trägt der Text darunter. -->
 			<Icon icon="lucide:cloud" width="24" class="mx-auto mb-2 opacity-50" />
 			<p class="font-medium">Keine API-Wetterdaten verfügbar</p>
 			<p class="mt-1 text-sm">Diese Sichtung wurde vor der Weather-API-Integration erstellt.</p>

--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -283,7 +283,7 @@
 					icon="lucide:upload"
 					class="mb-2 h-8 w-8 transition-colors {isDragOver
 						? 'text-primary'
-						: 'text-base-content/40'}"
+						: 'text-base-content/70'}"
 				/>
 				<p class="text-sm font-medium {isDragOver ? 'text-primary' : ''}">
 					{isDragOver ? `${multiple ? 'Dateien' : 'Datei'} hier ablegen!` : title}

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -105,7 +105,7 @@
 	<!-- Info-Box: wie die Marker codiert sind -->
 	<div class="bg-base-300/50 mb-4 rounded-lg p-3 text-sm">
 		<div class="flex items-start gap-2">
-			<Icon icon="lucide:info" class="text-info mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+			<Icon icon="lucide:info" class="text-info-strong mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
 			<div>
 				<strong>So lesen Sie die Karte:</strong> Die Ringfarbe zeigt die Tiergruppe, das Symbol die Gruppe
 				als zweites Merkmal. Ab zwei Tieren steht die Anzahl unter dem Marker. Ein schwarzer Ring bedeutet
@@ -140,7 +140,7 @@
 				data-species-row={key}
 			>
 				<!-- 0/0-Arten ausgrauen: visuelle Teile abschwächen, Checkbox bleibt bedienbar -->
-				<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-40 grayscale' : ''}">
+				<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-60 grayscale' : ''}">
 					<div
 						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
 						style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol

--- a/src/lib/components/media/MediaGallery.svelte
+++ b/src/lib/components/media/MediaGallery.svelte
@@ -59,7 +59,7 @@
 		{#if imageFiles.length > 0}
 			<div class="mb-6">
 				<div class="mb-2 flex items-center gap-2">
-					<Icon icon="lucide:images" width="16" class="text-secondary" />
+					<Icon icon="lucide:images" width="16" class="text-secondary-strong" />
 					<h5 class="text-base-content/70 text-sm font-medium">
 						Bilder ({imageFiles.length})
 					</h5>
@@ -76,7 +76,7 @@
 		{#if videoFiles.length > 0}
 			<div class="mb-6">
 				<div class="mb-2 flex items-center gap-2">
-					<Icon icon="lucide:video" width="16" class="text-secondary" />
+					<Icon icon="lucide:video" width="16" class="text-secondary-strong" />
 					<h5 class="text-base-content/70 text-sm font-medium">
 						Videos ({videoFiles.length})
 					</h5>
@@ -93,7 +93,7 @@
 		{#if otherFiles.length > 0}
 			<div class="mb-6">
 				<div class="mb-2 flex items-center gap-2">
-					<Icon icon="lucide:file-text" width="16" class="text-secondary" />
+					<Icon icon="lucide:file-text" width="16" class="text-secondary-strong" />
 					<h5 class="text-base-content/70 text-sm font-medium">
 						Andere Dateien ({otherFiles.length})
 					</h5>
@@ -132,7 +132,7 @@
 {:else}
 	<div class="bg-base-100 flex items-center justify-center rounded-lg p-8 text-center">
 		<div class="space-y-3">
-			<Icon icon="lucide:images" width="32" class="text-base-content/40 mx-auto" />
+			<Icon icon="lucide:images" width="32" class="text-base-content/70 mx-auto" />
 			<p class="text-base-content/60 text-sm">Keine Medien vorhanden</p>
 		</div>
 	</div>

--- a/src/lib/components/media/MediaModal.svelte
+++ b/src/lib/components/media/MediaModal.svelte
@@ -153,7 +153,7 @@
 				{:else}
 					<!-- Andere Dateitypen - Vorschau nicht möglich -->
 					<div class="flex flex-col items-center justify-center py-12 text-center">
-						<Icon icon="lucide:file-type" width="48" class="text-base-content/40 mb-4" />
+						<Icon icon="lucide:file-type" width="48" class="text-base-content/70 mb-4" />
 						<h4 class="mb-2 text-lg font-semibold">Vorschau nicht verfügbar</h4>
 						<p class="text-base-content/60 mb-4">Für diesen Dateityp ist keine Vorschau möglich.</p>
 						<a
@@ -213,7 +213,7 @@
 								{#if hasGPSData()}
 									<div class="bg-base-200 rounded-lg p-3">
 										<h5 class="mb-2 flex items-center gap-1 text-xs font-medium">
-											<Icon icon="lucide:map-pin" width="12" class="text-success" />
+											<Icon icon="lucide:map-pin" width="12" class="text-success-strong" />
 											GPS-Position
 										</h5>
 										<div class="space-y-1 text-xs">
@@ -238,7 +238,7 @@
 								{#if hasCameraData()}
 									<div class="bg-base-200 rounded-lg p-3">
 										<h5 class="mb-2 flex items-center gap-1 text-xs font-medium">
-											<Icon icon="lucide:settings" width="12" class="text-secondary" />
+											<Icon icon="lucide:settings" width="12" class="text-secondary-strong" />
 											Kamera-Einstellungen
 										</h5>
 										<div class="grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">

--- a/src/lib/components/weather/WeatherDataFetcher.svelte
+++ b/src/lib/components/weather/WeatherDataFetcher.svelte
@@ -153,7 +153,7 @@
 					{/if}
 				</p>
 				{#if weatherData._metadata?.dataType === 'forecast'}
-					<p class="text-warning">
+					<p class="text-warning-strong">
 						⚠️ Prognosedaten für heutige Sichtung (aktualisiert sich mehrmals täglich)
 					</p>
 				{/if}

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -9,7 +9,7 @@
 	display: block;
 	width: 100%;
 	height: var(--map-height, 400px);
-	border: 1px solid #ccc;
+	border: 1px solid var(--color-base-300);
 }
 
 .ol-map {
@@ -28,12 +28,12 @@
 }
 
 .ol-zoom button {
-	background-color: rgba(255, 255, 255, 0.9) !important;
+	background-color: color-mix(in oklab, var(--color-base-100) 90%, transparent) !important;
 	border: none !important;
 	border-radius: 4px !important;
-	color: #444 !important;
+	color: var(--color-base-content) !important;
 	font-weight: bold !important;
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+	box-shadow: var(--shadow-raised) !important;
 	margin: 2px !important;
 	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
 	height: 44px !important;
@@ -45,19 +45,19 @@
 }
 
 .ol-zoom button:hover {
-	background-color: rgba(255, 255, 255, 1) !important;
+	background-color: var(--color-base-100) !important;
 }
 
 /* OpenLayers Control Grundeinstellungen */
 .ol-control {
-	background-color: rgba(255, 255, 255, 0.4);
+	background-color: color-mix(in oklab, var(--color-base-100) 40%, transparent);
 	border-radius: 4px;
 	padding: 2px;
 }
 
 .ol-control button {
-	background-color: rgba(0, 60, 136, 0.5);
-	color: white;
+	background-color: var(--color-primary);
+	color: var(--color-primary-content);
 	border: none;
 	display: inline-block;
 	font-size: 14px;
@@ -71,7 +71,7 @@
 }
 
 .ol-control button:hover {
-	background-color: rgba(0, 60, 136, 0.7);
+	background-color: color-mix(in oklab, var(--color-primary) 85%, var(--color-base-content));
 }
 
 /* Zoom All Control */
@@ -83,17 +83,17 @@
 }
 
 .zoom-all-control button {
-	background-color: rgba(255, 255, 255, 0.9) !important;
+	background-color: color-mix(in oklab, var(--color-base-100) 90%, transparent) !important;
 	border: none !important;
 	border-radius: 4px !important;
-	color: #444 !important;
+	color: var(--color-base-content) !important;
 	cursor: pointer;
 	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
 	height: 44px !important;
 	width: 44px !important;
 	font-weight: bold !important;
 	font-size: 20px !important;
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+	box-shadow: var(--shadow-raised) !important;
 	margin: 2px !important;
 	display: flex !important;
 	align-items: center !important;
@@ -101,7 +101,7 @@
 }
 
 .zoom-all-control button:hover {
-	background-color: rgba(255, 255, 255, 1) !important;
+	background-color: var(--color-base-100) !important;
 }
 
 /* Location Control */
@@ -112,17 +112,17 @@
 }
 
 .location-control button {
-	background-color: rgba(255, 255, 255, 0.9) !important;
+	background-color: color-mix(in oklab, var(--color-base-100) 90%, transparent) !important;
 	border: none !important;
 	border-radius: 4px !important;
-	color: #444 !important;
+	color: var(--color-base-content) !important;
 	cursor: pointer;
 	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
 	height: 44px !important;
 	width: 44px !important;
 	font-weight: bold !important;
 	font-size: 20px !important;
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+	box-shadow: var(--shadow-raised) !important;
 	margin: 2px !important;
 	display: flex !important;
 	align-items: center !important;
@@ -132,7 +132,7 @@
 }
 
 .location-control button:hover {
-	background-color: rgba(255, 255, 255, 1) !important;
+	background-color: var(--color-base-100) !important;
 }
 
 /* N2: Aktives Tracking — Zustand hängt am aria-pressed-Attribut (ein Zustand,
@@ -154,8 +154,8 @@
 }
 
 .gps-control .gps-button {
-	background-color: rgba(255, 255, 255, 0.8);
-	border: 2px solid #ccc;
+	background-color: color-mix(in oklab, var(--color-base-100) 80%, transparent);
+	border: 2px solid var(--color-base-300);
 	border-radius: 4px;
 	width: 32px;
 	height: 32px;
@@ -163,16 +163,23 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	transition: all 0.3s ease;
+	/* Keine `transition: all`: Chromium wendet damit den aria-pressed-Wechsel
+	   unten nicht an — dieselbe Falle wie beim Location-Control. */
+	transition: background-color var(--motion-instant) var(--motion-ease);
 }
 
 .gps-control .gps-button:hover {
-	background-color: rgba(255, 255, 255, 1);
-	border-color: #3b82f6;
+	background-color: var(--color-base-100);
+	border-color: var(--color-primary);
 }
 
-.gps-control .gps-button[style*='background-color: rgb(59, 130, 246)'] {
-	border-color: #3b82f6;
+/* Aktives Tracking — Zustand hängt am aria-pressed-Attribut, das
+   FormLocationControl setzt (openLayersHelpers.ts). Vorher hing diese Regel an
+   einem Substring des inline gesetzten `style`-Attributs. */
+.gps-control .gps-button[aria-pressed='true'] {
+	background-color: var(--color-primary);
+	color: var(--color-primary-content);
+	border-color: var(--color-primary);
 }
 
 .gps-control .gps-button svg {
@@ -193,7 +200,7 @@
 .ol-attribution {
 	bottom: 0.5rem;
 	right: 0.5rem;
-	background-color: rgba(255, 255, 255, 0.8) !important;
+	background-color: color-mix(in oklab, var(--color-base-100) 80%, transparent) !important;
 	border-radius: 4px !important;
 	font-size: 0.75rem !important;
 }
@@ -211,8 +218,8 @@
 /* Drag Hint */
 .drag-hint {
 	font-size: 0.85rem;
-	color: #666;
-	background-color: #f9f9f9;
+	color: var(--color-base-content);
+	background-color: var(--color-base-200);
 	border-radius: 4px;
 	padding: 2px 8px;
 	display: inline-block;
@@ -222,10 +229,10 @@
 /* Info Popup Styling */
 #info {
 	position: absolute;
-	background: white;
+	background: var(--color-base-100);
 	border-radius: 4px;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-	border: 1px solid #ccc;
+	box-shadow: var(--shadow-floating);
+	border: 1px solid var(--color-base-300);
 	pointer-events: none;
 	font-size: 12px;
 	line-height: 1.4;
@@ -236,12 +243,13 @@
 }
 
 #info strong {
-	color: #1f2937;
+	color: var(--color-base-content);
 	font-weight: 600;
 }
 
 #info em {
-	color: #6b7280;
+	color: var(--color-base-content);
+	opacity: 0.7;
 	font-size: 0.75rem;
 }
 
@@ -260,7 +268,7 @@
 .ol-popup {
 	position: absolute;
 	background-color: var(--color-base-100);
-	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+	box-shadow: var(--shadow-floating);
 	padding: 44px 15px 15px 15px;
 	border-radius: 10px;
 	border: 1px solid var(--color-base-300);

--- a/src/lib/map/mapTokens.ts
+++ b/src/lib/map/mapTokens.ts
@@ -1,0 +1,43 @@
+/**
+ * mapTokens.ts — Theme-Brücke zum OpenLayers-Canvas
+ *
+ * OpenLayers zeichnet auf ein <canvas> und kann keine CSS-Variablen lesen.
+ * Hex-Werte sind dort deshalb notwendig, nicht nachlässig. Was bisher fehlte,
+ * war ein einziger Ort für sie: LocationControl.ts, openLayersHelpers.ts,
+ * optimizedMapController.ts und mapStyles.css führten je eigene Werte
+ * (#3b82f6, #2563eb, #6b7280, #f9fafb …) — keiner davon aus dem Theme.
+ *
+ * Die Werte hier sind die sRGB-Entsprechungen der oklch()-Tokens aus
+ * src/css/tokens.css. Sie sind NICHT frei wählbar: e2e/design-tokens.spec.ts
+ * liest die berechneten Theme-Farben im Browser aus und vergleicht sie mit
+ * diesen Konstanten. Ändert sich ein Theme-Wert, schlägt der Test fehl und
+ * zeigt, dass diese Datei nachzuziehen ist.
+ *
+ * Die MARKER-Palette bleibt bewusst außerhalb: sie folgt der Wong-Palette
+ * (farbfehlsichtigkeits-sicher) und steht in styleUtils.ts. Marker-Farben
+ * sind Datenkodierung, keine Markenfarben — sie dürfen sich nicht mit dem
+ * Theme mitbewegen.
+ */
+
+/** sRGB-Entsprechungen der Theme-Tokens (siehe src/css/tokens.css). */
+export const MAP_THEME = {
+	/** --color-primary — Auswahl, aktive Steuerelemente */
+	primary: '#004062',
+	/** --color-primary-content */
+	primaryContent: '#ffffff',
+	/** --color-base-100 — Popup-Fläche */
+	surface: '#e6ecf2',
+	/** --color-base-300 — Rahmen, Trennlinien */
+	border: '#bdc5ce',
+	/** --color-base-content — Popup-Text */
+	text: '#050c14',
+	/** --color-base-content bei 70 % auf base-100 (6,96:1) — Sekundärtext */
+	textMuted: '#4a5158',
+	/** --color-error — Fehlermeldung, Totfund-Markierung */
+	error: '#ac1922',
+	/** --color-warning-strong — Hinweis (die Flächenvariante #bb8500 erreicht
+	 *  als Textfarbe nur 2,74:1) */
+	warning: '#865100'
+} as const;
+
+export type MapThemeColor = keyof typeof MAP_THEME;

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -28,6 +28,7 @@ import {
 	getFeatureColorGroup
 } from './styleUtils';
 import { clusterDistanceForZoom, clusterMinDistanceFor } from './clusterConfig';
+import { MAP_THEME } from './mapTokens';
 import {
 	createClusterInfoText,
 	createClusterListContent,
@@ -145,18 +146,20 @@ export class SichtungenMap {
 					return new Style({
 						image: new Circle({
 							radius: 8,
-							fill: new Fill({ color: '#3b82f6' }),
-							stroke: new Stroke({ color: '#ffffff', width: 2 })
+							fill: new Fill({ color: MAP_THEME.primary }),
+							stroke: new Stroke({ color: MAP_THEME.primaryContent, width: 2 })
 						})
 					});
 				} else if (type === 'accuracy') {
 					return new Style({
 						stroke: new Stroke({
-							color: '#3b82f6',
+							color: MAP_THEME.primary,
 							width: 2
 						}),
 						fill: new Fill({
-							color: 'rgba(59, 130, 246, 0.1)'
+							// 10 % Deckkraft als 8-stelliges Hex — ol/color löst #RRGGBBAA auf,
+							// eine zweite Konstante in mapTokens.ts wäre dafür nicht nötig.
+							color: `${MAP_THEME.primary}1a`
 						})
 					});
 				}

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -48,7 +48,7 @@
 	<div class="card-body p-2">
 		<details class="collapse">
 			<summary class="collapse-title flex cursor-pointer items-center gap-2 text-sm font-medium">
-				<Icon icon="lucide:circle-help" width="16" class="text-info" />
+				<Icon icon="lucide:circle-help" width="16" class="text-info-strong" />
 				Hilfe & Tipps für eine wertvolle Sichtungsmeldung
 			</summary>
 			<div class="collapse-content text-base-content/80 text-sm">
@@ -66,7 +66,7 @@
 							</p>
 							<div class="bg-base-100 mt-3 rounded-lg p-3">
 								{#if !loading && fetchFailed}
-									<p class="text-base-content/50 text-center text-xs">
+									<p class="text-base-content/70 text-center text-xs">
 										Statistiken konnten nicht geladen werden
 									</p>
 								{:else}
@@ -180,12 +180,12 @@
 					<div class="alert alert-success">
 						<div>
 							<h4 class="mb-4 flex items-center justify-center gap-2 text-center font-semibold">
-								<Icon icon="lucide:chart-pie" width="16" class="text-success" />
+								<Icon icon="lucide:chart-pie" width="16" class="text-success-strong" />
 								Ihre Daten machen den Unterschied
 							</h4>
 							<div class="grid grid-cols-1 gap-6 md:grid-cols-2">
 								<div class="bg-success/10 border-success/20 rounded-lg border p-4 text-center">
-									<div class="text-success mb-2 text-2xl font-bold">
+									<div class="text-success-strong mb-2 text-2xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
 										{:else}
@@ -207,7 +207,7 @@
 									</div>
 								</div>
 								<div class="bg-success/10 border-success/20 rounded-lg border p-4 text-center">
-									<div class="text-success mb-2 text-2xl font-bold">
+									<div class="text-success-strong mb-2 text-2xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
 										{:else if statistics && statistics.totalSightings > 0}
@@ -235,7 +235,7 @@
 					<div class="alert alert-warning">
 						<div>
 							<h4 class="flex items-center gap-2 font-semibold">
-								<Icon icon="lucide:triangle-alert" width="16" class="text-warning" />
+								<Icon icon="lucide:triangle-alert" width="16" class="text-warning-strong" />
 								Totfunde - Besonders wichtig!
 							</h4>
 							<p class="mt-1 text-xs">
@@ -246,7 +246,7 @@
 							</p>
 							<div class="bg-warning/10 mt-3 rounded-lg p-3">
 								<div class="text-center">
-									<div class="text-warning mb-1 text-xl font-bold">
+									<div class="text-warning-strong mb-1 text-xl font-bold">
 										{#if loading}
 											<span class="loading loading-dots loading-sm"></span>
 										{:else}

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -28,7 +28,7 @@
 		<div class="mb-8 space-y-6 text-center">
 			<div class="flex justify-center">
 				<div class="bg-success/20 flex h-20 w-20 items-center justify-center rounded-full">
-					<Icon icon="lucide:check" width="40" class="text-success" />
+					<Icon icon="lucide:check" width="40" class="text-success-strong" />
 				</div>
 			</div>
 
@@ -45,11 +45,11 @@
 		<!-- Success Details -->
 		<div class="card bg-base-200 mb-8 shadow-xl">
 			<div class="card-body">
-				<h2 class="card-title text-success mb-4">Was passiert als Nächstes?</h2>
+				<h2 class="card-title text-success-strong mb-4">Was passiert als Nächstes?</h2>
 
 				<div class="space-y-4">
 					<div class="flex items-start gap-3">
-						<Icon icon="lucide:check-circle" width="24" height="24" class="text-success mt-1" />
+						<Icon icon="lucide:check-circle" width="24" height="24" class="text-success-strong mt-1" />
 						<div>
 							<h3 class="font-semibold">Bestätigung per E-Mail</h3>
 							<p class="text-base-content/70 text-sm">
@@ -61,7 +61,7 @@
 					</div>
 
 					<div class="flex items-start gap-3">
-						<Icon icon="lucide:activity" width="24" height="24" class="text-info mt-1" />
+						<Icon icon="lucide:activity" width="24" height="24" class="text-info-strong mt-1" />
 						<div>
 							<h3 class="font-semibold">Wissenschaftliche Auswertung</h3>
 							<p class="text-base-content/70 text-sm">
@@ -72,7 +72,7 @@
 
 					{#if submittedData?.mediaUpload}
 						<div class="flex items-start gap-3">
-							<Icon icon="lucide:camera" width="24" height="24" class="text-accent mt-1" />
+							<Icon icon="lucide:camera" width="24" height="24" class="text-accent-strong mt-1" />
 							<div>
 								<h3 class="font-semibold">Medien-Upload</h3>
 								<p class="text-base-content/70 text-sm">
@@ -85,7 +85,7 @@
 
 					{#if submittedData?.isDead}
 						<div class="flex items-start gap-3">
-							<Icon icon="lucide:triangle-alert" width="24" height="24" class="text-warning mt-1" />
+							<Icon icon="lucide:triangle-alert" width="24" height="24" class="text-warning-strong mt-1" />
 							<div>
 								<h3 class="font-semibold">Totfund gemeldet</h3>
 								<p class="text-base-content/70 text-sm">

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -46,7 +46,7 @@
 			{@const navigable = canNavigateTo(index)}
 			<li
 				class="step {currentStep >= index ? 'step-primary' : ''}"
-				class:opacity-50={!navigable && index > currentStep}
+				class:opacity-70={!navigable && index > currentStep}
 			>
 				<button
 					type="button"

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -29,7 +29,7 @@
 		<div class="bg-base-100 mb-4 rounded-lg p-4">
 			<div class="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
 				<div class="flex items-start gap-3">
-					<Icon icon="lucide:check-circle" width="20" height="20" class="text-success mt-0.5" />
+					<Icon icon="lucide:check-circle" width="20" height="20" class="text-success-strong mt-0.5" />
 					<div>
 						<p class="font-medium">Öffentliche Wissenschaftsdaten</p>
 						<p class="text-base-content/70 text-xs">
@@ -38,7 +38,7 @@
 					</div>
 				</div>
 				<div class="flex items-start gap-3">
-					<Icon icon="lucide:lock" width="20" height="20" class="text-info mt-0.5" />
+					<Icon icon="lucide:lock" width="20" height="20" class="text-info-strong mt-0.5" />
 					<div>
 						<p class="font-medium">Private Kontaktdaten</p>
 						<p class="text-base-content/70 text-xs">

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -617,8 +617,8 @@
 									{#if fileMetadata.exifData?.latitude && fileMetadata.exifData?.longitude}
 										<div class="bg-success/10 mt-1 rounded p-1.5">
 											<div class="flex items-center gap-1">
-												<Icon icon="lucide:map-pin" width="12" class="text-success" />
-												<span class="text-success text-xs font-medium">GPS</span>
+												<Icon icon="lucide:map-pin" width="12" class="text-success-strong" />
+												<span class="text-success-strong text-xs font-medium">GPS</span>
 												{#if isInBalticArea(fileMetadata.exifData.longitude, fileMetadata.exifData.latitude)}
 													<span class="badge badge-success badge-xs">Ostsee</span>
 												{:else}
@@ -684,7 +684,7 @@
 						     zwingend in eine Zeile — ohne Umbruch liefe sie über. -->
 						<div class="mb-3 flex flex-wrap items-center justify-between gap-2">
 							<div class="flex items-center gap-2">
-								<Icon icon="lucide:map-pin" class="text-success h-[18px] w-[18px]" />
+								<Icon icon="lucide:map-pin" class="text-success-strong h-[18px] w-[18px]" />
 								<h4 class="text-sm font-semibold">GPS-Position</h4>
 							</div>
 							<div class="badge badge-success badge-sm text-nowrap">
@@ -783,7 +783,7 @@
 									aria-hidden="true"
 									icon="lucide:check"
 									width="14"
-									class="text-success shrink-0"
+									class="text-success-strong shrink-0"
 								/>
 								Position, Datum und Uhrzeit aus dem Foto übernommen
 							</p>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -263,7 +263,7 @@
 				{#if hasError}
 					<Icon icon="lucide:x" width="14" class="text-error inline" />
 				{:else if isValid}
-					<Icon icon="lucide:check" width="14" class="text-success inline" />
+					<Icon icon="lucide:check" width="14" class="text-success-strong inline" />
 				{/if}
 			</span>
 		{/if}

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -212,7 +212,7 @@ describe('FieldRenderer', () => {
 			});
 
 			// Erfolgs-Icon (lucide:check) darf nicht gerendert sein
-			const check = screen.container.querySelector('.text-success');
+			const check = screen.container.querySelector('.text-success-strong');
 			expect(check).toBeNull();
 		});
 
@@ -224,7 +224,7 @@ describe('FieldRenderer', () => {
 				touched: true
 			});
 
-			const check = screen.container.querySelector('.text-success');
+			const check = screen.container.querySelector('.text-success-strong');
 			expect(check).not.toBeNull();
 		});
 
@@ -237,7 +237,7 @@ describe('FieldRenderer', () => {
 				error: 'Fehler'
 			});
 
-			const check = screen.container.querySelector('.text-success');
+			const check = screen.container.querySelector('.text-success-strong');
 			expect(check).toBeNull();
 		});
 	});

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -127,7 +127,7 @@
 			<!-- Wichtigste Regel zuerst -->
 			<div class="bg-warning/10 border-warning/30 mb-4 rounded-lg border p-3">
 				<h5 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
-					<Icon icon="lucide:triangle-alert" width="14" class="text-warning" aria-hidden="true" />
+					<Icon icon="lucide:triangle-alert" width="14" class="text-warning-strong" aria-hidden="true" />
 					Im Zweifel nicht raten
 				</h5>
 				<p class="text-base-content/80 text-xs">
@@ -200,7 +200,7 @@
 														</button>
 														<p class="text-base-content/70 mt-1 text-xs">{image.alt}</p>
 														{#if image.copyright}
-															<p class="text-base-content/50 text-xs">
+															<p class="text-base-content/70 text-xs">
 																<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 																{@html sanitizeHtml(image.copyright)}
 															</p>
@@ -215,7 +215,7 @@
 											<h6
 												class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold"
 											>
-												<Icon icon="lucide:eye" width="14" class="text-info" aria-hidden="true" />
+												<Icon icon="lucide:eye" width="14" class="text-info-strong" aria-hidden="true" />
 												So sieht es an der Oberfläche aus
 											</h6>
 											<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -11,6 +11,7 @@
 	import VerifyLocation from '$lib/report/components/form/VerifyLocation.svelte';
 	import { hasCoordinates, toCoordinate } from '$lib/report/components/form/coordinateValue';
 	import { openAncestorDetails } from '$lib/utils/fieldNavigation';
+	import SectionCard from '$lib/report/components/sections/SectionCard.svelte';
 	import LocationDescription from './LocationDescription.svelte';
 	import { requestCurrentPosition } from './geolocation';
 	import {
@@ -200,11 +201,7 @@
 	}
 </script>
 
-<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
-	<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
-		<Icon aria-hidden="true" icon="lucide:map-pin" width="20" class="text-primary" />
-		Positionsangabe
-	</h3>
+<SectionCard title="Positionsangabe" icon="lucide:map-pin" variant="inset">
 	<p class="text-base-content/70 mb-6 text-sm">
 		Wo haben Sie das Tier gesehen? Ein Foto mit GPS-Daten ist der schnellste Weg.
 	</p>
@@ -373,6 +370,6 @@
 	{#if latitude !== undefined && longitude !== undefined}
 		<VerifyLocation {longitude} {latitude} />
 	{/if}
-</div>
+</SectionCard>
 
 <LocationDescription />

--- a/src/lib/report/components/sections/DeadAnimal.svelte
+++ b/src/lib/report/components/sections/DeadAnimal.svelte
@@ -9,7 +9,7 @@
 			aria-hidden="true"
 			icon="lucide:triangle-alert"
 			width="16"
-			class="text-warning shrink-0"
+			class="text-warning-strong shrink-0"
 		/>
 		<span>Zusätzliche Informationen für Totfund</span>
 	</h4>

--- a/src/lib/report/components/sections/PositionAndTime.svelte
+++ b/src/lib/report/components/sections/PositionAndTime.svelte
@@ -1,21 +1,17 @@
 <script lang="ts">
-	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import PositionPanel from '$lib/report/components/form/position/PositionPanel.svelte';
+	import SectionCard from '$lib/report/components/sections/SectionCard.svelte';
 </script>
 
 <div class="space-y-6">
 	<PositionPanel />
 
 	<!-- Date and Time Section (always visible) -->
-	<div class="border-base-300 bg-base-200/50 rounded-lg border p-3 md:p-4">
-		<h3 class="mb-3 flex items-center gap-2 text-base font-semibold md:text-lg">
-			<Icon aria-hidden="true" icon="lucide:calendar" width="20" class="text-primary" />
-			Datum und Uhrzeit
-		</h3>
+	<SectionCard title="Datum und Uhrzeit" icon="lucide:calendar" variant="inset">
 		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 			<FormField name="sightingDate" />
 			<FormField name="sightingTime" />
 		</div>
-	</div>
+	</SectionCard>
 </div>

--- a/src/lib/report/components/sections/SectionCard.svelte
+++ b/src/lib/report/components/sections/SectionCard.svelte
@@ -2,31 +2,45 @@
 	import type { Snippet } from 'svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
+	/**
+	 * Zwei Varianten, ein Abschnittsmuster (siehe /styleguide → „Abschnitt").
+	 *
+	 * - `card`  — eigenständiger Abschnitt auf Seitenebene (DaisyUI-Karte).
+	 * - `inset` — untergeordneter Block innerhalb eines Schritts. Genau die Box,
+	 *   die `PositionAndTime.svelte` und `PositionPanel.svelte` bisher jeweils
+	 *   selbst zusammengesetzt haben.
+	 *
+	 * Der Hover-Zustand steht nicht mehr hier: `.card:hover` in `app.css` gilt
+	 * für alle Karten. Der frühere lokale `<style>`-Block hat ihn ein zweites Mal
+	 * definiert — mit `transition: all` und einem handgeschriebenen `box-shadow`
+	 * statt eines Elevation-Tokens.
+	 */
 	interface Props {
 		title: string;
 		icon: string;
+		variant?: 'card' | 'inset';
 		children: Snippet;
 	}
 
-	let { title, icon, children }: Props = $props();
+	let { title, icon, variant = 'card', children }: Props = $props();
 </script>
 
-<div class="card bg-base-200 shadow-sm">
-	<div class="card-body">
-		<h3 class="card-title flex items-center gap-2 text-lg">
+{#if variant === 'card'}
+	<div class="card bg-base-200 shadow-raised">
+		<div class="card-body">
+			<h3 class="card-title text-section flex items-center gap-2">
+				<Icon {icon} width="20" class="text-primary" aria-hidden="true" />
+				{title}
+			</h3>
+			{@render children()}
+		</div>
+	</div>
+{:else}
+	<div class="border-base-300 bg-base-200/50 rounded-box border p-3 md:p-4">
+		<h3 class="text-section mb-3 flex items-center gap-2 font-semibold">
 			<Icon {icon} width="20" class="text-primary" aria-hidden="true" />
 			{title}
 		</h3>
 		{@render children()}
 	</div>
-</div>
-
-<style>
-	.card {
-		transition: all 0.2s ease;
-	}
-	.card:hover {
-		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
-	}
-</style>
+{/if}

--- a/src/lib/report/components/sections/SectionCard.svelte.test.ts
+++ b/src/lib/report/components/sections/SectionCard.svelte.test.ts
@@ -1,0 +1,69 @@
+import { createRawSnippet } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import SectionCard from './SectionCard.svelte';
+
+/**
+ * Die `variant`-Prop ist der Grund, aus dem `PositionAndTime.svelte` und
+ * `PositionPanel.svelte` ihre Inline-Boxen aufgeben können. Geprüft wird
+ * deshalb genau das, was diese Aufrufstellen gebraucht haben: dass „inset"
+ * keine Karte ist (kein `card`, kein Schatten) und trotzdem denselben Titel
+ * mit Icon trägt.
+ *
+ * Der Hover wird hier NICHT geprüft — er kommt seit PR 2 aus `app.css`
+ * (`.card:hover`) und ist damit kein Verhalten dieser Komponente mehr.
+ */
+
+const body = () => createRawSnippet(() => ({ render: () => '<p>Inhalt</p>' }));
+
+describe('SectionCard', () => {
+	it('rendert Titel und Inhalt', async () => {
+		const { container } = render(SectionCard, {
+			title: 'Positionsangabe',
+			icon: 'lucide:map-pin',
+			children: body()
+		});
+
+		expect(container.querySelector('h3')?.textContent).toContain('Positionsangabe');
+	});
+
+	it('variant="card" (Default) ist eine DaisyUI-Karte', async () => {
+		const { container } = render(SectionCard, {
+			title: 'Sichtungsdetails',
+			icon: 'lucide:eye',
+			children: body()
+		});
+
+		const root = container.querySelector('div');
+		expect(root?.className).toContain('card');
+		expect(root?.className).toContain('shadow-raised');
+		// shadow-sm ist in design-system.md verboten — nur -raised/-floating.
+		expect(root?.className).not.toContain('shadow-sm');
+	});
+
+	it('variant="inset" ist ein eingebetteter Block ohne Karte und ohne Schatten', async () => {
+		const { container } = render(SectionCard, {
+			title: 'Datum und Uhrzeit',
+			icon: 'lucide:calendar',
+			variant: 'inset',
+			children: body()
+		});
+
+		const root = container.querySelector('div');
+		expect(root?.className).not.toContain('card');
+		expect(root?.className).not.toContain('shadow');
+		expect(root?.className).toContain('bg-base-200/50');
+		expect(container.querySelector('h3')?.textContent).toContain('Datum und Uhrzeit');
+	});
+
+	it('setzt das Icon dekorativ (aria-hidden), der Titel trägt die Bedeutung', async () => {
+		const { container } = render(SectionCard, {
+			title: 'Positionsangabe',
+			icon: 'lucide:map-pin',
+			variant: 'inset',
+			children: body()
+		});
+
+		expect(container.querySelector('h3 svg')?.getAttribute('aria-hidden')).toBe('true');
+	});
+});

--- a/src/lib/report/components/steps/Step3Observations.svelte
+++ b/src/lib/report/components/steps/Step3Observations.svelte
@@ -77,7 +77,7 @@
 			</button>
 		</div>
 
-		<div class="divider text-xs opacity-50">oder Details hinzufügen</div>
+		<div class="divider text-xs opacity-70">oder Details hinzufügen</div>
 	</div>
 
 	<Media></Media>

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -71,7 +71,7 @@
 			<div class="alert alert-info mt-4">
 				<div class="text-xs">
 					<p class="mb-2 flex items-center gap-2 font-medium">
-						<Icon icon="lucide:save" width="16" class="text-info" />
+						<Icon icon="lucide:save" width="16" class="text-info-strong" />
 						Automatische Speicherung für Komfort
 					</p>
 					<p>
@@ -81,7 +81,7 @@
 
 					{#if hasSavedContactData}
 						<div class="mt-3 flex items-center justify-between">
-							<span class="text-success font-medium">✓ Gespeicherte Kontaktdaten gefunden</span>
+							<span class="text-success-strong font-medium">✓ Gespeicherte Kontaktdaten gefunden</span>
 							<button
 								type="button"
 								class="btn btn-outline btn-error btn-sm min-h-11"

--- a/src/lib/server/services/configInitializer.ts
+++ b/src/lib/server/services/configInitializer.ts
@@ -38,19 +38,19 @@ const defaultConfigurations: ConfigItem[] = [
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Neue Sichtung - {{referenceId}}</title>
 	<style>
-		.alert-warning { background: #fef3c7; border-left: 4px solid #f59e0b; padding: 12px; margin: 16px 0; }
-		.alert-success { background: #dcfce7; border-left: 4px solid #10b981; padding: 12px; margin: 16px 0; }
-		.alert-info { background: #dbeafe; border-left: 4px solid #3b82f6; padding: 12px; margin: 16px 0; }
+		.alert-warning { background: {{colors.warningSurface}}; border-left: 4px solid {{colors.warningStrong}}; padding: 12px; margin: 16px 0; }
+		.alert-success { background: {{colors.successSurface}}; border-left: 4px solid {{colors.successStrong}}; padding: 12px; margin: 16px 0; }
+		.alert-info { background: {{colors.infoSurface}}; border-left: 4px solid {{colors.infoStrong}}; padding: 12px; margin: 16px 0; }
 		.badge { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; }
-		.badge-success { background: #10b981; color: white; }
-		.badge-warning { background: #f59e0b; color: white; }
-		.badge-error { background: #ef4444; color: white; }
-		.coordinates { font-family: monospace; background: #f3f4f6; padding: 4px 8px; border-radius: 4px; }
+		.badge-success { background: {{colors.successSurface}}; color: {{colors.text}}; }
+		.badge-warning { background: {{colors.warningSurface}}; color: {{colors.text}}; }
+		.badge-error { background: {{colors.errorSurface}}; color: {{colors.text}}; }
+		.coordinates { font-family: monospace; background: {{colors.page}}; padding: 4px 8px; border-radius: 4px; }
 	</style>
 </head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 650px; margin: 0 auto; padding: 20px; line-height: 1.6; color: #333;">
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 650px; margin: 0 auto; padding: 20px; line-height: 1.6; color: {{colors.text}};">
 	<!-- Header -->
-	<div style="background: linear-gradient(135deg, #0ea5e9 0%, #0284c7 100%); color: white; padding: 24px; border-radius: 8px; text-align: center; margin-bottom: 24px;">
+	<div style="background: {{colors.brand}}; color: {{colors.brandContent}}; padding: 24px; border-radius: 8px; text-align: center; margin-bottom: 24px;">
 		<h1 style="margin: 0; font-size: 24px;">🐋 Neue Sichtung eingegangen</h1>
 		<p style="margin: 8px 0 0 0; opacity: 0.9;">Referenz: <strong>{{referenceId}}</strong></p>
 		<p style="margin: 4px 0 0 0; font-size: 14px; opacity: 0.8;">{{currentDate}} um {{currentTime}}</p>
@@ -59,7 +59,7 @@ const defaultConfigurations: ConfigItem[] = [
 	<!-- Spam Check Warning -->
 	{{#if spamCheck.isHighRisk}}
 	<div class="alert-warning">
-		<h4 style="margin: 0 0 8px 0; color: #f59e0b;">⚠️ Spam-Verdacht (Score: {{spamCheck.score}})</h4>
+		<h4 style="margin: 0 0 8px 0; color: {{colors.warningStrong}};">⚠️ Spam-Verdacht (Score: {{spamCheck.score}})</h4>
 		<ul style="margin: 8px 0 0 20px; padding: 0;">
 			{{#each spamCheck.indicators}}
 			<li style="margin: 4px 0;">{{this}}</li>
@@ -71,8 +71,8 @@ const defaultConfigurations: ConfigItem[] = [
 
 	<!-- Geographic Validation -->
 	{{#if sighting.coordinatesFormatted}}
-	<div style="background: #f8fafc; padding: 20px; border-radius: 8px; margin: 20px 0;">
-		<h3 style="margin: 0 0 16px 0; color: #1e293b; display: flex; align-items: center;">
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}}; display: flex; align-items: center;">
 			📍 Positionsangabe
 			{{#if sighting.inBalticSeaGeo}}
 				<span class="badge badge-success" style="margin-left: 12px;">Ostsee ✓</span>
@@ -107,8 +107,8 @@ const defaultConfigurations: ConfigItem[] = [
 	{{/if}}
 
 	<!-- Sighting Details -->
-	<div style="background: #f8fafc; padding: 20px; border-radius: 8px; margin: 20px 0;">
-		<h3 style="margin: 0 0 16px 0; color: #1e293b;">🔍 Sichtungsdetails</h3>
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}};">🔍 Sichtungsdetails</h3>
 		<table style="width: 100%; border-collapse: collapse;">
 			<tr>
 				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top; width: 120px;">Datum:</td>
@@ -143,22 +143,22 @@ const defaultConfigurations: ConfigItem[] = [
 
 	<!-- Contact Information -->
 	{{#if sighting.email}}
-	<div style="background: #f0f9ff; padding: 20px; border-radius: 8px; margin: 20px 0;">
-		<h3 style="margin: 0 0 16px 0; color: #1e293b;">👤 Kontaktdaten</h3>
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}};">👤 Kontaktdaten</h3>
 		{{#if sighting.firstName}}
 		<p><strong>Name:</strong> {{sighting.firstName}} {{sighting.lastName}}</p>
 		{{/if}}
-		<p><strong>E-Mail:</strong> <a href="mailto:{{sighting.email}}" style="color: #0ea5e9;">{{sighting.email}}</a></p>
+		<p><strong>E-Mail:</strong> <a href="mailto:{{sighting.email}}" style="color: {{colors.brand}};">{{sighting.email}}</a></p>
 		{{#if sighting.phone}}
-		<p><strong>Telefon:</strong> <a href="tel:{{sighting.phone}}" style="color: #0ea5e9;">{{sighting.phone}}</a></p>
+		<p><strong>Telefon:</strong> <a href="tel:{{sighting.phone}}" style="color: {{colors.brand}};">{{sighting.phone}}</a></p>
 		{{/if}}
 	</div>
 	{{/if}}
 
 	<!-- Notes -->
 	{{#if sighting.notes}}
-	<div style="background: #fffbeb; border-left: 4px solid #f59e0b; padding: 20px; border-radius: 8px; margin: 20px 0;">
-		<h3 style="margin: 0 0 12px 0; color: #92400e;">💬 Bemerkungen</h3>
+	<div style="background: {{colors.warningSurface}}; border-left: 4px solid {{colors.warningStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 12px 0; color: {{colors.warningStrong}};">💬 Bemerkungen</h3>
 		<p style="margin: 0; white-space: pre-wrap;">{{sighting.notes}}</p>
 	</div>
 	{{/if}}
@@ -167,7 +167,7 @@ const defaultConfigurations: ConfigItem[] = [
 	{{#if spamCheck.indicators}}
 	{{#unless spamCheck.isHighRisk}}
 	{{#if spamCheck.score}}
-	<div style="background: #fef3c7; padding: 16px; border-radius: 6px; margin: 20px 0; font-size: 14px;">
+	<div style="background: {{colors.warningSurface}}; padding: 16px; border-radius: 6px; margin: 20px 0; font-size: 14px;">
 		<p style="margin: 0 0 8px 0;"><strong>Hinweise zur Qualitätsprüfung (Score: {{spamCheck.score}}):</strong></p>
 		<ul style="margin: 0; padding-left: 20px;">
 			{{#each spamCheck.indicators}}
@@ -181,13 +181,13 @@ const defaultConfigurations: ConfigItem[] = [
 	
 	<!-- Action Button -->
 	<div style="text-align: center; margin: 32px 0;">
-		<a href="{{adminUrl}}" style="display: inline-block; background: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%); color: white; padding: 16px 32px; text-decoration: none; border-radius: 8px; font-weight: bold; box-shadow: 0 4px 12px rgba(29, 78, 216, 0.3);">
+		<a href="{{adminUrl}}" style="display: inline-block; background: {{colors.brand}}; color: {{colors.brandContent}}; padding: 16px 32px; text-decoration: none; border-radius: 8px; font-weight: bold;">
 			🔍 Sichtung im Admin-Bereich prüfen
 		</a>
 	</div>
 
 	<!-- Footer -->
-	<div style="text-align: center; margin-top: 32px; padding-top: 24px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 14px;">
+	<div style="text-align: center; margin-top: 32px; padding-top: 24px; border-top: 1px solid {{colors.border}}; color: {{colors.textMuted}}; font-size: 14px;">
 		<p style="margin: 0;">Ostsee-Tiere · Sichtungsmeldungen für den Meeresschutz</p>
 		<p style="margin: 8px 0 0 0;">Diese E-Mail wurde automatisch generiert am {{currentDate}} um {{currentTime}}</p>
 	</div>

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -18,6 +18,7 @@ import nodemailer, { type SendMailOptions, type Transporter } from 'nodemailer';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { ConfigRepository } from '$lib/server/db/configRepository';
+import { emailColorContext } from '$lib/server/templates/emailTokens';
 
 // Dynamic environment variables for Docker runtime
 const NODE_ENV = env.NODE_ENV ?? 'development';
@@ -278,7 +279,11 @@ export class EmailService {
 				adminUrl,
 				currentDate: formatLocalDateTime(new Date(), 'date'),
 				currentTime: formatLocalDateTime(new Date(), 'time'),
-				spamCheck: spamIndicators
+				spamCheck: spamIndicators,
+				// Farbpalette als Kontext statt als Literale in der Vorlage. Auch
+				// eine in der DB gespeicherte Vorlage bekommt sie damit — sonst
+				// wären genau die Templates ausgenommen, die niemand reviewt.
+				...emailColorContext()
 			};
 
 			// Compile template

--- a/src/lib/server/templates/emailTokens.test.ts
+++ b/src/lib/server/templates/emailTokens.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Handlebars from 'handlebars';
+import { describe, expect, it } from 'vitest';
+import { getDefaultConfigurationsByCategory } from '$lib/server/services/configInitializer';
+import { EMAIL_COLORS, emailColorContext } from './emailTokens';
+
+/**
+ * Der Guard für die E-Mail-Seite des Design Systems.
+ *
+ * Warum kein DOM-Scan wie bei `e2e/design-tokens.spec.ts`: E-Mail-HTML wird nie
+ * in einem Browser dieses Projekts gerendert. Die Prüfung muss deshalb über die
+ * Vorlagen-Quelltexte laufen — beide, die Datei und den DB-Default aus
+ * `configInitializer.ts`. Der DB-Default wurde bisher übersehen, weil er als
+ * Template-Literal in einer Service-Datei steht und nicht wie eine Vorlage aussieht.
+ */
+
+const templateDir = dirname(fileURLToPath(import.meta.url));
+
+const fileTemplate = readFileSync(join(templateDir, 'sightingNotificationTemplate.html'), 'utf-8');
+
+const dbDefaultTemplate = String(
+	getDefaultConfigurationsByCategory()['email']?.find(
+		(item) => item.key === 'notification.email.template'
+	)?.value ?? ''
+);
+
+const TEMPLATES = [
+	['sightingNotificationTemplate.html', fileTemplate],
+	['configInitializer: notification.email.template', dbDefaultTemplate]
+] as const;
+
+describe('E-Mail-Vorlagen — Farben kommen aus emailTokens', () => {
+	for (const [name, template] of TEMPLATES) {
+		it(`${name}: keine hartcodierten Hex-Werte`, () => {
+			const offenders = template.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+			expect(offenders, 'Farbe gehört nach emailTokens.ts, im Template {{colors.…}}').toEqual([]);
+		});
+
+		/* Verläufe widersprechen `--depth: 1` / `--noise: 0`: die App zeichnet
+		   Flächen einfarbig. Zwei Verläufe im Kopfbereich und auf dem Button
+		   waren der einzige Ort, an dem das nicht galt. */
+		it(`${name}: keine Verlaufsflächen`, () => {
+			expect(template).not.toContain('linear-gradient');
+			expect(template).not.toContain('radial-gradient');
+		});
+
+		it(`${name}: benutzt nur Farbnamen, die es in EMAIL_COLORS gibt`, () => {
+			const used = [...template.matchAll(/\{\{colors\.([a-zA-Z]+)\}\}/g)].map(
+				(match) => match[1] ?? ''
+			);
+			expect(used.length, 'Vorlage referenziert überhaupt Theme-Farben').toBeGreaterThan(0);
+
+			const unknown = [...new Set(used)].filter((name) => !(name in EMAIL_COLORS));
+			expect(unknown, 'unbekannter Farbname — Tippfehler rendert als leerer String').toEqual([]);
+		});
+
+		it(`${name}: rendert mit emailColorContext() ohne offene Platzhalter`, () => {
+			const html = Handlebars.compile(template)(emailColorContext());
+			expect(html).not.toContain('{{colors.');
+			expect(html).toContain(EMAIL_COLORS.brand);
+		});
+	}
+});

--- a/src/lib/server/templates/emailTokens.ts
+++ b/src/lib/server/templates/emailTokens.ts
@@ -1,0 +1,56 @@
+/**
+ * emailTokens.ts — Farbpalette für E-Mail-Templates
+ *
+ * Warum eine eigene Datei und nicht die CSS-Variablen: E-Mail-Clients
+ * (Outlook, Gmail-Web, Apple Mail) unterstützen weder oklch() noch
+ * color-mix() noch CSS-Variablen zuverlässig. E-Mail braucht sRGB-Hex,
+ * inline gesetzt.
+ *
+ * Was diese Datei ersetzt: rund 40 hartcodierte Hex-Werte in
+ * sightingNotificationTemplate.html und configInitializer.ts, die aus der
+ * Tailwind-Default-Palette stammten (#0ea5e9 als Kopffarbe, #1d4ed8 als
+ * Button, #f59e0b, #10b981, #dc2626) — das Meeresmuseum-Blau kam in keiner
+ * E-Mail vor. Ebenfalls entfallen: zwei linear-gradient-Flächen, die dem
+ * --depth: 1 / --noise: 0-Charakter der App widersprechen.
+ *
+ * Die Werte sind die sRGB-Entsprechungen von src/css/tokens.css und werden
+ * von e2e/design-tokens.spec.ts gegen das Theme geprüft.
+ */
+
+export const EMAIL_COLORS = {
+	/** Kopfbereich, Buttons — --color-primary. Weiß darauf: 10,98:1 */
+	brand: '#004062',
+	brandContent: '#ffffff',
+
+	/** Seitenhintergrund — --color-base-200 */
+	page: '#d1d8df',
+	/** Karten-/Abschnittsfläche — --color-base-100 */
+	surface: '#e6ecf2',
+	/** Rahmen, Trennlinien — --color-base-300 */
+	border: '#bdc5ce',
+
+	/** Fließtext — --color-base-content. 16,53:1 auf surface */
+	text: '#050c14',
+	/** Sekundärtext — base-content bei 70 %. 6,96:1 auf surface */
+	textMuted: '#4a5158',
+
+	/* Status. -surface ist die Fläche, -strong die Text-/Icon-Farbe.
+	   Auf einer Tint-Fläche gehört der Text in text, nicht in die
+	   Statusfarbe — dieselbe Regel wie in der App. */
+	infoSurface: '#dbe6ec',
+	infoStrong: '#00648f',
+	successSurface: '#dbe8dd',
+	successStrong: '#006d09',
+	warningSurface: '#efe4cc',
+	warningStrong: '#865100',
+	errorSurface: '#eddcdd',
+	errorStrong: '#ac1922'
+} as const;
+
+/**
+ * Handlebars-Helper-Kontext. In den Templates dann {{colors.brand}} statt
+ * eines Literals — damit ist die E-Mail erstmals an das System gebunden.
+ */
+export function emailColorContext() {
+	return { colors: EMAIL_COLORS };
+}

--- a/src/lib/server/templates/sightingNotificationTemplate.html
+++ b/src/lib/server/templates/sightingNotificationTemplate.html
@@ -9,36 +9,50 @@
 		style="
 			font-family: Arial, sans-serif;
 			line-height: 1.6;
-			color: #333;
+			color: {{colors.text}};
 			max-width: 600px;
 			margin: 0 auto;
 			padding: 20px;
 		"
 	>
-		<div style="background: #0ea5e9; color: white; padding: 20px; border-radius: 8px 8px 0 0">
+		<div
+			style="
+				background: {{colors.brand}};
+				color: {{colors.brandContent}};
+				padding: 20px;
+				border-radius: 8px 8px 0 0;
+			"
+		>
 			<h1 style="margin: 0; font-size: 24px">🐋 Neue Sichtung eingegangen</h1>
 		</div>
 
-		<div style="background: #f8fafc; padding: 20px; border: 1px solid #e2e8f0; border-top: none">
-			<h2 style="color: #1e40af; margin-top: 0">Referenz-ID: {{referenceId}}</h2>
+		<div
+			style="
+				background: {{colors.surface}};
+				padding: 20px;
+				border: 1px solid {{colors.border}};
+				border-top: none;
+			"
+		>
+			<h2 style="color: {{colors.brand}}; margin-top: 0">Referenz-ID: {{referenceId}}</h2>
 
 			{{#if spamCheck.isHighRisk}}
 			<div
 				style="
-					background: #fef2f2;
-					border: 1px solid #fecaca;
+					background: {{colors.errorSurface}};
+					border: 1px solid {{colors.errorStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #dc2626">⚠️ Spam-Warnung (Hochrisiko)</h3>
-				<p style="color: #991b1b; margin: 5px 0">
+				<h3 style="margin-top: 0; color: {{colors.errorStrong}}">⚠️ Spam-Warnung (Hochrisiko)</h3>
+				<p style="color: {{colors.text}}; margin: 5px 0">
 					<strong>Heuristik-Score:</strong> {{spamCheck.score}}
 				</p>
 				{{#if spamCheck.indicators.length}}
-				<p style="color: #991b1b; margin: 5px 0"><strong>Indikatoren:</strong></p>
-				<ul style="color: #991b1b; margin: 5px 0">
+				<p style="color: {{colors.text}}; margin: 5px 0"><strong>Indikatoren:</strong></p>
+				<ul style="color: {{colors.text}}; margin: 5px 0">
 					{{#each spamCheck.indicators}}
 					<li>{{this}}</li>
 					{{/each}}
@@ -48,20 +62,22 @@
 			{{else}} {{#if spamCheck.score}}
 			<div
 				style="
-					background: #fffbeb;
-					border: 1px solid #fcd34d;
+					background: {{colors.warningSurface}};
+					border: 1px solid {{colors.warningStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #92400e">⚡ Spam-Hinweis (Geringes Risiko)</h3>
-				<p style="color: #78350f; margin: 5px 0">
+				<h3 style="margin-top: 0; color: {{colors.warningStrong}}">
+					⚡ Spam-Hinweis (Geringes Risiko)
+				</h3>
+				<p style="color: {{colors.text}}; margin: 5px 0">
 					<strong>Heuristik-Score:</strong> {{spamCheck.score}}
 				</p>
 				{{#if spamCheck.indicators.length}}
-				<p style="color: #78350f; margin: 5px 0"><strong>Indikatoren:</strong></p>
-				<ul style="color: #78350f; margin: 5px 0">
+				<p style="color: {{colors.text}}; margin: 5px 0"><strong>Indikatoren:</strong></p>
+				<ul style="color: {{colors.text}}; margin: 5px 0">
 					{{#each spamCheck.indicators}}
 					<li>{{this}}</li>
 					{{/each}}
@@ -71,28 +87,30 @@
 			{{else}}
 			<div
 				style="
-					background: #f0fdf4;
-					border: 1px solid #86efac;
+					background: {{colors.successSurface}};
+					border: 1px solid {{colors.successStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #166534">✅ Spam-Analyse: Kein Spam erkannt</h3>
-				<p style="color: #14532d; margin: 5px 0"><strong>Heuristik-Score:</strong> 0</p>
+				<h3 style="margin-top: 0; color: {{colors.successStrong}}">
+					✅ Spam-Analyse: Kein Spam erkannt
+				</h3>
+				<p style="color: {{colors.text}}; margin: 5px 0"><strong>Heuristik-Score:</strong> 0</p>
 			</div>
 			{{/if}} {{/if}} {{#if sighting.inBalticSea}} {{#unless sighting.inBalticSeaGeo}}
 			<div
 				style="
-					background: #fef3c7;
-					border: 1px solid #fbbf24;
+					background: {{colors.warningSurface}};
+					border: 1px solid {{colors.warningStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #d97706">🌊 Position außerhalb Ostsee</h3>
-				<p style="color: #92400e">
+				<h3 style="margin-top: 0; color: {{colors.warningStrong}}">🌊 Position außerhalb Ostsee</h3>
+				<p style="color: {{colors.text}}">
 					Die angegebene Position liegt außerhalb der typischen Ostsee-Grenzen. Bitte prüfen Sie die
 					Koordinaten.
 				</p>
@@ -100,23 +118,30 @@
 			{{/unless}} {{else}}
 			<div
 				style="
-					background: #fee2e2;
-					border: 1px solid #fca5a5;
+					background: {{colors.errorSurface}};
+					border: 1px solid {{colors.errorStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #dc2626">🌍 Position außerhalb Ostsee</h3>
-				<p style="color: #991b1b">
+				<h3 style="margin-top: 0; color: {{colors.errorStrong}}">🌍 Position außerhalb Ostsee</h3>
+				<p style="color: {{colors.text}}">
 					Die angegebene Position liegt deutlich außerhalb der Ostsee. Bitte überprüfen Sie diese
 					Sichtung sorgfältig.
 				</p>
 			</div>
 			{{/if}}
 
-			<div style="background: white; padding: 15px; border-radius: 6px; margin: 15px 0">
-				<h3 style="margin-top: 0; color: #059669">📍 Sichtungsdetails</h3>
+			<div
+				style="
+					background: {{colors.page}};
+					padding: 15px;
+					border-radius: 6px;
+					margin: 15px 0;
+				"
+			>
+				<h3 style="margin-top: 0; color: {{colors.brand}}">📍 Sichtungsdetails</h3>
 				<p><strong>Datum:</strong> {{sighting.sightingDate}}</p>
 				<p><strong>Tierart:</strong> {{sighting.species}}</p>
 				{{#if sighting.totalCount}}
@@ -133,19 +158,36 @@
 			</div>
 
 			{{#if sighting.notes}}
-			<div style="background: white; padding: 15px; border-radius: 6px; margin: 15px 0">
-				<h3 style="margin-top: 0; color: #7c3aed">💬 Bemerkungen</h3>
+			<div
+				style="
+					background: {{colors.page}};
+					padding: 15px;
+					border-radius: 6px;
+					margin: 15px 0;
+				"
+			>
+				<h3 style="margin-top: 0; color: {{colors.brand}}">💬 Bemerkungen</h3>
 				<p>{{sighting.notes}}</p>
 			</div>
 			{{/if}} {{#if sighting.firstName}}
-			<div style="background: white; padding: 15px; border-radius: 6px; margin: 15px 0">
-				<h3 style="margin-top: 0; color: #0369a1">👤 Kontaktdaten</h3>
+			<div
+				style="
+					background: {{colors.page}};
+					padding: 15px;
+					border-radius: 6px;
+					margin: 15px 0;
+				"
+			>
+				<h3 style="margin-top: 0; color: {{colors.brand}}">👤 Kontaktdaten</h3>
 				<p>
 					<strong>Name:</strong> {{sighting.firstName}}{{#if sighting.lastName}}
 					{{sighting.lastName}}{{/if}}
 				</p>
 				{{#if sighting.email}}
-				<p><strong>E-Mail:</strong> <a href="mailto:{{sighting.email}}">{{sighting.email}}</a></p>
+				<p>
+					<strong>E-Mail:</strong>
+					<a href="mailto:{{sighting.email}}" style="color: {{colors.brand}}">{{sighting.email}}</a>
+				</p>
 				{{/if}} {{#if sighting.phone}}
 				<p><strong>Telefon:</strong> {{sighting.phone}}</p>
 				{{/if}}
@@ -153,15 +195,15 @@
 			{{/if}} {{#if sighting.isDead}}
 			<div
 				style="
-					background: #fef2f2;
-					border: 1px solid #fecaca;
+					background: {{colors.errorSurface}};
+					border: 1px solid {{colors.errorStrong}};
 					border-radius: 6px;
 					padding: 15px;
 					margin: 15px 0;
 				"
 			>
-				<h3 style="margin-top: 0; color: #dc2626">💀 Totfund</h3>
-				<p style="color: #991b1b">Diese Sichtung betrifft ein totes Tier.</p>
+				<h3 style="margin-top: 0; color: {{colors.errorStrong}}">💀 Totfund</h3>
+				<p style="color: {{colors.text}}">Diese Sichtung betrifft ein totes Tier.</p>
 				{{#if sighting.deadCondition}}
 				<p><strong>Zustand:</strong> {{sighting.deadCondition}}</p>
 				{{/if}} {{#if sighting.deadSize}}
@@ -174,8 +216,8 @@
 				<a
 					href="{{adminUrl}}"
 					style="
-						background: #1d4ed8;
-						color: white;
+						background: {{colors.brand}};
+						color: {{colors.brandContent}};
 						padding: 12px 24px;
 						text-decoration: none;
 						border-radius: 6px;
@@ -187,9 +229,9 @@
 				</a>
 			</div>
 
-			<hr style="border: none; border-top: 1px solid #e2e8f0; margin: 20px 0" />
+			<hr style="border: none; border-top: 1px solid {{colors.border}}; margin: 20px 0" />
 
-			<p style="font-size: 12px; color: #64748b; text-align: center">
+			<p style="font-size: 12px; color: {{colors.textMuted}}; text-align: center">
 				Diese E-Mail wurde automatisch vom Ostsee-Tiere System generiert.<br />
 				Gesendet am {{currentDate}} um {{currentTime}} Uhr
 			</p>

--- a/src/lib/utils/map/openLayersHelpers.ts
+++ b/src/lib/utils/map/openLayersHelpers.ts
@@ -35,6 +35,7 @@ export class FormLocationControl extends Control {
 		button.innerHTML = '📍';
 		button.title = 'GPS-Position anzeigen';
 		button.className = 'gps-button';
+		button.setAttribute('aria-pressed', 'false');
 
 		const element = document.createElement('div');
 		element.className = 'ol-control gps-control';
@@ -70,9 +71,10 @@ export class FormLocationControl extends Control {
 	}
 
 	private startTracking() {
-		// Button-Erscheinungsbild aktualisieren
-		this.button.style.backgroundColor = '#3b82f6';
-		this.button.style.color = 'white';
+		// Zustand über aria-pressed statt Inline-Farben — ein Zustand, eine Quelle.
+		// Die Farben stehen in mapStyles.css (.gps-button[aria-pressed='true']);
+		// der Button ist DOM, kein Canvas, und braucht deshalb keine Hex-Werte.
+		this.button.setAttribute('aria-pressed', 'true');
 		this.button.title = 'GPS-Tracking stoppen';
 
 		// Kontinuierliche Positionsverfolgung starten
@@ -109,8 +111,7 @@ export class FormLocationControl extends Control {
 		this.isTracking = false;
 
 		// Button-Erscheinungsbild zurücksetzen
-		this.button.style.backgroundColor = 'rgba(0, 60, 136, 0.5)';
-		this.button.style.color = 'white';
+		this.button.setAttribute('aria-pressed', 'false');
 		this.button.title = 'GPS-Position anzeigen';
 	}
 

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -136,9 +136,9 @@
 					<div
 						class="mb-6 flex justify-center transition-transform duration-300 group-hover:scale-110"
 					>
-						<Icon icon="lucide:map" width="48" class="text-secondary" />
+						<Icon icon="lucide:map" width="48" class="text-secondary-strong" />
 					</div>
-					<h3 class="card-title text-secondary mb-4 justify-center text-xl">Interaktive Karte</h3>
+					<h3 class="card-title text-secondary-strong mb-4 justify-center text-xl">Interaktive Karte</h3>
 					<p class="text-base-content/80 text-base leading-relaxed">
 						Visualisieren Sie <strong>alle Sichtungen</strong> auf einer detaillierten Karte der
 						Ostsee und entdecken Sie <em>Muster und Hotspots</em>.
@@ -154,9 +154,9 @@
 					<div
 						class="mb-6 flex justify-center transition-transform duration-300 group-hover:scale-110"
 					>
-						<Icon icon="lucide:chart-pie" width="48" class="text-accent" />
+						<Icon icon="lucide:chart-pie" width="48" class="text-accent-strong" />
 					</div>
-					<h3 class="card-title text-accent mb-4 justify-center text-xl">Offene Daten</h3>
+					<h3 class="card-title text-accent-strong mb-4 justify-center text-xl">Offene Daten</h3>
 					<p class="text-base-content/80 text-base leading-relaxed">
 						Alle Daten sind für <strong>Forschungszwecke verfügbar</strong> und können in
 						verschiedenen Formaten <em>exportiert</em> werden.
@@ -208,7 +208,7 @@
 	<!-- Data Protection & Security Section -->
 	<div class="mb-16">
 		<h2 class="mb-8 flex items-center justify-center gap-3 text-center text-3xl font-bold">
-			<Icon icon="lucide:shield-check" width="30" class="text-success" />
+			<Icon icon="lucide:shield-check" width="30" class="text-success-strong" />
 			Datenschutz & Sicherheit
 		</h2>
 
@@ -217,7 +217,7 @@
 			<div class="card bg-base-100 border-success/20 border shadow-xl">
 				<div class="card-body">
 					<div class="mb-4 flex items-center gap-2">
-						<Icon icon="lucide:shield-check" width="30" class="text-success" />
+						<Icon icon="lucide:shield-check" width="30" class="text-success-strong" />
 						<h3 class="card-title">Datenschutz</h3>
 					</div>
 					<p class="mb-4 text-sm text-base-content/80">
@@ -226,19 +226,19 @@
 					</p>
 					<ul class="space-y-2 text-sm">
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong mt-1" />
 							<span>Freiwillige Angabe personenbezogener Daten</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong mt-1" />
 							<span>Verschlüsselte Übertragung aller Daten</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong mt-1" />
 							<span>Keine Weitergabe an unbefugte Dritte</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong mt-1" />
 							<span>Anonymisierte öffentliche Darstellung</span>
 						</li>
 					</ul>
@@ -259,7 +259,7 @@
 			<div class="card bg-base-100 border-info/20 border shadow-xl">
 				<div class="card-body">
 					<div class="mb-4 flex items-center gap-2">
-						<Icon icon="lucide:lock" width="30" class="text-info" />
+						<Icon icon="lucide:lock" width="30" class="text-info-strong" />
 						<h3 class="card-title">Technische Sicherheit</h3>
 					</div>
 					<p class="mb-4 text-sm text-base-content/80">
@@ -268,19 +268,19 @@
 					</p>
 					<ul class="space-y-2 text-sm">
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-info mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-info-strong mt-1" />
 							<span>HTTPS/SSL-Verschlüsselung für alle Verbindungen</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-info mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-info-strong mt-1" />
 							<span>Sichere Authentifizierung mit Auth0</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-info mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-info-strong mt-1" />
 							<span>Regelmäßige Sicherheitsupdates</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<Icon icon="lucide:check" width="16" class="text-info mt-1" />
+							<Icon icon="lucide:check" width="16" class="text-info-strong mt-1" />
 							<span>Gehostete Infrastruktur in Deutschland/EU</span>
 						</li>
 					</ul>
@@ -293,7 +293,7 @@
 								href="https://auth0.com"
 								target="_blank"
 								rel="noopener noreferrer"
-								class="text-info font-semibold hover:underline">Auth0</a
+								class="text-info-strong font-semibold hover:underline">Auth0</a
 							>
 							– der führenden Plattform für sichere Authentifizierung und Autorisierung.
 						</p>
@@ -307,7 +307,7 @@
 			class="border-success/10 mt-8 rounded-lg border bg-gradient-to-r from-green-50 to-emerald-50 p-6"
 		>
 			<div class="flex items-start gap-4">
-				<Icon icon="lucide:file-text" width="24" class="text-success" />
+				<Icon icon="lucide:file-text" width="24" class="text-success-strong" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">DSGVO-Konformität</h4>
 					<p class="mb-3 text-sm text-base-content/80">
@@ -316,19 +316,19 @@
 					</p>
 					<div class="grid gap-3 text-sm md:grid-cols-2">
 						<div class="flex items-center gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong" />
 							<span>Recht auf Auskunft</span>
 						</div>
 						<div class="flex items-center gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong" />
 							<span>Recht auf Berichtigung</span>
 						</div>
 						<div class="flex items-center gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong" />
 							<span>Recht auf Löschung</span>
 						</div>
 						<div class="flex items-center gap-2">
-							<Icon icon="lucide:check" width="16" class="text-success" />
+							<Icon icon="lucide:check" width="16" class="text-success-strong" />
 							<span>Recht auf Datenübertragbarkeit</span>
 						</div>
 					</div>
@@ -365,7 +365,7 @@
 	<div class="bg-base-200 mb-16 rounded-lg p-8">
 		<div class="mb-6 flex flex-col items-center justify-center gap-2">
 			<h2 class="flex items-center gap-3 text-center text-3xl font-bold">
-				<Icon icon="lucide:zap" width="30" class="text-warning" />
+				<Icon icon="lucide:zap" width="30" class="text-warning-strong" />
 				Technologie
 			</h2>
 			<div class="badge badge-neutral badge-lg font-mono">Version {data.version}</div>
@@ -505,7 +505,7 @@ SOFTWARE.</pre>
 			class="border-purple/10 mt-8 rounded-lg border bg-gradient-to-r from-purple-50 to-indigo-50 p-6"
 		>
 			<div class="flex items-start gap-4">
-				<Icon icon="lucide:circle-alert" width="32" height="32" class="text-warning mt-1" />
+				<Icon icon="lucide:circle-alert" width="32" height="32" class="text-warning-strong mt-1" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">Fehler gefunden oder Verbesserungsvorschlag?</h4>
 					<p class="mb-3 text-sm text-base-content/80">
@@ -626,7 +626,7 @@ SOFTWARE.</pre>
 					</div>
 					<div class="stat">
 						<div class="stat-title">Aktive</div>
-						<div class="stat-value text-secondary">
+						<div class="stat-value text-secondary-strong">
 							{data.totalObservers != null
 								? new Intl.NumberFormat('de-DE').format(data.totalObservers)
 								: '500+'}
@@ -635,7 +635,7 @@ SOFTWARE.</pre>
 					</div>
 					<div class="stat">
 						<div class="stat-title">Für die</div>
-						<div class="stat-value text-accent">Wissenschaft</div>
+						<div class="stat-value text-accent-strong">Wissenschaft</div>
 						<div class="stat-desc">verfügbar</div>
 					</div>
 				</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -609,7 +609,7 @@
 								{sighting.referenceId}
 							</a>
 						{:else}
-							<span class="text-base-content/50 text-sm">Keine Referenz</span>
+							<span class="text-base-content/70 text-sm">Keine Referenz</span>
 						{/if}
 						<h3 class="mt-1 text-base font-semibold">{getSpeciesLabel(sighting.species)}</h3>
 					</div>
@@ -791,7 +791,7 @@
 											{sighting.referenceId}
 										</a>
 									{:else}
-										<span class="text-base-content/50">—</span>
+										<span class="text-base-content/70">—</span>
 									{/if}
 								</td>
 							{/if}
@@ -1053,7 +1053,7 @@
 					{/each}
 				</ul>
 			{:else}
-				<p class="text-success mt-4 text-sm">Keine Indikatoren gefunden.</p>
+				<p class="text-success-strong mt-4 text-sm">Keine Indikatoren gefunden.</p>
 			{/if}
 		{/if}
 

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -99,7 +99,7 @@
 		</button>
 	</div>
 </div>
-<div class="mb-4 text-sm text-gray-600">
+<div class="mb-4 text-sm text-base-content/70">
 	Referenz-ID: {sighting.referenceId}
 </div>
 
@@ -126,8 +126,8 @@
 					class="h-5 w-5 {result.isHighRisk
 						? 'text-error'
 						: result.score > 0
-							? 'text-warning'
-							: 'text-success'}"
+							? 'text-warning-strong'
+							: 'text-success-strong'}"
 				/>
 				<h3 class="card-title text-base">
 					{#if result.isHighRisk}

--- a/src/routes/admin/[id]/edit/+page.svelte
+++ b/src/routes/admin/[id]/edit/+page.svelte
@@ -65,7 +65,7 @@
 		</button>
 	</div>
 </div>
-<div class="mb-4 text-sm text-gray-600">
+<div class="mb-4 text-sm text-base-content/70">
 	Referenz-ID: {sighting.referenceId}
 </div>
 <AdminSightingEditForm {sighting} {onCancel} onSave={handleSave} />

--- a/src/routes/admin/docs/+page.svelte
+++ b/src/routes/admin/docs/+page.svelte
@@ -94,19 +94,19 @@
 				<div class="bg-warning/10 border-warning/20 rounded border p-4">
 					<ul class="space-y-2 text-sm">
 						<li class="flex items-start gap-2">
-							<span class="text-warning font-bold">•</span>
+							<span class="text-warning-strong font-bold">•</span>
 							<span>API-Schlüssel und Tokens niemals in Client-Code verwenden</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="text-warning font-bold">•</span>
+							<span class="text-warning-strong font-bold">•</span>
 							<span>Alle Admin-Aktionen werden protokolliert</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="text-warning font-bold">•</span>
+							<span class="text-warning-strong font-bold">•</span>
 							<span>Bei verdächtigen Aktivitäten wird die Session beendet</span>
 						</li>
 						<li class="flex items-start gap-2">
-							<span class="text-warning font-bold">•</span>
+							<span class="text-warning-strong font-bold">•</span>
 							<span>Lösch-Operationen können nicht rückgängig gemacht werden</span>
 						</li>
 					</ul>

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -134,7 +134,7 @@
 				<h1 class="text-base-content text-3xl font-bold">Statistiken</h1>
 				<p class="text-base-content/70 mt-2">
 					Analyse von {formatNumber(data.basicStats?.approved.totalSightings || 0)} freigegebenen Meerestier-Sichtungen
-					<span class="text-base-content/50">
+					<span class="text-base-content/70">
 						· {formatNumber(data.basicStats?.pending.totalSightings || 0)} noch nicht freigegeben
 					</span>
 				</p>
@@ -195,7 +195,7 @@
 								100
 						)})
 						<br />
-						<span class="text-warning"
+						<span class="text-warning-strong"
 							>{formatNumber(data.basicStats?.pending.totalSightings || 0)} noch offen</span
 						>
 					</div>
@@ -204,11 +204,11 @@
 
 			<div class="stats shadow">
 				<div class="stat">
-					<div class="stat-figure text-secondary">
+					<div class="stat-figure text-secondary-strong">
 						<Icon icon="lucide:activity" class="h-8 w-8" />
 					</div>
 					<div class="stat-title">Ø Gruppengröße</div>
-					<div class="stat-value text-secondary">
+					<div class="stat-value text-secondary-strong">
 						{formatNumber(
 							parseFloat(String(data.basicStats?.approved.avgGroupSize || 0)).toFixed(1)
 						)}
@@ -221,11 +221,11 @@
 
 			<div class="stats shadow">
 				<div class="stat">
-					<div class="stat-figure text-warning">
+					<div class="stat-figure text-warning-strong">
 						<Icon icon="lucide:trending-up" class="h-8 w-8" />
 					</div>
 					<div class="stat-title">Totfunde</div>
-					<div class="stat-value text-warning">
+					<div class="stat-value text-warning-strong">
 						{formatNumber(data.basicStats?.approved.deadAnimals || 0)}
 					</div>
 					<div class="stat-desc">
@@ -235,7 +235,7 @@
 								100
 						)} der freigegebenen
 						<br />
-						<span class="text-warning"
+						<span class="text-warning-strong"
 							>{formatNumber(data.basicStats?.pending.deadAnimals || 0)} noch offen</span
 						>
 					</div>
@@ -244,11 +244,11 @@
 
 			<div class="stats shadow">
 				<div class="stat">
-					<div class="stat-figure text-accent">
+					<div class="stat-figure text-accent-strong">
 						<Icon icon="lucide:calendar" class="h-8 w-8" />
 					</div>
 					<div class="stat-title">Mit Medien</div>
-					<div class="stat-value text-accent">
+					<div class="stat-value text-accent-strong">
 						{formatNumber(data.basicStats?.approved.withMedia || 0)}
 					</div>
 					<div class="stat-desc">
@@ -263,11 +263,11 @@
 
 			<div class="stats shadow">
 				<div class="stat">
-					<div class="stat-figure text-info">
+					<div class="stat-figure text-info-strong">
 						<Icon icon="lucide:users" class="h-8 w-8" />
 					</div>
 					<div class="stat-title">Unique Nutzer</div>
-					<div class="stat-value text-info">{formatNumber(data.userStats?.uniqueUsers || 0)}</div>
+					<div class="stat-value text-info-strong">{formatNumber(data.userStats?.uniqueUsers || 0)}</div>
 					<div class="stat-desc">
 						{formatNumber(data.userStats?.repeatUsers || 0)} Wiederholungs-Nutzer ({formatPercentage(
 							data.userStats?.repeatUserPercentage || 0
@@ -312,7 +312,7 @@
 											class={deadPerc > 30
 												? 'text-error font-bold'
 												: deadPerc > 15
-													? 'text-warning font-semibold'
+													? 'text-warning-strong font-semibold'
 													: ''}
 										>
 											{formatPercentage(species.deadPercentage)}
@@ -371,7 +371,7 @@
 						</div>
 						<div class="stat">
 							<div class="stat-title">Wiederkehrer</div>
-							<div class="stat-value text-secondary">
+							<div class="stat-value text-secondary-strong">
 								{formatNumber(data.userStats?.repeatUsers || 0)}
 							</div>
 							<div class="stat-desc">
@@ -380,7 +380,7 @@
 						</div>
 						<div class="stat">
 							<div class="stat-title">Eindeutige Schiffsnamen</div>
-							<div class="stat-value text-accent">
+							<div class="stat-value text-accent-strong">
 								{formatNumber(data.shipStats?.uniqueShips || 0)}
 							</div>
 							<div class="stat-desc">
@@ -514,7 +514,7 @@
 										{#if prevYear}
 											<span
 												class={change > 0
-													? 'text-success'
+													? 'text-success-strong'
 													: change < 0
 														? 'text-error'
 														: 'text-base-content'}
@@ -522,7 +522,7 @@
 												{change > 0 ? '+' : ''}{formatPercentage(change)}
 											</span>
 										{:else}
-											<span class="text-base-content/50">-</span>
+											<span class="text-base-content/70">-</span>
 										{/if}
 									</td>
 									<td class="w-32">
@@ -602,14 +602,14 @@
 						</div>
 						<div class="stat">
 							<div class="stat-title">Durchschnitt</div>
-							<div class="stat-value text-secondary">
+							<div class="stat-value text-secondary-strong">
 								{formatNumber((totalRecentSightings / 30).toFixed(1))}
 							</div>
 							<div class="stat-desc">Sichtungen pro Tag</div>
 						</div>
 						<div class="stat">
 							<div class="stat-title">Aktivste Tage</div>
-							<div class="stat-value text-accent">{data.recentActivity.length}</div>
+							<div class="stat-value text-accent-strong">{data.recentActivity.length}</div>
 							<div class="stat-desc">Tage mit Meldungen</div>
 						</div>
 					</div>

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -83,15 +83,15 @@
 					<h3 class="mb-2 text-sm font-semibold">Öffentliche Endpunkte:</h3>
 					<div class="space-y-2">
 						<div class="rounded bg-base-200 p-2 text-xs">
-							<code class="text-info">GET /api/sightings</code>
+							<code class="text-info-strong">GET /api/sightings</code>
 							<span class="ml-2 text-base-content/60">Öffentliche Sichtungen</span>
 						</div>
 						<div class="rounded bg-base-200 p-2 text-xs">
-							<code class="text-info">POST /api/sightings</code>
+							<code class="text-info-strong">POST /api/sightings</code>
 							<span class="ml-2 text-base-content/60">Neue Sichtung melden</span>
 						</div>
 						<div class="rounded bg-base-200 p-2 text-xs">
-							<code class="text-info">POST /api/files/upload</code>
+							<code class="text-info-strong">POST /api/files/upload</code>
 							<span class="ml-2 text-base-content/60">Dateien hochladen</span>
 						</div>
 					</div>

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -91,13 +91,13 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔍 Sichtungen</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-success">GET</code> /sightings - Öffentliche Sichtungen</div>
-						<div><code class="text-info">POST</code> /sightings - Neue Sichtung</div>
+						<div><code class="text-success-strong">GET</code> /sightings - Öffentliche Sichtungen</div>
+						<div><code class="text-info-strong">POST</code> /sightings - Neue Sichtung</div>
 						<div>
-							<code class="text-success">GET</code> /sightings/{'{id}'} - Einzelne Sichtung
+							<code class="text-success-strong">GET</code> /sightings/{'{id}'} - Einzelne Sichtung
 						</div>
 						<div>
-							<code class="text-orange-600">PUT</code> /sightings/{'{id}'} - Sichtung ändern
+							<code class="text-warning-strong">PUT</code> /sightings/{'{id}'} - Sichtung ändern
 						</div>
 						<div>
 							<code class="text-error">DELETE</code> /sightings/{'{id}'} - Sichtung löschen
@@ -110,9 +110,9 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔐 Authentifizierung</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-success">GET</code> /auth/login - Login starten</div>
-						<div><code class="text-success">GET</code> /auth/logout - Logout</div>
-						<div><code class="text-success">GET</code> /auth/callback - Auth0 Callback</div>
+						<div><code class="text-success-strong">GET</code> /auth/login - Login starten</div>
+						<div><code class="text-success-strong">GET</code> /auth/logout - Logout</div>
+						<div><code class="text-success-strong">GET</code> /auth/callback - Auth0 Callback</div>
 					</div>
 				</div>
 			</div>
@@ -121,7 +121,7 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">📁 Dateien</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-info">POST</code> /files/upload - Datei hochladen</div>
+						<div><code class="text-info-strong">POST</code> /files/upload - Datei hochladen</div>
 						<div><code class="text-error">DELETE</code> /files/delete - Datei löschen</div>
 					</div>
 				</div>
@@ -131,10 +131,10 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">📊 Export</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-success">GET</code> /sightings/export/json - JSON Export</div>
-						<div><code class="text-success">GET</code> /sightings/export/csv - CSV Export</div>
-						<div><code class="text-success">GET</code> /sightings/export/xml - XML Export</div>
-						<div><code class="text-success">GET</code> /sightings/export/kml - KML Export</div>
+						<div><code class="text-success-strong">GET</code> /sightings/export/json - JSON Export</div>
+						<div><code class="text-success-strong">GET</code> /sightings/export/csv - CSV Export</div>
+						<div><code class="text-success-strong">GET</code> /sightings/export/xml - XML Export</div>
+						<div><code class="text-success-strong">GET</code> /sightings/export/kml - KML Export</div>
 					</div>
 				</div>
 			</div>
@@ -144,7 +144,7 @@
 					<h2 class="card-title text-lg">⚙️ Admin</h2>
 					<div class="space-y-1 text-sm">
 						<div>
-							<code class="text-info">PATCH</code> /sightings/{'{id}'}/verify - Prüfen und freigeben
+							<code class="text-info-strong">PATCH</code> /sightings/{'{id}'}/verify - Prüfen und freigeben
 						</div>
 					</div>
 				</div>
@@ -154,8 +154,8 @@
 				<div class="card-body">
 					<h2 class="card-title text-lg">🌍 Geo</h2>
 					<div class="space-y-1 text-sm">
-						<div><code class="text-success">GET</code> /geo/inBaltic - Ostsee-Prüfung</div>
-						<div><code class="text-success">GET</code> /map/sightings - Kartendaten</div>
+						<div><code class="text-success-strong">GET</code> /geo/inBaltic - Ostsee-Prüfung</div>
+						<div><code class="text-success-strong">GET</code> /map/sightings - Kartendaten</div>
 					</div>
 				</div>
 			</div>

--- a/src/routes/maintenance/+page.svelte
+++ b/src/routes/maintenance/+page.svelte
@@ -25,7 +25,7 @@
 			<!-- Maintenance Icon -->
 			<div class="mb-6 flex justify-center">
 				<div class="bg-warning/20 rounded-full p-6">
-					<Icon icon="lucide:settings" class="text-warning size-16 animate-spin" />
+					<Icon icon="lucide:settings" class="text-warning-strong size-16 animate-spin" />
 				</div>
 			</div>
 


### PR DESCRIPTION
Letzter Teil der Design-System-Serie (nach #615 Styleguide und #618 Feldmodus). Drei Bereiche umgingen bisher das Theme; jeder hat jetzt genau **einen** Ort, an dem seine Werte stehen.

## Was sich ändert

| Bereich | Vorher | Jetzt |
| --- | --- | --- |
| `BooleanStatus` (in jeder `DataTableRow`) | `bg-green-100 text-green-800` / `bg-gray-100 text-gray-600` | `badge badge-success` / `badge badge-ghost` |
| Admin-Metazeilen (3 Stellen) | `text-gray-600` | `text-base-content/70` |
| OpenLayers | `#3b82f6`, `rgba(0,60,136,.5)`, `#444`, `#ccc` … verteilt auf vier Dateien | `src/lib/map/mapTokens.ts` (Canvas) bzw. `var(--color-*)` (DOM) |
| E-Mail | ~40 Hex-Werte aus der Tailwind-Palette, 2 `linear-gradient` | `src/lib/server/templates/emailTokens.ts`, `{{colors.*}}` im Template |
| `SectionCard` | eine Variante + lokaler `<style>`-Hover | `variant='card' \| 'inset'`, Hover aus `app.css` |

Die **Wong-Palette in `styleUtils.ts` bleibt unangetastet** — das sind Datenfarben, farbfehlsichtigkeits-sicher gewählt, und sie dürfen sich nicht mit dem Theme mitbewegen.

## Der Guard ist scharf

Die Gruppe „verbotene Kombinationen im DOM" in `e2e/design-tokens.spec.ts` verliert ihr `test.fixme` — **ohne dass eine Regex angefasst wurde**.

Dafür musste der ganze Bestand ran, nicht nur die drei gescannten Routen: alle `text-{info,success,warning,secondary,accent}` auf die `-strong`-Variante, Text unter Deckkraft `/40` und `/50` auf `/70`. Nur die Routen zu reparieren hätte den Guard beim nächsten Eintrag in `ROUTES` sofort wieder rot gemacht.

## Zwei Funde nebenbei

**Der GPS-Button trug seinen Zustand in Inline-Farben**, und die CSS-Regel griff auf einen Substring des `style`-Attributs zu:

```css
.gps-control .gps-button[style*='background-color: rgb(59, 130, 246)']
```

Beim reinen Farbtausch wäre diese Regel still gestorben. Der Zustand hängt jetzt an `aria-pressed` — wie beim `LocationControl` seit N2. Das `transition: all` musste dabei weg: Chromium wendet `!important`-Zustandswechsel darunter nicht an.

**`SectionCard` definierte den Karten-Hover ein zweites Mal**, mit handgeschriebenem `box-shadow` statt Elevation-Token. Der lokale `<style>`-Block entfällt; `app.css` besitzt den Hover für alle Karten.

## Tests

- `src/lib/server/templates/emailTokens.test.ts` — prüft **beide** Vorlagen (Datei und DB-Default aus `configInitializer.ts`) auf Hex-Werte, Verläufe, unbekannte Farbnamen und offene Platzhalter. Der DB-Default wurde bisher übersehen, weil er als Template-Literal in einer Service-Datei steht.
- `src/lib/report/components/sections/SectionCard.svelte.test.ts` — deckt die neue Variante ab.

Verifiziert: `npm run test:quick` grün (2267 Tests), `npx playwright test` 180 grün / 1 übersprungen, `design-tokens.spec.ts` 38/38 inklusive aller neun DOM-Scan-Tests. Die Benachrichtigungsmail wurde real verschickt und im Client geprüft.

## Vor dem Deploy beachten

`ConfigRepository` hat Vorrang vor der Datei-Vorlage. Der Schlüssel `notification.email.template` wurde in der lokalen DB **und in Supabase** bereits auf die neue Fassung gesetzt (vorher: 6905 Zeichen, 2 Verläufe, 30 Hex-Werte — jetzt byte-identisch zur Datei). Weitere Umgebungen brauchen denselben Schritt, sonst verschicken sie weiter die alte Optik.

## Nicht in diesem PR

- Projektlogo im Mail-Kopf statt 🐋 — braucht ein rasterisiertes PNG (das Logo ist eine Svelte-Komponente, SVG funktioniert in E-Mail nicht) und CID-Einbettung in `emailService.ts`, weil Remote-Bilder standardmäßig blockiert werden.
- Es gibt **keine Bestätigungsmail an den Melder**; die einzigen zwei `sendMail`-Aufrufe gehen an interne Adressen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
