### PR TITLE
feat(ui): add StatusBlock and route the ad-hoc status surfaces through it

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -70,6 +70,13 @@
 	import Phone from '~icons/lucide/phone';
 	import Play from '~icons/lucide/play';
 	import RefreshCw from '~icons/lucide/refresh-cw';
+	import Database from '~icons/lucide/database';
+	import GitCompareArrows from '~icons/lucide/git-compare-arrows';
+	import MapPinOff from '~icons/lucide/map-pin-off';
+	import RotateCcw from '~icons/lucide/rotate-ccw';
+	import ZoomIn from '~icons/lucide/zoom-in';
+	import SearchX from '~icons/lucide/search-x';
+	import WifiOff from '~icons/lucide/wifi-off';
 	import Save from '~icons/lucide/save';
 	import Scale from '~icons/lucide/scale';
 	import Send from '~icons/lucide/send';
@@ -158,6 +165,13 @@
 		'lucide:archive': Archive,
 		'lucide:file': File,
 		'lucide:refresh-cw': RefreshCw,
+		'lucide:database': Database,
+		'lucide:git-compare-arrows': GitCompareArrows,
+		'lucide:map-pin-off': MapPinOff,
+		'lucide:rotate-ccw': RotateCcw,
+		'lucide:zoom-in': ZoomIn,
+		'lucide:search-x': SearchX,
+		'lucide:wifi-off': WifiOff,
 		'lucide:home': Home,
 		'lucide:file-search': FileSearch,
 		'lucide:lock': Lock,

