### PR TITLE
fix(ui): UI/UX-Befunde aus dem Review vom 2026-07-30 abarbeiten

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -170,6 +170,40 @@ export const saveSighting = async (
 
 ---
 
+## `ostsee` und `ostsee_geo` — die Namen sind vertauscht
+
+Zwei Spalten in `sichtungen` bedeuten scheinbar dasselbe. Sie tun es nicht, und ihre
+Namen legen die Bedeutungen **verkehrt herum** nahe:
+
+| Spalte       | Drizzle          | Prüfung                                           |
+| ------------ | ---------------- | ------------------------------------------------- |
+| `ostsee`     | `inBalticSea`    | exaktes Ostsee-Polygon — **streng**               |
+| `ostsee_geo` | `inBalticSeaGeo` | Bounding Box 9,4–30,2° E / 53–66° N — **schwach** |
+
+Das „geo" sitzt an der _groben_ Prüfung. Deren Rechteck umfasst Jütland, Schonen,
+Nordostdeutschland, Polen und das Baltikum — eine Meldung aus Hannover läge darin.
+Fachliche Aussagen („liegt in der Ostsee") gehören deshalb ausschließlich auf
+`ostsee`.
+
+`ostsee_geo` ist `integer` und hat **drei** Werte: `0` = keine Position im
+Kartenbereich, `1` = drin, `2` = drin (nur Altsystem, 15.225 Zeilen, endet
+2025-11-09). Der Unterschied zwischen 1 und 2 ist aus den Daten nicht
+rekonstruierbar. **Immer `> 0` prüfen, nie `= 1`** — sonst fallen 79 % des
+Bestands lautlos heraus, genau so ist die entfernte `geographicStats`-Abfrage
+entstanden.
+
+Diese Erläuterung steht hier und **nicht als Kommentar an den Spalten**: Der
+CI-Job `migration-check` verlangt bei jeder Änderung an `schema.ts` eine
+Migration unter `drizzle/` — rein pfadbasiert, auch bei reinen Kommentaren, für
+die `db:generate` erwartungsgemäß „No schema changes" meldet. Diese Regeldatei
+lädt über `paths` bei jeder Datei unter `src/lib/server/db/**` und ist damit beim
+Bearbeiten des Schemas ohnehin im Kontext.
+
+Vollständige Referenz mit Messwerten, verworfenen Hypothesen zur `2` und zwei noch
+offenen Fehlern: `docs/OSTSEE_FLAGS.md`
+
+---
+
 ## Prüfstatus in Auswertungen — immer explizit
 
 Der Prüfstatus selbst ist in `.claude/rules/api.md` geregelt: **genau zwei Zustände**

--- a/.claude/rules/geo.md
+++ b/.claude/rules/geo.md
@@ -48,6 +48,35 @@ Response: { inBaltic: boolean, inChartArea: boolean, longitude, latitude }
 
 ---
 
+## Persistenz: `ostsee` und `ostsee_geo` — Namen sind irreführend
+
+Die beiden Ergebnisse landen in zwei Spalten, deren Namen die Bedeutungen
+**verkehrt herum** nahelegen:
+
+| Ergebnis      | Spalte       | Prüfung                      |
+| ------------- | ------------ | ---------------------------- |
+| `inBaltic`    | `ostsee`     | exaktes Polygon — **streng** |
+| `inChartArea` | `ostsee_geo` | Bounding Box — **schwach**   |
+
+Der Zusatz „geo" sitzt also an der _groben_ Prüfung. Zwei Konsequenzen für jeden
+neuen Code:
+
+1. Fachliche Aussagen („liegt in der Ostsee") nur über **`ostsee`**. `ostsee_geo`
+   ist ein Kartenbereichs-Filter; sein Rechteck umfasst Jütland, Schonen,
+   Nordostdeutschland, Polen und das Baltikum.
+2. `ostsee_geo` hat **drei** Werte: `0` = keine Position im Kartenbereich, `1` =
+   drin, `2` = drin (nur Altsystem, 15.225 Zeilen). Deshalb **immer `> 0` prüfen,
+   nie `= 1`** — sonst fallen 79 % des Bestands lautlos heraus.
+
+Die Invariante „Polygon liegt in der Bounding Box" gilt **nicht**: die Westgrenze
+9,4° E schneidet Kieler Bucht und Flensburger Förde ab (126 Zeilen mit
+`ostsee = 1` westlich davon). Wer `BALTIC_SEA_BBOX` anfasst, prüft das mit.
+
+Vollständige Referenz inkl. Messwerten und zwei noch offener Fehler:
+`docs/OSTSEE_FLAGS.md`
+
+---
+
 ## Schlüsseldateien
 
 | Datei                                      | Zweck                              |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,18 +144,19 @@ Erst der manuelle Workflow **Promote to Production** (mit Approval am Environmen
 
 ## Weitere Dokumentation
 
-| Dokument                           | Inhalt                                                          |
-| ---------------------------------- | --------------------------------------------------------------- |
-| `.claude/README.md`                | Aufbau der Claude-Konfiguration                                 |
-| `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen                         |
-| `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)                          |
-| `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                                           |
-| `docs/RELEASE_PIPELINE.md`         | Release → Staging → Production, Image-Tags, Promotion, Rollback |
-| `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                        |
-| `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                            |
-| `docs/ENVIRONMENT.md`              | Umgebungsvariablen, inkl. Zeitzonen-Konvention (Abschnitt `TZ`) |
-| `docs/WORKTREES.md`                | Worktree-Setup, geteilte Ressourcen, Ports                      |
-| `docs/DATABASE_MIGRATION.md`       | DB Migrationen                                                  |
+| Dokument                           | Inhalt                                                                |
+| ---------------------------------- | --------------------------------------------------------------------- |
+| `.claude/README.md`                | Aufbau der Claude-Konfiguration                                       |
+| `docs/DESIGN_GUIDE.md`             | Design-Prinzipien, Ist-Zustand, Grenzen                               |
+| `docs/CONFIGURATION_USAGE.md`      | ConfigService (Laufzeit-Konfiguration)                                |
+| `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                                                 |
+| `docs/OSTSEE_FLAGS.md`             | `ostsee` vs. `ostsee_geo` — Namen sind irreführend, `2` im Altbestand |
+| `docs/RELEASE_PIPELINE.md`         | Release → Staging → Production, Image-Tags, Promotion, Rollback       |
+| `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                              |
+| `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                                  |
+| `docs/ENVIRONMENT.md`              | Umgebungsvariablen, inkl. Zeitzonen-Konvention (Abschnitt `TZ`)       |
+| `docs/WORKTREES.md`                | Worktree-Setup, geteilte Ressourcen, Ports                            |
+| `docs/DATABASE_MIGRATION.md`       | DB Migrationen                                                        |
 
 Themenspezifische Regeln in `.claude/rules/` laden automatisch, sobald passende Dateien bearbeitet werden — sie müssen hier nicht aufgezählt werden.
 

--- a/docs/OSTSEE_FLAGS.md
+++ b/docs/OSTSEE_FLAGS.md
@@ -1,0 +1,196 @@
+# Die beiden Ostsee-Flags: `ostsee` und `ostsee_geo`
+
+Stand: 2026-07-30. Zahlen aus der lokalen Datenbank (19.880 Zeilen); sie weichen
+von Produktion leicht ab (siehe `docs/WORKTREES.md` zur geteilten Dev-DB).
+
+Die Tabelle `sichtungen` hat zwei Spalten, die beide „liegt in der Ostsee"
+bedeuten könnten. Sie bedeuten **nicht dasselbe**, und ihre Namen legen die
+Bedeutungen genau verkehrt herum nahe. Dieses Dokument ist die verbindliche
+Referenz.
+
+---
+
+## Kurzfassung
+
+| Spalte       | Drizzle-Feld     | Bedeutung heute                            | Wer schreibt        |
+| ------------ | ---------------- | ------------------------------------------ | ------------------- |
+| `ostsee`     | `inBalticSea`    | Punkt liegt **im exakten Ostsee-Polygon**  | neue App, Altsystem |
+| `ostsee_geo` | `inBalticSeaGeo` | Punkt liegt **in der groben Bounding Box** | neue App, Altsystem |
+
+`ostsee` ist die **strenge** Prüfung, `ostsee_geo` die **schwache** — obwohl der
+Zusatz „geo" das Gegenteil suggeriert. Das ist die wichtigste Aussage dieses
+Dokuments und die Ursache der beiden Fehler weiter unten.
+
+---
+
+## Wie die Werte entstehen
+
+Beide Werte stammen aus **einem** Aufruf in `src/lib/server/db/mapFormToSighting.ts`:
+
+```ts
+({ inBaltic, inChartArea } = checkBalticSeaFile(lon, lat));
+// …
+inBalticSea: inBaltic ? 1 : 0,       // ostsee
+inBalticSeaGeo: inChartArea ? 1 : 0  // ostsee_geo
+```
+
+`checkBalticSeaFile` (`src/lib/server/geo/checkBalticSeaFile.ts`) liefert:
+
+- **`inBaltic`** — Punkt-in-Polygon gegen die Natural-Earth-Ostsee-Geometrie
+  (RBush-Index + Turf.js). Präzise Küstenlinie.
+- **`inChartArea`** — reine Bounding-Box-Prüfung gegen `BALTIC_SEA_BBOX`
+  (`src/lib/utils/geo/checkBalticSea.ts`):
+
+  | Grenze | Wert    |
+  | ------ | ------- |
+  | West   | 9,4° E  |
+  | Ost    | 30,2° E |
+  | Süd    | 53,0° N |
+  | Nord   | 66,0° N |
+
+  Dieses Rechteck umfasst große Landflächen (Jütland, Schonen, Nordostdeutschland,
+  Polen, Baltikum) und Wasser, das keine Ostsee ist. Eine Sichtung in Hannover
+  läge darin.
+
+Ohne verwertbare Koordinaten sind beide Werte `0`.
+
+---
+
+## Wertebereich
+
+`ostsee_geo` ist als `integer` deklariert und enthält **drei** Werte, nicht zwei:
+
+| Wert | Zeilen | Zeitraum (`created`)     | Bedeutung                             |
+| ---- | ------ | ------------------------ | ------------------------------------- |
+| `0`  | 657    | 2012-05-31 – 2025-11-10  | keine verwertbare Position            |
+| `1`  | 3.998  | 2012-05-29 – **laufend** | Position im Kartenbereich             |
+| `2`  | 15.225 | 2012-05-21 – 2025-11-09  | Position im Kartenbereich (Altsystem) |
+
+**Die neue App schreibt ausschließlich `0` und `1`.** Der Wert `2` endet exakt am
+Cutoff des Altsystems (letzter Schreibvorgang 2025-11-10, vgl. den
+Freigabe-Workflow) und wird nie wieder entstehen.
+
+### Was `1` von `2` unterscheidet: nichts Auffindbares
+
+Beide bedeuten „im Kartenbereich". Geprüft und jeweils **ohne** Trennschärfe:
+
+| Prüfung                 | Ergebnis                                                                      |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| Bounding Box            | `1`: 3.983 von 3.998 drin · `2`: 15.208 von 15.225 drin — praktisch gleich    |
+| Geografische Lage       | Ø 11,26° E / 54,64° N gegen Ø 10,86° E / 54,85° N, gleiche Wertebereiche      |
+| Zeitverlauf             | beide Werte laufen 2012–2025 **parallel**, kein Semantikwechsel               |
+| ID-Bereiche             | 173–29.180 gegen 157–29.178 — vollständig überlappend, kein Import-Batch      |
+| `eingangskanal`         | `2` überwiegt in **jedem** Kanal                                              |
+| `vonwo` / `schiffsname` | `2` korreliert mit Schiffsmeldungen, erklärt sich aber aus der Grundrate 79 % |
+
+**Fazit:** Die Unterscheidung ist aus den Daten nicht rekonstruierbar. Sie müsste
+aus dem Quellcode des Altsystems oder vom Deutschen Meeresmuseum kommen. Solange
+das offen ist, gilt die einzige belastbare Auslegung:
+
+> **`ostsee_geo = 0` heißt „keine Position im Kartenbereich", jeder Wert `> 0`
+> heißt „Position im Kartenbereich".**
+
+Genau so behandelt der Code die Spalte bereits — `!!sighting.inBalticSeaGeo` in
+`emailService.ts` und `{#if sighting.inBalticSeaGeo}` in den Svelte-Vorlagen machen
+aus `2` ein `true`. Eine Abfrage darf deshalb **nie** auf `= 1` prüfen.
+
+---
+
+## Fehler 1: Statistik-Abfrage zählte nur 0 und 1
+
+War in `src/routes/admin/statistics/+page.server.ts`:
+
+```ts
+inBalticSea:      COUNT(CASE WHEN ostsee_geo = 1 THEN 1 END)
+outsideBalticSea: COUNT(CASE WHEN ostsee_geo = 0 THEN 1 END)
+```
+
+Damit fielen die 15.225 Zeilen mit `2` lautlos heraus — 79 % der Daten. Die
+Abfrage ist am 2026-07-30 entfernt worden; sie wurde ohnehin nie gerendert.
+Eine Neufassung muss `> 0` statt `= 1` prüfen.
+
+---
+
+## Fehler 2: Die Admin-Übersicht zeigt die falsche Spalte (offen)
+
+`src/routes/admin/+page.svelte` beschriftet die Spalte mit **„Ostsee"**, rendert
+darin aber `inBalticSeaGeo`:
+
+```svelte
+{ key: 'inBalticSeaGeo', label: 'Ostsee', sortKey: null }
+…
+{#if sighting.inBalticSeaGeo}
+```
+
+Weil `ostsee_geo` die Bounding Box ist, erscheinen **9.316 Zeilen** mit
+`ostsee = 0` (also nachweislich **nicht** in der Ostsee) in dieser Spalte als „in
+der Ostsee". Eine Meldung aus Hamburg oder Hannover würde dort als Ostsee-Sichtung
+ausgewiesen.
+
+Die Detailansicht macht es richtig — `AdminSightingView.svelte` zeigt beide Werte
+getrennt als „In der Ostsee" und „In der Ostsee (geo)".
+
+**Korrektur:** In der Übersicht `inBalticSea` unter dem Label „Ostsee" rendern
+und `inBalticSeaGeo`, wenn überhaupt, als eigene Spalte „Kartenbereich".
+
+---
+
+## Fehler 3: Die Bounding Box schneidet die Ostsee im Westen ab (offen)
+
+Erwartbar wäre, dass das Polygon in der Bounding Box liegt, also
+`ostsee = 1 → ostsee_geo > 0`. Das gilt **nicht**: die Westgrenze steht auf
+9,4° E, das Ostsee-Polygon reicht westlicher (Kieler Bucht, Flensburger Förde,
+dänische Meerengen).
+
+- **126 Zeilen** haben `ostsee = 1` bei einer Länge **unter 9,4° E**.
+- **533 Zeilen** haben `ostsee = 1` und `ostsee_geo = 0` (alle aus dem Altsystem).
+- Die jüngsten echten Meldungen liegen bei 9,59° E — 0,19° von der Kante.
+
+Eine neue Sichtung in der Flensburger Förde bekäme damit `ostsee = 1` und
+`ostsee_geo = 0` und würde in der Admin-Übersicht (Fehler 2) als „nicht Ostsee"
+geführt.
+
+Der Kommentar an `BALTIC_SEA_BBOX` nennt die Westgrenze „etwa Skagerrak" — das
+Skagerrak liegt bei 8–11° E, die Grenze ist also zu eng gewählt. Eine Korrektur
+auf ca. **8,5° E** würde das Polygon einschließen; sie berührt aber auch die
+Karten-Extent-Begrenzung (`.claude/rules/maps.md`) und will deshalb bewusst
+entschieden werden.
+
+---
+
+## Die E-Mail-Benachrichtigung ist korrekt
+
+Die Handlebars-Vorlage (Default in `configInitializer.ts`) staffelt richtig:
+`inBalticSeaGeo` ist die äußere, gröbere Bedingung, `inBalticSea` die
+Verfeinerung. Der Fall „im Polygon, aber außerhalb der Bounding Box" wird als
+**„Ostsee-Rand — bitte Plausibilität prüfen"** ausgewiesen. Das ist für die
+Westkante genau die passende Aussage.
+
+---
+
+## Wo das verankert ist
+
+Kurzfassungen liegen in `.claude/rules/database.md` (lädt bei jeder Datei unter
+`src/lib/server/db/**`, also auch beim Bearbeiten des Schemas) und in
+`.claude/rules/geo.md` (lädt bei den Geo-Modulen).
+
+**Bewusst nicht als Kommentar an den Spalten in `schema.ts`:** Der CI-Job
+`migration-check` verlangt bei jeder Änderung an `schema.ts` eine Migration unter
+`drizzle/` — rein pfadbasiert, auch bei reinen Kommentaränderungen, für die
+`db:generate` erwartungsgemäß „No schema changes" meldet. Wer die Erklärung dorthin
+verschiebt, macht die CI rot, ohne dass es etwas zu migrieren gäbe.
+
+---
+
+## Regeln für neuen Code
+
+1. **Öffentliche Aussagen über „liegt in der Ostsee" nur über `ostsee`.**
+   `ostsee_geo` ist ein Kartenbereichs-Filter, keine fachliche Aussage.
+2. **Nie auf `ostsee_geo = 1` prüfen** — immer `> 0`, sonst verschwindet der
+   Altbestand.
+3. **`ostsee_geo` ist `notNull` mit Default 0, `ostsee` ist nullable.** Diese
+   Asymmetrie ist Altbestand. Praktisch enthält `ostsee` derzeit **keine**
+   `NULL`-Werte (0 von 19.880 Zeilen geprüft), die Spalte erlaubt sie aber — eine
+   Auswertung sollte sie deshalb trotzdem abfangen, statt sich darauf zu verlassen.
+4. **Keinen dritten Wert einführen.** Wer eine neue Abstufung braucht, legt eine
+   eigene Spalte an, statt die ungeklärte `2` zu erweitern.

--- a/e2e/fixtures/mockApi.ts
+++ b/e2e/fixtures/mockApi.ts
@@ -22,6 +22,79 @@ export async function mockMapSightingsSuccess(page: Page): Promise<void> {
 	);
 }
 
+/** Jahr, für das `mockMapSightingsWithFeatures` Daten liefert. */
+export const MOCK_SIGHTINGS_YEAR = 2024;
+
+/**
+ * Liefert eine feste Handvoll sichtbarer Sichtungen und blockiert gleichzeitig
+ * alle externen Kacheln.
+ *
+ * Gedacht für Tests, die eine **Veränderung des Kartenbilds** messen (z. B. ob ein
+ * Pan wirkt). Dafür müssen zwei Dinge gelten, die `mockMapSightingsSuccess` nicht
+ * erfüllt:
+ *
+ * 1. Es muss überhaupt etwas gezeichnet werden — die leere FeatureCollection dort
+ *    ergibt eine unveränderliche Fläche, an der sich kein Pan ablesen lässt.
+ * 2. Der Hintergrund darf sich **nicht von selbst** ändern. Nachladende
+ *    OSM-Kacheln würden das Bild auch ohne Pan verändern und einen Test, der auf
+ *    „Bild hat sich geändert" prüft, fälschlich grün machen. Deshalb werden
+ *    `tile.openstreetmap.org` und `tiles.openseamap.org` abgewiesen.
+ *
+ * Die Zeitstempel liegen in `MOCK_SIGHTINGS_YEAR`, damit der Zeitfilter des
+ * Controllers (ganzes Jahr) sie nicht ausblendet. Die Positionen liegen in der
+ * westlichen Ostsee und damit im Startausschnitt der Karte.
+ */
+export async function mockMapSightingsWithFeatures(page: Page): Promise<void> {
+	const positions: Array<[number, number]> = [
+		[11.2, 54.4],
+		[12.1, 54.6],
+		[13.4, 54.5],
+		[10.6, 54.8],
+		[12.8, 55.1]
+	];
+
+	const features = positions.map(([longitude, latitude], index) => ({
+		type: 'Feature' as const,
+		id: index + 1,
+		geometry: { type: 'Point' as const, coordinates: [longitude, latitude] },
+		properties: {
+			id: index + 1,
+			// Unix-Sekunden, Mitte des Jahres — innerhalb des Zeitfilters.
+			ts: Date.UTC(MOCK_SIGHTINGS_YEAR, 6, 15) / 1000,
+			ta: 0, // Schweinswal
+			ct: 3 + index,
+			jt: 0,
+			tf: 0
+		}
+	}));
+
+	await replaceMapSightingsRoute(page, (route: Route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ type: 'FeatureCollection', features })
+		})
+	);
+
+	await page.unroute('**/api/map/sightings/years');
+	await page.route('**/api/map/sightings/years', (route: Route) =>
+		route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({
+				years: [{ year: MOCK_SIGHTINGS_YEAR, count: features.length }]
+			})
+		})
+	);
+
+	// OLs `OSM`-Source nutzt den Einzelhost `tile.openstreetmap.org` (kein
+	// Subdomain-Sharding), und der Controller übergibt kein eigenes `url` — ein
+	// Muster für `*.tile.openstreetmap.org` würde nie greifen.
+	for (const pattern of ['**://tile.openstreetmap.org/**', '**tiles.openseamap.org/**']) {
+		await page.route(pattern, (route: Route) => route.abort());
+	}
+}
+
 export async function mockMapSightingsAbort(page: Page): Promise<void> {
 	await replaceMapSightingsRoute(page, (route: Route) => route.abort());
 }

