### PR TITLE
fix(api): align legacy REST API with the binding contract

### DIFF
--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -468,6 +468,66 @@ server error occurred"}` und damit einen `error`-Schlüssel, den die flache
 Vertragsform nicht kennt. `static/openapi.yml` dokumentiert für 500 deshalb
 beide Formen.
 
+## Korrektur 2026-07-30: `fax` und `totfund` wurden verworfen
+
+Beide Felder standen in der Validierung, landeten aber nirgends — dieselbe
+Fehlerklasse wie bei `sonstige_auffaelligkeiten` oben.
+
+- **`fax`**: Die DB-Spalte `fax` existiert seit immer, aber das Feld fehlte im
+  Formular-Schema (`sightingSchema`) und damit in `SightingFormData`. Der
+  Legacy-Adapter hatte kein Ziel für den Wert. `fax` ist jetzt im Schema (ohne
+  `.meta()`, also kein Formularfeld) und wird von `mapFormToSighting`
+  geschrieben.
+- **`totfund`**: `isDead` wurde ausschließlich aus `anzahl_gesamt = 0`
+  abgeleitet. Ein explizites `totfund: 1` bei `anzahl_gesamt > 0` verschwand.
+  Beide Wege gelten jetzt, und beide werden string-tolerant ausgewertet — der
+  Formulardaten-Pfad liefert `Object.fromEntries(formData.entries())`, also
+  Strings, und `'0' === 0` ist in TypeScript false.
+
+## Bewusst nicht umgesetzt: der Ostsee-Filter in `showreports.json`
+
+Abschnitt 4 beschreibt die Grundmenge als „approved **and marked as lying in the
+Baltic Sea**". Der zweite Teil ist **absichtlich nicht implementiert**. Der
+Endpunkt filtert ausschließlich `freigegeben_am IS NOT NULL`.
+
+**Grund 1 — der Marker wurde nicht durchgängig gepflegt.** Messung am
+2026-07-30 über die 19.262 freigegebenen Zeilen der lokalen DB:
+
+| Spalte       | `= 1`  | `= 0` | `NULL` |
+| ------------ | ------ | ----- | ------ |
+| `ostsee`     | 10.028 | 9.234 | 0      |
+| `ostsee_geo` | 3.838  |       |        |
+
+Von den 9.234 Zeilen mit `ostsee = 0` liegen **9.135 (98,9 %) im Kartenbereich**
+(53–66 N, 9–31 O) — es sind plausible Ostsee-Sichtungen. Umgekehrt tragen 179
+Zeilen mit `ostsee = 1` überhaupt keine Koordinaten; der Marker ist also nicht
+koordinatenabgeleitet. Die Trefferquote schwankt zudem jahrgangsweise stark
+(2012: 93 %, 2020: 27 %, 2021: 73 %), was auf einen Prozess- oder Importwechsel
+deutet, nicht auf eine stabile fachliche Bedeutung.
+
+Ein Filter auf `ostsee = 1` würde damit rund **9.100 echte Sichtungen (48 %)**
+aus der öffentlichen Ausgabe entfernen. `ostsee = 1 OR ostsee_geo = 1` wären
+immer noch 7.383 (38 %).
+
+**Grund 2 — `.claude/rules/api.md` verbietet es.** Dort ist die öffentliche
+Grundmenge verbindlich auf `approvedAt IS NOT NULL` festgelegt, ausdrücklich für
+die Legacy-API **und** die moderne Karte (`/api/map/sightings`, via
+`approvedOnly()` aus `src/lib/server/db/approvalFilter.ts`), mit der Begründung,
+dass zwei verschiedene Filter für zwei öffentliche Flächen zwangsläufig
+auseinanderlaufen. Ein zusätzlicher Marker-Filter nur hier wäre genau dieser
+Fall.
+
+**Was das für Clients heißt:** Die Ergebnismenge ist eine Obermenge dessen, was
+die Spec beschreibt. Ein Client bekommt zusätzliche Meldungen, keine fehlenden —
+die verträglichere Richtung. Die Felder `bm`/`va` wären der vertragsgemäße Weg,
+das Ergebnis der Positionsprüfung an Clients zu übermitteln — sie werden derzeit
+gar nicht ausgeliefert, auch nicht an eingeloggte Admins.
+
+**Offen:** Wenn der Marker fachlich doch maßgeblich ist, gehört er vor einer
+Aktivierung nachgezogen — bewertbar nur mit einer Aussage der DMM dazu, was
+`ostsee = 0` bei einer Sichtung mitten in der Ostsee bedeuten soll. Bis dahin
+bleibt der Filter aus.
+
 ## Zeitzonen-Semantik
 
 Alle Datums-/Uhrzeitwerte dieser Legacy API sind **deutsche Ortszeit

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -344,10 +344,10 @@ Antwort wurde trotzdem als aktive Aussage gespeichert.
 
 Messung 2026-07-29 (19.880 Zeilen):
 
-| Feld         | Zeilen mit `0`   | davon mit Freitext | Freitext-Quote der übrigen Werte |
-| ------------ | ---------------- | ------------------ | -------------------------------- |
-| `verteilung` | 15.129 (76,1 %)  | 632 (4,2 %)        | 0,0–0,6 %                        |
-| `verhalten`  | 9.192 (46,2 %)   | 892 (9,7 %)        | 0,0–0,4 %                        |
+| Feld         | Zeilen mit `0`  | davon mit Freitext | Freitext-Quote der übrigen Werte |
+| ------------ | --------------- | ------------------ | -------------------------------- |
+| `verteilung` | 15.129 (76,1 %) | 632 (4,2 %)        | 0,0–0,6 %                        |
+| `verhalten`  | 9.192 (46,2 %)  | 892 (9,7 %)        | 0,0–0,4 %                        |
 
 Bei `verteilung` war „Sonstige Verteilung" dadurch mit 76 % die dominierende
 Kategorie — vor „Einzeln" (3.046). Rechnet man die Nicht-Antworten heraus, ist
@@ -425,6 +425,48 @@ Antrieb nur niemand angegeben hat — dort ist `5` streng genommen zu stark.
 Bewusst in Kauf genommen: Ein eigener Wert „Antrieb unbekannt" wäre eine dritte
 Vertragsänderung an derselben Spalte, und eine erfundene Antriebsart wiegt
 schwerer als „kein Boot" bei einem Kajak.
