### PR TITLE
fix(ui): keep error toasts on screen and stop leaking JSON parse errors

### DIFF
--- a/src/lib/components/ToastContainer.svelte
+++ b/src/lib/components/ToastContainer.svelte
@@ -15,7 +15,7 @@
 			type={toast.type}
 			title={toast.title || ''}
 			message={toast.message}
-			duration={toast.duration || 5000}
+			duration={toast.duration ?? 5000}
 			dismissible={!!toast.dismissible}
 			onDismiss={() => removeToast(toast.id)}
 		/>

--- a/src/lib/components/ToastContainer.svelte.test.ts
+++ b/src/lib/components/ToastContainer.svelte.test.ts
@@ -1,0 +1,67 @@
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { clearAllToasts, errorToast, successToast } from '$lib/stores/toastState.svelte';
+import ToastContainer from './ToastContainer.svelte';
+
+/**
+ * Regression: `ToastContainer` reichte die Dauer als `toast.duration || 5000`
+ * weiter. `errorToast()` setzt bewusst `duration: 0` (= nicht automatisch
+ * schließen), aber `0` ist falsy — daraus wurden 5000 ms. Fehler-Toasts
+ * verschwanden also nach 5 Sekunden, obwohl sie stehen bleiben sollen.
+ *
+ * Die Zeit wird mit Fake-Timern vorgespult; abgefragt wird direkt am DOM,
+ * weil die wiederholenden `expect.element`-Matcher selbst auf Timern sitzen.
+ */
+describe('ToastContainer — automatisches Schließen', () => {
+	beforeEach(() => {
+		clearAllToasts();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		clearAllToasts();
+	});
+
+	it('schließt einen errorToast mit duration: 0 nicht automatisch', async () => {
+		vi.useFakeTimers();
+		render(ToastContainer);
+
+		errorToast('Der Server hat nicht geantwortet');
+		await tick();
+
+		expect(document.body.textContent).toContain('Der Server hat nicht geantwortet');
+
+		// Weit über die 5000 ms hinaus, die der Fallback fälschlich gesetzt hat.
+		await vi.advanceTimersByTimeAsync(30_000);
+		await tick();
+
+		expect(document.body.textContent).toContain('Der Server hat nicht geantwortet');
+	});
+
+	it('schließt einen successToast nach der Standarddauer weiterhin automatisch', async () => {
+		vi.useFakeTimers();
+		render(ToastContainer);
+
+		successToast('Sichtung gespeichert');
+		await tick();
+
+		expect(document.body.textContent).toContain('Sichtung gespeichert');
+
+		await vi.advanceTimersByTimeAsync(5_000);
+		await tick();
+
+		expect(document.body.textContent).not.toContain('Sichtung gespeichert');
+	});
+
+	it('behält den Titel-Fallback für Toasts ohne Titel', async () => {
+		vi.useFakeTimers();
+		render(ToastContainer);
+
+		errorToast('Ohne Titel');
+		await tick();
+
+		// Kein leerer Titel-Knoten: `title || ''` bleibt korrekt und unangetastet.
+		expect(document.body.querySelector('h3')).toBeNull();
+	});
+});

--- a/src/lib/form/submitSightingForm.test.ts
+++ b/src/lib/form/submitSightingForm.test.ts
@@ -87,4 +87,52 @@ describe('submitSightingForm', () => {
 
 		await expect(submitSightingForm(validFormValues)).rejects.toThrow('Failed to fetch');
 	});