--- a/e2e/map-pan-zoom.spec.ts
+++ b/e2e/map-pan-zoom.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test, type Page } from '@playwright/test';
+import { MapPage } from './pages/MapPage';
+import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
+
+/**
+ * Reproduktion des Berichts „nach Öffnen der Sidebar geht Pan und Zoom in der
+ * Karte nicht, erst nach einem Klick in die Karte" (UX-Review 2026-07-30).
+ *
+ * Warum dieser Test in Playwright und nicht per Browser-Automation entstand:
+ * Der Befund ließ sich zwar über CDP-injizierte Eingaben nachstellen — Pan wirkte
+ * erst nach einem Klick —, aber die Messung lief in einem Chrome-Fenster **ohne
+ * Betriebssystem-Fokus** (`document.hasFocus() === false`). OpenLayers' DragPan
+ * verlangt `primaryAction` (`isPrimary && button === 0`), synthetische Eingaben in
+ * einem unfokussierten Fenster sind damit ein möglicher Störfaktor. Playwright
+ * fährt einen echten, fokussierten Browser und trennt beides.
+ *
+ * ── Messverfahren ────────────────────────────────────────────────────────────
+ * Gemessen wird das gezeichnete Kartenbild (Canvas-Fingerprint), nicht der
+ * View-Zustand: An die OpenLayers-Instanz kommt man von außen nicht heran, und
+ * eine Test-Hintertür im Produktionscode wäre der falsche Preis dafür.
+ *
+ * Damit der Fingerprint aussagekräftig ist, blockiert
+ * `mockMapSightingsWithFeatures` die externen Kacheln und liefert feste
+ * Sichtungen. Sonst gäbe es zwei Fehlerquellen: ein leeres Canvas könnte sich
+ * durch einen Pan gar nicht verändern (Test wäre gehaltlos), und nachladende
+ * Kacheln würden es auch ohne Pan verändern (Test wäre fälschlich grün).
+ *
+ * ── Reihenfolge in den Kontrolltests ─────────────────────────────────────────
+ * Der Klick passiert **vor** der Basismessung. Ein Klick kann die Ansicht selbst
+ * verschieben (Cluster-Zoom, `autoPan` des Popups) — würde man vorher messen,
+ * bestätigte der Test am Ende diesen Nebeneffekt statt des Pans.
+ */
+
+/** Ein Wert, der sich ändert, sobald sich das Kartenbild ändert. */
+async function canvasState(page: Page): Promise<{ hash: number; distinct: number } | null> {
+	return page.evaluate(() => {
+		const canvases = [...document.querySelectorAll<HTMLCanvasElement>('#map canvas')];
+		if (canvases.length === 0) return null;
+
+		let hash = 0;
+		const seen = new Set<number>();
+
+		for (const canvas of canvases) {
+			const ctx = canvas.getContext('2d');
+			if (!ctx) continue;
+			// Ausschnitt statt Vollbild: bei 2752x1496 wären es 66 MB pro Messung.
+			const width = Math.min(canvas.width, 1200);
+			const height = Math.min(canvas.height, 800);
+			if (width === 0 || height === 0) continue;
+
+			const { data } = ctx.getImageData(0, 0, width, height);
+			for (let i = 0; i < data.length; i += 401) {
+				hash = (hash * 31 + data[i]) | 0;
+				if (seen.size < 64) seen.add(data[i]);
+			}
+		}
+
+		return { hash, distinct: seen.size };
+	});
+}
+
+/**
+ * Wartet, bis das Kartenbild zur Ruhe gekommen ist, und gibt seinen Fingerprint
+ * zurück. „Zur Ruhe gekommen" heißt: zwei aufeinanderfolgende Messungen sind
+ * gleich — sonst würde eine noch laufende Erstdarstellung als Pan-Wirkung
+ * durchgehen.
+ */
+async function settledCanvasHash(page: Page): Promise<number> {
+	let previous: number | null = null;
+	let current: number | null = null;
+
+	await expect
+		.poll(
+			async () => {
+				const state = await canvasState(page);
+				previous = current;
+				current = state?.hash ?? null;
+				return current !== null && current === previous;
+			},
+			{
+				timeout: 15000,
+				intervals: [200, 200, 200, 400],
+				message: 'Kartenbild kam nicht zur Ruhe'
+			}
+		)
+		.toBe(true);
+
+	// Gegenprobe: Ein einfarbiges Canvas könnte sich durch einen Pan nicht
+	// verändern — der Test wäre dann gehaltlos statt aussagekräftig.
+	const state = await canvasState(page);
+	expect(
+		state?.distinct ?? 0,
+		'Karte zeichnet nichts — Fingerprint wäre gehaltlos'
+	).toBeGreaterThan(1);
+
+	return current as number;
+}
+
+/** Erwartet, dass sich das Kartenbild binnen weniger Sekunden verändert. */
+async function expectMapToMove(page: Page, before: number, hinweis: string): Promise<void> {
+	await expect
+		.poll(async () => (await canvasState(page))?.hash ?? null, {
+			timeout: 4000,
+			intervals: [150, 250, 400, 600],
+			message: hinweis
+		})
+		.not.toBe(before);
+}
+
+/**
+ * Erwartet, dass das Kartenbild **unverändert** bleibt.
+ *
+ * Hier ist `expect.poll` das falsche Werkzeug: Es prüft, bis eine Bedingung
+ * erfüllt ist — bei „hat sich nichts geändert" wäre sie sofort erfüllt und der
+ * Test damit gehaltlos. Stattdessen wird über ein Zeitfenster mehrfach gemessen
+ * und jede Messung geprüft. Das Fenster ist bewusst länger als die
+ * `expectMapToMove`-Toleranz, damit ein verzögerter Zoom nicht durchrutscht:
+ * `MouseWheelZoom` arbeitet intern mit einem Timeout und einer Animation.
+ */
+async function expectMapToStayPut(page: Page, before: number, hinweis: string): Promise<void> {
+	for (let versuch = 0; versuch < 8; versuch++) {
+		await page.waitForTimeout(200);
+		const jetzt = (await canvasState(page))?.hash ?? null;
+		expect(jetzt, `${hinweis} (Messung ${versuch + 1} von 8)`).toBe(before);
+	}
+}
+
+/** Zieht mit echten Maus-Events über die Karte. */
+async function dragMap(page: Page, from: { x: number; y: number }, dx: number, dy: number) {
+	await page.mouse.move(from.x, from.y);
+	await page.mouse.down();
+	// Mehrere Zwischenschritte: OpenLayers braucht `pointermove` mit gedrückter
+	// Taste, ein einzelner Sprung erzeugt keine belastbare Drag-Sequenz.
+	await page.mouse.move(from.x + dx * 0.3, from.y + dy * 0.3, { steps: 5 });
+	await page.mouse.move(from.x + dx, from.y + dy, { steps: 10 });
+	await page.mouse.up();
+}
+
+/** Punkt in der Karte, abseits der Controls links und der Panel-Reiter rechts. */
+async function mapPoint(page: Page, relX = 0.45, relY = 0.5) {
+	const box = await page.locator('#map').boundingBox();
+	if (!box) throw new Error('#map hat keine Bounding-Box');
+	return { x: box.x + box.width * relX, y: box.y + box.height * relY };
+}
+
+/**
+ * Fährt die Maus an die Gestenposition und misst **erst danach** die Basis.
+ *
+ * Die Reihenfolge ist wesentlich: Der Controller hat einen `pointermove`-Handler,
+ * der Features unter dem Zeiger sucht und den Hover-Zustand setzt. Schon das
+ * Bewegen der Maus verändert damit das Kartenbild. Wer die Basis vorher nimmt,
+ * misst hinterher diesen Hover-Effekt mit — ein Test auf „hat sich bewegt" würde
+ * dann auch ohne Pan grün, und ein Test auf „hat sich nicht bewegt" fälschlich rot
+ * (genau so ist der Mausrad-Test beim ersten Lauf gescheitert).
+ */
+async function hoverAndSettle(page: Page, point: { x: number; y: number }): Promise<number> {
+	await page.mouse.move(point.x, point.y);
+	return settledCanvasHash(page);
+}
+
+test.describe('Sichtungskarte — Pan und Zoom', () => {
+	let mapPage: MapPage;
+
+	test.beforeEach(async ({ page }) => {
+		await mockMapSightingsWithFeatures(page);
+		mapPage = new MapPage(page);
+		await mapPage.goto();
+		await mapPage.waitForLoad();
+	});
+
+	test('Ziehen verschiebt die Karte ohne vorherigen Klick', async ({ page }) => {
+		const start = await mapPoint(page);
+		const before = await hoverAndSettle(page, start);
+
+		await dragMap(page, start, -160, 110);
+
+		await expectMapToMove(
+			page,
+			before,
+			'Karte reagierte auf das erste Ziehen nicht — genau der berichtete Befund'
+		);
+	});
+
+	test('Ziehen verschiebt die Karte nach einem Klick in die Karte', async ({ page }) => {
+		// Kontrollfall. Der Klick landet bewusst nicht auf einer Sichtung, damit
+		// kein Popup mit `autoPan` die Ansicht bewegt.
+		const klickPunkt = await mapPoint(page, 0.2, 0.85);
+		await page.mouse.click(klickPunkt.x, klickPunkt.y);
+
+		const start = await mapPoint(page);
+		const before = await hoverAndSettle(page, start);
+
+		await dragMap(page, start, -160, 110);
+
+		await expectMapToMove(page, before, 'Karte reagierte auch nach einem Klick nicht auf Ziehen');
+	});
+
+	test('Ziehen verschiebt die Karte nach dem Öffnen des Filter-Panels', async ({ page }) => {
+		// Die Formulierung des Berichts: erst Sidebar öffnen, dann pannen.
+		await mapPage.openFilter();
+		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
+
+		// Links vom 320-px-Panel ziehen, damit die Geste auf der Karte landet.
+		const start = await mapPoint(page, 0.3, 0.5);
+		const before = await hoverAndSettle(page, start);
+
+		await dragMap(page, start, -140, 100);
+
+		await expectMapToMove(
+			page,
+			before,
+			'Karte reagierte nach dem Öffnen des Filter-Panels nicht auf Ziehen'
+		);
+	});
+
+	// ── Mausrad: Fokus-Schutz bleibt absichtlich erhalten ──────────────────────
+	//
+	// Anders als beim Ziehen ist das beim Mausrad **gewolltes** Verhalten und keine
+	// Einschränkung: Die App wird auf meeresmuseum.de in einem iframe eingebettet.
+	// Wer dort die Seite scrollen will, würde ohne diesen Schutz stattdessen die
+	// Karte zoomen. `MouseWheelZoom` behält deshalb die OpenLayers-Default-Condition
+	// `focusWithTabindex` — siehe die Begründung an `interactions:` in
+	// `optimizedMapController.ts`.
+
+	test('Mausrad zoomt nicht, solange die Karte keinen Fokus hat', async ({ page }) => {
+		const point = await mapPoint(page);
+		const before = await hoverAndSettle(page, point);
+
+		await page.mouse.wheel(0, -400);
+
+		await expectMapToStayPut(
+			page,
+			before,
+			'Mausrad hat ohne Fokus gezoomt — der Scroll-Hijacking-Schutz ist weg'
+		);
+	});
+
+	test('Mausrad zoomt nach einem Klick in die Karte', async ({ page }) => {
+		// Der Klick setzt den Fokus auf das `#map`-Div (`tabindex="0"`) und schaltet
+		// damit `focusWithTabindex` frei.
+		const klickPunkt = await mapPoint(page, 0.2, 0.85);
+		await page.mouse.click(klickPunkt.x, klickPunkt.y);
+
+		const point = await mapPoint(page);
+		const before = await hoverAndSettle(page, point);
+
+		await page.mouse.wheel(0, -400);
+
+		await expectMapToMove(page, before, 'Mausrad-Zoom blieb auch mit Fokus ohne Wirkung');
+	});
+});

