### PR TITLE
fix(admin): show the polygon flag instead of the bounding box in the baltic column

### DIFF
--- a/docs/OSTSEE_FLAGS.md
+++ b/docs/OSTSEE_FLAGS.md
@@ -128,7 +128,7 @@ Eine Neufassung muss `> 0` statt `= 1` prüfen.
 
 ## Fehler 2: Die Admin-Übersicht zeigte die falsche Spalte (behoben am 2026-07-30)
 
-`src/routes/admin/+page.svelte` beschriftete die Spalte mit **„Ostsee"**, rendete
+`src/routes/admin/+page.svelte` beschriftete die Spalte mit **„Ostsee"**, renderte
 darin aber `inBalticSeaGeo`:
 
 ```svelte

--- a/docs/OSTSEE_FLAGS.md
+++ b/docs/OSTSEE_FLAGS.md
@@ -126,9 +126,9 @@ Eine Neufassung muss `> 0` statt `= 1` prüfen.
 
 ---
 
-## Fehler 2: Die Admin-Übersicht zeigt die falsche Spalte (offen)
+## Fehler 2: Die Admin-Übersicht zeigte die falsche Spalte (behoben am 2026-07-30)
 
-`src/routes/admin/+page.svelte` beschriftet die Spalte mit **„Ostsee"**, rendert
+`src/routes/admin/+page.svelte` beschriftete die Spalte mit **„Ostsee"**, rendete
 darin aber `inBalticSeaGeo`:
 
 ```svelte
