### PR TITLE
fix(ui): close the white/black hole in the design-system scan

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -82,6 +82,21 @@ Verfügbar: `primary`, `secondary`, `accent`, `neutral`, `base-100/200/300`,
 `info`, `success`, `warning`, `error` — jeweils mit passendem `*-content` für Text
 **auf** dieser Farbe.
 
+**`bg-white`, `text-white` und `bg-black` gehören ausdrücklich zur verbotenen
+Palette** — auch mit Deckkraft-Suffix. Sie sehen harmloser aus als `bg-blue-700`,
+umgehen das Theme aber genauso vollständig, und der DOM-Scan konnte sie bis zum
+2026-07-30 strukturell nicht melden (Begründung in `design-system.md`). Die drei
+Ersatzfälle:
+
+| Bedarf                                     | Token                                 |
+| ------------------------------------------ | ------------------------------------- |
+| Helle Fläche (Karte, Codeblock, Platte)    | `bg-base-100`                         |
+| Dunkle Vollton-Fläche (helles Logo darauf) | `bg-neutral` + `text-neutral-content` |
+| Schleier über fremdem Inhalt               | `bg-scrim/<n>` + `text-on-scrim`      |
+
+`--scrim-surface`/`--scrim-foreground` stehen wie alle Farbwerte in
+`src/css/tokens.css`; `app.css` mappt sie im `@theme`-Block zu den Utilities.
+
 ---
 
 ## Kontraste sind handgeprüft — nicht beiläufig ändern

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -81,6 +81,8 @@ Die über 60 Verstöße des Altbestands sind mit PR 4/4 (#620) abgearbeitet; sei
 
 **Deckkraft-Suffixe werden mitgefangen** (seit 2026-07-30). `text-success/80` ist ein Verstoß wie `text-success`, und `bg-red-500/50` einer wie `bg-red-500`. Die Deckkraft-Regel vergleicht gegen die Schwelle /60 statt gegen die Literale 40 und 50 — ein `/30` auf Text ist damit ebenfalls ein Verstoß.
 
+**`white` und `black` ebenfalls** (seit 2026-07-30). `bg-white`, `text-white`, `bg-black` und deren Deckkraft-Varianten umgehen das Theme genauso vollständig wie `bg-gray-100`, wurden von der Paletten-Regel aber strukturell nie erfasst: Sie tragen keine Farbstufe, und das Muster verlangte hinter dem Farbnamen eine Ziffernfolge. Es ist dieselbe Fehlerklasse wie beim Deckkraft-Suffix — die Lücke saß in der Grammatik des Musters, nicht in der Aufzählung der Farben. Der Ersatz ist je nach Fall `bg-base-100`, `bg-neutral`/`text-neutral-content` oder `bg-scrim/<n>`/`text-on-scrim` (siehe „Schleier über fremdem Inhalt" unten).
+
 **Was der Scan nicht sieht:** `hover:`-Zustände (er liest den Ruhezustand — dafür gilt die Regel „`text-error` nicht auf `base-300`" unten) und `fill-`/`stroke-` (nur `text-` steht im Muster; im Bestand gibt es derzeit keine solche Fundstelle).
 
 **Beim Beheben nicht mechanisch ersetzen:** Erst prüfen, ob die Farbe an der Stelle Bedeutung trägt. Dekorative Icons und Zierelemente gehören auf `base-content/70` — nicht auf eine Statusfarbe mit `-strong`. Trägt ein Zeichen gar keine Bedeutung (Trennpunkt, Zierglyphe), gehört zusätzlich `aria-hidden="true"` daran; Beispiel: die Danksagungs-Trennpunkte in `src/routes/about/+page.svelte`.
@@ -352,6 +354,8 @@ Vor der Nutzung einer Utility prüfen, ob sie im Setup überhaupt existiert.
 - Neue eigene Utility (`text-*-strong`, `shadow-raised`, `text-support`, …) heißt: Eintrag im `@theme`-Block von `app.css`. Ein Token, das nur in `src/css/tokens.css` steht, ist eine CSS-Variable — **keine** Utility-Klasse. Fehlt der `@theme`-Eintrag, ist `class="text-warning-strong"` genau so tot wie `animate-in`.
 - **Und ein Feld auf `/styleguide`.** Tailwind erzeugt eine Utility nur, wenn ihr Name als vollständiger String im gescannten Quelltext steht — sieben der dreizehn eigenen Utilities haben ihre einzige Aufrufstelle auf dieser Seite. Ein dort gelöschtes Farbfeld nimmt die Klasse still aus dem Build. Abgesichert durch `e2e/design-tokens.spec.ts` → „Utilities haben einen Vertreter auf /styleguide": Der Test liest die Tokens aus `tokens.css` und verlangt für jeden ein Element mit der zugehörigen Klasse.
 
+  **`bg-scrim` und `text-on-scrim` stehen bewusst außerhalb dieser Gruppe.** Der Wächter zielt auf Utilities, deren einzige Aufrufstelle `/styleguide` ist — dort nimmt ein gelöschtes Farbfeld die Klasse still aus dem Build. Die Schleier-Utilities haben zehn Aufrufstellen in Komponenten; sie können nicht versehentlich verschwinden. Ein `UTILITY_GROUPS`-Eintrag würde außerdem ein Element mit dem unverdünnten `bg-scrim` auf der Seite erzwingen — eine Klasse, die es sonst nirgends gibt, nur damit ein Test grün wird. Wer den Schleier später auf `/styleguide` zeigen will (die Deckkraft-Tabelle oben wäre der Ort), kann die Gruppe nachziehen.
+
 ---
 
 ## Randbereiche: wo Hex-Werte erlaubt sind
@@ -365,6 +369,46 @@ Drei Bereiche dürfen Hex-Werte enthalten — aber jeweils nur an **einer** Stel
 | E-Mail-Templates  | Clients kennen `oklch()`/`color-mix()` nicht       | `src/lib/server/templates/emailTokens.ts` |
 
 Überall sonst gilt weiterhin: keine Hex-Werte, keine Tailwind-Paletten-Farben (`daisyui.md`). Abgesichert durch den DOM-Scan in `e2e/design-tokens.spec.ts`.
+
+**Der Overlay-Schleier ist bewusst _kein_ vierter Eintrag.** Er sah lange nach einem aus: `bg-black/50` hinter einem Medien-Modal ließ sich mit „das Theme kennt keine Abdunklung" begründen, und das stimmte sogar. Nur ist eine Abdunklung kein Fall, den ein Canvas oder ein E-Mail-Client erzwingt — sie war schlicht nie modelliert. Seit dem 2026-07-30 gibt es dafür ein Token (`--scrim-surface` → `bg-scrim/<n>`, `text-on-scrim`, siehe unten). Damit ist der Bereich kein Randbereich mehr, sondern normale Token-Nutzung, und die Paletten-Regel im Scan bleibt ausnahmslos.
+
+---
+
+## Schleier über fremdem Inhalt: `bg-scrim/<n>`
+
+Ein Schleier verdunkelt etwas, das die App nicht kennt — ein hochgeladenes Foto, ein Videobild, eine Kartenkachel, die Seite hinter einem Modal. Er ist damit **keine Fläche des Themes**, sondern eine Abschwächung dessen, was darunter liegt.
+
+```svelte
+<!-- ❌ FALSCH — umgeht das Theme, seit 2026-07-30 vom Scan gemeldet -->
+<div class="bg-black/40"><Icon icon="lucide:eye" class="text-white" /></div>
+
+<!-- ✅ RICHTIG -->
+<div class="bg-scrim/40"><Icon icon="lucide:eye" class="text-on-scrim" /></div>
+```
+
+Drei Punkte, die dabei regelmäßig verwechselt werden:
+
+- **Der Farbton gehört ins Token, die Deckkraft an die Aufrufstelle.** `--scrim-surface` ist neutrales Schwarz und **kein** Markenton: jede Farbe mit Chroma verschiebt den Farbton des Fotos darunter. Wie viel durchscheinen soll, hängt dagegen vom Bild ab und bleibt Komponentensache.
+- **`text-on-scrim`, nicht `*-content`.** Ein Schleier ist per Definition durchscheinend; `*-content` gilt laut der Regel ganz oben ausschließlich auf Vollton-Flächen. Der eigene Name hält beide Konventionen sauber getrennt.
+- **Ein Schleier ist nicht dasselbe wie eine Fläche, die zufällig hell oder dunkel sein muss.** Braucht ein Element eine helle Fläche (Logo-Platte, Codeblock), ist das `bg-base-100`; braucht es eine dunkle (weißes Logo darauf), ist das `bg-neutral` mit `text-neutral-content`. Nur wenn fremder Inhalt _durchscheinen_ soll, ist es ein Schleier.
+
+**Ein Schleier über einer bekannten Theme-Fläche ist ein Verdachtsfall, kein Schleier.** Genau daran hing der auffälligste Fehler des Bestands: In `MediaThumbnail.svelte` lag ein `bg-black/20` nicht über einem Foto, sondern über `bg-base-200` — das weiße Icon darauf erreichte 2,27:1 und verfehlte WCAG 1.4.11 (3:1). Ist der Untergrund bekannt, ist der Kontrast ausrechenbar und gehört ausgerechnet (dort jetzt `/60` = 7,34:1).
+
+### Trägt der Schleier einen Vordergrund, ist `/60` die Untergrenze
+
+Über fremdem Inhalt ist der Kontrast nicht bestimmt — aber sein **schlechtester Fall** ist es sehr wohl: ein Foto, das an der Stelle des Icons reinweiß ist. Weiß auf einem schwarzen Schleier über Weiß, gerechnet:
+
+| Schleier | Kontrast (weißer Vordergrund über weißem Bild) | WCAG 1.4.11 (3:1) |
+| -------- | ---------------------------------------------- | ----------------- |
+| `/20`    | 1,61:1                                         | ❌                |
+| `/30`    | 2,11:1                                         | ❌                |
+| `/40`    | 2,85:1                                         | ❌                |
+| `/50`    | 3,98:1                                         | ✅                |
+| `/60`    | **5,74:1**                                     | ✅                |
+
+**Regel:** Sobald auf dem Schleier selbst etwas Sichtbares liegt — Icon, Spinner, Text — gilt `bg-scrim/60` als Untergrenze. `/60` und nicht das gerade noch ausreichende `/50`, aus demselben Grund wie bei der Deckkraft-Untergrenze für Text: Der Wert soll nicht auf der Schwelle balancieren.
+
+Ausgenommen sind Schleier **ohne** eigenen Vordergrund. Ein reiner Modal-Backdrop (`MediaModal`, `DeleteDialog`, das Hilfe-Overlay in `SightingsMapView`) und ein inhaltsloser Hover-Hinweis (`MediaThumbnail`, Video-Zweig, `/20`) dürfen leichter sein — was dort gelesen werden muss, steht auf einer eigenen `bg-base-100`-Fläche darüber, nicht auf dem Schleier.
 
 ---
 

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -297,8 +297,52 @@ der Code sauber war, nicht weil die Regel griff.
 `e2e/helpers/bannedClasses.test.ts` stellt deshalb jede Regel an konstruierten
 Beispielen scharf und läuft in `npm run test:quick` mit. Die Gegenprobe dazu ist
 gefahren: Nimmt man das Deckkraft-Suffix aus dem Statusfarben-Muster, fallen
-2 von 30 Fällen; ersetzt man den Schwellenvergleich wieder durch die Aufzählung
-`(40|50)`, fallen 5.
+2 von 46 Fällen; ersetzt man den Schwellenvergleich wieder durch die Aufzählung
+`(40|50)`, fallen 5; nimmt man `white|black` aus dem Paletten-Muster, fallen 9.
+
+### Die zweite Lücke derselben Regel: `white` und `black`
+
+Beim Schließen der Deckkraft-Lücke fiel eine zweite auf, gleicher Bauart. Das
+Paletten-Muster verlangte hinter dem Farbnamen eine Farbstufe (`-\d{2,3}`) —
+`bg-white`, `text-white`, `bg-black` und ihre Deckkraft-Varianten tragen keine
+und konnten deshalb **strukturell** nie gemeldet werden. Nicht eine vergessene
+Farbe in der Aufzählung, sondern die Form des Musters: dieselbe Fehlerklasse wie
+das fehlende Suffix.
+
+Im Bestand standen 27 Fundstellen. Bewertet wurde jede einzeln, mit drei
+Ausgängen:
+
+| Fall                                         | Antwort                             | Beispiel                                       |
+| -------------------------------------------- | ----------------------------------- | ---------------------------------------------- |
+| Helle Fläche (Codeblock, Logo-Platte, Karte) | `bg-base-100`                       | Lizenztext auf `/about`, DMM-Platte auf `/map` |
+| Dunkle Vollton-Fläche (helles Logo darauf)   | `bg-neutral`/`text-neutral-content` | Auth0-Panel auf `/about` (Logo ist `#FFFEFA`)  |
+| Schleier über fremdem Inhalt                 | `bg-scrim/<n>`/`text-on-scrim`      | Modal-Backdrops, Foto- und Video-Overlays      |
+
+Der dritte Fall war der Grund, warum die Lücke plausibel aussah: Für „dunkle
+etwas anderes" gab es wirklich kein Token. Statt daraus eine Ausnahme in der
+Regel zu machen — über die Klassenliste allein ohnehin nicht entscheidbar, weil
+der Scan nicht sieht, was unter einem Element liegt — hat das Theme jetzt eines
+(`--scrim-surface` in `src/css/tokens.css`). Die Regel bleibt damit ausnahmslos.
+
+**Echte Fehler steckten darunter.** Der auffälligste: In `MediaThumbnail.svelte`
+lag ein `bg-black/20` nicht über einem Foto, sondern über `bg-base-200`. Das
+weiße Icon darauf erreichte 2,27:1 und verfehlte WCAG 1.4.11 (3:1). Steht jetzt
+auf `/60` (7,34:1).
+
+Der erste Anlauf hat daraus die falsche Regel abgeleitet — „bei bekanntem
+Untergrund ist der Kontrast ausrechenbar, über fremdem Inhalt nicht". Das stimmt
+für den _tatsächlichen_ Kontrast, aber nicht für den **schlechtesten Fall**: Ein
+Foto, das an der Stelle des Icons reinweiß ist, ist genauso ausrechenbar. Weiß
+auf `/40` über Weiß sind 2,85:1, auf `/30` sogar 2,11:1 — drei weitere Overlays
+(Foto- und Artfoto-Lupe, Upload-Spinner) lagen damit ebenfalls unter 3:1. Alle
+Schleier, die selbst einen Vordergrund tragen, stehen jetzt auf `/60` (5,74:1
+über Weiß); reine Backdrops ohne eigenen Vordergrund bleiben leichter. Die
+Untergrenze steht als Regel in `.claude/rules/design-system.md`.
+
+Die Reihenfolge war dabei nicht beliebig: Erst die 27 Fundstellen bewerten, dann
+die Regel schärfen. Andersherum wäre der Scan über mehrere Routen rot gewesen,
+bevor überhaupt entschieden war, was an jeder Stelle richtig ist — und der
+schnellste Weg zurück auf grün wäre das Aufweichen der Regel gewesen.
 
 ### Vollabdeckung in CI seit dem 2026-07-30
 

--- a/e2e/helpers/bannedClasses.test.ts
+++ b/e2e/helpers/bannedClasses.test.ts
@@ -108,6 +108,74 @@ describe('TAILWIND_PALETTE', () => {
 		expect(TAILWIND_PALETTE.offends('text-gray-700')).toBe(true);
 	});
 
+	/* Die zweite strukturelle Lücke derselben Regel, gefunden beim Schließen der
+	   Deckkraft-Lücke: `white` und `black` tragen keine Farbstufe, das `-\d{2,3}`
+	   im Muster konnte sie deshalb nie treffen. Sie umgehen das Theme aber
+	   genauso vollständig wie `bg-gray-100` — im Bestand standen 27 solche
+	   Fundstellen, darunter ein `bg-black/20` über `bg-base-200`, auf dem ein
+	   weißes Icon 2,27:1 erreichte.
+
+	   Deckkraft gehört ausdrücklich dazu: Ein Schleier ist der häufigste Fall,
+	   und genau er hat die Lücke jahrelang plausibel aussehen lassen. Die
+	   Antwort darauf ist `bg-scrim/<n>` (--scrim-surface in tokens.css), nicht
+	   eine Ausnahme in dieser Regel. */
+	it.each(['bg-white', 'text-white', 'bg-black', 'text-black', 'border-white'])(
+		'meldet %s',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(true);
+		}
+	);
+
+	it.each(['bg-black/50', 'bg-white/95', 'text-white/70', 'bg-black/5'])(
+		'meldet %s mit Deckkraft-Suffix',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(true);
+		}
+	);
+
+	/* Der Ersatz muss durchkommen, sonst ist die Regel unerfüllbar. */
+	it.each(['bg-scrim', 'bg-scrim/40', 'text-on-scrim', 'bg-neutral', 'text-neutral-content'])(
+		'lässt %s durch',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+		}
+	);
+
+	/* Die Aufzählung war auf die Töne beschränkt, die im Bestand vorkamen — zwölf
+	   von 22. Ein `bg-teal-500` wäre also durchgerutscht, ohne dass an der Regel
+	   etwas „kaputt" gewesen wäre. */
+	it.each([
+		'bg-stone-100',
+		'text-lime-600',
+		'bg-teal-500/40',
+		'text-cyan-700',
+		'bg-violet-400',
+		'text-purple-900',
+		'bg-fuchsia-300',
+		'text-pink-500',
+		'bg-rose-600',
+		'bg-neutral-500'
+	])('meldet %s', (className) => {
+		expect(TAILWIND_PALETTE.offends(className)).toBe(true);
+	});
+
+	/* `neutral` steht als Paletten-Ton in der Liste UND ist ein Theme-Token. Die
+	   Farbstufe im Muster trennt beide — sonst hätte das Schließen der einen
+	   Lücke die Ersatz-Klasse aus dem Auth0-Panel verboten. */
+	it.each(['bg-neutral', 'text-neutral-content', 'bg-neutral/50'])(
+		'lässt das Theme-Token %s durch',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+		}
+	);
+
+	/* Verankerung: `white`/`black` dürfen nicht als Teilwort anschlagen —
+	   `bg-whitesmoke` gibt es in Tailwind nicht, aber eine eigene Utility mit
+	   dem Präfix wäre kein Verstoß. */
+	it.each(['bg-whitesmoke', 'text-blackboard'])('lässt %s durch', (className) => {
+		expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+	});
+
 	/* base-200 ist ein Theme-Token und darf nicht an der Ziffernregel hängen
 	   bleiben; base-content/40 gehört der Regel oben. */
 	it.each(['bg-base-200', 'text-base-content/40', 'bg-primary', 'border-base-300'])(

--- a/e2e/helpers/bannedClasses.ts
+++ b/e2e/helpers/bannedClasses.ts
@@ -125,18 +125,85 @@ export const BELOW_OPACITY_FLOOR: BannedRule = {
 };
 
 /**
+ * Farbstufige Paletten-Farbtöne — `bg-red-500`, `text-gray-700`.
+ *
+ * **Vollständig, nicht nach Bestand.** Die Liste enthielt zwölf der 22 Töne aus
+ * Tailwind 4 — die zehn fehlenden (`stone`, `neutral`, `lime`, `teal`, `cyan`,
+ * `violet`, `purple`, `fuchsia`, `pink`, `rose`) hatten schlicht keine
+ * Fundstelle. Das ist die Lücke-in-den-Daten-Variante genau des Fehlers, dessen
+ * Grammatik-Variante diese Datei sonst beschreibt: Eine Regel, die nur die
+ * Farben kennt, die schon jemand benutzt hat, meldet die erste neue nicht.
+ *
+ * `neutral` ist der einzige Eintrag, der auch ein Theme-Token ist. Das ist
+ * folgenlos, weil das Muster hinter dem Ton eine Farbstufe verlangt:
+ * `bg-neutral-500` (Palette) schlägt an, `bg-neutral` und `text-neutral-content`
+ * (Theme) nicht.
+ */
+const PALETTE_HUES = [
+	'slate',
+	'gray',
+	'zinc',
+	'neutral',
+	'stone',
+	'red',
+	'orange',
+	'amber',
+	'yellow',
+	'lime',
+	'green',
+	'emerald',
+	'teal',
+	'cyan',
+	'sky',
+	'blue',
+	'indigo',
+	'violet',
+	'purple',
+	'fuchsia',
+	'pink',
+	'rose'
+] as const;
+
+/**
  * Tailwind-Paletten-Farben am Theme vorbei.
  *
  * Das Deckkraft-Suffix ist hier aus demselben Grund optional wie oben:
  * `bg-red-500/50` umgeht das Theme genauso vollständig wie `bg-red-500`.
+ *
+ * **`white` und `black` stehen als eigene Alternative im Muster** (seit
+ * 2026-07-30) und nicht bei den Farbtönen oben. Das ist keine Kosmetik, sondern
+ * der Grund, warum die Regel sie über Monate nicht melden konnte: Beide tragen
+ * keine Farbstufe, und das `-\d{2,3}` hinter dem Farbton hat sie deshalb
+ * strukturell verfehlt — nicht durch eine vergessene Zeile in der Aufzählung,
+ * sondern durch die Form des Musters. Dieselbe Fehlerklasse wie beim
+ * Deckkraft-Suffix darüber: Die Lücke saß in der Grammatik, nicht in den Daten.
+ *
+ * Umgangen wird das Theme dabei genauso vollständig. Im Bestand standen 27
+ * Fundstellen; die schädlichste war ein `bg-black/20` über `bg-base-200` in
+ * `MediaThumbnail.svelte`, auf dem ein weißes Icon 2,27:1 erreichte — hier ist
+ * die Regel also nicht nur formal im Recht.
+ *
+ * **Warum es dafür keine Ausnahme gibt.** Der häufigste Fall war ein
+ * Overlay-Schleier über fremdem Inhalt (Foto, Videobild, Kartenkachel, Seite
+ * hinter einem Modal), und für den galt bis dahin zu Recht „das Theme kennt
+ * keine Abdunklung". Genau diese plausible Ausnahme hat die Lücke am Leben
+ * gehalten und die echten Fehler mit durchgelassen. Statt sie hier
+ * festzuschreiben, hat das Theme jetzt ein Token dafür (`--scrim-surface` in
+ * `src/css/tokens.css` → `bg-scrim/<n>`, `text-on-scrim`). Damit hat jede
+ * Aufrufstelle eine Antwort, und die Regel bleibt ausnahmslos — eine Regel mit
+ * Ausnahme wäre über die Klassenliste allein ohnehin nicht entscheidbar, weil
+ * der Scan nicht sieht, was unter einem Element liegt.
+ *
+ * Die Verankerung trägt `white`/`black` als ganzes Wort: `bg-whitesmoke` (oder
+ * eine eigene Utility mit diesem Präfix) ist kein Verstoß.
  */
 const TAILWIND_PALETTE_PATTERN = new RegExp(
-	String.raw`^(?:bg|text|border)-(?:gray|slate|zinc|red|green|blue|yellow|amber|emerald|sky|indigo|orange)-\d{2,3}${OPACITY_SUFFIX}$`
+	String.raw`^(?:bg|text|border)-(?:(?:${PALETTE_HUES.join('|')})-\d{2,3}|white|black)${OPACITY_SUFFIX}$`
 );
 
 /** Tailwind-Paletten-Farbe statt Theme-Token. */
 export const TAILWIND_PALETTE: BannedRule = {
-	hint: 'Theme-Tokens statt Tailwind-Palette (daisyui.md)',
+	hint: 'Theme-Tokens statt Tailwind-Palette (daisyui.md). Für white/black: eine helle oder dunkle Vollton-Fläche ist bg-base-100 bzw. bg-neutral (mit *-content); ein Schleier über fremdem Inhalt ist bg-scrim/<n> mit text-on-scrim.',
 	offends: (className) => TAILWIND_PALETTE_PATTERN.test(className)
 };
 

--- a/src/app.css
+++ b/src/app.css
@@ -127,6 +127,13 @@
 	--color-secondary-strong: var(--brand-sea-400);
 	--color-accent-strong: var(--status-accent-strong);
 
+	/* Schleier über fremdem Inhalt (Foto, Videobild, Kartenkachel, Seite hinter
+	   einem Modal). Begründung des Werts steht an --scrim-surface in tokens.css;
+	   hier steht er, damit `bg-scrim/40` und `text-on-scrim` als Utilities
+	   existieren. */
+	--color-scrim: var(--scrim-surface);
+	--color-on-scrim: var(--scrim-foreground);
+
 	--shadow-raised: var(--elevation-raised);
 	--shadow-floating: var(--elevation-floating);
 

--- a/src/css/tokens.css
+++ b/src/css/tokens.css
@@ -63,6 +63,34 @@
 	     beides: Fläche (weiß darauf 7,20) und Vordergrund (6,05 / 5,01). */
 	--status-accent-strong: oklch(0.475 0.047 215); /* #3c636d  5,52 / 4,57 */
 
+	/* Overlay-Schleier. Kein Markenton, und das ist der Punkt: Ein Schleier ist
+	   keine Fläche, sondern eine ABDUNKLUNG von etwas Fremdem — einem Foto, einem
+	   Videobild, der Kartenkachel, der Seite hinter einem Modal. Jede Farbe mit
+	   Chroma verschiebt dabei den Farbton dessen, was darunter liegt; ein
+	   blaustichiger Schleier macht aus einem Schweinswalfoto ein blaustichiges
+	   Schweinswalfoto. Neutrales Schwarz ist der einzige Ton, der nur die
+	   Helligkeit senkt.
+
+	   Deshalb steht der Wert hier und nicht als `bg-black/40` in neun
+	   Komponenten: „das Theme kennt keine Abdunklung" war jahrelang die
+	   Begründung dafür, an dieser einen Stelle an der Palette vorbeizugreifen —
+	   und damit die Lücke, durch die auch echte Fehler durchrutschten
+	   (`bg-black/20` über `bg-base-200` in MediaThumbnail: weißes Icon auf
+	   2,27:1). Mit einem Token gibt es die Ausnahme nicht mehr, und die
+	   Scan-Regel in `e2e/helpers/bannedClasses.ts` kann `black`/`white`
+	   ausnahmslos verbieten.
+
+	   Die Deckkraft bleibt an der Aufrufstelle (`bg-scrim/40`): sie hängt davon
+	   ab, wie viel vom Untergrund noch lesbar sein soll, und ist damit
+	   Komponentensache — anders als der Farbton. */
+	--scrim-surface: oklch(0 0 0);
+	/* Vordergrund AUF einem Schleier. Bewusst nicht `--color-scrim-content`:
+	   `*-content` gehört laut design-system.md ausschließlich auf Vollton-
+	   Flächen, und ein Schleier ist per Definition durchscheinend. Der Name
+	   `text-on-scrim` sagt an der Aufrufstelle dasselbe, ohne die Konvention zu
+	   verwässern, gegen die die `*-content`-Regel steht. */
+	--scrim-foreground: oklch(1 0 0);
+
 	/* ── Ebene 2: semantische Tokens ────────────────────────────────────── */
 
 	/* Vordergrund-Statusfarben. In Komponenten als text-info-strong,
@@ -75,6 +103,11 @@
 	   --brand-sea-400 (#42626a). Gemessen 5,54 / 4,58. */
 	--color-secondary-strong: var(--brand-sea-400);
 	--color-accent-strong: var(--status-accent-strong);
+
+	/* Schleier und sein Vordergrund. In Komponenten als bg-scrim/<n> und
+	   text-on-scrim verfügbar (siehe @theme-Block in app.css). */
+	--color-scrim: var(--scrim-surface);
+	--color-on-scrim: var(--scrim-foreground);
 
 	/* Typografie — sechs Rollen. Keine freien text-*-Utilities mehr für
 	   Fließtext und Überschriften.

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -31,9 +31,10 @@
      Statusänderung ansagen; der Inhalt wird nur bei Sichtbarkeit gerendert. -->
 <div role="status" aria-live="polite">
 	{#if isVisible}
-		<!-- Backdrop (rein visuell) -->
+		<!-- Backdrop (rein visuell). Schleier über der Kartenkachel, kein Theme-Ton:
+		     bg-scrim/<n> (--scrim-surface in tokens.css). -->
 		<div
-			class="animate-fade-in fixed inset-0 z-40 bg-black/30 backdrop-blur-sm transition-all duration-300"
+			class="animate-fade-in bg-scrim/30 fixed inset-0 z-40 backdrop-blur-sm transition-all duration-300"
 		></div>
 
 		<!-- Loading Content -->

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -903,8 +903,13 @@
 	<!-- Logo (unten rechts) - optional -->
 	{#if showLogo}
 		<div class="group absolute right-1 bottom-6 z-30">
+			<!-- Helle Platte, weil /dmm-logo.png durchgängig dunkel auf transparent
+			     zeichnet (nachgemessen: 14.097 deckende Pixel, alle unter L 128) und
+			     über dunklen Kacheln sonst verschwindet. Das ist ein Flächenbedarf,
+			     kein Schleier — base-100 ist die helle Fläche des Themes; das /95
+			     bleibt, damit die Karte durchschimmert. -->
 			<div
-				class="border-primary/10 rounded-xl border bg-white/95 p-1 shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:shadow-2xl"
+				class="border-primary/10 bg-base-100/95 rounded-xl border p-1 shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:shadow-2xl"
 			>
 				<div class="flex flex-col items-center">
 					<img
@@ -921,7 +926,9 @@
 
 	<!-- Tastatur-Hilfe Modal -->
 	{#if showKeyboardHelp}
-		<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<!-- Schleier über der Karte, kein Theme-Ton: bg-scrim/<n>
+		     (--scrim-surface in tokens.css). -->
+		<div class="bg-scrim/50 fixed inset-0 z-50 flex items-center justify-center">
 			<div
 				role="dialog"
 				aria-modal="true"

--- a/src/lib/components/media/MediaModal.svelte
+++ b/src/lib/components/media/MediaModal.svelte
@@ -308,8 +308,9 @@
 		</div>
 	</div>
 
-	<!-- Backdrop -->
-	<form method="dialog" class="modal-backdrop bg-black/60 backdrop-blur-sm">
+	<!-- Backdrop. Schleier über der Seite dahinter, kein Theme-Ton: bg-scrim/<n>
+	     (--scrim-surface in tokens.css). -->
+	<form method="dialog" class="modal-backdrop bg-scrim/60 backdrop-blur-sm">
 		<button onclick={onClose} aria-label="Modal schließen">Schließen</button>
 	</form>
 </dialog>

--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -61,11 +61,15 @@
 					}
 				}}
 			/>
-			<!-- Hover Overlay -->
+			<!-- Hover Overlay. bg-scrim/<n> statt bg-black/<n>: der Wert steht seit
+			     dem 2026-07-30 als --scrim-surface in tokens.css. Ein Schleier ist
+			     keine Fläche des Themes, sondern eine Abdunklung des Fotos darunter —
+			     die Begründung, warum das Token neutrales Schwarz ist und nicht
+			     bg-neutral, steht dort. -->
 			<div
-				class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100"
+				class="bg-scrim/60 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 			>
-				<Icon icon="lucide:eye" width="24" class="text-white" />
+				<Icon icon="lucide:eye" width="24" class="text-on-scrim" />
 			</div>
 
 			<!-- GPS Badge für Bilder -->
@@ -99,15 +103,17 @@
 			<!-- Play Icon Overlay -->
 			<div class="absolute inset-0 flex items-center justify-center">
 				<div
-					class="rounded-full bg-black/60 p-3 transition-all group-hover:scale-110 group-hover:bg-black/80"
+					class="bg-scrim/60 group-hover:bg-scrim/80 rounded-full p-3 transition-all group-hover:scale-110"
 				>
-					<Icon icon="lucide:play" width="24" class="text-white" />
+					<Icon icon="lucide:play" width="24" class="text-on-scrim" />
 				</div>
 			</div>
 
-			<!-- Hover Overlay -->
+			<!-- Hover Overlay. Trägt nichts, was gelesen werden muss — /20 ist hier
+			     eine reine Andeutung über dem Videobild und bleibt deshalb, anders als
+			     im Zweig darunter, unverändert. -->
 			<div
-				class="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 transition-opacity group-hover:opacity-100"
+				class="bg-scrim/20 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 			></div>
 		</div>
 	{:else}
@@ -122,11 +128,16 @@
 				</p>
 			</div>
 
-			<!-- Hover Overlay -->
+			<!-- Hover Overlay. Der einzige der drei Zweige, der NICHT über fremdem
+			     Bildinhalt liegt: darunter steht bg-base-200 (#d1d8df), eine bekannte
+			     Theme-Fläche. Der vorherige Schleier auf /20 ergab dort für das Icon
+			     gerechnete 2,27:1 und verfehlte WCAG 1.4.11 (3:1) — anders als bei
+			     Foto und Video war das kein „hängt vom Inhalt ab", sondern ein fester,
+			     zu niedriger Wert. Mit /60 sind es 7,34:1. -->
 			<div
-				class="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 transition-opacity group-hover:opacity-100"
+				class="bg-scrim/60 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 			>
-				<Icon icon="lucide:download" width="20" class="text-white" />
+				<Icon icon="lucide:download" width="20" class="text-on-scrim" />
 			</div>
 		</div>
 	{/if}

--- a/src/lib/components/ui/Dialog/DeleteDialog.svelte
+++ b/src/lib/components/ui/Dialog/DeleteDialog.svelte
@@ -59,7 +59,9 @@
 			<button class="btn btn-error" onclick={confirm}>Löschen</button>
 		</div>
 	</div>
-	<form method="dialog" class="modal-backdrop bg-black/50">
+	<!-- Schleier über der Seite dahinter, kein Theme-Ton: bg-scrim/<n>
+	     (--scrim-surface in tokens.css). -->
+	<form method="dialog" class="modal-backdrop bg-scrim/50">
 		<button aria-label="Dialog schließen" onclick={cancel}>
 			<span class="sr-only">Dialog schließen</span>
 		</button>

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -565,11 +565,13 @@
 										{/if}
 
 										{#await mediaFile.uploadedFile}
-											<!-- Loading spinner overlay -->
+											<!-- Loading spinner overlay. Liegt über der hochgeladenen Bildvorschau,
+											     also über fremdem Inhalt: bg-scrim/<n> und text-on-scrim
+											     (--scrim-surface in tokens.css). -->
 											<div
-												class="absolute inset-0 flex items-center justify-center rounded bg-black/30"
+												class="bg-scrim/60 absolute inset-0 flex items-center justify-center rounded"
 											>
-												<div class="loading loading-spinner loading-sm text-white"></div>
+												<div class="loading loading-spinner loading-sm text-on-scrim"></div>
 											</div>
 
 											<!-- Upload progress indicator -->

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -127,7 +127,12 @@
 			<!-- Wichtigste Regel zuerst -->
 			<div class="bg-warning/10 border-warning/30 mb-4 rounded-lg border p-3">
 				<h5 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
-					<Icon icon="lucide:triangle-alert" width="14" class="text-warning-strong" aria-hidden="true" />
+					<Icon
+						icon="lucide:triangle-alert"
+						width="14"
+						class="text-warning-strong"
+						aria-hidden="true"
+					/>
 					Im Zweifel nicht raten
 				</h5>
 				<p class="text-base-content/80 text-xs">
@@ -192,10 +197,12 @@
 																class="h-32 w-full object-cover transition-all group-hover:brightness-110"
 																loading="lazy"
 															/>
+															<!-- Schleier über dem Artfoto, kein Theme-Ton: bg-scrim/<n>
+															     und text-on-scrim (--scrim-surface in tokens.css). -->
 															<div
-																class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100"
+																class="bg-scrim/60 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 															>
-																<Icon icon="lucide:zoom-in" width="24" class="text-white" />
+																<Icon icon="lucide:zoom-in" width="24" class="text-on-scrim" />
 															</div>
 														</button>
 														<p class="text-base-content/70 mt-1 text-xs">{image.alt}</p>
@@ -215,7 +222,12 @@
 											<h6
 												class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold"
 											>
-												<Icon icon="lucide:eye" width="14" class="text-info-strong" aria-hidden="true" />
+												<Icon
+													icon="lucide:eye"
+													width="14"
+													class="text-info-strong"
+													aria-hidden="true"
+												/>
 												So sieht es an der Oberfläche aus
 											</h6>
 											<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -138,7 +138,9 @@
 					>
 						<Icon icon="lucide:map" width="48" class="text-secondary-strong" />
 					</div>
-					<h3 class="card-title text-secondary-strong mb-4 justify-center text-xl">Interaktive Karte</h3>
+					<h3 class="card-title text-secondary-strong mb-4 justify-center text-xl">
+						Interaktive Karte
+					</h3>
 					<p class="text-base-content/80 text-base leading-relaxed">
 						Visualisieren Sie <strong>alle Sichtungen</strong> auf einer detaillierten Karte der
 						Ostsee und entdecken Sie <em>Muster und Hotspots</em>.
@@ -220,7 +222,7 @@
 						<Icon icon="lucide:shield-check" width="30" class="text-success-strong" />
 						<h3 class="card-title">Datenschutz</h3>
 					</div>
-					<p class="mb-4 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-4 text-sm">
 						Ihre Daten sind bei uns sicher. Wir verarbeiten alle personenbezogenen Daten gemäß der
 						EU-Datenschutz-Grundverordnung (DSGVO) und dem Bundesdatenschutzgesetz (BDSG).
 					</p>
@@ -262,7 +264,7 @@
 						<Icon icon="lucide:lock" width="30" class="text-info-strong" />
 						<h3 class="card-title">Technische Sicherheit</h3>
 					</div>
-					<p class="mb-4 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-4 text-sm">
 						Wir nutzen modernste Sicherheitstechnologien, um Ihre Daten und unsere Plattform zu
 						schützen.
 					</p>
@@ -284,11 +286,15 @@
 							<span>Gehostete Infrastruktur in Deutschland/EU</span>
 						</li>
 					</ul>
-					<div class="border-info/10 mt-4 rounded-lg border bg-black p-3">
+					<!-- Dunkle Fläche ist hier keine Laune: /auth0.svg zeichnet in #FFFEFA auf
+					     transparent und wäre auf base-100 unsichtbar. Der Bedarf ist damit
+					     „dunkle Vollton-Fläche" — und dafür gibt es ein Token. bg-neutral
+					     (#3a4048) trägt sein neutral-content mit 10,5:1. -->
+					<div class="border-info/10 bg-neutral mt-4 rounded-lg border p-3">
 						<a href="https://auth0.com" target="_blank" rel="noopener noreferrer"
 							><img src="/auth0.svg" alt="Auth0 Logo" class=" mx-auto mb-4" /></a
 						>
-						<p class="text-xs text-white">
+						<p class="text-neutral-content text-xs">
 							Gesichert durch <a
 								href="https://auth0.com"
 								target="_blank"
@@ -310,7 +316,7 @@
 				<Icon icon="lucide:file-text" width="24" class="text-success-strong" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">DSGVO-Konformität</h4>
-					<p class="mb-3 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-3 text-sm">
 						Als öffentliche Einrichtung nehmen wir den Datenschutz besonders ernst. Unsere Plattform
 						erfüllt alle Anforderungen der europäischen Datenschutz-Grundverordnung:
 					</p>
@@ -339,7 +345,7 @@
 		<!-- Contact for Data Protection -->
 		<div class="bg-base-200 mt-8 rounded-lg p-6 text-center">
 			<h4 class="mb-3 font-semibold">Fragen zum Datenschutz?</h4>
-			<p class="mb-4 text-sm text-base-content/80">
+			<p class="text-base-content/80 mb-4 text-sm">
 				Bei Fragen zum Datenschutz oder zur Verarbeitung Ihrer Daten können Sie sich jederzeit an
 				uns wenden:
 			</p>
@@ -370,26 +376,26 @@
 			</h2>
 			<div class="badge badge-neutral badge-lg font-mono">Version {data.version}</div>
 		</div>
-		<p class="mx-auto mb-8 max-w-3xl text-center text-base-content/80">
+		<p class="text-base-content/80 mx-auto mb-8 max-w-3xl text-center">
 			Unsere Plattform nutzt moderne Web-Technologien für eine optimale Benutzererfahrung und
 			zuverlässige Datenverarbeitung.
 		</p>
 		<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
 			<div class="text-center">
 				<div class="badge badge-primary badge-lg">SvelteKit</div>
-				<p class="mt-2 text-xs text-base-content/70">Modern Web Framework</p>
+				<p class="text-base-content/70 mt-2 text-xs">Modern Web Framework</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-secondary badge-lg">PostGIS</div>
-				<p class="mt-2 text-xs text-base-content/70">Geografische Datenbank</p>
+				<p class="text-base-content/70 mt-2 text-xs">Geografische Datenbank</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-accent badge-lg">OpenAPI</div>
-				<p class="mt-2 text-xs text-base-content/70">Standardisierte API</p>
+				<p class="text-base-content/70 mt-2 text-xs">Standardisierte API</p>
 			</div>
 			<div class="text-center">
 				<div class="badge badge-info badge-lg">OpenLayers</div>
-				<p class="mt-2 text-xs text-base-content/70">Interaktive Karten</p>
+				<p class="text-base-content/70 mt-2 text-xs">Interaktive Karten</p>
 			</div>
 		</div>
 	</div>
@@ -409,16 +415,16 @@
 						<Icon icon="lucide:file-text" width="32" height="32" class="text-primary" />
 						<h3 class="card-title">Projekt-Lizenz</h3>
 					</div>
-					<p class="mb-4 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-4 text-sm">
 						Die Ostsee-Tiere Plattform ist Open Source Software und steht unter der MIT-Lizenz. Dies
 						bedeutet, dass der Quellcode frei verfügbar ist und für eigene Projekte genutzt werden
 						kann.
 					</p>
-					<div class="rounded-lg bg-base-200 p-4">
+					<div class="bg-base-200 rounded-lg p-4">
 						<div class="mb-2 font-mono text-xs font-semibold">MIT License</div>
-						<div class="max-h-48 overflow-y-auto rounded border border-base-300 bg-white p-3">
+						<div class="border-base-300 bg-base-100 max-h-48 overflow-y-auto rounded border p-3">
 							<pre
-								class="font-mono text-xs whitespace-pre-wrap text-base-content/70">Copyright (c) 2025-2026 Ostsee-Tiere WebApp Contributors
+								class="text-base-content/70 font-mono text-xs whitespace-pre-wrap">Copyright (c) 2025-2026 Ostsee-Tiere WebApp Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -464,36 +470,36 @@ SOFTWARE.</pre>
 						<Icon icon="lucide:archive" width="32" height="32" class="text-primary" />
 						<h3 class="card-title">Verwendete Technologien</h3>
 					</div>
-					<p class="mb-4 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-4 text-sm">
 						Diese Plattform baut auf bewährten Open Source Technologien auf:
 					</p>
 					<div class="space-y-2 text-xs">
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">SvelteKit</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">TailwindCSS</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">DaisyUI</span>
 							<span class="badge badge-sm">MIT</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">OpenLayers</span>
 							<span class="badge badge-sm">BSD-2</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">PostgreSQL</span>
 							<span class="badge badge-sm">PostgreSQL</span>
 						</div>
-						<div class="flex items-center justify-between rounded bg-base-200 p-2">
+						<div class="bg-base-200 flex items-center justify-between rounded p-2">
 							<span class="font-medium">Drizzle ORM</span>
 							<span class="badge badge-sm">Apache-2.0</span>
 						</div>
 					</div>
-					<p class="mt-3 text-xs text-base-content/60">
+					<p class="text-base-content/60 mt-3 text-xs">
 						Alle verwendeten Bibliotheken sind sorgfältig ausgewählt und lizenzkonform eingesetzt.
 					</p>
 				</div>
@@ -508,7 +514,7 @@ SOFTWARE.</pre>
 				<Icon icon="lucide:circle-alert" width="32" height="32" class="text-warning-strong mt-1" />
 				<div class="flex-1">
 					<h4 class="mb-2 font-semibold">Fehler gefunden oder Verbesserungsvorschlag?</h4>
-					<p class="mb-3 text-sm text-base-content/80">
+					<p class="text-base-content/80 mb-3 text-sm">
 						Wir freuen uns über Ihr Feedback! Die Ostsee-Tiere Plattform wird kontinuierlich
 						weiterentwickelt. Ihre Hinweise helfen uns dabei, die Plattform zu verbessern.
 					</p>
@@ -548,7 +554,7 @@ SOFTWARE.</pre>
 				<Icon icon="lucide:heart" width="20" height="20" class="text-primary" />
 				Danksagung
 			</h4>
-			<p class="mb-4 text-sm text-base-content/80">
+			<p class="text-base-content/80 mb-4 text-sm">
 				Wir danken allen Entwicklern und Organisationen, die durch ihre Open Source Projekte diese
 				Plattform ermöglichen. Besonderer Dank gilt:
 			</p>

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -208,15 +208,15 @@
 				Sie können die OpenAPI-Spezifikation in diesen Tools verwenden:
 			</p>
 			<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-				<div class="rounded border bg-white p-4">
+				<div class="bg-base-100 rounded border p-4">
 					<h3 class="mb-2 font-medium">Postman</h3>
 					<p class="text-base-content/70 text-xs">Importieren Sie die YAML-Datei für API-Tests</p>
 				</div>
-				<div class="rounded border bg-white p-4">
+				<div class="bg-base-100 rounded border p-4">
 					<h3 class="mb-2 font-medium">Insomnia</h3>
 					<p class="text-base-content/70 text-xs">Laden Sie die Spezifikation für REST-Tests</p>
 				</div>
-				<div class="rounded border bg-white p-4">
+				<div class="bg-base-100 rounded border p-4">
 					<h3 class="mb-2 font-medium">Swagger Editor</h3>
 					<p class="text-base-content/70 text-xs">Online-Editor für OpenAPI-Specs</p>
 				</div>


### PR DESCRIPTION
## Warum

Die Paletten-Regel des DOM-Scans (`TAILWIND_PALETTE`) konnte `bg-white`, `text-white`, `bg-black` und deren Deckkraft-Varianten **strukturell** nie melden: Ihr Muster verlangte hinter dem Farbnamen eine Farbstufe (`-\d{2,3}`), die diese Klassen nicht haben. Sie umgehen das Theme `meeresmuseum` aber genauso vollständig wie `bg-gray-100`.

Das ist dieselbe Fehlerklasse wie die Deckkraft-Lücke aus #636 — die Lücke saß in der **Grammatik** des Musters, nicht in der Aufzählung der Farben. Gefunden beim Schließen jener Lücke; Bestand waren 27 Fundstellen.

## Reihenfolge

Bewusst: erst die 27 Fundstellen einzeln bewertet, **dann** die Regel geschärft. Andersherum wäre der Scan über mehrere Routen rot gewesen, bevor entschieden war, was an jeder Stelle richtig ist — und der schnellste Weg zurück auf grün wäre das Aufweichen der Regel gewesen.

## Bewertung: drei Ausgänge, nicht zwei

| Bedarf | Antwort | Wo |
|---|---|---|
| Helle Fläche | `bg-base-100` | Lizenz-Codeblock `/about`, 3 Karten `/docs/api/fallback`, DMM-Logo-Platte `/map` |
| Dunkle **Vollton**-Fläche | `bg-neutral` + `text-neutral-content` | Auth0-Panel `/about` |
| Schleier über fremdem Inhalt | `bg-scrim/<n>` + `text-on-scrim` (neu) | 9 Stellen: Modal-Backdrops, Foto-/Video-Overlays, Karten-Ladeschleier |

Zwei Stellen wurden vor dem Ersetzen nachgemessen statt geraten: `/auth0.svg` zeichnet in `#FFFEFA` — die dunkle Fläche ist echter Bedarf (`bg-neutral` trägt sein `neutral-content` mit 10,5:1). `dmm-logo.png` ist umgekehrt durchgängig dunkel auf transparent (14.097 deckende Pixel, kein einziger heller) — die helle Platte muss bleiben.

## Warum ein Token statt einer Ausnahme

Ein Schleier hatte bis hierhin zu Recht kein Token („das Theme kennt keine Abdunklung"). Genau diese plausible Ausnahme hat die Lücke am Leben gehalten. Sie festzuschreiben wäre nicht prüfbar gewesen: Der Scan sieht nur Klassenlisten und kann nicht entscheiden, ob unter einem `bg-black/40` ein Foto oder `bg-base-200` liegt.

Deshalb `--scrim-surface`/`--scrim-foreground` in `tokens.css` → `bg-scrim/<n>`, `text-on-scrim`. Neutrales Schwarz, kein Markenton — jede Farbe mit Chroma verschiebt den Farbton des Fotos darunter. Der Farbton steht im Token, die Deckkraft bleibt an der Aufrufstelle. Die Randbereiche-Tabelle bleibt damit bei drei Einträgen; die Regel bleibt ausnahmslos.

## Vier echte WCAG-1.4.11-Verstöße steckten darunter

- **`MediaThumbnail`, Zweig „Andere Dateitypen":** `bg-black/20` lag nicht über einem Foto, sondern über `bg-base-200`. Weißes Icon: **2,27:1** → `/60` (7,34:1).
- **Foto-Lupe, Artfoto-Lupe (`/40` = 2,85:1) und Upload-Spinner (`/30` = 2,11:1)** über hellem Bildinhalt → `/60`.

Der zweite Punkt kam aus dem Review und hat eine Fehleinschätzung von mir korrigiert: Ich hatte dokumentiert, über fremdem Inhalt sei der Kontrast nicht bestimmbar. Der *tatsächliche* nicht — der **schlechteste Fall** (Foto an der Icon-Stelle reinweiß) sehr wohl. Neue Regel in `design-system.md`: Trägt ein Schleier selbst einen Vordergrund, ist `/60` die Untergrenze (5,74:1 über Weiß). Reine Backdrops ohne eigenen Vordergrund bleiben leichter — was gelesen werden muss, steht dort auf `bg-base-100`.

## Außerdem

`PALETTE_HUES` von 12 auf alle 22 Tailwind-Töne ergänzt (`stone`, `neutral`, `lime`, `teal`, `cyan`, `violet`, `purple`, `fuchsia`, `pink`, `rose`). Die zehn fehlenden hatten nur keine Fundstelle — die Lücke-in-den-**Daten**-Variante desselben Musters. `neutral` ist auch Theme-Token; die Farbstufe im Muster trennt beide (`bg-neutral-500` schlägt an, `bg-neutral` nicht), abgesichert durch eigene Testfälle.

## Gegenproben

- **Unit, RED zuerst:** 9 von 46 Fällen fielen vor der Musteränderung.
- **Regel-Gegenprobe:** `white|black` wieder herausgenommen → dieselben 9 fallen.
- **Scan-Gegenprobe** (wie in #636): `bg-black/25` in `/about` eingefügt → Test rot mit exakt dieser Klasse in der Meldung; zurückgenommen → 7/7 grün.

`npm run test:quick` 2330/2330 · `design-tokens.spec.ts` 66/66, dreimal stabil.

## Bekannte Grenzen (bewusst offen)

- **Scan-Reichweite:** Die DOM-Routen sind `/`, `/map`, `/about`, `/admin*`. Modal-Backdrops und Hover-/Upload-Zustände rendern dort im Ruhezustand nicht — ein Rückfall auf `bg-black/50` in `MediaModal` bliebe unbemerkt. Bekannte Grenze des Ruhezustand-Scans, in `design-system.md` bereits notiert.
- **`/styleguide`-Wächter:** `bg-scrim`/`text-on-scrim` stehen bewusst außerhalb. Der Wächter zielt auf Utilities, deren einzige Aufrufstelle die Seite ist; die Schleier-Utilities haben zehn Aufrufstellen in Komponenten. Begründung steht in `design-system.md`.
- **Diff-Rauschen in `about/+page.svelte`:** Der Prettier-Hook hat beim Speichern die Tailwind-Klassen der ganzen Datei neu sortiert. Altbestand, kein Nebeneffekt der Token — vorher waren 21 `.svelte`-Dateien unformatiert, danach 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