+
+## Zusätzlich akzeptiert: `sonstige_auffälligkeiten` (Umlaut-Variante)
+
+Vertragsname ist und bleibt `sonstige_auffaelligkeiten` (mit `ae`), so wie ihn
+das Originaldokument nennt.
+
+Diese Implementierung las bis zum 2026-07-30 **ausschließlich** die
+Umlaut-Schreibweise `sonstige_auffälligkeiten` (`src/lib/legacy-api/types.ts`,
+`yup-validation.ts`, `field-mapping.ts`). Ein spec-konformer Client verlor
+seinen Freitext dadurch kommentarlos — `otherObservations` wurde `''`, ohne
+Validierungsfehler.
+
+**Seit dem 2026-07-30 werden beide Schreibweisen gelesen**, der Vertragsname hat
+Vorrang, wenn beide im selben Request stehen. Die Umlaut-Variante ist in
+`static/openapi.yml` als `deprecated` markiert und existiert nur, damit bereits
+gegen diese App gebaute Clients nichts verlieren. Neue Clients benutzen
+`sonstige_auffaelligkeiten`.
+
+Kein Effekt auf Ausgaben: `showreports.json` liefert dieses Feld nicht.
+
+## Korrektur 2026-07-30: Form der Fehlerantwort
+
+Der Abschnitt [Validation Errors](#validation-errors) war schon immer die
+verbindliche Form (`message` als String, `errors` daneben) — die
+Implementierung wich davon ab und schachtelte
+`{"message": {"message": …, "errors": …}}`. `static/openapi.yml` beschrieb mit
+`{"error": …, "message": …}` eine dritte, wieder andere Struktur ohne
+`errors`-Objekt.
+
+Beide sind seit dem 2026-07-30 auf die flache Form des Originaldokuments
+korrigiert. Ein Client, der `message` vertragsgemäß als Text liest, bekam vorher
+ein Objekt.
+
+Betroffen sind der 400er-Validierungsfehler, die `"No data send."`-Antwort
+(die dieser Endpunkt mit Status **200** ausliefert) und der 500er-Pfad für
+unerwartete Fehler.
+
+**Nicht** betroffen ist der 500er nach einem fehlgeschlagenen Schreibvorgang: Er
+liefert weiterhin `{"error": "Failed to save sighting", "message": "Internal
+server error occurred"}` und damit einen `error`-Schlüssel, den die flache
+Vertragsform nicht kennt. `static/openapi.yml` dokumentiert für 500 deshalb
+beide Formen.
 
 ## Zeitzonen-Semantik
 

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -490,8 +490,13 @@ Abschnitt 4 beschreibt die Grundmenge als „approved **and marked as lying in t
 Baltic Sea**". Der zweite Teil ist **absichtlich nicht implementiert**. Der
 Endpunkt filtert ausschließlich `freigegeben_am IS NOT NULL`.
 
-**Grund 1 — der Marker wurde nicht durchgängig gepflegt.** Messung am
-2026-07-30 über die 19.262 freigegebenen Zeilen der lokalen DB:
+**Grund 1 — `ostsee = 0` heißt „nicht berechnet", nicht „nicht in der Ostsee".**
+Die Berechnung des Wertes wurde erst nachträglich eingeführt; für den davor
+entstandenen Bestand steht der Default `0` in der Spalte, ohne dass je eine
+Positionsprüfung stattgefunden hätte. Der Wert ist damit **kein** Prädikat, auf
+das man filtern kann — er ist teilweise unbefüllt.
+
+Messung am 2026-07-30 über die 19.262 freigegebenen Zeilen der lokalen DB:
 
 | Spalte       | `= 1`  | `= 0` | `NULL` |
 | ------------ | ------ | ----- | ------ |
@@ -499,11 +504,15 @@ Endpunkt filtert ausschließlich `freigegeben_am IS NOT NULL`.
 | `ostsee_geo` | 3.838  |       |        |
 
 Von den 9.234 Zeilen mit `ostsee = 0` liegen **9.135 (98,9 %) im Kartenbereich**
-(53–66 N, 9–31 O) — es sind plausible Ostsee-Sichtungen. Umgekehrt tragen 179
-Zeilen mit `ostsee = 1` überhaupt keine Koordinaten; der Marker ist also nicht
-koordinatenabgeleitet. Die Trefferquote schwankt zudem jahrgangsweise stark
-(2012: 93 %, 2020: 27 %, 2021: 73 %), was auf einen Prozess- oder Importwechsel
-deutet, nicht auf eine stabile fachliche Bedeutung.
+(53–66 N, 9–31 O) — es sind plausible Ostsee-Sichtungen, für die nur niemand die
+Prüfung gerechnet hat. Umgekehrt tragen 179 Zeilen mit `ostsee = 1` überhaupt
+keine Koordinaten.
+
+Die Quote schwankt jahrgangsweise stark und **nicht monoton** (2012: 93 %, 2020:
+27 %, 2021: 73 %). Sie folgt also nicht einfach dem Einführungszeitpunkt — für
+einen Backfill heißt das, dass die vorhandenen `1`-Werte nicht automatisch
+vertrauenswürdiger sind als die `0`-Werte und die Herkunft der Altwerte mit
+geklärt werden muss.
 
 Ein Filter auf `ostsee = 1` würde damit rund **9.100 echte Sichtungen (48 %)**
 aus der öffentlichen Ausgabe entfernen. `ostsee = 1 OR ostsee_geo = 1` wären
@@ -523,10 +532,17 @@ die verträglichere Richtung. Die Felder `bm`/`va` wären der vertragsgemäße W
 das Ergebnis der Positionsprüfung an Clients zu übermitteln — sie werden derzeit
 gar nicht ausgeliefert, auch nicht an eingeloggte Admins.
 
-**Offen:** Wenn der Marker fachlich doch maßgeblich ist, gehört er vor einer
-Aktivierung nachgezogen — bewertbar nur mit einer Aussage der DMM dazu, was
-`ostsee = 0` bei einer Sichtung mitten in der Ostsee bedeuten soll. Bis dahin
-bleibt der Filter aus.
+**Offen — Backfill, aber erst nach der Überarbeitung der Geo-Funktion.** Der
+Bestand muss nachgerechnet werden, bevor der Filter überhaupt bewertbar ist. Das
+darf aber nicht mit der heutigen Prüfung passieren: Die Küstenabgrenzung wird
+gerade überarbeitet (Stand `docs/archive/`-Analyse vom 2026-07-29: eine
+Distanzschwelle taugt nicht als Kriterium, weil Schlei, Elbe und Trave bis 74 km
+„binnenlands" liegen — brauchbar ist nur eine ungeteilte OSM-Küstenlinie). Ein
+Backfill mit der alten Funktion müsste danach ein zweites Mal laufen und würde
+zwischenzeitlich falsche Werte als geprüft ausweisen.
+
+Reihenfolge also: Geo-Funktion überarbeiten → Backfill → Marker bewerten →
+Filter entscheiden. Bis dahin bleibt der Filter aus.
 
 ## Zeitzonen-Semantik
 

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -1061,6 +1061,24 @@ export const sightingSchemaBase = yup.object().shape({
 	 * Telefonnummer für Rückfragen
 	 * Optional, Freitextfeld
 	 */
+	/**
+	 * Faxnummer
+	 *
+	 * Ausschließlich für die Legacy-REST-API: `docs/LEGACY_API_SPECIFICATION.md`
+	 * führt `fax` als optionales Feld, und die DB-Spalte existiert seit immer —
+	 * nur fehlte das Feld hier, weshalb der Legacy-Adapter den Wert bis
+	 * 2026-07-30 stillschweigend verwarf.
+	 *
+	 * **Bewusst ohne `.meta()`**: Das Formular rendert seine Felder aus den
+	 * expliziten Listen in `formConfig.ts`, nicht aus dem Schema. Ohne Metadaten
+	 * bleibt `fax` damit ein reines Datenfeld und taucht in keinem Schritt auf.
+	 */
+	fax: yup
+		.string()
+		.max(64, 'Die Faxnummer darf nicht länger als 64 Zeichen sein.')
+		.label('Faxnummer')
+		.notRequired(),
+
 	phone: yup
 		.string()
 		.max(64, 'Die Telefonnummer darf nicht länger als 64 Zeichen sein.')

--- a/src/lib/legacy-api/error-messages.test.ts
+++ b/src/lib/legacy-api/error-messages.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Vertragstest für die Fehler-Response-Form der Legacy REST API
+ *
+ * Verbindlich ist die **flache** Struktur aus dem Originaldokument
+ * (`docs/archive/Sichtungsdb-Web-Schnittstelle.pdf`, Abschnitt „Bei
+ * Validierungsfehlern") und `docs/LEGACY_API_SPECIFICATION.md`:
+ *
+ *     {"message": "Validation failed.", "errors": {"anzahl_gesamt": ["…"]}}
+ *
+ * Die frühere geschachtelte Form (`{"message":{"message":…}}`) liefert einem
+ * Client, der `message` als Text liest, ein Objekt — deshalb sichern diese
+ * Tests den Typ von `message` explizit ab, nicht nur die Feldnamen.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createOriginalApiErrorResponse, createSimpleErrorResponse } from './error-messages';
+
+describe('createOriginalApiErrorResponse', () => {
+	it('liefert message als String, nicht als verschachteltes Objekt', () => {
+		const response = createOriginalApiErrorResponse('Validation failed.');
+
+		expect(typeof response.message).toBe('string');
+		expect(response.message).toBe('Validation failed.');
+	});
+
+	it('legt Feldfehler flach neben message unter errors ab', () => {
+		const response = createOriginalApiErrorResponse('Validation failed.', {
+			anzahl_gesamt: ['Dieses Feld kann nicht leer gelassen werden.']
+		});
+
+		expect(response).toEqual({
+			message: 'Validation failed.',
+			errors: {
+				anzahl_gesamt: ['Dieses Feld kann nicht leer gelassen werden.']
+			}
+		});
+	});
+
+	it('lässt errors weg, wenn keine Feldfehler vorliegen', () => {
+		expect(createOriginalApiErrorResponse('Internal server error')).toEqual({
+			message: 'Internal server error'
+		});
+		expect(createOriginalApiErrorResponse('Internal server error', {})).toEqual({
+			message: 'Internal server error'
+		});
+	});
+});
+
+describe('createSimpleErrorResponse', () => {
+	it('liefert message als String', () => {
+		const response = createSimpleErrorResponse('No data send.');
+
+		expect(typeof response.message).toBe('string');
+		expect(response).toEqual({ message: 'No data send.' });
+	});
+});

--- a/src/lib/legacy-api/error-messages.ts
+++ b/src/lib/legacy-api/error-messages.ts
@@ -1,8 +1,11 @@
 /**
- * @fileoverview German error messages for Legacy REST API
+ * @fileoverview Error message literals and response builders for the Legacy REST API
  *
- * Provides German error messages that match exactly with the original
- * schweinswalsichtung.de API for 100% compatibility.
+ * Provides the wording used by the original schweinswalsichtung.de API, verbatim,
+ * for 100% compatibility. The strings are NOT all German — the original API mixes
+ * languages, and its top-level messages ("Validation failed.", "No data send.")
+ * are English. Only the field-level messages are German; those live in
+ * `yup-validation.ts`.
  *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
@@ -11,9 +14,11 @@
 import type { LegacyErrorResponse, LegacySimpleErrorResponse } from './types.js';
 
 /**
- * German error messages that match the original API exactly
+ * Message literals taken verbatim from the original API — English wording
+ * included, see the file header. Do not translate: the exact string is part
+ * of the contract.
  */
-export const GERMAN_ERROR_MESSAGES = {
+export const LEGACY_API_MESSAGES = {
 	// General validation
 	NO_DATA_SEND: 'No data send.'
 } as const;

--- a/src/lib/legacy-api/error-messages.ts
+++ b/src/lib/legacy-api/error-messages.ts
@@ -1,12 +1,14 @@
 /**
  * @fileoverview German error messages for Legacy REST API
- * 
- * Provides German error messages that match exactly with the original 
+ *
+ * Provides German error messages that match exactly with the original
  * schweinswalsichtung.de API for 100% compatibility.
- * 
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
+
+import type { LegacyErrorResponse, LegacySimpleErrorResponse } from './types.js';
 
 /**
  * German error messages that match the original API exactly
@@ -16,34 +18,40 @@ export const GERMAN_ERROR_MESSAGES = {
 	NO_DATA_SEND: 'No data send.'
 } as const;
 
-
 /**
  * Creates the exact error response format from the original API
+ *
+ * Die Struktur ist **flach** — `message` ist ein String, `errors` liegt
+ * daneben, genau wie im Originaldokument
+ * (`docs/archive/Sichtungsdb-Web-Schnittstelle.pdf`, Abschnitt „Bei
+ * Validierungsfehlern") und in `docs/LEGACY_API_SPECIFICATION.md`:
+ *
+ * ```json
+ * { "message": "Validation failed.", "errors": { "anzahl_gesamt": ["…"] } }
+ * ```
+ *
+ * Bis 2026-07-30 wurde `message` hier als Objekt (`message.message`)
+ * geschachtelt. Ein Client, der `message` vertragsgemäß als Text liest, bekam
+ * dadurch ein Objekt.
  */
 export function createOriginalApiErrorResponse(
-	mainMessage: string, 
+	mainMessage: string,
 	fieldErrors?: Record<string, string[]>
-): { message: { message: string; errors?: Record<string, string[]> } } {
-	const response: { message: { message: string; errors?: Record<string, string[]> } } = {
-		message: {
-			message: mainMessage
-		}
+): LegacyErrorResponse {
+	const response: LegacyErrorResponse = {
+		message: mainMessage
 	};
-	
+
 	if (fieldErrors && Object.keys(fieldErrors).length > 0) {
-		response.message.errors = fieldErrors;
+		response.errors = fieldErrors;
 	}
-	
+
 	return response;
 }
 
 /**
  * Creates simple error response for cases like "No data send"
  */
-export function createSimpleErrorResponse(message: string): { message: { message: string } } {
-	return {
-		message: {
-			message
-		}
-	};
+export function createSimpleErrorResponse(message: string): LegacySimpleErrorResponse {
+	return { message };
 }

--- a/src/lib/legacy-api/field-mapping.test.ts
+++ b/src/lib/legacy-api/field-mapping.test.ts
@@ -134,7 +134,7 @@ describe('mapLegacyToCurrentSchema — sonstige_auffaelligkeiten', () => {
 		expect(result.otherObservations).toBe('Tier war deutlich verletzt');
 	});
 
-	it('gibt der Vertragsschreibweise den Vorrang, wenn beide gesendet werden', () => {
+	it('gibt der Vertragsschreibweise den Vorrang, wenn beide gefüllt sind', () => {
 		const result = mapLegacyToCurrentSchema({
 			...minimalRequest(),
 			sonstige_auffaelligkeiten: 'Vertragsform',
@@ -142,6 +142,20 @@ describe('mapLegacyToCurrentSchema — sonstige_auffaelligkeiten', () => {
 		} as LegacySightingRequest);
 
 		expect(result.otherObservations).toBe('Vertragsform');
+	});
+
+	it('rettet den Umlaut-Text, wenn der Vertragsname leer mitgesendet wird', () => {
+		// Bewusst `||` und nicht `??`: Ein Serializer, der abwesende Felder als
+		// "" ausgibt, würde mit `??` den vorhandenen Text verwerfen — genau der
+		// stille Datenverlust, den diese Änderung behebt. Vorrang gilt deshalb
+		// unter gefüllten Werten, nicht gegen einen leeren gegen einen gefüllten.
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			sonstige_auffaelligkeiten: '',
+			sonstige_auffälligkeiten: 'Tier war deutlich verletzt'
+		} as LegacySightingRequest);
+
+		expect(result.otherObservations).toBe('Tier war deutlich verletzt');
 	});
 
 	it('bleibt ohne Angabe ein leerer String', () => {

--- a/src/lib/legacy-api/field-mapping.test.ts
+++ b/src/lib/legacy-api/field-mapping.test.ts
@@ -105,3 +105,48 @@ describe('mapLegacyToCurrentSchema — explizite Nullen bleiben erhalten', () =>
 		expect(result.species).toBe(SpeciesEnum.GREY_SEAL);
 	});
 });
+
+/**
+ * Das Originaldokument (`docs/archive/Sichtungsdb-Web-Schnittstelle.pdf`, Zeile
+ * „sonstige_auffaelligkeiten … Auffälligkeiten … Text … Nein") und
+ * `docs/LEGACY_API_SPECIFICATION.md` nennen das Feld ohne Umlaut. Die
+ * Implementierung las bis 2026-07-30 ausschließlich `sonstige_auffälligkeiten`
+ * — ein spec-konformer Client verlor seinen Freitext deshalb kommentarlos.
+ *
+ * Beide Schreibweisen werden angenommen, die Vertragsform hat Vorrang.
+ */
+describe('mapLegacyToCurrentSchema — sonstige_auffaelligkeiten', () => {
+	it('übernimmt die Vertragsschreibweise mit ae', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			sonstige_auffaelligkeiten: 'Tier war deutlich verletzt'
+		} as LegacySightingRequest);
+
+		expect(result.otherObservations).toBe('Tier war deutlich verletzt');
+	});
+
+	it('übernimmt weiterhin die bestehende Umlaut-Schreibweise', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			sonstige_auffälligkeiten: 'Tier war deutlich verletzt'
+		} as LegacySightingRequest);
+
+		expect(result.otherObservations).toBe('Tier war deutlich verletzt');
+	});
+
+	it('gibt der Vertragsschreibweise den Vorrang, wenn beide gesendet werden', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			sonstige_auffaelligkeiten: 'Vertragsform',
+			sonstige_auffälligkeiten: 'Umlautform'
+		} as LegacySightingRequest);
+
+		expect(result.otherObservations).toBe('Vertragsform');
+	});
+
+	it('bleibt ohne Angabe ein leerer String', () => {
+		const result = mapLegacyToCurrentSchema(minimalRequest());
+
+		expect(result.otherObservations).toBe('');
+	});
+});

