### PR TITLE
fix(test): stop flaky stream-abort tests colliding with unrelated ports

### DIFF
--- a/legacy-inbox/src/routes/createSighting.test.js
+++ b/legacy-inbox/src/routes/createSighting.test.js
@@ -74,15 +74,20 @@ const sende = (koerper, kopfzeilen = { 'Content-Type': 'application/json' }) =>
 	fetch(`${basis}/rest_sichtungen`, { method: 'POST', headers: kopfzeilen, body: koerper });
 
 /**
- * Rohes TCP statt fetch: simuliert einen Client, der die Verbindung mitten in
- * der Übertragung abbricht. Ein Content-Length-Versprechen, das nie eingelöst
- * wird, plus ein Half-Close (FIN) auf der Schreibseite reicht, damit Node den
- * Body-Stream serverseitig mit einem Fehler statt mit 'end' abschließt — die
- * Leseseite bleibt offen, damit die Antwort noch gelesen werden kann.
+ * Rohes Socket statt fetch: simuliert einen Client, der die Verbindung mitten
+ * in der Übertragung abbricht. Ein Content-Length-Versprechen, das nie
+ * eingelöst wird, plus ein Half-Close (FIN) auf der Schreibseite reicht,
+ * damit Node den Body-Stream serverseitig mit einem Fehler statt mit 'end'
+ * abschließt — die Leseseite bleibt offen, damit die Antwort noch gelesen
+ * werden kann.
+ *
+ * Verbindet über einen Unix-Domain-Socket-Pfad, nicht über einen per
+ * server.listen(0) vergebenen TCP-Port (siehe serverAufUnixSocket() unten für
+ * die Begründung).
  */