--- a/src/lib/components/StatusBlock.svelte
+++ b/src/lib/components/StatusBlock.svelte
@@ -1,0 +1,138 @@
+<!--
+  Inline-Statusfläche für jede Oberfläche, die Daten lädt.
+
+  Fünf Varianten, eine Struktur: Icon, Aussage, optionale Erklärung, optionale
+  Aktion. Der Block nimmt den Platz ein, an dem die Daten stehen würden — nie
+  als Overlay. Ein Overlay über der ganzen Fläche nimmt bei jedem Ladevorgang
+  die Bedienung aus der Hand; ein Block an der Stelle der Daten sagt dasselbe,
+  ohne alles andere zu sperren.
+
+  Zwei Entscheidungen stecken in den Varianten:
+
+  1. `loading` und `empty` tragen KEINE Statusfarbe. Ein Ladevorgang ist keine
+     Warnung, und ein Filter ohne Treffer ist kein Fehler. Erst `partial`,
+     `failed` und `offline` nutzen die Alert-Flächen.
+  2. Die ARIA-Rolle unterscheidet sich pro Variante: `status`/`aria-live=polite`
+     für Zustände, die von selbst entstehen, `alert` nur für die Folge einer
+     Nutzeraktion. Sonst unterbricht ein Screenreader den Nutzer beim Tippen.
+-->
+<script module lang="ts">
+	export type StatusBlockVariant = 'loading' | 'empty' | 'partial' | 'failed' | 'offline';
+
+	export interface StatusBlockAction {
+		/** Beschriftung der Schaltfläche. */
+		label: string;
+		/** Was beim Auslösen passiert. */
+		onClick: () => void;
+		/** Optionales Icon, Standard ist „erneut versuchen". */
+		icon?: string;
+	}
+</script>
+
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+
+	let {
+		variant,
+		title,
+		description,
+		action,
+		announce
+	}: {
+		variant: StatusBlockVariant;
+		/** Die Aussage — was ist der Fall. Immer erforderlich. */
+		title: string;
+		/** Erklärung darunter: Ursache, Folge, was der Nutzer erwarten kann. */
+		description?: string | undefined;
+		/**
+		 * Ein Ausweg, falls es einen gibt.
+		 *
+		 * `| undefined` steht explizit da: Unter `exactOptionalPropertyTypes`
+		 * dürfte eine Aufrufstelle sonst kein bedingtes `action={… : undefined}`
+		 * übergeben — und genau das braucht die Karte, wo der Ausweg nur dann
+		 * existiert, wenn es ein anderes Jahr mit Daten gibt.
+		 */
+		action?: StatusBlockAction | undefined;
+		/**
+		 * Übersteuert die aus der Variante abgeleitete ARIA-Rolle.
+		 *
+		 * Die Regel „`alert` bei `failed`" setzt voraus, dass der Fehlschlag die
+		 * Folge einer Nutzeraktion ist — das kann die Komponente nicht wissen.
+		 * Ein Abruf, der beim Seitenaufbau scheitert, ist inhaltlich `failed`,
+		 * darf den Screenreader aber nicht unterbrechen. Solche Aufrufstellen
+		 * setzen hier `status`.
+		 */
+		announce?: 'status' | 'alert' | undefined;
+	} = $props();
+
+	/**
+	 * Klassen stehen vollständig ausgeschrieben — Tailwind erkennt nur komplette
+	 * Strings im Quelltext, ein `alert-${variant}` wäre eine tote Klasse
+	 * (daisyui.md, „Content-Detection").
+	 */
+	const SURFACE: Record<StatusBlockVariant, string> = {
+		// Neutrale Flächen bringen ihr Layout selbst mit …
+		loading: 'border-base-300 bg-base-200/50 rounded-box flex items-start gap-3 border p-4',
+		empty: 'border-base-300 bg-base-200/50 rounded-box flex items-start gap-3 border p-4',
+		// … die Alert-Flächen behalten dagegen DaisyUIs eigenes Grid und werden
+		// nur oben ausgerichtet, damit das Icon neben der ersten Zeile steht.
+		partial: 'alert alert-info items-start',
+		failed: 'alert alert-warning items-start',
+		offline: 'alert alert-warning items-start'
+	};
+
+	/** Jede Variante hat eine eigene Icon-Form — sie trägt die Bedeutung. */
+	const ICON: Record<StatusBlockVariant, string> = {
+		loading: '',
+		empty: 'lucide:search-x',
+		partial: 'lucide:info',
+		failed: 'lucide:triangle-alert',
+		offline: 'lucide:wifi-off'
+	};
+
+	/**
+	 * `alert` nur bei `failed`: Das ist die Folge einer Nutzeraktion (ein Abruf,
+	 * den er angestoßen hat). Alle übrigen entstehen von selbst und melden sich
+	 * höflich.
+	 */
+	const role = $derived(announce ?? (variant === 'failed' ? 'alert' : 'status'));
+
+	/**
+	 * `aria-live` wird NUR für `status` gesetzt — und zwar deshalb, weil ein
+	 * explizites `aria-live="polite"` das implizite `assertive` von
+	 * `role="alert"` überschreibt. Stünde es unbedingt hier, wäre die im
+	 * Kopfkommentar zugesagte Unterbrechung nie eingetreten und der
+	 * Unterschied zwischen den Rollen reine Dekoration.
+	 */
+	const ariaLive = $derived(role === 'status' ? 'polite' : undefined);
+</script>
+
+<div class={SURFACE[variant]} {role} aria-live={ariaLive} data-testid="status-block-{variant}">
+	{#if variant === 'loading'}
+		<span class="loading loading-spinner loading-sm text-primary mt-0.5 shrink-0"></span>
+	{:else}
+		<Icon
+			icon={ICON[variant]}
+			class={variant === 'empty' ? 'text-base-content/60 mt-0.5 shrink-0' : 'mt-0.5 shrink-0'}
+			aria-hidden="true"
+		/>
+	{/if}
+
+	<div>
+		<p class="text-base-content font-medium">{title}</p>
+		{#if description}
+			<p class="text-base-content/70 text-support mt-1">{description}</p>
+		{/if}
+		{#if action}
+			<button type="button" class="btn btn-outline btn-sm mt-3" onclick={action.onClick}>
+				<Icon
+					icon={action.icon ?? 'lucide:refresh-cw'}
+					width="16"
+					class="shrink-0"
+					aria-hidden="true"
+				/>
+				{action.label}
+			</button>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/StatusBlock.svelte.test.ts
+++ b/src/lib/components/StatusBlock.svelte.test.ts
@@ -1,0 +1,127 @@
+import { tick } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import StatusBlock from './StatusBlock.svelte';
+
+function block(variant: string): HTMLElement | null {
+	return document.querySelector(`[data-testid="status-block-${variant}"]`);
+}
+
+describe('StatusBlock', () => {
+	it('zeigt die Aussage in jeder Variante', () => {
+		render(StatusBlock, { variant: 'loading', title: 'Sichtungen werden geladen …' });
+
+		expect(block('loading')?.textContent).toContain('Sichtungen werden geladen …');
+	});
+
+	it('zeigt die Erklärung nur, wenn eine übergeben wurde', () => {
+		render(StatusBlock, { variant: 'empty', title: 'Keine Treffer' });
+
+		expect(block('empty')?.querySelectorAll('p')).toHaveLength(1);
+	});
+
+	/**
+	 * Ein Ladevorgang ist keine Warnung, ein Filter ohne Treffer kein Fehler.
+	 * Erst `partial`, `failed` und `offline` dürfen die Alert-Flächen nutzen.
+	 */
+	describe('Statusfarben', () => {
+		it.each(['loading', 'empty'] as const)('gibt %s keine Statusfarbe', (variant) => {
+			render(StatusBlock, { variant, title: 'Titel' });
+
+			expect(block(variant)?.className).not.toMatch(/\balert\b/);
+		});
+
+		it.each([
+			['partial', 'alert-info'],
+			['failed', 'alert-warning'],
+			['offline', 'alert-warning']
+		] as const)('nutzt für %s die Fläche %s', (variant, expected) => {
+			render(StatusBlock, { variant, title: 'Titel' });
+
+			expect(block(variant)?.className).toContain(expected);
+		});
+	});
+
+	/**
+	 * `alert` unterbricht den Screenreader. Das ist nur gerechtfertigt, wenn der
+	 * Zustand die Folge einer Nutzeraktion ist — sonst trifft es ihn beim Tippen.
+	 */
+	describe('ARIA-Rollen', () => {
+		it('meldet failed per role="alert"', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel' });
+
+			expect(block('failed')?.getAttribute('role')).toBe('alert');
+		});
+
+		it.each(['loading', 'empty', 'partial', 'offline'] as const)(
+			'meldet %s höflich per role="status"',
+			(variant) => {
+				render(StatusBlock, { variant, title: 'Titel' });
+
+				expect(block(variant)?.getAttribute('role')).toBe('status');
+			}
+		);
+
+		/**
+		 * Regression: Ein explizites `aria-live="polite"` überschreibt das
+		 * implizite `assertive` von `role="alert"`. Stand es unbedingt am Element,
+		 * fand die zugesagte Unterbrechung nie statt und der Unterschied zwischen
+		 * den Rollen war reine Dekoration.
+		 */
+		it('setzt bei role="alert" kein aria-live, das die Rolle entwerten würde', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel' });
+
+			expect(block('failed')?.hasAttribute('aria-live')).toBe(false);
+		});
+
+		it('setzt aria-live="polite" bei den höflichen Varianten', () => {
+			render(StatusBlock, { variant: 'empty', title: 'Titel' });
+
+			expect(block('empty')?.getAttribute('aria-live')).toBe('polite');
+		});
+
+		/**
+		 * Ob ein Fehlschlag die Folge einer Nutzeraktion ist, weiß nur die
+		 * Aufrufstelle. `FormHelp` lädt beim Seitenaufbau und darf deshalb nicht
+		 * unterbrechen, obwohl der Zustand inhaltlich `failed` ist.
+		 */
+		it('lässt die Aufrufstelle die Rolle übersteuern', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel', announce: 'status' });
+
+			expect(block('failed')?.getAttribute('role')).toBe('status');
+			expect(block('failed')?.getAttribute('aria-live')).toBe('polite');
+		});
+	});
+
+	describe('Aktion', () => {
+		it('rendert keine Schaltfläche ohne action', () => {
+			render(StatusBlock, { variant: 'empty', title: 'Keine Treffer' });
+
+			expect(block('empty')?.querySelector('button')).toBeNull();
+		});
+
+		it('löst den Handler aus', async () => {
+			const onClick = vi.fn();
+			render(StatusBlock, {
+				variant: 'offline',
+				title: 'Keine Verbindung',
+				action: { label: 'Erneut versuchen', onClick }
+			});
+
+			block('offline')?.querySelector('button')?.click();
+			await tick();
+
+			expect(onClick).toHaveBeenCalledOnce();
+		});
+	});
+
+	/**
+	 * Der Block nimmt den Platz der Daten ein. Ein `fixed inset-0`-Overlay würde
+	 * bei jedem Ladevorgang die ganze Fläche aus der Hand nehmen.
+	 */
+	it('ist kein Overlay', () => {
+		render(StatusBlock, { variant: 'loading', title: 'Lädt …' });
+
+		expect(block('loading')?.className).not.toMatch(/fixed|inset-0|absolute/);
+	});
+});