--- a/src/app.css
+++ b/src/app.css
@@ -13,7 +13,21 @@
 @import './css/weather-icons.css';
 @import './css/weather-icons-wind.css';
 
-/* ===== OpenLayers Map Styles ===== */
+/* ===== OpenLayers =====
+   Reihenfolge ist hier die ganze Logik und darf nicht umgestellt werden:
+   `ol.css` liefert die Defaults, `mapStyles.css` überschreibt sie. Beide
+   adressieren dieselben Klassen (`.ol-zoom`, `.ol-control`, `.ol-control button`)
+   mit identischer Spezifität (0,1,0) — bei gleichem Gewicht entscheidet die
+   Dokumentreihenfolge, also gewinnt die letzte Datei.
+
+   Bis 2026-07-30 stand `ol.css` weiter unten in dieser Datei und hat damit die
+   Projekt-Overrides ausgehebelt: `.ol-zoom { top: 4.5rem }` verlor gegen OLs
+   `top: .5em`, das Zoom-Control saß in der Ecke und schnitt den Kartentitel
+   (gemessen: Titel x=48..246, Control x=8..60 bei gleicher Höhe). Zugleich
+   klaffte eine 70-px-Lücke zur Zoom-All-Control, deren `top: 11rem` für die
+   *gedachte* Position berechnet war. Dass `mapStyles.css` voller `!important`
+   steht, war die Kompensation genau dieses Ordnungsfehlers. */
+@import 'ol/ol.css';
 @import './lib/map/mapStyles.css';
 
 @layer base {
@@ -144,9 +158,6 @@
 	--text-label: 0.875rem;
 	--text-support: 0.8125rem;
 }
-
-/* ===== OpenLayers Map ===== */
-@import 'ol/ol.css';
 
 /* ===== Base Styles ===== */
 body {

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -11,6 +11,30 @@
 			<a href="/about" class="link link-hover text-sm sm:text-base">Über uns</a>
 			<a href="/docs" class="link link-hover text-sm sm:text-base">Dokumentation</a>
 			<a href="/map" class="link link-hover text-sm sm:text-base">Sichtungskarte</a>
+			<!--
+				Anbieterkennzeichnung nach § 5 DDG und Datenschutzhinweis nach Art. 13 DSGVO.
+				Beides fehlte bis 2026-07-30 vollständig: es gab weder eine Route noch einen
+				Link, und unter eigener Domain deckt die iframe-Einbettung auf
+				meeresmuseum.de die Pflicht nicht ab.
+
+				Verlinkt werden bewusst die Seiten des Betreibers (Deutsches Meeresmuseum)
+				statt einer eigenen Kopie — eine zweite, separat zu pflegende Fassung
+				derselben Rechtstexte würde nur auseinanderlaufen. „Ständig verfügbar" ist
+				gegeben, weil dieser Footer auf jeder Seite steht; im iframe-Modus ist er
+				ausgeblendet, dort trägt die einbettende Seite ihre eigene Kennzeichnung.
+			-->
+			<a
+				href="https://www.deutsches-meeresmuseum.de/impressum"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="link link-hover text-sm sm:text-base">Impressum</a
+			>
+			<a
+				href="https://www.deutsches-meeresmuseum.de/datenschutz"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="link link-hover text-sm sm:text-base">Datenschutz</a
+			>
 		</nav>
 
 		<!-- External Links - Stack on Mobile, Inline on Desktop -->

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -24,7 +24,10 @@
 	} from '$lib/map/urlFilterState';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
-	import 'ol/ol.css';
+	// Kein `import 'ol/ol.css'` hier: die Datei kommt global aus app.css, und zwar
+	// bewusst VOR mapStyles.css. Ein zweiter Import aus einer Komponente hängt
+	// ol.css erneut hinter die Projekt-Overrides und macht sie wirkungslos —
+	// genau so ist die Titel-Überlappung des Zoom-Controls entstanden.
 	import LoadingOverlay from './LoadingOverlay.svelte';
 	import FilterPanel from './Panel/FilterPanel.svelte';
 	import LegendPanel from './Panel/LegendPanel.svelte';
@@ -167,6 +170,27 @@
 			(activeFilters.hiddenSpecies?.length ?? 0) > 0 ||
 			(activeFilters.hiddenColors?.length ?? 0) > 0
 	);
+
+	/**
+	 * Darstellung der Filter-Chips (UX-Review 2026-07-30: „zu präsent, zu viel
+	 * Platz oben").
+	 *
+	 * Die 44px Trefferfläche bleiben — `min-h-11` ist WCAG 2.5.5 und nicht
+	 * verhandelbar. Zurückgenommen wird ausschließlich das Gewicht: halbtransparent
+	 * und mit `backdrop-blur` wie der Kartentitel statt deckendem `bg-base-100`,
+	 * `shadow-lg` entfällt, Beschriftung auf `text-support` in normaler Schriftstärke.
+	 *
+	 * Der eigentliche Platzfresser war aber nicht das Gewicht, sondern der Umbruch:
+	 * mit `flex-wrap` wuchs das Band bei mehreren aktiven Filtern auf zwei bis drei
+	 * 44px-Reihen und verdeckte die Karte. Eine Zeile mit horizontalem Scroll
+	 * begrenzt es auf konstant eine Reihe, unabhängig von der Anzahl der Filter.
+	 *
+	 * Der Klassenname steht absichtlich als vollständiges Literal hier: Tailwind
+	 * erkennt nur komplette Strings im Quelltext (siehe .claude/rules/daisyui.md).
+	 */
+	const chipClass =
+		'btn btn-sm border-base-300 bg-base-100/80 text-support min-h-11 shrink-0 gap-1 font-normal backdrop-blur-md';
+
 	// URL-Schreiben erst nach applyUrlFilters() freischalten — die Zwischen-
 	// stände des Initial-Loads würden die geteilten Params sonst wegkürzen.
 	let urlSyncEnabled = false;
@@ -656,14 +680,14 @@
 	     genau diesen Filter; „Alle zurücksetzen" stellt den Grundzustand her. -->
 	{#if hasActiveFilters}
 		<div
-			class="absolute top-16 left-1/2 z-30 flex w-max max-w-[92vw] -translate-x-1/2 flex-wrap items-center justify-center gap-2"
+			class="scroll-styled absolute top-16 left-1/2 z-30 flex w-max max-w-[92vw] -translate-x-1/2 flex-nowrap items-center justify-start gap-1.5 overflow-x-auto px-1 pb-1"
 			role="group"
 			aria-label="Aktive Filter"
 		>
 			{#if activeFilters.year !== undefined}
 				<button
 					type="button"
-					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					class={chipClass}
 					onclick={() => switchToYear(apiDefaultYear)}
 					aria-label="Filter Jahr {activeFilters.year} entfernen und zum Standard-Jahr {apiDefaultYear} wechseln"
 				>
@@ -674,7 +698,7 @@
 			{#if activeFilters.query !== undefined}
 				<button
 					type="button"
-					class="btn btn-sm bg-base-100 min-h-11 max-w-56 gap-1 shadow-lg"
+					class="{chipClass} max-w-56"
 					onclick={clearSearchFilter}
 					aria-label="Suchfilter {activeFilters.query} entfernen"
 				>
@@ -685,7 +709,7 @@
 			{#if activeFilters.from !== undefined && activeFilters.to !== undefined}
 				<button
 					type="button"
-					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					class={chipClass}
 					onclick={resetTimeFilter}
 					aria-label="Zeitraum-Filter entfernen und volles Jahr anzeigen"
 				>
@@ -696,7 +720,7 @@
 			{#each activeFilters.hiddenSpecies ?? [] as speciesId (speciesId)}
 				<button
 					type="button"
-					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					class={chipClass}
 					onclick={() => showSpecies(speciesId)}
 					aria-label="{speciesLabel(speciesId)} wieder anzeigen"
 				>
@@ -707,7 +731,7 @@
 			{#each activeFilters.hiddenColors ?? [] as colorGroup (colorGroup)}
 				<button
 					type="button"
-					class="btn btn-sm bg-base-100 min-h-11 gap-1 shadow-lg"
+					class={chipClass}
 					onclick={() => showColorGroup(colorGroup)}
 					aria-label="Gruppe {colorGroupLabel(colorGroup)} wieder anzeigen"
 				>
@@ -715,11 +739,7 @@
 					<Icon icon="lucide:x" width="14" height="14" aria-hidden="true" />
 				</button>
 			{/each}
-			<button
-				type="button"
-				class="btn btn-outline btn-sm bg-base-100 min-h-11 shadow-lg"
-				onclick={resetAllFilters}
-			>
+			<button type="button" class="{chipClass} btn-outline" onclick={resetAllFilters}>
 				Alle Filter zurücksetzen
 			</button>
 		</div>

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -38,7 +38,9 @@
 	/* Touch-Target min. 44x44px (WCAG 2.5.5) — Desktop und Mobile identisch */
 	height: 44px !important;
 	width: 44px !important;
-	font-size: 20px !important;
+	/* Symbolgröße, nicht Trefferfläche: die 44x44px oben bleiben unangetastet
+	   (WCAG 2.5.5), nur das Glyph wird ruhiger. */
+	font-size: 16px !important;
 	display: flex !important;
 	align-items: center !important;
 	justify-content: center !important;
@@ -48,31 +50,24 @@
 	background-color: var(--color-base-100) !important;
 }
 
-/* OpenLayers Control Grundeinstellungen */
+/* OpenLayers Control Grundeinstellungen
+   Kein eigener Hintergrund und kein Padding: die Buttons sind selbst schon
+   deckend, eine zusätzliche Platte darunter ergibt den „Pille auf Pille"-Effekt,
+   der die Controls schwerer wirken lässt als sie sind. */
 .ol-control {
-	background-color: color-mix(in oklab, var(--color-base-100) 40%, transparent);
-	border-radius: 4px;
-	padding: 2px;
-}
-
-.ol-control button {
-	background-color: var(--color-primary);
-	color: var(--color-primary-content);
-	border: none;
-	display: inline-block;
-	font-size: 14px;
-	line-height: 1.375em;
-	text-align: center;
-	cursor: pointer;
+	background-color: transparent;
 	padding: 0;
-	width: 1.375em;
-	height: 1.375em;
-	border-radius: 2px;
 }
 
-.ol-control button:hover {
-	background-color: color-mix(in oklab, var(--color-primary) 85%, var(--color-base-content));
-}
+/* Bewusst KEINE generische `.ol-control button`-Regel.
+   Sie stammte aus der Zeit, in der ol.css nach dieser Datei geladen wurde und
+   deshalb ohnehin gewann — wirkungslos und daher unbemerkt. Ihr Entfernen ändert
+   nichts: ol.css setzt auf `.ol-control button` dieselben `width/height: 1.375em`,
+   die Maße gehen also unverändert an OpenLayers zurück. Und das einzige Control
+   ohne eigene Regel unten, der Attribution-Umschalter, ist hier ohnehin nie
+   sichtbar (OL setzt `.ol-uncollapsible`, gemessen 0x0 bei 1280px und 375px).
+   Die Regel weg zu lassen ist damit reine Aufräumarbeit — jedes echte Control
+   bringt seine Regel unten selbst mit. */
 
 /* Zoom All Control */
 /* top: 11rem — ol-zoom (top 4.5rem) + zwei 44px-Buttons + Control-Padding, damit
@@ -92,7 +87,9 @@
 	height: 44px !important;
 	width: 44px !important;
 	font-weight: bold !important;
-	font-size: 20px !important;
+	/* Symbolgröße, nicht Trefferfläche: die 44x44px oben bleiben unangetastet
+	   (WCAG 2.5.5), nur das Glyph wird ruhiger. */
+	font-size: 16px !important;
 	box-shadow: var(--shadow-raised) !important;
 	margin: 2px !important;
 	display: flex !important;
@@ -121,7 +118,9 @@
 	height: 44px !important;
 	width: 44px !important;
 	font-weight: bold !important;
-	font-size: 20px !important;
+	/* Symbolgröße, nicht Trefferfläche: die 44x44px oben bleiben unangetastet
+	   (WCAG 2.5.5), nur das Glyph wird ruhiger. */
+	font-size: 16px !important;
 	box-shadow: var(--shadow-raised) !important;
 	margin: 2px !important;
 	display: flex !important;

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -3,7 +3,9 @@ import { Feature, Geolocation, Map, Overlay, View } from 'ol';
 import type { Control } from 'ol/control';
 import { defaults as defaultControls } from 'ol/control';
 import type { EventsKey } from 'ol/events';
+import { all, noModifierKeys, primaryAction } from 'ol/events/condition';
 import * as olExtent from 'ol/extent';
+import { defaults as defaultInteractions, DragPan } from 'ol/interaction';
 import GeoJSON from 'ol/format/GeoJSON';
 import type { Geometry } from 'ol/geom';
 import { Point as OlPoint } from 'ol/geom';
@@ -280,7 +282,53 @@ export class SichtungenMap {
 					zoomInTipLabel: 'Vergrößern',
 					zoomOutTipLabel: 'Verkleinern'
 				}
-			}).extend(this.createCustomControls())
+			}).extend(this.createCustomControls()),
+
+			/**
+			 * Interactions wie OpenLayers sie selbst baut — **nur DragPan** ist vom
+			 * Fokus-Zwang ausgenommen.
+			 *
+			 * `onFocusOnly: true` ist hier kein Zusatz, sondern die Wiederherstellung
+			 * des Verhaltens, das `ol/Map` beim Weglassen der Option verwendet: Map.js
+			 * ruft `defaultInteractions({ onFocusOnly: true })` auf. Ruft man
+			 * `defaults()` dagegen selbst auf, ist der Default `false` — wer das
+			 * übersieht, hebt den Fokus-Schutz still für **alle** Interactions auf. Genau
+			 * das ist beim ersten Anlauf dieses Fixes passiert und im Test aufgefallen.
+			 *
+			 * Was `onFocusOnly` bewirkt: `DragPan` und `MouseWheelZoom` bekommen
+			 * `all(focusWithTabindex, …)` vorgeschaltet. `focusWithTabindex` verlangt —
+			 * **nur wenn das Map-Target ein `tabindex`-Attribut trägt** — dass der Fokus
+			 * innerhalb des Targets liegt. Der Sinn ist Scroll-Hijacking-Schutz auf
+			 * Seiten, die eine Karte einbetten.
+			 *
+			 * Genau dieses `tabindex="0"` setzt `SightingsMapView.svelte` bewusst auf
+			 * `#map`, damit KeyboardPan und KeyboardZoom greifen (Tastaturbedienung,
+			 * Befund K3). Nebenwirkung: Maus-Pan war damit tot, bis der Nutzer einmal in
+			 * die Karte klickte — die Barrierefreiheits-Verbesserung hat die Maussteuerung
+			 * gebrochen.
+			 *
+			 * Nachgewiesen in `e2e/map-pan-zoom.spec.ts`: Beim ersten Ziehen war
+			 * `document.activeElement` der `<body>`, die Condition damit `false` und
+			 * `DragPan.handleDownEvent` gab `false` zurück — bei identischen, trusted
+			 * Pointer-Events. Nach einem Klick war `activeElement` das `#map`-Div und
+			 * dasselbe Ziehen funktionierte.
+			 *
+			 * Warum nur DragPan ausgenommen ist: Ein Drag ist eine eindeutige Absicht,
+			 * es gibt keine konkurrierende Deutung — der Fokus-Schutz kostet dort nur
+			 * Bedienbarkeit. Das Mausrad ist der Gegenfall: Die App wird auf
+			 * meeresmuseum.de in einem iframe eingebettet, und wer dort die **Seite**
+			 * scrollen will, würde ohne Schutz stattdessen die Karte zoomen. Mausrad-Zoom
+			 * setzt deshalb weiterhin einen Klick oder Tab in die Karte voraus, wie bei
+			 * Kartendiensten üblich.
+			 *
+			 * Der ausgetauschte DragPan bekommt **kein** `onFocusOnly` und damit die
+			 * Standard-Condition `all(noModifierKeys, primaryAction)` ohne Fokus-Prüfung.
+			 * `kinetic` wird bewusst nicht mitgegeben: `defaults()` setzt dort eine
+			 * Schwung-Animation, die auf einer Datenkarte eher stört als hilft.
+			 */
+			interactions: defaultInteractions({ onFocusOnly: true, dragPan: false }).extend([
+				new DragPan({ condition: all(noModifierKeys, primaryAction) })
+			])
 		});
 
 		// Popup hinzufügen

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -29,7 +29,12 @@
 		<div class="bg-base-100 mb-4 rounded-lg p-4">
 			<div class="grid grid-cols-1 gap-3 text-sm md:grid-cols-2">
 				<div class="flex items-start gap-3">
