### PR TITLE
test(ui): close the two known holes in the design-system scan

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -75,9 +75,17 @@ Gemessen auf `base-100` (Rechnung wie in `daisyui.md`, im Browser nach sRGB):
 
 **Gegenprobe:** Steht die Farbe hinter `text-`, `fill-` oder `stroke-`, muss `-strong` dranhängen. Steht sie hinter `bg-`, `btn-`, `badge-` oder `alert-`, darf sie es nicht.
 
-Die über 60 Verstöße des Altbestands sind mit PR 4/4 (#620) abgearbeitet; seither ist die Gruppe „verbotene Kombinationen im DOM" in `e2e/design-tokens.spec.ts` ein **aktiver Guard** und kein `fixme` mehr. Sie fährt `/`, `/map`, `/about` sowie vier Admin-Routen (Session über `e2e/helpers/adminSession.ts`, ohne Auth0 — Begründung dort). Eine neue Fundstelle gehört an der Aufrufstelle behoben — nicht durch Aufweichen der Regex.
+Die über 60 Verstöße des Altbestands sind mit PR 4/4 (#620) abgearbeitet; seither ist die Gruppe „verbotene Kombinationen im DOM" in `e2e/design-tokens.spec.ts` ein **aktiver Guard** und kein `fixme` mehr. Sie fährt `/`, `/map`, `/about` sowie vier Admin-Routen (Session über `e2e/helpers/adminSession.ts`, ohne Auth0 — Begründung dort) — seit dem 2026-07-30 **alle sieben auch in CI**, gegen einen Postgres-Service mit Seed. Eine neue Fundstelle gehört an der Aufrufstelle behoben — nicht durch Aufweichen der Regel.
 
-**Was der Scan nicht sieht:** Seine Regex verlangt hinter dem Farbnamen ein Leerzeichen oder das Zeilenende. Ein Deckkraft-Suffix schiebt sich dazwischen, `text-success/80` rutscht also durch (real gefunden in `DropzoneEnhanced.svelte`). Und `hover:`-Zustände tauchen in `getComputedStyle` im Ruhezustand ohnehin nicht auf. Beim Prüfen per `grep` gilt außerdem: **`grep -o` schneidet das `-strong`-Suffix aus der Ausgabezeile**, ein nachgeschaltetes `grep -v -- -strong` filtert dann ins Leere und meldet jede korrekte Verwendung als Verstoß — so entstand die inzwischen korrigierte „32 Fundstellen"-Liste in `docs/DESIGN_SYSTEM.md`.
+**Die Regeln stehen in `e2e/helpers/bannedClasses.ts`,** nicht als Regex-Literale im Spec, und sind über `bannedClasses.test.ts` an konstruierten Beispielen abgesichert (läuft in `npm run test:quick`). Der Grund: Ein Scan über einen konformen Bestand belegt nichts über die Regel — genau daran ist die Deckkraft-Lücke unentdeckt geblieben.
+
+**Deckkraft-Suffixe werden mitgefangen** (seit 2026-07-30). `text-success/80` ist ein Verstoß wie `text-success`, und `bg-red-500/50` einer wie `bg-red-500`. Die Deckkraft-Regel vergleicht gegen die Schwelle /60 statt gegen die Literale 40 und 50 — ein `/30` auf Text ist damit ebenfalls ein Verstoß.
+
+**Was der Scan nicht sieht:** `hover:`-Zustände (er liest den Ruhezustand — dafür gilt die Regel „`text-error` nicht auf `base-300`" unten) und `fill-`/`stroke-` (nur `text-` steht im Muster; im Bestand gibt es derzeit keine solche Fundstelle).
+
+**Beim Beheben nicht mechanisch ersetzen:** Erst prüfen, ob die Farbe an der Stelle Bedeutung trägt. Dekorative Icons und Zierelemente gehören auf `base-content/70` — nicht auf eine Statusfarbe mit `-strong`. Trägt ein Zeichen gar keine Bedeutung (Trennpunkt, Zierglyphe), gehört zusätzlich `aria-hidden="true"` daran; Beispiel: die Danksagungs-Trennpunkte in `src/routes/about/+page.svelte`.
+
+Beim Prüfen per `grep` gilt außerdem: **`grep -o` schneidet das `-strong`-Suffix aus der Ausgabezeile**, ein nachgeschaltetes `grep -v -- -strong` filtert dann ins Leere und meldet jede korrekte Verwendung als Verstoß — so entstand die inzwischen korrigierte „32 Fundstellen"-Liste in `docs/DESIGN_SYSTEM.md`. Die Regeln im Scan umgehen das, indem sie die Klassenliste splitten und jede Klasse gegen ein verankertes Muster prüfen.
 
 ---
 
@@ -156,7 +164,7 @@ gerechnet — die Differenz beträgt hier bis zu 0,08):
 | /50   | **3,54 ❌** | **3,39 ❌** | **3,23 ❌** |
 | /40   | **2,64 ❌** | **2,56 ❌** | **2,46 ❌** |
 
-**Regel:** `/60` ist die Untergrenze für Text, und nur auf `base-100` und `base-200`. `/40` und `/50` (bzw. `opacity-40`/`opacity-50`) sind ausschließlich für dekorative Flächen — nie für Zeichen, die gelesen werden müssen.
+**Regel:** `/60` ist die Untergrenze für Text, und nur auf `base-100` und `base-200`. **Jeder Wert darunter** — `/50`, `/40`, `/30`, … bzw. das entsprechende `opacity-*` — ist ausschließlich für dekorative Flächen und für Zeichen ohne Bedeutung; nie für etwas, das gelesen werden muss. Der Scan prüft das als Schwelle und nicht als Aufzählung (`e2e/helpers/bannedClasses.ts`), damit `/30` nicht durchrutscht wie früher.
 
 Sekundärtext gehört auf `/70`, nicht auf `/60`: Hilfetexte werden im Feld gelesen, bei Sonnenlicht an Deck, und dort ist der reale Kontrast deutlich niedriger als der gemessene.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,48 @@ jobs:
     permissions:
       contents: read
 
+    # Eine Quelle für die Verbindung: Die Migrations- und Seed-Skripte lesen sie
+    # aus `process.env`, der von Playwright gestartete Dev-Server über
+    # `$env/dynamic/private` aus der `.env` (siehe src/lib/server/db/index.ts).
+    # Der „Setup environment"-Schritt unten schreibt denselben Wert dorthin —
+    # beide Seiten müssen hier übereinstimmen, sonst migriert der Job eine andere
+    # Datenbank als die, welche die Seiten lesen.
+    env:
+      DATABASE_POSTGRES_URL: postgresql://ci:ci@localhost:5432/ostsee_ci
+
+    # PostGIS, nicht plain Postgres: `sichtungen.location` ist eine
+    # geometry(point)-Spalte (drizzle/0000_initial.sql), die Migration scheitert
+    # ohne die Extension. Dasselbe Image wie in docker-compose.yml — das
+    # postgis/postgis-Image aktiviert die Extension beim initdb selbst in
+    # POSTGRES_DB, ein eigenes `CREATE EXTENSION` ist deshalb nicht nötig.
+    #
+    # Warum überhaupt: Ohne Datenbank übersprang der Scan in
+    # design-tokens.spec.ts ausgerechnet /admin und /admin/statistics — die zwei
+    # datenreichsten Seiten, auf denen Datentabelle, Statusbadges, stat-value und
+    # Paginierung sitzen. Nebeneffekt der alten Lage: rund 50 s Wartezeit im
+    # smoke-Shard, weil die DB-Verbindungen in Timeouts liefen.
+    services:
+      postgres:
+        image: postgis/postgis:18-3.6
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: ostsee_ci
+        ports:
+          - 5432:5432
+        # `-h 127.0.0.1` erzwingt TCP und ist kein Detail: Der Entrypoint des
+        # Postgres-Images startet während `initdb` einen temporären Server, der
+        # NUR auf dem Unix-Socket lauscht — dort laufen dann die Init-Skripte,
+        # inklusive dem, das PostGIS anlegt. Ein `pg_isready` über den Socket
+        # meldet in diesem Fenster „bereit", während die Datenbank noch nicht
+        # existiert. Lokal nachgestellt: `pg_isready` sagte 4 s vor der Datenbank
+        # „accepting connections". Über TCP gibt es das Fenster nicht.
+        options: >-
+          --health-cmd "pg_isready -h 127.0.0.1 -U ci -d ostsee_ci"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -298,14 +340,74 @@ jobs:
           node-version: "24"
           cache: "npm"
 
+      # `.env` liest der Dev-Server (über Vite) und liest der Testprozess
+      # (e2e/helpers/adminSession.ts ruft dotenv auf, für SESSION_SECRET und
+      # COOKIE_NAME). Der Platzhalter aus .env.example genügt dafür — beide Seiten
+      # müssen nur denselben Wert sehen.
+      #
+      # Die Zuweisungen unten sind mit `sed` gesetzt und nicht angehängt, damit
+      # die Datei jede Variable genau einmal enthält: Bei zwei Zeilen mit
+      # demselben Namen entscheidet die Reihenfolge, und das wäre ein stiller
+      # Unterschied zwischen dotenv und Vite.
       - name: Setup environment
-        run: cp .env.example .env
+        run: |
+          cp .env.example .env
+          sed -i "s|^DATABASE_POSTGRES_URL=.*|DATABASE_POSTGRES_URL=\"${DATABASE_POSTGRES_URL}\"|" .env
+          # SKIP_DB_CHECK aus .env.example gilt hier nicht mehr: Es gibt jetzt eine
+          # Datenbank. Bleibt der Skip an, fällt ein Ausfall des Postgres-Service
+          # nicht als 503 auf, sondern erst irgendwo im Seiten-Load — und die
+          # Lücke, die dieser Job schließt, wäre wieder offen.
+          sed -i 's|^SKIP_DB_CHECK=.*|SKIP_DB_CHECK="false"|' .env
+          grep -cE '^DATABASE_POSTGRES_URL=' .env | grep -qx 1
+          grep -E '^(DATABASE_POSTGRES_URL|SKIP_DB_CHECK)=' .env
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run SvelteKit sync
         run: npx svelte-kit sync
+
+      # Zweiter Wächter neben dem Health-Check: Er stellt sicher, dass PostGIS
+      # wirklich installiert ist. `sichtungen.location` ist geometry(point) — ohne
+      # die Extension scheitert die erste Migration mit „type geometry does not
+      # exist", und das ist eine Meldung, die man ohne diesen Schritt drei
+      # Ebenen tiefer sucht.
+      #
+      # Über das `postgres`-Paket aus node_modules und nicht über `psql`: Ein
+      # `psql` auf dem Runner-Image ist eine Zusage der Image-Zusammenstellung,
+      # das Paket ist eine Zusage der package-lock.json.
+      - name: Verify PostGIS is ready
+        run: |
+          node --input-type=module -e '
+            const { default: postgres } = await import("postgres");
+            const ATTEMPTS = 30;
+            for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+              const sql = postgres(process.env.DATABASE_POSTGRES_URL, { max: 1, connect_timeout: 5 });
+              try {
+                const [row] = await sql`SELECT postgis_version() AS version`;
+                console.log(`PostGIS bereit: ${row.version}`);
+                await sql.end();
+                process.exit(0);
+              } catch (error) {
+                await sql.end({ timeout: 1 }).catch(() => {});
+                if (attempt === ATTEMPTS) {
+                  const reason = error.message || error.code || String(error);
+                  console.error(`::error::PostGIS ist nach ${ATTEMPTS} Versuchen nicht erreichbar: ${reason}`);
+                  process.exit(1);
+                }
+                await new Promise((resolve) => setTimeout(resolve, 2000));
+              }
+            }
+          '
+
+      # Ausschließlich die committeten Migrationen — kein `drizzle-kit push`.
+      # Begründung in scripts/docker-migrate.ts; hier zählt zusätzlich, dass CI
+      # damit denselben Weg fährt wie der Produktions-Container.
+      - name: Apply database migrations
+        run: npm run db:migrate
+
+      - name: Seed E2E test data
+        run: npm run db:seed:e2e
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,13 +385,21 @@ jobs:
               const sql = postgres(process.env.DATABASE_POSTGRES_URL, { max: 1, connect_timeout: 5 });
               try {
                 const [row] = await sql`SELECT postgis_version() AS version`;
+                if (!row) throw new Error("SELECT postgis_version() lieferte keine Zeile");
                 console.log(`PostGIS bereit: ${row.version}`);
                 await sql.end();
                 process.exit(0);
               } catch (error) {
                 await sql.end({ timeout: 1 }).catch(() => {});
                 if (attempt === ATTEMPTS) {
-                  const reason = error.message || error.code || String(error);
+                  // Erst auf Objekt prüfen, dann Felder lesen: `throw null` ist
+                  // erlaubtes JS, und ein catch-Block, der beim Formulieren der
+                  // Meldung selbst wirft, verdeckt genau die Ursache, die er
+                  // melden soll. `code` bleibt als Rückfall, weil ein
+                  // ECONNREFUSED aus `postgres` hier nachweislich mit leerer
+                  // `message` ankam.
+                  const fields = error && typeof error === "object" ? error : {};
+                  const reason = fields.message || fields.code || String(error);
                   console.error(`::error::PostGIS ist nach ${ATTEMPTS} Versuchen nicht erreichbar: ${reason}`);
                   process.exit(1);
                 }

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -273,7 +273,7 @@ Datenfarben müssen über Theme-Änderungen hinweg stabil bleiben.
 ## Prüfung
 
 ```bash
-npm run test:quick                              # Lint, Types, svelte-check, Unit
+npm run test:quick                              # Lint, Types, svelte-check, Unit (inkl. Scan-Regeln)
 npx playwright test e2e/design-tokens.spec.ts   # Token-Kontraste + DOM-Scan
 npx playwright test e2e/form-a11y.spec.ts       # Fokus, Alerts, error-Buttons
 ```
@@ -282,26 +282,71 @@ npx playwright test e2e/form-a11y.spec.ts       # Fokus, Alerts, error-Buttons
 `/styleguide` (dort steht jede Kombination genau einmal), die App gegen
 verbotene Kombinationen (Statusfarbe als Vordergrund, Deckkraft unter /60,
 Tailwind-Paletten-Klassen) und die **Vollständigkeit von `/styleguide`** selbst.
-
-Der DOM-Scan deckt seit dem 2026-07-29 auch `/admin`, `/admin/statistics`,
-`/admin/docs` und `/admin/settings` ab. Die Session dafür stellt
-`e2e/helpers/adminSession.ts` selbst aus — mit `SESSION_SECRET` signiert, ohne
-Auth0. Die Begründung steht dort ausführlich; kurz: Auth0 erklärt die
-Universal-Login-Routen als nicht für Automation gedacht, und ein
-ROPG-Token konsumiert diese App nirgends, weil ihre Session ein
-selbstsigniertes JWT ist. Zwei Wächter verhindern, dass der Scan eine
-Ausweichseite misst und grün meldet: Umleitung zu Auth0 und 401/403 sind harte
-Fehler mit eigener Meldung.
-
-**Teilabdeckung in CI, bewusst:** Der E2E-Job in `ci.yml` startet keinen
-Postgres (`cp .env.example .env`, kein `services:`-Block). `/admin` und
-`/admin/statistics` antworten dort mit 5xx und werden **ausdrücklich
-übersprungen** — sichtbar im Report, nicht still grün. `/admin/docs` und
-`/admin/settings` laufen auch ohne Datenbank. Wer die zwei fehlenden Routen in
-CI abdecken will, braucht einen Postgres-Service im `e2e`-Job; lokal sind alle
-vier grün.
 Gemessen wird im Browser, weil `oklch()` und `color-mix(in oklab, …)` erst nach
 dem Gamut-Mapping nach sRGB als Kontrastwert lesbar sind.
+
+### Die drei Scan-Regeln liegen in Node, nicht im Browser
+
+Seit dem 2026-07-30 stehen sie als reine Funktionen in
+`e2e/helpers/bannedClasses.ts`; der Browser gibt nur noch Klassenlisten heraus,
+gefiltert wird in Node. Das hat einen Grund, der über Aufräumen hinausgeht: Ein
+Scan über einen konformen Bestand belegt nichts über die Regel. Genau daran ist
+die Deckkraft-Lücke unten monatelang unentdeckt geblieben — sie war grün, weil
+der Code sauber war, nicht weil die Regel griff.
+
+`e2e/helpers/bannedClasses.test.ts` stellt deshalb jede Regel an konstruierten
+Beispielen scharf und läuft in `npm run test:quick` mit. Die Gegenprobe dazu ist
+gefahren: Nimmt man das Deckkraft-Suffix aus dem Statusfarben-Muster, fallen
+2 von 30 Fällen; ersetzt man den Schwellenvergleich wieder durch die Aufzählung
+`(40|50)`, fallen 5.
+
+### Vollabdeckung in CI seit dem 2026-07-30
+
+Der DOM-Scan deckt `/`, `/map`, `/about` sowie `/admin`, `/admin/statistics`,
+`/admin/docs` und `/admin/settings` ab — **alle sieben auch in CI**. Der
+`e2e`-Job in `ci.yml` fährt dafür einen `postgis/postgis:18-3.6`-Service (dasselbe
+Image wie `docker-compose.yml`; PostGIS ist nötig, weil `sichtungen.location` eine
+`geometry(point)`-Spalte ist), wendet die committeten Migrationen an und legt über
+`npm run db:seed:e2e` 60 Sichtungen an.
+
+Die 60 sind keine runde Zahl, sondern drei Schwellen: > 50 (`defaultPageSize`) für
+eine **bedienbare** Paginierung, > 1 Zeile für die Zebra-Streifen, ≥ 2 Kalenderjahre
+für die Spalte „Entwicklung" der Jahrestrend-Tabelle. Der Seed ist über
+`kommentar_intern = 'e2e-seed'` idempotent und mit `npm run db:seed:e2e:purge`
+wieder entfernbar — die lokale Datenbank ist laut `docs/WORKTREES.md` über alle
+Worktrees geteilt.
+
+**Vorher war die Aufteilung die schlechtestmögliche:** Übersprungen wurden genau
+die zwei datenreichen Seiten — Datentabelle, Statusbadges, `stat-value`,
+Paginierung. Dass die vier übrigen Routen sauber sind, sagte darüber nichts.
+Nebeneffekt: rund 50 s Wartezeit im Smoke-Shard, weil die DB-Verbindungen in
+Timeouts liefen.
+
+**Der Skip-Pfad steht noch, aber nur lokal.** Wer ohne `npm run db:start` fährt,
+bekommt für die vier DB-Routen einen sichtbaren Skip. **In CI ist derselbe Fall ein
+harter Fehler** (`if (process.env.CI) throw`): Ein übersprungener Test in CI ist
+kein Test.
+
+**Drei Wächter gegen „vakuum-grün".** Eine leere Tabelle liefert ein DOM ohne eine
+einzige verbotene Kombination — der Scan wäre grün, ohne die Seite gesehen zu
+haben, genau wie bei einem Auth0-Redirect oder einer 403-Seite. Deshalb:
+
+| Wächter                   | Fehlerfall, den er abfängt                                   |
+| ------------------------- | ------------------------------------------------------------ |
+| Umleitung ≠ eigene Origin | Session-Cookie nicht akzeptiert (SESSION_SECRET/COOKIE_NAME) |
+| Status 401/403            | Cookie gilt, aber `roles` reicht nicht für `requireUserRole` |
+| `renders`-Sonden          | Seite antwortet 200 und rendert trotzdem nichts              |
+
+Die Sonden prüfen Mindestzahlen, nicht bloß Status < 500: ≥ 10 Tabellenzeilen und
+ein **bedienbares** „Nächste Seite" auf `/admin`; ≥ 5 `stat-value`, ≥ 2 Jahreszeilen
+und ≥ 2 Zeilen Artenverteilung auf `/admin/statistics`. Nachgestellt: Ruft man
+`/admin` mit einem Filter ohne Treffer auf, sind alle drei Klassen-Scans grün und
+nur die Sonde rot.
+
+Die Session stellt `e2e/helpers/adminSession.ts` selbst aus — mit `SESSION_SECRET`
+signiert, ohne Auth0. Die Begründung steht dort ausführlich; kurz: Auth0 erklärt die
+Universal-Login-Routen als nicht für Automation gedacht, und ein ROPG-Token
+konsumiert diese App nirgends, weil ihre Session ein selbstsigniertes JWT ist.
 
 Die dritte Gruppe hängt an einer Eigenschaft der Seite, die man ihr nicht
 ansieht: Sie ist Schaufenster **und** Lieferbedingung. Tailwind erzeugt eine
@@ -455,13 +500,42 @@ gelesen werden müssen, hier also zu Recht nicht.
 **Ein echter Fund fiel bei der Gegenprüfung an, außerhalb des Admin-Bereichs:**
 `text-success/80` in
 `src/lib/report/components/form/fields/DropzoneEnhanced.svelte:628` (GPS-Koordinaten
-auf `bg-success/10`) — inzwischen auf `text-base-content/70` korrigiert. Der
-DOM-Scan in `e2e/design-tokens.spec.ts` hatte sie nicht gemeldet: Seine Regex
-verlangt hinter dem Farbnamen Leerzeichen oder Zeilenende, ein
-Deckkraft-Suffix wie `/80` schiebt sich dazwischen. Die Lücke ist bekannt und
-absichtlich nicht im Rahmen dieses PR geschlossen worden.
+auf `bg-success/10`) — inzwischen auf `text-base-content/70` korrigiert.
+
+**Die Lücke, die ihn verdeckte, ist seit dem 2026-07-30 zu.** Sie war keine
+Randnotiz: Die alte Regex verlangte hinter dem Farbnamen Leerzeichen oder
+Zeilenende, und ein Deckkraft-Suffix schiebt sich dazwischen. `text-success` misst
+auf `base-100` 3,81:1, mit `/80` weniger — eine Statusfarbe mit Deckkraft auf einem
+Tint derselben Farbe ist die Fehlerklasse, für die die `*-content`-Regel überhaupt
+existiert, nur eine Ebene tiefer.
+
+Alle drei Regeln in `e2e/helpers/bannedClasses.ts` fangen das Suffix jetzt mit.
+Statt die Wortgrenzen um ein optionales `/<zahl>` zu erweitern, splittet der Scan
+die Klassenliste an Weißraum und prüft jede Klasse gegen ein **verankertes** Muster
+(`^text-success(/\d+)?$`). Das ist gleichwertig, hat aber kein
+Überlappungsproblem bei zwei Treffern in einer Liste, benennt in der Meldung die
+konkrete Klasse — und `-strong`/`-content` fallen durch die Verankerung heraus statt
+durch ein nachgeschaltetes `grep -v`, an dem die Liste oben gescheitert ist.
+
+Bei der Deckkraft-Regel wurde dabei aus der Aufzählung `(40|50)` ein
+**Schwellenvergleich gegen /60**. Die alte Fassung hätte ein `/30` oder `/25`
+genauso durchgelassen wie das `/80`.
+
+Was die Regeln weiterhin **nicht** sehen: `hover:`-Varianten (der Scan liest den
+Ruhezustand) und `fill-`/`stroke-` (nur `text-` ist im Muster; im Bestand gibt es
+derzeit keine solche Fundstelle).
+
+**Beim Aufräumen einer Fundstelle gilt:** Erst prüfen, ob die Farbe dort Bedeutung
+trägt. Ein dekoratives Icon oder ein Zierelement gehört auf `base-content/70` —
+nicht mechanisch auf `-strong`. So wurden die vier Trennpunkte in der Danksagung
+auf `/about` behandelt, die der erweiterte Scan als Erstes gemeldet hat: `opacity-30`
+→ `text-base-content/70` **plus** `aria-hidden="true"`, weil Screenreader dort
+bisher „Svelte Team Bullet Tailwind Labs Bullet …" vorlasen.
 
 ### Reproduktion
+
+Verbindlich sind die Regeln in `e2e/helpers/bannedClasses.ts` — die `grep`-Befehle
+unten sind der schnelle Blick von Hand, nicht die Prüfung.
 
 ```bash
 # Statusfarbe als Vordergrund ohne -strong.
@@ -474,8 +548,9 @@ grep -rnE '\b(text|fill|stroke)-(secondary|accent|info|success|warning)(/[0-9]+)
 grep -rnoE '\b(text|fill|stroke)-(secondary|accent|info|success|warning)(/[0-9]+)?(-strong|-content)?' \
   src/routes/admin src/lib/components/admin | grep -vE '(-strong|-content)$'
 
-# Deckkraft unter /60 auf Text (Treffer einzeln ansehen: dekorative Flächen
-# und Icons ohne Textinhalt sind zulässig)
-grep -rnE '\btext-base-content/(40|50)\b|\bopacity-(40|50)\b' \
+# Deckkraft unter /60 auf Text — jeder Wert darunter, nicht nur 40 und 50.
+# Treffer einzeln ansehen: dekorative Flächen und Icons ohne Textinhalt sind
+# zulässig (die /60-Untergrenze gilt für Zeichen, die gelesen werden müssen).
+grep -rnE '\btext-base-content/([1-5]?[0-9])\b|\bopacity-([1-5]?[0-9])\b' \
   src/routes/admin src/lib/components/admin
 ```

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -7,6 +7,13 @@ import {
 	type Page
 } from '@playwright/test';
 import { seedAdminSession } from './helpers/adminSession';
+import {
+	BELOW_OPACITY_FLOOR,
+	findOffenders,
+	STATUS_AS_FOREGROUND,
+	TAILWIND_PALETTE,
+	type ScannedElement
+} from './helpers/bannedClasses';
 import { formatRatio, measureContrast } from './helpers/contrast';
 
 /**
@@ -274,11 +281,47 @@ test.describe('Styleguide — Bedienung', () => {
    eine Flächen-Statusfarbe als Vordergrund verwendet, Text unter Deckkraft /60
    setzt oder eine Tailwind-Paletten-Farbe am Theme vorbei nutzt.
 
-   Die Regex NICHT aufweichen, um die Gruppe grün zu halten: sie wäre genau
-   dann wertlos, wenn sie nur noch findet, was ohnehin konform ist. Eine neue
+   Die drei Regeln stehen seit dem 2026-07-30 in `helpers/bannedClasses.ts` und
+   nicht mehr als Regex-Literale in den `page.evaluate()`-Callbacks hier. Der
+   Grund steht dort ausführlich; kurz: Sie waren so nur mit laufendem Browser
+   prüfbar, und ein Scan über einen konformen Bestand belegt nichts über die
+   Regel — genau daran ist die Deckkraft-Lücke (`text-success/80`) unentdeckt
+   geblieben. `helpers/bannedClasses.test.ts` stellt sie jetzt an konstruierten
+   Beispielen scharf.
+
+   Die Regeln NICHT aufweichen, um die Gruppe grün zu halten: sie wären genau
+   dann wertlos, wenn sie nur noch finden, was ohnehin konform ist. Eine neue
    Fundstelle gehört an der Aufrufstelle behoben — `text-*-strong` statt
-   `text-*`, `/70` statt `/50`, Theme-Token statt Tailwind-Palette. */
+   `text-*`, `/70` statt `/50`, Theme-Token statt Tailwind-Palette. Und bei
+   dekorativen Icons und Zierelementen ist `base-content/70` die richtige
+   Antwort, nicht ein mechanisches `-strong`: eine Statusfarbe, die keine
+   Bedeutung trägt, gehört gar nicht dorthin. */
 test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
+	/** Belegt, dass die Seite wirklich Inhalt gerendert hat. */
+	interface ContentProbe {
+		/** Erscheint in der Fehlermeldung. */
+		readonly what: string;
+		readonly selector: string;
+		readonly min: number;
+	}
+
+	interface ScanRoute {
+		readonly path: string;
+		readonly auth: boolean;
+		readonly needsDb: boolean;
+		readonly renders?: readonly ContentProbe[];
+	}
+
+	/* Die Fixtures, die beide Helfer unten brauchen. Als eigener Typ, weil die
+	   Form sonst zweimal ausgeschrieben dasteht und beim Ergänzen einer Fixture
+	   auseinanderlaufen kann. */
+	type ScanFixtures = {
+		page: Page;
+		context: BrowserContext;
+		request: APIRequestContext;
+		baseURL: string | undefined;
+	};
+
 	/* Ruhezustand-Scan. Hover-Zustände tauchen in getComputedStyle nicht auf
 	   und sind hier deshalb nicht prüfbar — dafür gilt die Regel in
 	   design-system.md („text-error nicht auf base-300").
@@ -287,12 +330,63 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 	   nicht schmutzig: Eine Prüfung von Hand über alle sechs Routen fand null
 	   Verstöße — aber eben von Hand. Der Zugang läuft über `seedAdminSession`
 	   (dort steht, warum nicht über die Auth0-Oberfläche). */
-	const ROUTES = [
+	const ROUTES: readonly ScanRoute[] = [
 		{ path: '/', auth: false, needsDb: false },
 		{ path: '/map', auth: false, needsDb: false },
 		{ path: '/about', auth: false, needsDb: false },
-		{ path: '/admin', auth: true, needsDb: true },
-		{ path: '/admin/statistics', auth: true, needsDb: true },
+		/* Die `renders`-Sonden sind für die beiden datengetriebenen Seiten keine
+		   Zugabe, sondern der Kern ihrer Aussagekraft: Eine leere Tabelle liefert
+		   ein DOM ohne eine einzige verbotene Kombination und wäre damit
+		   vakuum-grün — genau wie es der Auth0-Redirect und die 403-Seite gewesen
+		   wären, gegen die die Wächter unten stehen. Status < 500 ist dafür kein
+		   Beleg. */
+		{
+			path: '/admin',
+			auth: true,
+			needsDb: true,
+			renders: [
+				/* Beide Layouts stehen gleichzeitig im DOM (`md:hidden` /
+				   `hidden md:block` sind reines CSS); die Tabelle ist die mit den
+				   Zebra-Streifen und den Statusbadges. Mehrere Zeilen, weil eine
+				   einzelne Zeile kein Zebra ergibt. */
+				{ what: 'Tabellenzeilen', selector: 'table.table-zebra tbody tr', min: 10 },
+				/* Paginierung erscheint immer, aber mit einer Seite ist jede
+				   Navigations-Schaltfläche deaktiviert. Erst ein bedienbares
+				   „Nächste Seite" belegt, dass der Bestand über eine Seite
+				   hinausgeht und die Muster im Ruhezustand messbar sind. */
+				{
+					what: 'Paginierung über mehr als eine Seite',
+					selector: '.join button[title="Nächste Seite"]:not([disabled])',
+					min: 1
+				}
+			]
+		},
+		{
+			path: '/admin/statistics',
+			auth: true,
+			needsDb: true,
+			renders: [
+				/* `stat-value` trägt die Statusfarben-Muster dieser Seite
+				   (text-secondary-strong, text-warning-strong, text-accent-strong,
+				   text-info-strong) — ohne Zahlen dahinter ist der Scan blind. */
+				{ what: 'Kennzahlen', selector: '.stat-value', min: 5 },
+				/* Über die Kopfzeile selektiert und nicht über eine Klasse: die
+				   Seite hat mehrere Tabellen, und `table` vs. `table-zebra` ist
+				   Gestaltung, die sich ändern darf. Zwei Zeilen sind das Minimum,
+				   damit die Entwicklungs-Spalte überhaupt rechnet — bei einem
+				   einzigen Jahr bleibt sie leer. */
+				{
+					what: 'Jahreszeilen im Trend (mehrjährige Daten)',
+					selector: 'table:has(thead th:text-is("Jahr")) tbody tr',
+					min: 2
+				},
+				{
+					what: 'Zeilen in der Artenverteilung',
+					selector: 'table:has(thead th:text-is("Art")) tbody tr',
+					min: 2
+				}
+			]
+		},
 		/* /admin/docs hat nur ein +page.ts und keinen Server-Load — die einzige
 		   Admin-Route, die ohne Datenbank vollständig rendert. */
 		{ path: '/admin/docs', auth: true, needsDb: false },
@@ -332,29 +426,30 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 	   Kombination steht — die Prüfung meldete dann grün, ohne je die Seite
 	   gesehen zu haben, um die es geht. */
 	const openRoute = async (
-		{
-			page,
-			context,
-			request,
-			baseURL
-		}: {
-			page: Page;
-			context: BrowserContext;
-			request: APIRequestContext;
-			baseURL: string | undefined;
-		},
-		route: (typeof ROUTES)[number]
+		{ page, context, request, baseURL }: ScanFixtures,
+		route: ScanRoute
 	) => {
-		/* Der E2E-Job in ci.yml startet keinen Postgres (`cp .env.example .env`,
-		   kein services:-Block). Datengetriebene Admin-Seiten sind dort nicht
-		   prüfbar. Das ausdrücklich zu überspringen ist ehrlicher als ein Scan
-		   über eine Fehlerseite — und es steht im Report, statt still grün zu
-		   sein. Wer die Routen auch in CI abdecken will, hängt einen
-		   Postgres-Service in den Job; dann greift dieser Zweig nicht mehr. */
+		/* Seit dem 2026-07-30 fährt der E2E-Job einen Postgres-Service samt
+		   Migrationen und Seed (ci.yml, Job `e2e`). Dieser Zweig ist damit **nur
+		   noch** der lokale Komfortpfad für einen Lauf ohne `npm run db:start`.
+
+		   In CI ist er ausdrücklich ein Fehler und kein Skip: Ein übersprungener
+		   Test in CI ist kein Test, und übersprungen wären ausgerechnet die zwei
+		   datenreichsten Seiten — Datentabelle, Statusbadges, `stat-value`,
+		   Paginierung. Dass die vier übrigen Routen sauber sind, sagt darüber
+		   nichts. */
 		if (route.needsDb && !(await databaseAvailable(request))) {
+			if (process.env.CI) {
+				throw new Error(
+					`${route.path} braucht eine Datenbank, und /api/map/sightings antwortet nicht. ` +
+						'In CI ist das ein Fehler: Der `e2e`-Job startet einen Postgres-Service, wendet die ' +
+						'Migrationen an und legt Testdaten an (ci.yml). Schlägt die Sonde hier fehl, ist einer ' +
+						'dieser Schritte kaputt — nicht die Route.'
+				);
+			}
 			test.skip(
 				true,
-				`${route.path} braucht eine Datenbank, und /api/map/sightings antwortet nicht — CI fährt E2E ohne Postgres. Die Route bleibt ungeprüft.`
+				`${route.path} braucht eine Datenbank, und /api/map/sightings antwortet nicht. Lokal: npm run db:start && npm run db:push. In CI wäre das ein harter Fehler.`
 			);
 		}
 
@@ -397,6 +492,44 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 		}
 	};
 
+	/* Trennt Ernten von Bewerten: Der Browser gibt nur Klassenlisten heraus,
+	   gefiltert wird in Node mit den Regeln aus `helpers/bannedClasses.ts` — also
+	   mit demselben Code, den `bannedClasses.test.ts` an konstruierten Beispielen
+	   prüft. Vorher stand je Regel ein Regex-Literal in einem eigenen
+	   `page.evaluate()`; drei Kopien einer Grenzbedingung sind drei Orte, an denen
+	   sie schiefgehen kann. */
+	const harvestClasses = (page: Page): Promise<ScannedElement[]> =>
+		page.evaluate(() =>
+			[...document.querySelectorAll('[class]')].map((el) => ({
+				tag: el.tagName.toLowerCase(),
+				/* getAttribute('class'), NICHT el.className: bei SVG-Elementen ist
+				   className ein SVGAnimatedString, das als "[object SVGAnimatedString]"
+				   stringifiziert — der Scan würde ausgerechnet die Icons verfehlen, für
+				   die die Statusfarben-Regel gedacht ist (Icon.svelte rendert
+				   <svg class="…">). */
+				classes: el.getAttribute('class') ?? '',
+				hasText: (el.textContent ?? '').trim().length > 0
+			}))
+		);
+
+	const scanRoute = async (
+		fixtures: ScanFixtures,
+		route: ScanRoute
+	): Promise<ScannedElement[]> => {
+		await openRoute(fixtures, route);
+
+		for (const probe of route.renders ?? []) {
+			expect(
+				await fixtures.page.locator(probe.selector).count(),
+				`${route.path} rendert keine ${probe.what} (mindestens ${probe.min} erwartet, Selektor: ${probe.selector}). ` +
+					'Der Scan hätte damit ein DOM ohne verbotene Kombination gemessen und wäre grün geworden, ohne die Seite gesehen zu haben. ' +
+					'Prüfe den Seed (npm run db:seed:e2e) und den Server-Load der Route.'
+			).toBeGreaterThanOrEqual(probe.min);
+		}
+
+		return harvestClasses(fixtures.page);
+	};
+
 	for (const route of ROUTES) {
 		test(`${route.path}: keine Statusfarbe als Textfarbe`, async ({
 			page,
@@ -404,23 +537,8 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			request,
 			baseURL
 		}) => {
-			await openRoute({ page, context, request, baseURL }, route);
-			const offenders = await page.evaluate(() => {
-				/* getAttribute('class'), NICHT el.className: bei SVG-Elementen ist
-				   className ein SVGAnimatedString, das als "[object SVGAnimatedString]"
-				   stringifiziert — der Scan würde ausgerechnet die Icons verfehlen, für
-				   die diese Regel gedacht ist (Icon.svelte rendert <svg class="…">). */
-				const cls = (el: Element) => el.getAttribute('class') ?? '';
-				const banned = /(^|\s)text-(info|success|warning|secondary|accent)(\s|$)/;
-				return [...document.querySelectorAll('[class]')]
-					.filter((el) => banned.test(cls(el)))
-					.map((el) => `${el.tagName.toLowerCase()}.${cls(el)}`)
-					.slice(0, 20);
-			});
-			expect(
-				offenders,
-				'Flächen-Statusfarben als Vordergrund verwenden — stattdessen text-*-strong'
-			).toEqual([]);
+			const elements = await scanRoute({ page, context, request, baseURL }, route);
+			expect(findOffenders(STATUS_AS_FOREGROUND, elements), STATUS_AS_FOREGROUND.hint).toEqual([]);
 		});
 
 		test(`${route.path}: keine Textfarbe unter Deckkraft /60`, async ({
@@ -429,16 +547,8 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			request,
 			baseURL
 		}) => {
-			await openRoute({ page, context, request, baseURL }, route);
-			const offenders = await page.evaluate(() => {
-				const cls = (el: Element) => el.getAttribute('class') ?? '';
-				const banned = /(^|\s)(text-base-content\/(40|50)|opacity-(40|50))(\s|$)/;
-				return [...document.querySelectorAll('[class]')]
-					.filter((el) => banned.test(cls(el)) && (el.textContent ?? '').trim().length > 0)
-					.map((el) => `${el.tagName.toLowerCase()}.${cls(el)}`)
-					.slice(0, 20);
-			});
-			expect(offenders, '/40 und /50 sind dekorativ, nicht für Text').toEqual([]);
+			const elements = await scanRoute({ page, context, request, baseURL }, route);
+			expect(findOffenders(BELOW_OPACITY_FLOOR, elements), BELOW_OPACITY_FLOOR.hint).toEqual([]);
 		});
 
 		test(`${route.path}: keine Tailwind-Paletten-Farben`, async ({
@@ -447,17 +557,8 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			request,
 			baseURL
 		}) => {
-			await openRoute({ page, context, request, baseURL }, route);
-			const offenders = await page.evaluate(() => {
-				const cls = (el: Element) => el.getAttribute('class') ?? '';
-				const banned =
-					/(^|\s)(bg|text|border)-(gray|slate|zinc|red|green|blue|yellow|amber|emerald|sky|indigo|orange)-\d{2,3}(\s|$)/;
-				return [...document.querySelectorAll('[class]')]
-					.filter((el) => banned.test(cls(el)))
-					.map((el) => `${el.tagName.toLowerCase()}.${cls(el)}`)
-					.slice(0, 20);
-			});
-			expect(offenders, 'Theme-Tokens statt Tailwind-Palette (daisyui.md)').toEqual([]);
+			const elements = await scanRoute({ page, context, request, baseURL }, route);
+			expect(findOffenders(TAILWIND_PALETTE, elements), TAILWIND_PALETTE.hint).toEqual([]);
 		});
 	}
 });

