### PR TITLE
fix(ci): run E2E tests for PRs that only touch e2e/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
 
     outputs:
-      needs-e2e: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.dependencies == 'true' || github.event_name == 'push' }}
+      needs-e2e: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.dependencies == 'true' || steps.filter.outputs.e2e == 'true' || github.event_name == 'push' }}
       has-code-changes: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.backend == 'true' }}
       needs-migration-check: ${{ steps.filter.outputs.db-schema == 'true' || steps.filter.outputs.db-migrations == 'true' }}
 
@@ -46,6 +46,28 @@ jobs:
             backend:
               - 'src/routes/api/**'
               - 'src/lib/server/**'
+            # Die Tests selbst sind Code. Ohne diesen Filter fiel ein PR, der nur
+            # unter `e2e/` änderte, in den Doc-Only-Fall: `needs-e2e` blieb false,
+            # und `E2E Tests` wie `Component Tests` wurden übersprungen. Genau so
+            # liefen #636 und #641 durch — beide verschärften die Scan-Regel in
+            # `e2e/helpers/bannedClasses.ts`, aber nur deren Unit-Test lief (über
+            # `Validate` → `npm run test:unit`, das `e2e/helpers/*.test.ts`
+            # einsammelt, siehe vitest.config.ts). Der DOM-Scan in
+            # `e2e/design-tokens.spec.ts` — der Teil, der die Reichweite der Regel
+            # gegen die echten Routen prüft — lief nie.
+            #
+            # `scripts/seed-e2e.ts` gehört dazu, weil der E2E-Job es als
+            # „Seed E2E test data" ausführt; sonst wäre eine kaputte Seed-Datei
+            # ungetestet gemergt. `playwright.config.ts` und `vite.config.ci.ts`
+            # stehen hier der Klarheit halber, obwohl `frontend` sie über
+            # `*.config.ts` heute schon einfängt — dieser Filter soll die
+            # E2E-Eingaben vollständig benennen, nicht auf einen Zufallstreffer
+            # bauen.
+            e2e:
+              - 'e2e/**'
+              - 'playwright.config.ts'
+              - 'vite.config.ci.ts'
+              - 'scripts/seed-e2e.ts'
             docs:
               - '*.md'
               - 'docs/**'

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -31,6 +31,13 @@ import { formatRatio, measureContrast } from './helpers/contrast';
  * Dieser Test hätte die beiden kritischen Befunde des Reviews am Tag ihrer
  * Entstehung gefunden: weißer Text auf warning (3,26:1) und auf secondary
  * (3,19:1).
+ *
+ * Damit er das auch in CI tut, muss er dort laufen: Bis zum `e2e`-Filter in
+ * `.github/workflows/ci.yml` galt ein PR, der nur `e2e/` anfasste, als
+ * Doc-Only — `needs-e2e` blieb false und dieser Scan wurde übersprungen. In
+ * #636 und #641 wurde deshalb die Regel in `helpers/bannedClasses.ts`
+ * verschärft, ohne dass ihre Reichweite je gegen die echten Routen lief;
+ * grün war nur der Unit-Test der Regel.
  */
 
 const AA_TEXT = 4.5;
@@ -425,10 +432,7 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 	   die SvelteKit-Fehlerseite liefern ein DOM, in dem keine einzige verbotene
 	   Kombination steht — die Prüfung meldete dann grün, ohne je die Seite
 	   gesehen zu haben, um die es geht. */
-	const openRoute = async (
-		{ page, context, request, baseURL }: ScanFixtures,
-		route: ScanRoute
-	) => {
+	const openRoute = async ({ page, context, request, baseURL }: ScanFixtures, route: ScanRoute) => {
 		/* Seit dem 2026-07-30 fährt der E2E-Job einen Postgres-Service samt
 		   Migrationen und Seed (ci.yml, Job `e2e`). Dieser Zweig ist damit **nur
 		   noch** der lokale Komfortpfad für einen Lauf ohne `npm run db:start`.
@@ -512,10 +516,7 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			}))
 		);
 
-	const scanRoute = async (
-		fixtures: ScanFixtures,
-		route: ScanRoute
-	): Promise<ScannedElement[]> => {
+	const scanRoute = async (fixtures: ScanFixtures, route: ScanRoute): Promise<ScannedElement[]> => {
 		await openRoute(fixtures, route);
 
 		for (const probe of route.renders ?? []) {


### PR DESCRIPTION
## Problem

`needs-e2e` ([ci.yml:22](.github/workflows/ci.yml#L22)) wurde aus `frontend`, `backend` und `dependencies` abgeleitet. Für `e2e/**` gab es **keinen** Filter — ein PR, der nur unter `e2e/` änderte, fiel in den Doc-Only-Fall und übersprang `E2E Tests`, `Component Tests` und `Compliance Check`.

Zwei reale Fälle: #636 und #641. Beide verschärften die Scan-Regel in `e2e/helpers/bannedClasses.ts`, aber in CI lief davon nur der Unit-Test — über `Validate` → `npm run test:unit`, das `e2e/helpers/*.test.ts` mit einsammelt ([vitest.config.ts:87](vitest.config.ts#L87)). Der DOM-Scan in `e2e/design-tokens.spec.ts`, also genau der Teil, der die *Reichweite* der Regel gegen die sieben echten Routen prüft, lief in beiden PRs nie.

## Änderung

Neuer Filter `e2e`, aufgenommen in den `needs-e2e`-Ausdruck:

| Pfad | Warum |
| --- | --- |
| `e2e/**` | Die Specs und Helper selbst |
| `scripts/seed-e2e.ts` | Der E2E-Job führt es als „Seed E2E test data" aus — bisher von **keinem** Filter abgedeckt |
| `playwright.config.ts`, `vite.config.ci.ts` | Heute schon zufällig über `frontend` → `*.config.ts` erfasst; hier explizit, damit der Filter die E2E-Eingaben vollständig benennt |

## `has-code-changes` — bewusst unverändert

Anders als in der Ausgangsanalyse vermutet gatet `has-code-changes` **nicht** `Compliance Check`: Der Job ([ci.yml:503](.github/workflows/ci.yml#L503)) hängt allein am Label `dependencies` bzw. am Branch-Präfix `dependabot/` und liest gar keinen `changes`-Output. `has-code-changes` schaltet ausschließlich die Coverage-Variante des Unit-Test-Schritts plus Artefakt-Upload. Da `coverage.include` auf `src/lib/**/*.ts` steht, bewegt eine reine e2e-Änderung dort keine Zeile — `e2e` dort aufzunehmen würde nur einen Coverage-Lauf und einen 30-Tage-Artefakt-Upload ohne Aussage kosten.

## Verifikation

Dieser PR ist der Test. `pull_request`-Workflows laufen aus dem Merge-Ref, also mit dem `ci.yml` **dieses** PRs. Geändert sind nur `.github/workflows/ci.yml` (matcht keinen einzigen Filter) und `e2e/design-tokens.spec.ts`. `frontend`, `backend` und `dependencies` bleiben damit alle `false` — wenn `E2E Tests` und `Component Tests` hier laufen, kann das nur der neue `e2e`-Filter ausgelöst haben. Vor dieser Änderung wären beide übersprungen worden.

Die Änderung an `design-tokens.spec.ts` ist ein Kommentar im Datei-Header, der die geschlossene Lücke dort festhält. (Zwei benachbarte Funktionssignaturen hat der Prettier-Hook beim Speichern eingeklappt — mechanisch, ohne Verhaltensänderung.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)