### PR TITLE
feat(report): Feldfehler des Servers durchreichen und zum Feld springen

### DIFF
--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -301,6 +301,84 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 		});
 	});
 
+	/**
+	 * Der Sprung zum abgelehnten Feld.
+	 *
+	 * `message` ist bei einem `VALIDATION_ERROR` immer derselbe Satz und nennt
+	 * kein Feld — der Nutzer stand vorher auf Schritt 4 vor „Validierungsfehler
+	 * bei der Eingabe" und hatte keinen Hinweis, dass das gemeinte Feld zwei
+	 * Schritte zurück liegt. Die Feldkarte aus `errors` macht daraus ein Ziel.
+	 */
+	test('Feldfehler: Server nennt ein Feld aus Schritt 1 — Formular springt dorthin', async ({
+		page
+	}) => {
+		await page.route('**/api/sightings', (route) => {
+			route.fulfill({
+				status: 400,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe',
+					errors: { waterway: 'Fahrwasser darf höchstens 100 Zeichen haben' }
+				})
+			});
+		});
+
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await fillAllSteps(formPage, page);
+		await formPage.clickSubmit();
+
+		// Zurück auf Schritt 1 — dort steht das abgelehnte Feld
+		await expectCurrentStep(page, /Position & Zeit/i);
+
+		// Das Feld trägt die Meldung des Servers selbst …
+		const waterway = page.locator('[data-testid="field-waterway"]');
+		await expect(page.getByText('Fahrwasser darf höchstens 100 Zeichen haben')).toBeVisible({
+			timeout: 5000
+		});
+		await expect(waterway).toHaveAttribute('aria-invalid', 'true');
+
+		// … und bekommt den Fokus (fieldNavigation fokussiert nach ~500 ms)
+		await expect(waterway).toBeFocused({ timeout: 5000 });
+
+		// Der Zustand über der Navigation bleibt bestehen — er trägt Referenz und
+		// Wiederholen, das Feld trägt den Grund.
+		await expect(page.locator('[data-testid="submit-status-failed"]')).toBeVisible();
+	});
+
+	test('Feldfehler auf dem aktuellen Schritt: kein Sprung, Feld zeigt den Grund', async ({
+		page
+	}) => {
+		await page.route('**/api/sightings', (route) => {
+			route.fulfill({
+				status: 400,
+				contentType: 'application/json',
+				body: JSON.stringify({
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe',
+					errors: { email: 'Diese E-Mail-Adresse ist bereits gesperrt' }
+				})
+			});
+		});
+
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await fillAllSteps(formPage, page);
+		await formPage.clickSubmit();
+
+		await expectCurrentStep(page, /Kontaktdaten/i);
+		await expect(page.getByText('Diese E-Mail-Adresse ist bereits gesperrt')).toBeVisible({
+			timeout: 5000
+		});
+		await expect(page.locator('[data-testid="field-email"]')).toHaveAttribute(
+			'aria-invalid',
+			'true'
+		);
+	});
+
 	test('Netzwerkfehler: Route abgebrochen — als Verbindungsproblem erkannt', async ({ page }) => {
 		await page.route('**/api/sightings', (route) => {
 			route.abort('connectionrefused');

--- a/src/lib/form/submitSightingForm.test.ts
+++ b/src/lib/form/submitSightingForm.test.ts
@@ -222,6 +222,120 @@ describe('submitSightingForm', () => {
 				httpStatus: 400
 			});
 		});
+
+		/**
+		 * Der eigentliche Punkt: `message` ist bei `VALIDATION_ERROR` immer derselbe
+		 * Satz („Validierungsfehler bei der Eingabe") und nennt kein Feld. Welches
+		 * Feld gemeint ist, steht ausschließlich in `errors` — wird das verworfen,
+		 * kann die Oberfläche nicht zum Feld springen.
+		 */
+		it('reicht die Feldkarte eines Validierungsfehlers durch', async () => {
+			mockResponse({
+				status: 400,
+				body: {
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe',
+					errors: {
+						waterway: 'Fahrwasser darf höchstens 100 Zeichen haben',
+						email: 'Bitte geben Sie eine gültige E-Mail-Adresse an'
+					}
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'rejected',
+				message: 'Validierungsfehler bei der Eingabe',
+				fields: {
+					waterway: 'Fahrwasser darf höchstens 100 Zeichen haben',
+					email: 'Bitte geben Sie eine gültige E-Mail-Adresse an'
+				}
+			});
+		});
+
+		/**
+		 * `INVALID_FIELDS` (ebenfalls 400) trägt statt `errors` nur die nackten
+		 * Feldnamen in `rejectedFields` — die Whitelist-Prüfung kennt keine Meldung
+		 * pro Feld. Damit die Aufrufstelle beide Fälle gleich behandeln kann,
+		 * entsteht daraus dieselbe Feldkarte; den Text stellt der Client.
+		 */
+		it('macht aus rejectedFields dieselbe Feldkarte', async () => {
+			mockResponse({
+				status: 400,
+				body: {
+					success: false,
+					code: 'INVALID_FIELDS',
+					message: 'Unerlaubte Felder: nickname',
+					rejectedFields: ['nickname']
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'rejected',
+				message: 'Unerlaubte Felder: nickname',
+				fields: { nickname: 'Dieses Feld darf nicht mitgesendet werden' }
+			});
+		});
+
+		/**
+		 * Die dritte Quelle, und die einzige mit einem anderen Status:
+		 * `checkForbiddenAdminFields` läuft VOR der Whitelist-Prüfung und antwortet
+		 * mit **403** und `forbiddenFields`. `verified` gehört hierher und kann
+		 * `rejectedFields` deshalb nie erreichen — die beiden Listen sind
+		 * disjunkt, nicht austauschbar.
+		 */
+		it('liest auch die forbiddenFields eines 403', async () => {
+			mockResponse({
+				status: 403,
+				body: {
+					success: false,
+					code: 'FORBIDDEN_FIELDS',
+					message: 'Die folgenden Felder dürfen nicht von Clients gesetzt werden: verified',
+					forbiddenFields: ['verified']
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'rejected',
+				message: 'Die folgenden Felder dürfen nicht von Clients gesetzt werden: verified',
+				fields: { verified: 'Dieses Feld darf nicht mitgesendet werden' }
+			});
+		});
+
+		/**
+		 * `exactOptionalPropertyTypes`: ohne Feldbezug fehlt die Eigenschaft, sie
+		 * steht nicht auf `undefined` — sonst müsste jede Aufrufstelle beides prüfen.
+		 */
+		it('lässt die Feldkarte weg, wenn der Server keine liefert', async () => {
+			mockResponse({
+				status: 422,
+				body: { success: false, code: 'DATABASE_ERROR', message: 'Die Daten konnten nicht …' }
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'rejected',
+				message: 'Die Daten konnten nicht …'
+			});
+		});
+
+		/** Ein Feld ohne Meldungstext ist kein Sprungziel — es würde leer anzeigen. */
+		it('überspringt Einträge ohne Meldungstext', async () => {
+			mockResponse({
+				status: 400,
+				body: {
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: 'Validierungsfehler bei der Eingabe',
+					errors: { waterway: '', email: 'Pflichtfeld' }
+				}
+			});
+
+			await expect(submitSightingForm(validFormValues)).resolves.toStrictEqual({
+				status: 'rejected',
+				message: 'Validierungsfehler bei der Eingabe',
+				fields: { email: 'Pflichtfeld' }
+			});
+		});
 	});
 
 	describe("status 'ratelimited'", () => {

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -50,10 +50,15 @@ export type SubmitResult =
 const FALLBACK_MESSAGE = 'Die Sichtung konnte nicht gespeichert werden';
 
 /**
- * Meldung für ein Feld aus `rejectedFields`/`forbiddenFields`. Der Server
- * liefert dort nur Feldnamen und begründet die Ablehnung gesammelt in `message`.
+ * Meldung für ein Feld aus einer der beiden Namenslisten des Servers —
+ * `rejectedFields` (400) **und** `forbiddenFields` (403). Der Server liefert
+ * dort nur Feldnamen und begründet die Ablehnung gesammelt in `message`.
+ *
+ * Der Name ist deshalb bewusst neutral gehalten und greift keine der beiden
+ * Listen auf: Ein `FORBIDDEN_…` hier würde beim Lesen so wirken, als gälte die
+ * Meldung nur für den 403er-Zweig.
  */
-const FORBIDDEN_FIELD_MESSAGE = 'Dieses Feld darf nicht mitgesendet werden';
+const DISALLOWED_FIELD_MESSAGE = 'Dieses Feld darf nicht mitgesendet werden';
 
 /** Antwortkörper der Sichtungs-API, soweit der Client ihn auswertet. */
 interface SightingApiResponse {
@@ -103,7 +108,7 @@ function readFieldErrors(body: SightingApiResponse | null): Record<string, strin
 
 	for (const field of [...(body?.rejectedFields ?? []), ...(body?.forbiddenFields ?? [])]) {
 		if (typeof field === 'string' && field.length > 0) {
-			fields[field] ??= FORBIDDEN_FIELD_MESSAGE;
+			fields[field] ??= DISALLOWED_FIELD_MESSAGE;
 		}
 	}
 

--- a/src/lib/form/submitSightingForm.ts
+++ b/src/lib/form/submitSightingForm.ts
@@ -31,30 +31,91 @@ import type { SightingFormValues } from '$lib/types/Form';
  * Wiederholen an; `describeSubmitFailure` unten macht aus jedem Fall den Satz,
  * den der Nutzer liest, und arbeitet `retryAfter` als Information in ihn ein.
  *
- * **Kein Feldbezug bei `rejected`, und das ist eine offene Lücke, kein
- * Entwurf.** Ein Sprung zum abgelehnten Feld wäre die richtige Reaktion, ist
- * aber mit diesem Typ nicht möglich: `rejected` trägt nur einen String, und der
- * lautet bei einem Validierungsfehler „Validierungsfehler bei der Eingabe".
- * Die Feldinformation existiert — `POST /api/sightings` liefert bei 400 ein
- * `errors: Record<pfad, meldung>` mit —, wird von `SightingApiResponse` unten
- * aber nicht gelesen. Wer den Sprung nachrüstet, erweitert dort und hier, nicht
- * am Server.
+ * **Feldbezug bei `rejected`.** `message` allein reicht dafür nicht: Bei einem
+ * Validierungsfehler lautet sie immer „Validierungsfehler bei der Eingabe" und
+ * nennt kein Feld — der Nutzer stand damit vor einem Satz, der ihm nicht sagte,
+ * wo er suchen soll, womöglich drei Schritte entfernt. `fields` trägt deshalb
+ * zusätzlich die Karte Feldname → Meldung, aus der die Aufrufstelle den Sprung
+ * zum ersten betroffenen Feld baut (`ModernReportForm.svelte`). Alle drei
+ * Quellen des Servers laufen darin zusammen, siehe {@link readFieldErrors}.
  */
 export type SubmitResult =
 	| { status: 'ok'; id: number }
 	| { status: 'offline' }
 	| { status: 'server'; httpStatus: number }
-	| { status: 'rejected'; message: string }
+	| { status: 'rejected'; message: string; fields?: Record<string, string> }
 	| { status: 'ratelimited'; retryAfter?: number };
 
 /** Fehlermeldung, die der Nutzer sieht, wenn der Server keine eigene liefert. */
 const FALLBACK_MESSAGE = 'Die Sichtung konnte nicht gespeichert werden';
+
+/**
+ * Meldung für ein Feld aus `rejectedFields`/`forbiddenFields`. Der Server
+ * liefert dort nur Feldnamen und begründet die Ablehnung gesammelt in `message`.
+ */
+const FORBIDDEN_FIELD_MESSAGE = 'Dieses Feld darf nicht mitgesendet werden';
 
 /** Antwortkörper der Sichtungs-API, soweit der Client ihn auswertet. */
 interface SightingApiResponse {
 	success?: boolean;
 	id?: number;
 	message?: string;
+	/** `code: 'VALIDATION_ERROR'` (400) — Yup-Pfad → Meldung, aus `abortEarly: false`. */
+	errors?: Record<string, string>;
+	/** `code: 'INVALID_FIELDS'` (400) — Feldnamen außerhalb der Whitelist. */
+	rejectedFields?: string[];
+	/** `code: 'FORBIDDEN_FIELDS'` (403) — Admin-Felder, die Clients nicht setzen dürfen. */
+	forbiddenFields?: string[];
+}
+
+/**
+ * Führt die drei Feld-Quellen des Servers zu einer Karte zusammen.
+ *
+ * `POST /api/sightings` benennt abgelehnte Felder auf drei Wegen, und sie sind
+ * disjunkt — welcher greift, entscheidet der Server vor allen anderen Prüfungen:
+ *
+ * | Feld              | Code                | Status | Inhalt              |
+ * | ----------------- | ------------------- | ------ | ------------------- |
+ * | `forbiddenFields` | `FORBIDDEN_FIELDS`  | 403    | nur Namen           |
+ * | `rejectedFields`  | `INVALID_FIELDS`    | 400    | nur Namen           |
+ * | `errors`          | `VALIDATION_ERROR`  | 400    | Pfad → Meldung      |
+ *
+ * Für die Oberfläche ist das derselbe Vorgang — ein Feld, das korrigiert werden
+ * muss —, deshalb entsteht hier eine einheitliche Form. Für die beiden
+ * Namenslisten stellt der Client den Text, weil der Server dort keinen pro Feld
+ * liefert.
+ *
+ * Einträge ohne Meldungstext fallen weg: Ein Feld als ungültig zu markieren,
+ * ohne sagen zu können warum, ist schlechter als es unmarkiert zu lassen.
+ *
+ * @returns die Karte, oder `undefined` wenn kein Feld benannt ist — die
+ *   Eigenschaft wird dann weggelassen (`exactOptionalPropertyTypes`), statt auf
+ *   `undefined` zu stehen.
+ */
+function readFieldErrors(body: SightingApiResponse | null): Record<string, string> | undefined {
+	const fields: Record<string, string> = {};
+
+	for (const [field, message] of Object.entries(body?.errors ?? {})) {
+		if (typeof message === 'string' && message.length > 0) {
+			fields[field] = message;
+		}
+	}
+
+	for (const field of [...(body?.rejectedFields ?? []), ...(body?.forbiddenFields ?? [])]) {
+		if (typeof field === 'string' && field.length > 0) {
+			fields[field] ??= FORBIDDEN_FIELD_MESSAGE;
+		}
+	}
+
+	return Object.keys(fields).length > 0 ? fields : undefined;
+}
+
+/** Baut den `rejected`-Fall inklusive Feldkarte, sofern der Server eine liefert. */
+function toRejected(message: string, body: SightingApiResponse | null): SubmitResult {
+	const fields = readFieldErrors(body);
+	return fields === undefined
+		? { status: 'rejected', message }
+		: { status: 'rejected', message, fields };
 }
 
 /**
@@ -167,7 +228,7 @@ export async function submitSightingForm(values: SightingFormValues): Promise<Su
 		// verbotene Felder) — der Text nennt das betroffene Feld und hilft dem
 		// Nutzer. 5xx-Meldungen sind generisch; dort zählt nur „wiederholbar".
 		if (response.status < 500 && body?.message) {
-			return { status: 'rejected', message: body.message };
+			return toRejected(body.message, body);
 		}
 		return { status: 'server', httpStatus: response.status };
 	}
@@ -178,7 +239,7 @@ export async function submitSightingForm(values: SightingFormValues): Promise<Su
 
 	// 2xx, aber der Körper widerspricht sich oder ist unlesbar.
 	if (body?.success === false && body.message) {
-		return { status: 'rejected', message: body.message };
+		return toRejected(body.message, body);
 	}
 	return { status: 'server', httpStatus: response.status };
 }

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -12,6 +12,7 @@
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
+	import { resolveServerFieldErrors } from '$lib/report/serverFieldErrors';
 	import { initialFormState } from '$lib/report/formConfig';
 	import { toast } from '$lib/stores/toastState.svelte';
 	import {
@@ -26,6 +27,7 @@
 	import type { FormContext, SightingFormData, UserContactData } from '$lib/types';
 	import type { SightingFormValues } from '$lib/types/Form';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
+	import { scrollToFirstError } from '$lib/utils/fieldNavigation';
 	import { createId } from '@paralleldrive/cuid2';
 	import { formStepsConfig } from '$lib/report/formConfig';
 	import { ValidationError } from 'yup';
@@ -147,6 +149,14 @@
 					// Aussage tragen, nicht zwei unabhängig entstandene.
 					const failure = describeSubmitFailure(result);
 
+					// Hat der Server Felder benannt, ist die Meldung über der Navigation
+					// nicht die vollständige Antwort — sie lautet bei einer Validierung
+					// immer „Validierungsfehler bei der Eingabe". Das Ziel steht in
+					// `fields`; siehe `applyServerFieldErrors`.
+					if (result.status === 'rejected' && result.fields) {
+						applyServerFieldErrors(result.fields);
+					}
+
 					if (result.status === 'offline') {
 						submitState = 'offline';
 					} else {
@@ -223,6 +233,58 @@
 	function retrySubmit(): void {
 		void handleFinalSubmit(new Event('submit')).catch((error: unknown) => {
 			logger.error({ error }, 'Erneuter Absendeversuch fehlgeschlagen');
+		});
+	}
+
+	/**
+	 * Übernimmt die Feldfehler einer Server-Ablehnung ins Formular und führt zum
+	 * ersten betroffenen Feld.
+	 *
+	 * Das ist derselbe Weg, den die Vorab-Validierung in `handleFinalSubmit` unten
+	 * für Yup-Fehler geht — nur mit den Feldern des Servers als Quelle. Beide
+	 * Fälle sind für den Nutzer dasselbe Ereignis: „ein Feld stimmt nicht, und es
+	 * kann in einem anderen Schritt liegen". Getrennt bleiben sie trotzdem: dieser
+	 * Weg mischt die Fehler und scrollt selbst, der andere setzt sie und überlässt
+	 * das Scrollen der Schritt-Navigation.
+	 *
+	 * Die Fehler werden **gemischt**, nicht gesetzt: Ein bereits sichtbarer
+	 * Client-Fehler an einem anderen Feld ist damit nicht plötzlich weg, nur weil
+	 * der Server ein zusätzliches Feld beanstandet.
+	 *
+	 * `scrollToFirstError` läuft erst im nächsten Frame — der Schrittwechsel oben
+	 * ist zu diesem Zeitpunkt noch nicht gerendert, das Zielfeld existiert also
+	 * noch gar nicht im DOM.
+	 *
+	 * **Abhängigkeit, die nicht offensichtlich ist:** Nach dem `throw` unten läuft
+	 * in `StepNavigation.handleFormSubmission` der Catch-Zweig mit
+	 * `showValidationError()`, das einen ZWEITEN `scrollToFirstError` samt
+	 * eigenem Fokus-Timeout auslöst. Zwei konkurrierende Sprünge entstehen daraus
+	 * heute nicht, weil `handleFinalSubmit` gegen das volle Schema vorvalidiert:
+	 * Der Server wird nur mit client-seitig gültigen Daten erreicht, `validateStep`
+	 * findet dort nichts und `showValidationError` steigt sofort wieder aus. Wer
+	 * dieses Vorab-Gate lockert, muss die beiden Sprünge gegeneinander absichern.
+	 */
+	function applyServerFieldErrors(serverFields: Record<string, string>): void {
+		const { fields, targetStep, fieldOrder } = resolveServerFieldErrors(
+			serverFields,
+			formStepsConfig,
+			currentStep
+		);
+
+		// Ausschließlich unbekannte Felder benannt — es gibt nichts anzuspringen und
+		// nichts zu markieren. Die Meldung selbst steht weiterhin in `SubmitStatus`.
+		if (Object.keys(fields).length === 0) {
+			return;
+		}
+
+		formContext.errors.update((current) => ({ ...current, ...fields }));
+
+		if (targetStep !== null) {
+			currentStep = targetStep;
+		}
+
+		requestAnimationFrame(() => {
+			scrollToFirstError(fields, fieldOrder);
 		});
 	}
 

--- a/src/lib/report/serverFieldErrors.test.ts
+++ b/src/lib/report/serverFieldErrors.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { FormStep } from '$lib/types';
+import { resolveServerFieldErrors } from './serverFieldErrors';
+
+const steps: FormStep[] = [
+	{ id: 'a', title: 'Position & Zeit', description: '', fields: ['latitude', 'waterway'] },
+	{ id: 'b', title: 'Details', description: '', fields: ['species', 'totalCount'] },
+	{ id: 'c', title: 'Kontakt', description: '', fields: ['email', 'privacyConsent'] }
+];
+
+describe('resolveServerFieldErrors', () => {
+	it('nennt den frühesten betroffenen Schritt als Sprungziel', () => {
+		const result = resolveServerFieldErrors({ email: 'ungültig', waterway: 'zu lang' }, steps, 2);
+
+		expect(result.targetStep).toBe(0);
+	});
+
+	it('verzichtet auf den Sprung, wenn die Fehler schon sichtbar sind', () => {
+		const result = resolveServerFieldErrors({ email: 'ungültig' }, steps, 2);
+
+		expect(result.targetStep).toBeNull();
+	});
+
+	/**
+	 * Die Reihenfolge stammt aus dem ZIEL-Schritt, nicht aus dem aktuellen —
+	 * sonst springt `scrollToFirstError` auf das Feld, das in der Server-Antwort
+	 * zufällig zuerst stand, statt auf das oberste im Formular.
+	 */
+	it('liefert die Feldreihenfolge des Zielschritts', () => {
+		const result = resolveServerFieldErrors({ waterway: 'zu lang', latitude: 'fehlt' }, steps, 2);
+
+		expect(result.targetStep).toBe(0);
+		expect(result.fieldOrder).toEqual(['latitude', 'waterway']);
+	});
+
+	it('liefert ohne Sprung die Reihenfolge des aktuellen Schritts', () => {
+		const result = resolveServerFieldErrors({ email: 'ungültig' }, steps, 2);
+
+		expect(result.fieldOrder).toEqual(['email', 'privacyConsent']);
+	});
+
+	/**
+	 * Der eigentliche Grund für den Filter: Ein Fehler an einem Feld, das in
+	 * keinem Schritt steht, hat kein Bedienelement — `updateField` löscht nur den
+	 * Fehler des GEÄNDERTEN Feldes, also bliebe er bis zum nächsten Absenden im
+	 * Store hängen, ohne dass ihn jemand sehen oder beheben könnte.
+	 *
+	 * Erreichbar ist das: `POST /api/sightings` fällt bei unerwarteter
+	 * Fehlerstruktur auf den Schlüssel `allgemein` zurück, und `referenceId`,
+	 * `entryChannel` oder `weatherData.*` kommen aus dem Schema, stehen aber in
+	 * keinem Schritt.
+	 */
+	it('verwirft Felder, die in keinem Schritt stehen', () => {
+		const result = resolveServerFieldErrors(
+			{ allgemein: 'Unbekannter Validierungsfehler', email: 'ungültig' },
+			steps,
+			2
+		);
+
+		expect(result.fields).toEqual({ email: 'ungültig' });
+	});
+
+	it('liefert eine leere Karte, wenn ausschließlich unbekannte Felder benannt sind', () => {
+		const result = resolveServerFieldErrors({ referenceId: 'kaputt' }, steps, 2);
+
+		expect(result.fields).toEqual({});
+		expect(result.targetStep).toBeNull();
+	});
+
+	/** Ein unbekanntes Feld darf das Sprungziel nicht mitbestimmen. */
+	it('bestimmt das Sprungziel nur aus den bekannten Feldern', () => {
+		const result = resolveServerFieldErrors({ allgemein: 'irgendwas', species: 'fehlt' }, steps, 2);
+
+		expect(result.targetStep).toBe(1);
+		expect(result.fieldOrder).toEqual(['species', 'totalCount']);
+	});
+});

--- a/src/lib/report/serverFieldErrors.ts
+++ b/src/lib/report/serverFieldErrors.ts
@@ -1,0 +1,52 @@
+import type { FormStep } from '$lib/types';
+import { findStepForErrors } from './findStepForErrors';
+
+/** Das Sprungziel einer Server-Ablehnung, fertig zum Anwenden. */
+export interface ServerFieldErrorTarget {
+	/** Die benannten Felder, reduziert auf die, die das Formular tatsächlich zeigt. */
+	fields: Record<string, string>;
+	/** Schritt, zu dem gesprungen werden muss — `null`, wenn kein Sprung nötig ist. */
+	targetStep: number | null;
+	/** Feldreihenfolge des Schritts, in dem der Sprung landet. */
+	fieldOrder: string[];
+}
+
+/**
+ * Bereitet die Feldkarte einer Server-Ablehnung für die Anzeige auf.
+ *
+ * Reine Funktion ohne Svelte-/Store-Abhängigkeit — die eigentliche Anwendung
+ * (Fehler in den Store schreiben, Schritt wechseln, scrollen) bleibt in
+ * `ModernReportForm.svelte`, die Entscheidungen stehen hier und sind in Node
+ * testbar.
+ *
+ * **Warum gefiltert wird.** Der Server kann Felder benennen, die in keinem
+ * Schritt stehen: `POST /api/sightings` fällt bei unerwarteter Fehlerstruktur
+ * auf den Schlüssel `allgemein` zurück, und `referenceId`, `entryChannel` oder
+ * `weatherData.*` gehören zum Schema, aber zu keinem Formularschritt. Ein
+ * solcher Eintrag hätte kein Element zum Anspringen (`scrollToFirstError`
+ * fände nichts), kein Sprungziel (`findStepForErrors` ignoriert ihn ohnehin)
+ * — und vor allem kein Bedienelement, das ihn wieder löscht: `updateField`
+ * entfernt nur den Fehler des *geänderten* Feldes. Er bliebe bis zum nächsten
+ * Absenden im Store hängen. Was niemand sehen und niemand beheben kann, gehört
+ * nicht hinein; die Meldung selbst bleibt in `SubmitStatus` sichtbar.
+ */
+export function resolveServerFieldErrors(
+	fields: Record<string, string>,
+	steps: FormStep[],
+	currentStep: number
+): ServerFieldErrorTarget {
+	const knownFields = new Set(steps.flatMap((step) => step.fields));
+	const visibleFields = Object.fromEntries(
+		Object.entries(fields).filter(([field]) => knownFields.has(field))
+	);
+
+	const targetStep = findStepForErrors(Object.keys(visibleFields), steps, currentStep);
+
+	return {
+		fields: visibleFields,
+		targetStep,
+		// `targetStep ?? currentStep`: Ohne Sprung bleibt der aktuelle Schritt das
+		// Ziel — dort stehen die Felder dann bereits.
+		fieldOrder: steps[targetStep ?? currentStep]?.fields ?? []
+	};
+}


### PR DESCRIPTION
## Problem

Bei einem abgelehnten Sichtungs-Submit (HTTP 400) sah der Nutzer nur den generischen Satz „Validierungsfehler bei der Eingabe" — und erfuhr nicht, welches Feld gemeint ist. Möglicherweise lag es drei Schritte zurück.

Die Information existierte bereits auf dem Server. Der Client warf sie weg: `SightingApiResponse` in `src/lib/form/submitSightingForm.ts` deklarierte nur `success`, `id` und `message`. Im JSDoc von `SubmitResult` war das ausdrücklich als offene Lücke markiert (aufgefallen im Copilot-Review zu #642).

## Lösung

`SubmitResult`'s `rejected`-Fall trägt jetzt `fields: Record<feldname, meldung>`. Darin laufen **alle drei** Quellen des Endpunkts zusammen — sie sind disjunkt, welche greift entscheidet der Server vor allen anderen Prüfungen:

| Feld              | Code               | Status | Inhalt         |
| ----------------- | ------------------ | ------ | -------------- |
| `forbiddenFields` | `FORBIDDEN_FIELDS` | 403    | nur Namen      |
| `rejectedFields`  | `INVALID_FIELDS`   | 400    | nur Namen      |
| `errors`          | `VALIDATION_ERROR` | 400    | Pfad → Meldung |

Für die beiden Namenslisten stellt der Client den Text, weil der Server dort keinen pro Feld liefert.

`ModernReportForm` schreibt die Fehler in den Formular-Store, springt zum frühesten betroffenen Schritt und scrollt zum ersten Feld — derselbe Weg, den die Yup-Vorab-Validierung schon geht. Die Fehler werden **gemischt**, nicht gesetzt: ein bereits sichtbarer Client-Fehler an einem anderen Feld verschwindet nicht, nur weil der Server ein zusätzliches beanstandet.

Die Entscheidungen dahinter stehen in der neuen reinen Funktion `resolveServerFieldErrors` (`src/lib/report/serverFieldErrors.ts`) — Zielschritt, Feldreihenfolge und die Filterung — und sind damit ohne Browser testbar.

**Der Server wurde nicht angefasst.** Er lieferte bereits alles.

## Warum unbekannte Felder verworfen werden

Der Server kann Felder benennen, die in keinem Formularschritt stehen: der Fallback-Schlüssel `allgemein`, außerdem `referenceId`, `entryChannel`, `weatherData.*`. Ein solcher Eintrag hätte kein Element zum Anspringen, kein Sprungziel — und vor allem **kein Bedienelement, das ihn wieder löscht**: `updateField` entfernt nur den Fehler des *geänderten* Feldes. Er bliebe bis zum nächsten Absenden im Store hängen. Die Meldung selbst bleibt in `SubmitStatus` sichtbar.

## Tests (Test-First)

- **`submitSightingForm.test.ts`** — 5 neue Fälle: `errors` durchgereicht, `rejectedFields` und `forbiddenFields` in dieselbe Form gebracht, keine Feldkarte ohne Feldbezug (`exactOptionalPropertyTypes`: Eigenschaft fehlt, steht nicht auf `undefined`), leere Meldungen verworfen. Vor der Implementierung rot verifiziert.
- **`serverFieldErrors.test.ts`** (neu) — 7 Fälle für Zielschritt, Feldreihenfolge des Zielschritts und die Filterung.
- **`e2e/form-submit.spec.ts`** — 2 neue Tests: Mock-400 mit `waterway` schickt das Formular von Schritt 4 zurück zu Schritt 1, markiert das Feld `aria-invalid`, zeigt dort die Server-Meldung und fokussiert es; zweiter Test für ein Feld auf dem aktuellen Schritt (kein Sprung, Meldung trotzdem am Feld).

## Verifikation

- `npm run test:quick` — Lint, Type-Check, Svelte-Check, 2403 Unit-Tests ✅
- `npm run test:e2e -- form-submit.spec.ts` — 15 passed, 1 skipped (der DB-abhängige) ✅

Code-Review-Befunde aus dem Erstentwurf sind eingearbeitet: die dritte Feldquelle (`forbiddenFields`, 403) wurde zunächst übersehen, das Testbeispiel `rejectedFields: ['verified']` beschrieb ein Serververhalten, das es nicht gibt (`verified` steht in `FORBIDDEN_ADMIN_FIELDS` und erreicht den 400-Zweig nie). Zusätzlich dokumentiert: Der zweite `scrollToFirstError` aus `StepNavigation.showValidationError` kollidiert heute nur deshalb nicht, weil `handleFinalSubmit` gegen das volle Schema vorvalidiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
