### PR TITLE
refactor(report): make submit failures distinguishable via a discriminated result

### DIFF
--- a/src/lib/form/submitSightingForm.test.ts
+++ b/src/lib/form/submitSightingForm.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { submitSightingForm } from './submitSightingForm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeSubmitFailure, submitSightingForm } from './submitSightingForm';
 
-// Mock clearStorage
+// Mock clearStorage — die Funktion darf ihn nicht mehr aufrufen (siehe unten).
 vi.mock('$lib/storage/localStorage', () => ({
 	clearStorage: vi.fn()
 }));
@@ -20,11 +20,27 @@ const validFormValues = {
 	longitude: 10.5
 } as Parameters<typeof submitSightingForm>[0];
 
-function mockFetchResponse(body: object, status = 200): void {
+/** Baut eine Antwort-Attrappe inklusive Headers und optional kaputtem Körper. */
+function mockResponse(options: {
+	status: number;
+	body?: object;
+	unparseable?: boolean;
+	headers?: Record<string, string>;
+}): void {
+	const { status, body, unparseable, headers = {} } = options;
+
 	global.fetch = vi.fn().mockResolvedValue({
 		ok: status >= 200 && status < 300,
 		status,
-		json: () => Promise.resolve(body)
+		headers: {
+			get: (name: string) => headers[name] ?? null
+		},
+		json: () =>
+			unparseable
+				? Promise.reject(
+						new SyntaxError('Unexpected token \'<\', "<html><bo"... is not valid JSON')
+					)
+				: Promise.resolve(body ?? {})
 	});
 }
 
@@ -33,106 +49,245 @@ describe('submitSightingForm', () => {
 		vi.clearAllMocks();
 	});
 
-	it('gibt { id, success: true } bei erfolgreicher Submission zurück', async () => {
-		mockFetchResponse({ success: true, id: 42 }, 201);
-
-		const result = await submitSightingForm(validFormValues);
-
-		expect(result).toEqual({ id: 42, success: true });
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
-	it('ruft clearStorage bei erfolgreicher Submission auf', async () => {
-		mockFetchResponse({ success: true, id: 42 }, 201);
+	describe("status 'ok'", () => {
+		it('gibt die Sichtungs-ID zurück', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 42, referenceId: 'clx8k2p9a' } });
 
-		await submitSightingForm(validFormValues);
-
-		expect(clearStorage).toHaveBeenCalledOnce();
-	});
-
-	it('sendet POST an /api/sightings mit JSON Content-Type', async () => {
-		mockFetchResponse({ success: true, id: 1 }, 201);
-
-		await submitSightingForm(validFormValues);
-
-		expect(global.fetch).toHaveBeenCalledWith('/api/sightings', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(validFormValues)
-		});
-	});
-
-	it('wirft Error mit Server-Message wenn success=false', async () => {
-		mockFetchResponse({ success: false, message: 'Validierung fehlgeschlagen' }, 400);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow('Validierung fehlgeschlagen');
-	});
-
-	it('wirft Error mit Fallback-Message wenn keine Server-Message vorhanden', async () => {
-		mockFetchResponse({ success: false }, 500);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-			'Die Sichtung konnte nicht gespeichert werden'
-		);
-	});
-
-	it('ruft clearStorage NICHT bei Fehler auf', async () => {
-		mockFetchResponse({ success: false, message: 'Fehler' }, 400);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow();
-		expect(clearStorage).not.toHaveBeenCalled();
-	});
-
-	it('propagiert Netzwerkfehler wenn fetch fehlschlägt', async () => {
-		global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow('Failed to fetch');
-	});
-
-	/**
-	 * Regression: `response.json()` lief vor der `response.ok`-Prüfung. Ein 502
-	 * mit HTML-Fehlerseite (Reverse Proxy, Gateway) warf damit einen
-	 * JSON-Parse-Fehler, dessen Rohtext ungefiltert beim Nutzer landete.
-	 */
-	describe('Antworten, die kein JSON sind', () => {
-		function mockNonJsonResponse(status: number) {
-			global.fetch = vi.fn().mockResolvedValue({
-				ok: status >= 200 && status < 300,
-				status,
-				json: () =>
-					Promise.reject(
-						new SyntaxError('Unexpected token \'<\', "<html><bo"... is not valid JSON')
-					)
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ok',
+				id: 42
 			});
-		}
+		});
 
-		it('meldet einen 502 mit HTML-Body als verständlichen Fehler', async () => {
-			mockNonJsonResponse(502);
+		it('sendet POST an /api/sightings mit JSON Content-Type', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 1 } });
 
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-				'Die Sichtung konnte nicht gespeichert werden'
+			await submitSightingForm(validFormValues);
+
+			expect(global.fetch).toHaveBeenCalledWith('/api/sightings', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validFormValues)
+			});
+		});
+
+		/**
+		 * Der Speicher wird bewusst NICHT hier geräumt, sondern in
+		 * `ModernReportForm.svelte` nach dem `onSubmit`-Callback. Zwei Gründe:
+		 *
+		 * 1. Diese Funktion ist Transport — der Lebenszyklus des Formularspeichers
+		 *    gehört der Komponente, die das Formular hält.
+		 * 2. Der frühere Aufruf hier lief, bevor `onSubmit` durch war. Scheiterte
+		 *    dieser Callback, war der Speicher schon leer und die Eingaben weg —
+		 *    im Widerspruch zum Kommentar an der Aufrufstelle („Fehler in onSubmit
+		 *    soll Formular erhalten"). Die Komponente räumt mit
+		 *    `clearFormDataOnly()` + `CURRENT_STEP = 0` denselben Umfang.
+		 */
+		it('räumt den Speicher nicht selbst auf — dafür ist die Aufrufstelle zuständig', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 42 } });
+
+			await submitSightingForm(validFormValues);
+
+			expect(clearStorage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("status 'offline'", () => {
+		it('erkennt den TypeError von fetch als fehlende Verbindung', async () => {
+			global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		/**
+		 * WLAN an Bord ohne Uplink: `navigator.onLine` meldet `true`, `fetch`
+		 * scheitert trotzdem. Für dieses Projekt der Regelfall — der TypeError
+		 * allein muss deshalb genügen.
+		 */
+		it('erkennt Offline auch, wenn navigator.onLine true meldet', async () => {
+			vi.stubGlobal('navigator', { onLine: true });
+			global.fetch = vi.fn().mockRejectedValue(new TypeError('Load failed'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		it('wertet navigator.onLine === false als zusätzliches Signal', async () => {
+			vi.stubGlobal('navigator', { onLine: false });
+			global.fetch = vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		it('verschluckt Fehler nicht, die keine Netzwerkfehler sind', async () => {
+			vi.stubGlobal('navigator', { onLine: true });
+			global.fetch = vi.fn().mockRejectedValue(new RangeError('Ungültiger Header'));
+
+			await expect(submitSightingForm(validFormValues)).rejects.toThrow('Ungültiger Header');
+		});
+	});
+
+	describe("status 'server'", () => {
+		it('meldet einen 500 mit dem HTTP-Status', async () => {
+			mockResponse({
+				status: 500,
+				body: { success: false, code: 'SERVER_ERROR', message: 'Ein unbekannter Fehler' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 500
+			});
+		});
+
+		/**
+		 * Regression: `response.json()` lief vor der `response.ok`-Prüfung. Ein 502
+		 * mit HTML-Fehlerseite warf einen JSON-Parse-Fehler, dessen Rohtext beim
+		 * Nutzer landete.
+		 */
+		it('meldet einen 502 mit HTML-Body als Serverfehler statt als Parse-Fehler', async () => {
+			mockResponse({ status: 502, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 502
+			});
+		});
+
+		it('behandelt eine unlesbare 200-Antwort als Serverfehler', async () => {
+			mockResponse({ status: 200, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 200
+			});
+		});
+
+		it('behandelt eine 201 ohne ID als Serverfehler', async () => {
+			mockResponse({ status: 201, body: { success: true } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 201
+			});
+		});
+	});
+
+	describe("status 'rejected'", () => {
+		it('reicht die Validierungsmeldung eines 400 durch', async () => {
+			mockResponse({
+				status: 400,
+				body: {
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe'
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Validierungsfehler bei der Eingabe'
+			});
+		});
+
+		it('behandelt einen 422 (Datenbank-Integrität) als Ablehnung', async () => {
+			mockResponse({
+				status: 422,
+				body: { success: false, code: 'DATABASE_ERROR', message: 'Die Daten konnten nicht …' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Die Daten konnten nicht …'
+			});
+		});
+
+		it('behandelt eine 200 mit success: false als Ablehnung', async () => {
+			mockResponse({ status: 200, body: { success: false, message: 'Doppelte Meldung' } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Doppelte Meldung'
+			});
+		});
+
+		it('fällt bei einem 400 ohne Meldung auf Serverfehler zurück', async () => {
+			mockResponse({ status: 400, body: { success: false } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 400
+			});
+		});
+	});
+
+	describe("status 'ratelimited'", () => {
+		/**
+		 * `enforceRateLimit()` wirft `error(429, '… (45s)')`. SvelteKit liefert das
+		 * als `{ message }` ohne `Retry-After`-Header aus — die Sekunden stehen
+		 * ausschließlich im Text.
+		 */
+		it('liest die Wartezeit aus der Meldung der Middleware', async () => {
+			mockResponse({
+				status: 429,
+				body: { message: 'Rate limit exceeded. Try again after 14:23:11 (45s)' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ratelimited',
+				retryAfter: 45
+			});
+		});
+
+		it('bevorzugt einen Retry-After-Header, falls ein Proxy ihn setzt', async () => {
+			mockResponse({
+				status: 429,
+				body: { message: 'Rate limit exceeded. Try again after 14:23:11 (45s)' },
+				headers: { 'Retry-After': '120' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ratelimited',
+				retryAfter: 120
+			});
+		});
+
+		it('kommt ohne Wartezeit aus, wenn keine ermittelbar ist', async () => {
+			mockResponse({ status: 429, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'ratelimited'
+			});
+		});
+	});
+
+	describe('describeSubmitFailure', () => {
+		it('nennt bei offline das Schicksal der Daten', () => {
+			expect(describeSubmitFailure({ status: 'offline' })).toContain(
+				'Eingaben bleiben vollständig gespeichert'
 			);
 		});
 
-		it('lässt den rohen Parse-Fehler nicht zum Nutzer durch', async () => {
-			mockNonJsonResponse(502);
-
-			await expect(submitSightingForm(validFormValues)).rejects.not.toThrow(/Unexpected token/);
-		});
-
-		it('räumt den Speicher bei einem 502 nicht auf', async () => {
-			mockNonJsonResponse(502);
-
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow();
-			expect(clearStorage).not.toHaveBeenCalled();
-		});
-
-		it('meldet auch eine unlesbare 200-Antwort verständlich', async () => {
-			mockNonJsonResponse(200);
-
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-				'Die Sichtung konnte nicht gespeichert werden'
+		it('nennt bei einem Rate Limit die Wartezeit', () => {
+			expect(describeSubmitFailure({ status: 'ratelimited', retryAfter: 45 })).toContain(
+				'45 Sekunden'
 			);
-			expect(clearStorage).not.toHaveBeenCalled();
+		});
+
+		it('reicht die Ablehnungsmeldung unverändert durch', () => {
+			expect(describeSubmitFailure({ status: 'rejected', message: 'Feld X fehlt' })).toBe(
+				'Feld X fehlt'
+			);
+		});
+
+		it('zeigt bei einem Serverfehler keinen technischen Rohtext', () => {
+			const message = describeSubmitFailure({ status: 'server', httpStatus: 502 });
+
+			expect(message).toBe('Die Sichtung konnte nicht gespeichert werden');
+			expect(message).not.toMatch(/502|Unexpected token/);
 		});
 	});
 });

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -3,39 +3,36 @@
  *
  * Dieses Modul implementiert die Client-seitige Logik zur Übermittlung
  * von Sichtungsformularen an die Server-API. Es verwaltet die HTTP-
- * Kommunikation, Fehlerbehandlung und automatische Bereinigung des
- * lokalen Browser-Speichers nach erfolgreicher Übermittlung.
+ * Kommunikation und übersetzt jedes mögliche Ergebnis in einen
+ * unterscheidbaren Zustand, den die Oberfläche verschieden behandeln kann.
  *
  * @author Ostsee-Tiere Team
  * @since 1.0.0
  */
 
-import { clearStorage } from '$lib/storage/localStorage';
 import type { SightingFormValues } from '$lib/types/Form';
 
 /**
- * Übermittelt validierte Sichtungsformulardaten an die Server-API
+ * Ergebnis einer Übermittlung — bewusst ein diskriminiertes Result statt eines
+ * geworfenen `Error`.
  *
- * Diese Funktion führt eine POST-Anfrage an den `/api/sightings` Endpunkt
- * durch und verarbeitet die Antwort. Bei erfolgreicher Übermittlung wird
- * der lokale Browser-Speicher automatisch bereinigt.
+ * Vorher warf die Funktion für jeden Fehler denselben `Error`. „Kein Netz",
+ * „Server down", „Validierung abgelehnt" und „Rate Limit" waren für die
+ * Oberfläche damit nicht unterscheidbar — sie konnte nur die Meldung anzeigen.
+ * Bei fehlendem Netz kam diese Meldung sogar direkt vom Browser („Failed to
+ * fetch"), also unübersetzt und ohne Bezug zur Anwendung.
  *
- * @param values Vollständig validierte Sichtungsformulardaten
- * @returns Promise mit Sichtungs-ID und Erfolgsstatus
- *
- * @example
- * try {
- *   const result = await submitSightingForm(formData);
- *   console.log(`Sichtung ${result.id} erfolgreich gespeichert`);
- * } catch (error) {
- *   console.error('Fehler beim Speichern:', error.message);
- * }
- *
- * @throws {Error} Bei Netzwerkfehlern, Validierungsfehlern oder Server-Problemen
- *
- * @note Bereinigt automatisch den localStorage bei erfolgreicher Übermittlung
- * @note Verwendet JSON-Serialisierung für komplexe Formularstrukturen
+ * Die vier Fehlerfälle verlangen unterschiedliche Reaktionen:
+ * `offline` → Absenden vorab sperren, `server` → Wiederholen anbieten,
+ * `rejected` → zum Feld springen, `ratelimited` → warten lassen.
  */
+export type SubmitResult =
+	| { status: 'ok'; id: number }
+	| { status: 'offline' }
+	| { status: 'server'; httpStatus: number }
+	| { status: 'rejected'; message: string }
+	| { status: 'ratelimited'; retryAfter?: number };
+
 /** Fehlermeldung, die der Nutzer sieht, wenn der Server keine eigene liefert. */
 const FALLBACK_MESSAGE = 'Die Sichtung konnte nicht gespeichert werden';
 
@@ -63,33 +60,134 @@ async function readJsonBody(response: Response): Promise<SightingApiResponse | n
 	}
 }
 
-export async function submitSightingForm(
-	values: SightingFormValues
-): Promise<{ id: number; success: boolean }> {
+/**
+ * Erkennt, ob ein von `fetch` geworfener Fehler ein Verbindungsproblem ist.
+ *
+ * `fetch` wirft nur bei Netzwerk- und Konfigurationsfehlern; ein HTTP-Fehlerstatus
+ * ist für `fetch` ein Erfolg. Der Netzwerkfall ist immer ein `TypeError`.
+ *
+ * `navigator.onLine === false` ist dabei ein zusätzliches, aber kein notwendiges
+ * Signal: Es meldet nur, ob eine Netzwerkschnittstelle aktiv ist, nicht ob das
+ * Internet erreichbar ist. WLAN an Bord ohne Uplink meldet `true` und lässt
+ * `fetch` trotzdem scheitern — für dieses Projekt der Regelfall. Der `TypeError`
+ * allein genügt deshalb bereits.
+ */
+function isNetworkFailure(cause: unknown): boolean {
+	if (cause instanceof TypeError) return true;
+	return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
+
+/**
+ * Ermittelt, wie lange bis zum nächsten Versuch gewartet werden muss.
+ *
+ * `enforceRateLimit()` (`$lib/server/middleware/rateLimit.ts`) wirft
+ * `error(429, 'Rate limit exceeded. Try again after 14:23:11 (45s)')`. SvelteKit
+ * liefert das als `{ message }` aus und setzt **keinen** `Retry-After`-Header —
+ * die Sekunden stehen nur im Text. Der Header wird trotzdem zuerst gelesen,
+ * damit ein vorgeschalteter Reverse Proxy, der selbst drosselt, korrekt greift.
+ */
+function parseRetryAfter(response: Response, message: string | undefined): number | undefined {
+	const header = response.headers?.get?.('Retry-After');
+
+	if (header) {
+		const seconds = Number(header);
+		if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds);
+
+		// RFC 9110 erlaubt alternativ ein HTTP-Datum.
+		const resetAt = Date.parse(header);
+		if (!Number.isNaN(resetAt)) return Math.max(0, Math.ceil((resetAt - Date.now()) / 1000));
+	}
+
+	const fromMessage = message?.match(/\((\d+)s\)/);
+	return fromMessage ? Number(fromMessage[1]) : undefined;
+}
+
+/**
+ * Übermittelt validierte Sichtungsformulardaten an die Server-API
+ *
+ * @param values Vollständig validierte Sichtungsformulardaten
+ * @returns Das Ergebnis als {@link SubmitResult} — die Funktion wirft für kein
+ *   erwartbares Fehlerbild. Geworfen wird nur weiter, was kein Netzwerkfehler
+ *   ist (etwa ein Programmierfehler beim Aufbau der Anfrage); solche Fehler zu
+ *   verschlucken würde sie unsichtbar machen.
+ *
+ * @note Räumt den Browser-Speicher **nicht** auf. Zuständig dafür ist
+ *   `ModernReportForm.svelte`, siehe Hinweis unten.
+ */
+export async function submitSightingForm(values: SightingFormValues): Promise<SubmitResult> {
+	let response: Response;
+
 	// HTTP POST-Anfrage an die Sichtungs-API mit JSON-Payload
-	const response = await fetch('/api/sightings', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json'
-		},
-		body: JSON.stringify(values) // Serialisiere komplette Formulardaten
-	});
+	try {
+		response = await fetch('/api/sightings', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify(values) // Serialisiere komplette Formulardaten
+		});
+	} catch (cause) {
+		if (isNetworkFailure(cause)) return { status: 'offline' };
+		throw cause;
+	}
 
-	// Statusprüfung VOR dem Parsen: Bei einem HTTP-Fehler ist der Körper oft
-	// kein JSON, und der Parse-Fehler würde die eigentliche Ursache verdecken.
+	// Der Körper wird einmal gelesen, BEVOR über den Status entschieden wird —
+	// die Verzweigungen unten brauchen ihn alle. Möglich ist das nur, weil
+	// `readJsonBody()` den Parse kapselt: Bei einem HTTP-Fehler ist der Körper
+	// oft kein JSON (HTML-Fehlerseite eines Proxy), und ein durchschlagender
+	// `SyntaxError` würde die eigentliche Ursache verdecken. Ohne diese Kapselung
+	// müsste die Statusprüfung zwingend vorher laufen.
+	const body = await readJsonBody(response);
+
+	if (response.status === 429) {
+		// `exactOptionalPropertyTypes`: die Eigenschaft wird weggelassen, nicht auf
+		// `undefined` gesetzt.
+		const retryAfter = parseRetryAfter(response, body?.message);
+		return retryAfter === undefined
+			? { status: 'ratelimited' }
+			: { status: 'ratelimited', retryAfter };
+	}
+
 	if (!response.ok) {
-		const body = await readJsonBody(response);
-		throw new Error(body?.message || FALLBACK_MESSAGE);
+		// 4xx mit lesbarer Meldung ist eine inhaltliche Ablehnung (Validierung,
+		// verbotene Felder) — der Text nennt das betroffene Feld und hilft dem
+		// Nutzer. 5xx-Meldungen sind generisch; dort zählt nur „wiederholbar".
+		if (response.status < 500 && body?.message) {
+			return { status: 'rejected', message: body.message };
+		}
+		return { status: 'server', httpStatus: response.status };
 	}
 
-	const result = await readJsonBody(response);
-
-	if (result?.success && typeof result.id === 'number') {
-		// Erfolgreiche Übermittlung: Lokalen Speicher bereinigen
-		clearStorage();
-		return { id: result.id, success: true };
+	if (body?.success === true && typeof body.id === 'number') {
+		return { status: 'ok', id: body.id };
 	}
 
-	// 2xx, aber unlesbar oder `success: false` — Server-Meldung oder Fallback.
-	throw new Error(result?.message || FALLBACK_MESSAGE);
+	// 2xx, aber der Körper widerspricht sich oder ist unlesbar.
+	if (body?.success === false && body.message) {
+		return { status: 'rejected', message: body.message };
+	}
+	return { status: 'server', httpStatus: response.status };
+}
+
+/**
+ * Übersetzt ein gescheitertes {@link SubmitResult} in einen Satz für den Nutzer.
+ *
+ * Zwischenschritt: Solange die Oberfläche Fehler nur als Text anzeigt, braucht
+ * sie eine Meldung. Ab `SubmitStatus` trägt die Komponente den Zustand selbst
+ * und wählt Wortlaut und Aktion pro Fall — dann bleibt hier nur noch der
+ * Fallback für Protokollzwecke.
+ */
+export function describeSubmitFailure(result: Exclude<SubmitResult, { status: 'ok' }>): string {
+	switch (result.status) {
+		case 'offline':
+			return 'Keine Internetverbindung. Ihre Eingaben bleiben vollständig gespeichert.';
+		case 'ratelimited':
+			return result.retryAfter
+				? `Zu viele Übermittlungen. Bitte versuchen Sie es in ${result.retryAfter} Sekunden erneut.`
+				: 'Zu viele Übermittlungen. Bitte versuchen Sie es später erneut.';
+		case 'rejected':
+			return result.message;
+		case 'server':
+			return FALLBACK_MESSAGE;
+	}
 }

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -6,7 +6,7 @@
 
 	import { browser } from '$app/environment';
 	import Icon from '$lib/components/Icon.svelte';
-	import { submitSightingForm } from '$lib/form/submitSightingForm';
+	import { describeSubmitFailure, submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
@@ -91,8 +91,15 @@
 
 				const result = await submitSightingForm(submitValues);
 
+				if (result.status !== 'ok') {
+					// Zwischenschritt: Die Oberfläche kann die vier Fehlerarten noch nicht
+					// unterschiedlich darstellen, deshalb wird hier auf eine Meldung
+					// eingedampft. `SubmitStatus` übernimmt den Zustand als Ganzes.
+					throw new Error(describeSubmitFailure(result));
+				}
+
 				// Speichere Benutzer-Kontaktdaten für zukünftige Formulare basierend auf Zustimmung
-				if (result.success) {
+				{
 					const userContactData: UserContactData = {
 						firstName: values.firstName,
 						lastName: values.lastName,
@@ -117,7 +124,11 @@
 
 				submissionError = null;
 				const submitResult = await onSubmit(submitValues);
-				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten)
+				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten).
+				// Diese Stelle ist seither die EINZIGE, die nach einer Übermittlung aufräumt:
+				// `submitSightingForm` rief zuvor zusätzlich `clearStorage()` — und zwar schon
+				// vor `onSubmit`, was den Kommentar oben aushebelte. `clearFormDataOnly()` plus
+				// das Zurücksetzen von CURRENT_STEP deckt denselben Umfang ab.
 				clearFormDataOnly(); // Clears only form data, keeps currentStep and user contact data
 				currentStep = 0;
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);


### PR DESCRIPTION
**PR 2 von 6 — Stack „Zustände". Basis: `fix/error-state-bugs` (#623).**

`submitSightingForm` warf für jeden Fehler denselben `Error`. „Kein Netz",
„Server down", „Validierung abgelehnt" und „Rate Limit" waren für die
Oberfläche damit nicht unterscheidbar — sie konnte nur die Meldung anzeigen.
Ohne Netz kam diese Meldung sogar direkt vom Browser („Failed to fetch"),
also unübersetzt und ohne Bezug zur Anwendung.

Die Funktion liefert jetzt ein diskriminiertes Result:

```ts
{ status: 'ok'; id }
| { status: 'offline' }
| { status: 'server'; httpStatus }
| { status: 'rejected'; message }
| { status: 'ratelimited'; retryAfter? }
```

### Entscheidungen darin

- **`offline`** — `fetch` wirft nur bei Netzwerkfehlern einen `TypeError`; der
  allein ist das Signal. `navigator.onLine === false` gilt als zusätzliches,
  nicht als notwendiges Indiz: **WLAN an Bord ohne Uplink meldet `true`,
  während jeder Request scheitert** — für dieses Projekt der Regelfall.
  Fehler, die keine Netzwerkfehler sind, werden weitergeworfen statt
  verschluckt.
- **`ratelimited`** — `enforceRateLimit()` wirft `error(429, '… (45s)')`.
  SvelteKit liefert das als `{ message }` **ohne** `Retry-After`-Header aus,
  die Sekunden stehen nur im Text; ein Header eines vorgeschalteten Proxy hat
  Vorrang, falls vorhanden.
- **`rejected` gegen `server`** — ein 4xx mit lesbarer Meldung nennt das
  betroffene Feld und hilft dem Nutzer. 5xx-Meldungen sind generisch, dort
  zählt nur „wiederholbar".

### `clearStorage()` ist aus diesem Modul verschwunden

Der Aufruf lief **vor** dem `onSubmit`-Callback. Scheiterte dieser, war der
Speicher schon leer und die Eingaben weg — im direkten Widerspruch zum
Kommentar an der Aufrufstelle („Fehler in onSubmit soll Formular erhalten").
`ModernReportForm` ist jetzt allein zuständig und deckt mit
`clearFormDataOnly()` plus `CURRENT_STEP = 0` denselben Umfang ab.

`describeSubmitFailure()` dampft einen Fehlschlag vorübergehend auf einen Satz
ein; ab PR 3 trägt `SubmitStatus` den Zustand selbst.

### Tests

22 Fälle über alle fünf Zweige. `npm run test:quick` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)