--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -175,9 +175,21 @@ test.describe('Sichtung melden — Formular absenden', () => {
 		await expect(submitButton).toBeEnabled({ timeout: 3000 });
 	});
 
-	// This test requires a running database — skip in CI (no DB service configured)
+	/* Braucht eine echte Datenbank — der Test schreibt eine Sichtung.
+	   Läuft seit dem 2026-07-30 auch in CI: Der `e2e`-Job fährt einen
+	   Postgres-Service und setzt DATABASE_POSTGRES_URL auf Job-Ebene (ci.yml).
+
+	   Der Wächter liest bewusst `process.env` des **Testprozesses** und nicht den
+	   Zustand des Servers. Das ist eine Annahme, keine Messung: Lokal kann der von
+	   Playwright gestartete Dev-Server seine URL aus `.env` haben, während der
+	   Testprozess sie nicht in `process.env` sieht — dann überspringt dieser Test,
+	   obwohl eine Datenbank steht. Umgekehrt gilt dasselbe. Wer das genauer
+	   braucht, sondiert wie `design-tokens.spec.ts` über einen HTTP-Endpunkt. */
 	test('Submit sendet Formular und zeigt Erfolgsseite', async ({ page }) => {
-		test.skip(!process.env.DATABASE_POSTGRES_URL, 'Requires database connection (skipped in CI)');
+		test.skip(
+			!process.env.DATABASE_POSTGRES_URL,
+			'Braucht eine Datenbank — DATABASE_POSTGRES_URL ist im Testprozess nicht gesetzt'
+		);
 		const formPage = new FormPage(page);
 		await formPage.goto();
 

--- a/e2e/helpers/bannedClasses.test.ts
+++ b/e2e/helpers/bannedClasses.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+	BELOW_OPACITY_FLOOR,
+	findOffenders,
+	OPACITY_FLOOR,
+	STATUS_AS_FOREGROUND,
+	TAILWIND_PALETTE,
+	type ScannedElement
+} from './bannedClasses';
+
+/**
+ * bannedClasses.test.ts — die drei Scan-Regeln an konstruierten Beispielen.
+ *
+ * **Warum es diesen Test gibt.** Der DOM-Scan in `e2e/design-tokens.spec.ts`
+ * kann nur finden, was im Bestand steht. Ist der Bestand sauber, ist er grün —
+ * auch dann, wenn die Regel eine Lücke hat. Genau so ist die Deckkraft-Lücke
+ * entstanden: `text-success/80` war der einzige Fall im Code, wurde von Hand
+ * gefunden und behoben, und der Scan blieb grün, weil er das Suffix nie sehen
+ * konnte. Ein Scan über einen konformen Bestand belegt nichts über die Regel.
+ *
+ * Deshalb steht hier je Regel ein Beispiel, das die Lücke reproduziert, und ein
+ * Gegenbeispiel, das nicht anschlagen darf. Wer die Muster später „vereinfacht"
+ * und dabei das Deckkraft-Suffix wieder verliert, macht diese Datei rot — nicht
+ * erst den nächsten Reviewer.
+ *
+ * Läuft im Node-Projekt von Vitest (`npm run test:unit`, damit auch in
+ * `test:quick`) und braucht keinen Browser: die Regeln sind reine Funktionen
+ * über Klassennamen. Gemessen wird die *Farbe* weiter im Browser — das ist die
+ * Kontrast-Gruppe in `design-tokens.spec.ts`.
+ */
+
+/** Baut ein Element, wie es der Scan aus dem Browser mitbringt. */
+const element = (classes: string, hasText = true): ScannedElement => ({
+	tag: 'span',
+	classes,
+	hasText
+});
+
+describe('STATUS_AS_FOREGROUND', () => {
+	/* Der eigentliche Testfall dieses PR: die Klasse, die der alte Scan nicht
+	   sehen konnte. Sie ist keine Erfindung — sie stand in
+	   DropzoneEnhanced.svelte auf einem bg-success/10-Tint. */
+	it('meldet eine Statusfarbe mit Deckkraft-Suffix', () => {
+		expect(findOffenders(STATUS_AS_FOREGROUND, [element('text-success/80 font-mono')])).toEqual([
+			'<span> text-success/80 — in class="text-success/80 font-mono"'
+		]);
+	});
+
+	it('meldet die Statusfarbe auch ohne Suffix', () => {
+		expect(STATUS_AS_FOREGROUND.offends('text-warning')).toBe(true);
+	});
+
+	/* Die Verankerung ersetzt das `grep -v -- -strong`, an dem die
+	   „32 Fundstellen"-Liste in docs/DESIGN_SYSTEM.md gescheitert ist. */
+	it.each(['text-warning-strong', 'text-warning-content', 'text-success-strong/80'])(
+		'lässt %s durch',
+		(className) => {
+			expect(STATUS_AS_FOREGROUND.offends(className)).toBe(false);
+		}
+	);
+
+	/* primary (9,22:1) und error (6,04:1) sind als Textfarbe zulässig. Stünden
+	   sie im Muster, wäre die halbe App rot — und die Regel damit erledigt. */
+	it.each(['text-primary', 'text-error', 'bg-warning', 'bg-success/10'])(
+		'lässt %s durch',
+		(className) => {
+			expect(STATUS_AS_FOREGROUND.offends(className)).toBe(false);
+		}
+	);
+});
+
+describe('BELOW_OPACITY_FLOOR', () => {
+	/* /30 lag im Bestand (admin/statistics, Heatmap) und wäre von der alten
+	   Aufzählung (40|50) nie gemeldet worden. Die Schwelle findet jeden Wert
+	   darunter, nicht zwei Literale. */
+	it.each([10, 25, 30, 40, 50, OPACITY_FLOOR - 1])('meldet /%i auf Text', (opacity) => {
+		expect(BELOW_OPACITY_FLOOR.offends(`text-base-content/${opacity}`)).toBe(true);
+		expect(BELOW_OPACITY_FLOOR.offends(`opacity-${opacity}`)).toBe(true);
+	});
+
+	it.each([OPACITY_FLOOR, 70, 80, 100])('lässt /%i durch', (opacity) => {
+		expect(BELOW_OPACITY_FLOOR.offends(`text-base-content/${opacity}`)).toBe(false);
+		expect(BELOW_OPACITY_FLOOR.offends(`opacity-${opacity}`)).toBe(false);
+	});
+
+	/* Dekoration ist erlaubt — das leere Heatmap-Feld auf text-base-content/30
+	   und das Leerzustands-Icon auf opacity-50 sind genau dieser Fall. */
+	it('lässt ein Element ohne Textinhalt durch', () => {
+		expect(findOffenders(BELOW_OPACITY_FLOOR, [element('text-base-content/30', false)])).toEqual(
+			[]
+		);
+	});
+
+	it('meldet dasselbe Element, sobald es Text trägt', () => {
+		expect(findOffenders(BELOW_OPACITY_FLOOR, [element('text-base-content/30', true)])).toEqual([
+			'<span> text-base-content/30 — in class="text-base-content/30"'
+		]);
+	});
+});
+
+describe('TAILWIND_PALETTE', () => {
+	/* Mit Deckkraft umgeht die Paletten-Farbe das Theme genauso vollständig. */
+	it('meldet eine Paletten-Farbe mit Deckkraft-Suffix', () => {
+		expect(TAILWIND_PALETTE.offends('bg-red-500/50')).toBe(true);
+	});
+
+	it('meldet eine Paletten-Farbe ohne Suffix', () => {
+		expect(TAILWIND_PALETTE.offends('text-gray-700')).toBe(true);
+	});
+
+	/* base-200 ist ein Theme-Token und darf nicht an der Ziffernregel hängen
+	   bleiben; base-content/40 gehört der Regel oben. */
+	it.each(['bg-base-200', 'text-base-content/40', 'bg-primary', 'border-base-300'])(
+		'lässt %s durch',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+		}
+	);
+});
+
+describe('findOffenders', () => {
+	/* Zwei Verstöße in einer Klassenliste: bei der Vorgänger-Regex mit
+	   `(^|\s)…(\s|$)` verschluckte der erste Treffer das trennende Leerzeichen,
+	   der zweite war danach nicht mehr auffindbar. */
+	it('findet beide Verstöße in einer Klassenliste', () => {
+		expect(findOffenders(STATUS_AS_FOREGROUND, [element('text-info/70 p-2 text-accent')])).toEqual([
+			'<span> text-info/70 text-accent — in class="text-info/70 p-2 text-accent"'
+		]);
+	});
+
+	it('kürzt die Fundliste auf das Limit', () => {
+		const many = Array.from({ length: 5 }, () => element('text-warning'));
+		expect(findOffenders(STATUS_AS_FOREGROUND, many, 2)).toHaveLength(2);
+	});
+
+	it('meldet einen konformen Bestand als leer', () => {
+		expect(
+			findOffenders(STATUS_AS_FOREGROUND, [
+				element('text-warning-strong'),
+				element('bg-success/10 text-base-content')
+			])
+		).toEqual([]);
+	});
+});