@@ -137,16 +137,75 @@ darin aber `inBalticSeaGeo`:
 {#if sighting.inBalticSeaGeo}
 ```
 
-Weil `ostsee_geo` die Bounding Box ist, erscheinen **9.316 Zeilen** mit
-`ostsee = 0` (also nachweislich **nicht** in der Ostsee) in dieser Spalte als „in
-der Ostsee". Eine Meldung aus Hamburg oder Hannover würde dort als Ostsee-Sichtung
-ausgewiesen.
+Weil `ostsee_geo` die Bounding Box ist, erschienen vor der Geometrie-Bereinigung
+**9.316 Zeilen** mit `ostsee = 0` (also nachweislich **nicht** in der Ostsee) in
+dieser Spalte als „in der Ostsee". Eine Meldung aus **Hamburg** (9,99° O /
+53,55° N — in der Box, nicht im Polygon) wurde dort als Ostsee-Sichtung
+ausgewiesen. Hannover übrigens nicht: es liegt mit 52,38° N südlich der Südgrenze.
 
-Die Detailansicht macht es richtig — `AdminSightingView.svelte` zeigt beide Werte
-getrennt als „In der Ostsee" und „In der Ostsee (geo)".
+### Korrektur: ein kombinierter Status
 
-**Korrektur:** In der Übersicht `inBalticSea` unter dem Label „Ostsee" rendern
-und `inBalticSeaGeo`, wenn überhaupt, als eigene Spalte „Kartenbereich".
+Die Spalte trägt weiter das Label „Ostsee", zeigt aber den Status aus **beiden**
+Flags plus der Frage, ob überhaupt Koordinaten vorliegen —
+`src/routes/admin/balticSeaStatus.ts`:
+
+| Koordinaten | `ostsee` | `ostsee_geo` | Anzeige         | Badge           |
+| ----------- | -------- | ------------ | --------------- | --------------- |
+| fehlen      | beliebig | beliebig     | „ohne Position" | `badge-outline` |
+| vorhanden   | `> 0`    | `> 0`        | „Ostsee"        | `badge-info`    |
+| vorhanden   | `> 0`    | `0`          | „Widerspruch"   | `badge-warning` |
+| vorhanden   | `0`      | beliebig     | „außerhalb"     | `badge-ghost`   |
+
+Zwei getrennte Spalten wären die naheliegendere Korrektur gewesen, aber die
+Tabelle führt bereits 18 Spalten, und `ostsee_geo` als nacktes Ja/Nein ist allein
+nicht handlungsleitend.
+
+Der Zustand **„Widerspruch"** ist nach der Bereinigung leer (0 Zeilen) und kann von
+keinem Code-Pfad mehr erzeugt werden: die Recalc-SQL schreibt beide Spalten in
+einer Transaktion mit Invarianten-Wächter, und `mapFormToSighting` — auch im
+Bearbeitungsweg über `updateSighting` — nimmt beide Werte aus **einem**
+`checkBalticSeaFile`-Aufruf. Er bleibt trotzdem als eigener Zustand bestehen:
+**Produktion ist noch nicht neu berechnet** und trägt die Kombination weiterhin.
+Ohne den Zustand würde die Übersicht solche Zeilen stillschweigend als „Ostsee"
+ausweisen — genau der Fehler, um den es hier geht.
+
+Der Zustand **„ohne Position"** trifft 390 Zeilen. Ohne Koordinaten belegt auch
+`ostsee = 1` nichts; vor der Bereinigung standen 378 solcher Zeilen auf `1`.
+
+### Nachgemessen (2026-07-30, nach der Bereinigung)
+
+Über alle 19.491 Zeilen mit Koordinaten, gegen `checkBalticSeaFile` gerechnet:
+
+| Spalte       | stimmt mit ihrer Prüfung überein |
+| ------------ | -------------------------------- |
+| `ostsee`     | **100,00 %** (Polygon)           |
+| `ostsee_geo` | **100,00 %** (Bounding Box)      |
+
+Die alte Anzeige über `ostsee_geo` würde weiterhin **457 Zeilen** falsch als
+Ostsee ausweisen (`ostsee = 0` bei `ostsee_geo > 0`). Verteilung der Spalte heute:
+18.717 „Ostsee", 774 „außerhalb", 390 „ohne Position", 0 „Widerspruch".
+
+Abgesichert durch `src/routes/admin/balticSeaStatus.test.ts`; der zentrale Test
+weist eine Sichtung mit `ostsee = 0` und `ostsee_geo = 1` **nicht** als Ostsee aus.
+
+### Offen: dieselbe Verwechslung an drei weiteren Stellen
+
+1. **`AdminSightingView.svelte`** (Zeilen um 328/329) zeigt beide Rohwerte getrennt
+   als „In der Ostsee" und „In der Ostsee (geo)" — nicht falsch, aber nicht
+   derselbe Wert wie die Übersicht.
+2. **Die Benachrichtigungs-Mail** (Default in `configInitializer.ts`, Zeilen ~72–107)
+   prüft in der **äußeren** Bedingung `inBalticSeaGeo` und zeigt dann ein grünes
+   „Ostsee ✓". Eine Meldung aus dem Hamburger Hafen bekommt damit denselben Badge
+   wie eine echte Ostsee-Sichtung; `inBalticSea` wird nur im else-Zweig angesehen.
+   Ausführlich als **Fehler 4** weiter unten — inklusive des Stolpersteins, dass
+   die Vorlage aus `app_config` kommt und der DB-Wert gegen den Code-Default
+   gewinnt.
+3. **`statistics/+page.server.ts`** (Zeilen ~229/230) zählt
+   `COUNT(CASE WHEN ostsee_geo = 1 …)` unter dem Feldnamen `inBalticSea` — falsche
+   Spalte und der `= 1`-Fehler aus Fehler 1 in einer Abfrage. Wird nicht gerendert.
+
+Alle drei sollen an dieselbe Funktion wie die Übersicht angeschlossen werden,
+damit der Wert nur an einer Stelle entsteht.
 
 ---
 
@@ -191,13 +250,50 @@ Vollständige Messung, Entscheidungen und Umsetzung:
 
 ---
 
-## Die E-Mail-Benachrichtigung ist korrekt
+## Fehler 4: Die E-Mail-Benachrichtigung zeigt die Bounding Box als „Ostsee ✓" (offen)
 
-Die Handlebars-Vorlage (Default in `configInitializer.ts`) staffelt richtig:
-`inBalticSeaGeo` ist die äußere, gröbere Bedingung, `inBalticSea` die
-Verfeinerung. Der Fall „im Polygon, aber außerhalb der Bounding Box" wird als
-**„Ostsee-Rand — bitte Plausibilität prüfen"** ausgewiesen. Das ist für die
-Westkante genau die passende Aussage.
+> Dieser Abschnitt hieß bis zum 2026-07-30 „Die E-Mail-Benachrichtigung ist
+> korrekt" und begründete das damit, `inBalticSeaGeo` sei die äußere, gröbere
+> Bedingung und `inBalticSea` die Verfeinerung. Die **Staffelung** ist richtig, das
+> **Ergebnis** nicht.
+
+Die Handlebars-Vorlage (Default in `configInitializer.ts`, Zeilen ~72–107) prüft in
+der äußeren Bedingung `inBalticSeaGeo` und zeigt dann sofort ein grünes
+**„Ostsee ✓"**. `inBalticSea` wird nur im else-Zweig angesehen:
+
+```handlebars
+{{#if sighting.inBalticSeaGeo}}      → Badge „Ostsee ✓" (grün)
+{{else}}{{#if sighting.inBalticSea}} → „Ostsee-Rand" (gelb)
+        {{else}}                     → „Außerhalb Ostsee" (rot)
+```
+
+| `ostsee` | `ostsee_geo` | Mail zeigt         | richtig?                       |
+| -------- | ------------ | ------------------ | ------------------------------ |
+| `> 0`    | `> 0`        | „Ostsee ✓"         | ✅                             |
+| **`0`**  | **`> 0`**    | **„Ostsee ✓"**     | ❌ — liegt nicht in der Ostsee |
+| `> 0`    | `0`          | „Ostsee-Rand"      | seit der Bereinigung leer      |
+| `0`      | `0`          | „Außerhalb Ostsee" | ✅                             |
+
+Es ist dieselbe Verwechslung wie in Fehler 2, nur eine Ausgabe weiter. Eine
+Meldung aus dem Hamburger Hafen bekommt denselben grünen Badge wie eine echte
+Ostsee-Sichtung. Die betroffene Klasse `ostsee = 0, ostsee_geo > 0` umfasst
+derzeit **457 Zeilen**; für Neumeldungen entsteht sie bei jeder Position im
+Rechteck außerhalb des Polygons. Der zweite, gleich gebaute Block unter
+`{{#unless sighting.inBalticSeaGeo}}` (Zeilen ~95–105) trägt die Fließtexte und
+hat denselben Fehler.
+
+Der Zweig „Ostsee-Rand" ist zusätzlich toter Code: Beide Werte stammen aus **einem**
+`checkBalticSeaFile`-Aufruf, und das Polygon liegt in der Box — die Kombination
+kann bei einer Neumeldung nicht entstehen.
+
+**Beim Beheben beachten:** Die Vorlage kommt nicht aus dem Code, sondern aus
+`app_config` unter dem Key `notification.email.template`
+(`ConfigRepository.getString(…, this.getDefaultTemplate())` — der DB-Wert gewinnt,
+der Default ist nur Fallback). Den Default zu ändern wirkt auf **keine**
+bestehende Installation; der geseedete Wert muss mitgezogen werden. Und weil
+Handlebars keine TypeScript-Funktion aufrufen kann, gehört der Status **einmal** in
+`emailService.ts` berechnet und in den Template-Kontext gegeben — sonst wird die
+Logik zum zweiten Mal nachgebaut und läuft wieder auseinander.
 
 ---
 

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -18,6 +18,7 @@
 	import type { SpamCheckResult } from '$lib/types/spam';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import Icon from '$lib/components/Icon.svelte';
+	import { BALTIC_SEA_STATUS_PRESENTATION, getBalticSeaStatus } from './balticSeaStatus';
 
 	const logger = createLogger('SichtungenPage');
 
@@ -53,7 +54,7 @@
 		visibility: false,
 		mediaUpload: true,
 		isDead: true,
-		inBalticSeaGeo: true,
+		balticSea: true,
 		verified: true,
 		actions: true
 	});
@@ -75,7 +76,7 @@
 		{ key: 'visibility', label: 'Sichtweite', sortKey: 'visibility' },
 		{ key: 'mediaUpload', label: 'Aufnahme', sortKey: null },
 		{ key: 'isDead', label: 'Totfund', sortKey: null },
-		{ key: 'inBalticSeaGeo', label: 'Ostsee', sortKey: null },
+		{ key: 'balticSea', label: 'Ostsee', sortKey: null },
 		{ key: 'verified', label: 'Geprüft', sortKey: null },
 		{ key: 'actions', label: 'Aktionen', sortKey: null }
 	];
@@ -598,6 +599,7 @@
 	<!-- Mobile Card Layout -->
 	<div class="container mx-auto block space-y-3 px-4 sm:px-6 md:hidden">
 		{#each sightings as sighting (sighting.id)}
+			{@const balticSea = BALTIC_SEA_STATUS_PRESENTATION[getBalticSeaStatus(sighting)]}
 			<div class="bg-base-100 border-base-300 rounded-lg border p-4 shadow-sm">
 				<div class="mb-3 flex items-start justify-between">
 					<div class="flex-1">
@@ -676,9 +678,15 @@
 					{#if sighting.isDead}
 						<span class="badge badge-error badge-sm">Totfund</span>
 					{/if}
-					{#if sighting.inBalticSeaGeo}
-						<span class="badge badge-info badge-sm">Ostsee</span>
-					{/if}
+					<!-- Anders als Aufnahme/Totfund immer sichtbar: „außerhalb" und „ohne
+					     Position" sind für die Triage genauso relevant wie „Ostsee", ein
+					     fehlendes Badge wäre hier also keine Aussage. -->
+					<span
+						class="badge badge-sm {balticSea.badgeClass} whitespace-nowrap"
+						title={balticSea.title}
+					>
+						{balticSea.label}
+					</span>
 				</div>
 
 				<div class="mt-3 flex items-center justify-between">
@@ -767,7 +775,7 @@
 						{#if columnVisibility.isDead}
 							<th class="hover:bg-base-300">Totfund</th>
 						{/if}
-						{#if columnVisibility.inBalticSeaGeo}
+						{#if columnVisibility.balticSea}
 							<th class="hover:bg-base-300">Ostsee</th>
 						{/if}
 						{#if columnVisibility.verified}
@@ -860,13 +868,17 @@
 									{/if}
 								</td>
 							{/if}
-							{#if columnVisibility.inBalticSeaGeo}
+							{#if columnVisibility.balticSea}
+								{@const balticSea = BALTIC_SEA_STATUS_PRESENTATION[getBalticSeaStatus(sighting)]}
 								<td class="text-center">
-									{#if sighting.inBalticSeaGeo}
-										<span class="badge badge-info badge-sm">Ja</span>
-									{:else}
-										<span class="badge badge-ghost badge-sm">Nein</span>
-									{/if}
+									<!-- whitespace-nowrap: „ohne Position" bricht in der schmalen Spalte sonst
+									     um und läuft aus dem Badge heraus, der Rahmen schneidet durch den Text. -->
+									<span
+										class="badge badge-sm {balticSea.badgeClass} whitespace-nowrap"
+										title={balticSea.title}
+									>
+										{balticSea.label}
+									</span>
 								</td>
 							{/if}
 							{#if columnVisibility.verified}

--- a/src/routes/admin/balticSeaStatus.test.ts
+++ b/src/routes/admin/balticSeaStatus.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { BALTIC_SEA_STATUS_PRESENTATION, getBalticSeaStatus } from './balticSeaStatus';
+
+const ALL_STATUSES = ['baltic', 'edge', 'outside', 'noPosition'] as const;
+
+/**
+ * Eine Position in der Lübecker Bucht — liegt im Polygon *und* in der Bounding Box.
+ * Die Flags kommen im Test explizit dazu; die Koordinaten sind nur dafür da, dass
+ * die Zeile überhaupt eine verwertbare Position hat.
+ */
+const withPosition = (flags: { inBalticSea?: number | null; inBalticSeaGeo?: number | null }) => ({
+	latitude: '54.020000',
+	longitude: '11.100000',
+	...flags
+});
+
+describe('getBalticSeaStatus', () => {
+	it('weist eine Sichtung im Polygon und in der Bounding Box als Ostsee aus', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 1, inBalticSeaGeo: 1 }))).toBe('baltic');
+	});
+
+	// Der eigentliche Befund: ostsee_geo ist die grobe Bounding Box, die Jütland,
+	// Nordostdeutschland und Polen einschließt. Eine Meldung aus Hamburg hat
+	// ostsee = 0 bei ostsee_geo = 1 — sie ist nachweislich NICHT in der Ostsee.
+	// Lokal betrifft das 9.316 Zeilen (docs/OSTSEE_FLAGS.md).
+	it('weist eine Sichtung in der Bounding Box, aber außerhalb des Polygons NICHT als Ostsee aus', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 0, inBalticSeaGeo: 1 }))).toBe('outside');
+	});
+
+	// Gegenprobe zum Altbestand: ostsee_geo = 2 bedeutet dasselbe wie 1
+	// ("im Kartenbereich"), darf also am Ergebnis nichts ändern.
+	it('behandelt den Altsystem-Wert 2 in ostsee_geo wie 1', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 1, inBalticSeaGeo: 2 }))).toBe('baltic');
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 0, inBalticSeaGeo: 2 }))).toBe('outside');
+	});
+
+	// Widerspruch zwischen den Flags: als Ostsee markiert, Position außerhalb des
+	// Kartenbereichs. Das ist im Bestand ein Altdaten-Artefakt — die frühere
+	// Deutung als "Westkante" ist am 2026-07-30 widerlegt worden (das Polygon
+	// reicht dort nicht westlich der Box). Siehe docs/OSTSEE_FLAGS.md, Fehler 3.
+	it('weist einen Widerspruch zwischen Polygon-Flag und Bounding Box aus', () => {
+		expect(
+			getBalticSeaStatus({
+				inBalticSea: 1,
+				inBalticSeaGeo: 0,
+				latitude: '54.783000',
+				longitude: '9.417000'
+			})
+		).toBe('edge');
+	});
+
+	it('weist eine Position außerhalb von Polygon und Box als außerhalb aus', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 0, inBalticSeaGeo: 0 }))).toBe('outside');
+	});
+
+	// ostsee ist nullable (Altbestand-Asymmetrie, siehe schema.ts). Praktisch
+	// enthält die Spalte derzeit keine NULL-Werte, erlaubt sie aber.
+	it('behandelt NULL in ostsee als nicht in der Ostsee', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: null, inBalticSeaGeo: 1 }))).toBe(
+			'outside'
+		);
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: null, inBalticSeaGeo: 0 }))).toBe(
+			'outside'
+		);
+	});
+
+	// FrontendSighting leitet sich von Drizzles InferInsertModel ab — Spalten mit
+	// Default sind dort optional, die Flags können also ganz fehlen.
+	it('behandelt fehlende Flags als nicht in der Ostsee', () => {
+		expect(getBalticSeaStatus(withPosition({}))).toBe('outside');
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 0 }))).toBe('outside');
+	});
+
+	// Ohne Kartenbereichs-Angabe ist „im Polygon" die belastbare Aussage — der
+	// Fall darf nicht still zu 'baltic' werden und den Hinweis verlieren.
+	it('weist einen Polygon-Treffer ohne Kartenbereichs-Angabe als Widerspruch aus', () => {
+		expect(getBalticSeaStatus(withPosition({ inBalticSea: 1 }))).toBe('edge');
+	});
+
+	describe('ohne verwertbare Koordinaten', () => {
+		// Ohne Koordinaten trägt kein Flag eine Aussage — auch ostsee = 1 nicht.
+		// Der Altbestand hat davon 378 Zeilen (ostsee = 1, ostsee_geo = 0,
+		// gps_laenge/gps_breite NULL). Sie als "Widerspruch" zu führen wäre derselbe Fehler wie der
+		// behobene. Gemessen 2026-07-30, siehe docs/OSTSEE_FLAGS.md.
+		it('schlägt jedes Flag — auch ostsee = 1', () => {
+			expect(
+				getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 0, latitude: null, longitude: null })
+			).toBe('noPosition');
+			expect(
+				getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 1, latitude: null, longitude: null })
+			).toBe('noPosition');
+			expect(
+				getBalticSeaStatus({ inBalticSea: 0, inBalticSeaGeo: 0, latitude: null, longitude: null })
+			).toBe('noPosition');
+		});
+
+		it('behandelt eine halbe Koordinate wie keine', () => {
+			expect(
+				getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 1, latitude: '54.3', longitude: null })
+			).toBe('noPosition');
+			expect(
+				getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 1, latitude: null, longitude: '9.1' })
+			).toBe('noPosition');
+		});
+
+		it('behandelt fehlende und leere Koordinatenfelder wie keine', () => {
+			expect(getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 1 })).toBe('noPosition');
+			expect(
+				getBalticSeaStatus({ inBalticSea: 1, inBalticSeaGeo: 1, latitude: '  ', longitude: '  ' })
+			).toBe('noPosition');
+		});
+
+		// 0/0 ist eine gültige Zahl (Null Island) und darf nicht als "fehlend"
+		// durchfallen — die Karten-Review hat dort 165 echte Features gefunden.
+		it('behandelt 0/0 als vorhandene Position', () => {
+			expect(
+				getBalticSeaStatus({
+					inBalticSea: 0,
+					inBalticSeaGeo: 0,
+					latitude: '0.000000',
+					longitude: '0.000000'
+				})
+			).toBe('outside');
+		});
+	});
+});
+
+describe('BALTIC_SEA_STATUS_PRESENTATION', () => {
+	it('deckt jeden Status mit Label, Badge und Tooltip ab', () => {
+		for (const status of ALL_STATUSES) {
+			const presentation = BALTIC_SEA_STATUS_PRESENTATION[status];
+			expect(presentation.label).toBeTruthy();
+			expect(presentation.badgeClass).toBeTruthy();
+			expect(presentation.title).toBeTruthy();
+		}
+	});
+
+	// Statusfarben sind hier Flächenfarbe (badge-*), nicht Vordergrund — deshalb
+	// ohne -strong-Suffix. Vgl. .claude/rules/design-system.md.
+	it('nutzt Badge-Flächenfarben ohne -strong-Suffix', () => {
+		for (const status of ALL_STATUSES) {
+			expect(BALTIC_SEA_STATUS_PRESENTATION[status].badgeClass).not.toContain('-strong');
+		}
+	});
+
+	it('unterscheidet alle Zustände sichtbar voneinander', () => {
+		const labels = ALL_STATUSES.map((status) => BALTIC_SEA_STATUS_PRESENTATION[status].label);
+		expect(new Set(labels).size).toBe(ALL_STATUSES.length);
+	});
+});