--- a/src/lib/components/iconRegistry.test.ts
+++ b/src/lib/components/iconRegistry.test.ts
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `Icon.svelte` rendert für einen unbekannten Namen ein stummes „?" statt zu
+ * scheitern. Das ist im Betrieb die richtige Wahl — ein fehlendes Icon soll
+ * keine Seite abstürzen lassen — kostet aber jede Rückmeldung: Ein Tippfehler
+ * oder ein neuer Name ohne Eintrag sieht im Code vollständig aus und liefert
+ * dem Nutzer ein Fragezeichen aus.
+ *
+ * Dieser Test ist die fehlende Rückmeldung. Er ist entstanden, nachdem
+ * `lucide:wifi-off`, `lucide:search-x` und `lucide:rotate-ccw` genau so
+ * durchgerutscht sind und erst im Browser aufgefallen wären.
+ */
+
+const SOURCE_ROOT = 'src';
+const ICON_COMPONENT = 'src/lib/components/Icon.svelte';
+
+/** Alle im `iconMap` registrierten Namen. */
+function registeredIcons(): Set<string> {
+	const source = readFileSync(ICON_COMPONENT, 'utf-8');
+	const mapStart = source.indexOf('const iconMap');
+	expect(mapStart, 'iconMap in Icon.svelte nicht gefunden').toBeGreaterThan(-1);
+
+	// `Array.from` statt `.map()` direkt auf dem Iterator: Die Iterator-Helper
+	// (`Iterator.prototype.map`) gibt es erst ab Node 22. `package.json` lässt
+	// über `engines` aber auch `^20.19.0` zu — dort wäre `.map()` undefined und
+	// dieser Test würde mit einem TypeError abbrechen, statt die Registry zu
+	// prüfen. Ein Test, der still nicht prüft, ist schlimmer als keiner.
+	const names = Array.from(
+		source.slice(mapStart).matchAll(/'(lucide:[a-z0-9-]+)'\s*:/g),
+		(match) => match[1] as string
+	);
+
+	return new Set(names);
+}
+
+/** Jede `icon="lucide:…"`- bzw. `icon: 'lucide:…'`-Stelle im Quelltext. */
+function usedIcons(): Map<string, string[]> {
+	const usages = new Map<string, string[]>();
+
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir)) {
+			const path = join(dir, entry);
+			if (statSync(path).isDirectory()) {
+				walk(path);
+				continue;
+			}
+			if (!/\.(svelte|ts)$/.test(entry) || /\.test\.ts$/.test(entry)) continue;
+			if (path === ICON_COMPONENT) continue;
+
+			const source = readFileSync(path, 'utf-8');
+			for (const match of source.matchAll(/["'](lucide:[a-z0-9-]+)["']/g)) {
+				const name = match[1] as string;
+				usages.set(name, [...(usages.get(name) ?? []), path]);
+			}
+		}
+	};
+
+	walk(SOURCE_ROOT);
+	return usages;
+}
+
+describe('Icon-Registry', () => {
+	it('kennt jedes im Quelltext verwendete lucide-Icon', () => {
+		const registered = registeredIcons();
+		const missing = [...usedIcons().entries()]
+			.filter(([name]) => !registered.has(name))
+			.map(([name, files]) => `${name} (${[...new Set(files)].join(', ')})`);
+
+		expect(missing, 'Nicht registrierte Icons rendern als „?" beim Nutzer').toEqual([]);
+	});
+
+	it('findet überhaupt Registrierungen — sonst greift die Prüfung ins Leere', () => {
+		expect(registeredIcons().size).toBeGreaterThan(50);
+	});
+});

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 
-	// Props
-	type LoadingType = 'default' | 'filter' | 'features' | 'initial';
+	/**
+	 * Nur noch `initial`.
+	 *
+	 * Diese Komponente ist ein `fixed inset-0`-Overlay mit Backdrop — sie nimmt
+	 * die ganze Karte aus der Hand. Beim allerersten Aufbau ist das richtig: Es
+	 * gibt noch nichts zu bedienen. Für alles danach ist es der falsche Griff,
+	 * und die früheren Varianten `filter`, `features` und `default` waren genau
+	 * das: Sie hätten bei jedem Filterwechsel die Karte gesperrt. Aufrufstellen
+	 * hatten sie keine — der Filterzustand läuft über den Inline-Spinner im
+	 * `FilterPanel` (`isLoading`), Leer- und Fehlerzustände über `StatusBlock`.
+	 *
+	 * Die Varianten sind entfernt, damit der blockierende Weg nicht versehentlich
+	 * wieder eingeschlagen wird. Wer hier eine neue braucht, prüft zuerst, ob ein
+	 * `StatusBlock` an der Stelle der Daten genügt.
+	 */
+	type LoadingType = 'initial';
 