--- a/e2e/helpers/bannedClasses.ts
+++ b/e2e/helpers/bannedClasses.ts
@@ -1,0 +1,169 @@
+/**
+ * bannedClasses.ts — die verbotenen Klassenkombinationen als Daten.
+ *
+ * **Warum eine eigene Datei.** Die drei Regeln standen vorher als
+ * Regex-Literale in `page.evaluate()`-Callbacks in `design-tokens.spec.ts`. Das
+ * hatte zwei Folgen: Sie waren nur über einen laufenden Browser prüfbar, und
+ * niemand konnte sie an einem konstruierten Beispiel scharf stellen. Die
+ * Deckkraft-Lücke (unten) ist genau daran über Monate unentdeckt geblieben —
+ * gefunden wurde sie von Hand, nicht vom Test.
+ *
+ * Hier stehen die Regeln deshalb als reine Funktionen, prüfbar in Node
+ * (`bannedClasses.test.ts`) und benutzt vom DOM-Scan. Der Browser sammelt nur
+ * noch die Klassenlisten ein; gefiltert wird in Node mit **demselben** Code, den
+ * der Unit-Test scharf stellt. Eine Regel, die eine Lücke hat, hat sie damit an
+ * genau einer Stelle.
+ *
+ * **Die geschlossene Lücke.** Die Vorgängerversion verlangte hinter dem
+ * Farbnamen ein Leerzeichen oder das Zeilenende (`(^|\s)text-success(\s|$)`).
+ * Ein Deckkraft-Suffix schiebt sich dazwischen, `text-success/80` rutschte also
+ * durch — und das ist keine Randnotiz: `text-success` misst auf `base-100`
+ * 3,81:1, mit `/80` weniger. Eine Statusfarbe mit Deckkraft auf einem Tint
+ * derselben Farbe ist die Fehlerklasse, für die die `*-content`-Regel überhaupt
+ * existiert, nur eine Ebene tiefer.
+ *
+ * Statt die Grenzen um ein optionales Suffix zu erweitern, splittet dieses Modul
+ * die Klassenliste vorher an Weißraum und prüft jede Klasse einzeln gegen ein
+ * verankertes Muster. Das ist zu `(^|\s)…(\s|$)` gleichwertig, hat aber kein
+ * Überlappungsproblem bei zwei Treffern in einer Liste und benennt in der
+ * Fehlermeldung die konkrete Klasse statt der ganzen Zeile.
+ *
+ * Referenz für die Werte: `.claude/rules/design-system.md`.
+ */
+
+/**
+ * Untergrenze der Deckkraft für Zeichen, die gelesen werden müssen.
+ *
+ * `base-content/60` misst 4,94:1 auf `base-100` und 4,62:1 auf `base-200`, `/50`
+ * nur noch 3,54 bzw. 3,39:1 (`design-system.md`, im Browser gemessen). Der Wert
+ * ist deshalb eine Schwelle und keine Aufzählung: Die Vorgängerversion kannte
+ * nur die Literale `40` und `50` und hätte ein `/30` oder `/25` genauso
+ * durchgelassen wie das `/80` oben.
+ */
+export const OPACITY_FLOOR = 60;
+
+/** Ein Element, wie der DOM-Scan es aus dem Browser mitbringt. */
+export interface ScannedElement {
+	/** Kleingeschriebener Tag-Name, nur für die Fehlermeldung. */
+	readonly tag: string;
+	/**
+	 * Der rohe `class`-Attributwert.
+	 *
+	 * Muss aus `getAttribute('class')` stammen, **nicht** aus `el.className`:
+	 * bei SVG-Elementen ist `className` ein `SVGAnimatedString` und
+	 * stringifiziert als `"[object SVGAnimatedString]"` — der Scan würde
+	 * ausgerechnet die Icons verfehlen, für die die Statusfarben-Regel gedacht
+	 * ist (`Icon.svelte` rendert `<svg class="…">`).
+	 */
+	readonly classes: string;
+	/** Trägt das Element (oder ein Nachfahre) sichtbaren Text? */
+	readonly hasText: boolean;
+}
+
+/** Eine verbotene Kombination, prüfbar an einer einzelnen Klasse. */
+export interface BannedRule {
+	/** Erscheint als Begründung in der Fehlermeldung des Tests. */
+	readonly hint: string;
+	/** Trifft auf **eine** Klasse zu (die Liste ist vorher gesplittet). */
+	readonly offends: (className: string) => boolean;
+	/**
+	 * Nur Elemente mit Textinhalt prüfen.
+	 *
+	 * Die Deckkraft-Untergrenze gilt laut `design-system.md` für Zeichen, die
+	 * gelesen werden müssen — ein dekoratives Leerzustands-Icon auf
+	 * `opacity-50` ist zulässig, und die Heatmap-Zelle auf
+	 * `text-base-content/30` in `admin/statistics` ist bei Intensität 0 leer.
+	 */
+	readonly textOnly?: boolean;
+}
+
+/**
+ * Statusfarben, die ausschließlich Flächenfarbe sind.
+ *
+ * `primary` und `error` fehlen bewusst: sie erreichen als Textfarbe 9,22:1 bzw.
+ * 6,04:1 auf `base-100` und sind dort erlaubt (`design-system.md`,
+ * „Statusfarben haben zwei Rollen"). Für Text gehört an die übrigen fünf ein
+ * `-strong` — das Muster unten schließt es über die Verankerung aus.
+ */
+const SURFACE_ONLY_COLORS = ['info', 'success', 'warning', 'secondary', 'accent'] as const;
+
+/** Optionales Tailwind-Deckkraft-Suffix, z. B. das `/80` in `text-success/80`. */
+const OPACITY_SUFFIX = String.raw`(?:\/\d{1,3})?`;
+
+const STATUS_AS_FOREGROUND_PATTERN = new RegExp(
+	String.raw`^text-(?:${SURFACE_ONLY_COLORS.join('|')})${OPACITY_SUFFIX}$`
+);
+
+/**
+ * Flächen-Statusfarbe als Vordergrund.
+ *
+ * Die Verankerung erledigt hier die Arbeit, die vorher ein `grep -v -- -strong`
+ * tun sollte: `text-warning-strong` und `text-warning-content` passen nicht auf
+ * `^text-warning(/\d+)?$` und werden deshalb nie gemeldet. Genau daran ist die
+ * „32 Fundstellen"-Liste in `docs/DESIGN_SYSTEM.md` gescheitert — `grep -o`
+ * schnitt das Suffix vor dem Filter ab.
+ */
+export const STATUS_AS_FOREGROUND: BannedRule = {
+	hint: 'Flächen-Statusfarben als Vordergrund verwenden — stattdessen text-*-strong. Bei dekorativen Icons und Zierelementen ist text-base-content/70 die richtige Antwort, nicht -strong.',
+	offends: (className) => STATUS_AS_FOREGROUND_PATTERN.test(className)
+};
+
+/**
+ * `text-base-content/<n>` und `opacity-<n>` — der Zahlwert wird verglichen, nicht
+ * aufgezählt.
+ */
+const OPACITY_BEARING_PATTERN = /^(?:text-base-content\/|opacity-)(\d{1,3})$/;
+
+/** Textfarbe unter der Deckkraft-Untergrenze. */
+export const BELOW_OPACITY_FLOOR: BannedRule = {
+	hint: `Deckkraft unter /${OPACITY_FLOOR} ist dekorativ, nicht für Text — Sekundärtext gehört auf /70`,
+	textOnly: true,
+	offends: (className) => {
+		const match = OPACITY_BEARING_PATTERN.exec(className);
+		return match !== null && Number(match[1]) < OPACITY_FLOOR;
+	}
+};
+
+/**
+ * Tailwind-Paletten-Farben am Theme vorbei.
+ *
+ * Das Deckkraft-Suffix ist hier aus demselben Grund optional wie oben:
+ * `bg-red-500/50` umgeht das Theme genauso vollständig wie `bg-red-500`.
+ */
+const TAILWIND_PALETTE_PATTERN = new RegExp(
+	String.raw`^(?:bg|text|border)-(?:gray|slate|zinc|red|green|blue|yellow|amber|emerald|sky|indigo|orange)-\d{2,3}${OPACITY_SUFFIX}$`
+);
+
+/** Tailwind-Paletten-Farbe statt Theme-Token. */
+export const TAILWIND_PALETTE: BannedRule = {
+	hint: 'Theme-Tokens statt Tailwind-Palette (daisyui.md)',
+	offends: (className) => TAILWIND_PALETTE_PATTERN.test(className)
+};
+
+/** Standardobergrenze für die Fundliste — mehr als 20 Zeilen liest niemand. */
+const DEFAULT_LIMIT = 20;
+
+/**
+ * Meldet die Aufrufstellen, die gegen `rule` verstoßen.
+ *
+ * @returns Liste der Fundstellen (leer = konform), auf `limit` gekürzt.
+ */
+export function findOffenders(
+	rule: BannedRule,
+	elements: readonly ScannedElement[],
+	limit = DEFAULT_LIMIT
+): string[] {
+	const offenders: string[] = [];
+
+	for (const element of elements) {
+		if (rule.textOnly && !element.hasText) continue;
+
+		const offending = element.classes.split(/\s+/).filter((name) => name && rule.offends(name));
+		if (offending.length === 0) continue;
+
+		offenders.push(`<${element.tag}> ${offending.join(' ')} — in class="${element.classes}"`);
+		if (offenders.length >= limit) break;
+	}
+
+	return offenders;
+}