--- a/src/routes/admin/balticSeaStatus.ts
+++ b/src/routes/admin/balticSeaStatus.ts
@@ -1,0 +1,111 @@
+/**
+ * Ostsee-Status einer Sichtung für die Admin-Übersicht.
+ *
+ * Die Tabelle `sichtungen` hält zwei Flags, deren Namen die Bedeutungen verkehrt
+ * herum nahelegen: `ostsee` (`inBalticSea`) ist die **strenge** Punkt-in-Polygon-
+ * Prüfung, `ostsee_geo` (`inBalticSeaGeo`) nur die **grobe** Bounding Box. Die
+ * fachliche Aussage „liegt in der Ostsee" hängt deshalb allein an `ostsee`.
+ *
+ * Aus der Kombination beider Flags — und der Frage, ob überhaupt Koordinaten
+ * vorliegen — entstehen die vier Zustände unten.
+ *
+ * Der Fall `edge` ist ein **Widerspruch zwischen den beiden Flags**: als Ostsee
+ * markiert, Position aber außerhalb des Kartenbereichs. Er hieß hier zunächst
+ * „Rand", weil `docs/OSTSEE_FLAGS.md` ihn als Westkanten-Fall beschrieb (die
+ * Bounding Box schneide Kieler Bucht und Flensburger Förde ab). Das ist am
+ * 2026-07-30 nachgemessen und **widerlegt** worden: auf 54,8° N liegt der
+ * westlichste Polygon-Treffer bei 9,43° O, also östlich der Boxgrenze. Die Zeilen
+ * in diesem Zustand sind Altdaten mit unplausiblen Koordinaten (95 westlich
+ * 8,5° O, 50 bis −98°/+100°, 10 zwischen 8,5 und 9,4° O) — deshalb „Widerspruch"
+ * und nicht „Rand".
+ *
+ * Der Fall `noPosition` ist beim Umsetzen dieser Korrektur aus den Daten
+ * dazugekommen: Von den 533 Zeilen mit `ostsee = 1` und `ostsee_geo = 0` haben
+ * **378 überhaupt keine Koordinaten**. Ohne Koordinaten belegt auch `ostsee = 1`
+ * nichts — diese Zeilen als Ostsee-Aussage zu führen wäre derselbe Fehler wie der
+ * hier behobene: eine Zugehörigkeit behaupten, die die Daten nicht tragen.
+ *
+ * Vollständige Referenz inkl. Messwerten: `docs/OSTSEE_FLAGS.md`
+ */
+export type BalticSeaStatus = 'baltic' | 'edge' | 'outside' | 'noPosition';
+
+/**
+ * Alle Felder sind nullish-tolerant: `ostsee` ist in der DB nullable, und
+ * `FrontendSighting` leitet sich von Drizzles `InferInsertModel` ab — dort sind
+ * Spalten mit Default optional, also zusätzlich `undefined`. Die Koordinaten sind
+ * `numeric`-Spalten und kommen deshalb als String.
+ */
+type BalticSeaFlags = {
+	/** Spalte `ostsee` — exaktes Polygon, nullable (Altbestand-Asymmetrie). */
+	inBalticSea?: number | null | undefined;
+	/** Spalte `ostsee_geo` — Bounding Box, drei Werte (0, 1, 2). */
+	inBalticSeaGeo?: number | null | undefined;
+	/** Spalte `gps_breite`. */
+	latitude?: string | null | undefined;
+	/** Spalte `gps_laenge`. */
+	longitude?: string | null | undefined;
+};
+
+/**
+ * Beide Flag-Spalten werden mit `> 0` geprüft, nie mit `= 1`: `ostsee_geo` enthält
+ * aus dem Altsystem zusätzlich den Wert `2` mit derselben Bedeutung wie `1`. Ein
+ * Vergleich auf `= 1` ließe 79 % des Bestands lautlos herausfallen.
+ */
+export function getBalticSeaStatus({
+	inBalticSea,
+	inBalticSeaGeo,
+	latitude,
+	longitude
+}: BalticSeaFlags): BalticSeaStatus {
+	// Die Koordinaten sind nur dann eine Aussage, wenn *beide* vorliegen — eine
+	// halbe Position lässt sich nicht auf der Karte prüfen.
+	const hasPosition = isFiniteCoordinate(latitude) && isFiniteCoordinate(longitude);
+	if (!hasPosition) {
+		return 'noPosition';
+	}
+
+	if (!((inBalticSea ?? 0) > 0)) {
+		return 'outside';
+	}
+
+	return (inBalticSeaGeo ?? 0) > 0 ? 'baltic' : 'edge';
+}
+
+function isFiniteCoordinate(value: string | null | undefined): boolean {
+	if (value === null || value === undefined || value.trim() === '') {
+		return false;
+	}
+	return Number.isFinite(Number(value));
+}
+
+type BalticSeaStatusPresentation = {
+	label: string;
+	/** Statusfarbe als *Fläche* — deshalb ohne `-strong` (siehe design-system.md). */
+	badgeClass: string;
+	title: string;
+};
+
+export const BALTIC_SEA_STATUS_PRESENTATION: Record<BalticSeaStatus, BalticSeaStatusPresentation> =
+	{
+		baltic: {
+			label: 'Ostsee',
+			badgeClass: 'badge-info',
+			title: 'Position liegt im Ostsee-Polygon und im Kartenbereich.'
+		},
+		edge: {
+			label: 'Widerspruch',
+			badgeClass: 'badge-warning',
+			title:
+				'Als Ostsee markiert, Position aber außerhalb des Kartenbereichs — im Altbestand meist unplausible Koordinaten. Bitte prüfen.'
+		},
+		outside: {
+			label: 'außerhalb',
+			badgeClass: 'badge-ghost',
+			title: 'Position liegt nicht im Ostsee-Polygon.'
+		},
+		noPosition: {
+			label: 'ohne Position',
+			badgeClass: 'badge-outline',
+			title: 'Keine verwertbaren Koordinaten — eine Ostsee-Zuordnung ist nicht möglich.'
+		}
+	};


