### PR TITLE
fix(api): correct required-field message for legacy vorname/name

### DIFF
--- a/src/lib/legacy-api/yup-validation.test.ts
+++ b/src/lib/legacy-api/yup-validation.test.ts
@@ -52,6 +52,22 @@ describe('legacyApiSchema — sonstige_auffaelligkeiten', () => {
 	});
 });
 
+describe('legacyApiSchema — required vs. max Fehlermeldungen', () => {
+	it('meldet fehlenden Vornamen als Pflichtfeld, nicht als "zu lang"', async () => {
+		const { vorname, ...rest } = minimalRequest();
+		const result = await validateLegacySightingWithYup(rest as LegacySightingRequest);
+
+		expect(result.errors.vorname).toEqual(['Dieses Feld kann nicht leer gelassen werden.']);
+	});
+
+	it('meldet fehlenden Nachnamen als Pflichtfeld, nicht als "zu lang"', async () => {
+		const { name, ...rest } = minimalRequest();
+		const result = await validateLegacySightingWithYup(rest as LegacySightingRequest);
+
+		expect(result.errors.name).toEqual(['Dieses Feld kann nicht leer gelassen werden.']);
+	});
+});
+
 describe('createLegacyErrorFromYup', () => {
 	it('erzeugt die flache Fehlerform aus dem Originaldokument', () => {
 		const response = createLegacyErrorFromYup({

--- a/src/lib/legacy-api/yup-validation.ts
+++ b/src/lib/legacy-api/yup-validation.ts
@@ -25,12 +25,12 @@ export const legacyApiSchema = yup.object().shape({
 
 	vorname: yup
 		.string()
-		.required('Der Vorname darf nicht länger als 64 Zeichen sein.')
+		.required('Dieses Feld kann nicht leer gelassen werden.')
 		.max(64, 'Der Vorname darf nicht länger als 64 Zeichen sein.'),
 
 	name: yup
 		.string()
-		.required('Der Name darf nicht länger als 64 Zeichen sein.')
+		.required('Dieses Feld kann nicht leer gelassen werden.')
 		.max(64, 'Der Name darf nicht länger als 64 Zeichen sein.'),
 
 	email: yup


### PR DESCRIPTION
## Summary
- `vorname` und `name` meldeten bei fehlendem Feld fälschlich die "zu lang"-Meldung (`.max()`), weil `.required(...)` deren Text kopiert hatte, statt einer Pflichtfeld-Meldung.
- Fix: `.required(...)` nutzt jetzt `'Dieses Feld kann nicht leer gelassen werden.'` — dasselbe Muster, das bereits für `anzahl_gesamt` verwendet wird und als Beispiel in `docs/LEGACY_API_SPECIFICATION.md` dokumentiert ist. `.max(64, ...)` bleibt für den "zu lang"-Fall unverändert.

## Test plan
- [x] Reproduzierender Test zuerst geschrieben (RED), dann Fix (GREEN)
- [x] `npx vitest run src/lib/legacy-api/yup-validation.test.ts` — 6/6 grün
- [x] `npm run test:unit` — 2405/2405 grün, keine Regressionen
- [x] Manuell via curl gegen `POST /rest_sichtungen` verifiziert: fehlendes Feld → Pflichtfeld-Meldung, vorhandenes aber zu langes Feld → weiterhin "zu lang"-Meldung

🤖 Generated with [Claude Code](https://claude.com/claude-code)