### PR TITLE
feat(ui): show a connection badge while offline

### DIFF
--- a/e2e/submit-offline.spec.ts
+++ b/e2e/submit-offline.spec.ts
@@ -61,6 +61,33 @@ test.describe('Absenden ohne Internetverbindung', () => {
 		await expect(page.locator('[data-testid="field-email"]')).toHaveValue('max@example.com');
 	});
 
+	/**
+	 * Regression: Das Abzeichen rendert online nichts — aber sein Wrapper stand
+	 * dauerhaft im DOM und war in `.navbar-end` (`gap-2`) ein Flex-Item der
+	 * Breite 0. Gemessen waren das 8px toter Abstand auf jeder Seite. Die
+	 * Live-Region liegt jetzt `sr-only` und damit außerhalb des Flusses.
+	 */
+	test('kostet bei bestehender Verbindung keinen Platz in der Navbar', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		const layout = await page.evaluate(() => {
+			const end = document.querySelector('.navbar-end');
+			if (!end) return null;
+			return {
+				inFlowChildren: [...end.children].filter(
+					(el) => getComputedStyle(el).position !== 'absolute'
+				).length,
+				badgeVisible: !!document.querySelector('[data-testid^="connection-badge"]')
+			};
+		});
+
+		expect(layout).not.toBeNull();
+		expect(layout!.badgeVisible).toBe(false);
+		// Menü (Desktop) + Dropdown (Mobil) — kein drittes, leeres Flex-Item.
+		expect(layout!.inFlowChildren).toBe(2);
+	});
+
 	test('gibt das Absenden wieder frei, sobald die Verbindung zurück ist', async ({
 		page,
 		context

--- a/src/lib/components/ConnectionBadge.svelte
+++ b/src/lib/components/ConnectionBadge.svelte
@@ -1,0 +1,101 @@
+<!--
+  Ein Zustand, kein Alarm.
+
+  Erscheint nur, wenn keine Verbindung besteht. Damit weiß der Mensch schon
+  beim Ausfüllen, was ihn beim Absenden erwartet — statt es am Ende zu
+  erfahren, wenn die Arbeit getan ist.
+
+  Drei Entscheidungen stecken darin:
+
+  1. **Kein Dauer-Indikator für „online".** Ein Zustand, der 99 % der Zeit
+     dasselbe sagt, wird nicht gelesen. Im Normalfall kostet die Komponente
+     deshalb nicht nur keine Aufmerksamkeit, sondern auch keinen Platz —
+     siehe die Trennung unten.
+  2. **„Wieder online" darf flüchtig sein.** Es ist die eine Stelle, an der
+     ein verschwindender Hinweis richtig ist: Er verlangt keine Handlung, er
+     nimmt nur eine Sorge weg. Die Frist liegt in `connectionState`.
+  3. **Der Zustand kommt nicht aus `navigator.onLine` allein.** Das meldet nur
+     eine aktive Netzwerkschnittstelle, nicht ob das Internet erreichbar ist —
+     WLAN an Bord ohne Uplink meldet „online" und lässt jeden Request
+     scheitern. Die Herleitung steht in `connectionState.svelte.ts`.
+
+  **Warum Ansage und Anzeige getrennt sind:** Eine Live-Region muss schon im
+  DOM stehen, BEVOR sich ihr Inhalt ändert — wird sie zusammen mit ihrem Text
+  eingefügt, sagen viele Screenreader nichts. Ein dauerhaft gerendertes
+  Wrapper-Element ist aber auch dauerhaft ein Flex-Item: In der Navbar
+  (`gap-2`) erzeugte es im Online-Fall gemessene 8px Abstand um ein leeres
+  `<div>` herum. Beides zusammen geht nur, wenn die Live-Region aus dem Layout
+  genommen wird — `sr-only` ist absolut positioniert und damit kein Flex-Item.
+  Die sichtbare Fläche wird daneben ganz normal bedingt gerendert.
+-->
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { connection, watchConnection } from '$lib/stores/connectionState.svelte';
+
+	let {
+		/** Blendet den erklärenden Zusatz aus — für enge Leisten. */
+		compact = false,
+		/**
+		 * Ob diese Instanz die Live-Region stellt.
+		 *
+		 * Es können mehrere Abzeichen gleichzeitig im Bild sein — in der Navbar
+		 * und im ortsfesten Schritt-Balken. Zwei Live-Regionen mit demselben Text
+		 * lassen den Screenreader „Offline" doppelt ansagen. Deshalb meldet nur
+		 * die globale Instanz in der Navbar; die übrigen sind rein visuell.
+		 */
+		announce = true,
+		/**
+		 * Layout-Klassen für die sichtbare Fläche.
+		 *
+		 * Bewusst hier und nicht an einem Wrapper der Aufrufstelle: Ein Wrapper
+		 * mit `mb-2` behielte seinen Abstand auch dann, wenn nichts zu sehen ist.
+		 * Am Element selbst verschwindet er mit ihm.
+		 */
+		class: className = ''
+	}: { compact?: boolean; announce?: boolean; class?: string } = $props();
+
+	// Mehrfaches Anmelden ist unkritisch: Jede Instanz meldet ihre eigenen
+	// Listener wieder ab, der Zustand dahinter ist derselbe.
+	$effect(() => watchConnection());
+
+	/** Was der Screenreader hört. Leer, solange alles in Ordnung ist. */
+	const liveText = $derived(
+		connection.isOffline
+			? 'Keine Internetverbindung. Ihre Eingaben werden gespeichert.'
+			: connection.justReconnected
+				? 'Wieder online.'
+				: ''
+	);
+
+	const SURFACE =
+		'bg-base-200/95 rounded-box border-base-300 flex items-center gap-2 border px-3 py-2';
+</script>
+
+{#if announce}
+	<!--
+		Dauerhaft im DOM, dauerhaft im Accessibility-Baum, aber ohne jede Wirkung
+		aufs Layout (`sr-only` ist absolut positioniert). Die sichtbaren Flächen
+		unten sind deshalb `aria-hidden` — sonst stünde derselbe Text zweimal im
+		Baum.
+	-->
+	<span class="sr-only" role="status" aria-live="polite">{liveText}</span>
+{/if}
+
+{#if connection.isOffline}
+	<div class="{SURFACE} {className}" data-testid="connection-badge-offline" aria-hidden="true">
+		<span class="text-warning-strong flex items-center gap-2 text-sm font-medium">
+			<Icon icon="lucide:wifi-off" width="16" class="shrink-0" aria-hidden="true" />
+			Offline
+		</span>
+		{#if !compact}
+			<span class="text-base-content/70 text-support">Eingaben werden gespeichert</span>
+		{/if}
+	</div>
+{:else if connection.justReconnected}
+	<div class="{SURFACE} {className}" data-testid="connection-badge-reconnected" aria-hidden="true">
+		<span class="text-success-strong flex items-center gap-2 text-sm font-medium">
+			<Icon icon="lucide:wifi" width="16" class="shrink-0" aria-hidden="true" />
+			Wieder online
+		</span>
+	</div>
+{/if}

--- a/src/lib/components/ConnectionBadge.svelte.test.ts
+++ b/src/lib/components/ConnectionBadge.svelte.test.ts
@@ -1,0 +1,225 @@
+import { connection } from '$lib/stores/connectionState.svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import ConnectionBadge from './ConnectionBadge.svelte';
+
+function badge(state: 'offline' | 'reconnected'): HTMLElement | null {
+	return document.querySelector(`[data-testid="connection-badge-${state}"]`);
+}
+
+describe('ConnectionBadge', () => {
+	beforeEach(() => {
+		connection.reset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		connection.reset();
+	});
+
+	/**
+	 * Ein Zustand, der 99 % der Zeit dasselbe sagt, wird nicht gelesen. Im
+	 * Normalfall darf die Komponente deshalb keinen Platz kosten.
+	 */
+	it('rendert nichts, solange die Verbindung steht', async () => {
+		render(ConnectionBadge);
+		await tick();
+
+		expect(badge('offline')).toBeNull();
+		expect(badge('reconnected')).toBeNull();
+	});
+
+	/**
+	 * Regression: Vorher stand ein leeres Wrapper-`<div>` dauerhaft im DOM. In
+	 * der Navbar (`.navbar-end` mit `gap-2`) war das ein Flex-Item mit Breite 0
+	 * — gemessen 8px toter Abstand, obwohl nichts zu sehen war. Die Live-Region
+	 * bleibt deshalb `sr-only` (absolut positioniert, kein Flex-Item), die
+	 * sichtbare Fläche wird bedingt gerendert.
+	 */
+	it('hinterlässt online nur die layoutneutrale Live-Region', async () => {
+		const { container } = render(ConnectionBadge);
+		await tick();
+
+		// `getComputedStyle` taugt hier nicht: Die Browser-Komponententests laden
+		// Tailwinds CSS nicht, `sr-only` wäre also wirkungslos gemessen. Geprüft
+		// wird deshalb der Vertrag (die Klasse); die tatsächliche Layout-Wirkung
+		// misst `e2e/submit-offline.spec.ts` an der echten Navbar.
+		expect(container.children).toHaveLength(1);
+		expect(container.children[0]?.className).toContain('sr-only');
+	});
+
+	/**
+	 * Die Layout-Klassen gehören an die sichtbare Fläche, nicht an einen
+	 * Wrapper der Aufrufstelle — sonst bliebe deren Abstand im Online-Fall
+	 * stehen.
+	 */
+	it('reicht Layout-Klassen an die sichtbare Fläche durch', async () => {
+		render(ConnectionBadge, { class: 'mb-2 md:hidden' });
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.className).toContain('mb-2');
+		expect(badge('offline')?.className).toContain('md:hidden');
+	});
+
+	it('zeigt den Offline-Zustand mit der Zusage zu den Eingaben', async () => {
+		render(ConnectionBadge);
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.textContent).toContain('Offline');
+		expect(badge('offline')?.textContent).toContain('Eingaben werden gespeichert');
+	});
+
+	it('lässt den Zusatz im kompakten Modus weg', async () => {
+		render(ConnectionBadge, { compact: true });
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.textContent).toContain('Offline');
+		expect(badge('offline')?.textContent).not.toContain('Eingaben werden gespeichert');
+	});
+
+	/**
+	 * Navbar und Schritt-Balken zeigen das Abzeichen gleichzeitig. Zwei
+	 * Live-Regionen mit demselben Text lassen den Screenreader „Offline" doppelt
+	 * ansagen — nur die globale Instanz meldet.
+	 */
+	describe('Live-Region', () => {
+		/**
+		 * Die Region muss schon im DOM stehen, BEVOR sich ihr Inhalt ändert —
+		 * wird sie zusammen mit ihrem Text eingefügt, sagen viele Screenreader
+		 * nichts. Sie ist deshalb auch im Online-Fall vorhanden, nur leer.
+		 */
+		it('steht schon vor dem Zustandswechsel bereit', async () => {
+			const { container } = render(ConnectionBadge);
+			await tick();
+
+			const live = container.querySelector('[role="status"]');
+			expect(live).not.toBeNull();
+			expect(live?.textContent?.trim()).toBe('');
+		});
+
+		it('trägt den Text der Ansage, nicht die sichtbare Fläche', async () => {
+			const { container } = render(ConnectionBadge);
+			connection.reportUnreachable();
+			await tick();
+
+			expect(container.querySelector('[role="status"]')?.textContent).toContain(
+				'Keine Internetverbindung'
+			);
+			// Sonst stünde derselbe Text zweimal im Accessibility-Baum.
+			expect(badge('offline')?.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		it('bleibt mit announce={false} stumm, aber sichtbar', async () => {
+			const { container } = render(ConnectionBadge, { announce: false });
+			connection.reportUnreachable();
+			await tick();
+
+			expect(container.querySelector('[role="status"]')).toBeNull();
+			expect(container.querySelector('[aria-live]')).toBeNull();
+			expect(badge('offline')).not.toBeNull();
+		});
+	});
+
+	/**
+	 * WLAN an Bord ohne Uplink: `navigator.onLine` meldet `true`, jeder Request
+	 * scheitert trotzdem. Das Ergebnis des letzten echten Requests hat deshalb
+	 * das letzte Wort.
+	 */
+	it('folgt dem letzten Request-Ergebnis, nicht navigator.onLine', async () => {
+		render(ConnectionBadge);
+		expect(navigator.onLine).toBe(true);
+
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')).not.toBeNull();
+	});
+
+	/**
+	 * Regression: `isOffline` allein taugt nicht als Sperrbedingung. `fetch`
+	 * wirft denselben TypeError bei einem Server-Neustart oder CORS-Fehler wie
+	 * bei fehlendem Netz — dort bleibt `navigator.onLine` auf `true` und es
+	 * feuert nie ein `online`-Ereignis, das den Zustand aufheben könnte. Wer
+	 * daran hart sperrt, sperrt bis zum Neuladen.
+	 */
+	describe('sicheres gegen vermutetes Offline', () => {
+		it('meldet ein gescheitertes Request-Ergebnis NICHT als sicheres Offline', () => {
+			connection.reportUnreachable();
+
+			expect(connection.isOffline).toBe(true);
+			expect(connection.isInterfaceDown).toBe(false);
+		});
+
+		it('meldet eine abgeschaltete Schnittstelle als sicheres Offline', async () => {
+			// Erst rendern: `watchConnection()` hängt am `$effect` der Komponente,
+			// ohne Instanz hört niemand auf das Ereignis.
+			render(ConnectionBadge);
+			await tick();
+
+			window.dispatchEvent(new Event('offline'));
+			await tick();
+
+			expect(connection.isInterfaceDown).toBe(true);
+		});
+	});
+
+	describe('Wieder online', () => {
+		it('erscheint nach der Rückkehr aus dem Offline-Zustand', async () => {
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			await tick();
+			connection.reportReachable();
+			await tick();
+
+			expect(badge('offline')).toBeNull();
+			expect(badge('reconnected')?.textContent).toContain('Wieder online');
+		});
+
+		it('erscheint nicht, wenn es nie offline war', async () => {
+			render(ConnectionBadge);
+
+			connection.reportReachable();
+			await tick();
+
+			expect(badge('reconnected')).toBeNull();
+		});
+
+		/**
+		 * Die eine Stelle, an der ein flüchtiger Hinweis richtig ist: Er verlangt
+		 * keine Handlung, er nimmt nur eine Sorge weg.
+		 */
+		it('verschwindet nach 4 Sekunden wieder', async () => {
+			vi.useFakeTimers();
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			connection.reportReachable();
+			await tick();
+			expect(badge('reconnected')).not.toBeNull();
+
+			await vi.advanceTimersByTimeAsync(4000);
+			await tick();
+
+			expect(badge('reconnected')).toBeNull();
+		});
+
+		it('steht kurz vor Ablauf der Frist noch', async () => {
+			vi.useFakeTimers();
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			connection.reportReachable();
+			await tick();
+
+			await vi.advanceTimersByTimeAsync(3500);
+			await tick();
+
+			expect(badge('reconnected')).not.toBeNull();
+		});
+	});
+});

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -76,6 +76,7 @@
 	import RotateCcw from '~icons/lucide/rotate-ccw';
 	import ZoomIn from '~icons/lucide/zoom-in';
 	import SearchX from '~icons/lucide/search-x';
+	import Wifi from '~icons/lucide/wifi';
 	import WifiOff from '~icons/lucide/wifi-off';
 	import Save from '~icons/lucide/save';
 	import Scale from '~icons/lucide/scale';
@@ -171,6 +172,7 @@
 		'lucide:rotate-ccw': RotateCcw,
 		'lucide:zoom-in': ZoomIn,
 		'lucide:search-x': SearchX,
+		'lucide:wifi': Wifi,
 		'lucide:wifi-off': WifiOff,
 		'lucide:home': Home,
 		'lucide:file-search': FileSearch,

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
 	import type { PublicUser } from '$lib/types/User';
@@ -69,7 +70,13 @@
 						<span class="text-base-content/70 text-lg font-semibold">Admin</span>
 					{/if}
 				</div>
-				<div class="navbar-end">
+				<div class="navbar-end gap-2">
+					<!--
+						Sichtbar nur ohne Verbindung — im Normalfall rendert die Komponente
+						nichts und kostet keinen Platz.
+					-->
+					<ConnectionBadge compact />
+
 					<!-- Desktop menu -->
 					<div class="hidden lg:flex lg:items-center lg:gap-4">
 						<ul class="menu menu-horizontal px-1">

--- a/src/lib/report/components/form/StepProgressCompact.svelte
+++ b/src/lib/report/components/form/StepProgressCompact.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import { canNavigateToStep } from '$lib/form/validation/stepNavigation';
 	import { getFormContext } from '$lib/report/formContext';
 	import type { FormStep } from '$lib/report/types';
@@ -39,6 +40,21 @@
 		}
 	}
 </script>
+
+<!--
+	Der Verbindungszustand steht im ortsfesten Balken und nicht nur in der
+	Navbar: Auf dem Telefon ist die Navbar beim Ausfüllen längst weggescrollt,
+	der Balken ist die einzige dauerhaft sichtbare Fläche. Hier steht die Zusage
+	zu den Eingaben ausgeschrieben — im Formular ist sie die eigentliche Sorge.
+
+	`announce={false}`, weil die Instanz in der Navbar dieselbe Meldung bereits
+	als Live-Region trägt; zwei davon sagen dem Screenreader „Offline" doppelt.
+
+	Die Layout-Klassen gehen als `class` an die Komponente statt an einen
+	Wrapper: Ein Wrapper mit `mb-2` behielte seinen Abstand auch dann, wenn gar
+	nichts zu sehen ist.
+-->
+<ConnectionBadge announce={false} class="mb-2 md:hidden" />
 
 <nav class="flex items-center gap-3 md:hidden" aria-label="Formular-Schritte">
 	<p class="text-support text-base-content/70 shrink-0">

--- a/src/lib/stores/connectionState.svelte.ts
+++ b/src/lib/stores/connectionState.svelte.ts
@@ -31,6 +31,34 @@ let interfaceUp = $state(true);
 /** Was der letzte echte Request über die Erreichbarkeit gesagt hat. */
 let lastRequest = $state<'unknown' | 'reachable' | 'unreachable'>('unknown');
 
+/**
+ * Wie lange „Wieder online" stehen bleibt.
+ *
+ * Das ist die eine Stelle in diesem Regelwerk, an der ein flüchtiger Hinweis
+ * richtig ist: Er verlangt keine Handlung, er nimmt nur eine Sorge weg. Ein
+ * Dauer-Indikator für „online" dagegen sagt 99 % der Zeit dasselbe und wird
+ * deshalb nicht gelesen.
+ */
+const RECONNECTED_NOTICE_MS = 4000;
+
+let reconnected = $state(false);
+let reconnectedTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Zeigt „Wieder online", aber nur wenn es vorher wirklich offline war. */
+function noteReconnection(wasOffline: boolean): void {
+	if (!browser || !wasOffline) return;
+
+	reconnected = true;
+	// Gegen `null` prüfen, nicht auf truthy: Der Typ lässt jeden `number` zu, und
+	// `0` wäre falsy. (Die HTML-Spezifikation verlangt zwar einen Handle > 0, aber
+	// der Vertrag hier ist der Typ, nicht die Spezifikation eines Zielsystems.)
+	if (reconnectedTimer !== null) clearTimeout(reconnectedTimer);
+	reconnectedTimer = setTimeout(() => {
+		reconnected = false;
+		reconnectedTimer = null;
+	}, RECONNECTED_NOTICE_MS);
+}
+
 export const connection = {
 	/**
 	 * `true`, wenn abgesendete Daten den Server nicht erreichen würden.
@@ -64,10 +92,22 @@ export const connection = {
 		return !interfaceUp;
 	},
 
+	/**
+	 * `true` für {@link RECONNECTED_NOTICE_MS} nach der Rückkehr aus dem
+	 * Offline-Zustand — und nur dann. Wer nie offline war, sieht nichts.
+	 */
+	get justReconnected(): boolean {
+		return reconnected;
+	},
+
 	/** Ein Request kam durch — überstimmt jedes ältere Signal. */
 	reportReachable(): void {
+		// Kein `this`: Die Methode soll auch nach einer Destrukturierung
+		// (`const { reportReachable } = connection`) funktionieren.
+		const wasOffline = !interfaceUp || lastRequest === 'unreachable';
 		lastRequest = 'reachable';
 		interfaceUp = true;
+		noteReconnection(wasOffline);
 	},
 
 	/** Ein Request scheiterte am Netz (`status: 'offline'` aus `submitSightingForm`). */
@@ -83,6 +123,11 @@ export const connection = {
 	reset(): void {
 		lastRequest = 'unknown';
 		interfaceUp = browser ? navigator.onLine : true;
+		reconnected = false;
+		if (reconnectedTimer !== null) {
+			clearTimeout(reconnectedTimer);
+			reconnectedTimer = null;
+		}
 	}
 };
 
@@ -98,10 +143,12 @@ export function watchConnection(): () => void {
 	interfaceUp = navigator.onLine;
 
 	const handleOnline = (): void => {
+		const wasOffline = connection.isOffline;
 		interfaceUp = true;
 		// Die alte Erfahrung gilt nicht mehr: Es ist eine neue Verbindung, und ob
 		// sie trägt, weiß erst der nächste echte Request.
 		lastRequest = 'unknown';
+		noteReconnection(wasOffline);
 	};
 	const handleOffline = (): void => {
 		interfaceUp = false;


### PR DESCRIPTION
**PR 5 von 6 — Stack „Zustände". Basis: `feat/status-block` (#626).**

Wer das Formular ausfüllt, soll **während** des Ausfüllens erfahren, dass keine
Verbindung besteht — nicht am Ende, wenn die Arbeit getan ist und „Absenden"
nichts tut.

### Entscheidungen

- **Kein Dauer-Indikator für „online".** Ein Zustand, der 99 % der Zeit
  dasselbe sagt, wird nicht gelesen. Bei bestehender Verbindung rendert die
  Komponente nichts und kostet keinen Platz.
- **„Wieder online" darf flüchtig sein.** Das ist die eine Stelle, an der ein
  verschwindender Hinweis richtig ist: Er verlangt keine Handlung, er nimmt nur
  eine Sorge weg. Vier Sekunden, dann weg. Er erscheint auch nur, wenn es
  vorher wirklich offline war.
- **Der Zustand kommt nicht aus `navigator.onLine` allein.** Das meldet nur
  eine aktive Netzwerkschnittstelle, nicht ob das Internet erreichbar ist —
  WLAN an Bord ohne Uplink meldet „online" und lässt jeden Request scheitern.
  `connectionState` (aus #625) behandelt das Ergebnis des letzten echten
  Requests als letztes Wort, die Browser-Ereignisse nur als schnelles
  Vorab-Signal.

### Platzierung

`PublicNavbar` und der ortsfeste Schritt-Balken — auf dem Telefon ist die
Navbar beim Ausfüllen längst weggescrollt. Beide sind gleichzeitig sichtbar,
deshalb ist **nur die globale Instanz in der Navbar eine Live-Region**; zwei
würden dem Screenreader „Offline" doppelt ansagen. Die Instanz im Balken
schreibt dafür aus, dass die Eingaben gespeichert werden — im Formular ist das
die eigentliche Sorge.

### Tests

10 Komponenten-Fälle, darunter das Vier-Sekunden-Fenster, dass der Hinweis nie
ohne vorangegangenen Offline-Zustand erscheint, und die Unterscheidung zwischen
sicherem und vermutetem Offline.

`lucide:wifi` fehlte in der Icon-Registry; der Guard-Test aus #626 hat es vor
dem Browser gefunden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)