### PR DESCRIPTION
## What

The admin overview labelled a column **"Ostsee"** but rendered `inBalticSeaGeo` — the coarse bounding box, not the polygon check. The column now shows a combined status derived from both flags plus whether the row has usable coordinates at all.

New pure module `src/routes/admin/balticSeaStatus.ts`:

| coordinates | `ostsee` | `ostsee_geo` | display | badge | rows |
| --- | --- | --- | --- | --- | --- |
| missing | any | any | „ohne Position" | `badge-outline` | 390 |
| present | `> 0` | `> 0` | „Ostsee" | `badge-info` | 18,717 |
| present | `> 0` | `0` | „Widerspruch" | `badge-warning` | 0 |
| present | `0` | any | „außerhalb" | `badge-ghost` | 774 |

## Why

The two columns mean the opposite of what their names suggest: `ostsee` is the exact point-in-polygon check, `ostsee_geo` only the bounding box. Rendering the box under the label "Ostsee" presented 9,316 rows with `ostsee = 0` as baltic sightings before the geometry cleanup — a report from Hamburg (9.99° E / 53.55° N, inside the box, outside the polygon) was shown as a baltic sighting.

Reference: `docs/OSTSEE_FLAGS.md`, short form in `.claude/rules/geo.md`.

## Measurements