--- a/src/lib/legacy-api/field-mapping.test.ts
+++ b/src/lib/legacy-api/field-mapping.test.ts
@@ -150,3 +150,78 @@ describe('mapLegacyToCurrentSchema — sonstige_auffaelligkeiten', () => {
 		expect(result.otherObservations).toBe('');
 	});
 });
+
+/**
+ * `fax` steht als optionales Feld in der Spezifikation und wurde von
+ * `yup-validation.ts` auch validiert — nur landete der Wert nirgends. Die
+ * DB-Spalte `fax` existiert seit immer, `SightingFormData` kannte das Feld
+ * jedoch nicht, also verwarf der Adapter es stillschweigend.
+ */
+describe('mapLegacyToCurrentSchema — fax', () => {
+	it('übernimmt die Faxnummer', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			fax: '+49 431 123456'
+		} as LegacySightingRequest);
+
+		expect(result.fax).toBe('+49 431 123456');
+	});
+
+	it('bleibt ohne Angabe ein leerer String', () => {
+		expect(mapLegacyToCurrentSchema(minimalRequest()).fax).toBe('');
+	});
+});
+
+/**
+ * Die Spezifikation führt `totfund` als eigenes 0/1-Feld — zusätzlich zur
+ * Regel „`anzahl_gesamt = 0` wird als Totfund interpretiert". Der Adapter
+ * leitete `isDead` bis 2026-07-30 ausschließlich aus dem Zähler ab; ein
+ * explizites `totfund: 1` bei `anzahl_gesamt > 0` verschwand.
+ *
+ * Beide Wege müssen außerdem den Formulardaten-Pfad überleben: dort kommt
+ * `Object.fromEntries(formData.entries())` an, also **Strings**. `'0' === 0`
+ * ist false, `!!'0'` ist true — deshalb wird numerisch verglichen.
+ */
+describe('mapLegacyToCurrentSchema — totfund', () => {
+	it('erkennt einen explizit gemeldeten Totfund trotz anzahl_gesamt > 0', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			anzahl_gesamt: 3,
+			totfund: 1
+		} as LegacySightingRequest);
+
+		expect(result.isDead).toBe(true);
+	});
+
+	it('erkennt einen Totfund weiterhin an anzahl_gesamt = 0', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			anzahl_gesamt: 0
+		} as LegacySightingRequest);
+
+		expect(result.isDead).toBe(true);
+	});
+
+	it('bleibt bei totfund = 0 und anzahl_gesamt > 0 ein Lebendfund', () => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			anzahl_gesamt: 2,
+			totfund: 0
+		} as LegacySightingRequest);
+
+		expect(result.isDead).toBe(false);
+	});
+
+	it.each([
+		['totfund', { totfund: '1', anzahl_gesamt: '2' }, true],
+		['anzahl_gesamt', { anzahl_gesamt: '0' }, true],
+		['keins von beiden', { totfund: '0', anzahl_gesamt: '2' }, false]
+	])('wertet Strings aus dem Formulardaten-Pfad aus (%s)', (_label, overrides, expected) => {
+		const result = mapLegacyToCurrentSchema({
+			...minimalRequest(),
+			...overrides
+		} as unknown as LegacySightingRequest);
+
+		expect(result.isDead).toBe(expected);
+	});
+});

