### PR TITLE
chore(ci): watch the legacy-inbox dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,7 +76,8 @@ updates:
   #
   # Das wiegt hier schwerer als beim Hauptrepo: Der Dienst ist ein
   # unauthentifizierter Endpunkt im offenen Netz und hält bis zum Import die
-  # einzige Kopie eingegangener Sichtungen, inklusive Namen und Anschriften.
+  # einzige Kopie eingegangener Sichtungen, inklusive Namen, E-Mail-Adressen,
+  # Anschriften und Telefonnummern.
   #
   # Anders als oben sind Major-Updates hier nicht ausgeschlossen. Bei vier
   # direkten Abhängigkeiten ist ein Major überschaubar zu prüfen, und ein

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,44 @@ updates:
     commit-message:
       prefix: 'chore(deps)'
 
+  # legacy-inbox — eigenes Lockfile, deshalb ein eigener Eintrag.
+  #
+  # Der Dienst wird getrennt vom Hauptrepo auf einen Plesk-Server ausgeliefert
+  # und dort per `npm ci` aus `legacy-inbox/package-lock.json` installiert. Der
+  # Eintrag oben für `/` erfasst dieses Lockfile nicht — ohne diesen Block
+  # liefen die vier Abhängigkeiten des Dienstes unbeobachtet.
+  #
+  # Das wiegt hier schwerer als beim Hauptrepo: Der Dienst ist ein
+  # unauthentifizierter Endpunkt im offenen Netz und hält bis zum Import die
+  # einzige Kopie eingegangener Sichtungen, inklusive Namen und Anschriften.
+  #
+  # Anders als oben sind Major-Updates hier nicht ausgeschlossen. Bei vier
+  # direkten Abhängigkeiten ist ein Major überschaubar zu prüfen, und ein
+  # ausgeschlossenes Major bedeutet bei einer Sicherheitslücke, dass der
+  # Hinweis ausbleibt.
+  - package-ecosystem: 'npm'
+    directory: '/legacy-inbox'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Europe/Berlin'
+    open-pull-requests-limit: 3
+    groups:
+      legacy-inbox-dependencies:
+        applies-to: version-updates
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+    labels:
+      - 'dependencies'
+      - 'automated'
+      - 'legacy-inbox'
+    commit-message:
+      prefix: 'chore(deps)'
+
   # GitHub Actions - grouped together
   - package-ecosystem: 'github-actions'
     directory: '/'


### PR DESCRIPTION
`legacy-inbox/` bringt ein eigenes `package-lock.json` mit, weil der Dienst getrennt vom Hauptrepo auf den Plesk-Server ausgeliefert und dort per `npm ci` installiert wird. Der bestehende Dependabot-Eintrag für `/` erfasst dieses Lockfile nicht — die vier Abhängigkeiten des Dienstes liefen seit #651 unbeobachtet.

Das wiegt dort schwerer als im Hauptrepo: Der Dienst ist ein unauthentifizierter Endpunkt im offenen Netz und hält bis zum Import die einzige Kopie eingegangener Sichtungen, inklusive Namen, Anschriften und Telefonnummern.

## Eine bewusste Abweichung vom bestehenden Eintrag

Der `/`-Eintrag schließt Major-Updates aus (`version-update:semver-major`). Für diesen Block habe ich das **nicht** übernommen.

Bei vier direkten Abhängigkeiten — `@turf/boolean-point-in-polygon`, `@turf/helpers`, `rbush`, `yup` — ist ein Major überschaubar zu prüfen. Und ein ausgeschlossenes Major heißt im Ernstfall: Wenn die Behebung einer Sicherheitslücke nur in der nächsten Hauptversion landet, bleibt der Hinweis aus. Beim Hauptrepo mit seinen vielen Paketen ist der Ausschluss eine vernünftige Lärmbremse; hier überwiegt der Nachteil.

Wenn du das anders siehst, ist es eine Zeile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)