### PR TITLE
docs: correct `latest` tag semantics in run-release.sh and deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ docker run -p 3000:3000 --env-file .env ghcr.io/jansinger/ostsee-tiere:productio
 
 Vollständige Tag-Semantik und der Promotion-Ablauf: [Release-Pipeline](docs/RELEASE_PIPELINE.md)
 
+Bricht `docker pull` mit `denied` ab, ist das Package nicht öffentlich: vorher
+`docker login ghcr.io` mit einem Token mit `read:packages`-Scope.
+
 ### Dokumentation
 
 - 📘 [Docker Deployment Guide](docs/DOCKER_DEPLOYMENT.md) - Vollständige Deployment-Anleitung

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -240,8 +240,11 @@ docker compose -f docker-compose.production.yml logs -f
 The `run-release.sh` script simplifies running Docker releases with a local PostgreSQL database:
 
 ```bash
-# Run latest release
+# Run the released production build (tag `latest`)
 ./run-release.sh
+
+# Run the newest, not-yet-verified release
+./run-release.sh staging
 
 # Run specific version
 ./run-release.sh v2.0.3
@@ -1348,7 +1351,7 @@ API_AUDIENCE=your-api-audience
 ### Step 3: Run the Release
 
 ```bash
-# Run latest release
+# Run the released production build (tag `latest`)
 ./run-release.sh
 
 # The script automatically:
@@ -1404,7 +1407,8 @@ https://localhost:3443
 ### Step 5: Commands Reference
 
 ```bash
-./run-release.sh              # Run latest release
+./run-release.sh              # Run the released production build (tag `latest`)
+./run-release.sh staging      # Run the newest, not-yet-verified release
 ./run-release.sh v2.0.3       # Run specific version
 ./run-release.sh stop         # Stop container
 ./run-release.sh logs         # View logs (follow mode)

--- a/run-release.sh
+++ b/run-release.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 #
-# Run the latest release Docker image with local PostgreSQL and optional Caddy SSL proxy
+# Run a released Docker image with local PostgreSQL and optional Caddy SSL proxy
 #
 # Usage:
-#   ./run-release.sh           # Run latest release (with Caddy if available)
+#   ./run-release.sh           # Released production build (with Caddy if available)
 #   ./run-release.sh start     # Same as above
-#   ./run-release.sh v2.1.0    # Run specific version
+#   ./run-release.sh staging   # Newest release, not yet verified
+#   ./run-release.sh v2.5.5    # Run specific version
 #   ./run-release.sh stop      # Stop running container and Caddy
 #   ./run-release.sh logs      # View container logs
 #   ./run-release.sh status    # Show status of container and Caddy
@@ -147,22 +148,25 @@ case "$VERSION" in
         exit 0
         ;;
     start)
-        # "start" is the default action — treat it as "latest"
+        # "start" is the default action. `latest` tracks the RELEASED PRODUCTION
+        # build (moved only by promote-production.yml), not the newest release —
+        # that one is `staging`. See docs/RELEASE_PIPELINE.md.
         VERSION="latest"
         ;;
     help|--help|-h)
         echo "Usage: ./run-release.sh [command|version]"
         echo ""
         echo "Commands:"
-        echo "  start          Start with latest release (default)"
+        echo "  start          Start the released production build (default)"
         echo "  stop           Stop running container and Caddy"
         echo "  logs           View container logs"
         echo "  status         Show status of container and Caddy"
         echo "  help           Show this help"
         echo ""
         echo "Version:"
-        echo "  v2.1.0         Start specific version"
-        echo "  latest         Start latest release (default)"
+        echo "  v2.5.5         Start a specific version"
+        echo "  latest         Released production build (default)"
+        echo "  staging        Newest release, not yet verified"
         exit 0
         ;;
 esac


### PR DESCRIPTION
## Warum

[PR #617](https://github.com/jansinger/ostsee-tiere/pull/617) hat `latest` vom Build-Zeiger zum **Production-Zeiger** gemacht — bewegt ausschließlich von `promote-production.yml` nach manueller Freigabe. `docs/RELEASE_PIPELINE.md` und `.claude/rules/docker.md` wurden damals mitgezogen, drei weitere Stellen nicht: Sie beschreiben weiter das alte Verhalten und behaupten, `latest` sei das neueste Release. Das ist `staging`.

> **Rebase-Hinweis:** [#645](https://github.com/jansinger/ostsee-tiere/pull/645) hat den README-Abschnitt parallel und gleichwertig korrigiert. Bei der Konfliktauflösung habe ich dessen Fassung übernommen — vom ursprünglichen README-Teil bleiben hier nur die 3 Zeilen zur Package-Sichtbarkeit, die dort fehlten.

Aufgefallen bei der Prüfung, ob nach dem GitHub-Rename (`ostsee-sichtung` → `ostsee-tiere`, ad3c39f) alle Doku-Referenzen stimmen. Namentlich: ja, alle 27 `ghcr.io`-Pfade zeigen korrekt auf `ostsee-tiere`.

## Was geändert wurde

**`run-release.sh`** — Header, `start`-Kommentar und Hilfetext sagten dreimal "latest release". Dazu ist `staging` jetzt dokumentiert; das Argument hat der Script schon immer akzeptiert, es stand nur nirgends.

**`docs/DOCKER_DEPLOYMENT.md`** — die drei `# Run latest release`-Kommentare in den Beispielblöcken (Zeilen 243, 1351, 1407), plus `staging`-Variante. Die Tag-Tabelle bei Zeile 1174 war bereits korrekt.

**`README.md`** — 3 Zeilen: Ein frisch angelegtes GHCR-Package ist **privat by default**, und kein Workflow setzt die Sichtbarkeit (`grep visibility .github/workflows/*.yml` → keine Treffer). Anonymes `docker pull` schlägt also fehl, bis das Package öffentlich geschaltet wird.

## Für Reviewer

**Keine Verhaltensänderung.** `run-release.sh` bleibt bei `VERSION="latest"` — `latest` und `production` zeigen per Pipeline-Design auf denselben Digest, eine Umstellung wäre semantisch ein No-op mit unnötigem Risiko. Der Diff im Script ist ausschließlich Kommentar und `echo`.

## Nicht Teil dieses PRs

Die Doku stimmt jetzt, die Beispiele sind aber erst ausführbar, wenn das Package unter dem neuen Namen existiert:

- `ghcr.io/jansinger/ostsee-tiere` ist derzeit **nicht pullbar** (anonymer Token → `DENIED`), während `ostsee-sichtung` öffentlich mit 118 Tags antwortet.
- Das alte Package hat **weder `production` noch `staging`** — das Schema kam am 2026-07-29, das letzte Release v2.5.5 war am 2026-07-15. Der in `.env.docker` dokumentierte Default `IMAGE_TAG=production` hat damit unter **keinem** der beiden Namen je aufgelöst.
- Nötig: `docker-publish.yml` per `workflow_dispatch` mit `v2.5.5` anstoßen → Sichtbarkeit auf public → **Promote to Production** laufen lassen.

## Tests

Doku- und Kommentaränderung, daher kein Test — Ausnahme nach `.claude/rules/testing.md`.

Verifiziert: `bash -n run-release.sh` (OK), `npx prettier --check` auf beiden Markdown-Dateien (sauber), Pre-Commit-Hook mit `lint` + `type-check` (0 Errors; 2 vorbestehende `any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`, nicht von diesem PR berührt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)