### PR TITLE
feat(report): replace the submit error toast with a persistent SubmitStatus

### DIFF
--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -250,10 +250,16 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 
 		// Formular sollte auf Step 4 bleiben (kein Wechsel zur Erfolgsseite)
 		await expectCurrentStep(page, /Kontaktdaten/i);
-		// Error-Toast sollte die Server-Fehlermeldung anzeigen
-		await expect(page.getByText('Interner Serverfehler')).toBeVisible({
-			timeout: 5000
-		});
+
+		// Der Fehlschlag steht als SubmitStatus über der Navigation — nicht mehr
+		// als Toast. Die Server-Meldung eines 5xx wird bewusst NICHT gezeigt: sie
+		// ist generisch („Ein unbekannter Fehler ist aufgetreten") und sagt dem
+		// Nutzer weniger als die Zusage, dass seine Eingaben erhalten bleiben.
+		const status = page.locator('[data-testid="submit-status-failed"]');
+		await expect(status).toBeVisible({ timeout: 5000 });
+		await expect(status).toContainText('Ihre Eingaben sind nicht verloren');
+		await expect(status).toContainText('Versuch 1 von 3');
+		await expect(status.getByRole('button', { name: /Erneut absenden/i })).toBeVisible();
 	});
 
 	test('Validation-Rejection: Server gibt 400 zurück — Fehlermeldung sichtbar', async ({
@@ -283,7 +289,7 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 		});
 	});
 
-	test('Netzwerkfehler: Route abgebrochen — Error-Handling greift', async ({ page }) => {
+	test('Netzwerkfehler: Route abgebrochen — als Verbindungsproblem erkannt', async ({ page }) => {
 		await page.route('**/api/sightings', (route) => {
 			route.abort('connectionrefused');
 		});
@@ -295,9 +301,23 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 
 		// Formular bleibt auf Step 4
 		await expectCurrentStep(page, /Kontaktdaten/i);
-		// Fehlermeldung sichtbar
-		await expect(
-			page.getByText('Fehler beim Absenden des Formulars. Bitte versuchen Sie es erneut.')
-		).toBeVisible({ timeout: 5000 });
+
+		// `fetch` wirft hier einen TypeError — das ist ein Verbindungsproblem, kein
+		// Serverfehler, und wird als solches gezeigt. Genau der Fall „WLAN an Bord
+		// ohne Uplink": `navigator.onLine` meldet weiter `true`.
+		const status = page.locator('[data-testid="submit-status-offline"]');
+		await expect(status).toBeVisible({ timeout: 5000 });
+		await expect(status).toContainText('Eingaben bleiben vollständig gespeichert');
+
+		// Aber NICHT gesperrt: Der Zustand ist hier nur aus einem gescheiterten
+		// Request abgeleitet — `navigator.onLine` meldet weiter `true`, und ohne
+		// `online`-Ereignis würde ihn nichts wieder aufheben. Eine harte Sperre
+		// hielte den Nutzer bis zum Neuladen fest. Gesperrt wird nur beim sicheren
+		// Nein des Browsers (siehe e2e/submit-offline.spec.ts).
+		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		await expect(status.getByRole('button', { name: /Trotzdem versuchen/i })).toBeVisible();
 	});
 });

--- a/e2e/submit-offline.spec.ts
+++ b/e2e/submit-offline.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import { expectCurrentStep, fillStep1, fillStep2, fillStep4 } from './helpers/form-helpers';
+import { FormPage } from './pages/FormPage';
+
+/**
+ * Ohne Verbindung wird das Absenden vorab gesperrt, statt den Versuch scheitern
+ * zu lassen — ein Fehlschlag, den man vorhersehen kann, ist keine Fehlermeldung
+ * wert. Der Nutzer sieht stattdessen den Grund und die Zusage, dass seine
+ * Eingaben erhalten bleiben.
+ */
+test.describe('Absenden ohne Internetverbindung', () => {
+	test('sperrt den Absenden-Button, nennt den Grund und behält die Eingaben', async ({
+		page,
+		context
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Bis zum letzten Schritt durchfüllen
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Verhalten|Beobachtung/i);
+
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Kontakt/i);
+
+		await fillStep4(formPage);
+
+		// Netz abschalten — Chromium feuert dabei das `offline`-Ereignis.
+		await context.setOffline(true);
+
+		const status = page.locator('[data-testid="submit-status-offline"]');
+		await expect(status).toBeVisible();
+		await expect(status).toContainText('Keine Internetverbindung');
+		await expect(status).toContainText('Eingaben bleiben vollständig gespeichert');
+
+		// Der Button bleibt fokussierbar (`aria-disabled` statt `disabled`), damit
+		// die Tastaturposition erhalten bleibt — die Sperre sitzt im Handler.
+		const submit = page.getByRole('button', { name: /Formular absenden/i });
+		await expect(submit).toHaveAttribute('aria-disabled', 'true');
+
+		// Ohne `force` würde Playwright wegen `aria-disabled` gar nicht erst
+		// klicken und nur die eigene Actionability-Prüfung bestätigen.
+		await submit.click({ force: true });
+
+		// Immer noch auf dem Kontaktschritt — es wurde nichts abgeschickt.
+		await expectCurrentStep(page, /Kontakt/i);
+		await expect(status).toBeVisible();
+
+		// Zusage einlösen: Nach einem Neuladen sind die Eingaben noch da.
+		// Erst wieder online gehen — ein Reload ohne Netz lädt das Dokument nicht.
+		await context.setOffline(false);
+		await page.reload();
+		await page.locator('[data-testid="field-firstName"]').waitFor({ state: 'visible' });
+
+		await expect(page.locator('[data-testid="field-firstName"]')).toHaveValue('Max');
+		await expect(page.locator('[data-testid="field-email"]')).toHaveValue('max@example.com');
+	});
+
+	test('gibt das Absenden wieder frei, sobald die Verbindung zurück ist', async ({
+		page,
+		context
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Kontakt/i);
+
+		await context.setOffline(true);
+		await expect(page.locator('[data-testid="submit-status-offline"]')).toBeVisible();
+
+		await context.setOffline(false);
+
+		await expect(page.locator('[data-testid="submit-status-offline"]')).toBeHidden();
+		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	});
+});

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -4,8 +4,10 @@
 	import FormActions from './form/FormActions.svelte';
 	import RequiredConsent from './form/RequiredConsent.svelte';
 
