### PR TITLE
feat(ui): SubmitStatus, StatusBlock und ConnectionBadge nach main bringen

### DIFF
--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -262,10 +262,16 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 
 		// Formular sollte auf Step 4 bleiben (kein Wechsel zur Erfolgsseite)
 		await expectCurrentStep(page, /Kontaktdaten/i);
-		// Error-Toast sollte die Server-Fehlermeldung anzeigen
-		await expect(page.getByText('Interner Serverfehler')).toBeVisible({
-			timeout: 5000
-		});
+
+		// Der Fehlschlag steht als SubmitStatus über der Navigation — nicht mehr
+		// als Toast. Die Server-Meldung eines 5xx wird bewusst NICHT gezeigt: sie
+		// ist generisch („Ein unbekannter Fehler ist aufgetreten") und sagt dem
+		// Nutzer weniger als die Zusage, dass seine Eingaben erhalten bleiben.
+		const status = page.locator('[data-testid="submit-status-failed"]');
+		await expect(status).toBeVisible({ timeout: 5000 });
+		await expect(status).toContainText('Ihre Eingaben sind nicht verloren');
+		await expect(status).toContainText('Versuch 1 von 3');
+		await expect(status.getByRole('button', { name: /Erneut absenden/i })).toBeVisible();
 	});
 
 	test('Validation-Rejection: Server gibt 400 zurück — Fehlermeldung sichtbar', async ({
@@ -295,7 +301,7 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 		});
 	});
 
-	test('Netzwerkfehler: Route abgebrochen — Error-Handling greift', async ({ page }) => {
+	test('Netzwerkfehler: Route abgebrochen — als Verbindungsproblem erkannt', async ({ page }) => {
 		await page.route('**/api/sightings', (route) => {
 			route.abort('connectionrefused');
 		});
@@ -307,9 +313,23 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 
 		// Formular bleibt auf Step 4
 		await expectCurrentStep(page, /Kontaktdaten/i);
-		// Fehlermeldung sichtbar
-		await expect(
-			page.getByText('Fehler beim Absenden des Formulars. Bitte versuchen Sie es erneut.')
-		).toBeVisible({ timeout: 5000 });
+
+		// `fetch` wirft hier einen TypeError — das ist ein Verbindungsproblem, kein
+		// Serverfehler, und wird als solches gezeigt. Genau der Fall „WLAN an Bord
+		// ohne Uplink": `navigator.onLine` meldet weiter `true`.
+		const status = page.locator('[data-testid="submit-status-offline"]');
+		await expect(status).toBeVisible({ timeout: 5000 });
+		await expect(status).toContainText('Eingaben bleiben vollständig gespeichert');
+
+		// Aber NICHT gesperrt: Der Zustand ist hier nur aus einem gescheiterten
+		// Request abgeleitet — `navigator.onLine` meldet weiter `true`, und ohne
+		// `online`-Ereignis würde ihn nichts wieder aufheben. Eine harte Sperre
+		// hielte den Nutzer bis zum Neuladen fest. Gesperrt wird nur beim sicheren
+		// Nein des Browsers (siehe e2e/submit-offline.spec.ts).
+		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		await expect(status.getByRole('button', { name: /Trotzdem versuchen/i })).toBeVisible();
 	});
 });

--- a/e2e/submit-offline.spec.ts
+++ b/e2e/submit-offline.spec.ts
@@ -61,6 +61,33 @@ test.describe('Absenden ohne Internetverbindung', () => {
 		await expect(page.locator('[data-testid="field-email"]')).toHaveValue('max@example.com');
 	});
 