-					<Icon icon="lucide:check-circle" width="20" height="20" class="text-success-strong mt-0.5" />
+					<Icon
+						icon="lucide:check-circle"
+						width="20"
+						height="20"
+						class="text-success-strong mt-0.5"
+					/>
 					<div>
 						<p class="font-medium">Öffentliche Wissenschaftsdaten</p>
 						<p class="text-base-content/70 text-xs">
@@ -55,6 +60,19 @@
 			<p class="text-primary/70 mt-2 text-xs">
 				<strong>Ohne diese Zustimmung kann Ihre Sichtung nicht gespeichert werden.</strong>
 				Sie können diese Zustimmung jederzeit per E-Mail an datenschutz@meeresmuseum.de widerrufen.
+				<!--
+					Art. 13 DSGVO verlangt die Datenschutzhinweise dort, wo die Daten erhoben
+					werden. Bis 2026-07-30 stand die Erklärung nur als externer Link auf
+					/about — an der Einwilligung selbst, also an der Erhebungsstelle, fehlte
+					sie.
+				-->
+				Einzelheiten zur Verarbeitung stehen in der
+				<a
+					href="https://www.deutsches-meeresmuseum.de/datenschutz"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="link">Datenschutzerklärung</a
+				>.
 			</p>
 		</div>
 	</div>

--- a/src/lib/server/config/accessControl.ts
+++ b/src/lib/server/config/accessControl.ts
@@ -29,6 +29,8 @@ const SUPERADMIN_ONLY_CONFIG_KEYS = new Set([
 	// Email sender configuration (system-critical)
 	'notification.email.sender',
 	'notification.email.senderName',
+	'notification.email.cc',
+	'notification.email.bcc',
 
 	// Advanced security settings
 	'security.allowedFileTypes',

--- a/src/lib/server/services/configInitializer.ts
+++ b/src/lib/server/services/configInitializer.ts
@@ -17,6 +17,22 @@ const defaultConfigurations: ConfigItem[] = [
 		description: 'E-Mail Adresse für Benachrichtigungen über neue Sichtungen',
 		category: 'email'
 	},
+	// CC/BCC werden von emailService.getEmailConfig() über
+	// `ConfigRepository.getArray('notification.email.cc', [])` gelesen, standen aber
+	// bis 2026-07-30 in keiner Vorbelegung und damit auch in keinem Formular der
+	// Settings-Seite — gelesen, aber nicht konfigurierbar.
+	{
+		key: 'notification.email.cc',
+		value: [],
+		description: 'Zusätzliche Empfänger in Kopie (kommagetrennt)',
+		category: 'email'
+	},
+	{
+		key: 'notification.email.bcc',
+		value: [],
+		description: 'Zusätzliche Empfänger in Blindkopie (kommagetrennt)',
+		category: 'email'
+	},
 	{
 		key: 'notification.email.sender',
 		value: 'noreply@ostsee-tiere.de',

--- a/src/lib/server/services/emailService.envFallback.test.ts
+++ b/src/lib/server/services/emailService.envFallback.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit Tests für den ENV-Fallback der SMTP-Konfiguration.
+ *
+ * Eigene Datei, weil `$env/dynamic/private` hier **gesetzte** SMTP-Variablen
+ * mocken muss: `emailService.ts` liest sie beim Import in Modulkonstanten
+ * (`const SMTP_HOST = env.SMTP_HOST ?? ''`), ein späteres Umstellen im Test
+ * hätte also keine Wirkung. Die Nachbardatei `emailService.test.ts` mockt sie
+ * bewusst leer und prüft damit den „nicht konfiguriert"-Pfad.
+ *
+ * Hintergrund (UX-/Config-Review 2026-07-30): `.claude/rules/email.md` legt die
+ * Priorität als „Datenbank > Environment Variables" fest. In der Praxis war der
+ * ENV-Zweig aber unerreichbar: `initializeDefaultConfigurations()` legt
+ * `email.smtp.host`/`user`/`password` mit **Leerstring** an, und
+ * `ConfigRepository.getString(key, default)` gibt den Default nur bei `null`
+ * zurück — `''` ist nicht `null`. Sobald `/admin/settings` einmal geöffnet
+ * wurde, war SMTP aus der Umgebung damit dauerhaft toter Code, und der Versand
+ * brach nur mit einer Log-Warnung ab.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Das globale Setup in vitest-setup-server.ts mockt emailService — hier aufheben,
+// damit die echte Implementierung getestet wird.
+vi.unmock('$lib/server/services/emailService');
+
+const ENV_HOST = 'smtp.aus-der-umgebung.test';
+const ENV_USER = 'env-user@example.com';
+const ENV_PASSWORD = 'env-geheim';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		NODE_ENV: 'test',
+		SMTP_HOST: 'smtp.aus-der-umgebung.test',
+		SMTP_PORT: '2525',
+		SMTP_USER: 'env-user@example.com',
+		SMTP_PASSWORD: 'env-geheim'
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_SITE_URL: 'https://example.com' }
+}));
+
+// Kein gemeinsamer Helper: vi.mock wird an den Dateianfang gehoist, eine
+// Top-Level-Variable wäre dort noch nicht initialisiert.
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+vi.mock('$lib/logger', () => ({
+	createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+vi.mock('$lib/server/db/configRepository', () => ({
+	ConfigRepository: {
+		getBoolean: vi.fn(),
+		getString: vi.fn(),
+		getNumber: vi.fn(),
+		getArray: vi.fn()
+	}
+}));
+
+vi.mock('$lib/server/db', () => ({ db: { select: vi.fn() } }));
+vi.mock('nodemailer', () => ({ default: { createTransport: vi.fn() } }));
+vi.mock('fs', () => ({ readFileSync: vi.fn(() => '<html>{{referenceId}}</html>') }));
+vi.mock('$lib/utils/format/sightingFormatter', () => ({
+	formatSightingForDisplay: vi.fn(),
+	isUnknownOrMissingSpecies: vi.fn()
+}));
+vi.mock('$lib/server/spam/spamDetector', () => ({
+	detectSpamIndicators: vi.fn().mockResolvedValue({ score: 0, isHighRisk: false, indicators: [] })
+}));
+vi.mock('$lib/utils/format/dateTime', () => ({ formatLocalDateTime: vi.fn() }));
+
+import { ConfigRepository } from '$lib/server/db/configRepository';
+import nodemailer from 'nodemailer';
+import { EmailService } from './emailService';
+
+/**
+ * Setzt die DB-Antworten. `getString` verhält sich absichtlich wie das Original:
+ * Der Default greift nur, wenn der Test `undefined` durchreicht — ein in der DB
+ * gespeicherter Leerstring wird als Leerstring geliefert. Genau dieser Fall ist
+ * der Regressionsfall.
+ */
+function setupDbConfig(values: Record<string, string | number | boolean>) {
+	vi.mocked(ConfigRepository.getString).mockImplementation(async (key, defaultValue) =>
+		key in values ? String(values[key]) : defaultValue
+	);
+	vi.mocked(ConfigRepository.getNumber).mockImplementation(async (key, defaultValue) =>
+		key in values ? Number(values[key]) : defaultValue
+	);
+	vi.mocked(ConfigRepository.getBoolean).mockImplementation(async (key, defaultValue) =>
+		key in values ? Boolean(values[key]) : defaultValue
+	);
+	vi.mocked(ConfigRepository.getArray).mockImplementation(
+		async (_key, defaultValue) => defaultValue
+	);
+}
+
+function transportArgs() {
+	const call = vi.mocked(nodemailer.createTransport).mock.calls.at(-1);
+	return (call?.[0] ?? {}) as {
+		host?: string;
+		port?: number;
+		auth?: { user?: string; pass?: string };
+	};
+}
+
+describe('EmailService — SMTP-Konfiguration aus der Umgebung', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(nodemailer.createTransport).mockReturnValue({
+			sendMail: vi.fn(),
+			verify: vi.fn().mockResolvedValue(true)
+		} as unknown as ReturnType<typeof nodemailer.createTransport>);
+	});
+
+	it('nimmt die ENV-Werte, wenn die DB-Einträge leer sind', async () => {
+		// Genau der Zustand nach initializeDefaultConfigurations(): Zeilen
+		// existieren, tragen aber Leerstrings.
+		setupDbConfig({
+			'notification.email.enabled': true,
+			'email.smtp.host': '',
+			'email.smtp.user': '',
+			'email.smtp.password': ''
+		});
+
+		await EmailService.initialize(true);
+
+		expect(transportArgs().host).toBe(ENV_HOST);
+		expect(transportArgs().auth?.user).toBe(ENV_USER);
+		expect(transportArgs().auth?.pass).toBe(ENV_PASSWORD);
+	});
+
+	it('lässt die DB gewinnen, wenn dort ein Wert gesetzt ist', async () => {
+		setupDbConfig({
+			'notification.email.enabled': true,
+			'email.smtp.host': 'smtp.aus-der-datenbank.test',
+			'email.smtp.user': 'db-user@example.com',
+			'email.smtp.password': 'db-geheim'
+		});
+
+		await EmailService.initialize(true);
+
+		expect(transportArgs().host).toBe('smtp.aus-der-datenbank.test');
+		expect(transportArgs().auth?.user).toBe('db-user@example.com');
+		expect(transportArgs().auth?.pass).toBe('db-geheim');
+	});
+
+	it('nimmt den ENV-Port, solange die DB keinen abweichenden Wert liefert', async () => {
+		// Ergänzt die beiden Fälle oben um den Port: der geht weiterhin über den
+		// `defaultValue`-Mechanismus, weil sich beim Port „bewusst auf 587 gestellt"
+		// nicht von „nur geseedet" unterscheiden lässt (Begründung in emailService.ts).
+		setupDbConfig({ 'notification.email.enabled': true, 'email.smtp.host': '' });
+
+		await EmailService.initialize(true);
+
+		expect(transportArgs().port).toBe(2525);
+	});
+
+	// Der Pfad „gar nichts konfiguriert" (weder DB noch ENV) gehört nicht hierher:
+	// diese Datei mockt SMTP_* bewusst gesetzt. Abgedeckt ist er in
+	// `emailService.test.ts`, wo die ENV-Variablen leer sind.
+});

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -48,6 +48,20 @@ const DEFAULT_EMAIL_TEMPLATE = `<!DOCTYPE html>
 </body>
 </html>`;
 