+	import SubmitStatus, { type SubmitState } from './form/SubmitStatus.svelte';
+
 	import { browser } from '$app/environment';
-	import Icon from '$lib/components/Icon.svelte';
+	import { connection, watchConnection } from '$lib/stores/connectionState.svelte';
 	import { describeSubmitFailure, submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
@@ -71,8 +73,48 @@
 		});
 	}
 
-	// Status für Fehleranzeige
-	let submissionError = $state<string | null>(null);
+	/**
+	 * Zustand der Übermittlung — getragen von `SubmitStatus` über der Navigation.
+	 *
+	 * Ersetzt den früheren `submissionError`-Alert plus den Submit-Fehler-Toast:
+	 * beide sagten nur, DASS etwas schiefging, nicht was mit den Daten passiert
+	 * ist und was der Nutzer jetzt tun kann.
+	 */
+	let submitState = $state<SubmitState>('idle');
+	/** Überschrift im Zustand `failed` — je nach Fehlerart eine andere. */
+	let submitTitle = $state('Der Server hat nicht geantwortet');
+	/** Zählt die Absende-Versuche, damit „Wiederholen" sichtbar etwas bewirkt. */
+	let submitAttempt = $state(0);
+
+	// Verbindungszustand an die Browser-Ereignisse binden.
+	$effect(() => watchConnection());
+
+	/**
+	 * Ohne Verbindung wird vorab gesperrt, statt den Versuch scheitern zu lassen.
+	 * Ein laufender Submit behält seinen eigenen Zustand — sonst überschriebe ein
+	 * kurzer Aussetzer die Anzeige mitten in der Übertragung.
+	 */
+	$effect(() => {
+		if (connection.isOffline) {
+			// NUR aus `idle` heraus. Ein bereits angezeigter Fehlschlag darf nicht
+			// überschrieben werden: Er verschwände beim nächsten Verbindungswechsel
+			// von selbst wieder — genau das, was `SubmitStatus` ausschließt.
+			if (submitState === 'idle') submitState = 'offline';
+		} else if (submitState === 'offline') {
+			submitState = 'idle';
+		}
+	});
+
+	/**
+	 * Hart gesperrt wird nur beim sicheren Nein des Browsers.
+	 *
+	 * `connection.isOffline` ist auch dann wahr, wenn lediglich der letzte
+	 * Request an einem `TypeError` gescheitert ist — das wirft `fetch` aber auch
+	 * bei einem Server-Neustart oder einem CORS-Fehler, und dort feuert nie ein
+	 * `online`-Ereignis, das den Zustand wieder aufhebt. An dieser Bedingung
+	 * gesperrt käme der Nutzer nur durch ein Neuladen wieder heraus.
+	 */
+	const submitBlocked = $derived(submitState === 'offline' && connection.isInterfaceDown);
 
 	// Formular initialisieren
 	const formProps = {
@@ -89,14 +131,35 @@
 				// set mediaUpload indicator
 				submitValues.mediaUpload = uploadedFiles ? uploadedFiles.length > 0 : false;
 
+				submitAttempt += 1;
+				submitState = 'submitting';
+
 				const result = await submitSightingForm(submitValues);
 
 				if (result.status !== 'ok') {
-					// Zwischenschritt: Die Oberfläche kann die vier Fehlerarten noch nicht
-					// unterschiedlich darstellen, deshalb wird hier auf eine Meldung
-					// eingedampft. `SubmitStatus` übernimmt den Zustand als Ganzes.
-					throw new Error(describeSubmitFailure(result));
+					// Jede Fehlerart bekommt ihren eigenen Zustand: `offline` sperrt das
+					// Absenden vorab, die übrigen bieten Wiederholen an. Liegt bereits
+					// eine Aufnahme auf dem Server, gilt die Datenzusage nicht mehr
+					// uneingeschränkt — dafür gibt es `partial`.
+					connection[result.status === 'offline' ? 'reportUnreachable' : 'reportReachable']();
+
+					// Einmal berechnen: Anzeige und geworfene Meldung sollen dieselbe
+					// Aussage tragen, nicht zwei unabhängig entstandene.
+					const failure = describeSubmitFailure(result);
+
+					if (result.status === 'offline') {
+						submitState = 'offline';
+					} else {
+						submitState = submitValues.mediaUpload ? 'partial' : 'failed';
+						submitTitle = failure;
+					}
+
+					throw new Error(failure);
 				}
+
+				connection.reportReachable();
+				submitState = 'idle';
+				submitAttempt = 0;
 
 				// Speichere Benutzer-Kontaktdaten für zukünftige Formulare basierend auf Zustimmung
 				{
@@ -122,7 +185,6 @@
 					);
 				}
 
-				submissionError = null;
 				const submitResult = await onSubmit(submitValues);
 				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten).
 				// Diese Stelle ist seither die EINZIGE, die nach einer Übermittlung aufräumt:
@@ -134,14 +196,35 @@
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);
 				return submitResult;
 			} catch (error: unknown) {
-				submissionError = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
-				logger.error(error, submissionError);
+				const message = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
+				// Scheitert erst der `onSubmit`-Callback (nicht die Übermittlung),
+				// steht `submitState` noch auf `submitting` — auch dieser Fall ist ein
+				// Fehlschlag und braucht die Wiederholen-Fläche.
+				if (submitState === 'submitting') {
+					submitState = 'failed';
+					submitTitle = message;
+				}
+				logger.error(error, message);
 				throw error;
 			}
 		}
 	};
 
 	let formContext: FormContext = $state({} as FormContext);