+
+	/**
+	 * Regression: `response.json()` lief vor der `response.ok`-Prüfung. Ein 502
+	 * mit HTML-Fehlerseite (Reverse Proxy, Gateway) warf damit einen
+	 * JSON-Parse-Fehler, dessen Rohtext ungefiltert beim Nutzer landete.
+	 */
+	describe('Antworten, die kein JSON sind', () => {
+		function mockNonJsonResponse(status: number) {
+			global.fetch = vi.fn().mockResolvedValue({
+				ok: status >= 200 && status < 300,
+				status,
+				json: () =>
+					Promise.reject(
+						new SyntaxError('Unexpected token \'<\', "<html><bo"... is not valid JSON')
+					)
+			});
+		}
+
+		it('meldet einen 502 mit HTML-Body als verständlichen Fehler', async () => {
+			mockNonJsonResponse(502);
+
+			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
+				'Die Sichtung konnte nicht gespeichert werden'
+			);
+		});
+
+		it('lässt den rohen Parse-Fehler nicht zum Nutzer durch', async () => {
+			mockNonJsonResponse(502);
+
+			await expect(submitSightingForm(validFormValues)).rejects.not.toThrow(/Unexpected token/);
+		});
+
+		it('räumt den Speicher bei einem 502 nicht auf', async () => {
+			mockNonJsonResponse(502);
+
+			await expect(submitSightingForm(validFormValues)).rejects.toThrow();
+			expect(clearStorage).not.toHaveBeenCalled();
+		});
+
+		it('meldet auch eine unlesbare 200-Antwort verständlich', async () => {
+			mockNonJsonResponse(200);
+
+			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
+				'Die Sichtung konnte nicht gespeichert werden'
+			);
+			expect(clearStorage).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -36,6 +36,33 @@ import type { SightingFormValues } from '$lib/types/Form';
  * @note Bereinigt automatisch den localStorage bei erfolgreicher Übermittlung
  * @note Verwendet JSON-Serialisierung für komplexe Formularstrukturen
  */
+/** Fehlermeldung, die der Nutzer sieht, wenn der Server keine eigene liefert. */
+const FALLBACK_MESSAGE = 'Die Sichtung konnte nicht gespeichert werden';
+
+/** Antwortkörper der Sichtungs-API, soweit der Client ihn auswertet. */
+interface SightingApiResponse {
+	success?: boolean;
+	id?: number;
+	message?: string;
+}
+
+/**
+ * Liest den Antwortkörper als JSON — und gibt `null` zurück, wenn das nicht geht.
+ *
+ * Nicht jede Antwort auf dieser Route ist JSON: Ein 502 kommt als HTML-Fehlerseite
+ * des Reverse Proxy, ein 504 als Klartext des Gateways. `response.json()` wirft
+ * dort einen `SyntaxError`, dessen Rohtext („Unexpected token '<' …") für den
+ * Nutzer bedeutungslos ist. Der Parse-Fehler wird deshalb hier abgefangen und
+ * nicht weitergereicht.
+ */
+async function readJsonBody(response: Response): Promise<SightingApiResponse | null> {
+	try {
+		return (await response.json()) as SightingApiResponse;
+	} catch {
+		return null;
+	}
+}
+
 export async function submitSightingForm(
 	values: SightingFormValues
 ): Promise<{ id: number; success: boolean }> {
@@ -48,17 +75,21 @@ export async function submitSightingForm(
 		body: JSON.stringify(values) // Serialisiere komplette Formulardaten
 	});
 
-	// Parse JSON-Antwort vom Server
-	const result = await response.json();
+	// Statusprüfung VOR dem Parsen: Bei einem HTTP-Fehler ist der Körper oft
+	// kein JSON, und der Parse-Fehler würde die eigentliche Ursache verdecken.
+	if (!response.ok) {
+		const body = await readJsonBody(response);
+		throw new Error(body?.message || FALLBACK_MESSAGE);
+	}
 
-	if (response.ok && result.success) {
+	const result = await readJsonBody(response);
+
+	if (result?.success && typeof result.id === 'number') {
 		// Erfolgreiche Übermittlung: Lokalen Speicher bereinigen
 		clearStorage();
 		return { id: result.id, success: true };
-	} else {
-		// Fehlerbehandlung: Server-Fehlermeldung oder Fallback verwenden
-		return Promise.reject(
-			new Error(result.message || 'Die Sichtung konnte nicht gespeichert werden')
-		);
 	}
+
+	// 2xx, aber unlesbar oder `success: false` — Server-Meldung oder Fallback.
+	throw new Error(result?.message || FALLBACK_MESSAGE);
 }


### PR DESCRIPTION
**PR 1 von 6 — Stack „Zustände". Muss vor den folgenden gemergt werden.**

Zwei unabhängige Bugs im Fehlerpfad.

### Fehler-Toasts verschwanden nach 5 Sekunden

`ToastContainer` reichte die Dauer als `toast.duration || 5000` weiter.
`errorToast()` setzt bewusst `duration: 0` (= nicht automatisch schließen),
aber `0` ist falsy — aus dem „bleibt stehen" wurden still 5 Sekunden. Jetzt
`??`, das nur für `undefined` einspringt. Das benachbarte `title || ''` ist
korrekt und bleibt unangetastet.

### Der rohe JSON-Parse-Fehler landete beim Nutzer

`submitSightingForm` rief `response.json()` **vor** der `response.ok`-Prüfung.
Ein 502 antwortet mit der HTML-Fehlerseite des Reverse Proxy, der Parse warf
also einen `SyntaxError`, dessen Rohtext („Unexpected token '<' …") dem Nutzer
als Begründung angezeigt wurde. Die Statusprüfung läuft jetzt zuerst und der
Parse ist gekapselt; ein Körper, der kein JSON ist, fällt auf die
Klartext-Meldung zurück. Im Erfolgsfall ändert sich nichts.

### Tests

- `ToastContainer.svelte.test.ts` — ein `errorToast` mit `duration: 0`
  übersteht 30 s Fake-Zeit, ein `successToast` schließt weiterhin bei 5 s.
- `submitSightingForm.test.ts` — 502 mit HTML-Body, unlesbare 200, und dass
  keiner der beiden den lokalen Speicher räumt.

`npm run test:quick` grün (2284 Tests), `npm run check` 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)