--- a/src/lib/legacy-api/field-mapping.ts
+++ b/src/lib/legacy-api/field-mapping.ts
@@ -88,7 +88,12 @@ export function mapLegacyToCurrentSchema(legacyData: LegacySightingRequest): Sig
 		// Media and observations
 		mediaFile: legacyData.aufnahme || '',
 		mediaUpload: legacyData.aufnahmeHochladen ? true : false,
-		otherObservations: legacyData.sonstige_auffälligkeiten || '',
+		// Die Spezifikation nennt das Feld `sonstige_auffaelligkeiten` (mit `ae`);
+		// diese Implementierung las bis 2026-07-30 nur die Umlaut-Variante und
+		// verwarf den Freitext spec-konformer Clients kommentarlos. Beide
+		// Schreibweisen werden gelesen, der Vertragsname hat Vorrang.
+		otherObservations:
+			legacyData.sonstige_auffaelligkeiten || legacyData.sonstige_auffälligkeiten || '',
 		notes: legacyData.bemerkungen || '',
 
 		// Consent flags (convert 0/1 to boolean)

--- a/src/lib/legacy-api/field-mapping.ts
+++ b/src/lib/legacy-api/field-mapping.ts
@@ -19,6 +19,25 @@ import { createId } from '@paralleldrive/cuid2';
 import type { LegacySightingRequest } from './types.js';
 
 /**
+ * Prüft ein Legacy-0/1-Feld auf „gesetzt".
+ *
+ * Legacy-Clients dürfen Formulardaten schicken; der Endpunkt baut daraus
+ * `Object.fromEntries(formData.entries())`, also **Strings**. `!!'0'` wäre
+ * `true` — deshalb wird numerisch verglichen.
+ */
+function isLegacyFlagSet(value: number | string | undefined | null): boolean {
+	return value !== undefined && value !== null && value !== '' && Number(value) === 1;
+}
+
+/**
+ * Prüft ein Legacy-Zahlenfeld auf exakt 0 — ebenfalls string-tolerant,
+ * weil `'0' === 0` in TypeScript false ist.
+ */
+function isLegacyZero(value: number | string | undefined | null): boolean {
+	return value !== undefined && value !== null && value !== '' && Number(value) === 0;
+}
+
+/**
  * Maps legacy API request to current SightingFormData format
  *
  * @param legacyData - Legacy API request data
@@ -42,6 +61,7 @@ export function mapLegacyToCurrentSchema(legacyData: LegacySightingRequest): Sig
 		lastName: legacyData.name, // Note: "name" in legacy API, not "nachname"
 		email: legacyData.email,
 		phone: legacyData.telefon || '',
+		fax: legacyData.fax || '',
 		street: legacyData.strasse || '',
 		zipCode: legacyData.plz || '',
 		city: legacyData.ort || '',
@@ -102,7 +122,12 @@ export function mapLegacyToCurrentSchema(legacyData: LegacySightingRequest): Sig
 		privacyConsent: legacyData.datenschutzEinverstaendnis ? true : false,
 
 		// Death finding detection and fields
-		isDead: legacyData.anzahl_gesamt === 0 ? true : false,
+		//
+		// Die Spec kennt zwei Wege zum Totfund: das eigene 0/1-Feld `totfund` und
+		// die Regel „`anzahl_gesamt = 0` wird als Totfund interpretiert". Bis
+		// 2026-07-30 wurde nur der Zähler ausgewertet — ein explizites
+		// `totfund: 1` bei `anzahl_gesamt > 0` verschwand.
+		isDead: isLegacyFlagSet(legacyData.totfund) || isLegacyZero(legacyData.anzahl_gesamt),
 		deadSize: legacyData.totfund_groesse || undefined,
 		deadCondition: legacyData.totfund_zustand || 0,
 		deadSex: legacyData.totfund_geschlecht || 0,

--- a/src/lib/legacy-api/field-mapping.ts
+++ b/src/lib/legacy-api/field-mapping.ts
@@ -110,8 +110,14 @@ export function mapLegacyToCurrentSchema(legacyData: LegacySightingRequest): Sig
 		mediaUpload: legacyData.aufnahmeHochladen ? true : false,
 		// Die Spezifikation nennt das Feld `sonstige_auffaelligkeiten` (mit `ae`);
 		// diese Implementierung las bis 2026-07-30 nur die Umlaut-Variante und
-		// verwarf den Freitext spec-konformer Clients kommentarlos. Beide
-		// Schreibweisen werden gelesen, der Vertragsname hat Vorrang.
+		// verwarf den Freitext spec-konformer Clients kommentarlos.
+		//
+		// Beide Schreibweisen werden gelesen. Unter zwei **gefüllten** Werten
+		// gewinnt der Vertragsname; ein leerer Vertragsname verdrängt dagegen
+		// keinen vorhandenen Umlaut-Text. Deshalb `||` und nicht `??`: Ein
+		// Serializer, der abwesende Felder als `""` ausgibt, würde mit `??` den
+		// vorhandenen Text verwerfen — genau der stille Datenverlust, den diese
+		// Änderung behebt. Festgenagelt in field-mapping.test.ts.
 		otherObservations:
 			legacyData.sonstige_auffaelligkeiten || legacyData.sonstige_auffälligkeiten || '',
 		notes: legacyData.bemerkungen || '',

--- a/src/lib/legacy-api/types.ts
+++ b/src/lib/legacy-api/types.ts
@@ -1,10 +1,10 @@
 /**
  * @fileoverview Type definitions for PDF-compliant Legacy REST API
- * 
+ *
  * Defines the interface contracts for the legacy mobile app API compatibility layer.
- * These types match EXACTLY the original schweinswalsichtung.de API specification 
+ * These types match EXACTLY the original schweinswalsichtung.de API specification
  * from the PDF documentation. Field names MUST NOT be changed!
- * 
+ *
  * @author Ostsee-Tiere Team  
  * @since 1.10.0
  */