+
+	/**
+	 * Erneuter Versuch aus `SubmitStatus` heraus.
+	 *
+	 * `handleFinalSubmit` wirft bei einem Fehlschlag weiter, damit die
+	 * Schritt-Navigation ihren Weg zum fehlerhaften Feld gehen kann. Hier gibt es
+	 * keinen solchen Aufrufer — der Zustand steht bereits in `submitState`, das
+	 * erneute Werfen wäre nur eine unbehandelte Rejection in der Konsole.
+	 */
+	function retrySubmit(): void {
+		void handleFinalSubmit(new Event('submit')).catch((error: unknown) => {
+			logger.error({ error }, 'Erneuter Absendeversuch fehlgeschlagen');
+		});
+	}
 
 	// Formularstatus
 	async function handleFinalSubmit(e: Event): Promise<void> {
@@ -245,13 +328,12 @@
 		</div>
 	{/if}
 
-	<!-- Error Message -->
-	{#if submissionError}
-		<div class="alert alert-error mb-6" role="alert">
-			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
-			<span>{submissionError}</span>
-		</div>
-	{/if}
+	<!--
+		Der frühere `submissionError`-Alert stand hier oben, weit weg von der
+		Schaltfläche, die ihn ausgelöst hat — auf dem Telefon außerhalb des
+		Bildschirms. Er ist in `SubmitStatus` aufgegangen, das direkt über der
+		Schritt-Navigation sitzt.
+	-->
 
 	<!-- Step Progress -->
 	<FormSteps steps={formStepsConfig} bind:currentStep />
@@ -275,7 +357,21 @@
 			<!-- Required Privacy Consent - Prominent placement before submit -->
 			<RequiredConsent {currentStep} />
 
-			<StepNavigation bind:currentStep onSubmit={handleFinalSubmit} />
+			<!--
+				`referenceId` kommt aus `savedFormData`, nicht aus `$form`: `formContext`
+				wird erst über `bind:context` gefüllt, beim Server-Rendering ist `$form`
+				an dieser Stelle noch undefiniert. Die Referenz steht ohnehin fest — sie
+				entsteht einmal beim Aufbau des Formulars und ändert sich nie.
+			-->
+			<SubmitStatus
+				state={submitState}
+				title={submitTitle}
+				attempt={submitAttempt}
+				referenceId={savedFormData.referenceId ?? ''}
+				onRetry={submitBlocked ? undefined : retrySubmit}
+			/>
+
+			<StepNavigation bind:currentStep onSubmit={handleFinalSubmit} {submitBlocked} />
 		</div>
 	</div>
 

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -22,11 +22,18 @@
 	let {
 		currentStep = $bindable(0),
 		totalSteps = $bindable(formStepsConfig.length),
-		onSubmit
+		onSubmit,
+		submitBlocked = false
 	}: {
 		onSubmit?: (e: Event) => Promise<void>;
 		currentStep?: number;
 		totalSteps?: number;
+		/**
+		 * Sperrt „Absenden" vorab, statt den Versuch scheitern zu lassen. Die
+		 * Begründung steht in `SubmitStatus` über dieser Navigation — ein
+		 * vorhersehbarer Fehlschlag ist keine Fehlermeldung wert.
+		 */
+		submitBlocked?: boolean;
 	} = $props();
 
 	const formContext = getFormContext();
@@ -98,8 +105,18 @@
 	}
 
 	// Navigation functions
+	/** Absenden ist gesperrt — nur auf dem letzten Schritt relevant. */
+	const isSubmitBlocked = $derived(isLastStep && submitBlocked);
+
 	async function nextStep(): Promise<void> {
 		try {
+			// Wächter zur `aria-disabled`-Sperre am Button: Das Element bleibt
+			// fokussierbar (siehe design-system.md), die eigentliche Sperre sitzt hier.
+			if (isSubmitBlocked) {
+				logger.info('Absenden gesperrt — keine Verbindung');
+				return;
+			}
+
 			if (!canGoNext) {
 				logger.warn({ currentStep }, 'Validation failed for current step');
 				attemptedStep = currentStep;
@@ -142,8 +159,13 @@
 			logger.info('Form submitted successfully');
 		} catch (error) {
 			logger.error({ error }, 'Error during form submission');
-			toast.error('Fehler beim Absenden des Formulars. Bitte versuchen Sie es erneut.');
-			// Navigate to first error field if validation failed
+			// Kein Toast mehr: Der Fehlschlag steht als `SubmitStatus` direkt über
+			// dieser Navigation, verschwindet nicht von selbst und trägt die
+			// Wiederholen-Aktion. Ein Toast daneben wäre eine zweite Anzeige
+			// derselben Sache — und die flüchtigere von beiden.
+			// Der Validierungs-Toast in `showValidationError` bleibt: der ist
+			// flüchtig, verlangt keine Handlung an Ort und Stelle und begleitet
+			// den Sprung zum fehlerhaften Feld.
 			await showValidationError();
 		}
 	}
@@ -272,15 +294,27 @@
 			</button>
 		{/if}
 
+		<!--
+			`aria-disabled` statt `disabled` für die Verbindungssperre: Das Element
+			bleibt fokussierbar, damit die Tastaturposition erhalten bleibt und der
+			Grund erreichbar ist (design-system.md). Der laufende Submit sperrt
+			weiterhin hart über `disabled` — dort ist der Zustand von sehr kurzer
+			Dauer und ein Doppelklick hätte echte Folgen.
+		-->
 		<button
 			type="button"
 			onclick={nextStep}
 			disabled={$isSubmitting}
+			aria-disabled={isSubmitBlocked}
 			class="btn btn-primary"
+			class:btn-disabled={isSubmitBlocked}
 			aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
+			title={isSubmitBlocked ? 'Ohne Internetverbindung kann nicht abgesendet werden' : undefined}
 		>
 			{#if $isSubmitting}
 				<span class="loading loading-spinner loading-sm"></span>
+			{:else if isSubmitBlocked}
+				<Icon icon="lucide:wifi-off" width="16" class="shrink-0" aria-hidden="true" />
 			{/if}
 			{isLastStep ? 'Absenden' : 'Weiter →'}
 		</button>

--- a/src/lib/report/components/form/SubmitStatus.svelte
+++ b/src/lib/report/components/form/SubmitStatus.svelte
@@ -1,0 +1,238 @@
+<!--
+  Zustandsfläche direkt über der Schritt-Navigation, dort wo „Absenden" steht.
+
+  Ersetzt den Submit-Fehler-Toast vollständig. Ein Toast ist für Flüchtiges da —
+  eine bestätigende Randnotiz, die keine Handlung verlangt. Ein gescheitertes
+  Absenden verlangt eine Handlung, und die gehört an den Ort der Handlung, nicht
+  in eine Ecke, die nach fünf Sekunden leer ist.
+
+  Drei Regeln, die diese Komponente durchhält:
+
+  1. Sie verschwindet nie von selbst. Kein `setTimeout`, keine Dauer-Prop. Wer
+     den Fehler wegbekommen will, sendet erneut oder korrigiert etwas.
+  2. Jeder Fehlerzustand nennt das Schicksal der Daten. Die häufigste Sorge nach
+     einem Fehlschlag ist „ist jetzt alles weg?" — und sie ist beantwortbar.
+     Einzige Ausnahme ist `partial`: dort liegt die Aufnahme schon auf dem
+     Server, das lässt sich nicht als „bleibt bei Ihnen" beschreiben.
+  3. Die Referenz-ID steht im Fehlerfall im Text. Sie existiert bereits
+     (`createId()` in `ModernReportForm`), wurde dem Nutzer aber nie gezeigt —
+     ausgerechnet im Fehlerfall braucht er sie für die Rückfrage.
+-->
+<script module lang="ts">
+	// Typ-Export gehört in den Modul-Block — der Instanz-Block kann in Svelte 5
+	// keine Typen exportieren.
+	export type SubmitState = 'idle' | 'submitting' | 'offline' | 'failed' | 'partial';
+</script>
+
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { ORPHAN_RETENTION_HOURS } from '$lib/constants/uploadRetention';
+
+	let {
+		state = 'idle',
+		attempt = 0,
+		maxAttempts = 3,
+		referenceId = '',
+		title = 'Der Server hat nicht geantwortet',
+		onRetry
+	}: {
+		/** Aktueller Zustand der Übermittlung. `idle` rendert nichts. */
+		state?: SubmitState;
+		/**
+		 * Überschrift im Zustand `failed`. Voreinstellung ist der Serverausfall;
+		 * eine inhaltliche Ablehnung oder ein Rate Limit setzt hier den eigenen
+		 * Satz ein, während Datenzusage, Referenz und Wiederholen gleich bleiben.
+		 */
+		title?: string;
+		/** Anzahl der bisherigen Versuche. 0 = noch keiner, blendet den Zähler aus. */
+		attempt?: number;
+		/** Bezugsgröße für den Zähler („Versuch 2 von 3"). */
+		maxAttempts?: number;
+		/** Referenz der Meldung — im Fehlerfall die Nummer für die Rückfrage. */
+		referenceId?: string;
+		/**
+		 * Löst einen erneuten Versuch aus. Fehlt er, wird keine Schaltfläche gezeigt.
+		 *
+		 * Auch der Offline-Zustand trägt sie, sobald der Aufrufer sie übergibt: Der
+		 * Zustand kann aus einem einzelnen gescheiterten Request abgeleitet sein
+		 * und dann falsch liegen (siehe `connection.isInterfaceDown`). Ohne einen
+		 * Weg heraus wäre der Nutzer in diesem Fall bis zum Neuladen gefangen.
+		 */
+		onRetry?: (() => void) | undefined;
+	} = $props();
+
+	/**
+	 * Anlaufstelle bei anhaltenden Problemen.
+	 *
+	 * Bewusst die Kontaktseite des Museums und **keine E-Mail-Adresse**: Der
+	 * Entwurf nannte `sichtungen@meeresmuseum.de`, wofür es im Bestand keinen
+	 * Beleg gibt. Eine Adresse, die niemand liest, ist im Fehlerfall schlimmer
+	 * als gar keine — dann läuft die Rückfrage ins Leere und der Nutzer hält es
+	 * für erledigt.
+	 *
+	 * Diese URL ist belegt: `src/routes/about/+page.svelte:353` zeigt sie
+	 * Nutzern bereits als „Kontakt aufnehmen". Die einzige weitere Adresse im
+	 * Bestand ist `datenschutz@meeresmuseum.de` (`RequiredConsent.svelte`) —
+	 * eine Datenschutz-Stelle, die für eine gescheiterte Übermittlung der
+	 * falsche Adressat wäre.
+	 */
+	const CONTACT_URL = 'https://www.deutsches-meeresmuseum.de/kontakt';
+
+	const showAttemptCounter = $derived(attempt > 0);
+	const showReference = $derived(referenceId.length > 0);
+
+	/**
+	 * „Versuch 4 von 3" wäre Unsinn. Über der Bezugsgröße zählt die Komponente
+	 * nur noch weiter, statt eine Grenze zu behaupten, die niemand durchsetzt —
+	 * `ModernReportForm` begrenzt die Versuche nicht.
+	 */
+	const attemptLabel = $derived(
+		attempt > maxAttempts
+			? `Das war Versuch ${attempt}.`
+			: `Das war Versuch ${attempt} von ${maxAttempts}.`
+	);
+</script>
+
+{#if state === 'submitting'}
+	<!--
+		Kein Alert und keine Statusfarbe: Ein Ladevorgang ist keine Warnung.
+		Die sichtbare Rückmeldung trägt der Absenden-Button selbst; dieser Block
+		existiert für die Ansage an Screenreader.
+	-->
+	<div
+		class="border-base-300 bg-base-200/50 rounded-box mb-2 flex items-start gap-3 border p-4"
+		role="status"
+		aria-live="polite"
+		data-testid="submit-status-submitting"
+	>
+		<span class="loading loading-spinner loading-sm text-primary mt-0.5"></span>
+		<p class="text-base-content font-medium">Ihre Meldung wird gesendet …</p>
+	</div>
+{:else if state === 'offline'}
+	<!--
+		`role="status"`: Der Offline-Zustand entsteht von selbst, oft während der
+		Nutzer noch tippt. Ein `role="alert"` würde den Screenreader mitten im
+		Satz unterbrechen, ohne dass etwas passiert wäre.
+	-->
+	<div
+		class="alert alert-warning mb-2 items-start"
+		role="status"
+		aria-live="polite"
+		data-testid="submit-status-offline"
+	>
+		<Icon icon="lucide:wifi-off" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">Keine Internetverbindung</p>
+			<p class="text-base-content mt-1 text-sm">
+				Die Meldung kann gerade nicht abgeschickt werden.
+				<strong>Ihre Eingaben bleiben vollständig gespeichert</strong> — auch wenn Sie diese Seite schließen.
+				Sobald Sie wieder Empfang haben, können Sie hier absenden.
+			</p>
+			{#if onRetry}
+				<!--
+					Nur sichtbar, wenn der Aufrufer den Zustand nicht als sicher ansieht:
+					Ist er aus einem einzelnen gescheiterten Request abgeleitet, kann er
+					falsch sein — ohne diesen Weg bliebe der Nutzer bis zum Neuladen
+					gefangen, denn ohne `online`-Ereignis hebt ihn nichts wieder auf.
+				-->
+				<button type="button" class="btn btn-primary btn-sm mt-3" onclick={onRetry}>
+					<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+					Trotzdem versuchen
+				</button>
+			{/if}
+		</div>
+	</div>
+{:else if state === 'failed'}
+	<!--
+		`role="alert"`, wie auch bei `partial`. Dieser Zustand ist die unmittelbare Folge
+		einer Nutzeraktion („Absenden"), die Unterbrechung ist also erwartet und
+		trägt Information.
+	-->
+	<div class="alert alert-error mb-2 items-start" role="alert" data-testid="submit-status-failed">
+		<Icon icon="lucide:circle-alert" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">{title}</p>
+			<p class="text-base-content mt-1 text-sm">
+				<strong>Ihre Eingaben sind nicht verloren.</strong>
+				{#if showAttemptCounter}
+					{attemptLabel}
+				{/if}
+				{#if showReference}
+					Bitte geben Sie bei einer Rückfrage die unten stehende Referenz an.
+				{/if}
+				Bei anhaltenden Problemen erreichen Sie uns über die
+				<a class="link" href={CONTACT_URL} target="_blank" rel="noopener noreferrer">
+					Kontaktseite des Museums
+				</a>.
+			</p>
+			<div class="mt-3 flex flex-wrap items-center gap-2">
+				{#if onRetry}
+					<button type="button" class="btn btn-primary btn-sm" onclick={onRetry}>
+						<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+						Erneut absenden
+					</button>
+				{/if}
+				{#if showReference}
+					<span
+						class="text-base-content/70 font-mono text-sm"
+						data-testid="submit-status-reference"
+					>
+						Referenz: {referenceId}
+					</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+{:else if state === 'partial'}
+	<!--
+		Der einzige Zustand, der die Datenzusage nicht geben kann: Die Aufnahme
+		liegt bereits auf dem Server. Die Frist kommt aus `ORPHAN_RETENTION_HOURS`
+		— derselben Konstante, aus der `UPLOAD_NOTICE` an der Dropzone schöpft und
+		nach der das Aufräum-Tool tatsächlich löscht. Eine hier hineingeschriebene
+		Zahl könnte davon abweichen und wäre dann eine falsche Zusage.
+	-->
+	<!--
+		`role="alert"` wie bei `failed`: `partial` entsteht, weil jemand
+		„Absenden" gedrückt hat — es ist ein Unterfall des Fehlschlags und keine
+		von selbst auflaufende Meldung. Die Unterbrechung ist damit erwartet und
+		trägt Information. Zwei gleichzeitige Live-Regionen können dabei nicht
+		entstehen: `failed` und `partial` schließen einander aus.
+	-->
+	<div
+		class="alert alert-warning mb-2 items-start"
+		role="alert"
+		data-testid="submit-status-partial"
+	>
+		<Icon icon="lucide:triangle-alert" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">Aufnahme übertragen, Meldung nicht</p>
+			<p class="text-base-content mt-1 text-sm">
+				<!--
+					Der Grund gehört auch hierhin. Vorher trug nur `failed` ihn, und eine
+					Meldung mit angehängter Aufnahme landet immer in `partial` — eine
+					abgelehnte Eingabe („E-Mail ungültig") verschwand damit spurlos hinter
+					dem Aufbewahrungshinweis, und der Nutzer wiederholte ins Leere.
+				-->
+				{title}
+				{#if showAttemptCounter}
+					{attemptLabel}
+				{/if}
+			</p>
+			<p class="text-base-content mt-1 text-sm">
+				Ihre Aufnahme liegt bereits bei uns. Wir löschen sie automatisch, wenn die Meldung nicht
+				innerhalb von {ORPHAN_RETENTION_HOURS} Stunden ankommt.
+			</p>
+			<div class="mt-3 flex flex-wrap items-center gap-2">
+				{#if onRetry}
+					<button type="button" class="btn btn-primary btn-sm" onclick={onRetry}>
+						<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+						Erneut absenden
+					</button>
+				{/if}
+				{#if showReference}
+					<span class="text-base-content/70 font-mono text-sm">Referenz: {referenceId}</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/report/components/form/SubmitStatus.svelte.test.ts
+++ b/src/lib/report/components/form/SubmitStatus.svelte.test.ts
@@ -1,0 +1,256 @@
+import { ORPHAN_RETENTION_HOURS } from '$lib/constants/uploadRetention';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import SubmitStatus from './SubmitStatus.svelte';
+
+/** Findet den Statusblock im gerenderten Dokument. */
+function block(testid: string): HTMLElement | null {
+	return document.querySelector(`[data-testid="${testid}"]`);
+}
+
+describe('SubmitStatus', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('rendert im Zustand idle nichts', () => {
+		const { container } = render(SubmitStatus, { state: 'idle' });
+
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	describe('offline', () => {
+		it('nennt das Schicksal der Daten', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.textContent).toContain(
+				'Eingaben bleiben vollständig gespeichert'
+			);
+		});
+
+		/**
+		 * Der Offline-Zustand entsteht von selbst, oft während der Nutzer noch
+		 * tippt. `role="alert"` würde den Screenreader mitten im Satz unterbrechen.
+		 */
+		it('meldet sich höflich per role="status", nicht per role="alert"', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.getAttribute('role')).toBe('status');
+			expect(document.querySelector('[role="alert"]')).toBeNull();
+		});
+	});
+
+	/**
+	 * `failed` und `partial` entstehen beide, weil jemand „Absenden" gedrückt
+	 * hat — die Unterbrechung ist dort erwartet. `offline` und `submitting`
+	 * laufen von selbst auf und melden sich höflich. Weil die Zustände einander
+	 * ausschließen, kann nie mehr als eine Live-Region gleichzeitig feuern.
+	 */
+	describe('ARIA-Rollen', () => {
+		it.each([
+			['failed', 'alert'],
+			['partial', 'alert'],
+			['offline', 'status'],
+			['submitting', 'status']
+		] as const)('meldet %s per role="%s"', (state, expected) => {
+			render(SubmitStatus, { state });
+
+			expect(block(`submit-status-${state}`)?.getAttribute('role')).toBe(expected);
+		});
+
+		it('rendert nie zwei Live-Regionen gleichzeitig', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			expect(document.querySelectorAll('[role="alert"], [role="status"]')).toHaveLength(1);
+		});
+	});
+
+	describe('failed', () => {
+		it('unterbricht per role="alert", weil es die Folge einer Nutzeraktion ist', () => {
+			render(SubmitStatus, { state: 'failed' });
+
+			expect(block('submit-status-failed')?.getAttribute('role')).toBe('alert');
+		});
+
+		it('sagt zu, dass die Eingaben erhalten bleiben', () => {
+			render(SubmitStatus, { state: 'failed' });
+
+			expect(block('submit-status-failed')?.textContent).toContain(
+				'Ihre Eingaben sind nicht verloren'
+			);
+		});
+
+		it('zeigt die Referenz-ID für die Rückfrage', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: 'clx8k2p9a0001' });
+
+			expect(block('submit-status-reference')?.textContent).toContain('clx8k2p9a0001');
+			expect(block('submit-status-failed')?.textContent).toContain(
+				'bei einer Rückfrage die unten stehende Referenz'
+			);
+		});
+
+		/**
+		 * Der Entwurf nannte `sichtungen@meeresmuseum.de` — dafür gibt es im
+		 * Bestand keinen Beleg. Eine Adresse, die niemand liest, ist im Fehlerfall
+		 * schlimmer als gar keine: die Rückfrage läuft ins Leere und der Nutzer
+		 * hält es für erledigt. Verlinkt wird deshalb die Kontaktseite, die
+		 * `about/+page.svelte` Nutzern ohnehin schon zeigt.
+		 */
+		it('nennt keine unbelegte E-Mail-Adresse', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: 'clx8k2p9a0001' });
+
+			const html = block('submit-status-failed')?.innerHTML ?? '';
+			expect(html).not.toMatch(/mailto:/);
+			expect(html).not.toMatch(/@meeresmuseum\.de/);
+			expect(html).toContain('https://www.deutsches-meeresmuseum.de/kontakt');
+		});
+
+		it('zeigt keine Referenzzeile, solange keine ID vorliegt', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: '' });
+
+			expect(block('submit-status-reference')).toBeNull();
+		});
+
+		it('macht sichtbar, der wievielte Versuch das war', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 2, maxAttempts: 3 });
+
+			expect(block('submit-status-failed')?.textContent).toContain('Versuch 2 von 3');
+		});
+
+		it('blendet den Zähler vor dem ersten Versuch aus', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 0 });
+
+			expect(block('submit-status-failed')?.textContent).not.toContain('Versuch');
+		});
+
+		/**
+		 * Die Versuche sind nirgends begrenzt — `ModernReportForm` zählt einfach
+		 * weiter. „Das war Versuch 4 von 3" wäre eine Grenze, die niemand
+		 * durchsetzt.
+		 */
+		it('behauptet oberhalb der Bezugsgröße keine Grenze mehr', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 4, maxAttempts: 3 });
+
+			const text = block('submit-status-failed')?.textContent ?? '';
+			expect(text).toContain('Das war Versuch 4.');
+			expect(text).not.toContain('von 3');
+		});
+
+		it('setzt die übergebene Überschrift ein', () => {
+			render(SubmitStatus, { state: 'failed', title: 'Zu viele Übermittlungen' });
+
+			expect(block('submit-status-failed')?.textContent).toContain('Zu viele Übermittlungen');
+		});
+
+		it('löst über die Schaltfläche einen erneuten Versuch aus', async () => {
+			const onRetry = vi.fn();
+			render(SubmitStatus, { state: 'failed', onRetry });
+
+			const button = block('submit-status-failed')?.querySelector('button');
+			button?.click();
+			await tick();
+
+			expect(onRetry).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('partial', () => {
+		/**
+		 * Der einzige Zustand, der die Datenzusage nicht geben kann: Die Aufnahme
+		 * liegt schon auf dem Server.
+		 */
+		it('gibt keine uneingeschränkte Datenzusage', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			const text = block('submit-status-partial')?.textContent ?? '';
+			expect(text).toContain('liegt bereits bei uns');
+			expect(text).not.toContain('bleiben vollständig gespeichert');
+		});
+
+		/**
+		 * Die Frist stammt aus derselben Konstante, aus der `UPLOAD_NOTICE` an der
+		 * Dropzone schöpft und nach der das Aufräum-Tool tatsächlich löscht — eine
+		 * fest hineingeschriebene Zahl könnte davon abweichen.
+		 */
+		it('nennt genau die Frist, die auch tatsächlich angewendet wird', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			expect(block('submit-status-partial')?.textContent).toContain(
+				`${ORPHAN_RETENTION_HOURS} Stunden`
+			);
+		});
+
+		/**
+		 * Regression: Eine Meldung mit angehängter Aufnahme landet IMMER in
+		 * `partial` — auch bei einer inhaltlichen Ablehnung. Solange dieser Zweig
+		 * `title` nicht rendert, verschwindet der eigentliche Grund („E-Mail
+		 * ungültig") hinter dem Aufbewahrungshinweis und der Nutzer wiederholt
+		 * ins Leere.
+		 */
+		it('nennt auch hier den Grund des Fehlschlags', () => {
+			render(SubmitStatus, {
+				state: 'partial',
+				title: 'Validierungsfehler bei der Eingabe',
+				attempt: 1
+			});
+
+			const text = block('submit-status-partial')?.textContent ?? '';
+			expect(text).toContain('Validierungsfehler bei der Eingabe');
+			expect(text).toContain('Das war Versuch 1 von 3.');
+		});
+	});
+
+	/**
+	 * Regression: Der Offline-Zustand kann aus einem einzelnen gescheiterten
+	 * Request abgeleitet sein und dann falsch liegen — `fetch` wirft denselben
+	 * TypeError bei einem Server-Neustart. Ohne Ausweg bliebe der Nutzer bis zum
+	 * Neuladen gefangen, denn ohne `online`-Ereignis hebt nichts den Zustand auf.
+	 */
+	describe('Ausweg aus dem Offline-Zustand', () => {
+		it('bietet einen Versuch an, wenn der Aufrufer einen Handler übergibt', async () => {
+			const onRetry = vi.fn();
+			render(SubmitStatus, { state: 'offline', onRetry });
+
+			const button = block('submit-status-offline')?.querySelector('button');
+			expect(button?.textContent).toContain('Trotzdem versuchen');
+
+			button?.click();
+			await tick();
+
+			expect(onRetry).toHaveBeenCalledOnce();
+		});
+
+		it('zeigt keine Schaltfläche, wenn die Sperre sicher ist', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.querySelector('button')).toBeNull();
+		});
+	});
+
+	describe('submitting', () => {
+		it('trägt keine Statusfarbe — ein Ladevorgang ist keine Warnung', () => {
+			render(SubmitStatus, { state: 'submitting' });
+
+			const element = block('submit-status-submitting');
+			expect(element?.className).not.toMatch(/alert-(warning|error|info|success)/);
+			expect(element?.getAttribute('role')).toBe('status');
+		});
+	});
+
+	/**
+	 * Die Komponente verschwindet nie von selbst — anders als der Toast, den sie
+	 * ersetzt. Wer den Fehler wegbekommen will, sendet erneut.
+	 */
+	it('verschwindet nicht von selbst', async () => {
+		vi.useFakeTimers();
+		render(SubmitStatus, { state: 'failed' });
+
+		expect(block('submit-status-failed')).not.toBeNull();
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		await tick();
+
+		expect(block('submit-status-failed')).not.toBeNull();
+	});
+});