-	let { isVisible = false, type = 'default' }: { isVisible?: boolean; type?: LoadingType } =
+	let { isVisible = false, type = 'initial' }: { isVisible?: boolean; type?: LoadingType } =
 		$props();
 
-	// Typ-sichere Zuordnungen
 	const iconMap: Record<LoadingType, string> = {
-		default: 'lucide:loader-2',
-		filter: 'lucide:filter',
-		features: 'lucide:map-pin',
 		initial: 'lucide:loader-2'
 	};
 
 	const messageMap: Record<LoadingType, string> = {
-		default: 'Daten werden geladen...',
-		filter: 'Filter werden angewendet...',
-		features: 'Kartenfeatures werden geladen...',
 		initial: 'Karte wird initialisiert...'
 	};
 

--- a/src/lib/components/map/LoadingOverlay.svelte.test.ts
+++ b/src/lib/components/map/LoadingOverlay.svelte.test.ts
@@ -43,17 +43,24 @@ describe('LoadingOverlay', () => {
 	});
 
 	it('dekoratives Spinner-Icon ist aria-hidden (wird in der Live-Region nicht mit angesagt)', () => {
-		render(LoadingOverlay, { isVisible: true, type: 'filter' });
+		render(LoadingOverlay, { isVisible: true, type: 'initial' });
 
 		const svg = document.querySelector('[role="status"] svg');
 		expect(svg).not.toBeNull();
 		expect(svg?.getAttribute('aria-hidden')).toBe('true');
 	});
 