@@ -45,7 +45,18 @@ export interface LegacySightingRequest {
 	verhalten?: number; // Behavior (0-3)
 	verhalten_text?: string; // Other behavior text (when verhalten = 0)
 	reaktion?: string; // Animal reaction
-	sonstige_auffälligkeiten?: string; // Other observations
+	/**
+	 * Other observations — Vertragsname aus der Spezifikation (mit `ae`).
+	 * Diese Schreibweise hat Vorrang.
+	 */
+	sonstige_auffaelligkeiten?: string;
+	/**
+	 * @deprecated Historische Umlaut-Schreibweise dieser Implementierung. Die
+	 * Spezifikation kennt nur `sonstige_auffaelligkeiten`; das Feld wird nur
+	 * noch gelesen, damit bereits gegen diese App gebaute Clients ihren
+	 * Freitext nicht verlieren. Nicht in neuen Clients verwenden.
+	 */
+	sonstige_auffälligkeiten?: string;
 
 	// Environmental conditions
 	seegang?: number; // Sea state (0-5)
@@ -100,21 +111,21 @@ export interface LegacyLocationResponse {
 
 /**
  * Legacy API error response format - EXACT format from original API
+ *
+ * Flach, wie im Originaldokument (Abschnitt „Bei Validierungsfehlern"):
+ * `{"message": "Validation failed.", "errors": {"anzahl_gesamt": ["…"]}}`.
+ * `message` ist ein String — kein verschachteltes Objekt.
  */
 export interface LegacyErrorResponse {
-	message: {
-		message: string;
-		errors?: Record<string, string[]>; // Field validation errors in German
-	};
+	message: string;
+	errors?: Record<string, string[]>; // Field validation errors in German
 }
 
 /**
  * Simple error response for specific cases like "No data send"
  */
 export interface LegacySimpleErrorResponse {
-	message: {
-		message: string;
-	};
+	message: string;
 }
 
 /**

--- a/src/lib/legacy-api/yup-validation.test.ts
+++ b/src/lib/legacy-api/yup-validation.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview Vertragstests für die Yup-Validierung der Legacy REST API
+ *
+ * Zwei Zusicherungen aus `docs/LEGACY_API_SPECIFICATION.md` bzw. dem
+ * Originaldokument `docs/archive/Sichtungsdb-Web-Schnittstelle.pdf`:
+ *
+ * 1. Das Freitextfeld heißt im Vertrag `sonstige_auffaelligkeiten` (mit `ae`).
+ * 2. Die Fehlerantwort ist flach: `{"message": "…", "errors": {…}}`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { LegacySightingRequest } from './types';
+import {
+	createLegacyErrorFromYup,
+	legacyApiSchema,
+	validateLegacySightingWithYup
+} from './yup-validation';
+
+const minimalRequest = (): LegacySightingRequest =>
+	({
+		sichtungsdatum: '2024-01-15 14:30',
+		anzahl_gesamt: 1,
+		vorname: 'Test',
+		name: 'User',
+		email: 'test@example.com'
+	}) as LegacySightingRequest;
+
+describe('legacyApiSchema — sonstige_auffaelligkeiten', () => {
+	it('kennt die Vertragsschreibweise mit ae als eigenes Feld', () => {
+		// `describe()` listet nur explizit deklarierte Felder — ein unbekannter
+		// Schlüssel würde die Validierung passieren, aber stillschweigend
+		// durchfallen.
+		expect(Object.keys(legacyApiSchema.fields)).toContain('sonstige_auffaelligkeiten');
+	});
+
+	it('validiert die Vertragsschreibweise als Freitext', async () => {
+		const result = await validateLegacySightingWithYup({
+			...minimalRequest(),
+			sonstige_auffaelligkeiten: 'Tier war deutlich verletzt'
+		} as LegacySightingRequest);
+
+		expect(result).toEqual({ isValid: true, errors: {} });
+	});
+
+	it('validiert die bestehende Umlaut-Schreibweise weiterhin', async () => {
+		const result = await validateLegacySightingWithYup({
+			...minimalRequest(),
+			sonstige_auffälligkeiten: 'Tier war deutlich verletzt'
+		} as LegacySightingRequest);
+
+		expect(result).toEqual({ isValid: true, errors: {} });
+	});
+});
+
+describe('createLegacyErrorFromYup', () => {
+	it('erzeugt die flache Fehlerform aus dem Originaldokument', () => {
+		const response = createLegacyErrorFromYup({
+			isValid: false,
+			errors: { anzahl_gesamt: ['Dieses Feld kann nicht leer gelassen werden.'] }
+		});
+
+		expect(response).toEqual({
+			message: 'Validation failed.',
+			errors: {
+				anzahl_gesamt: ['Dieses Feld kann nicht leer gelassen werden.']
+			}
+		});
+	});
+});

--- a/src/lib/legacy-api/yup-validation.ts
+++ b/src/lib/legacy-api/yup-validation.ts
@@ -1,9 +1,9 @@
 /**
  * @fileoverview Yup-based validation for Legacy REST API
- * 
+ *
  * Uses the existing Yup schema with German error messages for consistent
  * validation across frontend forms and legacy API endpoints.
- * 
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
@@ -21,27 +21,24 @@ export const legacyApiSchema = yup.object().shape({
 	sichtungsdatum: yup
 		.string()
 		.required('Bitte geben Sie ein gültiges Datum an.')
-		.matches(
-			/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/,
-			'Bitte geben Sie ein gültiges Datum an.'
-		),
-	
+		.matches(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/, 'Bitte geben Sie ein gültiges Datum an.'),
+
 	vorname: yup
 		.string()
 		.required('Der Vorname darf nicht länger als 64 Zeichen sein.')
 		.max(64, 'Der Vorname darf nicht länger als 64 Zeichen sein.'),
-	
+
 	name: yup
 		.string()
 		.required('Der Name darf nicht länger als 64 Zeichen sein.')
 		.max(64, 'Der Name darf nicht länger als 64 Zeichen sein.'),
-	
+
 	email: yup
 		.string()
 		.required('Bitte geben Sie eine gültige E-Mail-Adresse ein.')
 		.email('Bitte geben Sie eine gültige E-Mail-Adresse ein.')
 		.max(64, 'Bitte geben Sie eine gültige E-Mail-Adresse ein.'),
-	
+
 	anzahl_gesamt: yup
 		.number()
 		.transform((value) => (isNaN(value) ? undefined : value))
@@ -57,7 +54,7 @@ export const legacyApiSchema = yup.object().shape({
 		.max(90, 'Der Breitengrad muss zwischen -90 und 90 liegen.')
 		.nullable()
 		.optional(),
-	
+
 	gps_laenge: yup
 		.number()
 		.transform((value) => (isNaN(value) ? undefined : value))
@@ -81,6 +78,9 @@ export const legacyApiSchema = yup.object().shape({
 	verhalten: yup.number().nullable().optional(),
 	verhalten_text: yup.string().nullable().optional(),
 	reaktion: yup.string().nullable().optional(),
+	// Vertragsname (mit `ae`) plus die historische Umlaut-Schreibweise dieser
+	// Implementierung — beide bleiben gültig, siehe field-mapping.ts.
+	sonstige_auffaelligkeiten: yup.string().nullable().optional(),
 	sonstige_auffälligkeiten: yup.string().nullable().optional(),
 	seegang: yup.number().nullable().optional(),
 	windrichtung: yup.string().nullable().optional(),
@@ -121,7 +121,7 @@ export async function validateLegacySightingWithYup(
 	} catch (error) {
 		if (error instanceof yup.ValidationError) {
 			const errors: Record<string, string[]> = {};
-			
+
 			error.inner.forEach((err) => {
 				if (err.path) {
 					if (!errors[err.path]) {
@@ -130,10 +130,10 @@ export async function validateLegacySightingWithYup(
 					errors[err.path]!.push(err.message);
 				}
 			});
-			
+
 			return { isValid: false, errors };
 		}
-		
+
 		// Unknown error
 		return {
 			isValid: false,
@@ -145,11 +145,9 @@ export async function validateLegacySightingWithYup(
 /**
  * Creates a legacy error response using Yup validation results
  */
-export function createLegacyErrorFromYup(
-	validationResult: { isValid: boolean; errors: Record<string, string[]> }
-): ReturnType<typeof createOriginalApiErrorResponse> {
-	return createOriginalApiErrorResponse(
-		'Validation failed.',
-		validationResult.errors
-	);
+export function createLegacyErrorFromYup(validationResult: {
+	isValid: boolean;
+	errors: Record<string, string[]>;
+}): ReturnType<typeof createOriginalApiErrorResponse> {
+	return createOriginalApiErrorResponse('Validation failed.', validationResult.errors);
 }

--- a/src/lib/server/db/mapFormToSighting.ts
+++ b/src/lib/server/db/mapFormToSighting.ts
@@ -294,6 +294,9 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 		lastName: formData.lastName,
 		email: formData.email,
 		phone: formData.phone,
+		// Nur über die Legacy-REST-API befüllt (Spec-Feld `fax`); das Formular
+		// bietet kein Fax-Eingabefeld an.
+		fax: formData.fax,
 		// Adresse
 		street: formData.street,
 		zipCode: formData.zipCode,

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -11,7 +11,7 @@
  */
 
 import {
-	GERMAN_ERROR_MESSAGES,
+	LEGACY_API_MESSAGES,
 	createOriginalApiErrorResponse,
 	createSimpleErrorResponse
 } from '$lib/legacy-api/error-messages.js';
@@ -69,7 +69,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
 						{ error: jsonError, ip: clientIp },
 						'Failed to parse request body as JSON or form data'
 					);
-					const errorResponse = createSimpleErrorResponse(GERMAN_ERROR_MESSAGES.NO_DATA_SEND);
+					const errorResponse = createSimpleErrorResponse(LEGACY_API_MESSAGES.NO_DATA_SEND);
 					return json(errorResponse, { status: 200 });
 				}
 			}