--- a/src/lib/stores/connectionState.svelte.ts
+++ b/src/lib/stores/connectionState.svelte.ts
@@ -1,0 +1,117 @@
+/**
+ * Verbindungszustand der Anwendung.
+ *
+ * `navigator.onLine` allein reicht hier nicht: Es meldet nur, ob eine
+ * Netzwerkschnittstelle aktiv ist, nicht ob das Internet erreichbar ist. WLAN an
+ * Bord ohne Uplink meldet `true` — und ist für dieses Projekt der Regelfall,
+ * nicht die Ausnahme.
+ *
+ * Der Zustand wird deshalb aus zwei Quellen gebildet:
+ *
+ * | Quelle                     | Aussagekraft                          | Rolle           |
+ * | -------------------------- | ------------------------------------- | --------------- |
+ * | `navigator.onLine`         | Schnittstelle aktiv (notwendig)       | Vorab-Signal    |
+ * | Ergebnis eines echten POST | Server erreichbar (hinreichend)       | Letztes Wort    |
+ *
+ * Ein gescheiterter Request setzt den Zustand auf offline; erst ein
+ * erfolgreicher Request oder ein `online`-Event des Browsers hebt ihn wieder auf.
+ *
+ * **SSR:** Modulweiter `$state` wird auf dem Server zwischen Requests geteilt.
+ * Hier ist das unkritisch — der Wert trägt keine Nutzerdaten und startet immer
+ * als „online". Verändert wird er ausschließlich im Browser: über
+ * `watchConnection()` (an Ereignisse gebunden) und über die Rückmeldungen aus
+ * echten Requests.
+ */
+
+import { browser } from '$app/environment';
+
+/** Meldung des Browsers: Ist überhaupt eine Netzwerkschnittstelle aktiv? */
+let interfaceUp = $state(true);
+
+/** Was der letzte echte Request über die Erreichbarkeit gesagt hat. */
+let lastRequest = $state<'unknown' | 'reachable' | 'unreachable'>('unknown');
+
+export const connection = {
+	/**
+	 * `true`, wenn abgesendete Daten den Server nicht erreichen würden.
+	 *
+	 * Beide Quellen dürfen das auslösen: eine abgeschaltete Schnittstelle ist ein
+	 * sicheres Nein, ein gescheiterter Request ebenfalls.
+	 */
+	get isOffline(): boolean {
+		return !interfaceUp || lastRequest === 'unreachable';
+	},
+
+	/**
+	 * `true` nur, wenn der Browser die Schnittstelle selbst als abgeschaltet
+	 * meldet — das ist ein **sicheres** Nein.
+	 *
+	 * Der Unterschied zu {@link isOffline} entscheidet, ob die Anwendung das
+	 * Absenden vorab sperren darf. Ein gescheiterter Request ist ein starkes
+	 * Indiz, aber kein Beweis: `isNetworkFailure()` in `submitSightingForm`
+	 * wertet jeden `TypeError` von `fetch` als Verbindungsproblem, und den wirft
+	 * `fetch` auch bei `ERR_CONNECTION_REFUSED` (Server startet neu), bei
+	 * CORS-Fehlern und bei DNS-Aussetzern. In all diesen Fällen bleibt
+	 * `navigator.onLine` auf `true` und es feuert **nie** ein `online`-Ereignis,
+	 * das den Zustand wieder aufheben könnte.
+	 *
+	 * Würde die Sperre an `isOffline` hängen, käme der Nutzer aus ihr nur durch
+	 * ein Neuladen wieder heraus — und verlöre damit genau die Sicherheit, die
+	 * der Offline-Hinweis ihm zusagt. Gesperrt wird deshalb nur beim sicheren
+	 * Nein; im Verdachtsfall bleibt „Trotzdem versuchen" erreichbar.
+	 */
+	get isInterfaceDown(): boolean {
+		return !interfaceUp;
+	},
+
+	/** Ein Request kam durch — überstimmt jedes ältere Signal. */
+	reportReachable(): void {
+		lastRequest = 'reachable';
+		interfaceUp = true;
+	},
+
+	/** Ein Request scheiterte am Netz (`status: 'offline'` aus `submitSightingForm`). */
+	reportUnreachable(): void {
+		lastRequest = 'unreachable';
+	},
+
+	/**
+	 * Setzt nur die Request-Historie zurück, nicht das Browser-Signal.
+	 * Gedacht für Tests und für das `online`-Ereignis, nach dem die alte
+	 * Erfahrung nichts mehr über die neue Verbindung aussagt.
+	 */
+	reset(): void {
+		lastRequest = 'unknown';
+		interfaceUp = browser ? navigator.onLine : true;
+	}
+};
+
+/**
+ * Bindet den Zustand an die `online`/`offline`-Ereignisse des Browsers.
+ *
+ * Gibt die Abmeldefunktion zurück, damit sie direkt aus einem `$effect`
+ * verwendet werden kann. Auf dem Server ein No-op.
+ */
+export function watchConnection(): () => void {
+	if (!browser) return () => {};
+
+	interfaceUp = navigator.onLine;
+
+	const handleOnline = (): void => {
+		interfaceUp = true;
+		// Die alte Erfahrung gilt nicht mehr: Es ist eine neue Verbindung, und ob
+		// sie trägt, weiß erst der nächste echte Request.
+		lastRequest = 'unknown';
+	};
+	const handleOffline = (): void => {
+		interfaceUp = false;
+	};
+
+	window.addEventListener('online', handleOnline);
+	window.addEventListener('offline', handleOffline);
+
+	return () => {
+		window.removeEventListener('online', handleOnline);
+		window.removeEventListener('offline', handleOffline);
+	};
+}


