### PR TITLE
fix(api): let passenger load the legacy-inbox without top-level await

### DIFF
--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -106,6 +106,33 @@ Pfadfehler soll beim Deploy auffallen und nicht bei der ersten echten Sichtung.
 Knapper Plattenplatz verhindert den Start dagegen **nicht**, sondern wird laut
 protokolliert; siehe Abschnitt „Plattenplatz" unten.
 
+### Zwei Startfehler mit eindeutiger Signatur
+
+**`Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yup'`**
+
+Im Verzeichnis des Dienstes fehlt `node_modules`. Plesks „NPM install"
+arbeitet im Application Root; zeigt der auf einen Symlink, geht die
+Installation je nach Plesk-Version ins Leere. Zuverlässig ist der Weg über
+SSH, im echten Verzeichnis:
+
+    cd <anwendungswurzel>
+    npm ci
+
+Danach die Anwendung neu starten und prüfen:
+
+    ls node_modules | grep -E '^(yup|rbush)$'
+
+**`Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with top-level await`**
+
+Passenger lädt die Anwendung per `require()`, und Node lädt ESM aus CJS nur,
+wenn der Modulgraph kein Top-Level-`await` enthält. `app.js` hält sich daran
+und trägt oben einen Kommentar, der erklärt warum — wer den asynchronen Start
+dort wieder auf die oberste Ebene zieht, bricht das Deployment, ohne dass ein
+lokales `node app.js` etwas davon merkt.
+
+Der Test „lässt sich laden, wie Passenger es lädt" in `app.test.js` deckt
+genau diesen Ladeweg ab.
+
 ## In den Posteingang schauen
 
 Es gibt bewusst keine Oberfläche — die Dateien liegen im Dateisystem:

--- a/legacy-inbox/app.js
+++ b/legacy-inbox/app.js
@@ -1,29 +1,57 @@
+/**
+ * Einstiegspunkt des Dienstes.
+ *
+ * **Hier darf kein Top-Level-`await` stehen.** Phusion Passenger lädt die
+ * Anwendung über `require()`
+ * (`/usr/share/passenger/helper-scripts/node-loader.js`). Node kann ein
+ * ESM-Modul aus CJS heraus laden, aber nur wenn dessen Graph kein
+ * Top-Level-`await` enthält — sonst bricht der Start mit
+ * `ERR_REQUIRE_ASYNC_MODULE` ab, bevor eine Zeile eigener Code läuft.
+ *
+ * Ein direkter Aufruf (`node app.js`) verträgt Top-Level-`await` dagegen
+ * anstandslos. Der Unterschied fällt deshalb erst auf dem Server auf, und dort
+ * als Startfehler ohne erkennbaren Bezug zum eigenen Code. Der asynchrone Teil
+ * gehört darum in `starte()`.
+ *
+ * Dass `server.listen()` erst asynchron aufgerufen wird, stört Passenger
+ * nicht — es wartet darauf, dass die Anwendung zu lauschen beginnt.
+ */
 import { leseKonfiguration } from './src/config.js';
 import { erstelleServer } from './src/server.js';
 import { erstelleStore } from './src/store.js';
 import { erstelleRateLimit } from './src/rateLimit.js';
 import { pruefeStartbedingungen } from './src/startPruefung.js';
 