--- a/e2e/map-lazy-loading.spec.ts
+++ b/e2e/map-lazy-loading.spec.ts
@@ -8,7 +8,9 @@ const isCI = process.env.CI === 'true';
 
 test.describe('Map Page', () => {
 	test('loads map page and shows content', async ({ page }) => {
-		// Mock sightings API — CI has no real database
+		// Mock sightings API — der Test prüft das Nachladen der Karten-Komponente,
+		// nicht die Daten. Seit dem 2026-07-30 steht in CI eine Datenbank (ci.yml);
+		// der Mock bleibt, damit dieser Test unabhängig von ihrem Inhalt ist.
 		await mockMapSightingsSuccess(page);
 		const mapPage = new MapPage(page);
 		await mapPage.goto();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
 		"db:push": "drizzle-kit push",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "node scripts/docker-migrate.ts",
+		"db:seed:e2e": "node scripts/seed-e2e.ts",
+		"db:seed:e2e:purge": "node scripts/seed-e2e.ts --purge",
 		"db:studio": "drizzle-kit studio",
 		"generate:licenses": "node src/tools/generate-license-notices.js",
 		"license:check": "license-checker --summary",

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -1,0 +1,319 @@
+/**
+ * Testdaten für die E2E-Läufe gegen eine frische Datenbank.
+ *
+ * **Warum es das braucht.** Der DOM-Scan in `e2e/design-tokens.spec.ts` fährt
+ * `/admin` und `/admin/statistics` mit. Beide Seiten rendern ausschließlich, was
+ * die Datenbank hergibt — eine leere Tabelle liefert ein DOM ohne eine einzige
+ * verbotene Kombination. Der Scan wäre dann grün, ohne die Muster je gesehen zu
+ * haben, um die es geht: Datentabelle, Zebra-Streifen, Statusbadges,
+ * `stat-value`, Paginierung. „Vakuum-grün" ist schlechter als rot, weil es
+ * niemandem auffällt.
+ *
+ * Ein Datensatz genügt dafür nicht. Die Menge hier ist auf drei Schwellen
+ * ausgelegt, die alle drei überschritten werden müssen:
+ *
+ * 1. **Mehr als eine Seite** — die Paginierung rendert immer, aber bei einer
+ *    Seite ist jede Navigations-Schaltfläche deaktiviert. `defaultPageSize` ist
+ *    50 (`configService.ts`), also braucht es > 50 Zeilen.
+ * 2. **Mehr als eine Zeile** — sonst gibt es kein Zebra-Streifen-Paar.
+ * 3. **Mehrere Jahre** — die Spalte „Entwicklung" der Jahrestrend-Tabelle
+ *    rechnet gegen das Vorjahr und bleibt bei einem einzigen Jahr leer.
+ *
+ * **Idempotent über einen Marker.** Alle Zeilen tragen
+ * `kommentar_intern = 'e2e-seed'` und werden vor dem Einfügen darüber gelöscht.
+ * Das macht den Lauf wiederholbar und die Zeilen in einer Entwickler-Datenbank
+ * jederzeit wieder entfernbar (`--purge`) — die lokale DB ist laut
+ * `docs/WORKTREES.md` über alle Worktrees geteilt, ein Seed ohne Rückweg wäre
+ * dort keine gute Idee.
+ *
+ * Ausführung: `npm run db:seed:e2e` (Node ≥ 22.18, natives Type Stripping —
+ * dasselbe Verfahren wie `scripts/docker-migrate.ts`).
+ */
+import postgres from 'postgres';
+
+/** Erkennungsmerkmal der Seed-Zeilen. Nicht ändern — `--purge` hängt daran. */
+const SEED_MARKER = 'e2e-seed';
+
+/**
+ * Zeilenzahl. 60 > 50 (`defaultPageSize`) ergibt genau zwei Seiten — die
+ * kleinste Menge, die eine bedienbare Paginierung belegt.
+ */
+const ROW_COUNT = 60;
+
+/** Kalenderjahre der Sichtungsdaten (Jahrestrends brauchen mindestens zwei). */
+const YEARS = [2024, 2025, 2026];
+
+/**
+ * `tierart`-Werte aus `SpeciesEnum` (`src/lib/report/formOptions/species.ts`):
+ * Schweinswal, Kegelrobbe, Seehund, Delphin, Zwergwal. Bewusst echte Codes —
+ * ein unbekannter Wert würde in der Artenverteilung als „Nicht angegeben"
+ * erscheinen und die Tabelle wertlos machen.
+ */
+const SPECIES = [0, 1, 2, 3, 5];
+
+/**
+ * Melder-Adressen. Sechs Adressen auf 60 Zeilen heißt zehn Meldungen je
+ * Adresse — `repeatUsers` und `topObservers` filtern auf `COUNT(*) > 1`, und
+ * `topObservers` schließt `%@meeresmuseum.de` ausdrücklich aus.
+ */
+const REPORTER_EMAILS = [
+	'anke.b@example.invalid',
+	'bengt.c@example.invalid',
+	'clara.d@example.invalid',
+	'dorte.e@example.invalid',
+	'eike.f@example.invalid',
+	'frida.g@example.invalid'
+];
+
+const SHIP_NAMES = ['MS Seeadler', 'MS Kranich', 'MS Möwe'];
+
+/** Positionen in der westlichen Ostsee — plausibel, damit /map etwas zeigt. */
+const POSITIONS = [
+	{ lat: 54.31, lon: 12.09 },
+	{ lat: 54.52, lon: 13.64 },
+	{ lat: 54.09, lon: 11.31 },
+	{ lat: 54.78, lon: 14.02 },
+	{ lat: 54.44, lon: 12.71 }
+];
+
+interface SeedRow {
+	sichtungsdatum: Date;
+	created: Date;
+	tierart: number;
+	anzahl_gesamt: number;
+	anzahl_jung: number;
+	entfernung: number;
+	verteilung: number;
+	verhalten: number;
+	seegang: number;
+	sichtweite: number;
+	gps_breite: string;
+	gps_laenge: string;
+	geprueft: number;
+	freigegeben_am: Date | null;
+	totfund: number;
+	aufnahmeHochladen: number;
+	ostsee_geo: number;
+	email: string;
+	schiffsname: string | null;
+	windrichtung: string;
+	windstaerke: string;
+	referenz_id: string;
+	eingangskanal: number;
+	kommentar_intern: string;
+}
+
+/**
+ * Baut die Zeilen deterministisch.
+ *
+ * Bewusst ohne Zufall: Ein Seed, der bei jedem Lauf andere Zahlen erzeugt, macht
+ * einen fehlgeschlagenen CI-Lauf nicht reproduzierbar — und die Streuung, auf die
+ * es hier ankommt, ist keine statistische, sondern eine über die Zustände der
+ * Oberfläche (geprüft/ungeprüft, freigegeben/offen, Totfund, mit Aufnahme).
+ *
+ * @param now - Bezugszeitpunkt für die „letzte 30 Tage"-Werte (Heatmap)
+ */
+function buildRows(now: Date): SeedRow[] {
+	return Array.from({ length: ROW_COUNT }, (_, i) => {
+		const year = YEARS[i % YEARS.length];
+		/* 10:30 UTC liegt in beiden Zeitzonen-Auslegungen im selben Kalendertag —
+		   `sichtungsdatum` hält UTC, gruppiert wird in Berliner Ortszeit
+		   (`sqlTimeZone.ts`). Eine Sichtung um 00:30 Ortszeit würde je nach
+		   Auslegung ins Vorjahr rutschen und die Jahreszählung unscharf machen. */
+		const sichtungsdatum = new Date(Date.UTC(year, i % 12, (i % 27) + 1, 10, 30));
+
+		/* Das letzte Drittel meldet „gerade eben": Die Aktivitäts-Heatmap auf
+		   /admin/statistics wertet `created` der letzten 30 Tage aus und wäre
+		   sonst durchgehend auf Intensität 0 — also ohne einen einzigen
+		   Vollton-Zustand im DOM. */
+		const isRecent = i >= ROW_COUNT - 20;
+		const created = isRecent
+			? new Date(now.getTime() - ((i % 20) + 1) * 24 * 60 * 60 * 1000)
+			: sichtungsdatum;
+
+		/* 48 geprüft, 12 ungeprüft. Alles, was die Statistik auswertet, filtert auf
+		   `geprueft = 1`; die ungeprüften halten den „Prüfen"-Zustand der Badges
+		   und Aktionsknöpfe in der Liste am Leben. */
+		const verified = i % 5 === 0 ? 0 : 1;
+
+		/* Freigegeben und offen müssen BEIDE vorkommen: basicStats läuft zweimal,
+		   einmal über `freigegeben_am IS NOT NULL` und einmal über IS NULL, und
+		   zeigt beide Blöcke getrennt an (approvalFilter.ts). Wäre eine der beiden
+		   Mengen leer, stünden dort Nullen — und Nullen sind kein Inhalt. */
+		const approved = verified === 1 && i % 2 === 0;
+
+		const position = POSITIONS[i % POSITIONS.length];
+
+		return {
+			sichtungsdatum,
+			created,
+			tierart: SPECIES[i % SPECIES.length],
+			anzahl_gesamt: 1 + (i % 7),
+			anzahl_jung: i % 3,
+			entfernung: 1 + (i % 4),
+			verteilung: 1 + (i % 3),
+			/* != 0, weil die Datenqualitäts-Kennzahl „mit Verhaltensangabe" genau
+			   darauf zählt (`ne(sightings.behavior, 0)`). */
+			verhalten: 1 + (i % 5),
+			seegang: i % 6,
+			sichtweite: 1 + (i % 3),
+			gps_breite: position.lat.toFixed(6),
+			gps_laenge: position.lon.toFixed(6),
+			geprueft: verified,
+			freigegeben_am: approved ? created : null,
+			totfund: i % 11 === 0 ? 1 : 0,
+			aufnahmeHochladen: i % 4 === 0 ? 1 : 0,
+			ostsee_geo: i % 9 === 0 ? 0 : 1,
+			email: REPORTER_EMAILS[i % REPORTER_EMAILS.length],
+			schiffsname: i % 3 === 0 ? SHIP_NAMES[i % SHIP_NAMES.length] : null,
+			windrichtung: ['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW'][i % 8],
+			windstaerke: String(1 + (i % 8)),
+			referenz_id: `E2E-${String(i + 1).padStart(3, '0')}`,
+			eingangskanal: i % 3,
+			kommentar_intern: SEED_MARKER
+		};
+	});
+}
+
+const COLUMNS = [
+	'sichtungsdatum',
+	'created',
+	'tierart',
+	'anzahl_gesamt',
+	'anzahl_jung',
+	'entfernung',
+	'verteilung',
+	'verhalten',
+	'seegang',
+	'sichtweite',
+	'gps_breite',
+	'gps_laenge',
+	'geprueft',
+	'freigegeben_am',
+	'totfund',
+	'aufnahmeHochladen',
+	'ostsee_geo',
+	'email',
+	'schiffsname',
+	'windrichtung',
+	'windstaerke',
+	'referenz_id',
+	'eingangskanal',
+	'kommentar_intern'
+] as const satisfies readonly (keyof SeedRow)[];
+
+/**
+ * Prüft, dass `COLUMNS` und die Felder von `SeedRow` sich vollständig decken.
+ *
+ * **Warum zur Laufzeit und nicht über den Typ.** Das `satisfies` oben deckt nur
+ * eine Richtung ab (jeder Eintrag ist ein gültiger Schlüssel) — und selbst das
+ * nur, wenn jemand die Datei typprüft. `npm run type-check` tut das **nicht**:
+ * `tsconfig.json` erbt sein `include` von `.svelte-kit/tsconfig.json`, und
+ * `scripts/` steht dort nicht drin. Nachgemessen mit `tsc --listFiles` — aus
+ * `scripts/` ist nur `docker-migrate.ts` im Programm, und das nur, weil ein Test
+ * unter `src/` es importiert. ESLint sieht die Datei (verifiziert), ist hier aber
+ * nicht typbewusst.
+ *
+ * Eine Zusicherung, die nicht ausgeführt wird, ist keine Zusicherung. Diese hier
+ * läuft bei jedem Seed-Lauf, also auch in CI.
+ *
+ * Der Fehlerfall ohne sie: Ein neues Feld in `SeedRow`, das in `COLUMNS` fehlt,
+ * wird stillschweigend nicht eingefügt. Die Spalte behält ihren Default, und
+ * auffallen würde es erst als „Seite rendert nichts" im E2E-Report — zwei
+ * Schritte von der Ursache entfernt.
+ */
+function assertColumnsMatch(row: SeedRow): void {
+	const fields = Object.keys(row);
+	const missing = fields.filter((field) => !COLUMNS.includes(field as (typeof COLUMNS)[number]));
+	const extra = COLUMNS.filter((column) => !fields.includes(column));
+
+	if (missing.length > 0 || extra.length > 0) {
+		throw new Error(
+			'COLUMNS und SeedRow sind nicht deckungsgleich — der Insert würde Felder stillschweigend verlieren. ' +
+				`In SeedRow, aber nicht in COLUMNS: [${missing.join(', ')}]. ` +
+				`In COLUMNS, aber nicht in SeedRow: [${extra.join(', ')}].`
+		);
+	}
+}
+
+async function main(): Promise<void> {
+	const url = process.env.DATABASE_POSTGRES_URL;
+	if (!url) {
+		throw new Error(
+			'DATABASE_POSTGRES_URL fehlt. Lokal steht die URL in .env, in CI setzt sie der e2e-Job (ci.yml).'
+		);
+	}
+
+	const purgeOnly = process.argv.includes('--purge');
+	const sql = postgres(url, { max: 1 });
+
+	try {
+		const deleted = await sql`
+			DELETE FROM sichtungen WHERE kommentar_intern = ${SEED_MARKER} RETURNING id
+		`;
+		console.log(`🧹 ${deleted.length} vorhandene Seed-Zeilen entfernt`);
+
+		if (purgeOnly) {
+			console.log('✅ --purge: nichts neu angelegt');
+			return;
+		}
+
+		const rows = buildRows(new Date());
+		const [firstRow] = rows;
+		if (!firstRow) throw new Error(`buildRows lieferte keine Zeile (ROW_COUNT = ${ROW_COUNT})`);
+		assertColumnsMatch(firstRow);
+		await sql`INSERT INTO sichtungen ${sql(rows, ...COLUMNS)}`;
+
+		/* `location` getrennt, weil der Wert aus einer PostGIS-Funktion kommt und
+		   nicht als Parameter im Bulk-Insert stehen kann. Ohne Geometrie liefert
+		   /api/map/sightings — die Datenbank-Sonde des DOM-Scans — keine Features,
+		   und /map bliebe leer. */
+		await sql`
+			UPDATE sichtungen
+			SET location = ST_SetSRID(ST_MakePoint(gps_laenge::float8, gps_breite::float8), 4326)
+			WHERE kommentar_intern = ${SEED_MARKER}
+		`;
+
+		/* Gegenprobe im Seed selbst: Ohne sie würde ein stillschweigend
+		   fehlgeschlagener Insert erst im E2E-Report als „Seite rendert keine
+		   Tabellenzeilen" auftauchen — zwei Schritte entfernt von der Ursache. */
+		const [summary] = await sql<
+			[{ total: number; verified: number; approved: number; years: number }]
+		>`
+			SELECT
+				COUNT(*)::int AS total,
+				COUNT(*) FILTER (WHERE geprueft = 1)::int AS verified,
+				COUNT(*) FILTER (WHERE freigegeben_am IS NOT NULL)::int AS approved,
+				COUNT(DISTINCT EXTRACT(year FROM sichtungsdatum AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin'))::int AS years
+			FROM sichtungen
+			WHERE kommentar_intern = ${SEED_MARKER}
+		`;
+
+		if (summary.total !== ROW_COUNT) {
+			throw new Error(`Seed hat ${summary.total} statt ${ROW_COUNT} Zeilen angelegt`);
+		}
+		if (summary.years < 2) {
+			throw new Error(
+				`Seed deckt nur ${summary.years} Jahr(e) ab — die Jahrestrend-Tabelle braucht mindestens zwei`
+			);
+		}
+		if (summary.approved === 0 || summary.approved === summary.verified) {
+			throw new Error(
+				'Seed enthält nicht beide Freigabezustände — die Statistik zeigt sonst einen leeren Block'
+			);
+		}
+
+		console.log(
+			`✅ ${summary.total} Sichtungen angelegt: ${summary.verified} geprüft, ${summary.approved} freigegeben, ${summary.years} Jahre`
+		);
+	} finally {
+		await sql.end();
+	}
+}
+
+try {
+	await main();
+} catch (error: unknown) {
+	console.error('[seed-e2e] FEHLER:', error instanceof Error ? error.message : error);
+	process.exit(1);
+}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -552,6 +552,12 @@ SOFTWARE.</pre>
 				Wir danken allen Entwicklern und Organisationen, die durch ihre Open Source Projekte diese
 				Plattform ermöglichen. Besonderer Dank gilt:
 			</p>
+			<!-- Die Trennpunkte zwischen den Links sind reine Zier: `aria-hidden`, weil
+			     Screenreader bisher „Svelte Team Bullet Tailwind Labs Bullet …" vorlasen,
+			     und `text-base-content/70` statt `opacity-30`, weil ein Punkt ein Zeichen
+			     und keine Fläche ist — die Deckkraft-Untergrenze /60 aus
+			     design-system.md gilt hier also. /70 ist die dort für Zierelemente
+			     vorgesehene Stufe. -->
 			<div class="flex flex-wrap justify-center gap-4 text-sm">
 				<a
 					href="https://svelte.dev"
@@ -559,28 +565,28 @@ SOFTWARE.</pre>
 					rel="noopener noreferrer"
 					class="link link-hover">Svelte Team</a
 				>
-				<span class="opacity-30">•</span>
+				<span class="text-base-content/70" aria-hidden="true">•</span>
 				<a
 					href="https://tailwindcss.com"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="link link-hover">Tailwind Labs</a
 				>
-				<span class="opacity-30">•</span>
+				<span class="text-base-content/70" aria-hidden="true">•</span>
 				<a
 					href="https://openlayers.org"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="link link-hover">OpenLayers Contributors</a
 				>
-				<span class="opacity-30">•</span>
+				<span class="text-base-content/70" aria-hidden="true">•</span>
 				<a
 					href="https://auth0.com"
 					target="_blank"
 					rel="noopener noreferrer"
 					class="link link-hover">Auth0</a
 				>
-				<span class="opacity-30">•</span>
+				<span class="text-base-content/70" aria-hidden="true">•</span>
 				<a
 					href="https://www.postgresql.org"
 					target="_blank"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -76,7 +76,15 @@ export default defineConfig({
 				test: {
 					name: 'server',
 					environment: 'node',
-					include: ['src/**/*.{test,spec}.{js,ts}'],
+					/* `e2e/helpers/` steht hier bewusst mit — und bewusst nur dieses
+					   Unterverzeichnis. Die Scan-Regeln aus `bannedClasses.ts` sind
+					   reine Funktionen über Klassennamen und gehören damit in
+					   `test:quick`, nicht erst in einen Playwright-Shard. Ein
+					   breiteres `e2e/**` würde dagegen die Playwright-Specs
+					   einsammeln (`e2e/basic.test.ts`, `e2e/homepage.test.ts`), die
+					   `@playwright/test` als Runner brauchen und unter Vitest
+					   scheitern. */
+					include: ['src/**/*.{test,spec}.{js,ts}', 'e2e/helpers/*.{test,spec}.{js,ts}'],
 					exclude: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 					setupFiles: ['./vitest-setup-server.ts'],
 					// Force UTC timezone for consistent date/time tests across environments


### PR DESCRIPTION
Schließt die beiden Löcher, die am Design-System-Wächter dokumentiert und offen waren.

## Teil 1 — Der Scan sah keine Deckkraft-Suffixe

Die Statusfarben-Regex verlangte hinter dem Farbnamen Leerzeichen oder Zeilenende, also rutschte `text-success/80` durch — die eine bekannte Fundstelle wurde von Hand gefunden, nicht vom Test. `text-success` misst auf `base-100` 3,81:1, mit `/80` weniger.

Alle drei Regeln fangen das Suffix jetzt mit. Sie sind dabei aus den `page.evaluate()`-Callbacks nach `e2e/helpers/bannedClasses.ts` gewandert, als reine Funktionen: **Ein Scan über einen konformen Bestand belegt nichts über die Regel** — genau so ist die Lücke entstanden. `bannedClasses.test.ts` stellt jede Regel an konstruierten Beispielen scharf und läuft in `npm run test:quick`.

Zwei Regeln haben mehr als ein Suffix bekommen:

- Die Deckkraft-Regel vergleicht gegen die **Schwelle /60** statt gegen die Literale `40|50` — `/30` rutschte vorher genauso durch wie `/80`.
- Jede Klasse wird **verankert** geprüft (Liste vorher an Weißraum gesplittet) statt innerhalb der Liste gematcht. Das behebt einen Überlappungsfehler, der einen zweiten Verstoß im selben `class`-Attribut verdeckte, und ersetzt das `grep -v -- -strong`, an dem die „32 Fundstellen"-Liste gescheitert ist.

Der erweiterte Scan wurde sofort rot — auf vier Trennpunkten in der Danksagung auf `/about` (`opacity-30`). Die tragen keine Bedeutung, also `text-base-content/70` **plus** `aria-hidden="true"`: Screenreader lasen dort bisher „Svelte Team Bullet Tailwind Labs Bullet …".

## Teil 2 — CI übersprang die zwei wichtigsten Admin-Routen

Der `e2e`-Job fuhr `cp .env.example .env` ohne Postgres, also übersprangen `/admin` und `/admin/statistics` — genau die Seiten mit Datentabelle, Statusbadges, `stat-value` und Paginierung. Dazu rund 50 s Wartezeit im Smoke-Shard durch Verbindungs-Timeouts.

Jetzt: `postgis/postgis:18-3.6`-Service (dasselbe Image wie `docker-compose.yml`; PostGIS ist Pflicht, weil `sichtungen.location` eine `geometry(point)`-Spalte ist), committete Migrationen, 60 Sichtungen über `npm run db:seed:e2e`.

Die 60 sind drei Schwellen, keine runde Zahl: **> 50** (`defaultPageSize`) für eine bedienbare Paginierung, **> 1 Zeile** für Zebra-Streifen, **≥ 2 Kalenderjahre** für die Spalte „Entwicklung". Der Seed ist über `kommentar_intern = 'e2e-seed'` idempotent und mit `npm run db:seed:e2e:purge` wieder entfernbar — die lokale DB ist über alle Worktrees geteilt.

Der Skip-Pfad bleibt für lokale Läufe ohne `npm run db:start`; **in CI wirft dieselbe Bedingung.** Ein übersprungener Test in CI ist kein Test.

Gegen „vakuum-grün": Eine leere Tabelle liefert ein DOM ohne eine einzige verbotene Kombination, Status < 500 belegt also nichts. Jede datengetriebene Route prüft jetzt Mindestinhalt — ≥ 10 Tabellenzeilen und ein **bedienbares** „Nächste Seite" auf `/admin`; ≥ 5 `stat-value`, ≥ 2 Jahreszeilen und ≥ 2 Zeilen Artenverteilung auf `/admin/statistics`.

## Gegenproben — grün allein zählt nicht

| Zusicherung | Gegenprobe |
| --- | --- |
| Regex fängt das Suffix | Injiziertes `text-success/80` macht den Scan rot; die alte Regex verfehlt es nachweislich |
| Unit-Test ist tragend | Jede der drei Verallgemeinerungen zurückgenommen → 2, 5 bzw. 1 Fall rot |
| Kein Vakuum-Grün | `/admin` mit Filter ohne Treffer: alle drei Klassen-Scans grün, **nur** die Sonde rot |
| Seed-Spaltenliste vollständig | Feld ohne Spalte und Spalte ohne Feld — beide Richtungen werfen mit Namen |
| CI-Pfad läuft | Migration + Seed + alle 7 Routen grün gegen einen Wegwerf-PostGIS-Container |
| Server liest die Seed-DB | Öffentliche API liefert genau 24 Features = die 24 freigegebenen Seed-Zeilen, nicht die Tausende der lokalen DB |
| `Setup environment` ist korrekt | In `ubuntu:24.04` gegen die echte `.env.example` gefahren — GNU und BSD `sed -i` unterscheiden sich |

Zwei Dinge, die dabei aufgefallen sind statt angenommen zu werden:

**Der Health-Check prüft über TCP.** `pg_isready` über den Unix-Socket meldete 4 s **vor** der Existenz der Datenbank „accepting connections" — der Entrypoint fährt während `initdb` einen temporären, nur auf dem Socket lauschenden Server, und dort laufen die Init-Skripte inklusive PostGIS. Danach war die Verbindung von außen noch mehrere Sekunden abgewiesen. Deshalb `-h 127.0.0.1` plus ein eigener Warteschritt, der explizit `postgis_version()` abfragt.

**Der Seed prüft seine Spaltenliste zur Laufzeit, nicht über Typen.** `tsconfig.json` erbt sein `include` von `.svelte-kit/tsconfig.json`, das `scripts/` nicht abdeckt — `npm run type-check` öffnet diese Datei nie (gemessen mit `tsc --listFiles`). Ein `satisfies` dort hätte wie eine Garantie ausgesehen und nichts durchgesetzt. Das ist dieselbe Fehlerklasse wie die Lücke, um die es in diesem PR geht.

**Nebeneffekt, verifiziert:** `form-submit.spec.ts` hat einen DB-abhängigen Submit-Test, der an `process.env.DATABASE_POSTGRES_URL` des *Testprozesses* hing und in CI immer übersprang. Er läuft jetzt, besteht und schreibt eine echte Zeile. Der veraltete Kommentar ist korrigiert und die Annahme, die er trifft, aufgeschrieben.

## Prüfstand

- `npm run test:quick`: 2301 Tests grün (inkl. der 30 neuen Regel-Tests)
- Alle drei E2E-Shards gegen die geseedete CI-DB: **209 grün, 0 übersprungen**
- `svelte-check`: 0 Fehler
- Doku nachgezogen: `docs/DESIGN_SYSTEM.md` und `.claude/rules/design-system.md` — die dort notierten Einschränkungen sind durch den neuen Stand ersetzt, samt der Regel „bei Fundstellen nicht mechanisch ersetzen".

## Folge-Issues — nicht in diesem PR umgesetzt

- #634 — Sitzung läuft still ab: Das Session-JWT erbt `exp` aus dem Auth0-Token, die gleitende `maxAge`-Verlängerung zieht es nicht mit.
- #635 — `SESSION_SECRET` allein genügt für eine Admin-Session.

Nicht als Issue angelegt, aber notiert: Die Paletten-Regel kann `bg-white`/`text-white`/`bg-black` strukturell nicht sehen (sie verlangt eine Farbstufe mit Ziffern) — 27 Fundstellen, von denen manche zu Recht so sind (Overlay-Schleier über Bildinhalt) und die deshalb einzeln bewertet werden müssen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