### PR DESCRIPTION
**PR 3 von 6 — Stack „Zustände". Basis: `refactor/submit-result` (#624).**

Ein Toast ist für Dinge da, die vorbei sind: eine Bestätigung, die keine
Antwort verlangt. Ein gescheitertes Absenden verlangt eine Antwort — und die
gehört an den Ort der Handlung, nicht in eine Ecke, die fünf Sekunden später
leer ist. Der Submit-Fehler-Toast in `StepNavigation` und der
`submissionError`-Alert am Kopf von `ModernReportForm` sagten beide nur, **dass**
etwas kaputtging; keiner sagte, was mit den Daten passiert ist oder was jetzt
zu tun wäre.

### Neue Komponente `SubmitStatus`

Sitzt direkt über der Schritt-Navigation. Fünf Zustände (`idle` rendert
nichts), drei Regeln:

1. **Sie verschwindet nie von selbst.** Kein `setTimeout`, keine Dauer-Prop.
2. **Jeder Fehlerzustand nennt das Schicksal der Daten.** `offline` und
   `failed` sagen zu, dass die Eingaben erhalten bleiben. `partial` kann das
   nicht — die Aufnahme liegt schon auf dem Server — und nennt stattdessen die
   Aufbewahrungsfrist aus `ORPHAN_RETENTION_HOURS`, derselben Konstante, aus
   der `UPLOAD_NOTICE` schöpft und nach der das Aufräum-Tool löscht.
   *Der Design-Entwurf sagte „14 Tage", der Code sagt 24 Stunden — die
   Konstante gewinnt, eine hineingeschriebene Zahl wäre eine falsche Zusage.*