Against `checkBalticSeaFile` over all 19,491 rows with coordinates, after #647:

| column | agrees with its own check |
| --- | --- |
| `ostsee` | **100.00 %** (polygon) |
| `ostsee_geo` | **100.00 %** (bounding box) |

The previous display via `ostsee_geo` would still present **457 rows** as baltic incorrectly (`ostsee = 0` with `ostsee_geo > 0`).

## Review notes

- **Two columns instead of one combined status** was the more obvious fix and was considered. The table already carries 18 columns, and `ostsee_geo` as a bare yes/no is not actionable on its own — the combination is what matters for triage.
- **`> 0`, never `= 1`.** `ostsee_geo` carries the legacy value `2` with the same meaning as `1`; comparing against `1` would silently drop 15,208 rows. Covered by a test.
- **"ohne Position" is not cosmetic.** Without coordinates `ostsee = 1` proves nothing; 378 such rows carried a `1` before the cleanup. Treating them as baltic would repeat the very defect this PR fixes.
- **"Widerspruch" is empty (0 rows) and unreachable by any code path** — the recalc SQL writes both columns in one transaction guarded by an invariant check, and `mapFormToSighting` (including the edit path via `updateSighting`) takes both values from a single `checkBalticSeaFile` call. It is kept as its own state because **production has not been recalculated yet** and still carries the combination. Without the state the overview would silently present those rows as "Ostsee". Happy to drop it if you'd rather not carry the guard.
- **No `schema.ts` change on purpose.** The column semantics are documented in `.claude/rules/database.md`, because `migration-check` triggers path-based on `schema.ts` and would demand a migration that `db:generate` does not produce for comment-only edits.
- **`whitespace-nowrap` on the badge** is load-bearing: „ohne Position" otherwise wraps inside the narrow column and overflows the badge, with the border cutting through the text. Found by visual check, not by tests.