-const konfiguration = leseKonfiguration(process.env);
-const store = await erstelleStore({ datenVerzeichnis: konfiguration.datenVerzeichnis });
-await store.initialisiere();
+async function starte() {
+	const konfiguration = leseKonfiguration(process.env);
+	const store = await erstelleStore({ datenVerzeichnis: konfiguration.datenVerzeichnis });
+	await store.initialisiere();
 
-// Beschreibbarkeit ist Abbruchgrund, knapper Platz nur ein lauter Hinweis —
-// Begründung beider Entscheidungen in src/startPruefung.js.
-try {
-	await pruefeStartbedingungen({ store, datenVerzeichnis: konfiguration.datenVerzeichnis });
-} catch (fehler) {
-	console.error(fehler.message);
-	process.exit(1);
+	// Beschreibbarkeit ist Abbruchgrund, knapper Platz nur ein lauter Hinweis —
+	// Begründung beider Entscheidungen in src/startPruefung.js.
+	try {
+		await pruefeStartbedingungen({ store, datenVerzeichnis: konfiguration.datenVerzeichnis });
+	} catch (fehler) {
+		console.error(fehler.message);
+		process.exit(1);
+	}
+
+	const rateLimit = erstelleRateLimit({
+		proIpProStunde: konfiguration.rateLimitProIp,
+		globalProStunde: konfiguration.rateLimitGlobal
+	});
+
+	const server = erstelleServer({ konfiguration, store, rateLimit });
+	server.listen(konfiguration.port, () => {
+		console.log(`legacy-inbox lauscht auf Port ${konfiguration.port}`);
+		console.log(`Datenverzeichnis: ${konfiguration.datenVerzeichnis}`);
+	});
 }
 
-const rateLimit = erstelleRateLimit({
-	proIpProStunde: konfiguration.rateLimitProIp,
-	globalProStunde: konfiguration.rateLimitGlobal
-});
-
-const server = erstelleServer({ konfiguration, store, rateLimit });
-server.listen(konfiguration.port, () => {
-	console.log(`legacy-inbox lauscht auf Port ${konfiguration.port}`);
-	console.log(`Datenverzeichnis: ${konfiguration.datenVerzeichnis}`);
+starte().catch((fehler) => {
+	// Fängt unter anderem die fehlende Umgebungsvariable ab, die
+	// leseKonfiguration() wirft. Ohne diesen Handler bliebe davon nur eine
+	// unbehandelte Promise-Ablehnung übrig.
+	console.error(fehler instanceof Error ? fehler.message : String(fehler));
+	process.exit(1);
 });

--- a/legacy-inbox/app.test.js
+++ b/legacy-inbox/app.test.js
@@ -29,7 +29,50 @@ function starte(umgebung) {
 	});
 }
 
+/**
+ * Lädt app.js so, wie Phusion Passenger es auf dem Plesk-Server tut: per
+ * `require()` aus einem CJS-Kontext heraus
+ * (`/usr/share/passenger/helper-scripts/node-loader.js`).
+ *
+ * Dieser Ladeweg unterscheidet sich vom direkten `node app.js` in genau einem
+ * Punkt, und der hat den Dienst beim ersten Deploy am Starten gehindert: Node
+ * lädt ESM aus CJS nur, wenn der Modulgraph kein Top-Level-`await` enthält.
+ * Sonst gibt es ERR_REQUIRE_ASYNC_MODULE, bevor eigener Code läuft — und
+ * `node app.js` allein hätte das nie gezeigt.
+ */
+function starteWiePassenger(umgebung) {
+	return new Promise((fertig) => {
+		const prozess = spawn(
+			process.execPath,
+			[
+				'--input-type=commonjs',
+				'-e',
+				`require(${JSON.stringify(path.join(WURZEL, 'app.js'))});` +
+					'setTimeout(() => process.exit(0), 2000);'
+			],
+			{ env: { ...process.env, ...umgebung } }
+		);
+		let ausgabe = '';
+		prozess.stdout.on('data', (d) => (ausgabe += d));
+		prozess.stderr.on('data', (d) => (ausgabe += d));
+		prozess.on('exit', (code) => fertig({ ausgabe, code }));
+	});
+}
+
 describe('app.js', () => {
+	it('lässt sich laden, wie Passenger es lädt', async () => {
+		const verzeichnis = await mkdtemp(path.join(tmpdir(), 'inbox-passenger-'));
+		const { ausgabe } = await starteWiePassenger({
+			LEGACY_INBOX_DATA_DIR: verzeichnis,
+			PORT: '0'
+		});
+
+		expect(ausgabe).not.toContain('ERR_REQUIRE_ASYNC_MODULE');
+		expect(ausgabe).toContain('lauscht auf Port');
+
+		await rm(verzeichnis, { recursive: true, force: true });
+	}, 20_000);
+
 	it('startet und meldet Port und Datenverzeichnis', async () => {
 		const verzeichnis = await mkdtemp(path.join(tmpdir(), 'inbox-app-'));
 		const { ausgabe } = await starte({ LEGACY_INBOX_DATA_DIR: verzeichnis, PORT: '0' });


### PR DESCRIPTION
Der Dienst startete auf dem Plesk-Server nicht:

```
Error [ERR_REQUIRE_ASYNC_MODULE]: require() cannot be used on an ESM graph with
top-level await. Use import() instead.
  From /usr/share/passenger/helper-scripts/node-loader.js
  Requiring .../legacy-inbox/app.js
```

## Ursache

Passenger lädt die Anwendung per `require()` aus einem CJS-Kontext. Node kann ESM aus CJS laden — aber nur, wenn der Modulgraph **kein Top-Level-`await`** enthält. `app.js` hatte genau das: `await erstelleStore(...)` und `await store.initialisiere()` auf oberster Ebene.

Der Start bricht damit ab, bevor eine Zeile eigener Code läuft.

## Warum die Tests das nicht gefunden haben

Der vorhandene Rauchtest startet `node app.js` — und ein direkter Aufruf verträgt Top-Level-`await` anstandslos. Die beiden Ladewege unterscheiden sich in genau diesem Punkt, und nur der eine wurde geprüft. Der Fehler konnte deshalb erst auf dem Server auftreten, dort als Startfehler ohne erkennbaren Bezug zum eigenen Code.

## Änderung

Der asynchrone Start liegt jetzt in `starte()`, aufgerufen mit einem `.catch()`. Dass `server.listen()` dadurch erst asynchron erfolgt, stört Passenger nicht — es wartet darauf, dass die Anwendung zu lauschen beginnt.

Darüber steht ein Kommentar, der den Grund festhält. Ohne ihn sieht der Aufbau wie eine willkürliche Stilentscheidung aus, die jemand später „aufräumt".

## Test

Neu: `lässt sich laden, wie Passenger es lädt` in `app.test.js` — lädt `app.js` per `require()` aus einem CJS-Kontext, also über denselben Weg wie der Server.

Gegen die bisherige Fassung schlägt er fehl:

```
AssertionError: expected '…' not to contain 'ERR_REQUIRE_ASYNC_MODULE'
```

## README

Zwei Startfehler mit eindeutiger Signatur sind jetzt dokumentiert: dieser und `ERR_MODULE_NOT_FOUND: Cannot find package 'yup'`, der auftritt, wenn Plesks „NPM install" über einen Symlink hinweg ins Leere läuft. Beide sind beim ersten Deploy tatsächlich aufgetreten.

2714 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)