3. **Die Referenz-ID wird im Fehlerfall gezeigt.** Sie existierte schon über
   `createId()`, wurde dem Nutzer aber nie gezeigt — und genau dann braucht er
   sie, wenn er nach einer nicht angekommenen Meldung fragt.

### Keine erfundene Kontaktadresse

Der Entwurf nannte `sichtungen@meeresmuseum.de`. Dafür gibt es im Bestand
keinen Beleg, und eine Adresse, die niemand liest, ist im Fehlerfall schlimmer
als gar keine — die Rückfrage läuft ins Leere, der Nutzer hält es für erledigt.

Der Text nennt jetzt die Referenz-ID und bittet, sie bei einer Rückfrage
anzugeben. Verlinkt wird die **belegte** Kontaktstelle
`https://www.deutsches-meeresmuseum.de/kontakt`, die `about/+page.svelte:353`
Nutzern ohnehin schon als „Kontakt aufnehmen" zeigt. Die einzige andere
Adresse im Bestand ist `datenschutz@meeresmuseum.de` — für eine gescheiterte
Übermittlung der falsche Adressat. Abgesichert durch einen Test, der `mailto:`
und `@meeresmuseum.de` im gerenderten Markup ausschließt.

### Offline sperrt vorab, statt scheitern zu lassen