-const sendeUnterbrochen = (port, teilkoerper) =>
+const sendeUnterbrochen = (sockPfad, teilkoerper) =>
 	new Promise((resolve, reject) => {
-		const socket = net.connect(port, '127.0.0.1', () => {
+		const socket = net.connect(sockPfad, () => {
 			socket.write(
 				'POST /rest_sichtungen HTTP/1.1\r\n' +
 					'Host: localhost\r\n' +
@@ -100,6 +105,34 @@ const sendeUnterbrochen = (port, teilkoerper) =>
 		socket.on('close', () => resolve(antwortRoh));
 		socket.on('error', reject);
 	});
+
+/**
+ * Schließt den übergebenen Server und ersetzt ihn durch einen auf einem
+ * Unix-Domain-Socket im Testverzeichnis — nur für sendeUnterbrochen(...)
+ * gebraucht.
+ *
+ * Grund: server.listen(0) lässt die Laufzeitumgebung einen freien TCP-Port
+ * wählen, aber "frei" ist nur eine Momentaufnahme beim Binden. In der Zeit
+ * zwischen dem close() des einen Servers und dem listen(0) des nächsten kann
+ * ein fremder, kurzlebiger Prozess denselben Port belegen (beobachtet auf
+ * einer Maschine mit vielen parallelen Kurzlebig-Listenern: der Client bekam
+ * eine SSH-Banner-Zeile bzw. eine fremde 401/404-Antwort statt der eigenen
+ * Serverantwort — die Sichtung landete dann folgerichtig nirgends, was wie
+ * ein Schreib-Race aussah, aber keins war). Ein Unix-Domain-Socket-Pfad liegt
+ * dagegen im mkdtemp-Testverzeichnis dieses Tests und ist damit exklusiv:
+ * kein anderer Prozess kann zufällig auf denselben Pfad binden.
+ */
+async function serverAufUnixSocket(aktuellerServer, store) {
+	await new Promise((fertig) => aktuellerServer.close(fertig));
+	const sockPfad = path.join(verzeichnis, 'ipc.sock');
+	const neuerServer = erstelleServer({
+		konfiguration: { maxBodyBytes: 262144 },
+		store,
+		rateLimit: erstelleRateLimit({ proIpProStunde: 100, globalProStunde: 1000 })
+	});
+	await new Promise((fertig) => neuerServer.listen(sockPfad, fertig));
+	return { server: neuerServer, sockPfad };
+}
 
 describe('POST /rest_sichtungen — der Leitsatz', () => {
 	it('hinterlässt auch bei vollständigem Unsinn eine Datei', async () => {
@@ -244,7 +277,12 @@ describe('POST /rest_sichtungen — Vertrag', () => {
 	});
 
 	it('schreibt trotzdem ab, wenn der Body-Stream mitten in der Übertragung abbricht', async () => {
-		const antwortRoh = await sendeUnterbrochen(server.address().port, '{"anzahl_gesamt": 1');
+		const store = await erstelleStore({ datenVerzeichnis: verzeichnis });
+		await store.initialisiere();
+		const ersetzt = await serverAufUnixSocket(server, store);
+		server = ersetzt.server;
+
+		const antwortRoh = await sendeUnterbrochen(ersetzt.sockPfad, '{"anzahl_gesamt": 1');
 
 		const [statuszeile] = antwortRoh.split('\r\n');
 		expect(statuszeile).toContain(' 400 ');
@@ -263,20 +301,15 @@ describe('POST /rest_sichtungen — Vertrag', () => {
 		// Antwortete der clientError-Handler selbst, käme beim Client ein 400
 		// an, obwohl nichts auf der Platte liegt — und ein 500, das ihn zum
 		// erneuten Versuch bewegen würde, wäre nicht mehr möglich.
-		await new Promise((fertig) => server.close(fertig));
-		server = erstelleServer({
-			konfiguration: { maxBodyBytes: 262144 },
-			store: {
-				istBeschreibbar: async () => false,
-				schreibe: async () => {
-					throw new Error('ENOSPC: no space left on device');
-				}
-			},
-			rateLimit: erstelleRateLimit({ proIpProStunde: 100, globalProStunde: 1000 })
+		const ersetzt = await serverAufUnixSocket(server, {
+			istBeschreibbar: async () => false,
+			schreibe: async () => {
+				throw new Error('ENOSPC: no space left on device');
+			}
 		});
-		await new Promise((fertig) => server.listen(0, fertig));
+		server = ersetzt.server;
 
-		const antwortRoh = await sendeUnterbrochen(server.address().port, '{"anzahl_gesamt": 1');
+		const antwortRoh = await sendeUnterbrochen(ersetzt.sockPfad, '{"anzahl_gesamt": 1');
 
 		const [statuszeile] = antwortRoh.split('\r\n');
 		expect(statuszeile).toContain(' 500 ');
@@ -290,7 +323,12 @@ describe('POST /rest_sichtungen — Vertrag', () => {
 		// task-5-report.md, Abschnitt "Fix: flakiger Stream-Abbruch-Test". Dieser
 		// Test prüft direkt gegen die Bytes auf der Leitung, dass stattdessen die
 		// vertragskonforme JSON-Form ankommt.
-		const antwortRoh = await sendeUnterbrochen(server.address().port, '{"anzahl_gesamt": 1');
+		const store = await erstelleStore({ datenVerzeichnis: verzeichnis });
+		await store.initialisiere();
+		const ersetzt = await serverAufUnixSocket(server, store);
+		server = ersetzt.server;
+
+		const antwortRoh = await sendeUnterbrochen(ersetzt.sockPfad, '{"anzahl_gesamt": 1');
 
 		const trennstelle = antwortRoh.indexOf('\r\n\r\n');
 		expect(trennstelle).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

- The reported "write race" in `createSighting.test.js` (the `sendeUnterbrochen()`-based stream-abort tests, incl. "schreibt trotzdem ab, wenn der Body-Stream mitten in der Übertragung abbricht") was investigated extensively: >20,000 instrumented trials directly measuring the ordering between `store.schreibe()` completing and the client observing socket `close` never found a violation. The write-before-respond invariant in `store.js`/`server.js`/`createSighting.js` holds.
- The actual cause: `server.listen(0)` hands the test an OS-assigned ephemeral TCP port, but "free" is only a snapshot at bind time. On a machine with many short-lived listeners, the raw socket client could occasionally reach an unrelated process that happened to grab the same port instead of our own test server (observed directly as an SSH banner line and stray 401/404 replies this app never sends). The sighting then never reached our code, so `abgewiesen/` stayed empty — exactly the `expected [] to have a length of 1 but got +0` symptom, but not a real race.
- Fix: the three `sendeUnterbrochen()`-based tests now connect over a Unix-domain-socket path inside the test's own `mkdtemp` directory (via a small `serverAufUnixSocket()` helper) instead of a `listen(0)` TCP port — exclusive to this test, no possible collision with another process. The `fetch()`-based tests are untouched.
- No production code changed — test-only fix.

## Test plan

- [x] `npm run lint` / `npx prettier --check` on the changed file — clean
- [x] `npx vitest run --project server legacy-inbox/src/routes/createSighting.test.js` — 16/16 pass
- [x] 30 clean sequential repeated runs of the file
- [x] 120 runs under deliberately heavy 6x-parallel stress (the same load that reproduced the underlying port-collision class in an unrelated, unmodified test in this file, confirming the diagnosis) — the three fixed tests never failed
- [x] 20 more sequential runs after a follow-up DRY cleanup (reusing the new helper consistently across all three tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)