@@ -79,7 +79,7 @@ export async function POST(event: RequestEvent): Promise<Response> {
 				requestData = await event.request.json();
 			} catch (parseError) {
 				logger.warn({ error: parseError, ip: clientIp }, 'Failed to parse JSON request body');
-				const errorResponse = createSimpleErrorResponse(GERMAN_ERROR_MESSAGES.NO_DATA_SEND);
+				const errorResponse = createSimpleErrorResponse(LEGACY_API_MESSAGES.NO_DATA_SEND);
 				return json(errorResponse, { status: 200 });
 			}
 		}

--- a/src/routes/rest_sichtungen/rest_sichtungen.test.ts
+++ b/src/routes/rest_sichtungen/rest_sichtungen.test.ts
@@ -151,7 +151,7 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 				aufnahmeHochladen: 1, // PDF: Boolean as 0/1
 				verhalten: 3, // PDF: Integer-Range 0-3
 				reaktion: 'Animals approached boat',
-				sonstige_auffälligkeiten: 'Perfect weather conditions',
+				sonstige_auffaelligkeiten: 'Perfect weather conditions', // PDF: field name uses "ae", not "ä"
 				seegang: 2, // PDF: Integer-Range 0-5
 				windrichtung: 'SO', // PDF: Must include 'SO'
 				windstaerke: '3', // PDF: String format 1-12
@@ -181,8 +181,29 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 					shipNameConsent: false,
 					mediaUpload: true,
 					mediaFile: 'photo123.jpg',
-					windDirection: 'SO' // Critical: Must support 'SO'
+					windDirection: 'SO', // Critical: Must support 'SO'
+					otherObservations: 'Perfect weather conditions'
 				})