Über das neue Modul `connectionState`: `navigator.onLine` und seine Ereignisse
sind nur ein schnelles Vorab-Signal, das Ergebnis des letzten echten Requests
hat das letzte Wort.

**Gesperrt wird aber nur beim sicheren Nein des Browsers**
(`connection.isInterfaceDown`). Der aus einem gescheiterten Request abgeleitete
Zustand genügt dafür nicht: `fetch` wirft denselben `TypeError` bei einem
Server-Neustart oder CORS-Fehler, und dort feuert nie ein `online`-Ereignis,
das ihn wieder aufheben könnte — der Nutzer käme nur durch ein Neuladen heraus.
Im Verdachtsfall bleibt „Trotzdem versuchen" erreichbar.

Die Sperre nutzt `aria-disabled` statt `disabled` (siehe `design-system.md`),
der Wächter sitzt im Handler, damit die Tastaturposition erhalten bleibt.

### Barrierefreiheit

`role="alert"` bei `failed` **und** `partial`: beide entstehen, weil jemand
„Absenden" gedrückt hat — `partial` ist ein Unterfall des Fehlschlags, keine
von selbst auflaufende Meldung. Da die Zustände einander ausschließen, feuern
nie zwei Live-Regionen gleichzeitig (per Test abgesichert). `offline` und
`submitting` laufen von selbst auf und melden sich höflich per `role="status"`.

Der Validierungs-Toast in `showValidationError` **bleibt**: der ist wirklich
flüchtig und begleitet den Sprung zum fehlerhaften Feld.

### Tests

- 25 Komponenten-Fälle
- 2 E2E-Fälle mit `context.setOffline`: Button gesperrt, Begründung sichtbar,
  Eingaben nach Reload noch da
- Zwei bestehende E2E-Fälle vom entfernten Toast auf die neuen Zustände
  umgeschrieben

`npm run test:quick` grün (2284), 216 Browser-Tests grün, 182 E2E grün,
`npm run check` 0 Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)