+	/**
+	 * Regression: Das Abzeichen rendert online nichts — aber sein Wrapper stand
+	 * dauerhaft im DOM und war in `.navbar-end` (`gap-2`) ein Flex-Item der
+	 * Breite 0. Gemessen waren das 8px toter Abstand auf jeder Seite. Die
+	 * Live-Region liegt jetzt `sr-only` und damit außerhalb des Flusses.
+	 */
+	test('kostet bei bestehender Verbindung keinen Platz in der Navbar', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		const layout = await page.evaluate(() => {
+			const end = document.querySelector('.navbar-end');
+			if (!end) return null;
+			return {
+				inFlowChildren: [...end.children].filter(
+					(el) => getComputedStyle(el).position !== 'absolute'
+				).length,
+				badgeVisible: !!document.querySelector('[data-testid^="connection-badge"]')
+			};
+		});
+
+		expect(layout).not.toBeNull();
+		expect(layout!.badgeVisible).toBe(false);
+		// Menü (Desktop) + Dropdown (Mobil) — kein drittes, leeres Flex-Item.
+		expect(layout!.inFlowChildren).toBe(2);
+	});
+
 	test('gibt das Absenden wieder frei, sobald die Verbindung zurück ist', async ({
 		page,
 		context

--- a/e2e/submit-offline.spec.ts
+++ b/e2e/submit-offline.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from '@playwright/test';
+import { expectCurrentStep, fillStep1, fillStep2, fillStep4 } from './helpers/form-helpers';
+import { FormPage } from './pages/FormPage';
+
+/**
+ * Ohne Verbindung wird das Absenden vorab gesperrt, statt den Versuch scheitern
+ * zu lassen — ein Fehlschlag, den man vorhersehen kann, ist keine Fehlermeldung
+ * wert. Der Nutzer sieht stattdessen den Grund und die Zusage, dass seine
+ * Eingaben erhalten bleiben.
+ */
+test.describe('Absenden ohne Internetverbindung', () => {
+	test('sperrt den Absenden-Button, nennt den Grund und behält die Eingaben', async ({
+		page,
+		context
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Bis zum letzten Schritt durchfüllen
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Verhalten|Beobachtung/i);
+
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Kontakt/i);
+
+		await fillStep4(formPage);
+
+		// Netz abschalten — Chromium feuert dabei das `offline`-Ereignis.
+		await context.setOffline(true);
+
+		const status = page.locator('[data-testid="submit-status-offline"]');
+		await expect(status).toBeVisible();
+		await expect(status).toContainText('Keine Internetverbindung');
+		await expect(status).toContainText('Eingaben bleiben vollständig gespeichert');
+
+		// Der Button bleibt fokussierbar (`aria-disabled` statt `disabled`), damit
+		// die Tastaturposition erhalten bleibt — die Sperre sitzt im Handler.
+		const submit = page.getByRole('button', { name: /Formular absenden/i });
+		await expect(submit).toHaveAttribute('aria-disabled', 'true');
+
+		// Ohne `force` würde Playwright wegen `aria-disabled` gar nicht erst
+		// klicken und nur die eigene Actionability-Prüfung bestätigen.
+		await submit.click({ force: true });
+
+		// Immer noch auf dem Kontaktschritt — es wurde nichts abgeschickt.
+		await expectCurrentStep(page, /Kontakt/i);
+		await expect(status).toBeVisible();
+
+		// Zusage einlösen: Nach einem Neuladen sind die Eingaben noch da.
+		// Erst wieder online gehen — ein Reload ohne Netz lädt das Dokument nicht.
+		await context.setOffline(false);
+		await page.reload();
+		await page.locator('[data-testid="field-firstName"]').waitFor({ state: 'visible' });
+
+		await expect(page.locator('[data-testid="field-firstName"]')).toHaveValue('Max');
+		await expect(page.locator('[data-testid="field-email"]')).toHaveValue('max@example.com');
+	});
+
+	test('gibt das Absenden wieder frei, sobald die Verbindung zurück ist', async ({
+		page,
+		context
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Sichtungsdetails/i);
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Kontakt/i);
+
+		await context.setOffline(true);
+		await expect(page.locator('[data-testid="submit-status-offline"]')).toBeVisible();
+
+		await context.setOffline(false);
+
+		await expect(page.locator('[data-testid="submit-status-offline"]')).toBeHidden();
+		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	});
+});

--- a/src/lib/components/ConnectionBadge.svelte
+++ b/src/lib/components/ConnectionBadge.svelte
@@ -1,0 +1,101 @@
+<!--
+  Ein Zustand, kein Alarm.
+
+  Erscheint nur, wenn keine Verbindung besteht. Damit weiß der Mensch schon
+  beim Ausfüllen, was ihn beim Absenden erwartet — statt es am Ende zu
+  erfahren, wenn die Arbeit getan ist.
+
+  Drei Entscheidungen stecken darin:
+
+  1. **Kein Dauer-Indikator für „online".** Ein Zustand, der 99 % der Zeit
+     dasselbe sagt, wird nicht gelesen. Im Normalfall kostet die Komponente
+     deshalb nicht nur keine Aufmerksamkeit, sondern auch keinen Platz —
+     siehe die Trennung unten.
+  2. **„Wieder online" darf flüchtig sein.** Es ist die eine Stelle, an der
+     ein verschwindender Hinweis richtig ist: Er verlangt keine Handlung, er
+     nimmt nur eine Sorge weg. Die Frist liegt in `connectionState`.
+  3. **Der Zustand kommt nicht aus `navigator.onLine` allein.** Das meldet nur
+     eine aktive Netzwerkschnittstelle, nicht ob das Internet erreichbar ist —
+     WLAN an Bord ohne Uplink meldet „online" und lässt jeden Request
+     scheitern. Die Herleitung steht in `connectionState.svelte.ts`.
+
+  **Warum Ansage und Anzeige getrennt sind:** Eine Live-Region muss schon im
+  DOM stehen, BEVOR sich ihr Inhalt ändert — wird sie zusammen mit ihrem Text
+  eingefügt, sagen viele Screenreader nichts. Ein dauerhaft gerendertes
+  Wrapper-Element ist aber auch dauerhaft ein Flex-Item: In der Navbar
+  (`gap-2`) erzeugte es im Online-Fall gemessene 8px Abstand um ein leeres
+  `<div>` herum. Beides zusammen geht nur, wenn die Live-Region aus dem Layout
+  genommen wird — `sr-only` ist absolut positioniert und damit kein Flex-Item.
+  Die sichtbare Fläche wird daneben ganz normal bedingt gerendert.
+-->
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { connection, watchConnection } from '$lib/stores/connectionState.svelte';
+
+	let {
+		/** Blendet den erklärenden Zusatz aus — für enge Leisten. */
+		compact = false,
+		/**
+		 * Ob diese Instanz die Live-Region stellt.
+		 *
+		 * Es können mehrere Abzeichen gleichzeitig im Bild sein — in der Navbar
+		 * und im ortsfesten Schritt-Balken. Zwei Live-Regionen mit demselben Text
+		 * lassen den Screenreader „Offline" doppelt ansagen. Deshalb meldet nur
+		 * die globale Instanz in der Navbar; die übrigen sind rein visuell.
+		 */
+		announce = true,
+		/**
+		 * Layout-Klassen für die sichtbare Fläche.
+		 *
+		 * Bewusst hier und nicht an einem Wrapper der Aufrufstelle: Ein Wrapper
+		 * mit `mb-2` behielte seinen Abstand auch dann, wenn nichts zu sehen ist.
+		 * Am Element selbst verschwindet er mit ihm.
+		 */
+		class: className = ''
+	}: { compact?: boolean; announce?: boolean; class?: string } = $props();
+
+	// Mehrfaches Anmelden ist unkritisch: Jede Instanz meldet ihre eigenen
+	// Listener wieder ab, der Zustand dahinter ist derselbe.
+	$effect(() => watchConnection());
+
+	/** Was der Screenreader hört. Leer, solange alles in Ordnung ist. */
+	const liveText = $derived(
+		connection.isOffline
+			? 'Keine Internetverbindung. Ihre Eingaben werden gespeichert.'
+			: connection.justReconnected
+				? 'Wieder online.'
+				: ''
+	);
+
+	const SURFACE =
+		'bg-base-200/95 rounded-box border-base-300 flex items-center gap-2 border px-3 py-2';
+</script>
+
+{#if announce}
+	<!--
+		Dauerhaft im DOM, dauerhaft im Accessibility-Baum, aber ohne jede Wirkung
+		aufs Layout (`sr-only` ist absolut positioniert). Die sichtbaren Flächen
+		unten sind deshalb `aria-hidden` — sonst stünde derselbe Text zweimal im
+		Baum.
+	-->
+	<span class="sr-only" role="status" aria-live="polite">{liveText}</span>
+{/if}
+
+{#if connection.isOffline}
+	<div class="{SURFACE} {className}" data-testid="connection-badge-offline" aria-hidden="true">
+		<span class="text-warning-strong flex items-center gap-2 text-sm font-medium">
+			<Icon icon="lucide:wifi-off" width="16" class="shrink-0" aria-hidden="true" />
+			Offline
+		</span>
+		{#if !compact}
+			<span class="text-base-content/70 text-support">Eingaben werden gespeichert</span>
+		{/if}
+	</div>
+{:else if connection.justReconnected}
+	<div class="{SURFACE} {className}" data-testid="connection-badge-reconnected" aria-hidden="true">
+		<span class="text-success-strong flex items-center gap-2 text-sm font-medium">
+			<Icon icon="lucide:wifi" width="16" class="shrink-0" aria-hidden="true" />
+			Wieder online
+		</span>
+	</div>
+{/if}

--- a/src/lib/components/ConnectionBadge.svelte.test.ts
+++ b/src/lib/components/ConnectionBadge.svelte.test.ts
@@ -1,0 +1,225 @@
+import { connection } from '$lib/stores/connectionState.svelte';
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import ConnectionBadge from './ConnectionBadge.svelte';
+
+function badge(state: 'offline' | 'reconnected'): HTMLElement | null {
+	return document.querySelector(`[data-testid="connection-badge-${state}"]`);
+}
+
+describe('ConnectionBadge', () => {
+	beforeEach(() => {
+		connection.reset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		connection.reset();
+	});
+
+	/**
+	 * Ein Zustand, der 99 % der Zeit dasselbe sagt, wird nicht gelesen. Im
+	 * Normalfall darf die Komponente deshalb keinen Platz kosten.
+	 */
+	it('rendert nichts, solange die Verbindung steht', async () => {
+		render(ConnectionBadge);
+		await tick();
+
+		expect(badge('offline')).toBeNull();
+		expect(badge('reconnected')).toBeNull();
+	});
+
+	/**
+	 * Regression: Vorher stand ein leeres Wrapper-`<div>` dauerhaft im DOM. In
+	 * der Navbar (`.navbar-end` mit `gap-2`) war das ein Flex-Item mit Breite 0
+	 * — gemessen 8px toter Abstand, obwohl nichts zu sehen war. Die Live-Region
+	 * bleibt deshalb `sr-only` (absolut positioniert, kein Flex-Item), die
+	 * sichtbare Fläche wird bedingt gerendert.
+	 */
+	it('hinterlässt online nur die layoutneutrale Live-Region', async () => {
+		const { container } = render(ConnectionBadge);
+		await tick();
+
+		// `getComputedStyle` taugt hier nicht: Die Browser-Komponententests laden
+		// Tailwinds CSS nicht, `sr-only` wäre also wirkungslos gemessen. Geprüft
+		// wird deshalb der Vertrag (die Klasse); die tatsächliche Layout-Wirkung
+		// misst `e2e/submit-offline.spec.ts` an der echten Navbar.
+		expect(container.children).toHaveLength(1);
+		expect(container.children[0]?.className).toContain('sr-only');
+	});
+
+	/**
+	 * Die Layout-Klassen gehören an die sichtbare Fläche, nicht an einen
+	 * Wrapper der Aufrufstelle — sonst bliebe deren Abstand im Online-Fall
+	 * stehen.
+	 */
+	it('reicht Layout-Klassen an die sichtbare Fläche durch', async () => {
+		render(ConnectionBadge, { class: 'mb-2 md:hidden' });
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.className).toContain('mb-2');
+		expect(badge('offline')?.className).toContain('md:hidden');
+	});
+
+	it('zeigt den Offline-Zustand mit der Zusage zu den Eingaben', async () => {
+		render(ConnectionBadge);
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.textContent).toContain('Offline');
+		expect(badge('offline')?.textContent).toContain('Eingaben werden gespeichert');
+	});
+
+	it('lässt den Zusatz im kompakten Modus weg', async () => {
+		render(ConnectionBadge, { compact: true });
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')?.textContent).toContain('Offline');
+		expect(badge('offline')?.textContent).not.toContain('Eingaben werden gespeichert');
+	});
+
+	/**
+	 * Navbar und Schritt-Balken zeigen das Abzeichen gleichzeitig. Zwei
+	 * Live-Regionen mit demselben Text lassen den Screenreader „Offline" doppelt
+	 * ansagen — nur die globale Instanz meldet.
+	 */
+	describe('Live-Region', () => {
+		/**
+		 * Die Region muss schon im DOM stehen, BEVOR sich ihr Inhalt ändert —
+		 * wird sie zusammen mit ihrem Text eingefügt, sagen viele Screenreader
+		 * nichts. Sie ist deshalb auch im Online-Fall vorhanden, nur leer.
+		 */
+		it('steht schon vor dem Zustandswechsel bereit', async () => {
+			const { container } = render(ConnectionBadge);
+			await tick();
+
+			const live = container.querySelector('[role="status"]');
+			expect(live).not.toBeNull();
+			expect(live?.textContent?.trim()).toBe('');
+		});
+
+		it('trägt den Text der Ansage, nicht die sichtbare Fläche', async () => {
+			const { container } = render(ConnectionBadge);
+			connection.reportUnreachable();
+			await tick();
+
+			expect(container.querySelector('[role="status"]')?.textContent).toContain(
+				'Keine Internetverbindung'
+			);
+			// Sonst stünde derselbe Text zweimal im Accessibility-Baum.
+			expect(badge('offline')?.getAttribute('aria-hidden')).toBe('true');
+		});
+
+		it('bleibt mit announce={false} stumm, aber sichtbar', async () => {
+			const { container } = render(ConnectionBadge, { announce: false });
+			connection.reportUnreachable();
+			await tick();
+
+			expect(container.querySelector('[role="status"]')).toBeNull();
+			expect(container.querySelector('[aria-live]')).toBeNull();
+			expect(badge('offline')).not.toBeNull();
+		});
+	});
+
+	/**
+	 * WLAN an Bord ohne Uplink: `navigator.onLine` meldet `true`, jeder Request
+	 * scheitert trotzdem. Das Ergebnis des letzten echten Requests hat deshalb
+	 * das letzte Wort.
+	 */
+	it('folgt dem letzten Request-Ergebnis, nicht navigator.onLine', async () => {
+		render(ConnectionBadge);
+		expect(navigator.onLine).toBe(true);
+
+		connection.reportUnreachable();
+		await tick();
+
+		expect(badge('offline')).not.toBeNull();
+	});
+
+	/**
+	 * Regression: `isOffline` allein taugt nicht als Sperrbedingung. `fetch`
+	 * wirft denselben TypeError bei einem Server-Neustart oder CORS-Fehler wie
+	 * bei fehlendem Netz — dort bleibt `navigator.onLine` auf `true` und es
+	 * feuert nie ein `online`-Ereignis, das den Zustand aufheben könnte. Wer
+	 * daran hart sperrt, sperrt bis zum Neuladen.
+	 */
+	describe('sicheres gegen vermutetes Offline', () => {
+		it('meldet ein gescheitertes Request-Ergebnis NICHT als sicheres Offline', () => {
+			connection.reportUnreachable();
+
+			expect(connection.isOffline).toBe(true);
+			expect(connection.isInterfaceDown).toBe(false);
+		});
+
+		it('meldet eine abgeschaltete Schnittstelle als sicheres Offline', async () => {
+			// Erst rendern: `watchConnection()` hängt am `$effect` der Komponente,
+			// ohne Instanz hört niemand auf das Ereignis.
+			render(ConnectionBadge);
+			await tick();
+
+			window.dispatchEvent(new Event('offline'));
+			await tick();
+
+			expect(connection.isInterfaceDown).toBe(true);
+		});
+	});
+
+	describe('Wieder online', () => {
+		it('erscheint nach der Rückkehr aus dem Offline-Zustand', async () => {
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			await tick();
+			connection.reportReachable();
+			await tick();
+
+			expect(badge('offline')).toBeNull();
+			expect(badge('reconnected')?.textContent).toContain('Wieder online');
+		});
+
+		it('erscheint nicht, wenn es nie offline war', async () => {
+			render(ConnectionBadge);
+
+			connection.reportReachable();
+			await tick();
+
+			expect(badge('reconnected')).toBeNull();
+		});
+
+		/**
+		 * Die eine Stelle, an der ein flüchtiger Hinweis richtig ist: Er verlangt
+		 * keine Handlung, er nimmt nur eine Sorge weg.
+		 */
+		it('verschwindet nach 4 Sekunden wieder', async () => {
+			vi.useFakeTimers();
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			connection.reportReachable();
+			await tick();
+			expect(badge('reconnected')).not.toBeNull();
+
+			await vi.advanceTimersByTimeAsync(4000);
+			await tick();
+
+			expect(badge('reconnected')).toBeNull();
+		});
+
+		it('steht kurz vor Ablauf der Frist noch', async () => {
+			vi.useFakeTimers();
+			render(ConnectionBadge);
+
+			connection.reportUnreachable();
+			connection.reportReachable();
+			await tick();
+
+			await vi.advanceTimersByTimeAsync(3500);
+			await tick();
+
+			expect(badge('reconnected')).not.toBeNull();
+		});
+	});
+});

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -70,6 +70,13 @@
 	import Phone from '~icons/lucide/phone';
 	import Play from '~icons/lucide/play';
 	import RefreshCw from '~icons/lucide/refresh-cw';
+	import Database from '~icons/lucide/database';
+	import GitCompareArrows from '~icons/lucide/git-compare-arrows';
+	import MapPinOff from '~icons/lucide/map-pin-off';
+	import RotateCcw from '~icons/lucide/rotate-ccw';
+	import ZoomIn from '~icons/lucide/zoom-in';
+	import SearchX from '~icons/lucide/search-x';
+	import WifiOff from '~icons/lucide/wifi-off';
 	import Save from '~icons/lucide/save';
 	import Scale from '~icons/lucide/scale';
 	import Send from '~icons/lucide/send';
@@ -158,6 +165,13 @@
 		'lucide:archive': Archive,
 		'lucide:file': File,
 		'lucide:refresh-cw': RefreshCw,
+		'lucide:database': Database,
+		'lucide:git-compare-arrows': GitCompareArrows,
+		'lucide:map-pin-off': MapPinOff,
+		'lucide:rotate-ccw': RotateCcw,
+		'lucide:zoom-in': ZoomIn,
+		'lucide:search-x': SearchX,
+		'lucide:wifi-off': WifiOff,
 		'lucide:home': Home,
 		'lucide:file-search': FileSearch,
 		'lucide:lock': Lock,

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -76,6 +76,7 @@
 	import RotateCcw from '~icons/lucide/rotate-ccw';
 	import ZoomIn from '~icons/lucide/zoom-in';
 	import SearchX from '~icons/lucide/search-x';
+	import Wifi from '~icons/lucide/wifi';
 	import WifiOff from '~icons/lucide/wifi-off';
 	import Save from '~icons/lucide/save';
 	import Scale from '~icons/lucide/scale';
@@ -171,6 +172,7 @@
 		'lucide:rotate-ccw': RotateCcw,
 		'lucide:zoom-in': ZoomIn,
 		'lucide:search-x': SearchX,
+		'lucide:wifi': Wifi,
 		'lucide:wifi-off': WifiOff,
 		'lucide:home': Home,
 		'lucide:file-search': FileSearch,

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
 	import type { PublicUser } from '$lib/types/User';
@@ -69,7 +70,13 @@
 						<span class="text-base-content/70 text-lg font-semibold">Admin</span>
 					{/if}
 				</div>
-				<div class="navbar-end">
+				<div class="navbar-end gap-2">
+					<!--
+						Sichtbar nur ohne Verbindung — im Normalfall rendert die Komponente
+						nichts und kostet keinen Platz.
+					-->
+					<ConnectionBadge compact />
+
 					<!-- Desktop menu -->
 					<div class="hidden lg:flex lg:items-center lg:gap-4">
 						<ul class="menu menu-horizontal px-1">

--- a/src/lib/components/StatusBlock.svelte
+++ b/src/lib/components/StatusBlock.svelte
@@ -1,0 +1,138 @@
+<!--
+  Inline-Statusfläche für jede Oberfläche, die Daten lädt.
+
+  Fünf Varianten, eine Struktur: Icon, Aussage, optionale Erklärung, optionale
+  Aktion. Der Block nimmt den Platz ein, an dem die Daten stehen würden — nie
+  als Overlay. Ein Overlay über der ganzen Fläche nimmt bei jedem Ladevorgang
+  die Bedienung aus der Hand; ein Block an der Stelle der Daten sagt dasselbe,
+  ohne alles andere zu sperren.
+
+  Zwei Entscheidungen stecken in den Varianten:
+
+  1. `loading` und `empty` tragen KEINE Statusfarbe. Ein Ladevorgang ist keine
+     Warnung, und ein Filter ohne Treffer ist kein Fehler. Erst `partial`,
+     `failed` und `offline` nutzen die Alert-Flächen.
+  2. Die ARIA-Rolle unterscheidet sich pro Variante: `status`/`aria-live=polite`
+     für Zustände, die von selbst entstehen, `alert` nur für die Folge einer
+     Nutzeraktion. Sonst unterbricht ein Screenreader den Nutzer beim Tippen.
+-->
+<script module lang="ts">
+	export type StatusBlockVariant = 'loading' | 'empty' | 'partial' | 'failed' | 'offline';
+
+	export interface StatusBlockAction {
+		/** Beschriftung der Schaltfläche. */
+		label: string;
+		/** Was beim Auslösen passiert. */
+		onClick: () => void;
+		/** Optionales Icon, Standard ist „erneut versuchen". */
+		icon?: string;
+	}
+</script>
+
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+
+	let {
+		variant,
+		title,
+		description,
+		action,
+		announce
+	}: {
+		variant: StatusBlockVariant;
+		/** Die Aussage — was ist der Fall. Immer erforderlich. */
+		title: string;
+		/** Erklärung darunter: Ursache, Folge, was der Nutzer erwarten kann. */
+		description?: string | undefined;
+		/**
+		 * Ein Ausweg, falls es einen gibt.
+		 *
+		 * `| undefined` steht explizit da: Unter `exactOptionalPropertyTypes`
+		 * dürfte eine Aufrufstelle sonst kein bedingtes `action={… : undefined}`
+		 * übergeben — und genau das braucht die Karte, wo der Ausweg nur dann
+		 * existiert, wenn es ein anderes Jahr mit Daten gibt.
+		 */
+		action?: StatusBlockAction | undefined;
+		/**
+		 * Übersteuert die aus der Variante abgeleitete ARIA-Rolle.
+		 *
+		 * Die Regel „`alert` bei `failed`" setzt voraus, dass der Fehlschlag die
+		 * Folge einer Nutzeraktion ist — das kann die Komponente nicht wissen.
+		 * Ein Abruf, der beim Seitenaufbau scheitert, ist inhaltlich `failed`,
+		 * darf den Screenreader aber nicht unterbrechen. Solche Aufrufstellen
+		 * setzen hier `status`.
+		 */
+		announce?: 'status' | 'alert' | undefined;
+	} = $props();
+
+	/**
+	 * Klassen stehen vollständig ausgeschrieben — Tailwind erkennt nur komplette
+	 * Strings im Quelltext, ein `alert-${variant}` wäre eine tote Klasse
+	 * (daisyui.md, „Content-Detection").
+	 */
+	const SURFACE: Record<StatusBlockVariant, string> = {
+		// Neutrale Flächen bringen ihr Layout selbst mit …
+		loading: 'border-base-300 bg-base-200/50 rounded-box flex items-start gap-3 border p-4',
+		empty: 'border-base-300 bg-base-200/50 rounded-box flex items-start gap-3 border p-4',
+		// … die Alert-Flächen behalten dagegen DaisyUIs eigenes Grid und werden
+		// nur oben ausgerichtet, damit das Icon neben der ersten Zeile steht.
+		partial: 'alert alert-info items-start',
+		failed: 'alert alert-warning items-start',
+		offline: 'alert alert-warning items-start'
+	};
+
+	/** Jede Variante hat eine eigene Icon-Form — sie trägt die Bedeutung. */
+	const ICON: Record<StatusBlockVariant, string> = {
+		loading: '',
+		empty: 'lucide:search-x',
+		partial: 'lucide:info',
+		failed: 'lucide:triangle-alert',
+		offline: 'lucide:wifi-off'
+	};
+
+	/**
+	 * `alert` nur bei `failed`: Das ist die Folge einer Nutzeraktion (ein Abruf,
+	 * den er angestoßen hat). Alle übrigen entstehen von selbst und melden sich
+	 * höflich.
+	 */
+	const role = $derived(announce ?? (variant === 'failed' ? 'alert' : 'status'));
+
+	/**
+	 * `aria-live` wird NUR für `status` gesetzt — und zwar deshalb, weil ein
+	 * explizites `aria-live="polite"` das implizite `assertive` von
+	 * `role="alert"` überschreibt. Stünde es unbedingt hier, wäre die im
+	 * Kopfkommentar zugesagte Unterbrechung nie eingetreten und der
+	 * Unterschied zwischen den Rollen reine Dekoration.
+	 */
+	const ariaLive = $derived(role === 'status' ? 'polite' : undefined);
+</script>
+
+<div class={SURFACE[variant]} {role} aria-live={ariaLive} data-testid="status-block-{variant}">
+	{#if variant === 'loading'}
+		<span class="loading loading-spinner loading-sm text-primary mt-0.5 shrink-0"></span>
+	{:else}
+		<Icon
+			icon={ICON[variant]}
+			class={variant === 'empty' ? 'text-base-content/60 mt-0.5 shrink-0' : 'mt-0.5 shrink-0'}
+			aria-hidden="true"
+		/>
+	{/if}
+
+	<div>
+		<p class="text-base-content font-medium">{title}</p>
+		{#if description}
+			<p class="text-base-content/70 text-support mt-1">{description}</p>
+		{/if}
+		{#if action}
+			<button type="button" class="btn btn-outline btn-sm mt-3" onclick={action.onClick}>
+				<Icon
+					icon={action.icon ?? 'lucide:refresh-cw'}
+					width="16"
+					class="shrink-0"
+					aria-hidden="true"
+				/>
+				{action.label}
+			</button>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/StatusBlock.svelte.test.ts
+++ b/src/lib/components/StatusBlock.svelte.test.ts
@@ -1,0 +1,127 @@
+import { tick } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import StatusBlock from './StatusBlock.svelte';
+
+function block(variant: string): HTMLElement | null {
+	return document.querySelector(`[data-testid="status-block-${variant}"]`);
+}
+
+describe('StatusBlock', () => {
+	it('zeigt die Aussage in jeder Variante', () => {
+		render(StatusBlock, { variant: 'loading', title: 'Sichtungen werden geladen …' });
+
+		expect(block('loading')?.textContent).toContain('Sichtungen werden geladen …');
+	});
+
+	it('zeigt die Erklärung nur, wenn eine übergeben wurde', () => {
+		render(StatusBlock, { variant: 'empty', title: 'Keine Treffer' });
+
+		expect(block('empty')?.querySelectorAll('p')).toHaveLength(1);
+	});
+
+	/**
+	 * Ein Ladevorgang ist keine Warnung, ein Filter ohne Treffer kein Fehler.
+	 * Erst `partial`, `failed` und `offline` dürfen die Alert-Flächen nutzen.
+	 */
+	describe('Statusfarben', () => {
+		it.each(['loading', 'empty'] as const)('gibt %s keine Statusfarbe', (variant) => {
+			render(StatusBlock, { variant, title: 'Titel' });
+
+			expect(block(variant)?.className).not.toMatch(/\balert\b/);
+		});
+
+		it.each([
+			['partial', 'alert-info'],
+			['failed', 'alert-warning'],
+			['offline', 'alert-warning']
+		] as const)('nutzt für %s die Fläche %s', (variant, expected) => {
+			render(StatusBlock, { variant, title: 'Titel' });
+
+			expect(block(variant)?.className).toContain(expected);
+		});
+	});
+
+	/**
+	 * `alert` unterbricht den Screenreader. Das ist nur gerechtfertigt, wenn der
+	 * Zustand die Folge einer Nutzeraktion ist — sonst trifft es ihn beim Tippen.
+	 */
+	describe('ARIA-Rollen', () => {
+		it('meldet failed per role="alert"', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel' });
+
+			expect(block('failed')?.getAttribute('role')).toBe('alert');
+		});
+
+		it.each(['loading', 'empty', 'partial', 'offline'] as const)(
+			'meldet %s höflich per role="status"',
+			(variant) => {
+				render(StatusBlock, { variant, title: 'Titel' });
+
+				expect(block(variant)?.getAttribute('role')).toBe('status');
+			}
+		);
+
+		/**
+		 * Regression: Ein explizites `aria-live="polite"` überschreibt das
+		 * implizite `assertive` von `role="alert"`. Stand es unbedingt am Element,
+		 * fand die zugesagte Unterbrechung nie statt und der Unterschied zwischen
+		 * den Rollen war reine Dekoration.
+		 */
+		it('setzt bei role="alert" kein aria-live, das die Rolle entwerten würde', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel' });
+
+			expect(block('failed')?.hasAttribute('aria-live')).toBe(false);
+		});
+
+		it('setzt aria-live="polite" bei den höflichen Varianten', () => {
+			render(StatusBlock, { variant: 'empty', title: 'Titel' });
+
+			expect(block('empty')?.getAttribute('aria-live')).toBe('polite');
+		});
+
+		/**
+		 * Ob ein Fehlschlag die Folge einer Nutzeraktion ist, weiß nur die
+		 * Aufrufstelle. `FormHelp` lädt beim Seitenaufbau und darf deshalb nicht
+		 * unterbrechen, obwohl der Zustand inhaltlich `failed` ist.
+		 */
+		it('lässt die Aufrufstelle die Rolle übersteuern', () => {
+			render(StatusBlock, { variant: 'failed', title: 'Titel', announce: 'status' });
+
+			expect(block('failed')?.getAttribute('role')).toBe('status');
+			expect(block('failed')?.getAttribute('aria-live')).toBe('polite');
+		});
+	});
+
+	describe('Aktion', () => {
+		it('rendert keine Schaltfläche ohne action', () => {
+			render(StatusBlock, { variant: 'empty', title: 'Keine Treffer' });
+
+			expect(block('empty')?.querySelector('button')).toBeNull();
+		});
+
+		it('löst den Handler aus', async () => {
+			const onClick = vi.fn();
+			render(StatusBlock, {
+				variant: 'offline',
+				title: 'Keine Verbindung',
+				action: { label: 'Erneut versuchen', onClick }
+			});
+
+			block('offline')?.querySelector('button')?.click();
+			await tick();
+
+			expect(onClick).toHaveBeenCalledOnce();
+		});
+	});
+
+	/**
+	 * Der Block nimmt den Platz der Daten ein. Ein `fixed inset-0`-Overlay würde
+	 * bei jedem Ladevorgang die ganze Fläche aus der Hand nehmen.
+	 */
+	it('ist kein Overlay', () => {
+		render(StatusBlock, { variant: 'loading', title: 'Lädt …' });
+
+		expect(block('loading')?.className).not.toMatch(/fixed|inset-0|absolute/);
+	});
+});

--- a/src/lib/components/iconRegistry.test.ts
+++ b/src/lib/components/iconRegistry.test.ts
@@ -1,0 +1,78 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `Icon.svelte` rendert für einen unbekannten Namen ein stummes „?" statt zu
+ * scheitern. Das ist im Betrieb die richtige Wahl — ein fehlendes Icon soll
+ * keine Seite abstürzen lassen — kostet aber jede Rückmeldung: Ein Tippfehler
+ * oder ein neuer Name ohne Eintrag sieht im Code vollständig aus und liefert
+ * dem Nutzer ein Fragezeichen aus.
+ *
+ * Dieser Test ist die fehlende Rückmeldung. Er ist entstanden, nachdem
+ * `lucide:wifi-off`, `lucide:search-x` und `lucide:rotate-ccw` genau so
+ * durchgerutscht sind und erst im Browser aufgefallen wären.
+ */
+
+const SOURCE_ROOT = 'src';
+const ICON_COMPONENT = 'src/lib/components/Icon.svelte';
+
+/** Alle im `iconMap` registrierten Namen. */
+function registeredIcons(): Set<string> {
+	const source = readFileSync(ICON_COMPONENT, 'utf-8');
+	const mapStart = source.indexOf('const iconMap');
+	expect(mapStart, 'iconMap in Icon.svelte nicht gefunden').toBeGreaterThan(-1);
+
+	// `Array.from` statt `.map()` direkt auf dem Iterator: Die Iterator-Helper
+	// (`Iterator.prototype.map`) gibt es erst ab Node 22. `package.json` lässt
+	// über `engines` aber auch `^20.19.0` zu — dort wäre `.map()` undefined und
+	// dieser Test würde mit einem TypeError abbrechen, statt die Registry zu
+	// prüfen. Ein Test, der still nicht prüft, ist schlimmer als keiner.
+	const names = Array.from(
+		source.slice(mapStart).matchAll(/'(lucide:[a-z0-9-]+)'\s*:/g),
+		(match) => match[1] as string
+	);
+
+	return new Set(names);
+}
+
+/** Jede `icon="lucide:…"`- bzw. `icon: 'lucide:…'`-Stelle im Quelltext. */
+function usedIcons(): Map<string, string[]> {
+	const usages = new Map<string, string[]>();
+
+	const walk = (dir: string): void => {
+		for (const entry of readdirSync(dir)) {
+			const path = join(dir, entry);
+			if (statSync(path).isDirectory()) {
+				walk(path);
+				continue;
+			}
+			if (!/\.(svelte|ts)$/.test(entry) || /\.test\.ts$/.test(entry)) continue;
+			if (path === ICON_COMPONENT) continue;
+
+			const source = readFileSync(path, 'utf-8');
+			for (const match of source.matchAll(/["'](lucide:[a-z0-9-]+)["']/g)) {
+				const name = match[1] as string;
+				usages.set(name, [...(usages.get(name) ?? []), path]);
+			}
+		}
+	};
+
+	walk(SOURCE_ROOT);
+	return usages;
+}
+
+describe('Icon-Registry', () => {
+	it('kennt jedes im Quelltext verwendete lucide-Icon', () => {
+		const registered = registeredIcons();
+		const missing = [...usedIcons().entries()]
+			.filter(([name]) => !registered.has(name))
+			.map(([name, files]) => `${name} (${[...new Set(files)].join(', ')})`);
+
+		expect(missing, 'Nicht registrierte Icons rendern als „?" beim Nutzer').toEqual([]);
+	});
+
+	it('findet überhaupt Registrierungen — sonst greift die Prüfung ins Leere', () => {
+		expect(registeredIcons().size).toBeGreaterThan(50);
+	});
+});

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -1,24 +1,31 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 
-	// Props
-	type LoadingType = 'default' | 'filter' | 'features' | 'initial';
+	/**
+	 * Nur noch `initial`.
+	 *
+	 * Diese Komponente ist ein `fixed inset-0`-Overlay mit Backdrop — sie nimmt
+	 * die ganze Karte aus der Hand. Beim allerersten Aufbau ist das richtig: Es
+	 * gibt noch nichts zu bedienen. Für alles danach ist es der falsche Griff,
+	 * und die früheren Varianten `filter`, `features` und `default` waren genau
+	 * das: Sie hätten bei jedem Filterwechsel die Karte gesperrt. Aufrufstellen
+	 * hatten sie keine — der Filterzustand läuft über den Inline-Spinner im
+	 * `FilterPanel` (`isLoading`), Leer- und Fehlerzustände über `StatusBlock`.
+	 *
+	 * Die Varianten sind entfernt, damit der blockierende Weg nicht versehentlich
+	 * wieder eingeschlagen wird. Wer hier eine neue braucht, prüft zuerst, ob ein
+	 * `StatusBlock` an der Stelle der Daten genügt.
+	 */
+	type LoadingType = 'initial';
 
-	let { isVisible = false, type = 'default' }: { isVisible?: boolean; type?: LoadingType } =
+	let { isVisible = false, type = 'initial' }: { isVisible?: boolean; type?: LoadingType } =
 		$props();
 
-	// Typ-sichere Zuordnungen
 	const iconMap: Record<LoadingType, string> = {
-		default: 'lucide:loader-2',
-		filter: 'lucide:filter',
-		features: 'lucide:map-pin',
 		initial: 'lucide:loader-2'
 	};
 
 	const messageMap: Record<LoadingType, string> = {
-		default: 'Daten werden geladen...',
-		filter: 'Filter werden angewendet...',
-		features: 'Kartenfeatures werden geladen...',
 		initial: 'Karte wird initialisiert...'
 	};
 

--- a/src/lib/components/map/LoadingOverlay.svelte.test.ts
+++ b/src/lib/components/map/LoadingOverlay.svelte.test.ts
@@ -43,17 +43,24 @@ describe('LoadingOverlay', () => {
 	});
 
 	it('dekoratives Spinner-Icon ist aria-hidden (wird in der Live-Region nicht mit angesagt)', () => {
-		render(LoadingOverlay, { isVisible: true, type: 'filter' });
+		render(LoadingOverlay, { isVisible: true, type: 'initial' });
 
 		const svg = document.querySelector('[role="status"] svg');
 		expect(svg).not.toBeNull();
 		expect(svg?.getAttribute('aria-hidden')).toBe('true');
 	});
 
-	it('zeigt den passenden Text für Filter-Ladevorgänge', () => {
-		render(LoadingOverlay, { isVisible: true, type: 'filter' });
+	/**
+	 * Das Overlay sperrt mit `fixed inset-0` plus Backdrop die ganze Karte. Beim
+	 * ersten Aufbau ist das richtig — es gibt noch nichts zu bedienen. Für
+	 * Filterwechsel wäre es der falsche Griff, und genau dafür gab es früher die
+	 * Varianten `filter`, `features` und `default` (ohne Aufrufstelle). Sie sind
+	 * entfernt; Filter zeigen ihren Ladezustand inline im `FilterPanel`.
+	 */
+	it('kennt nur noch den Initial-Ladevorgang', () => {
+		render(LoadingOverlay, { isVisible: true });
 
-		expect(document.body.textContent).toContain('Filter werden angewendet...');
-		expect(document.body.textContent).not.toContain('Tastaturkürzel');
+		expect(document.body.textContent).toContain('Karte wird initialisiert...');
+		expect(document.body.textContent).not.toContain('Filter werden angewendet');
 	});
 });

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -29,6 +29,7 @@
 	// ol.css erneut hinter die Projekt-Overrides und macht sie wirkungslos —
 	// genau so ist die Titel-Überlappung des Zoom-Controls entstanden.
 	import LoadingOverlay from './LoadingOverlay.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	import FilterPanel from './Panel/FilterPanel.svelte';
 	import LegendPanel from './Panel/LegendPanel.svelte';
 	import SightingsListView from './SightingsListView.svelte';
@@ -780,39 +781,47 @@
 		     dessen Toggle-Tab auch bei geschlossenem Panel mitrotiert. -->
 		<LoadingOverlay isVisible={isInitialLoading} type="initial" />
 
+		<!--
+			Die beiden Leer-Zustände waren zwei handgebaute Glas-Kästchen mit je
+			eigener Typografie und eigener Rollenauszeichnung. Inhaltlich sind sie
+			derselbe Fall — „hier stünden Daten, es gibt aber keine" — und laufen
+			jetzt beide über `StatusBlock`. Der Wrapper trägt nur noch die Position
+			und eine deckende Fläche, damit der Text über den Kartenkacheln lesbar
+			bleibt; Rolle, Icon und Abstände kommen aus der Komponente.
+		-->
+
 		<!-- Keine Sichtungen für das gewählte Jahr -->
 		{#if showNoResults}
 			<div
-				role="status"
-				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				style="box-shadow: var(--shadow-floating)"
 			>
-				<p class="text-base-content text-sm font-medium">
-					Keine Sichtungen für {currentDisplayedYear} vorhanden.
-				</p>
-				{#if latestYearWithData !== undefined && latestYearWithData !== currentDisplayedYear}
-					<button
-						type="button"
-						class="btn btn-primary btn-sm mt-2"
-						onclick={() => switchToYear(latestYearWithData!)}
-					>
-						Sichtungen {latestYearWithData} anzeigen
-					</button>
-				{/if}
+				<StatusBlock
+					variant="empty"
+					title="Keine Sichtungen für {currentDisplayedYear} vorhanden"
+					description="Für dieses Jahr liegen keine freigegebenen Meldungen vor."
+					action={latestYearWithData !== undefined && latestYearWithData !== currentDisplayedYear
+						? {
+								label: `Sichtungen ${latestYearWithData} anzeigen`,
+								onClick: () => switchToYear(latestYearWithData!),
+								icon: 'lucide:calendar'
+							}
+						: undefined}
+				/>
 			</div>
 		{/if}
 
 		<!-- Alle Sichtungen durch Filter ausgeblendet -->
 		{#if showNoVisibleResults}
 			<div
-				role="status"
-				class="glass absolute top-1/2 left-1/2 z-30 -translate-x-1/2 -translate-y-1/2 rounded-lg px-5 py-3 text-center shadow-lg backdrop-blur-md"
+				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				style="box-shadow: var(--shadow-floating)"
 			>
-				<p class="text-base-content text-sm font-medium">
-					Keine Sichtungen für den aktuellen Filter sichtbar.
-				</p>
-				<p class="text-base-content/60 mt-1 text-xs">
-					Passen Sie den Zeitraum oder die Tierart-Filter an.
-				</p>
+				<StatusBlock
+					variant="empty"
+					title="Keine Sichtungen für den aktuellen Filter sichtbar"
+					description="Passen Sie den Zeitraum oder die Tierart-Filter an."
+				/>
 			</div>
 		{/if}
 

--- a/src/lib/components/weather/WeatherDataFetcher.svelte
+++ b/src/lib/components/weather/WeatherDataFetcher.svelte
@@ -3,6 +3,7 @@
 	import type { WeatherDataWithMetadata } from '$lib/types';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	import WeatherDisplay from './WeatherDisplay.svelte';
 
 	interface Props {
@@ -152,12 +153,21 @@
 						<span class="badge badge-xs badge-info ml-2">aus Cache</span>
 					{/if}
 				</p>
-				{#if weatherData._metadata?.dataType === 'forecast'}
-					<p class="text-warning-strong">
-						⚠️ Prognosedaten für heutige Sichtung (aktualisiert sich mehrmals täglich)
-					</p>
-				{/if}
 			</div>
+
+			<!--
+				Prognosewerte sind unvollständige Daten, keine Warnung an den Nutzer —
+				`partial` ist dafür die richtige Variante. Vorher ein Absatz mit
+				Emoji-Warndreieck, der weder Form noch ARIA-Rolle hatte und im
+				Fließtext der Quellenangabe unterging.
+			-->
+			{#if weatherData._metadata?.dataType === 'forecast'}
+				<StatusBlock
+					variant="partial"
+					title="Prognosedaten für die heutige Sichtung"
+					description="Für heute liegen noch keine gemessenen Werte vor. Die Vorhersage aktualisiert sich mehrmals täglich."
+				/>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/src/lib/form/submitSightingForm.test.ts
+++ b/src/lib/form/submitSightingForm.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { submitSightingForm } from './submitSightingForm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describeSubmitFailure, submitSightingForm } from './submitSightingForm';
 
-// Mock clearStorage
+// Mock clearStorage — die Funktion darf ihn nicht mehr aufrufen (siehe unten).
 vi.mock('$lib/storage/localStorage', () => ({
 	clearStorage: vi.fn()
 }));
@@ -20,11 +20,27 @@ const validFormValues = {
 	longitude: 10.5
 } as Parameters<typeof submitSightingForm>[0];
 
-function mockFetchResponse(body: object, status = 200): void {
+/** Baut eine Antwort-Attrappe inklusive Headers und optional kaputtem Körper. */
+function mockResponse(options: {
+	status: number;
+	body?: object;
+	unparseable?: boolean;
+	headers?: Record<string, string>;
+}): void {
+	const { status, body, unparseable, headers = {} } = options;
+
 	global.fetch = vi.fn().mockResolvedValue({
 		ok: status >= 200 && status < 300,
 		status,
-		json: () => Promise.resolve(body)
+		headers: {
+			get: (name: string) => headers[name] ?? null
+		},
+		json: () =>
+			unparseable
+				? Promise.reject(
+						new SyntaxError('Unexpected token \'<\', "<html><bo"... is not valid JSON')
+					)
+				: Promise.resolve(body ?? {})
 	});
 }
 
@@ -33,106 +49,245 @@ describe('submitSightingForm', () => {
 		vi.clearAllMocks();
 	});
 
-	it('gibt { id, success: true } bei erfolgreicher Submission zurück', async () => {
-		mockFetchResponse({ success: true, id: 42 }, 201);
-
-		const result = await submitSightingForm(validFormValues);
-
-		expect(result).toEqual({ id: 42, success: true });
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
-	it('ruft clearStorage bei erfolgreicher Submission auf', async () => {
-		mockFetchResponse({ success: true, id: 42 }, 201);
+	describe("status 'ok'", () => {
+		it('gibt die Sichtungs-ID zurück', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 42, referenceId: 'clx8k2p9a' } });
 
-		await submitSightingForm(validFormValues);
-
-		expect(clearStorage).toHaveBeenCalledOnce();
-	});
-
-	it('sendet POST an /api/sightings mit JSON Content-Type', async () => {
-		mockFetchResponse({ success: true, id: 1 }, 201);
-
-		await submitSightingForm(validFormValues);
-
-		expect(global.fetch).toHaveBeenCalledWith('/api/sightings', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(validFormValues)
-		});
-	});
-
-	it('wirft Error mit Server-Message wenn success=false', async () => {
-		mockFetchResponse({ success: false, message: 'Validierung fehlgeschlagen' }, 400);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow('Validierung fehlgeschlagen');
-	});
-
-	it('wirft Error mit Fallback-Message wenn keine Server-Message vorhanden', async () => {
-		mockFetchResponse({ success: false }, 500);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-			'Die Sichtung konnte nicht gespeichert werden'
-		);
-	});
-
-	it('ruft clearStorage NICHT bei Fehler auf', async () => {
-		mockFetchResponse({ success: false, message: 'Fehler' }, 400);
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow();
-		expect(clearStorage).not.toHaveBeenCalled();
-	});
-
-	it('propagiert Netzwerkfehler wenn fetch fehlschlägt', async () => {
-		global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
-
-		await expect(submitSightingForm(validFormValues)).rejects.toThrow('Failed to fetch');
-	});
-
-	/**
-	 * Regression: `response.json()` lief vor der `response.ok`-Prüfung. Ein 502
-	 * mit HTML-Fehlerseite (Reverse Proxy, Gateway) warf damit einen
-	 * JSON-Parse-Fehler, dessen Rohtext ungefiltert beim Nutzer landete.
-	 */
-	describe('Antworten, die kein JSON sind', () => {
-		function mockNonJsonResponse(status: number) {
-			global.fetch = vi.fn().mockResolvedValue({
-				ok: status >= 200 && status < 300,
-				status,
-				json: () =>
-					Promise.reject(
-						new SyntaxError('Unexpected token \'<\', "<html><bo"... is not valid JSON')
-					)
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ok',
+				id: 42
 			});
-		}
+		});
 
-		it('meldet einen 502 mit HTML-Body als verständlichen Fehler', async () => {
-			mockNonJsonResponse(502);
+		it('sendet POST an /api/sightings mit JSON Content-Type', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 1 } });
 
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-				'Die Sichtung konnte nicht gespeichert werden'
+			await submitSightingForm(validFormValues);
+
+			expect(global.fetch).toHaveBeenCalledWith('/api/sightings', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validFormValues)
+			});
+		});
+
+		/**
+		 * Der Speicher wird bewusst NICHT hier geräumt, sondern in
+		 * `ModernReportForm.svelte` nach dem `onSubmit`-Callback. Zwei Gründe:
+		 *
+		 * 1. Diese Funktion ist Transport — der Lebenszyklus des Formularspeichers
+		 *    gehört der Komponente, die das Formular hält.
+		 * 2. Der frühere Aufruf hier lief, bevor `onSubmit` durch war. Scheiterte
+		 *    dieser Callback, war der Speicher schon leer und die Eingaben weg —
+		 *    im Widerspruch zum Kommentar an der Aufrufstelle („Fehler in onSubmit
+		 *    soll Formular erhalten"). Die Komponente räumt mit
+		 *    `clearFormDataOnly()` + `CURRENT_STEP = 0` denselben Umfang.
+		 */
+		it('räumt den Speicher nicht selbst auf — dafür ist die Aufrufstelle zuständig', async () => {
+			mockResponse({ status: 201, body: { success: true, id: 42 } });
+
+			await submitSightingForm(validFormValues);
+
+			expect(clearStorage).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("status 'offline'", () => {
+		it('erkennt den TypeError von fetch als fehlende Verbindung', async () => {
+			global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		/**
+		 * WLAN an Bord ohne Uplink: `navigator.onLine` meldet `true`, `fetch`
+		 * scheitert trotzdem. Für dieses Projekt der Regelfall — der TypeError
+		 * allein muss deshalb genügen.
+		 */
+		it('erkennt Offline auch, wenn navigator.onLine true meldet', async () => {
+			vi.stubGlobal('navigator', { onLine: true });
+			global.fetch = vi.fn().mockRejectedValue(new TypeError('Load failed'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		it('wertet navigator.onLine === false als zusätzliches Signal', async () => {
+			vi.stubGlobal('navigator', { onLine: false });
+			global.fetch = vi.fn().mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({ status: 'offline' });
+		});
+
+		it('verschluckt Fehler nicht, die keine Netzwerkfehler sind', async () => {
+			vi.stubGlobal('navigator', { onLine: true });
+			global.fetch = vi.fn().mockRejectedValue(new RangeError('Ungültiger Header'));
+
+			await expect(submitSightingForm(validFormValues)).rejects.toThrow('Ungültiger Header');
+		});
+	});
+
+	describe("status 'server'", () => {
+		it('meldet einen 500 mit dem HTTP-Status', async () => {
+			mockResponse({
+				status: 500,
+				body: { success: false, code: 'SERVER_ERROR', message: 'Ein unbekannter Fehler' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 500
+			});
+		});
+
+		/**
+		 * Regression: `response.json()` lief vor der `response.ok`-Prüfung. Ein 502
+		 * mit HTML-Fehlerseite warf einen JSON-Parse-Fehler, dessen Rohtext beim
+		 * Nutzer landete.
+		 */
+		it('meldet einen 502 mit HTML-Body als Serverfehler statt als Parse-Fehler', async () => {
+			mockResponse({ status: 502, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 502
+			});
+		});
+
+		it('behandelt eine unlesbare 200-Antwort als Serverfehler', async () => {
+			mockResponse({ status: 200, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 200
+			});
+		});
+
+		it('behandelt eine 201 ohne ID als Serverfehler', async () => {
+			mockResponse({ status: 201, body: { success: true } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 201
+			});
+		});
+	});
+
+	describe("status 'rejected'", () => {
+		it('reicht die Validierungsmeldung eines 400 durch', async () => {
+			mockResponse({
+				status: 400,
+				body: {
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe'
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Validierungsfehler bei der Eingabe'
+			});
+		});
+
+		it('behandelt einen 422 (Datenbank-Integrität) als Ablehnung', async () => {
+			mockResponse({
+				status: 422,
+				body: { success: false, code: 'DATABASE_ERROR', message: 'Die Daten konnten nicht …' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Die Daten konnten nicht …'
+			});
+		});
+
+		it('behandelt eine 200 mit success: false als Ablehnung', async () => {
+			mockResponse({ status: 200, body: { success: false, message: 'Doppelte Meldung' } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'rejected',
+				message: 'Doppelte Meldung'
+			});
+		});
+
+		it('fällt bei einem 400 ohne Meldung auf Serverfehler zurück', async () => {
+			mockResponse({ status: 400, body: { success: false } });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'server',
+				httpStatus: 400
+			});
+		});
+	});
+
+	describe("status 'ratelimited'", () => {
+		/**
+		 * `enforceRateLimit()` wirft `error(429, '… (45s)')`. SvelteKit liefert das
+		 * als `{ message }` ohne `Retry-After`-Header aus — die Sekunden stehen
+		 * ausschließlich im Text.
+		 */
+		it('liest die Wartezeit aus der Meldung der Middleware', async () => {
+			mockResponse({
+				status: 429,
+				body: { message: 'Rate limit exceeded. Try again after 14:23:11 (45s)' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ratelimited',
+				retryAfter: 45
+			});
+		});
+
+		it('bevorzugt einen Retry-After-Header, falls ein Proxy ihn setzt', async () => {
+			mockResponse({
+				status: 429,
+				body: { message: 'Rate limit exceeded. Try again after 14:23:11 (45s)' },
+				headers: { 'Retry-After': '120' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toEqual({
+				status: 'ratelimited',
+				retryAfter: 120
+			});
+		});
+
+		it('kommt ohne Wartezeit aus, wenn keine ermittelbar ist', async () => {
+			mockResponse({ status: 429, unparseable: true });
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'ratelimited'
+			});
+		});
+	});
+
+	describe('describeSubmitFailure', () => {
+		it('nennt bei offline das Schicksal der Daten', () => {
+			expect(describeSubmitFailure({ status: 'offline' })).toContain(
+				'Eingaben bleiben vollständig gespeichert'
 			);
 		});
 
-		it('lässt den rohen Parse-Fehler nicht zum Nutzer durch', async () => {
-			mockNonJsonResponse(502);
-
-			await expect(submitSightingForm(validFormValues)).rejects.not.toThrow(/Unexpected token/);
-		});
-
-		it('räumt den Speicher bei einem 502 nicht auf', async () => {
-			mockNonJsonResponse(502);
-
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow();
-			expect(clearStorage).not.toHaveBeenCalled();
-		});
-
-		it('meldet auch eine unlesbare 200-Antwort verständlich', async () => {
-			mockNonJsonResponse(200);
-
-			await expect(submitSightingForm(validFormValues)).rejects.toThrow(
-				'Die Sichtung konnte nicht gespeichert werden'
+		it('nennt bei einem Rate Limit die Wartezeit', () => {
+			expect(describeSubmitFailure({ status: 'ratelimited', retryAfter: 45 })).toContain(
+				'45 Sekunden'
 			);
-			expect(clearStorage).not.toHaveBeenCalled();
+		});
+
+		it('reicht die Ablehnungsmeldung unverändert durch', () => {
+			expect(describeSubmitFailure({ status: 'rejected', message: 'Feld X fehlt' })).toBe(
+				'Feld X fehlt'
+			);
+		});
+
+		it('zeigt bei einem Serverfehler keinen technischen Rohtext', () => {
+			const message = describeSubmitFailure({ status: 'server', httpStatus: 502 });
+
+			expect(message).toBe('Die Sichtung konnte nicht gespeichert werden');
+			expect(message).not.toMatch(/502|Unexpected token/);
 		});
 	});
 });

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -22,9 +22,23 @@ import type { SightingFormValues } from '$lib/types/Form';
  * Bei fehlendem Netz kam diese Meldung sogar direkt vom Browser („Failed to
  * fetch"), also unübersetzt und ohne Bezug zur Anwendung.
  *
- * Die vier Fehlerfälle verlangen unterschiedliche Reaktionen:
- * `offline` → Absenden vorab sperren, `server` → Wiederholen anbieten,
- * `rejected` → zum Feld springen, `ratelimited` → warten lassen.
+ * **Was dieser Typ leistet — und was nicht.** Er unterscheidet die Fälle und
+ * hängt an jeden das, was der Server dazu hergibt: den HTTP-Status (`server`),
+ * die Meldung des Servers (`rejected`), die Wartezeit (`ratelimited`). Wie
+ * darauf reagiert wird, entscheidet die Aufrufstelle — hier wird nichts
+ * erzwungen. `ModernReportForm` sperrt bei `offline` das Absenden über
+ * `connection.reportUnreachable()` und bietet in den übrigen drei Fällen
+ * Wiederholen an; `describeSubmitFailure` unten macht aus jedem Fall den Satz,
+ * den der Nutzer liest, und arbeitet `retryAfter` als Information in ihn ein.
+ *
+ * **Kein Feldbezug bei `rejected`, und das ist eine offene Lücke, kein
+ * Entwurf.** Ein Sprung zum abgelehnten Feld wäre die richtige Reaktion, ist
+ * aber mit diesem Typ nicht möglich: `rejected` trägt nur einen String, und der
+ * lautet bei einem Validierungsfehler „Validierungsfehler bei der Eingabe".
+ * Die Feldinformation existiert — `POST /api/sightings` liefert bei 400 ein
+ * `errors: Record<pfad, meldung>` mit —, wird von `SightingApiResponse` unten
+ * aber nicht gelesen. Wer den Sprung nachrüstet, erweitert dort und hier, nicht
+ * am Server.
  */
 export type SubmitResult =
 	| { status: 'ok'; id: number }

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -3,39 +3,36 @@
  *
  * Dieses Modul implementiert die Client-seitige Logik zur Übermittlung
  * von Sichtungsformularen an die Server-API. Es verwaltet die HTTP-
- * Kommunikation, Fehlerbehandlung und automatische Bereinigung des
- * lokalen Browser-Speichers nach erfolgreicher Übermittlung.
+ * Kommunikation und übersetzt jedes mögliche Ergebnis in einen
+ * unterscheidbaren Zustand, den die Oberfläche verschieden behandeln kann.
  *
  * @author Ostsee-Tiere Team
  * @since 1.0.0
  */
 
-import { clearStorage } from '$lib/storage/localStorage';
 import type { SightingFormValues } from '$lib/types/Form';
 
 /**
- * Übermittelt validierte Sichtungsformulardaten an die Server-API
+ * Ergebnis einer Übermittlung — bewusst ein diskriminiertes Result statt eines
+ * geworfenen `Error`.
  *
- * Diese Funktion führt eine POST-Anfrage an den `/api/sightings` Endpunkt
- * durch und verarbeitet die Antwort. Bei erfolgreicher Übermittlung wird
- * der lokale Browser-Speicher automatisch bereinigt.
+ * Vorher warf die Funktion für jeden Fehler denselben `Error`. „Kein Netz",
+ * „Server down", „Validierung abgelehnt" und „Rate Limit" waren für die
+ * Oberfläche damit nicht unterscheidbar — sie konnte nur die Meldung anzeigen.
+ * Bei fehlendem Netz kam diese Meldung sogar direkt vom Browser („Failed to
+ * fetch"), also unübersetzt und ohne Bezug zur Anwendung.
  *
- * @param values Vollständig validierte Sichtungsformulardaten
- * @returns Promise mit Sichtungs-ID und Erfolgsstatus
- *
- * @example
- * try {
- *   const result = await submitSightingForm(formData);
- *   console.log(`Sichtung ${result.id} erfolgreich gespeichert`);
- * } catch (error) {
- *   console.error('Fehler beim Speichern:', error.message);
- * }
- *
- * @throws {Error} Bei Netzwerkfehlern, Validierungsfehlern oder Server-Problemen
- *
- * @note Bereinigt automatisch den localStorage bei erfolgreicher Übermittlung
- * @note Verwendet JSON-Serialisierung für komplexe Formularstrukturen
+ * Die vier Fehlerfälle verlangen unterschiedliche Reaktionen:
+ * `offline` → Absenden vorab sperren, `server` → Wiederholen anbieten,
+ * `rejected` → zum Feld springen, `ratelimited` → warten lassen.
  */
+export type SubmitResult =
+	| { status: 'ok'; id: number }
+	| { status: 'offline' }
+	| { status: 'server'; httpStatus: number }
+	| { status: 'rejected'; message: string }
+	| { status: 'ratelimited'; retryAfter?: number };
+
 /** Fehlermeldung, die der Nutzer sieht, wenn der Server keine eigene liefert. */
 const FALLBACK_MESSAGE = 'Die Sichtung konnte nicht gespeichert werden';
 
@@ -63,33 +60,134 @@ async function readJsonBody(response: Response): Promise<SightingApiResponse | n
 	}
 }
 
-export async function submitSightingForm(
-	values: SightingFormValues
-): Promise<{ id: number; success: boolean }> {
+/**
+ * Erkennt, ob ein von `fetch` geworfener Fehler ein Verbindungsproblem ist.
+ *
+ * `fetch` wirft nur bei Netzwerk- und Konfigurationsfehlern; ein HTTP-Fehlerstatus
+ * ist für `fetch` ein Erfolg. Der Netzwerkfall ist immer ein `TypeError`.
+ *
+ * `navigator.onLine === false` ist dabei ein zusätzliches, aber kein notwendiges
+ * Signal: Es meldet nur, ob eine Netzwerkschnittstelle aktiv ist, nicht ob das
+ * Internet erreichbar ist. WLAN an Bord ohne Uplink meldet `true` und lässt
+ * `fetch` trotzdem scheitern — für dieses Projekt der Regelfall. Der `TypeError`
+ * allein genügt deshalb bereits.
+ */
+function isNetworkFailure(cause: unknown): boolean {
+	if (cause instanceof TypeError) return true;
+	return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
+
+/**
+ * Ermittelt, wie lange bis zum nächsten Versuch gewartet werden muss.
+ *
+ * `enforceRateLimit()` (`$lib/server/middleware/rateLimit.ts`) wirft
+ * `error(429, 'Rate limit exceeded. Try again after 14:23:11 (45s)')`. SvelteKit
+ * liefert das als `{ message }` aus und setzt **keinen** `Retry-After`-Header —
+ * die Sekunden stehen nur im Text. Der Header wird trotzdem zuerst gelesen,
+ * damit ein vorgeschalteter Reverse Proxy, der selbst drosselt, korrekt greift.
+ */
+function parseRetryAfter(response: Response, message: string | undefined): number | undefined {
+	const header = response.headers?.get?.('Retry-After');
+
+	if (header) {
+		const seconds = Number(header);
+		if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds);
+
+		// RFC 9110 erlaubt alternativ ein HTTP-Datum.
+		const resetAt = Date.parse(header);
+		if (!Number.isNaN(resetAt)) return Math.max(0, Math.ceil((resetAt - Date.now()) / 1000));
+	}
+
+	const fromMessage = message?.match(/\((\d+)s\)/);
+	return fromMessage ? Number(fromMessage[1]) : undefined;
+}
+
+/**
+ * Übermittelt validierte Sichtungsformulardaten an die Server-API
+ *
+ * @param values Vollständig validierte Sichtungsformulardaten
+ * @returns Das Ergebnis als {@link SubmitResult} — die Funktion wirft für kein
+ *   erwartbares Fehlerbild. Geworfen wird nur weiter, was kein Netzwerkfehler
+ *   ist (etwa ein Programmierfehler beim Aufbau der Anfrage); solche Fehler zu
+ *   verschlucken würde sie unsichtbar machen.
+ *
+ * @note Räumt den Browser-Speicher **nicht** auf. Zuständig dafür ist
+ *   `ModernReportForm.svelte`, siehe Hinweis unten.
+ */
+export async function submitSightingForm(values: SightingFormValues): Promise<SubmitResult> {
+	let response: Response;
+
 	// HTTP POST-Anfrage an die Sichtungs-API mit JSON-Payload
-	const response = await fetch('/api/sightings', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json'
-		},
-		body: JSON.stringify(values) // Serialisiere komplette Formulardaten
-	});
+	try {
+		response = await fetch('/api/sightings', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify(values) // Serialisiere komplette Formulardaten
+		});
+	} catch (cause) {
+		if (isNetworkFailure(cause)) return { status: 'offline' };
+		throw cause;
+	}
 
-	// Statusprüfung VOR dem Parsen: Bei einem HTTP-Fehler ist der Körper oft
-	// kein JSON, und der Parse-Fehler würde die eigentliche Ursache verdecken.
+	// Der Körper wird einmal gelesen, BEVOR über den Status entschieden wird —
+	// die Verzweigungen unten brauchen ihn alle. Möglich ist das nur, weil
+	// `readJsonBody()` den Parse kapselt: Bei einem HTTP-Fehler ist der Körper
+	// oft kein JSON (HTML-Fehlerseite eines Proxy), und ein durchschlagender
+	// `SyntaxError` würde die eigentliche Ursache verdecken. Ohne diese Kapselung
+	// müsste die Statusprüfung zwingend vorher laufen.
+	const body = await readJsonBody(response);
+
+	if (response.status === 429) {
+		// `exactOptionalPropertyTypes`: die Eigenschaft wird weggelassen, nicht auf
+		// `undefined` gesetzt.
+		const retryAfter = parseRetryAfter(response, body?.message);
+		return retryAfter === undefined
+			? { status: 'ratelimited' }
+			: { status: 'ratelimited', retryAfter };
+	}
+
 	if (!response.ok) {
-		const body = await readJsonBody(response);
-		throw new Error(body?.message || FALLBACK_MESSAGE);
+		// 4xx mit lesbarer Meldung ist eine inhaltliche Ablehnung (Validierung,
+		// verbotene Felder) — der Text nennt das betroffene Feld und hilft dem
+		// Nutzer. 5xx-Meldungen sind generisch; dort zählt nur „wiederholbar".
+		if (response.status < 500 && body?.message) {
+			return { status: 'rejected', message: body.message };
+		}
+		return { status: 'server', httpStatus: response.status };
 	}
 
-	const result = await readJsonBody(response);
-
-	if (result?.success && typeof result.id === 'number') {
-		// Erfolgreiche Übermittlung: Lokalen Speicher bereinigen
-		clearStorage();
-		return { id: result.id, success: true };
+	if (body?.success === true && typeof body.id === 'number') {
+		return { status: 'ok', id: body.id };
 	}
 
-	// 2xx, aber unlesbar oder `success: false` — Server-Meldung oder Fallback.
-	throw new Error(result?.message || FALLBACK_MESSAGE);
+	// 2xx, aber der Körper widerspricht sich oder ist unlesbar.
+	if (body?.success === false && body.message) {
+		return { status: 'rejected', message: body.message };
+	}
+	return { status: 'server', httpStatus: response.status };
+}
+
+/**
+ * Übersetzt ein gescheitertes {@link SubmitResult} in einen Satz für den Nutzer.
+ *
+ * Zwischenschritt: Solange die Oberfläche Fehler nur als Text anzeigt, braucht
+ * sie eine Meldung. Ab `SubmitStatus` trägt die Komponente den Zustand selbst
+ * und wählt Wortlaut und Aktion pro Fall — dann bleibt hier nur noch der
+ * Fallback für Protokollzwecke.
+ */
+export function describeSubmitFailure(result: Exclude<SubmitResult, { status: 'ok' }>): string {
+	switch (result.status) {
+		case 'offline':
+			return 'Keine Internetverbindung. Ihre Eingaben bleiben vollständig gespeichert.';
+		case 'ratelimited':
+			return result.retryAfter
+				? `Zu viele Übermittlungen. Bitte versuchen Sie es in ${result.retryAfter} Sekunden erneut.`
+				: 'Zu viele Übermittlungen. Bitte versuchen Sie es später erneut.';
+		case 'rejected':
+			return result.message;
+		case 'server':
+			return FALLBACK_MESSAGE;
+	}
 }

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -5,6 +5,7 @@
 	const logger = createLogger('components:FormHelp');
 	import SpeciesIdentificationHelp from './form/fields/SpeciesIdentificationHelp.svelte';
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 
 	// Keine Platzhalter-Zahlen: Statistiken werden erst angezeigt, wenn sie
 	// tatsächlich geladen wurden. Erfundene Fallback-Werte würden Bürgern sonst
@@ -66,9 +67,25 @@
 							</p>
 							<div class="bg-base-100 mt-3 rounded-lg p-3">
 								{#if !loading && fetchFailed}
-									<p class="text-base-content/70 text-center text-xs">
-										Statistiken konnten nicht geladen werden
-									</p>
+									<!--
+										Vorher eine graue Zeile ohne Form und ohne Einordnung: Sie sah
+										aus wie ein Platzhalter und ließ offen, ob jetzt das Formular
+										kaputt ist. Der StatusBlock sagt beides — was fehlt und was
+										trotzdem geht.
+									-->
+									<!--
+										`announce="status"`: Der Abruf startet beim Seitenaufbau, nicht
+										auf Knopfdruck — und er steckt in einem zugeklappten `<details>`.
+										Ein `role="alert"` würde den Screenreader hier über etwas
+										unterbrechen, das der Nutzer nicht angestoßen hat und gar nicht
+										sieht.
+									-->
+									<StatusBlock
+										variant="failed"
+										announce="status"
+										title="Statistiken konnten nicht geladen werden"
+										description="Das Formular funktioniert vollständig — nur die Zahlen in diesem Hilfetext fehlen."
+									/>
 								{:else}
 									<div class="grid grid-cols-2 gap-4 text-center text-sm">
 										<div>

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -6,7 +6,7 @@
 
 	import { browser } from '$app/environment';
 	import Icon from '$lib/components/Icon.svelte';
-	import { submitSightingForm } from '$lib/form/submitSightingForm';
+	import { describeSubmitFailure, submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
@@ -91,8 +91,15 @@
 
 				const result = await submitSightingForm(submitValues);
 
+				if (result.status !== 'ok') {
+					// Zwischenschritt: Die Oberfläche kann die vier Fehlerarten noch nicht
+					// unterschiedlich darstellen, deshalb wird hier auf eine Meldung
+					// eingedampft. `SubmitStatus` übernimmt den Zustand als Ganzes.
+					throw new Error(describeSubmitFailure(result));
+				}
+
 				// Speichere Benutzer-Kontaktdaten für zukünftige Formulare basierend auf Zustimmung
-				if (result.success) {
+				{
 					const userContactData: UserContactData = {
 						firstName: values.firstName,
 						lastName: values.lastName,
@@ -117,7 +124,11 @@
 
 				submissionError = null;
 				const submitResult = await onSubmit(submitValues);
-				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten)
+				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten).
+				// Diese Stelle ist seither die EINZIGE, die nach einer Übermittlung aufräumt:
+				// `submitSightingForm` rief zuvor zusätzlich `clearStorage()` — und zwar schon
+				// vor `onSubmit`, was den Kommentar oben aushebelte. `clearFormDataOnly()` plus
+				// das Zurücksetzen von CURRENT_STEP deckt denselben Umfang ab.
 				clearFormDataOnly(); // Clears only form data, keeps currentStep and user contact data
 				currentStep = 0;
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -4,8 +4,10 @@
 	import FormActions from './form/FormActions.svelte';
 	import RequiredConsent from './form/RequiredConsent.svelte';
 
+	import SubmitStatus, { type SubmitState } from './form/SubmitStatus.svelte';
+
 	import { browser } from '$app/environment';
-	import Icon from '$lib/components/Icon.svelte';
+	import { connection, watchConnection } from '$lib/stores/connectionState.svelte';
 	import { describeSubmitFailure, submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
@@ -71,8 +73,48 @@
 		});
 	}
 
-	// Status für Fehleranzeige
-	let submissionError = $state<string | null>(null);
+	/**
+	 * Zustand der Übermittlung — getragen von `SubmitStatus` über der Navigation.
+	 *
+	 * Ersetzt den früheren `submissionError`-Alert plus den Submit-Fehler-Toast:
+	 * beide sagten nur, DASS etwas schiefging, nicht was mit den Daten passiert
+	 * ist und was der Nutzer jetzt tun kann.
+	 */
+	let submitState = $state<SubmitState>('idle');
+	/** Überschrift im Zustand `failed` — je nach Fehlerart eine andere. */
+	let submitTitle = $state('Der Server hat nicht geantwortet');
+	/** Zählt die Absende-Versuche, damit „Wiederholen" sichtbar etwas bewirkt. */
+	let submitAttempt = $state(0);
+
+	// Verbindungszustand an die Browser-Ereignisse binden.
+	$effect(() => watchConnection());
+
+	/**
+	 * Ohne Verbindung wird vorab gesperrt, statt den Versuch scheitern zu lassen.
+	 * Ein laufender Submit behält seinen eigenen Zustand — sonst überschriebe ein
+	 * kurzer Aussetzer die Anzeige mitten in der Übertragung.
+	 */
+	$effect(() => {
+		if (connection.isOffline) {
+			// NUR aus `idle` heraus. Ein bereits angezeigter Fehlschlag darf nicht
+			// überschrieben werden: Er verschwände beim nächsten Verbindungswechsel
+			// von selbst wieder — genau das, was `SubmitStatus` ausschließt.
+			if (submitState === 'idle') submitState = 'offline';
+		} else if (submitState === 'offline') {
+			submitState = 'idle';
+		}
+	});
+
+	/**
+	 * Hart gesperrt wird nur beim sicheren Nein des Browsers.
+	 *
+	 * `connection.isOffline` ist auch dann wahr, wenn lediglich der letzte
+	 * Request an einem `TypeError` gescheitert ist — das wirft `fetch` aber auch
+	 * bei einem Server-Neustart oder einem CORS-Fehler, und dort feuert nie ein
+	 * `online`-Ereignis, das den Zustand wieder aufhebt. An dieser Bedingung
+	 * gesperrt käme der Nutzer nur durch ein Neuladen wieder heraus.
+	 */
+	const submitBlocked = $derived(submitState === 'offline' && connection.isInterfaceDown);
 
 	// Formular initialisieren
 	const formProps = {
@@ -89,14 +131,35 @@
 				// set mediaUpload indicator
 				submitValues.mediaUpload = uploadedFiles ? uploadedFiles.length > 0 : false;
 
+				submitAttempt += 1;
+				submitState = 'submitting';
+
 				const result = await submitSightingForm(submitValues);
 
 				if (result.status !== 'ok') {
-					// Zwischenschritt: Die Oberfläche kann die vier Fehlerarten noch nicht
-					// unterschiedlich darstellen, deshalb wird hier auf eine Meldung
-					// eingedampft. `SubmitStatus` übernimmt den Zustand als Ganzes.
-					throw new Error(describeSubmitFailure(result));
+					// Jede Fehlerart bekommt ihren eigenen Zustand: `offline` sperrt das
+					// Absenden vorab, die übrigen bieten Wiederholen an. Liegt bereits
+					// eine Aufnahme auf dem Server, gilt die Datenzusage nicht mehr
+					// uneingeschränkt — dafür gibt es `partial`.
+					connection[result.status === 'offline' ? 'reportUnreachable' : 'reportReachable']();
+
+					// Einmal berechnen: Anzeige und geworfene Meldung sollen dieselbe
+					// Aussage tragen, nicht zwei unabhängig entstandene.
+					const failure = describeSubmitFailure(result);
+
+					if (result.status === 'offline') {
+						submitState = 'offline';
+					} else {
+						submitState = submitValues.mediaUpload ? 'partial' : 'failed';
+						submitTitle = failure;
+					}
+
+					throw new Error(failure);
 				}
+
+				connection.reportReachable();
+				submitState = 'idle';
+				submitAttempt = 0;
 
 				// Speichere Benutzer-Kontaktdaten für zukünftige Formulare basierend auf Zustimmung
 				{
@@ -122,7 +185,6 @@
 					);
 				}
 
-				submissionError = null;
 				const submitResult = await onSubmit(submitValues);
 				// Reset nur nach erfolgreichem Submit (Fehler in onSubmit soll Formular erhalten).
 				// Diese Stelle ist seither die EINZIGE, die nach einer Übermittlung aufräumt:
@@ -134,14 +196,35 @@
 				saveToStorage(STORAGE_KEYS.CURRENT_STEP, 0);
 				return submitResult;
 			} catch (error: unknown) {
-				submissionError = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
-				logger.error(error, submissionError);
+				const message = (error as Error)?.message || 'Unbekannter Fehler bei der Übermittlung';
+				// Scheitert erst der `onSubmit`-Callback (nicht die Übermittlung),
+				// steht `submitState` noch auf `submitting` — auch dieser Fall ist ein
+				// Fehlschlag und braucht die Wiederholen-Fläche.
+				if (submitState === 'submitting') {
+					submitState = 'failed';
+					submitTitle = message;
+				}
+				logger.error(error, message);
 				throw error;
 			}
 		}
 	};
 
 	let formContext: FormContext = $state({} as FormContext);
+
+	/**
+	 * Erneuter Versuch aus `SubmitStatus` heraus.
+	 *
+	 * `handleFinalSubmit` wirft bei einem Fehlschlag weiter, damit die
+	 * Schritt-Navigation ihren Weg zum fehlerhaften Feld gehen kann. Hier gibt es
+	 * keinen solchen Aufrufer — der Zustand steht bereits in `submitState`, das
+	 * erneute Werfen wäre nur eine unbehandelte Rejection in der Konsole.
+	 */
+	function retrySubmit(): void {
+		void handleFinalSubmit(new Event('submit')).catch((error: unknown) => {
+			logger.error({ error }, 'Erneuter Absendeversuch fehlgeschlagen');
+		});
+	}
 
 	// Formularstatus
 	async function handleFinalSubmit(e: Event): Promise<void> {
@@ -245,13 +328,12 @@
 		</div>
 	{/if}
 
-	<!-- Error Message -->
-	{#if submissionError}
-		<div class="alert alert-error mb-6" role="alert">
-			<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
-			<span>{submissionError}</span>
-		</div>
-	{/if}
+	<!--
+		Der frühere `submissionError`-Alert stand hier oben, weit weg von der
+		Schaltfläche, die ihn ausgelöst hat — auf dem Telefon außerhalb des
+		Bildschirms. Er ist in `SubmitStatus` aufgegangen, das direkt über der
+		Schritt-Navigation sitzt.
+	-->
 
 	<!-- Step Progress -->
 	<FormSteps steps={formStepsConfig} bind:currentStep />
@@ -275,7 +357,21 @@
 			<!-- Required Privacy Consent - Prominent placement before submit -->
 			<RequiredConsent {currentStep} />
 
-			<StepNavigation bind:currentStep onSubmit={handleFinalSubmit} />
+			<!--
+				`referenceId` kommt aus `savedFormData`, nicht aus `$form`: `formContext`
+				wird erst über `bind:context` gefüllt, beim Server-Rendering ist `$form`
+				an dieser Stelle noch undefiniert. Die Referenz steht ohnehin fest — sie
+				entsteht einmal beim Aufbau des Formulars und ändert sich nie.
+			-->
+			<SubmitStatus
+				state={submitState}
+				title={submitTitle}
+				attempt={submitAttempt}
+				referenceId={savedFormData.referenceId ?? ''}
+				onRetry={submitBlocked ? undefined : retrySubmit}
+			/>
+
+			<StepNavigation bind:currentStep onSubmit={handleFinalSubmit} {submitBlocked} />
 		</div>
 	</div>
 

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -22,11 +22,18 @@
 	let {
 		currentStep = $bindable(0),
 		totalSteps = $bindable(formStepsConfig.length),
-		onSubmit
+		onSubmit,
+		submitBlocked = false
 	}: {
 		onSubmit?: (e: Event) => Promise<void>;
 		currentStep?: number;
 		totalSteps?: number;
+		/**
+		 * Sperrt „Absenden" vorab, statt den Versuch scheitern zu lassen. Die
+		 * Begründung steht in `SubmitStatus` über dieser Navigation — ein
+		 * vorhersehbarer Fehlschlag ist keine Fehlermeldung wert.
+		 */
+		submitBlocked?: boolean;
 	} = $props();
 
 	const formContext = getFormContext();
@@ -98,8 +105,18 @@
 	}
 
 	// Navigation functions
+	/** Absenden ist gesperrt — nur auf dem letzten Schritt relevant. */
+	const isSubmitBlocked = $derived(isLastStep && submitBlocked);
+
 	async function nextStep(): Promise<void> {
 		try {
+			// Wächter zur `aria-disabled`-Sperre am Button: Das Element bleibt
+			// fokussierbar (siehe design-system.md), die eigentliche Sperre sitzt hier.
+			if (isSubmitBlocked) {
+				logger.info('Absenden gesperrt — keine Verbindung');
+				return;
+			}
+
 			if (!canGoNext) {
 				logger.warn({ currentStep }, 'Validation failed for current step');
 				attemptedStep = currentStep;
@@ -142,8 +159,13 @@
 			logger.info('Form submitted successfully');
 		} catch (error) {
 			logger.error({ error }, 'Error during form submission');
-			toast.error('Fehler beim Absenden des Formulars. Bitte versuchen Sie es erneut.');
-			// Navigate to first error field if validation failed
+			// Kein Toast mehr: Der Fehlschlag steht als `SubmitStatus` direkt über
+			// dieser Navigation, verschwindet nicht von selbst und trägt die
+			// Wiederholen-Aktion. Ein Toast daneben wäre eine zweite Anzeige
+			// derselben Sache — und die flüchtigere von beiden.
+			// Der Validierungs-Toast in `showValidationError` bleibt: der ist
+			// flüchtig, verlangt keine Handlung an Ort und Stelle und begleitet
+			// den Sprung zum fehlerhaften Feld.
 			await showValidationError();
 		}
 	}
@@ -272,15 +294,27 @@
 			</button>
 		{/if}
 
+		<!--
+			`aria-disabled` statt `disabled` für die Verbindungssperre: Das Element
+			bleibt fokussierbar, damit die Tastaturposition erhalten bleibt und der
+			Grund erreichbar ist (design-system.md). Der laufende Submit sperrt
+			weiterhin hart über `disabled` — dort ist der Zustand von sehr kurzer
+			Dauer und ein Doppelklick hätte echte Folgen.
+		-->
 		<button
 			type="button"
 			onclick={nextStep}
 			disabled={$isSubmitting}
+			aria-disabled={isSubmitBlocked}
 			class="btn btn-primary"
+			class:btn-disabled={isSubmitBlocked}
 			aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
+			title={isSubmitBlocked ? 'Ohne Internetverbindung kann nicht abgesendet werden' : undefined}
 		>
 			{#if $isSubmitting}
 				<span class="loading loading-spinner loading-sm"></span>
+			{:else if isSubmitBlocked}
+				<Icon icon="lucide:wifi-off" width="16" class="shrink-0" aria-hidden="true" />
 			{/if}
 			{isLastStep ? 'Absenden' : 'Weiter →'}
 		</button>

--- a/src/lib/report/components/form/StepProgressCompact.svelte
+++ b/src/lib/report/components/form/StepProgressCompact.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import { canNavigateToStep } from '$lib/form/validation/stepNavigation';
 	import { getFormContext } from '$lib/report/formContext';
 	import type { FormStep } from '$lib/report/types';
@@ -39,6 +40,21 @@
 		}
 	}
 </script>
+
+<!--
+	Der Verbindungszustand steht im ortsfesten Balken und nicht nur in der
+	Navbar: Auf dem Telefon ist die Navbar beim Ausfüllen längst weggescrollt,
+	der Balken ist die einzige dauerhaft sichtbare Fläche. Hier steht die Zusage
+	zu den Eingaben ausgeschrieben — im Formular ist sie die eigentliche Sorge.
+
+	`announce={false}`, weil die Instanz in der Navbar dieselbe Meldung bereits
+	als Live-Region trägt; zwei davon sagen dem Screenreader „Offline" doppelt.
+
+	Die Layout-Klassen gehen als `class` an die Komponente statt an einen
+	Wrapper: Ein Wrapper mit `mb-2` behielte seinen Abstand auch dann, wenn gar
+	nichts zu sehen ist.
+-->
+<ConnectionBadge announce={false} class="mb-2 md:hidden" />
 
 <nav class="flex items-center gap-3 md:hidden" aria-label="Formular-Schritte">
 	<p class="text-support text-base-content/70 shrink-0">

--- a/src/lib/report/components/form/SubmitStatus.svelte
+++ b/src/lib/report/components/form/SubmitStatus.svelte
@@ -1,0 +1,238 @@
+<!--
+  Zustandsfläche direkt über der Schritt-Navigation, dort wo „Absenden" steht.
+
+  Ersetzt den Submit-Fehler-Toast vollständig. Ein Toast ist für Flüchtiges da —
+  eine bestätigende Randnotiz, die keine Handlung verlangt. Ein gescheitertes
+  Absenden verlangt eine Handlung, und die gehört an den Ort der Handlung, nicht
+  in eine Ecke, die nach fünf Sekunden leer ist.
+
+  Drei Regeln, die diese Komponente durchhält:
+
+  1. Sie verschwindet nie von selbst. Kein `setTimeout`, keine Dauer-Prop. Wer
+     den Fehler wegbekommen will, sendet erneut oder korrigiert etwas.
+  2. Jeder Fehlerzustand nennt das Schicksal der Daten. Die häufigste Sorge nach
+     einem Fehlschlag ist „ist jetzt alles weg?" — und sie ist beantwortbar.
+     Einzige Ausnahme ist `partial`: dort liegt die Aufnahme schon auf dem
+     Server, das lässt sich nicht als „bleibt bei Ihnen" beschreiben.
+  3. Die Referenz-ID steht im Fehlerfall im Text. Sie existiert bereits
+     (`createId()` in `ModernReportForm`), wurde dem Nutzer aber nie gezeigt —
+     ausgerechnet im Fehlerfall braucht er sie für die Rückfrage.
+-->
+<script module lang="ts">
+	// Typ-Export gehört in den Modul-Block — der Instanz-Block kann in Svelte 5
+	// keine Typen exportieren.
+	export type SubmitState = 'idle' | 'submitting' | 'offline' | 'failed' | 'partial';
+</script>
+
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { ORPHAN_RETENTION_HOURS } from '$lib/constants/uploadRetention';
+
+	let {
+		state = 'idle',
+		attempt = 0,
+		maxAttempts = 3,
+		referenceId = '',
+		title = 'Der Server hat nicht geantwortet',
+		onRetry
+	}: {
+		/** Aktueller Zustand der Übermittlung. `idle` rendert nichts. */
+		state?: SubmitState;
+		/**
+		 * Überschrift im Zustand `failed`. Voreinstellung ist der Serverausfall;
+		 * eine inhaltliche Ablehnung oder ein Rate Limit setzt hier den eigenen
+		 * Satz ein, während Datenzusage, Referenz und Wiederholen gleich bleiben.
+		 */
+		title?: string;
+		/** Anzahl der bisherigen Versuche. 0 = noch keiner, blendet den Zähler aus. */
+		attempt?: number;
+		/** Bezugsgröße für den Zähler („Versuch 2 von 3"). */
+		maxAttempts?: number;
+		/** Referenz der Meldung — im Fehlerfall die Nummer für die Rückfrage. */
+		referenceId?: string;
+		/**
+		 * Löst einen erneuten Versuch aus. Fehlt er, wird keine Schaltfläche gezeigt.
+		 *
+		 * Auch der Offline-Zustand trägt sie, sobald der Aufrufer sie übergibt: Der
+		 * Zustand kann aus einem einzelnen gescheiterten Request abgeleitet sein
+		 * und dann falsch liegen (siehe `connection.isInterfaceDown`). Ohne einen
+		 * Weg heraus wäre der Nutzer in diesem Fall bis zum Neuladen gefangen.
+		 */
+		onRetry?: (() => void) | undefined;
+	} = $props();
+
+	/**
+	 * Anlaufstelle bei anhaltenden Problemen.
+	 *
+	 * Bewusst die Kontaktseite des Museums und **keine E-Mail-Adresse**: Der
+	 * Entwurf nannte `sichtungen@meeresmuseum.de`, wofür es im Bestand keinen
+	 * Beleg gibt. Eine Adresse, die niemand liest, ist im Fehlerfall schlimmer
+	 * als gar keine — dann läuft die Rückfrage ins Leere und der Nutzer hält es
+	 * für erledigt.
+	 *
+	 * Diese URL ist belegt: `src/routes/about/+page.svelte:353` zeigt sie
+	 * Nutzern bereits als „Kontakt aufnehmen". Die einzige weitere Adresse im
+	 * Bestand ist `datenschutz@meeresmuseum.de` (`RequiredConsent.svelte`) —
+	 * eine Datenschutz-Stelle, die für eine gescheiterte Übermittlung der
+	 * falsche Adressat wäre.
+	 */
+	const CONTACT_URL = 'https://www.deutsches-meeresmuseum.de/kontakt';
+
+	const showAttemptCounter = $derived(attempt > 0);
+	const showReference = $derived(referenceId.length > 0);
+
+	/**
+	 * „Versuch 4 von 3" wäre Unsinn. Über der Bezugsgröße zählt die Komponente
+	 * nur noch weiter, statt eine Grenze zu behaupten, die niemand durchsetzt —
+	 * `ModernReportForm` begrenzt die Versuche nicht.
+	 */
+	const attemptLabel = $derived(
+		attempt > maxAttempts
+			? `Das war Versuch ${attempt}.`
+			: `Das war Versuch ${attempt} von ${maxAttempts}.`
+	);
+</script>
+
+{#if state === 'submitting'}
+	<!--
+		Kein Alert und keine Statusfarbe: Ein Ladevorgang ist keine Warnung.
+		Die sichtbare Rückmeldung trägt der Absenden-Button selbst; dieser Block
+		existiert für die Ansage an Screenreader.
+	-->
+	<div
+		class="border-base-300 bg-base-200/50 rounded-box mb-2 flex items-start gap-3 border p-4"
+		role="status"
+		aria-live="polite"
+		data-testid="submit-status-submitting"
+	>
+		<span class="loading loading-spinner loading-sm text-primary mt-0.5"></span>
+		<p class="text-base-content font-medium">Ihre Meldung wird gesendet …</p>
+	</div>
+{:else if state === 'offline'}
+	<!--
+		`role="status"`: Der Offline-Zustand entsteht von selbst, oft während der
+		Nutzer noch tippt. Ein `role="alert"` würde den Screenreader mitten im
+		Satz unterbrechen, ohne dass etwas passiert wäre.
+	-->
+	<div
+		class="alert alert-warning mb-2 items-start"
+		role="status"
+		aria-live="polite"
+		data-testid="submit-status-offline"
+	>
+		<Icon icon="lucide:wifi-off" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">Keine Internetverbindung</p>
+			<p class="text-base-content mt-1 text-sm">
+				Die Meldung kann gerade nicht abgeschickt werden.
+				<strong>Ihre Eingaben bleiben vollständig gespeichert</strong> — auch wenn Sie diese Seite schließen.
+				Sobald Sie wieder Empfang haben, können Sie hier absenden.
+			</p>
+			{#if onRetry}
+				<!--
+					Nur sichtbar, wenn der Aufrufer den Zustand nicht als sicher ansieht:
+					Ist er aus einem einzelnen gescheiterten Request abgeleitet, kann er
+					falsch sein — ohne diesen Weg bliebe der Nutzer bis zum Neuladen
+					gefangen, denn ohne `online`-Ereignis hebt ihn nichts wieder auf.
+				-->
+				<button type="button" class="btn btn-primary btn-sm mt-3" onclick={onRetry}>
+					<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+					Trotzdem versuchen
+				</button>
+			{/if}
+		</div>
+	</div>
+{:else if state === 'failed'}
+	<!--
+		`role="alert"`, wie auch bei `partial`. Dieser Zustand ist die unmittelbare Folge
+		einer Nutzeraktion („Absenden"), die Unterbrechung ist also erwartet und
+		trägt Information.
+	-->
+	<div class="alert alert-error mb-2 items-start" role="alert" data-testid="submit-status-failed">
+		<Icon icon="lucide:circle-alert" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">{title}</p>
+			<p class="text-base-content mt-1 text-sm">
+				<strong>Ihre Eingaben sind nicht verloren.</strong>
+				{#if showAttemptCounter}
+					{attemptLabel}
+				{/if}
+				{#if showReference}
+					Bitte geben Sie bei einer Rückfrage die unten stehende Referenz an.
+				{/if}
+				Bei anhaltenden Problemen erreichen Sie uns über die
+				<a class="link" href={CONTACT_URL} target="_blank" rel="noopener noreferrer">
+					Kontaktseite des Museums
+				</a>.
+			</p>
+			<div class="mt-3 flex flex-wrap items-center gap-2">
+				{#if onRetry}
+					<button type="button" class="btn btn-primary btn-sm" onclick={onRetry}>
+						<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+						Erneut absenden
+					</button>
+				{/if}
+				{#if showReference}
+					<span
+						class="text-base-content/70 font-mono text-sm"
+						data-testid="submit-status-reference"
+					>
+						Referenz: {referenceId}
+					</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+{:else if state === 'partial'}
+	<!--
+		Der einzige Zustand, der die Datenzusage nicht geben kann: Die Aufnahme
+		liegt bereits auf dem Server. Die Frist kommt aus `ORPHAN_RETENTION_HOURS`
+		— derselben Konstante, aus der `UPLOAD_NOTICE` an der Dropzone schöpft und
+		nach der das Aufräum-Tool tatsächlich löscht. Eine hier hineingeschriebene
+		Zahl könnte davon abweichen und wäre dann eine falsche Zusage.
+	-->
+	<!--
+		`role="alert"` wie bei `failed`: `partial` entsteht, weil jemand
+		„Absenden" gedrückt hat — es ist ein Unterfall des Fehlschlags und keine
+		von selbst auflaufende Meldung. Die Unterbrechung ist damit erwartet und
+		trägt Information. Zwei gleichzeitige Live-Regionen können dabei nicht
+		entstehen: `failed` und `partial` schließen einander aus.
+	-->
+	<div
+		class="alert alert-warning mb-2 items-start"
+		role="alert"
+		data-testid="submit-status-partial"
+	>
+		<Icon icon="lucide:triangle-alert" class="mt-0.5 shrink-0" aria-hidden="true" />
+		<div>
+			<p class="text-base-content font-bold">Aufnahme übertragen, Meldung nicht</p>
+			<p class="text-base-content mt-1 text-sm">
+				<!--
+					Der Grund gehört auch hierhin. Vorher trug nur `failed` ihn, und eine
+					Meldung mit angehängter Aufnahme landet immer in `partial` — eine
+					abgelehnte Eingabe („E-Mail ungültig") verschwand damit spurlos hinter
+					dem Aufbewahrungshinweis, und der Nutzer wiederholte ins Leere.
+				-->
+				{title}
+				{#if showAttemptCounter}
+					{attemptLabel}
+				{/if}
+			</p>
+			<p class="text-base-content mt-1 text-sm">
+				Ihre Aufnahme liegt bereits bei uns. Wir löschen sie automatisch, wenn die Meldung nicht
+				innerhalb von {ORPHAN_RETENTION_HOURS} Stunden ankommt.
+			</p>
+			<div class="mt-3 flex flex-wrap items-center gap-2">
+				{#if onRetry}
+					<button type="button" class="btn btn-primary btn-sm" onclick={onRetry}>
+						<Icon icon="lucide:refresh-cw" width="16" class="shrink-0" aria-hidden="true" />
+						Erneut absenden
+					</button>
+				{/if}
+				{#if showReference}
+					<span class="text-base-content/70 font-mono text-sm">Referenz: {referenceId}</span>
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/src/lib/report/components/form/SubmitStatus.svelte.test.ts
+++ b/src/lib/report/components/form/SubmitStatus.svelte.test.ts
@@ -1,0 +1,256 @@
+import { ORPHAN_RETENTION_HOURS } from '$lib/constants/uploadRetention';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import SubmitStatus from './SubmitStatus.svelte';
+
+/** Findet den Statusblock im gerenderten Dokument. */
+function block(testid: string): HTMLElement | null {
+	return document.querySelector(`[data-testid="${testid}"]`);
+}
+
+describe('SubmitStatus', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('rendert im Zustand idle nichts', () => {
+		const { container } = render(SubmitStatus, { state: 'idle' });
+
+		expect(container.textContent?.trim()).toBe('');
+	});
+
+	describe('offline', () => {
+		it('nennt das Schicksal der Daten', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.textContent).toContain(
+				'Eingaben bleiben vollständig gespeichert'
+			);
+		});
+
+		/**
+		 * Der Offline-Zustand entsteht von selbst, oft während der Nutzer noch
+		 * tippt. `role="alert"` würde den Screenreader mitten im Satz unterbrechen.
+		 */
+		it('meldet sich höflich per role="status", nicht per role="alert"', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.getAttribute('role')).toBe('status');
+			expect(document.querySelector('[role="alert"]')).toBeNull();
+		});
+	});
+
+	/**
+	 * `failed` und `partial` entstehen beide, weil jemand „Absenden" gedrückt
+	 * hat — die Unterbrechung ist dort erwartet. `offline` und `submitting`
+	 * laufen von selbst auf und melden sich höflich. Weil die Zustände einander
+	 * ausschließen, kann nie mehr als eine Live-Region gleichzeitig feuern.
+	 */
+	describe('ARIA-Rollen', () => {
+		it.each([
+			['failed', 'alert'],
+			['partial', 'alert'],
+			['offline', 'status'],
+			['submitting', 'status']
+		] as const)('meldet %s per role="%s"', (state, expected) => {
+			render(SubmitStatus, { state });
+
+			expect(block(`submit-status-${state}`)?.getAttribute('role')).toBe(expected);
+		});
+
+		it('rendert nie zwei Live-Regionen gleichzeitig', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			expect(document.querySelectorAll('[role="alert"], [role="status"]')).toHaveLength(1);
+		});
+	});
+
+	describe('failed', () => {
+		it('unterbricht per role="alert", weil es die Folge einer Nutzeraktion ist', () => {
+			render(SubmitStatus, { state: 'failed' });
+
+			expect(block('submit-status-failed')?.getAttribute('role')).toBe('alert');
+		});
+
+		it('sagt zu, dass die Eingaben erhalten bleiben', () => {
+			render(SubmitStatus, { state: 'failed' });
+
+			expect(block('submit-status-failed')?.textContent).toContain(
+				'Ihre Eingaben sind nicht verloren'
+			);
+		});
+
+		it('zeigt die Referenz-ID für die Rückfrage', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: 'clx8k2p9a0001' });
+
+			expect(block('submit-status-reference')?.textContent).toContain('clx8k2p9a0001');
+			expect(block('submit-status-failed')?.textContent).toContain(
+				'bei einer Rückfrage die unten stehende Referenz'
+			);
+		});
+
+		/**
+		 * Der Entwurf nannte `sichtungen@meeresmuseum.de` — dafür gibt es im
+		 * Bestand keinen Beleg. Eine Adresse, die niemand liest, ist im Fehlerfall
+		 * schlimmer als gar keine: die Rückfrage läuft ins Leere und der Nutzer
+		 * hält es für erledigt. Verlinkt wird deshalb die Kontaktseite, die
+		 * `about/+page.svelte` Nutzern ohnehin schon zeigt.
+		 */
+		it('nennt keine unbelegte E-Mail-Adresse', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: 'clx8k2p9a0001' });
+
+			const html = block('submit-status-failed')?.innerHTML ?? '';
+			expect(html).not.toMatch(/mailto:/);
+			expect(html).not.toMatch(/@meeresmuseum\.de/);
+			expect(html).toContain('https://www.deutsches-meeresmuseum.de/kontakt');
+		});
+
+		it('zeigt keine Referenzzeile, solange keine ID vorliegt', () => {
+			render(SubmitStatus, { state: 'failed', referenceId: '' });
+
+			expect(block('submit-status-reference')).toBeNull();
+		});
+
+		it('macht sichtbar, der wievielte Versuch das war', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 2, maxAttempts: 3 });
+
+			expect(block('submit-status-failed')?.textContent).toContain('Versuch 2 von 3');
+		});
+
+		it('blendet den Zähler vor dem ersten Versuch aus', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 0 });
+
+			expect(block('submit-status-failed')?.textContent).not.toContain('Versuch');
+		});
+
+		/**
+		 * Die Versuche sind nirgends begrenzt — `ModernReportForm` zählt einfach
+		 * weiter. „Das war Versuch 4 von 3" wäre eine Grenze, die niemand
+		 * durchsetzt.
+		 */
+		it('behauptet oberhalb der Bezugsgröße keine Grenze mehr', () => {
+			render(SubmitStatus, { state: 'failed', attempt: 4, maxAttempts: 3 });
+
+			const text = block('submit-status-failed')?.textContent ?? '';
+			expect(text).toContain('Das war Versuch 4.');
+			expect(text).not.toContain('von 3');
+		});
+
+		it('setzt die übergebene Überschrift ein', () => {
+			render(SubmitStatus, { state: 'failed', title: 'Zu viele Übermittlungen' });
+
+			expect(block('submit-status-failed')?.textContent).toContain('Zu viele Übermittlungen');
+		});
+
+		it('löst über die Schaltfläche einen erneuten Versuch aus', async () => {
+			const onRetry = vi.fn();
+			render(SubmitStatus, { state: 'failed', onRetry });
+
+			const button = block('submit-status-failed')?.querySelector('button');
+			button?.click();
+			await tick();
+
+			expect(onRetry).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('partial', () => {
+		/**
+		 * Der einzige Zustand, der die Datenzusage nicht geben kann: Die Aufnahme
+		 * liegt schon auf dem Server.
+		 */
+		it('gibt keine uneingeschränkte Datenzusage', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			const text = block('submit-status-partial')?.textContent ?? '';
+			expect(text).toContain('liegt bereits bei uns');
+			expect(text).not.toContain('bleiben vollständig gespeichert');
+		});
+
+		/**
+		 * Die Frist stammt aus derselben Konstante, aus der `UPLOAD_NOTICE` an der
+		 * Dropzone schöpft und nach der das Aufräum-Tool tatsächlich löscht — eine
+		 * fest hineingeschriebene Zahl könnte davon abweichen.
+		 */
+		it('nennt genau die Frist, die auch tatsächlich angewendet wird', () => {
+			render(SubmitStatus, { state: 'partial' });
+
+			expect(block('submit-status-partial')?.textContent).toContain(
+				`${ORPHAN_RETENTION_HOURS} Stunden`
+			);
+		});
+
+		/**
+		 * Regression: Eine Meldung mit angehängter Aufnahme landet IMMER in
+		 * `partial` — auch bei einer inhaltlichen Ablehnung. Solange dieser Zweig
+		 * `title` nicht rendert, verschwindet der eigentliche Grund („E-Mail
+		 * ungültig") hinter dem Aufbewahrungshinweis und der Nutzer wiederholt
+		 * ins Leere.
+		 */
+		it('nennt auch hier den Grund des Fehlschlags', () => {
+			render(SubmitStatus, {
+				state: 'partial',
+				title: 'Validierungsfehler bei der Eingabe',
+				attempt: 1
+			});
+
+			const text = block('submit-status-partial')?.textContent ?? '';
+			expect(text).toContain('Validierungsfehler bei der Eingabe');
+			expect(text).toContain('Das war Versuch 1 von 3.');
+		});
+	});
+
+	/**
+	 * Regression: Der Offline-Zustand kann aus einem einzelnen gescheiterten
+	 * Request abgeleitet sein und dann falsch liegen — `fetch` wirft denselben
+	 * TypeError bei einem Server-Neustart. Ohne Ausweg bliebe der Nutzer bis zum
+	 * Neuladen gefangen, denn ohne `online`-Ereignis hebt nichts den Zustand auf.
+	 */
+	describe('Ausweg aus dem Offline-Zustand', () => {
+		it('bietet einen Versuch an, wenn der Aufrufer einen Handler übergibt', async () => {
+			const onRetry = vi.fn();
+			render(SubmitStatus, { state: 'offline', onRetry });
+
+			const button = block('submit-status-offline')?.querySelector('button');
+			expect(button?.textContent).toContain('Trotzdem versuchen');
+
+			button?.click();
+			await tick();
+
+			expect(onRetry).toHaveBeenCalledOnce();
+		});
+
+		it('zeigt keine Schaltfläche, wenn die Sperre sicher ist', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.querySelector('button')).toBeNull();
+		});
+	});
+
+	describe('submitting', () => {
+		it('trägt keine Statusfarbe — ein Ladevorgang ist keine Warnung', () => {
+			render(SubmitStatus, { state: 'submitting' });
+
+			const element = block('submit-status-submitting');
+			expect(element?.className).not.toMatch(/alert-(warning|error|info|success)/);
+			expect(element?.getAttribute('role')).toBe('status');
+		});
+	});
+
+	/**
+	 * Die Komponente verschwindet nie von selbst — anders als der Toast, den sie
+	 * ersetzt. Wer den Fehler wegbekommen will, sendet erneut.
+	 */
+	it('verschwindet nicht von selbst', async () => {
+		vi.useFakeTimers();
+		render(SubmitStatus, { state: 'failed' });
+
+		expect(block('submit-status-failed')).not.toBeNull();
+
+		await vi.advanceTimersByTimeAsync(60_000);
+		await tick();
+
+		expect(block('submit-status-failed')).not.toBeNull();
+	});
+});

--- a/src/lib/stores/connectionState.svelte.ts
+++ b/src/lib/stores/connectionState.svelte.ts
@@ -1,0 +1,117 @@
+/**
+ * Verbindungszustand der Anwendung.
+ *
+ * `navigator.onLine` allein reicht hier nicht: Es meldet nur, ob eine
+ * Netzwerkschnittstelle aktiv ist, nicht ob das Internet erreichbar ist. WLAN an
+ * Bord ohne Uplink meldet `true` — und ist für dieses Projekt der Regelfall,
+ * nicht die Ausnahme.
+ *
+ * Der Zustand wird deshalb aus zwei Quellen gebildet:
+ *
+ * | Quelle                     | Aussagekraft                          | Rolle           |
+ * | -------------------------- | ------------------------------------- | --------------- |
+ * | `navigator.onLine`         | Schnittstelle aktiv (notwendig)       | Vorab-Signal    |
+ * | Ergebnis eines echten POST | Server erreichbar (hinreichend)       | Letztes Wort    |
+ *
+ * Ein gescheiterter Request setzt den Zustand auf offline; erst ein
+ * erfolgreicher Request oder ein `online`-Event des Browsers hebt ihn wieder auf.
+ *
+ * **SSR:** Modulweiter `$state` wird auf dem Server zwischen Requests geteilt.
+ * Hier ist das unkritisch — der Wert trägt keine Nutzerdaten und startet immer
+ * als „online". Verändert wird er ausschließlich im Browser: über
+ * `watchConnection()` (an Ereignisse gebunden) und über die Rückmeldungen aus
+ * echten Requests.
+ */
+
+import { browser } from '$app/environment';
+
+/** Meldung des Browsers: Ist überhaupt eine Netzwerkschnittstelle aktiv? */
+let interfaceUp = $state(true);
+
+/** Was der letzte echte Request über die Erreichbarkeit gesagt hat. */
+let lastRequest = $state<'unknown' | 'reachable' | 'unreachable'>('unknown');
+
+export const connection = {
+	/**
+	 * `true`, wenn abgesendete Daten den Server nicht erreichen würden.
+	 *
+	 * Beide Quellen dürfen das auslösen: eine abgeschaltete Schnittstelle ist ein
+	 * sicheres Nein, ein gescheiterter Request ebenfalls.
+	 */
+	get isOffline(): boolean {
+		return !interfaceUp || lastRequest === 'unreachable';
+	},
+
+	/**
+	 * `true` nur, wenn der Browser die Schnittstelle selbst als abgeschaltet
+	 * meldet — das ist ein **sicheres** Nein.
+	 *
+	 * Der Unterschied zu {@link isOffline} entscheidet, ob die Anwendung das
+	 * Absenden vorab sperren darf. Ein gescheiterter Request ist ein starkes
+	 * Indiz, aber kein Beweis: `isNetworkFailure()` in `submitSightingForm`
+	 * wertet jeden `TypeError` von `fetch` als Verbindungsproblem, und den wirft
+	 * `fetch` auch bei `ERR_CONNECTION_REFUSED` (Server startet neu), bei
+	 * CORS-Fehlern und bei DNS-Aussetzern. In all diesen Fällen bleibt
+	 * `navigator.onLine` auf `true` und es feuert **nie** ein `online`-Ereignis,
+	 * das den Zustand wieder aufheben könnte.
+	 *
+	 * Würde die Sperre an `isOffline` hängen, käme der Nutzer aus ihr nur durch
+	 * ein Neuladen wieder heraus — und verlöre damit genau die Sicherheit, die
+	 * der Offline-Hinweis ihm zusagt. Gesperrt wird deshalb nur beim sicheren
+	 * Nein; im Verdachtsfall bleibt „Trotzdem versuchen" erreichbar.
+	 */
+	get isInterfaceDown(): boolean {
+		return !interfaceUp;
+	},
+
+	/** Ein Request kam durch — überstimmt jedes ältere Signal. */
+	reportReachable(): void {
+		lastRequest = 'reachable';
+		interfaceUp = true;
+	},
+
+	/** Ein Request scheiterte am Netz (`status: 'offline'` aus `submitSightingForm`). */
+	reportUnreachable(): void {
+		lastRequest = 'unreachable';
+	},
+
+	/**
+	 * Setzt nur die Request-Historie zurück, nicht das Browser-Signal.
+	 * Gedacht für Tests und für das `online`-Ereignis, nach dem die alte
+	 * Erfahrung nichts mehr über die neue Verbindung aussagt.
+	 */
+	reset(): void {
+		lastRequest = 'unknown';
+		interfaceUp = browser ? navigator.onLine : true;
+	}
+};
+
+/**
+ * Bindet den Zustand an die `online`/`offline`-Ereignisse des Browsers.
+ *
+ * Gibt die Abmeldefunktion zurück, damit sie direkt aus einem `$effect`
+ * verwendet werden kann. Auf dem Server ein No-op.
+ */
+export function watchConnection(): () => void {
+	if (!browser) return () => {};
+
+	interfaceUp = navigator.onLine;
+
+	const handleOnline = (): void => {
+		interfaceUp = true;
+		// Die alte Erfahrung gilt nicht mehr: Es ist eine neue Verbindung, und ob
+		// sie trägt, weiß erst der nächste echte Request.
+		lastRequest = 'unknown';
+	};
+	const handleOffline = (): void => {
+		interfaceUp = false;
+	};
+
+	window.addEventListener('online', handleOnline);
+	window.addEventListener('offline', handleOffline);
+
+	return () => {
+		window.removeEventListener('online', handleOnline);
+		window.removeEventListener('offline', handleOffline);
+	};
+}

--- a/src/lib/stores/connectionState.svelte.ts
+++ b/src/lib/stores/connectionState.svelte.ts
@@ -31,6 +31,34 @@ let interfaceUp = $state(true);
 /** Was der letzte echte Request über die Erreichbarkeit gesagt hat. */
 let lastRequest = $state<'unknown' | 'reachable' | 'unreachable'>('unknown');
 
+/**
+ * Wie lange „Wieder online" stehen bleibt.
+ *
+ * Das ist die eine Stelle in diesem Regelwerk, an der ein flüchtiger Hinweis
+ * richtig ist: Er verlangt keine Handlung, er nimmt nur eine Sorge weg. Ein
+ * Dauer-Indikator für „online" dagegen sagt 99 % der Zeit dasselbe und wird
+ * deshalb nicht gelesen.
+ */
+const RECONNECTED_NOTICE_MS = 4000;
+
+let reconnected = $state(false);
+let reconnectedTimer: ReturnType<typeof setTimeout> | null = null;
+
+/** Zeigt „Wieder online", aber nur wenn es vorher wirklich offline war. */
+function noteReconnection(wasOffline: boolean): void {
+	if (!browser || !wasOffline) return;
+
+	reconnected = true;
+	// Gegen `null` prüfen, nicht auf truthy: Der Typ lässt jeden `number` zu, und
+	// `0` wäre falsy. (Die HTML-Spezifikation verlangt zwar einen Handle > 0, aber
+	// der Vertrag hier ist der Typ, nicht die Spezifikation eines Zielsystems.)
+	if (reconnectedTimer !== null) clearTimeout(reconnectedTimer);
+	reconnectedTimer = setTimeout(() => {
+		reconnected = false;
+		reconnectedTimer = null;
+	}, RECONNECTED_NOTICE_MS);
+}
+
 export const connection = {
 	/**
 	 * `true`, wenn abgesendete Daten den Server nicht erreichen würden.
@@ -64,10 +92,22 @@ export const connection = {
 		return !interfaceUp;
 	},
 
+	/**
+	 * `true` für {@link RECONNECTED_NOTICE_MS} nach der Rückkehr aus dem
+	 * Offline-Zustand — und nur dann. Wer nie offline war, sieht nichts.
+	 */
+	get justReconnected(): boolean {
+		return reconnected;
+	},
+
 	/** Ein Request kam durch — überstimmt jedes ältere Signal. */
 	reportReachable(): void {
+		// Kein `this`: Die Methode soll auch nach einer Destrukturierung
+		// (`const { reportReachable } = connection`) funktionieren.
+		const wasOffline = !interfaceUp || lastRequest === 'unreachable';
 		lastRequest = 'reachable';
 		interfaceUp = true;
+		noteReconnection(wasOffline);
 	},
 
 	/** Ein Request scheiterte am Netz (`status: 'offline'` aus `submitSightingForm`). */
@@ -83,6 +123,11 @@ export const connection = {
 	reset(): void {
 		lastRequest = 'unknown';
 		interfaceUp = browser ? navigator.onLine : true;
+		reconnected = false;
+		if (reconnectedTimer !== null) {
+			clearTimeout(reconnectedTimer);
+			reconnectedTimer = null;
+		}
 	}
 };
 
@@ -98,10 +143,12 @@ export function watchConnection(): () => void {
 	interfaceUp = navigator.onLine;
 
 	const handleOnline = (): void => {
+		const wasOffline = connection.isOffline;
 		interfaceUp = true;
 		// Die alte Erfahrung gilt nicht mehr: Es ist eine neue Verbindung, und ob
 		// sie trägt, weiß erst der nächste echte Request.
 		lastRequest = 'unknown';
+		noteReconnection(wasOffline);
 	};
 	const handleOffline = (): void => {
 		interfaceUp = false;

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -25,8 +25,11 @@
   Nur in dev erreichbar (siehe +page.server.ts daneben).
 -->
 <script lang="ts">
+	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 	import StatusBlock from '$lib/components/StatusBlock.svelte';
+	import SubmitStatus from '$lib/report/components/form/SubmitStatus.svelte';
+	import { connection } from '$lib/stores/connectionState.svelte';
 	/* Importiert statt abgeschrieben: die Marker-Palette ist Datenkodierung mit
 	   genau einer Quelle (design-system.md, „Randbereiche: wo Hex-Werte erlaubt
 	   sind"). Eine zweite Liste hier hätte den Absatz darunter — der
@@ -408,6 +411,77 @@
 				action={{ label: 'Erneut versuchen', onClick: () => {} }}
 			/>
 		</div>
+	</section>
+
+	<!-- ══ SubmitStatus ══ -->
+	<section class="mb-10">
+		<h2 class="text-title mb-1 font-bold">SubmitStatus</h2>
+		<p class="text-support text-base-content/70 mb-4">
+			Zustandsfläche direkt über „Absenden" — der Ersatz für den früheren Fehler-Toast. Sie
+			verschwindet <strong>nie</strong> von selbst: Ein gescheitertes Absenden verlangt eine
+			Handlung, und die gehört an den Ort der Handlung. Jeder Fehlerzustand nennt außerdem das
+			Schicksal der Daten; einzige Ausnahme ist <code>partial</code>, wo die Aufnahme schon auf dem
+			Server liegt. <code>idle</code> rendert nichts und fehlt deshalb hier.
+		</p>
+		<div>
+			<SubmitStatus state="submitting" />
+			<SubmitStatus state="offline" onRetry={() => {}} />
+			<SubmitStatus state="failed" attempt={2} referenceId="a7f3c1e9" onRetry={() => {}} />
+			<SubmitStatus
+				state="partial"
+				title="Die E-Mail-Adresse wurde nicht akzeptiert."
+				attempt={1}
+				referenceId="a7f3c1e9"
+				onRetry={() => {}}
+			/>
+		</div>
+	</section>
+
+	<!-- ══ ConnectionBadge ══ -->
+	<section class="mb-10">
+		<h2 class="text-title mb-1 font-bold">ConnectionBadge</h2>
+		<p class="text-support text-base-content/70 mb-4">
+			Ein Zustand, kein Alarm — sichtbar nur ohne Verbindung. Für „online" gibt es bewusst keinen
+			Dauer-Indikator: Was 99 % der Zeit dasselbe sagt, wird nicht gelesen. „Wieder online" ist die
+			eine Stelle, an der ein verschwindender Hinweis richtig ist.
+		</p>
+		<p class="text-support text-base-content/70 mb-4">
+			Deshalb steht hier <strong>kein nachgebauter Beispiel-Zustand</strong>, sondern die echte
+			Komponente am echten Zustand (<code>connectionState.svelte.ts</code>). Ein zweiter,
+			handgeschriebener Aufbau wäre beim ersten Wechsel an der Komponente falsch — und der Zustand
+			kommt nicht aus <code>navigator.onLine</code> allein, ließe sich also auch nicht per Prop ehrlich
+			vortäuschen. Die Schaltflächen unten setzen denselben Zustand, den ein gescheiterter Request setzt;
+			das Abzeichen in der Navbar reagiert mit.
+		</p>
+		<div class="flex flex-wrap items-center gap-2">
+			<button
+				type="button"
+				class="btn btn-outline btn-sm"
+				onclick={() => connection.reportUnreachable()}
+			>
+				Offline melden
+			</button>
+			<button
+				type="button"
+				class="btn btn-outline btn-sm"
+				onclick={() => connection.reportReachable()}
+			>
+				Wieder erreichbar melden
+			</button>
+			<button type="button" class="btn btn-ghost btn-sm" onclick={() => connection.reset()}>
+				Zurücksetzen
+			</button>
+		</div>
+		<div class="mt-3 space-y-2">
+			<ConnectionBadge announce={false} />
+			<ConnectionBadge announce={false} compact />
+		</div>
+		{#if !connection.isOffline && !connection.justReconnected}
+			<p class="text-support text-base-content/70 mt-3">
+				Zurzeit online — beide Abzeichen rendern nichts und kosten keinen Platz. Das ist der
+				Normalfall, nicht ein fehlendes Beispiel.
+			</p>
+		{/if}
 	</section>
 
 	<!-- ══ Formularfelder ══ -->

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -26,6 +26,7 @@
 -->
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
+	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	/* Importiert statt abgeschrieben: die Marker-Palette ist Datenkodierung mit
 	   genau einer Quelle (design-system.md, „Randbereiche: wo Hex-Werte erlaubt
 	   sind"). Eine zweite Liste hier hätte den Absatz darunter — der
@@ -368,6 +369,44 @@
 				<Icon icon="lucide:circle-alert" class="shrink-0" aria-hidden="true" />
 				<span>Bitte beheben Sie die 2 Fehler in „Position &amp; Zeit".</span>
 			</div>
+		</div>
+	</section>
+
+	<!-- ══ StatusBlock ══ -->
+	<section class="mb-10">
+		<h2 class="text-title mb-1 font-bold">StatusBlock</h2>
+		<p class="text-support text-base-content/70 mb-4">
+			Inline-Statusfläche für jede Oberfläche, die Daten lädt — nie als Overlay, sondern an der
+			Stelle, an der die Daten stünden. <code>loading</code> und <code>empty</code> tragen bewusst
+			<strong>keine</strong>
+			Statusfarbe: Ein Ladevorgang ist keine Warnung, ein Filter ohne Treffer kein Fehler.
+			<code>role</code>
+			ist <code>alert</code> nur bei <code>failed</code> — der Folge einer Nutzeraktion.
+		</p>
+		<div class="space-y-3">
+			<StatusBlock variant="loading" title="Sichtungen werden geladen …" />
+			<StatusBlock
+				variant="empty"
+				title="Keine Sichtungen in diesem Zeitraum"
+				description="Für 2026 liegen zwischen 1. Mai und 3. Mai keine freigegebenen Meldungen vor."
+				action={{ label: 'Zeitraum zurücksetzen', onClick: () => {}, icon: 'lucide:rotate-ccw' }}
+			/>
+			<StatusBlock
+				variant="partial"
+				title="Wetterdaten aus dem Zwischenspeicher"
+				description="Der Wetterdienst antwortet gerade nicht. Angezeigt werden die zuletzt abgerufenen Werte."
+			/>
+			<StatusBlock
+				variant="failed"
+				title="Statistiken konnten nicht geladen werden"
+				description="Das Formular funktioniert vollständig — nur die Zahlen in diesem Hilfetext fehlen."
+			/>
+			<StatusBlock
+				variant="offline"
+				title="Kartenmaterial braucht eine Verbindung"
+				description="Bereits geladene Kacheln bleiben sichtbar. Neue Bereiche erscheinen, sobald Sie wieder online sind."
+				action={{ label: 'Erneut versuchen', onClick: () => {} }}
+			/>
 		</div>
 	</section>
 


### PR DESCRIPTION
`SubmitStatus`, `StatusBlock` und `ConnectionBadge` waren mit #625/#626/#627 gebaut und getestet, sind aber **nie in `main` angekommen**: Die vier PRs des Stapels wurden jeweils in ihren Vorgänger gemerged, nur #623 (`fix/error-state-bugs`) erreichte `main`. Die Spitze blieb auf `origin/feat/connection-badge` stehen. #634 hält das als „Reihenfolge-Hinweis" fest und ist deshalb blockiert:

> Solange #625/#626 nicht in `main` sind, hat dieses Issue keine Bausteine.

Dieser PR bringt den Stapel auf den aktuellen `main` (4 Commits, `b91e6d6` als bereits angewendet übersprungen) und legt einen fünften obendrauf.

## Was hinzukommt

| Baustein                                             | Rolle                                                                       |
| ---------------------------------------------------- | --------------------------------------------------------------------------- |
| `src/lib/report/components/form/SubmitStatus.svelte` | Zustandsfläche über „Absenden" — Ersatz für den Fehler-Toast, verschwindet nie von selbst |
| `src/lib/components/StatusBlock.svelte`              | Inline-Statusfläche (`loading`/`empty`/`partial`/`failed`/`offline`), nie als Overlay |
| `src/lib/components/ConnectionBadge.svelte`          | Verbindungszustand, sichtbar nur ohne Verbindung                            |
| `src/lib/stores/connectionState.svelte.ts`           | Zustand aus zwei Quellen — `navigator.onLine` **und** echte Request-Ergebnisse |

Aufrufstellen: `SightingsMapView` (zwei Leer-Zustände), `WeatherDataFetcher` (Prognosehinweis), `FormHelp` (fehlgeschlagene Statistiken), `PublicNavbar` + `StepProgressCompact` (Abzeichen). `LoadingOverlay` verliert die drei blockierenden Varianten, die keine Aufrufstelle hatten.

## Gegen die verschärften Regeln geprüft

Zwischen dem Bau und heute liegen #632, #636, #637 und #639. Alle vier Punkte einzeln nachgesehen:

- **`white`/`black` verboten, Deckkraft-Suffixe werden gefangen (#637):** kein Treffer in den neuen Dateien.
- **`fill-`/`stroke-` (#641):** kein Treffer. Verifiziert nicht nur per `grep`, sondern indem der Commit aus #641 lokal auf diesen Stapel gesetzt und `e2e/design-tokens.spec.ts` damit gefahren wurde — **66/66 grün**. Deshalb ist die Reihenfolge #641 → dieser PR; danach läuft der Scan in CI ohnehin gegen die endgültige Regel.
- **Geänderte `-strong`-Werte** (u. a. `info-strong` auf `oklch(0.46 0.12 230)`): greifen über die Utilities automatisch. Die Statusflächen laufen über `alert-*`; die einzigen `-strong`-Vordergründe sitzen im `ConnectionBadge` auf `bg-base-200/95` — also auf `base-200` und nicht auf dem verbotenen `base-300`.
- **`scrim`-Token (#637), den es beim Bauen noch nicht gab:** **keiner der drei Bausteine ist ein Kandidat.** Alle drei sind Inline-Flächen; der Kopfkommentar von `StatusBlock` verwirft das Overlay ausdrücklich („Ein Overlay über der ganzen Fläche nimmt bei jedem Ladevorgang die Bedienung aus der Hand"). Die Overlays, die der Stapel anfasst (`LoadingOverlay`, `SightingsMapView`), tragen `bg-scrim` bereits aus `main` — der Rebase hat das erhalten. Der Leer-Zustand über den Kartenkacheln bekommt bewusst `bg-base-100` und keinen Schleier: dort soll nichts durchscheinen, sondern gelesen werden (`design-system.md`, „Ein Schleier ist nicht dasselbe wie eine Fläche, die zufällig hell sein muss").

## `/styleguide`

`StatusBlock` stand schon dort. `SubmitStatus` kommt in allen vier sichtbaren Zuständen dazu (`idle` rendert nichts).

`ConnectionBadge` lässt sich nicht per Prop stellen — sein Zustand kommt aus `connectionState` und bewusst nicht aus `navigator.onLine` allein. Statt eines zweiten, handgeschriebenen Aufbaus, der beim ersten Wechsel an der Komponente falsch wäre, steht dort die **echte** Komponente am echten Zustand, mit drei Schaltflächen, die denselben Zustand setzen wie ein gescheiterter Request. Im Online-Fall rendert sie nichts, und ein Satz sagt, dass das der Normalfall ist und kein fehlendes Beispiel.

Zur Erwartung „sonst schlägt der Vollständigkeitstest an": Der Test „Utilities haben einen Vertreter auf /styleguide" prüft **Utilities aus `tokens.css`**, keine Komponenten — er wäre also auch ohne diese Einträge grün geblieben. Der Eintrag gehört trotzdem dorthin: Die Seite ist die Referenz für das Vokabular, auf das sich #634 beruft.

## Prüfung

- `npm run test:quick` — 158 Dateien grün
- `npm run test:unit:client` — 19 Dateien / 219 Tests grün (inkl. der drei neuen Komponenten-Testdateien)
- `npm run check` — 0 Fehler; die eine Warnung (`tabindex` in `SightingsMapView`) steht so schon in `main`
- Playwright `design-tokens` + `submit-offline` + `form-submit` — 83/83 grün
- Visuell auf `/styleguide` geprüft: alle vier `SubmitStatus`-Zustände, beide Badge-Varianten offline **und** im „Wieder online"-Fenster; das Abzeichen in der Navbar reagiert mit.

Schließt die Bausteinlücke aus #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