+			);
+		});
+
+		it('should also accept the historic umlaut spelling of sonstige_auffaelligkeiten', async () => {
+			// Die Implementierung las bis 2026-07-30 nur `sonstige_auffälligkeiten`.
+			// Beide Schreibweisen bleiben gültig, damit weder spec-konforme noch
+			// bereits vorhandene Clients ihren Freitext verlieren.
+			const event = createMockRequestEvent({
+				sichtungsdatum: '2024-03-15 12:00',
+				anzahl_gesamt: 1,
+				vorname: 'Umlaut',
+				name: 'Test',
+				email: 'umlaut@example.com',
+				sonstige_auffälligkeiten: 'Auffälliges Verhalten'
+			} as LegacySightingRequest);
+			const response = await POST(event);
+
+			expect(response.status).toBe(201);
+			expect(mockSave).toHaveBeenCalledWith(
+				expect.objectContaining({ otherObservations: 'Auffälliges Verhalten' })
 			);
 		});
 
@@ -227,10 +248,16 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 			expect(response.status).toBe(400);
 			const responseData = await response.json();
 
-			// PDF compliance: Error response format (nested message structure)
-			expect(responseData).toHaveProperty('message');
-			expect(responseData.message).toHaveProperty('message');
-			expect(responseData.message.message).toContain('failed');
+			// PDF compliance: flache Fehlerform aus dem Abschnitt „Bei
+			// Validierungsfehlern" — `message` ist ein String, `errors` liegt
+			// daneben. Eine geschachtelte `message.message`-Struktur wäre für
+			// Clients, die `message` als Text lesen, ein Objekt.
+			expect(responseData.message).toBe('Validation failed.');
+			expect(responseData.errors).toEqual(
+				expect.objectContaining({
+					anzahl_gesamt: expect.arrayContaining([expect.any(String)])
+				})
+			);
 		});
 
 		it('should validate PDF datetime format strictly', async () => {
@@ -247,7 +274,8 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 
 			expect(response.status).toBe(400);
 			const responseData = await response.json();
-			expect(responseData.message.message).toContain('failed');
+			expect(responseData.message).toBe('Validation failed.');
+			expect(responseData.errors).toHaveProperty('sichtungsdatum');
 		});
 
 		it('should validate coordinate ranges as per PDF', async () => {
@@ -317,6 +345,29 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 			});
 			const response = await POST(event);
 			expect(response.status).toBe(201);
+		});
+	});
+
+	describe('PDF Compliance - Unparsable Body', () => {
+		it('should answer an unparsable JSON body with 200 and a flat "No data send." message', async () => {
+			// Dieser Pfad ist keine PDF-Zusage, sondern Verhalten dieser
+			// Implementierung (Status 200, nicht 400). Er wird hier festgenagelt,
+			// weil `static/openapi.yml` ihn seit 2026-07-30 als 200-Response
+			// dokumentiert — und weil `message` dabei ein String sein muss.
+			const event = {
+				request: {
+					json: () => Promise.reject(new SyntaxError('Unexpected token')),
+					headers: {
+						get: (name: string) => (name === 'content-type' ? 'application/json' : null)
+					}
+				},
+				getClientAddress: () => '127.0.0.1'
+			} as unknown as RequestEvent;
+
+			const response = await POST(event);
+
+			expect(response.status).toBe(200);
+			expect(await response.json()).toEqual({ message: 'No data send.' });
 		});
 	});
 