## Out of scope — same defect, two more places

Recorded in `docs/OSTSEE_FLAGS.md` as **error 4** and follow-up work, deliberately not in this PR:

1. **The notification mail** (default in `configInitializer.ts`, lines ~72–107) checks `inBalticSeaGeo` in its **outer** condition and then shows a green „Ostsee ✓"; `inBalticSea` is only consulted in the else branch. A report from Hamburg harbour gets the same badge as a genuine baltic sighting. The template lives in `app_config` (`notification.email.template`) and the DB value wins over the code default, so a fix needs its own migration path.
2. **`statistics/+page.server.ts`** (lines ~229/230) counts `COUNT(CASE WHEN ostsee_geo = 1 …)` under the field name `inBalticSea` — wrong column plus the `= 1` bug. Not rendered.

Both should be wired to the same function as the overview so the value is produced in one place only.

## Verification

- `npm run test:quick`: **2,441 tests passing** (162 files), 0 TypeScript errors, 0 svelte-check errors. The 2 lint warnings are pre-existing in `src/tests/contract/helpers/createEvent.ts`.
- 15 new unit tests, written before the implementation. The central one asserts that a sighting with `ostsee = 0` and `ostsee_geo = 1` is **not** presented as baltic.
- Checked in the browser (admin session via `seedAdminSession`, no Auth0): 14 header and 14 body cells, and the visible 50 rows distribute as 28 „Ostsee" / 16 „ohne Position" / 6 „außerhalb" / 0 „Widerspruch".

Finding originates from the UI/UX review of 2026-07-30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)