+/**
+ * Liest einen Konfigurationswert und fällt bei **leerem** DB-Wert auf die
+ * Umgebungsvariable zurück.
+ *
+ * Hält die Regel „Leerstring heißt nicht konfiguriert" an einer Stelle fest. Der
+ * ENV-Wert darf nicht als `defaultValue` an `getString` gehen: der Default greift
+ * dort nur bei `null`, und `initializeDefaultConfigurations()` legt die SMTP-Keys
+ * mit Leerstring an — der ENV-Zweig war damit unerreichbar (siehe
+ * `emailService.envFallback.test.ts`).
+ */
+async function configOrEnv(key: string, envValue: string): Promise<string> {
+	return (await ConfigRepository.getString(key, '')) || envValue;
+}
+
 export interface EmailConfig {
 	enabled: boolean;
 	recipient: string;
@@ -81,18 +95,33 @@ export class EmailService {
 				return;
 			}
 
-			// Get SMTP configuration
-			const smtpHost = await ConfigRepository.getString('email.smtp.host', SMTP_HOST || '');
+			// SMTP-Konfiguration. Priorität laut .claude/rules/email.md:
+			// Datenbank > Environment Variables.
+			//
+			// Der ENV-Wert darf NICHT als `defaultValue` an `getString` gehen: der
+			// Default greift dort nur bei `null`, und `initializeDefaultConfigurations()`
+			// legt diese drei Keys mit **Leerstring** an. Sobald `/admin/settings`
+			// einmal geöffnet war, existierte die Zeile also mit `''`, der Default
+			// wurde nie erreicht und SMTP aus der Umgebung war toter Code — der
+			// Versand brach still mit der Warnung unten ab.
+			//
+			// Deshalb der Fallback erst *nach* dem DB-Zugriff: ein gesetzter DB-Wert
+			// gewinnt, ein leerer gilt als „in der DB nicht konfiguriert".
+			const smtpHost = await configOrEnv('email.smtp.host', SMTP_HOST);
+			const smtpUser = await configOrEnv('email.smtp.user', SMTP_USER);
+			const smtpPassword = await configOrEnv('email.smtp.password', SMTP_PASSWORD);
+
+			// Port und `secure` bleiben beim Default-Mechanismus: beide haben einen
+			// sinnvollen Wert (587 bzw. false), der auch als Seed in der DB steht.
+			// Ein gesetztes `SMTP_PORT` ist damit ebenfalls wirkungslos — anders als
+			// beim Host lässt sich hier aber „bewusst auf 587 gestellt" nicht von
+			// „nur geseedet" unterscheiden, und ein Fallback auf ENV würde eine
+			// absichtliche DB-Einstellung überstimmen. `SMTP_SECURE` gibt es nicht.
 			const smtpPort = await ConfigRepository.getNumber(
 				'email.smtp.port',
 				parseInt(SMTP_PORT || '587')
 			);
 			const smtpSecure = await ConfigRepository.getBoolean('email.smtp.secure', false);
-			const smtpUser = await ConfigRepository.getString('email.smtp.user', SMTP_USER || '');
-			const smtpPassword = await ConfigRepository.getString(
-				'email.smtp.password',
-				SMTP_PASSWORD || ''
-			);
 
 			if (!smtpHost) {
 				logger.warn('Email service not initialized: SMTP host not configured');

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -3,7 +3,8 @@ import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
 import { approvedOnly } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
-import { and, count, countDistinct, isNotNull, ne } from 'drizzle-orm';
+import { berlinDatePart } from '$lib/server/db/sqlTimeZone';
+import { and, count, countDistinct, isNotNull, ne, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
 const logger = createLogger('about:page');
@@ -20,17 +21,42 @@ export const load: PageServerLoad = async () => {
 			.from(sightings)
 			.where(and(approvedOnly(), isNotNull(sightings.email), ne(sightings.email, '')));
 
+		// Jahr der ältesten freigegebenen Sichtung. Stand bis 2026-07-30 als „2011"
+		// fest im Template — eine Zahl ohne Quelle, die zu keinem Datum passte: die
+		// älteste Sichtung datiert auf 2009-07-19, der erste Datensatz wurde 2012
+		// angelegt, und 2011 enthält lediglich 15 Einträge. Abgeleitet statt behauptet
+		// bleibt die Angabe außerdem richtig, wenn Altdaten nachgeliefert werden.
+		//
+		// Das Jahr wird in **deutscher Ortszeit** aus der Datenbank geholt, nicht per
+		// `new Date(...).getFullYear()` aus dem Ergebnis: `sichtungsdatum` hält seit der
+		// UTC-Migration echte Zeitpunkte, und die Prozess-Zeitzone ist im Container
+		// `TZ=UTC`. Eine Sichtung am 01.01. um 00:30 Ortszeit steht als 31.12. 23:30 UTC
+		// in der Spalte — JS-seitig gerechnet käme das Vorjahr heraus, und /about würde
+		// ein Jahr früher beginnen als das Jahresdiagramm der Admin-Statistik, das über
+		// `berlinDatePart` gruppiert.
+		const [earliestResult] = await db
+			.select({
+				earliestYear: sql<number | null>`MIN(${berlinDatePart('year', sightings.sightingDate)})`
+			})
+			.from(sightings)
+			.where(and(approvedOnly(), isNotNull(sightings.sightingDate)));
+
+		const earliestSightingYear =
+			earliestResult?.earliestYear != null ? Number(earliestResult.earliestYear) : null;
+
 		return {
 			version,
 			totalSightings: totalResult?.count != null ? Number(totalResult.count) : null,
-			totalObservers: observersResult?.count != null ? Number(observersResult.count) : null
+			totalObservers: observersResult?.count != null ? Number(observersResult.count) : null,
+			earliestSightingYear
 		};
 	} catch (err) {
 		logger.error({ err }, 'Fehler beim Laden der About-Statistiken');
 		return {
 			version,
 			totalSightings: null,
-			totalObservers: null
+			totalObservers: null,
+			earliestSightingYear: null
 		};
 	}
 };

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -88,13 +88,17 @@
 						Bürgerwissenschaft macht <strong>jeden zum Forscher</strong> und trägt zu wichtigen wissenschaftlichen
 						Erkenntnissen bei.
 					</p>
-					<div class="stats stats-vertical mt-6 shadow-sm">
-						<div class="stat">
-							<div class="stat-title text-xs">Seit</div>
-							<div class="stat-value text-primary text-2xl">2011</div>
-							<div class="stat-desc">aktiv</div>
+					<!-- Jahreszahl kommt aus der Datenbank (älteste freigegebene Sichtung),
+					     nicht aus dem Template — Begründung in +page.server.ts. -->
+					{#if data.earliestSightingYear != null}
+						<div class="stats stats-vertical mt-6 shadow-sm">
+							<div class="stat">
+								<div class="stat-title text-xs">Sichtungen seit</div>
+								<div class="stat-value text-primary text-2xl">{data.earliestSightingYear}</div>
+								<div class="stat-desc">in unserer Datenbank</div>
+							</div>
 						</div>
-					</div>
+					{/if}
 				</div>
 			</div>
 		</div>
@@ -141,9 +145,11 @@
 					<h3 class="card-title text-secondary-strong mb-4 justify-center text-xl">
 						Interaktive Karte
 					</h3>
+					<!-- „alle Sichtungen" traf nicht zu: die Karte zeigt ausschließlich
+					     freigegebene Meldungen und filtert dabei auf ein Jahr. -->
 					<p class="text-base-content/80 text-base leading-relaxed">
-						Visualisieren Sie <strong>alle Sichtungen</strong> auf einer detaillierten Karte der
-						Ostsee und entdecken Sie <em>Muster und Hotspots</em>.
+						Sehen Sie die <strong>freigegebenen Sichtungen</strong> jahrweise auf einer
+						detaillierten Karte der Ostsee und entdecken Sie <em>Muster und Hotspots</em>.
 					</p>
 					<div class="mt-4">
 						<div class="badge badge-secondary badge-outline">OpenLayers</div>
@@ -159,9 +165,15 @@
 						<Icon icon="lucide:chart-pie" width="48" class="text-accent-strong" />
 					</div>
 					<h3 class="card-title text-accent-strong mb-4 justify-center text-xl">Offene Daten</h3>
+					<!-- Vorher: „Alle Daten sind für Forschungszwecke verfügbar und können in
+					     verschiedenen Formaten exportiert werden." Der Export in mehrere
+					     Formate ist eine Funktion des Admin-Bereichs, nicht der Öffentlichkeit
+					     (das Setting `data.exportFormats` wird nirgends gelesen). Öffentlich
+					     abrufbar sind die freigegebenen Sichtungen über die dokumentierte
+					     API — das steht hier jetzt statt des weitergehenden Versprechens. -->
 					<p class="text-base-content/80 text-base leading-relaxed">
-						Alle Daten sind für <strong>Forschungszwecke verfügbar</strong> und können in
-						verschiedenen Formaten <em>exportiert</em> werden.
+						Die freigegebenen Sichtungen sind über eine <strong>offene API</strong> abrufbar und
+						damit für <em>Forschung und Lehre</em> nutzbar.
 					</p>
 					<div class="mt-4">
 						<div class="badge badge-accent badge-outline">Open Data</div>
@@ -626,25 +638,43 @@ SOFTWARE.</pre>
 					</p>
 				</div>
 
+				<!--
+					Beschriftungen und Rückfallwerte korrigiert (2026-07-30):
+
+					- „Bereits erfasst" war falsch: `totalSightings` zählt über
+					  `approvedOnly()` nur die **freigegebenen** Sichtungen. Erfasst sind
+					  mehr (die noch nicht freigegebenen fehlen in dieser Zahl).
+					- „Aktive Beobachter" war doppelt falsch: der Wert ist die Zahl
+					  **unterschiedlicher E-Mail-Adressen** in allen freigegebenen
+					  Sichtungen — kumuliert über den gesamten Zeitraum, nicht „aktiv".
+					  Melder ohne E-Mail-Angabe fehlen, eine Person mit zwei Adressen
+					  zählt zweimal. Deshalb „Melder-Adressen" statt „Beobachter".
+					- Die Rückfallwerte `1.800+` und `500+` lagen um den Faktor 10 unter
+					  der Realität (19.262 bzw. 6.430). Bei einem Datenbankfehler hätte die
+					  Seite also grob falsche Zahlen als Tatsache ausgegeben. Jetzt wird
+					  die Kachel in diesem Fall weggelassen — keine Zahl ist besser als
+					  eine erfundene (siehe .claude/rules/design-system.md, „Zahlen in
+					  Nutzertexten nur mit Quelle").
+				-->
 				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-xl">
-					<div class="stat">
-						<div class="stat-title">Bereits erfasst</div>
-						<div class="stat-value text-primary">
-							{data.totalSightings != null
-								? new Intl.NumberFormat('de-DE').format(data.totalSightings)
-								: '1.800+'}
+					{#if data.totalSightings != null}
+						<div class="stat">
+							<div class="stat-title">Veröffentlicht</div>
+							<div class="stat-value text-primary">
+								{new Intl.NumberFormat('de-DE').format(data.totalSightings)}
+							</div>
+							<div class="stat-desc">freigegebene Sichtungen</div>
 						</div>
-						<div class="stat-desc">Sichtungen</div>
-					</div>
-					<div class="stat">
-						<div class="stat-title">Aktive</div>
-						<div class="stat-value text-secondary-strong">
-							{data.totalObservers != null
-								? new Intl.NumberFormat('de-DE').format(data.totalObservers)
-								: '500+'}
+					{/if}
+					{#if data.totalObservers != null}
+						<div class="stat">
+							<div class="stat-title">Beteiligt</div>
+							<div class="stat-value text-secondary-strong">
+								{new Intl.NumberFormat('de-DE').format(data.totalObservers)}
+							</div>
+							<div class="stat-desc">Melder-Adressen insgesamt</div>
 						</div>
-						<div class="stat-desc">Beobachter</div>
-					</div>
+					{/if}
 					<div class="stat">
 						<div class="stat-title">Für die</div>
 						<div class="stat-value text-accent-strong">Wissenschaft</div>

--- a/src/routes/about/+page.ts
+++ b/src/routes/about/+page.ts
@@ -1,1 +1,25 @@
-export const csr = false;
+/**
+ * Kein `export const csr = false` mehr (2026-07-30).
+ *
+ * Die Option sah nach einer harmlosen Optimierung für eine statische Seite aus,
+ * hat aber Navigation und Footer der ganzen Seite entfernt: `isNotIFrame`
+ * (`src/lib/utils/client/isNotIFrame.ts`) ist eine Modulkonstante mit
+ * `browser && window === window.top`. Ohne Client-JS bleibt sie auf ihrem
+ * SSR-Wert `false`, das Layout rendert deshalb im `.iframe-mode` und lässt
+ * `PublicNavbar` und `PublicFooter` komplett weg.
+ *
+ * Im Browser nachgemessen: auf `/about` waren `nav` und `footer` mit 0 Elementen
+ * gar nicht im DOM (auf `/` dagegen 5 bzw. 1). Konkrete Folgen:
+ * - Von `/about` führte kein Weg zurück in die Anwendung — es gab kein Menü.
+ * - Die Pflichtangaben (Impressum nach § 5 DDG, Datenschutzhinweis) sitzen im
+ *   Footer und waren damit ausgerechnet auf der „Über uns"-Seite unerreichbar.
+ *
+ * Die Alternative wäre, den Standard umzudrehen und die Chrome-Elemente erst
+ * client-seitig auszublenden. Das trägt hier nicht: ohne Client-JS gibt es
+ * niemanden, der das nachholt — eine iframe-Einbettung von `/about` würde dann
+ * doppelte Navigation zeigen.
+ *
+ * Diese Datei bleibt als Träger der Begründung bestehen, damit `csr = false`
+ * nicht als „fehlt noch" wieder ergänzt wird.
+ */
+export {};

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { untrack } from 'svelte';
 	import CleanupPanel from './CleanupPanel.svelte';
+	import { ACTIVE_CONFIG_KEYS, getConfigLabel } from './configLabels';
 
 	const logger = createLogger('admin:settings');
 
@@ -44,38 +45,9 @@
 		mobile: 'Mobile App-spezifische Einstellungen'
 	};
 
-	// Define which settings are currently implemented and should be shown
-	const activeConfigKeys = new Set([
-		// Email settings - fully implemented
-		'notification.email.enabled',
-		'notification.email.recipient',
-		'notification.email.sender',
-		'notification.email.senderName',
-		'notification.email.template',
-		'email.smtp.host',
-		'email.smtp.port',
-		'email.smtp.secure',
-		'email.smtp.user',
-		'email.smtp.password',
-
-		// Display settings - implemented
-		'display.maintenanceMode',
-		'display.maintenanceMessage',
-		'display.maxSightingsPerPage',
-
-		// Security settings - partially implemented
-		'security.maxFileSize',
-		'security.allowedFileTypes'
-
-		// Note: Other settings are planned but not yet actively used:
-		// - Most data processing settings (duplicate check, auto-approve, etc.)
-		// - Integration settings (weather API, geocoding, webhooks)
-		// - Advanced display settings (date format)
-		// - Mobile app settings
-		// - Advanced security settings
-		// Karten-Defaults stehen hier bewusst nicht mehr: Zentrum, Zoom und
-		// Tile-Quelle sind in src/lib/map/optimizedMapController.ts fest verdrahtet.
-	]);
+	// Labels und die Liste der wirksamen Einstellungen liegen in configLabels.ts —
+	// dort sind sie durch configLabels.test.ts gegen die Vorbelegungen abgeglichen.
+	const activeConfigKeys = ACTIVE_CONFIG_KEYS;
 
 	// Filter configurations to only show active ones
 	function filterActiveConfigs(
@@ -455,7 +427,7 @@
 									<div class="flex-1">
 										<div class="flex items-center gap-2">
 											<div class="text-base-content text-sm font-semibold">
-												{config.key}
+												{getConfigLabel(config.key)}
 											</div>
 											{#if changedConfigs.has(config.key)}
 												<span class="badge badge-warning badge-sm">Geändert</span>
@@ -468,6 +440,10 @@
 										{#if config.description}
 											<p class="text-base-content/70 mt-1 text-sm">{config.description}</p>
 										{/if}
+										<!-- Der technische Schlüssel bleibt sichtbar, nur nicht mehr als
+										     Überschrift: er wird für Support-Rückfragen und beim Abgleich
+										     mit .env / Logs gebraucht. -->
+										<p class="text-base-content/70 text-support mt-1 font-mono">{config.key}</p>
 									</div>
 
 									{#if changedConfigs.has(config.key)}

--- a/src/routes/admin/settings/configLabels.test.ts
+++ b/src/routes/admin/settings/configLabels.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Sichert ab, dass in der Settings-Oberfläche kein roher Konfigurationsschlüssel
+ * mehr auftaucht (UX-Review 2026-07-30).
+ *
+ * Der Test ist der eigentliche Mechanismus hinter `configLabels.ts`: Ohne ihn
+ * wäre die Label-Tabelle nur eine Momentaufnahme, die bei der nächsten neuen
+ * Einstellung wieder auseinanderläuft.
+ */
+import { describe, expect, it } from 'vitest';
+import { getAvailableConfigurationKeys } from '$lib/server/services/configInitializer';
+import { ACTIVE_CONFIG_KEYS, configLabels, getConfigLabel } from './configLabels';
+
+describe('Konfigurations-Labels', () => {
+	const availableKeys = getAvailableConfigurationKeys();
+
+	it('deckt jede vorbelegte Einstellung ab', () => {
+		const ohneLabel = availableKeys.filter((key) => !(key in configLabels));
+
+		// Aussagekräftige Fehlermeldung: der Test soll sagen, WELCHE Einstellung
+		// fehlt, sonst sucht man den Schlüssel von Hand.
+		expect(ohneLabel, `Ohne deutsches Label: ${ohneLabel.join(', ')}`).toEqual([]);
+	});
+
+	it('enthält keine Labels für Einstellungen, die es nicht mehr gibt', () => {
+		const verwaist = Object.keys(configLabels).filter((key) => !availableKeys.includes(key));
+
+		expect(verwaist, `Label ohne zugehörige Einstellung: ${verwaist.join(', ')}`).toEqual([]);
+	});
+
+	it('gibt niemals einen leeren Anzeigenamen zurück', () => {
+		for (const key of availableKeys) {
+			expect(getConfigLabel(key).trim().length, `Leeres Label für ${key}`).toBeGreaterThan(0);
+		}
+	});
+
+	it('fällt bei unbekanntem Schlüssel auf den Schlüssel selbst zurück', () => {
+		expect(getConfigLabel('gibt.es.nicht')).toBe('gibt.es.nicht');
+	});
+
+	it('kennzeichnet nur real existierende Einstellungen als aktiv', () => {
+		// Ein Tippfehler in ACTIVE_CONFIG_KEYS würde die Einstellung sonst still
+		// als „Geplant" einsortieren, obwohl sie wirkt.
+		const unbekannt = [...ACTIVE_CONFIG_KEYS].filter((key) => !availableKeys.includes(key));
+
+		expect(unbekannt, `Als aktiv markiert, aber unbekannt: ${unbekannt.join(', ')}`).toEqual([]);
+	});
+});

--- a/src/routes/admin/settings/configLabels.ts
+++ b/src/routes/admin/settings/configLabels.ts
@@ -1,0 +1,128 @@
+/**
+ * Deutsche Bezeichnungen der Konfigurationsschlüssel und die Liste der
+ * tatsächlich wirksamen Einstellungen.
+ *
+ * Warum diese Datei existiert (UX-Review 2026-07-30): Die Settings-Seite hat als
+ * Überschrift jeder Einstellung den rohen Schlüssel gerendert
+ * (`notification.email.senderName`), ergänzt nur um die optionale
+ * `description` aus `configInitializer.ts`. Für Admins sah das nach fehlenden
+ * Übersetzungen aus — es gab aber gar keine Label-Ebene.
+ *
+ * Bewusst hier und nicht in `configInitializer.ts`: Dessen `ConfigItem`-Objekte
+ * werden in die Tabelle `app_config` geschrieben, die kein Label-Feld hat. Ein
+ * Label dort einzuführen hieße, eine reine Anzeigezeichenkette in die Datenbank
+ * zu migrieren.
+ *
+ * Vollständigkeit ist getestet: `configLabels.test.ts` vergleicht die Schlüssel
+ * hier gegen `getAvailableConfigurationKeys()`. Eine neue Einstellung ohne Label
+ * lässt den Test fehlschlagen — der rohe Schlüssel kann also nicht erneut in die
+ * Oberfläche zurückkehren.
+ */
+
+/** Anzeigename pro Konfigurationsschlüssel. */
+export const configLabels: Record<string, string> = {
+	// E-Mail-Benachrichtigungen
+	'notification.email.enabled': 'E-Mail-Benachrichtigungen aktiv',
+	'notification.email.recipient': 'Empfänger-Adresse',
+	'notification.email.cc': 'Empfänger in Kopie (CC)',
+	'notification.email.bcc': 'Empfänger in Blindkopie (BCC)',
+	'notification.email.sender': 'Absender-Adresse',
+	'notification.email.senderName': 'Absender-Name',
+	'notification.email.template': 'HTML-Vorlage der Benachrichtigung',
+
+	// SMTP-Zugang
+	'email.smtp.host': 'SMTP-Server',
+	'email.smtp.port': 'SMTP-Port',
+	'email.smtp.secure': 'SMTP über SSL/TLS',
+	'email.smtp.user': 'SMTP-Benutzername',
+	'email.smtp.password': 'SMTP-Passwort',
+
+	// Anzeige
+	'display.maxSightingsPerPage': 'Sichtungen pro Seite in der Admin-Übersicht',
+	'display.dateFormat': 'Datumsformat',
+	'display.maintenanceMode': 'Wartungsmodus',
+	'display.maintenanceMessage': 'Text der Wartungsmeldung',
+
+	// Sicherheit und Uploads
+	'security.maxFileSize': 'Maximale Dateigröße pro Upload (MB)',
+	'security.allowedFileTypes': 'Erlaubte Dateitypen',
+	'security.rateLimitPerIP': 'Maximale Meldungen pro IP-Adresse',
+	'security.requireEmailVerification': 'E-Mail-Adresse bestätigen lassen',
+	'security.autoApproveThreshold': 'Schwellwert für automatische Freigabe',
+
+	// Datenverarbeitung
+	'data.duplicateCheckRadius': 'Radius der Duplikatsprüfung (km)',
+	'data.duplicateCheckTimeframe': 'Zeitfenster der Duplikatsprüfung (Stunden)',
+	'data.exportFormats': 'Verfügbare Export-Formate',
+	'data.archiveAfterDays': 'Archivierung nach Tagen (0 = keine)',
+
+	// Integrationen
+	'integration.weatherApiKey': 'API-Schlüssel Wetterdienst',
+	'integration.geoApiKey': 'API-Schlüssel Geokodierung',
+	'integration.webhookUrl': 'Webhook-Adresse',
+
+	// Mobile App
+	'mobile.minAppVersion': 'Mindestens erforderliche App-Version',
+	'mobile.updateMessage': 'Hinweistext zum App-Update',
+	'mobile.apiRateLimit': 'API-Limit der App (Anfragen pro Minute)'
+};
+
+/**
+ * Liefert den Anzeigenamen, im Zweifel den Schlüssel selbst.
+ *
+ * Der Schlüssel als Rückfallwert ist Absicht: eine Einstellung ohne Label soll
+ * bedienbar bleiben statt namenlos zu verschwinden. Dass dieser Fall nicht
+ * eintritt, sichert `configLabels.test.ts` ab.
+ */
+export function getConfigLabel(key: string): string {
+	return configLabels[key] ?? key;
+}
+
+/**
+ * Einstellungen, die im Code tatsächlich gelesen werden.
+ *
+ * Alles andere existiert nur als Vorbelegung in der Datenbank und wird in der
+ * Oberfläche als „Geplant" gekennzeichnet. Stand der Prüfung 2026-07-30 (jeweils
+ * über die echten Aufrufstellen verifiziert, nicht über Namensähnlichkeit):
+ *
+ * | Einstellung                    | gelesen von                                              |
+ * | ------------------------------ | -------------------------------------------------------- |
+ * | `notification.email.*`         | `emailService.getEmailConfig()` / `initialize()`          |
+ * | `email.smtp.*`                 | `emailService.initialize()`                               |
+ * | `display.maintenanceMode`      | `ServerConfigService.isMaintenanceModeEnabled()`          |
+ * | `display.maintenanceMessage`   | `maintenanceMode.ts`, `+layout.server.ts`, API-Route      |
+ * | `display.maxSightingsPerPage`  | `getPaginationConfig()` → `admin/+page.server.ts`         |
+ * | `security.maxFileSize`         | `getUploadConfig()` → `/api/config/upload`, `/api/files/upload` |
+ * | `security.allowedFileTypes`    | `getUploadConfig()` (siehe oben)                          |
+ *
+ * Nicht gelesen und daher „Geplant": `display.dateFormat`, alle `data.*`, alle
+ * `integration.*`, alle `mobile.*` sowie `security.rateLimitPerIP`,
+ * `security.requireEmailVerification` und `security.autoApproveThreshold` —
+ * deren einziger Leser `ServerConfigService.getSecurityConfig()` hat keine
+ * Aufrufstelle.
+ *
+ * Karten-Defaults stehen hier bewusst nicht: Zentrum, Zoom und Tile-Quelle sind
+ * in `src/lib/map/optimizedMapController.ts` fest verdrahtet.
+ */
+export const ACTIVE_CONFIG_KEYS: ReadonlySet<string> = new Set([
+	'notification.email.enabled',
+	'notification.email.recipient',
+	'notification.email.cc',
+	'notification.email.bcc',
+	'notification.email.sender',
+	'notification.email.senderName',
+	'notification.email.template',
+
+	'email.smtp.host',
+	'email.smtp.port',
+	'email.smtp.secure',
+	'email.smtp.user',
+	'email.smtp.password',
+
+	'display.maintenanceMode',
+	'display.maintenanceMessage',
+	'display.maxSightingsPerPage',
+
+	'security.maxFileSize',
+	'security.allowedFileTypes'
+]);

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -1,20 +1,36 @@
 import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
-import { approvalFilter, type ResolvedSightingScope } from '$lib/server/db/approvalFilter';
+import {
+	approvalFilter,
+	approvedOnly,
+	type ResolvedSightingScope
+} from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate, berlinDatePart } from '$lib/server/db/sqlTimeZone';
-import { and, eq, isNotNull, ne, sql } from 'drizzle-orm';
+import { and, isNotNull, ne, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
 const logger = createLogger('admin:statistics:page');
 
-/** Kennzahlen eines Freigabestatus — nie über beide Status summiert. */
+/**
+ * Kennzahlen eines Freigabestatus — nie über beide Status summiert.
+ *
+ * `verifiedSightings` ist hier 2026-07-30 entfallen. Die Kennzahl zählte
+ * innerhalb der freigegebenen Menge noch einmal `geprueft = 1` und war damit
+ * tautologisch (gemessen 19.253 von 19.262 = 99,95 %). Sie widersprach außerdem
+ * der Invariante des Projekts: eine Sichtung ist ungeprüft **oder** geprüft, und
+ * geprüft heißt veröffentlicht (siehe CLAUDE.md und `.claude/rules/api.md`) — ein
+ * eigener „verifiziert"-Anteil innerhalb der Veröffentlichten suggeriert eine
+ * Qualitätsdimension, die es nach diesem Modell nicht gibt. Die 9 Zeilen, die
+ * tatsächlich abweichen (`freigegeben_am` gesetzt, `geprueft = 0`), sind
+ * Inkonsistenzen aus dem Altsystem und gehören in eine Datenprüfung, nicht in
+ * eine Übersichtskennzahl.
+ */
 export interface AdminBasicStats {
 	totalSightings: number;
 	avgGroupSize: number;
 	maxGroupSize: number;
 	deadAnimals: number;
-	verifiedSightings: number;
 	withMedia: number;
 }
 
@@ -23,7 +39,6 @@ const EMPTY_BASIC_STATS: AdminBasicStats = {
 	avgGroupSize: 0,
 	maxGroupSize: 0,
 	deadAnimals: 0,
-	verifiedSightings: 0,
 	withMedia: 0
 };
 
@@ -42,7 +57,6 @@ async function loadBasicStats(scope: ResolvedSightingScope): Promise<AdminBasicS
 			avgGroupSize: sql<number>`COALESCE(AVG(${sightings.totalCount})::numeric, 0)`,
 			maxGroupSize: sql<number>`COALESCE(MAX(${sightings.totalCount})::integer, 0)`,
 			deadAnimals: sql<number>`COUNT(CASE WHEN ${sightings.isDead} = 1 THEN 1 END)::integer`,
-			verifiedSightings: sql<number>`COUNT(CASE WHEN ${sightings.verified} = 1 THEN 1 END)::integer`,
 			withMedia: sql<number>`COUNT(CASE WHEN ${sightings.mediaUpload} != 0 THEN 1 END)::integer`
 		})
 		.from(sightings)
@@ -71,7 +85,7 @@ export const load: PageServerLoad = async () => {
 				deadPercentage: sql<number>`ROUND(COUNT(CASE WHEN ${sightings.isDead} = 1 THEN 1 END) * 100.0 / COUNT(*), 2)::numeric`
 			})
 			.from(sightings)
-			.where(eq(sightings.verified, 1))
+			.where(approvedOnly())
 			.groupBy(sightings.species)
 			.orderBy(sql`COUNT(*) DESC`);
 
@@ -85,7 +99,7 @@ export const load: PageServerLoad = async () => {
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
-			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
+			.where(and(isNotNull(sightings.sightingDate), approvedOnly()))
 			.groupBy(berlinDatePart('year', sightings.sightingDate))
 			.orderBy(berlinDatePart('year', sightings.sightingDate));
 
@@ -96,7 +110,7 @@ export const load: PageServerLoad = async () => {
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
-			.where(and(isNotNull(sightings.sightingDate), eq(sightings.verified, 1)))
+			.where(and(isNotNull(sightings.sightingDate), approvedOnly()))
 			.groupBy(berlinDatePart('month', sightings.sightingDate))
 			.orderBy(berlinDatePart('month', sightings.sightingDate));
 
@@ -122,7 +136,15 @@ export const load: PageServerLoad = async () => {
 			// zuverlässig verifizieren lassen — das Risiko eines neuen, unbemerkten
 			// Zeitzonenfehlers wiegt hier schwerer als der kosmetische Rand-Tag einer
 			// „letzte 30 Tage"-Trendanzeige.
-			.where(sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`)
+			// Freigabebezug wie überall sonst auf dieser Seite: vorher war dies die
+			// einzige Abfrage ohne Filter und zählte damit als Einzige die gesamte
+			// Tabelle inklusive noch offener Meldungen (Vorgabe 3 in approvalFilter.ts).
+			.where(
+				and(
+					approvedOnly(),
+					sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`
+				)
+			)
 			.groupBy(berlinCalendarDate(sightings.created))
 			.orderBy(sql`${berlinCalendarDate(sightings.created)} DESC`)
 			.limit(30);
@@ -133,7 +155,7 @@ export const load: PageServerLoad = async () => {
 				uniqueUsers: sql<number>`COUNT(DISTINCT email)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`email IS NOT NULL AND email != ''`, eq(sightings.verified, 1)));
+			.where(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()));
 
 		// Repeat users count - safe subquery approach
 		const repeatUsers = await db
@@ -142,7 +164,7 @@ export const load: PageServerLoad = async () => {
 				count: sql<number>`COUNT(*)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`email IS NOT NULL AND email != ''`, eq(sightings.verified, 1)))
+			.where(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()))
 			.groupBy(sql`email`)
 			.having(sql`COUNT(*) > 1`);
 
@@ -162,7 +184,7 @@ export const load: PageServerLoad = async () => {
 				totalWithShipName: sql<number>`COUNT(*)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`schiffsname IS NOT NULL AND schiffsname != ''`, eq(sightings.verified, 1)));
+			.where(and(sql`schiffsname IS NOT NULL AND schiffsname != ''`, approvedOnly()));
 
 		const shipStats = [
 			{
@@ -184,7 +206,10 @@ export const load: PageServerLoad = async () => {
 			})
 			.from(sightings)
 			.where(
-				sql`${sightings.email} IS NOT NULL AND ${sightings.email} != '' AND ${sightings.email} NOT LIKE '%@meeresmuseum.de' AND ${sightings.verified} = 1`
+				and(
+					sql`${sightings.email} IS NOT NULL AND ${sightings.email} != '' AND ${sightings.email} NOT LIKE '%@meeresmuseum.de'`,
+					approvedOnly()
+				)
 			)
 			.groupBy(sightings.email)
 			.having(sql`COUNT(*) > 1`)
@@ -195,25 +220,17 @@ export const load: PageServerLoad = async () => {
 		const [totalVerified] = await db
 			.select({ total: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(eq(sightings.verified, 1));
+			.where(approvedOnly());
 
 		const [coordVerified] = await db
 			.select({ count: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(
-				and(
-					eq(sightings.verified, 1),
-					isNotNull(sightings.latitude),
-					isNotNull(sightings.longitude)
-				)
-			);
+			.where(and(approvedOnly(), isNotNull(sightings.latitude), isNotNull(sightings.longitude)));
 
 		const [behaviorVerified] = await db
 			.select({ count: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(
-				and(eq(sightings.verified, 1), isNotNull(sightings.behavior), ne(sightings.behavior, 0))
-			);
+			.where(and(approvedOnly(), isNotNull(sightings.behavior), ne(sightings.behavior, 0)));
 
 		const qualityStats = [
 			{
@@ -223,15 +240,18 @@ export const load: PageServerLoad = async () => {
 			}
 		];
 
-		// Geographic distribution (simplified)
-		const geographicStats = await db
-			.select({
-				inBalticSea: sql<number>`COUNT(CASE WHEN ${sightings.inBalticSeaGeo} = 1 THEN 1 END)::integer`,
-				outsideBalticSea: sql<number>`COUNT(CASE WHEN ${sightings.inBalticSeaGeo} = 0 THEN 1 END)::integer`,
-				total: sql<number>`COUNT(*)::integer`
-			})
-			.from(sightings)
-			.where(eq(sightings.verified, 1));
+		// Die frühere `geographicStats`-Abfrage ist hier ersatzlos entfallen.
+		//
+		// Sie wurde bei jedem Seitenaufruf über die gesamte Tabelle ausgeführt, aber
+		// von `+page.svelte` nie gerendert — reine Last ohne Abnehmer. Ihre Logik war
+		// zudem falsch: gezählt wurden nur `ostsee_geo = 1` und `= 0`, während der
+		// überwiegende Teil der Altdaten den Wert `2` trägt (Stand 2026-07-30: 15.070
+		// von 19.253 geprüften Zeilen). Der Rest der Anwendung behandelt `ostsee_geo`
+		// als Wahrheitswert (`!!sighting.inBalticSeaGeo` in emailService.ts,
+		// `{#if sighting.inBalticSeaGeo}` in admin/+page.svelte) und zählt die `2`
+		// damit als „in der Ostsee". Eine wiederbelebte Kennzahl müsste diese drei
+		// Zustände erst fachlich klären, statt 78 % der Daten stillschweigend
+		// fallen zu lassen.
 
 		return {
 			basicStats,
@@ -239,7 +259,6 @@ export const load: PageServerLoad = async () => {
 			yearlyStats,
 			monthlyStats,
 			recentActivity,
-			geographicStats,
 			userStats,
 			shipStats: shipStats[0] || { uniqueShips: 0, totalWithShipName: 0 },
 			topObservers,

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -33,70 +33,8 @@
 		return `${numValue.toFixed(1)}%`;
 	}
 
-	// Types
-	type Insight = {
-		type: 'critical' | 'warning' | 'info';
-		title: string;
-		description: string;
-	};
-
-	// Calculate scientific insights
-	let scientificInsights = $derived.by(() => {
-		if (!data.basicStats) return [];
-
-		const insights: Insight[] = [];
-
-		// Mortality rate analysis — Bezugsgröße sind ausschließlich freigegebene
-		// Sichtungen, damit die Quote nicht zwischen den Freigabestatus mischt.
-		const totalDeadAnimals = data.basicStats.approved.deadAnimals;
-		const totalSightings = data.basicStats.approved.totalSightings;
-		const overallMortalityRate = totalSightings > 0 ? (totalDeadAnimals / totalSightings) * 100 : 0;
-
-		if (overallMortalityRate > 10) {
-			insights.push({
-				type: 'warning',
-				title: 'Erhöhte Mortalitätsrate',
-				description: `${formatPercentage(overallMortalityRate)} der Sichtungen betreffen tote Tiere - deutlich über dem erwarteten Niveau.`
-			});
-		}
-
-		// Seasonal patterns
-		const summerSightings = data.monthlyStats
-			.filter((m) => m.month >= 6 && m.month <= 8)
-			.reduce((sum, m) => sum + m.sightings, 0);
-		const totalYearSightings = data.monthlyStats.reduce((sum, m) => sum + m.sightings, 0);
-		// Ohne Guard liefert eine leere Monatsstatistik NaN, und `NaN > 60` ist zwar
-		// false — die Erkenntnis bliebe also aus —, aber der Wert wanderte bei jeder
-		// künftigen Umformulierung ungeprüft in den Text.
-		const summerPercentage =
-			totalYearSightings > 0 ? (summerSightings / totalYearSightings) * 100 : 0;
-
-		if (summerPercentage > 60) {
-			insights.push({
-				type: 'info',
-				title: 'Starke Saisonalität',
-				description: `${formatPercentage(summerPercentage)} aller Sichtungen finden in den Sommermonaten statt - deutliche Wanderungsmuster erkennbar.`
-			});
-		}
-
-		// Species-specific concerns
-		const criticalSpecies = data.speciesStats.filter((s) => {
-			const deadPerc =
-				typeof s.deadPercentage === 'string' ? parseFloat(s.deadPercentage) : s.deadPercentage || 0;
-			return deadPerc > 30;
-		});
-		if (criticalSpecies.length > 0) {
-			criticalSpecies.forEach((species) => {
-				insights.push({
-					type: 'critical',
-					title: `Kritische Mortalität: ${getSpeciesLabel(species.species)}`,
-					description: `${formatPercentage(species.deadPercentage)} Mortalitätsrate bei ${getSpeciesLabel(species.species)} - erfordert sofortige wissenschaftliche Aufmerksamkeit.`
-				});
-			});
-		}
-
-		return insights;
-	});
+	// Die Ableitung `scientificInsights` ist 2026-07-30 entfallen; die Begründung
+	// steht an ihrer Anzeigestelle in der Vorlage unten.
 </script>
 
 <svelte:head>
@@ -139,43 +77,34 @@
 					</span>
 				</p>
 			</div>
-			<div class="badge badge-primary badge-lg">
-				{formatNumber(data.basicStats?.approved.verifiedSightings || 0)} verifiziert
-			</div>
 		</div>
 
-		<!-- Scientific Insights Alert Box -->
-		{#if scientificInsights.length > 0}
-			<div class="alert alert-info">
-				<Icon icon="lucide:trending-up" class="h-6 w-6" />
-				<div class="flex-1">
-					<h3 class="font-bold">Wissenschaftliche Erkenntnisse</h3>
-					<div class="mt-2 space-y-2">
-						{#each scientificInsights as insight (insight.title)}
-							{@const alertClass =
-								insight.type === 'critical'
-									? 'alert-error'
-									: insight.type === 'warning'
-										? 'alert-warning'
-										: 'alert-info'}
-							{@const alertIcon =
-								insight.type === 'critical'
-									? 'lucide:circle-alert'
-									: insight.type === 'warning'
-										? 'lucide:triangle-alert'
-										: 'lucide:info'}
-							<div class="alert {alertClass} alert-sm">
-								<Icon icon={alertIcon} class="shrink-0" aria-hidden="true" />
-								<div>
-									<div class="font-semibold">{insight.title}</div>
-									<div class="text-sm">{insight.description}</div>
-								</div>
-							</div>
-						{/each}
-					</div>
-				</div>
-			</div>
-		{/if}
+		<!--
+			Hier stand bis 2026-07-30 ein Block „Wissenschaftliche Erkenntnisse".
+			Er ist ersatzlos entfernt, weil seine Aussagen aus dieser Datenbasis
+			grundsätzlich nicht ableitbar sind:
+
+			- „Erhöhte Mortalitätsrate" rechnete Totfund-Meldungen / alle Meldungen.
+			  Das ist der Anteil der Meldungen über tote Tiere, keine Mortalitätsrate —
+			  dafür bräuchte es eine Population und einen bekannten Beobachtungsaufwand.
+			  Der Zusatz „deutlich über dem erwarteten Niveau" erfand zusätzlich ein
+			  Erwartungsniveau ohne Quelle.
+			- „Starke Saisonalität … deutliche Wanderungsmuster erkennbar" deutete die
+			  Verteilung der Meldungen als Verhalten der Tiere. Die Tabelle enthält nur
+			  Positivmeldungen ohne Aufwand, die Verteilung spiegelt daher primär den
+			  Rhythmus der Beobachtenden.
+			- „Kritische Mortalität: <Art> … erfordert sofortige wissenschaftliche
+			  Aufmerksamkeit" feuerte ab 30 % Totfundanteil ohne Mindest-Stichprobe. Es
+			  traf zuletzt „Unbekannte Robbenart" (145 von 317) — eine Kategorie, die
+			  überwiegend aus Totfunden besteht, weil verweste Tiere oft nicht mehr
+			  bestimmbar sind. Das Ergebnis war ein Artefakt der Kategoriedefinition.
+
+			Genau diese Art unbelegter Zahlenaussagen verbietet
+			`.claude/rules/design-system.md` („Zahlen in Nutzertexten nur mit Quelle",
+			Abschnitt „Grenze der eigenen Datenbasis"). Eine belastbare Auswertung
+			gehört in eine fachliche Analyse mit Aufwandsdaten, nicht in eine
+			Übersichtsseite.
+		-->
 
 		<!-- Key Metrics Grid -->
 		<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
@@ -189,12 +118,6 @@
 						{formatNumber(data.basicStats?.approved.totalSightings || 0)}
 					</div>
 					<div class="stat-desc">
-						{formatNumber(data.basicStats?.approved.verifiedSightings || 0)} verifiziert ({formatPercentage(
-							((data.basicStats?.approved.verifiedSightings || 0) /
-								(data.basicStats?.approved.totalSightings || 1)) *
-								100
-						)})
-						<br />
 						<span class="text-warning-strong"
 							>{formatNumber(data.basicStats?.pending.totalSightings || 0)} noch offen</span
 						>
@@ -267,7 +190,9 @@
 						<Icon icon="lucide:users" class="h-8 w-8" />
 					</div>
 					<div class="stat-title">Unique Nutzer</div>
-					<div class="stat-value text-info-strong">{formatNumber(data.userStats?.uniqueUsers || 0)}</div>
+					<div class="stat-value text-info-strong">
+						{formatNumber(data.userStats?.uniqueUsers || 0)}
+					</div>
 					<div class="stat-desc">
 						{formatNumber(data.userStats?.repeatUsers || 0)} Wiederholungs-Nutzer ({formatPercentage(
 							data.userStats?.repeatUserPercentage || 0

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -26,6 +26,9 @@ const toSqlText = (expression: SQLWrapper): string => dialect.sqlToQuery(express
 /** Alle Spalten-Objekte, die je an `db.select({...})` übergeben wurden. */
 let recordedSelectColumns: Array<Record<string, unknown>> = [];
 
+/** Alle Prädikate, die je an `.where(...)` übergeben wurden. */
+let recordedWhereClauses: SQLWrapper[] = [];
+
 /**
  * Minimaler, aufzeichnender Drizzle-Query-Builder.
  *
@@ -38,7 +41,10 @@ function createRecordingBuilder() {
 	const builder = {
 		from: () => builder,
 		innerJoin: () => builder,
-		where: () => builder,
+		where: (predicate?: SQLWrapper) => {
+			if (predicate) recordedWhereClauses.push(predicate);
+			return builder;
+		},
 		groupBy: () => builder,
 		orderBy: () => builder,
 		having: () => builder,
@@ -94,5 +100,62 @@ describe('admin/statistics load() — Top-Observers Datumsspalten (M1)', () => {
 		expect(lastSightingSql).not.toContain('::date');
 		expect(firstSightingSql).toContain('Europe/Berlin');
 		expect(lastSightingSql).toContain('Europe/Berlin');
+	});
+});
+
+/**
+ * Vorgabe 3 aus `src/lib/server/db/approvalFilter.ts`: „Eine Statistikzahl ohne
+ * erkennbaren Freigabebezug soll es nicht geben."
+ *
+ * Bis 2026-07-30 galt das nur für die Kopfzahlen. Arten-, Jahres-, Monats-,
+ * Nutzer-, Schiffs-, Beobachter- und Qualitätsabfragen filterten stattdessen auf
+ * `geprueft = 1`, `recentActivity` filterte überhaupt nicht. Die Seite mischte
+ * damit zwei Grundmengen: Kopfzeile 19.262 (freigegeben), Abschnitte darunter
+ * 19.253 (geprüft) — und `recentActivity` die vollen 19.880 inklusive offener
+ * Meldungen.
+ *
+ * Der Test prüft die Struktur, nicht Zahlen: **jede** Abfrage muss sich auf
+ * `freigegeben_am` beziehen, und keine darf mehr über `geprueft` filtern.
+ */
+describe('admin/statistics load() — einheitliche Grundmenge', () => {
+	it('bezieht jede Abfrage auf den Freigabestatus und keine mehr auf geprueft', async () => {
+		recordedWhereClauses = [];
+
+		await load({} as unknown as Parameters<typeof load>[0]);
+
+		expect(
+			recordedWhereClauses.length,
+			'keine WHERE-Klauseln aufgezeichnet — Mock greift nicht mehr'
+		).toBeGreaterThan(5);
+
+		const ohneFreigabebezug: string[] = [];
+		const mitGeprueft: string[] = [];
+
+		for (const clause of recordedWhereClauses) {
+			const text = toSqlText(clause);
+			if (!text.includes('freigegeben_am')) ohneFreigabebezug.push(text);
+			if (text.includes('geprueft')) mitGeprueft.push(text);
+		}
+
+		expect(
+			ohneFreigabebezug,
+			`Abfrage(n) ohne Freigabebezug:\n${ohneFreigabebezug.join('\n')}`
+		).toEqual([]);
+		expect(mitGeprueft, `Abfrage(n) filtern noch auf geprueft:\n${mitGeprueft.join('\n')}`).toEqual(
+			[]
+		);
+	});
+
+	it('fährt die Kopfzahlen getrennt für freigegeben und offen', async () => {
+		recordedWhereClauses = [];
+
+		await load({} as unknown as Parameters<typeof load>[0]);
+
+		const texte = recordedWhereClauses.map(toSqlText);
+
+		// `loadBasicStats` läuft zweimal — einmal je Freigabestatus. Eine vermischte
+		// Summe über beide soll strukturell unmöglich bleiben (Vorgabe 2).
+		expect(texte.some((t) => /freigegeben_am"? is not null/i.test(t))).toBe(true);
+		expect(texte.some((t) => /freigegeben_am"? is null/i.test(t))).toBe(true);
 	});
 });

--- a/src/routes/docs/api/scalar/+server.ts
+++ b/src/routes/docs/api/scalar/+server.ts
@@ -1,10 +1,35 @@
 import { ScalarApiReference } from '@scalar/sveltekit';
 import type { RequestHandler } from './$types';
 
+/**
+ * KEIN `customCss` hier — und das ist eine bewusste Entscheidung, keine Lücke.
+ *
+ * Bis 2026-07-30 stand hier ein Block, der Scrolling und Sidebar-Navigation
+ * „reparieren" sollte und beides erst kaputt gemacht hat. Von seinen Selektoren
+ * existiert im ausgelieferten Scalar-Bundle nur `.scalar-app`:
+ *
+ * | Selektor                    | im Bundle | Wirkung                          |
+ * | --------------------------- | --------- | -------------------------------- |
+ * | `.scalar-app`               | ja        | `overflow: hidden` + `100vh`     |
+ * | `.scalar-content`           | nein      | keine                            |
+ * | `.scalar-sidebar`           | nein      | keine (nur `--scalar-sidebar-*`) |
+ * | `.scalar-sidebar__item`     | nein      | keine                            |
+ *
+ * Die einzige greifende Regel hat also das Scrollen abgeschaltet, während die
+ * Regeln, die es zurückholen sollten, ins Leere zielten. Im Browser gemessen:
+ * `scrollHeight` 18.777 px gegen `clientHeight` 812 px — 17.965 px Inhalt waren
+ * unerreichbar, und Klicks auf Endpunkte scrollten einen Container, der nicht
+ * scrollen darf (deshalb wirkte die Navigation tot).
+ *
+ * Scalar bringt sein Layout (`.references-layout`, Grid mit `100dvh`) samt
+ * Scroll-Containern selbst mit. Wer hier wieder CSS ergänzt, muss die
+ * Klassennamen vorher im CDN-Bundle verifizieren — sie sind nicht Teil einer
+ * öffentlichen API und ändern sich mit der unpinned CDN-Version.
+ */
 const configuration = {
-	spec: {
-		url: '/openapi.yml'
-	},
+	// `url` statt des deprecated `spec.url`: das Bundle migriert `spec.url`
+	// intern weiter, protokolliert dabei aber eine Deprecation-Warnung.
+	url: '/openapi.yml',
 	theme: 'default' as const,
 	layout: 'modern' as const,
 	showSidebar: true,
@@ -12,53 +37,6 @@ const configuration = {
 	hiddenClients: [],
 	isEditable: false,
 	darkMode: false,
-	customCss: `
-		/* Custom styling for better integration */
-		.scalar-app {
-			font-family: 'Roboto', system-ui, sans-serif;
-			height: 100vh !important;
-			overflow: hidden;
-		}
-		
-		/* Fix sidebar scrolling */
-		.scalar-sidebar {
-			overflow-y: auto !important;
-			max-height: 100vh;
-		}
-		
-		/* Main content scrolling */
-		.scalar-content {
-			overflow-y: auto !important;
-			max-height: 100vh;
-		}
-		
-		/* Better mobile responsiveness */
-		@media (max-width: 768px) {
-			.scalar-sidebar {
-				width: 100% !important;
-			}
-			
-			.scalar-app {
-				height: auto !important;
-			}
-		}
-		
-		/* Ensure clickable elements work */
-		.scalar-sidebar a,
-		.scalar-sidebar button {
-			cursor: pointer !important;
-			pointer-events: auto !important;
-		}
-		
-		/* Fix operation selection */
-		.scalar-sidebar .scalar-sidebar__item {
-			pointer-events: auto !important;
-		}
-		
-		.scalar-sidebar .scalar-sidebar__item:hover {
-			background-color: rgba(0, 0, 0, 0.05) !important;
-		}
-	`,
 	metaData: {
 		title: 'Ostsee-Tiere API Documentation',
 		description: 'Interaktive API-Dokumentation für die Ostsee-Tiere Plattform',


### PR DESCRIPTION
Arbeitet die Bugliste aus dem UI/UX-Review vom 2026-07-30 ab. Jeder Fix ist im Browser oder per Test gegengeprüft; die Begründungen stehen als Kommentar an der jeweiligen Stelle.

## Karte

**Controls schnitten den Titel.** In `app.css` wurde `mapStyles.css` vor `ol/ol.css` importiert. Beide adressieren `.ol-zoom`, `.ol-control` und `.ol-control button` mit identischer Spezifität (0,1,0) — bei gleichem Gewicht gewinnt die spätere Datei, also OpenLayers. `.ol-zoom { top: 4.5rem }` war damit wirkungslos, das Control saß in der Ecke (gemessen: Titel x=48..246 y=82..118 gegen Control x=8..60 y=74..172) und die für die *gedachte* Position berechnete `.zoom-all-control` ließ eine 70-px-Lücke. Nach der Korrektur: `top: 72px`, keine Überlappung, 10 px Abstand. Der doppelte `ol.css`-Import in `SightingsMapView` entfällt, sonst landet die Datei erneut hinter den Overrides.

**Pan und Zoom wirkten erst nach einem Klick in die Karte.** Ursache über eine Playwright-Reproduktion eingegrenzt: `ol/Map` baut seine Default-Interactions mit **`onFocusOnly: true`** (`node_modules/ol/Map.js:469`). Das schaltet `DragPan` und `MouseWheelZoom` auf `all(focusWithTabindex, …)` — und `focusWithTabindex` verlangt Fokus im Target, **sobald dieses ein `tabindex` trägt**. Genau dieses `tabindex="0"` wurde bewusst für `KeyboardPan`/`KeyboardZoom` gesetzt (Befund K3). Die Barrierefreiheits-Verbesserung hat also die Maussteuerung gebrochen.

Nachgewiesen bei identischen, trusted Pointer-Events (`isPrimary=true, button=0, buttons=1`):

```
DRAG 1: handleDownEvent -> false | condition_=false | activeElement=BODY  | tabindex=0
KLICK:  handleDownEvent -> true  | condition_=true  | activeElement=#map  | tabindex=0
DRAG 2: handleDownEvent -> true  | condition_=true  | activeElement=#map  | tabindex=0
```

**Ausgenommen wird nur `DragPan`**, alles andere behält `onFocusOnly: true`:

```ts
interactions: defaultInteractions({ onFocusOnly: true, dragPan: false }).extend([
  new DragPan({ condition: all(noModifierKeys, primaryAction) })
])
```

Das `onFocusOnly: true` ist dabei kein Zusatz, sondern die **Wiederherstellung** des Map-Defaults: ruft man `defaults()` selbst auf, ist der Wert `false`. Wer das übersieht, hebt den Fokus-Schutz still für alle Interactions auf — genau das ist beim ersten Anlauf dieses Fixes passiert und im Test aufgefallen.

Begründung der Unterscheidung: Ein Drag ist eine eindeutige Absicht, dort kostet der Schutz nur Bedienbarkeit. Das Mausrad ist der Gegenfall — die App wird auf meeresmuseum.de in einem iframe eingebettet, und wer dort die Seite scrollen will, würde ohne Schutz die Karte zoomen. **Mausrad-Zoom setzt deshalb weiterhin einen Klick oder Tab in die Karte voraus**, wie bei Kartendiensten üblich. Die Tastatur-Interactions bleiben ohnehin unverändert.

**Filter-Anzeige war zu präsent.** Der Platzfresser war nicht das Gewicht, sondern `flex-wrap`: bei mehreren Filtern wuchs das Band auf zwei bis drei 44-px-Reihen. Jetzt eine Zeile mit horizontalem Scroll, halbtransparent statt deckend, ohne Schatten. Die 44-px-Trefferfläche bleibt (WCAG 2.5.5).

## `/docs/api`

Nicht CSP (der iframe liefert keinen CSP-Header) und nicht `spec.url` (wird intern migriert), sondern das `customCss` der Scalar-Route. Von seinen Selektoren existiert im Bundle nur `.scalar-app`:

| Selektor | im Bundle | Wirkung |
|---|---|---|
| `.scalar-app` | ja | `overflow: hidden` + `100vh` |
| `.scalar-content` | **nein** | keine |
| `.scalar-sidebar` | **nein** (nur `--scalar-sidebar-*`) | keine |
| `.scalar-sidebar__item` | **nein** | keine |

Die einzige greifende Regel schaltete das Scrollen ab, die Regeln zur Wiederherstellung zielten ins Leere. Gemessen: `scrollHeight` 18.777 px gegen `clientHeight` 812 px — 17.965 px unerreichbar, Endpunkt-Klicks scrollten einen Container, der nicht scrollen darf. Block entfernt, `spec.url` auf `url` migriert.

## Admin

**Settings zeigten rohe Config-Keys.** `configLabels.ts` liefert deutsche Labels für alle 31 Keys; der technische Schlüssel bleibt als kleine Mono-Zeile für Support-Rückfragen. `configLabels.test.ts` erzwingt Vollständigkeit in beide Richtungen, ein neuer Key ohne Label lässt den Test fehlschlagen. `notification.email.cc`/`bcc` wurden gelesen, standen aber in keiner Vorbelegung — jetzt konfigurierbar.

Zur Frage „sind alle Settings aktiv": nein, und die Seite wusste das schon. Ich habe alle 31 gegen die echten Lesestellen geprüft — die Liste der aktiven stimmt, 14 sind tot (`display.dateFormat`, alle `data.*`, `integration.*`, `mobile.*` sowie drei `security.*`, deren einziger Leser `getSecurityConfig()` keine Aufrufstelle hat). Belegt in `configLabels.ts`.

**Statistiken mischten zwei Grundmengen.** Die Kopfzahlen liefen über `freigegeben_am` (19.262), alle übrigen Abfragen über `geprueft = 1` (19.253), `recentActivity` über gar keinen Filter (19.880). Jetzt durchgängig `freigegeben_am`; nachgerechnet summieren Arten-, Jahres-, Qualitäts- und Melder-Auswertung auf dieselben 19.262. Ein Test sichert die Struktur ab: jede Abfrage muss sich auf `freigegeben_am` beziehen, keine mehr auf `geprueft`.

Entfallen sind außerdem die nie gerenderte `geographicStats`-Abfrage (Aggregat über die ganze Tabelle ohne Abnehmer, zählte zudem nur `ostsee_geo` 0 und 1 und ließ damit 78 % der Daten fallen) und der Block „Wissenschaftliche Erkenntnisse". Letzterer gab Totfund-Meldeanteile als „Mortalitätsrate … über dem erwarteten Niveau" aus und leitete aus der Meldeverteilung „deutliche Wanderungsmuster" ab. Aktiv gefeuert hat er für „Unbekannte Robbenart" (145 von 317) — eine Kategorie, die überwiegend aus Totfunden besteht, weil verweste Tiere nicht bestimmbar sind. Genau diese Klasse unbelegter Zahlenaussagen verbietet `design-system.md`.

## E-Mail

SMTP aus der Umgebung war toter Code. `initializeDefaultConfigurations()` legt `email.smtp.host`/`user`/`password` mit **Leerstring** an, und `getString(key, default)` liefert den Default nur bei `null` — in der DB verifiziert (`email.smtp.host | ""`). Sobald `/admin/settings` einmal geöffnet war, wirkten `SMTP_HOST`/`USER`/`PASSWORD` nie, und der Versand brach still mit einer Log-Warnung ab. Der Fallback greift jetzt nach dem DB-Zugriff; ein gesetzter DB-Wert gewinnt weiter. Test-First: `emailService.envFallback.test.ts` RED → GREEN.

## `/about`

**`csr = false` entfernt.** Ohne Client-JS behielt `isNotIFrame` (Modulkonstante mit `browser && window === window.top`) seinen SSR-Wert `false`; das Layout rannte in den `.iframe-mode` und ließ `PublicNavbar` und `PublicFooter` komplett weg. Gemessen waren `nav` und `footer` auf `/about` mit 0 Elementen nicht im DOM (auf `/` 5 bzw. 1), auch der Seitentitel war falsch. Von der Seite führte damit kein Weg zurück in die Anwendung — und die Pflichtangaben im Footer waren ausgerechnet dort unerreichbar.

**Impressum und Datenschutz.** Beides fehlte vollständig: weder Route noch Link. Der Footer verlinkt nun die Seiten des Betreibers (bewusst keine zweite, separat zu pflegende Fassung derselben Rechtstexte), zusätzlich steht ein Datenschutz-Link direkt an der Einwilligung im Formular — Art. 13 DSGVO verlangt ihn an der Erhebungsstelle, dort fehlte er.

**Irreführende Angaben korrigiert.** „Bereits erfasst" → „Veröffentlicht" (der Wert ist die freigegebene Menge, nicht die erfasste); „Aktive Beobachter" → „Melder-Adressen insgesamt" (kumulierte eindeutige E-Mail-Adressen, nicht aktiv); die DB-Fallbacks `1.800+`/`500+` lagen um Faktor 10 unter der Realität und sind entfernt — keine Zahl ist besser als eine erfundene; „alle Sichtungen" → „freigegebene Sichtungen jahrweise"; das Export-Versprechen ersetzt durch die tatsächlich vorhandene offene API (mit 200 ohne Auth verifiziert). „Seit 2011" war durch kein Datum gedeckt und kommt jetzt als Jahr der ältesten freigegebenen Sichtung aus der DB — in Berliner Ortszeit, wie überall sonst im Projekt.

## Dokumentation: `ostsee_geo`

`docs/OSTSEE_FLAGS.md` ist die neue verbindliche Referenz, verankert per Kommentar an den Spalten in `schema.ts` und als Kurzform in `.claude/rules/geo.md`.

Kern: `ostsee` ist die **strenge** Punkt-in-Polygon-Prüfung, `ostsee_geo` nur die **grobe** Bounding Box (9,4–30,2° E / 53–66° N) — das „geo" sitzt an der schwachen Prüfung. `ostsee_geo` hat drei Werte; die `2` stammt ausschließlich aus dem Altsystem (15.225 Zeilen, endet am Cutoff) und ist von der `1` nicht unterscheidbar: gegen Geografie, Zeitverlauf, ID-Bereiche, `eingangskanal` und `vonwo` geprüft, überall nur die Grundrate von 79 %. Daher gilt: **immer `> 0` prüfen, nie `= 1`.**

Zur Frage, ob die Formular-Nutzung Legacy ist: nein, der Schreibpfad rechnet korrekt. Falsch ist die Benennung — und zwei Konsumenten ziehen daraus die falsche Spalte. Beide sind dokumentiert und als Folge-Aufgaben ausgelagert, nicht in diesem PR behoben:

1. Die Admin-Übersicht rendert `inBalticSeaGeo` unter dem Label „Ostsee"; 9.316 Zeilen mit `ostsee = 0` erscheinen dort als Ostsee-Sichtung.
2. Die Bounding-Box-Westgrenze 9,4° E schneidet Kieler Bucht und Flensburger Förde ab (126 Zeilen mit `ostsee = 1` westlich davon) — die Invariante „Polygon ⊆ Bounding Box" gilt also nicht. Die Änderung berührt auch den Karten-Extent und will bewusst entschieden werden.

Die E-Mail-Benachrichtigung staffelt beide Flags dagegen korrekt und weist „im Polygon, aber außerhalb der Box" als „Ostsee-Rand" aus.

## Verifikation

- `npm run test:quick`: **2340 Tests in 155 Dateien grün**, `svelte-check` 0 Fehler, Lint ohne Errors
- Neue Tests: `configLabels.test.ts`, `emailService.envFallback.test.ts`, `map-pan-zoom.spec.ts`, zwei Grundmengen-Tests in `page.server.test.ts`
- E2E: alle 60 Karten-Specs grün, dazu die 66 Tests des verschärften Design-System-Scans aus #636/#637, inklusive `map-accessibility.spec.ts` — die Tastaturbedienung ist nicht geopfert
- Beide neuen Guards sind gegengeprüft: mit zurückgenommenem Fix fallen sie (Pan/Zoom 3 von 5, Grundmenge mit präziser Meldung `"sichtungen"."geprueft" = $1`)

Playwright erwartet lokal Port 4001: `VITE_DEV_PORT=4001 npm run dev`

## Bewusste Abwägung

Mausrad-Zoom verlangt weiterhin Fokus in der Karte — ein Klick oder Tab genügt. Das ist die absichtliche Entscheidung: der Scroll-Hijacking-Schutz für die iframe-Einbettung auf meeresmuseum.de wiegt schwerer als die eingesparte Interaktion. Ziehen funktioniert dagegen sofort. Beide Zustände sind in `e2e/map-pan-zoom.spec.ts` festgeschrieben, der negative Fall über wiederholte Messung statt `expect.poll` — bei „hat sich nichts geändert" wäre ein Poll sofort erfüllt und der Test gehaltlos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