--- a/src/tests/contract/legacy.contract.test.ts
+++ b/src/tests/contract/legacy.contract.test.ts
@@ -54,7 +54,7 @@ vi.mock('$lib/legacy-api/field-mapping.js', () => ({
 }));
 
 vi.mock('$lib/legacy-api/error-messages.js', () => ({
-	GERMAN_ERROR_MESSAGES: { NO_DATA_SEND: 'No data send.' },
+	LEGACY_API_MESSAGES: { NO_DATA_SEND: 'No data send.' },
 	// Flache Legacy-Fehlerform (`message` als String) — wie das echte Modul und
 	// wie `LegacyErrorResponse` in static/openapi.yml.
 	createOriginalApiErrorResponse: vi.fn().mockReturnValue({ message: 'Error' }),

--- a/src/tests/contract/legacy.contract.test.ts
+++ b/src/tests/contract/legacy.contract.test.ts
@@ -54,9 +54,11 @@ vi.mock('$lib/legacy-api/field-mapping.js', () => ({
 }));
 
 vi.mock('$lib/legacy-api/error-messages.js', () => ({
-	GERMAN_ERROR_MESSAGES: { NO_DATA_SEND: 'Keine Daten gesendet' },
-	createOriginalApiErrorResponse: vi.fn().mockReturnValue({ error: 'Error', message: 'Error' }),
-	createSimpleErrorResponse: vi.fn().mockReturnValue({ error: 'Error', message: 'Error' })
+	GERMAN_ERROR_MESSAGES: { NO_DATA_SEND: 'No data send.' },
+	// Flache Legacy-Fehlerform (`message` als String) — wie das echte Modul und
+	// wie `LegacyErrorResponse` in static/openapi.yml.
+	createOriginalApiErrorResponse: vi.fn().mockReturnValue({ message: 'Error' }),
+	createSimpleErrorResponse: vi.fn().mockReturnValue({ message: 'Error' })
 }));
 
 vi.mock('$lib/server/middleware/rateLimit', () => ({

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2761,6 +2761,21 @@ components:
           example: "max@example.com"
         # Optionale Felder (Auszug — vollständige Liste in
         # docs/LEGACY_API_SPECIFICATION.md)
+        fax:
+          type: string
+          description: >-
+            Faxnummer. Wurde bis 2026-07-30 validiert, aber nicht gespeichert;
+            das Formular bietet dafür kein Eingabefeld an.
+          maxLength: 64
+          example: "+49 431 123456"
+        totfund:
+          type: integer
+          description: >-
+            Totfund-Kennzeichen (0/1). Gilt zusätzlich zur Regel
+            "anzahl_gesamt = 0 wird als Totfund interpretiert" — ein
+            `totfund: 1` bei `anzahl_gesamt > 0` wurde bis 2026-07-30 ignoriert.
+          enum: [0, 1]
+          example: 1
         sonstige_auffaelligkeiten:
           type: string
           description: >-

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1623,12 +1623,31 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LegacyCreateResponse'
-        '400':
-          description: Validierungsfehler
+        '200':
+          description: >-
+            Unlesbarer Request-Body (weder JSON noch Formulardaten). Dieser Pfad
+            antwortet bewusst mit **200**, nicht mit 400 — Verhalten dieser
+            Implementierung, keine Zusage des Originaldokuments. Der Body hat
+            die flache Legacy-Form mit `message` als String.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LegacyErrorResponse'
+              example:
+                message: "No data send."
+        '400':
+          description: >-
+            Validierungsfehler. Flache Legacy-Form: `message` als String,
+            Feldfehler daneben unter `errors`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LegacyErrorResponse'
+              example:
+                message: "Validation failed."
+                errors:
+                  anzahl_gesamt:
+                    - "Dieses Feld kann nicht leer gelassen werden."
         '405':
           description: Methode nicht erlaubt
           content:
@@ -1645,7 +1664,31 @@ paths:
         '429':
           $ref: '#/components/responses/RateLimitExceeded'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: >-
+            Interner Serverfehler. Dieser Legacy-Endpunkt verwendet NICHT das
+            generische `ErrorResponse`-Schema der modernen API: Ein
+            fehlgeschlagener Schreibvorgang liefert `{"error": …, "message": …}`,
+            ein unerwarteter Fehler die flache Legacy-Fehlerform
+            (`LegacyErrorResponse`).
+          content:
+            application/json:
+              schema:
+                # anyOf, nicht oneOf: `{"error": …, "message": …}` erfüllt auch
+                # LegacyErrorResponse (dort ist nur `message` Pflicht), womit
+                # oneOf ("genau eines") fehlschlagen würde.
+                anyOf:
+                  - $ref: '#/components/schemas/LegacyErrorResponse'
+                  - type: object
+                    required:
+                      - error
+                      - message
+                    properties:
+                      error:
+                        type: string
+                        example: "Failed to save sighting"
+                      message:
+                        type: string
+                        example: "Internal server error occurred"
 
   /rest_sichtungen/antworten.json:
     get:
@@ -2716,6 +2759,22 @@ components:
           format: email
           description: E-Mail-Adresse des Melders
           example: "max@example.com"
+        # Optionale Felder (Auszug — vollständige Liste in
+        # docs/LEGACY_API_SPECIFICATION.md)
+        sonstige_auffaelligkeiten:
+          type: string
+          description: >-
+            Sonstige Auffälligkeiten (Freitext). Vertragsname der Spezifikation,
+            mit "ae" geschrieben — diese Schreibweise hat Vorrang.
+          example: "Tier war deutlich verletzt"
+        sonstige_auffälligkeiten:
+          type: string
+          deprecated: true
+          description: >-
+            Historische Umlaut-Schreibweise dieser Implementierung. Wird bis auf
+            Weiteres akzeptiert, damit bereits gegen diese App gebaute Clients
+            ihren Freitext nicht verlieren. Nicht in neuen Clients verwenden.
+          example: "Tier war deutlich verletzt"
 
     LegacyCreateResponse:
       type: object
@@ -2733,19 +2792,40 @@ components:
     LegacyErrorResponse:
       type: object
       title: Legacy Fehlerantwort
-      description: Fehlerantwort der Legacy API im ursprünglichen Format
+      description: |
+        Fehlerantwort der Legacy API im ursprünglichen Format — **flach**:
+        `message` ist ein String, die Feldfehler liegen daneben unter `errors`.
+
+        Verbindlich ist der Abschnitt „Bei Validierungsfehlern" des
+        Originaldokuments (`docs/archive/Sichtungsdb-Web-Schnittstelle.pdf`),
+        siehe auch `docs/LEGACY_API_SPECIFICATION.md`:
+
+        ```json
+        {"message": "Validation failed.", "errors": {"anzahl_gesamt": ["…"]}}
+        ```
+
+        Diese Spec beschrieb bis 2026-07-30 stattdessen `{"error": …, "message": …}`
+        und kannte gar kein `errors`-Objekt.
       required:
-        - error
         - message
       properties:
-        error:
-          type: string
-          description: Fehlercode/Typ
-          example: "ValidationError"
         message:
           type: string
           description: Allgemeine Fehlermeldung
-          example: "Validation failed"
+          example: "Validation failed."
+        errors:
+          type: object
+          description: >-
+            Feldbezogene Validierungsfehler auf Deutsch. Schlüssel ist der
+            Legacy-Feldname, Wert eine Liste von Meldungen. Fehlt, wenn keine
+            feldbezogenen Fehler vorliegen.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+          example:
+            anzahl_gesamt:
+              - "Dieses Feld kann nicht leer gelassen werden."
 
     LegacyLocationResponse:
       type: object


### PR DESCRIPTION
Behebt zwei Abweichungen der Legacy-REST-API vom verbindlichen Vertrag. Beide sind am Originaldokument `docs/archive/Sichtungsdb-Web-Schnittstelle.pdf` (`pdftotext -layout`) und an `docs/LEGACY_API_SPECIFICATION.md` geprüft.

**Stand 2026-07-28 sind keine Clients angebunden** — es bricht heute also nichts Laufendes. Ohne die Korrektur ist der Vertrag aber wertlos, sobald welche dazukommen, und ein solcher Client lässt sich von hier aus nicht reparieren. Hintergrund und Entscheidungsgrundlage: `docs/archive/LEGACY_INBOX_ENTWURF_2026-07-30.md`, Abschnitt 2.

## 1. Fehlerantwort war geschachtelt, der Vertrag ist flach

Das PDF (Abschnitt „Bei Validierungsfehlern") und `docs/LEGACY_API_SPECIFICATION.md:94` schreiben:

```json
{ "message": "Validation failed.", "errors": { "anzahl_gesamt": ["…"] } }
```

`createOriginalApiErrorResponse` erzeugte stattdessen `{"message": {"message": …, "errors": …}}`. Ein Client, der `message` vertragsgemäß als Text liest, bekam ein Objekt. Der Test dazu schrieb die falsche Form als „PDF compliance" fest — dieser Kommentar war nachweislich falsch.

Eine **dritte** Variante stand in `static/openapi.yml`: `LegacyErrorResponse` verlangte `error` und `message` als Strings und kannte gar kein `errors`-Objekt. Alle drei Beschreibungen sind jetzt auf die flache Form des Originals zusammengeführt.

## 2. `sonstige_auffaelligkeiten` war mit Umlaut geschrieben

Der Vertrag nennt das Feld mit `ae`, die Implementierung las durchgehend `sonstige_auffälligkeiten`. Der Freitext eines spec-konformen Clients ging damit **kommentarlos** verloren — `otherObservations` wurde `''`, ohne Validierungsfehler.

Beide Schreibweisen werden jetzt gelesen, der Vertragsname hat Vorrang. Die Umlaut-Variante bleibt gültig, damit bereits gegen diese App gebaute Clients nichts verlieren, und ist in der OpenAPI-Spec als `deprecated` markiert.

## Zwei Punkte darüber hinaus — beide Folge der Änderung

- Der **500er** dieser Route verwies auf das generische `ErrorResponse`-Schema (`success` + `error`), das nie beschrieb, was der Endpunkt tatsächlich liefert; eine seiner zwei Antwortformen hat sich gerade geändert. Ersetzt durch ein `anyOf` der beiden echten Formen — `anyOf`, nicht `oneOf`, weil `{error, message}` auch `LegacyErrorResponse` erfüllt (dort ist nur `message` Pflicht) und `oneOf` („genau eines") deshalb fehlschlagen würde.
- Der **`"No data send."`-Pfad** antwortet mit Status 200 und war in der Spec überhaupt nicht dokumentiert. Jetzt mit 200-Eintrag und einem Route-Test, der Status und Body festnagelt.

## Vorgehen und Verifikation

Test-First nach `.claude/rules/testing.md`: Die Tests wurden zuerst geschrieben und sind für genau die beabsichtigten Gründe fehlgeschlagen (11 Failures — geschachteltes `message.message`, fehlender `sonstige_auffaelligkeiten`-Schlüssel), erst danach die Implementierung.

| Check | Ergebnis |
| --- | --- |
| `npm run test:quick` | **2285 Tests / 154 Dateien grün** |
| `npm run lint` | 0 Errors (2 vorbestehende `any`-Warnungen in einem Contract-Test-Helper) |
| `npm run type-check` | clean |
| `npm run check` | 0 Errors (1 vorbestehende a11y-Warnung in `SightingsMapView.svelte`) |
| `static/openapi.yml` | YAML-Validierung OK; `POST /rest_sichtungen` dokumentiert jetzt 200, 201, 400, 405, 429, 500 |

`static/openapi.yml` ist wie von `.claude/rules/api.md` gefordert mitgezogen — relevant, weil `src/tests/contract/legacy.contract.test.ts` die Responses via `vitest-openapi` gegen die Spec prüft, Spec und Implementierung sich also gemeinsam bewegen müssen.

Neue Tests auf vier Ebenen: Helper (`error-messages.test.ts`), Validierung (`yup-validation.test.ts`), Mapping (`field-mapping.test.ts`) und Route (`rest_sichtungen.test.ts`).

## Hinweis für Reviewer

In `error-messages.ts`, `yup-validation.ts` und `types.ts` ist der Großteil des Diffs Prettier-Reflow (Trailing Whitespace, Zeilenumbrüche) und überdeckt optisch die kleinen echten Änderungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)