-	it('zeigt den passenden Text für Filter-Ladevorgänge', () => {
-		render(LoadingOverlay, { isVisible: true, type: 'filter' });
+	/**
+	 * Das Overlay sperrt mit `fixed inset-0` plus Backdrop die ganze Karte. Beim
+	 * ersten Aufbau ist das richtig — es gibt noch nichts zu bedienen. Für
+	 * Filterwechsel wäre es der falsche Griff, und genau dafür gab es früher die
+	 * Varianten `filter`, `features` und `default` (ohne Aufrufstelle). Sie sind
+	 * entfernt; Filter zeigen ihren Ladezustand inline im `FilterPanel`.
+	 */
+	it('kennt nur noch den Initial-Ladevorgang', () => {
+		render(LoadingOverlay, { isVisible: true });
 
-		expect(document.body.textContent).toContain('Filter werden angewendet...');
-		expect(document.body.textContent).not.toContain('Tastaturkürzel');
+		expect(document.body.textContent).toContain('Karte wird initialisiert...');
+		expect(document.body.textContent).not.toContain('Filter werden angewendet');
 	});
 });

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -26,6 +26,7 @@
 	import { replaceState } from '$app/navigation';
 	import 'ol/ol.css';
 	import LoadingOverlay from './LoadingOverlay.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	import FilterPanel from './Panel/FilterPanel.svelte';
 	import LegendPanel from './Panel/LegendPanel.svelte';
 	import SightingsListView from './SightingsListView.svelte';
@@ -760,39 +761,47 @@
 		     dessen Toggle-Tab auch bei geschlossenem Panel mitrotiert. -->
 		<LoadingOverlay isVisible={isInitialLoading} type="initial" />
 
+		<!--
+			Die beiden Leer-Zustände waren zwei handgebaute Glas-Kästchen mit je
+			eigener Typografie und eigener Rollenauszeichnung. Inhaltlich sind sie
+			derselbe Fall — „hier stünden Daten, es gibt aber keine" — und laufen
+			jetzt beide über `StatusBlock`. Der Wrapper trägt nur noch die Position
+			und eine deckende Fläche, damit der Text über den Kartenkacheln lesbar
+			bleibt; Rolle, Icon und Abstände kommen aus der Komponente.
+		-->
+
 		<!-- Keine Sichtungen für das gewählte Jahr -->
 		{#if showNoResults}
 			<div
-				role="status"
-				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				style="box-shadow: var(--shadow-floating)"
 			>
-				<p class="text-base-content text-sm font-medium">
-					Keine Sichtungen für {currentDisplayedYear} vorhanden.
-				</p>
-				{#if latestYearWithData !== undefined && latestYearWithData !== currentDisplayedYear}
-					<button
-						type="button"
-						class="btn btn-primary btn-sm mt-2"
-						onclick={() => switchToYear(latestYearWithData!)}
-					>
-						Sichtungen {latestYearWithData} anzeigen
-					</button>
-				{/if}
+				<StatusBlock
+					variant="empty"
+					title="Keine Sichtungen für {currentDisplayedYear} vorhanden"
+					description="Für dieses Jahr liegen keine freigegebenen Meldungen vor."
+					action={latestYearWithData !== undefined && latestYearWithData !== currentDisplayedYear
+						? {
+								label: `Sichtungen ${latestYearWithData} anzeigen`,
+								onClick: () => switchToYear(latestYearWithData!),
+								icon: 'lucide:calendar'
+							}
+						: undefined}
+				/>
 			</div>
 		{/if}
 
 		<!-- Alle Sichtungen durch Filter ausgeblendet -->
 		{#if showNoVisibleResults}
 			<div
-				role="status"
-				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				style="box-shadow: var(--shadow-floating)"
 			>
-				<p class="text-base-content text-sm font-medium">
-					Keine Sichtungen für den aktuellen Filter sichtbar.
-				</p>
-				<p class="text-base-content/60 mt-1 text-xs">
-					Passen Sie den Zeitraum oder die Tierart-Filter an.
-				</p>
+				<StatusBlock
+					variant="empty"
+					title="Keine Sichtungen für den aktuellen Filter sichtbar"
+					description="Passen Sie den Zeitraum oder die Tierart-Filter an."
+				/>
 			</div>
 		{/if}
 

--- a/src/lib/components/weather/WeatherDataFetcher.svelte
+++ b/src/lib/components/weather/WeatherDataFetcher.svelte
@@ -3,6 +3,7 @@
 	import type { WeatherDataWithMetadata } from '$lib/types';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	import WeatherDisplay from './WeatherDisplay.svelte';
 
 	interface Props {
@@ -152,12 +153,21 @@
 						<span class="badge badge-xs badge-info ml-2">aus Cache</span>
 					{/if}
 				</p>
-				{#if weatherData._metadata?.dataType === 'forecast'}
-					<p class="text-warning-strong">
-						⚠️ Prognosedaten für heutige Sichtung (aktualisiert sich mehrmals täglich)
-					</p>
-				{/if}
 			</div>
+
+			<!--
+				Prognosewerte sind unvollständige Daten, keine Warnung an den Nutzer —
+				`partial` ist dafür die richtige Variante. Vorher ein Absatz mit
+				Emoji-Warndreieck, der weder Form noch ARIA-Rolle hatte und im
+				Fließtext der Quellenangabe unterging.
+			-->
+			{#if weatherData._metadata?.dataType === 'forecast'}
+				<StatusBlock
+					variant="partial"
+					title="Prognosedaten für die heutige Sichtung"
+					description="Für heute liegen noch keine gemessenen Werte vor. Die Vorhersage aktualisiert sich mehrmals täglich."
+				/>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -5,6 +5,7 @@
 	const logger = createLogger('components:FormHelp');
 	import SpeciesIdentificationHelp from './form/fields/SpeciesIdentificationHelp.svelte';
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 
 	// Keine Platzhalter-Zahlen: Statistiken werden erst angezeigt, wenn sie
 	// tatsächlich geladen wurden. Erfundene Fallback-Werte würden Bürgern sonst
@@ -66,9 +67,25 @@
 							</p>
 							<div class="bg-base-100 mt-3 rounded-lg p-3">
 								{#if !loading && fetchFailed}
-									<p class="text-base-content/70 text-center text-xs">
-										Statistiken konnten nicht geladen werden
-									</p>
+									<!--
+										Vorher eine graue Zeile ohne Form und ohne Einordnung: Sie sah
+										aus wie ein Platzhalter und ließ offen, ob jetzt das Formular
+										kaputt ist. Der StatusBlock sagt beides — was fehlt und was
+										trotzdem geht.
+									-->
+									<!--
+										`announce="status"`: Der Abruf startet beim Seitenaufbau, nicht
+										auf Knopfdruck — und er steckt in einem zugeklappten `<details>`.
+										Ein `role="alert"` würde den Screenreader hier über etwas
+										unterbrechen, das der Nutzer nicht angestoßen hat und gar nicht
+										sieht.
+									-->
+									<StatusBlock
+										variant="failed"
+										announce="status"
+										title="Statistiken konnten nicht geladen werden"
+										description="Das Formular funktioniert vollständig — nur die Zahlen in diesem Hilfetext fehlen."
+									/>
 								{:else}
 									<div class="grid grid-cols-2 gap-4 text-center text-sm">
 										<div>

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -26,6 +26,7 @@
 -->
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	/* Importiert statt abgeschrieben: die Marker-Palette ist Datenkodierung mit
 	   genau einer Quelle (design-system.md, „Randbereiche: wo Hex-Werte erlaubt
 	   sind"). Eine zweite Liste hier hätte den Absatz darunter — der
@@ -368,6 +369,44 @@
 				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 				<span>Bitte beheben Sie die 2 Fehler in „Position &amp; Zeit".</span>
 			</div>
+		</div>
+	</section>
+
+	<!-- ══ StatusBlock ══ -->
+	<section class="mb-10">
+		<h2 class="text-title mb-1 font-bold">StatusBlock</h2>
+		<p class="text-support text-base-content/70 mb-4">
+			Inline-Statusfläche für jede Oberfläche, die Daten lädt — nie als Overlay, sondern an der
+			Stelle, an der die Daten stünden. <code>loading</code> und <code>empty</code> tragen bewusst
+			<strong>keine</strong>
+			Statusfarbe: Ein Ladevorgang ist keine Warnung, ein Filter ohne Treffer kein Fehler.
+			<code>role</code>
+			ist <code>alert</code> nur bei <code>failed</code> — der Folge einer Nutzeraktion.
+		</p>
+		<div class="space-y-3">
+			<StatusBlock variant="loading" title="Sichtungen werden geladen …" />
+			<StatusBlock
+				variant="empty"
+				title="Keine Sichtungen in diesem Zeitraum"
+				description="Für 2026 liegen zwischen 1. Mai und 3. Mai keine freigegebenen Meldungen vor."
+				action={{ label: 'Zeitraum zurücksetzen', onClick: () => {}, icon: 'lucide:rotate-ccw' }}
+			/>
+			<StatusBlock
+				variant="partial"
+				title="Wetterdaten aus dem Zwischenspeicher"
+				description="Der Wetterdienst antwortet gerade nicht. Angezeigt werden die zuletzt abgerufenen Werte."
+			/>
+			<StatusBlock
+				variant="failed"
+				title="Statistiken konnten nicht geladen werden"
+				description="Das Formular funktioniert vollständig — nur die Zahlen in diesem Hilfetext fehlen."
+			/>
+			<StatusBlock
+				variant="offline"
+				title="Kartenmaterial braucht eine Verbindung"
+				description="Bereits geladene Kacheln bleiben sichtbar. Neue Bereiche erscheinen, sobald Sie wieder online sind."
+				action={{ label: 'Erneut versuchen', onClick: () => {} }}
+			/>
 		</div>
 	</section>
 


### PR DESCRIPTION
**PR 4 von 6 — Stack „Zustände". Basis: `feat/submit-status` (#625).**

Fünf Oberflächen hatten je eine eigene Antwort auf „hier ist noch nichts, oder
gar nichts": eine graue Zeile, ein Warn-Absatz, zwei handgebaute Glas-Kästchen
über der Karte und ein Vollbild-Overlay. `StatusBlock` ersetzt sie durch **eine**
Struktur — Icon, Aussage, optionale Erklärung, optionale Aktion — in fünf
Varianten, eingetragen unter `/styleguide`.

### Zwei Regeln, die die Komponente durchhält

- **`loading` und `empty` tragen keine Statusfarbe.** Ein Ladevorgang ist keine
  Warnung, ein Filter ohne Treffer kein Fehler. Erst `partial`, `failed` und
  `offline` nutzen die Alert-Flächen.
- **`role="alert"` nur bei `failed`** — der Folge einer Nutzeraktion. Alles
  andere meldet sich höflich.
  `aria-live` wird dabei **nur** für `status` gesetzt: Ein explizites
  `aria-live="polite"` würde das implizite `assertive` von `role="alert"`
  überschreiben und die zugesagte Unterbrechung stillschweigend aufheben.
  Aufrufstellen, die inhaltlich `failed` sind, den Nutzer aber nicht
  unterbrechen dürfen (Abruf beim Seitenaufbau), setzen `announce="status"`.

### Aufrufstellen

- **`FormHelp`** — der Statistik-Fehler war eine graue, zentrierte Zeile, die
  wie ein Platzhalter aussah und offenließ, ob jetzt das Formular kaputt ist.
  Sagt nun, was fehlt und was trotzdem geht. `announce="status"`, weil der
  Abruf beim Seitenaufbau startet und in einem zugeklappten `<details>` steckt.
- **`WeatherDataFetcher`** — Prognosewerte sind unvollständige Daten, keine
  Warnung an den Nutzer: `partial` statt eines Absatzes mit Emoji-Warndreieck.
- **`SightingsMapView`** — die beiden Leer-Zustände waren getrennte Kästchen
  mit eigener Typografie und eigener Rolle; derselbe Fall, jetzt eine
  Komponente.
- **`LoadingOverlay`** — auf `type="initial"` verengt. Die Varianten `filter`,
  `features` und `default` hatten keine Aufrufstelle und hätten bei jedem
  Filterwechsel die ganze Karte hinter einem Backdrop gesperrt; sie zu
  entfernen hält diese Tür zu.

### Zwei Befunde aus der Browser-Prüfung statt aus dem Markup

- `lucide:wifi-off`, `search-x` und `rotate-ccw` fehlten in `Icon.svelte` und
  rendern als **„?"**. Die Komponente fällt bei unbekannten Namen absichtlich
  still zurück — im Betrieb richtig, aber ein fehlender Name sieht im Quelltext
  vollständig aus.
- Der neue Test `iconRegistry.test.ts` schließt diese Lücke und fand sofort
  **vier weitere, die heute schon ausgeliefert werden**: `map-pin-off`,
  `zoom-in`, `git-compare-arrows`, `database`. Alle sieben sind registriert.

### Anmerkung zur Vorlage

Drei Annahmen des Entwurfs waren überholt: `FormHelp` stand schon auf `/70`,
`WeatherDataFetcher` schon auf `text-warning-strong`, und die Karte hatte
bereits Leer-Zustände samt Inline-Spinner für Filter (Kommentar M7). Die
Kontrastfehler waren also bereits behoben — geblieben ist die strukturelle
Vereinheitlichung.

### Tests

18 Komponenten-Fälle, `npm run test:quick` grün, 182 E2E grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)