### PR TITLE
feat(admin): surface photo announcements the app can't upload

### DIFF
--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -25,6 +25,11 @@
 		getBalticSeaStatus,
 		type BalticSeaStatus
 	} from '$lib/utils/geo/balticSeaStatus';
+	import {
+		isPhotoAnnouncementPending,
+		PHOTO_ANNOUNCEMENT_LABEL,
+		PHOTO_ANNOUNCEMENT_TITLE
+	} from '$lib/utils/media/photoAnnouncement';
 	import Icon from '$lib/components/Icon.svelte';
 	import { untrack } from 'svelte';
 
@@ -104,6 +109,46 @@
 		const { label: value, badgeClass, title } = BALTIC_SEA_STATUS_PRESENTATION[status];
 
 		return { label, value, badgeClass, title };
+	}
+
+	/**
+	 * Rendert die „Upload"-Zeile der Legacy-Medien-Karte.
+	 *
+	 * Diese Karte wird nur gezeigt, wenn keine Datei angehängt ist (siehe die
+	 * `{#if currentSighting.uploadedFiles?.length}`-Weiche im Markup) — „keine
+	 * Datei" ist an dieser Stelle also bereits sichergestellt. Ist zusätzlich
+	 * `mediaUpload` gesetzt, kommt das Foto laut App per E-Mail nach
+	 * (`$lib/utils/media/photoAnnouncement.ts`); die reine Ja/Nein-Anzeige wäre
+	 * hier nicht von einem defekten Datensatz zu unterscheiden.
+	 *
+	 * Zeigt wie zuvor gar keine Zeile, wenn `mediaUpload` keinen Wert trägt
+	 * (`hasValue`) — dieselbe Bedingung, die vorher direkt an `BooleanDataRow`
+	 * übergeben wurde.
+	 * @returns Ein DataRowType Objekt oder undefined, wenn kein Wert vorliegt
+	 */
+	function MediaUploadRow(): DataRowType | undefined {
+		if (!hasValue(currentSighting.mediaUpload)) return undefined;
+
+		// Zählt die tatsächlich geladenen Dateien, statt sich allein auf die
+		// Template-Weiche zu verlassen — bleibt so auch dann richtig, wenn diese
+		// Funktion einmal außerhalb des aktuellen Kontexts wiederverwendet wird.
+		const attachedFileCount = currentSighting.uploadedFiles?.length ?? 0;
+
+		if (isPhotoAnnouncementPending(currentSighting.mediaUpload, attachedFileCount)) {
+			return {
+				label: 'Upload',
+				value: PHOTO_ANNOUNCEMENT_LABEL,
+				badgeClass: 'badge-info',
+				title: PHOTO_ANNOUNCEMENT_TITLE
+			};
+		}
+
+		return {
+			label: 'Upload',
+			value: '',
+			isBoolean: true,
+			booleanValue: Boolean(currentSighting.mediaUpload)
+		};
 	}
 
 	/**
@@ -320,7 +365,7 @@
 	const mediaRows = $derived(
 		[
 			DataRow('Aufnahme', currentSighting.mediaFile, hasValue(currentSighting.mediaFile)),
-			BooleanDataRow('Upload', currentSighting.mediaUpload, hasValue(currentSighting.mediaUpload)),
+			MediaUploadRow(),
 			// Ohne diese Einwilligung dürfen die Aufnahmen ausschließlich zur
 			// Prüfung der Meldung angesehen werden — nicht veröffentlicht.
 			BooleanDataRow(

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Foto-Ankündigung in der Admin-Detailansicht.
+ *
+ * Der rebuilte iOS-Client setzt `mediaUpload`, kann aber keine Datei
+ * hochladen — das Foto kommt per E-Mail nach. Ohne Einordnung zeigte die
+ * Detailansicht dafür nur „Upload: Ja" ohne jede Datei, was wie ein defekter
+ * Datensatz aussieht. Siehe `$lib/utils/media/photoAnnouncement.ts`.
+ */
+import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import AdminSightingView from './AdminSightingView.svelte';
+import type { FrontendSighting } from '$lib/types';
+import {
+	PHOTO_ANNOUNCEMENT_LABEL,
+	PHOTO_ANNOUNCEMENT_TITLE
+} from '$lib/utils/media/photoAnnouncement';
+
+// Minimales Objekt, wie an anderer Stelle bereits üblich
+// (src/lib/server/export/csvExport.timezone.test.ts) — die Komponente prüft
+// zur Laufzeit nur die tatsächlich gelesenen Felder, nicht das volle Schema.
+function baseSighting(overrides: Record<string, unknown> = {}): FrontendSighting {
+	return {
+		id: 1,
+		species: 0,
+		totalCount: 1,
+		sightingDate: new Date('2026-07-01T10:00:00Z'),
+		created: new Date('2026-07-01T09:00:00Z'),
+		mediaFile: null,
+		mediaUpload: 0,
+		mediaConsent: 0,
+		uploadedFiles: [],
+		...overrides
+	} as unknown as FrontendSighting;
+}
+
+describe('AdminSightingView — Foto-Ankündigung', () => {
+	it('zeigt einen Hinweis statt der reinen Ja/Nein-Anzeige, wenn ein Foto angekündigt, aber keine Datei angehängt ist', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({ mediaUpload: 1, uploadedFiles: [] })
+		});
+
+		const hint = page.getByText(PHOTO_ANNOUNCEMENT_LABEL);
+		await expect.element(hint).toBeVisible();
+		await expect.element(hint).toHaveClass(/badge-info/);
+		await expect.element(hint).toHaveAttribute('title', PHOTO_ANNOUNCEMENT_TITLE);
+	});
+
+	it('zeigt weiterhin die einfache Ja/Nein-Anzeige, wenn kein Foto angekündigt wurde', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({ mediaUpload: 0, uploadedFiles: [] })
+		});
+
+		// Mehrere Zeilen zeigen „Nein" (Totfund, Namensnennung, …) — deshalb
+		// gezielt die Upload-Zeile über ihre Beschriftung greifen.
+		await expect.element(page.getByRole('row', { name: 'Upload Nein' })).toBeVisible();
+		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
+	});
+
+	it('zeigt keinen Ankündigungs-Hinweis mehr, sobald eine Datei angehängt wurde (Medien-Galerie übernimmt)', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({
+				mediaUpload: 1,
+				uploadedFiles: [
+					{
+						id: 1,
+						fileName: 'foto.jpg',
+						originalName: 'foto.jpg',
+						mimeType: 'image/jpeg',
+						size: 1234,
+						url: '/uploads/foto.jpg'
+					}
+				]
+			})
+		});
+
+		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
+	});
+});

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Foto-Ankündigung in der Admin-Detailansicht.
  *
- * Der rebuilte iOS-Client setzt `mediaUpload`, kann aber keine Datei
+ * Der neu gebaute iOS-Client setzt `mediaUpload`, kann aber keine Datei
  * hochladen — das Foto kommt per E-Mail nach. Ohne Einordnung zeigte die
  * Detailansicht dafür nur „Upload: Ja" ohne jede Datei, was wie ein defekter
  * Datensatz aussieht. Siehe `$lib/utils/media/photoAnnouncement.ts`.

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -5,6 +5,7 @@
 	import type { FrontendSighting } from '$lib/types';
 	import { formatFileSize } from '$lib/utils/file/fileSize';
 	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
+	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('ExportModal');
@@ -89,6 +90,8 @@
 			filterDisplays.push('Nur mit Aufnahmen');
 		} else if (currentFilters.mediaUpload === '0') {
 			filterDisplays.push('Nur ohne Aufnahmen');
+		} else if (currentFilters.mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
+			filterDisplays.push('Nur angekündigt, Foto fehlt noch');
 		}
 
 		return filterDisplays.length > 0 ? filterDisplays : ['Keine Filter aktiv'];

--- a/src/lib/server/db/mediaUploadFilter.test.ts
+++ b/src/lib/server/db/mediaUploadFilter.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Gemeinsamer `mediaUpload`-Filter für Admin-Übersicht und
+ * Export.
+ *
+ * `admin/+page.server.ts` und `api/sightings/export/exportFilterParams.ts`
+ * pflegten bisher zwei unabhängige, wortgleiche `if (mediaUpload === '1') …`-
+ * Verzweigungen. Für den neuen Wert `announced_missing` — Foto laut App
+ * angekündigt (`aufnahmeHochladen = 1`), aber keine Datei in
+ * `sichtungen_dateien` angehängt (siehe `$lib/utils/media/photoAnnouncement.ts`)
+ * — reicht ein einfacher Spaltenvergleich nicht mehr; die beiden Kopien hier
+ * ebenfalls zu duplizieren liefe demselben Auseinanderlaufen entgegen, das
+ * `getBalticSeaStatus()` an anderer Stelle beheben sollte.
+ *
+ * Testansatz wie `statisticsApprovalScope.test.ts`: das Prädikat wird über den
+ * echten `PgDialect` zu SQL kompiliert, keine DB-Verbindung nötig.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING, mediaUploadCondition } from './mediaUploadFilter';
+
+const dialect = new PgDialect();
+const toSqlText = (condition: SQL): string => dialect.sqlToQuery(condition).sql;
+
+describe('mediaUploadCondition', () => {
+	it('liefert kein Prädikat für einen unbekannten oder fehlenden Wert', () => {
+		expect(mediaUploadCondition(null)).toBeUndefined();
+		expect(mediaUploadCondition(undefined)).toBeUndefined();
+		expect(mediaUploadCondition('all')).toBeUndefined();
+		expect(mediaUploadCondition('')).toBeUndefined();
+	});
+
+	it('filtert auf "mit Aufnahme" (mediaUpload = 1)', () => {
+		const condition = mediaUploadCondition('1');
+		expect(condition).toBeDefined();
+		expect(toSqlText(condition as SQL)).toContain('"aufnahmeHochladen" = $1');
+	});
+
+	it('filtert auf "ohne Aufnahme" (mediaUpload = 0)', () => {
+		const condition = mediaUploadCondition('0');
+		expect(condition).toBeDefined();
+		expect(toSqlText(condition as SQL)).toContain('"aufnahmeHochladen" = $1');
+	});
+
+	// Der eigentliche neue Fall: Foto angekündigt, aber (noch) keine Datei
+	// angehängt — die Arbeitsliste für Admins.
+	it('kombiniert "angekündigt" (mediaUpload = 1) mit "keine Datei angehängt" (NOT EXISTS)', () => {
+		const condition = mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING);
+		expect(condition).toBeDefined();
+
+		const text = toSqlText(condition as SQL);
+		expect(text).toContain('"aufnahmeHochladen" = $1');
+		expect(text).toContain('not exists'.toUpperCase());
+		expect(text).toContain('sichtungen_dateien');
+		// Korreliert über die Fremdschlüsselspalte, nicht über eine feste ID —
+		// sonst träfe die Bedingung jede Sichtung gleichermaßen.
+		expect(text).toContain('sichtung_id');
+	});
+});

--- a/src/lib/server/db/mediaUploadFilter.ts
+++ b/src/lib/server/db/mediaUploadFilter.ts
@@ -1,0 +1,48 @@
+/**
+ * Gemeinsames `mediaUpload`-Filterprädikat für die Admin-Übersicht
+ * (`routes/admin/+page.server.ts`) und den Export
+ * (`routes/api/sightings/export/exportFilterParams.ts`).
+ *
+ * Bewusst als reine, DB-lose Funktion: Sie baut ein Drizzle-Prädikat über die
+ * Schema-Spalten, führt aber keine Abfrage aus — dieselbe Trennung wie
+ * `approvalFilter.ts`. Beide Aufrufer hängen das Ergebnis an ihre eigene
+ * `and(...)`-Bedingungsliste.
+ */
+import { and, eq, sql, type SQL } from 'drizzle-orm';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+import { sightingFiles, sightings } from './schema';
+
+/**
+ * „Foto angekündigt, aber keine Datei angehängt" — der rebuilte iOS-Client
+ * (`OstSeeTiere/8`, Stand 2026-07-30) setzt `aufnahmeHochladen`, kann aber
+ * keine Datei hochladen; das Foto kommt per E-Mail nach. Dieselbe Aussage wie
+ * `isPhotoAnnouncementPending()` in `$lib/utils/media/photoAnnouncement.ts`,
+ * hier aber als SQL-Prädikat statt als Vergleich gegen einen geladenen
+ * Dateizähler — die Admin-Liste lädt `sichtungen_dateien` nicht pro Zeile.
+ *
+ * Re-Export, damit bestehende Aufrufer (`admin/+page.server.ts`,
+ * `exportFilterParams.ts`) den Wert weiterhin von hier beziehen können.
+ */
+export { MEDIA_UPLOAD_ANNOUNCED_MISSING };
+
+/**
+ * @param mediaUpload Der rohe Query-Parameter (`'1'`, `'0'`,
+ *   `'announced_missing'` oder alles andere/fehlend für „kein Filter").
+ * @returns Ein Prädikat für `and(...)`, oder `undefined`, wenn der Wert keinen
+ *   Filter auslöst.
+ */
+export function mediaUploadCondition(mediaUpload: string | null | undefined): SQL | undefined {
+	if (mediaUpload === '1') {
+		return eq(sightings.mediaUpload, 1);
+	}
+	if (mediaUpload === '0') {
+		return eq(sightings.mediaUpload, 0);
+	}
+	if (mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
+		return and(
+			eq(sightings.mediaUpload, 1),
+			sql`NOT EXISTS (SELECT 1 FROM ${sightingFiles} WHERE ${sightingFiles.sightingId} = ${sightings.id})`
+		);
+	}
+	return undefined;
+}

--- a/src/lib/server/db/mediaUploadFilter.ts
+++ b/src/lib/server/db/mediaUploadFilter.ts
@@ -10,10 +10,10 @@
  */
 import { and, eq, sql, type SQL } from 'drizzle-orm';
 import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
-import { sightingFiles, sightings } from './schema';
+import { sightingFiles, sightings } from '$lib/server/db/schema';
 
 /**
- * „Foto angekündigt, aber keine Datei angehängt" — der rebuilte iOS-Client
+ * „Foto angekündigt, aber keine Datei angehängt" — der neu gebaute iOS-Client
  * (`OstSeeTiere/8`, Stand 2026-07-30) setzt `aufnahmeHochladen`, kann aber
  * keine Datei hochladen; das Foto kommt per E-Mail nach. Dieselbe Aussage wie
  * `isPhotoAnnouncementPending()` in `$lib/utils/media/photoAnnouncement.ts`,

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -523,7 +523,7 @@ describe('EmailService', () => {
 		});
 
 		// ------------------------------------------------------------------
-		// Foto-Ankündigung (rebuilter iOS-Client, Stand 2026-07-30): Der
+		// Foto-Ankündigung (neu gebauter iOS-Client, Stand 2026-07-30): Der
 		// Client setzt `aufnahmeHochladen`, kann aber kein Foto hochladen —
 		// es kommt per E-Mail nach. Ohne einen Hinweis in der
 		// Benachrichtigungs-Mail weiß niemand, welcher Sichtung eine später

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -95,7 +95,8 @@ import {
 	isUnknownOrMissingSpecies
 } from '$lib/utils/format/sightingFormatter';
 import { formatLocalDateTime } from '$lib/utils/format/dateTime';
-import { EmailService } from './emailService';
+import Handlebars from 'handlebars';
+import { DEFAULT_EMAIL_TEMPLATE, EmailService } from './emailService';
 
 // Hilfsfunktionen zum Erstellen von Mocks
 function createMockTransporter(sendMailResult = { messageId: 'test-id-123' }) {
@@ -521,6 +522,73 @@ describe('EmailService', () => {
 			});
 		});
 
+		// ------------------------------------------------------------------
+		// Foto-Ankündigung (rebuilter iOS-Client, Stand 2026-07-30): Der
+		// Client setzt `aufnahmeHochladen`, kann aber kein Foto hochladen —
+		// es kommt per E-Mail nach. Ohne einen Hinweis in der
+		// Benachrichtigungs-Mail weiß niemand, welcher Sichtung eine später
+		// eintreffende Foto-Mail zuzuordnen ist.
+		// ------------------------------------------------------------------
+		describe('Foto-Ankündigung im Template-Kontext', () => {
+			async function renderMailFor(mediaUpload: unknown): Promise<string> {
+				vi.mocked(db.select).mockReturnValue({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([createMockSighting({ mediaUpload })])
+						})
+					})
+				} as any);
+
+				// Der globale Mock in `beforeEach` liefert ein festes Objekt ohne
+				// `mediaUpload`. Hier stattdessen wie die echte Implementierung
+				// das Feld unverändert durchreichen (`...restSighting` in
+				// `formatSightingForDisplay`) — sonst prüfte der Test nur den
+				// eigenen Mock, nicht die Verdrahtung von `loadSightingForEmail`.
+				vi.mocked(formatSightingForDisplay).mockImplementation(
+					(input) =>
+						({
+							species: 'Schweinswal',
+							sightingDate: '15.06.2024',
+							coordinatesFormatted: '54.5000° N, 12.3000° O',
+							mediaUpload: input.mediaUpload
+						}) as any
+				);
+
+				setupConfigRepositoryMocks({
+					enabled: true,
+					smtpHost: 'smtp.example.com',
+					// Minimale Vorlage — prüft die Verdrahtung, nicht das Layout des
+					// ausgelieferten Textes (das übernimmt notificationEmailDefault.test.ts).
+					template:
+						'<html>{{#if sighting.mediaUpload}}foto-angekuendigt:{{referenceId}}{{/if}}</html>'
+				});
+				await EmailService.initialize(false);
+
+				await EmailService.sendNewSightingNotification(42);
+
+				const mailOptions = mockTransporter.sendMail.mock.calls[0]?.[0];
+				return (mailOptions as { html: string }).html;
+			}
+
+			it('reicht ein gesetztes Flag als sighting.mediaUpload an die Vorlage durch', async () => {
+				const html = await renderMailFor(1);
+
+				expect(html).toContain('foto-angekuendigt:REF-42');
+			});
+
+			it('lässt den Block weg, wenn kein Foto angekündigt wurde', async () => {
+				const html = await renderMailFor(0);
+
+				expect(html).not.toContain('foto-angekuendigt');
+			});
+
+			it('lässt den Block bei null (kein Wert in der Zeile) ebenfalls weg', async () => {
+				const html = await renderMailFor(null);
+
+				expect(html).not.toContain('foto-angekuendigt');
+			});
+		});
+
 		it('gibt false zurück wenn DB-Abfrage fehlschlägt', async () => {
 			vi.mocked(db.select).mockReturnValue({
 				from: vi.fn().mockReturnValue({
@@ -703,6 +771,48 @@ describe('EmailService', () => {
 			const result = await EmailService.sendNewSightingNotification(42);
 
 			expect(result).toBe(true);
+		});
+
+		// ------------------------------------------------------------------
+		// DEFAULT_EMAIL_TEMPLATE ist der letzte Rückfall, wenn sowohl die
+		// DB-Konfiguration als auch die Datei `sightingNotificationTemplate.html`
+		// nicht lesbar sind. Direkter Handlebars-Test statt über den Service:
+		// `getEmailConfig()` liefert im Test immer einen konfigurierten
+		// `template`-Wert (siehe `setupConfigRepositoryMocks`) und erreicht
+		// `getDefaultTemplate()` deshalb nie — dieser Pfad ist nur so prüfbar.
+		describe('DEFAULT_EMAIL_TEMPLATE — Foto-Ankündigung', () => {
+			const render = Handlebars.compile(DEFAULT_EMAIL_TEMPLATE);
+
+			function renderWithMediaUpload(mediaUpload: boolean) {
+				return render({
+					referenceId: 'REF-99',
+					adminUrl: 'https://example.com/admin/1',
+					sighting: {
+						species: 'Schweinswal',
+						sightingDate: '30.07.2026',
+						coordinatesFormatted: '54.5000° N, 12.3000° O',
+						mediaUpload,
+						balticSea: { label: 'Ostsee' }
+					}
+				});
+			}
+
+			it('weist auch im letzten Rückfall auf das nachfolgende Foto hin', () => {
+				const html = renderWithMediaUpload(true);
+
+				expect(html).toContain('Foto angekündigt');
+				expect(html).toContain('REF-99');
+			});
+
+			it('lässt den Hinweis weg, wenn kein Foto angekündigt wurde', () => {
+				const html = renderWithMediaUpload(false);
+
+				expect(html).not.toContain('Foto angekündigt');
+			});
+
+			it('ist gültiges Handlebars und rendert ohne Ausnahme', () => {
+				expect(() => renderWithMediaUpload(true)).not.toThrow();
+			});
 		});
 	});
 });

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -37,7 +37,10 @@ const __dirname = dirname(__filename);
 const logger = createLogger('emailService');
 
 // Default email template as constant to avoid inline HTML
-const DEFAULT_EMAIL_TEMPLATE = `<!DOCTYPE html>
+// Exportiert, damit dieser letzte Rückfallpfad (DB **und** Datei nicht
+// lesbar) direkt mit Handlebars getestet werden kann — siehe
+// emailService.test.ts, "DEFAULT_EMAIL_TEMPLATE — Foto-Ankündigung".
+export const DEFAULT_EMAIL_TEMPLATE = `<!DOCTYPE html>
 <html lang="de">
 <head>
 	<meta charset="UTF-8">
@@ -48,6 +51,9 @@ const DEFAULT_EMAIL_TEMPLATE = `<!DOCTYPE html>
 	<p><strong>Tierart:</strong> {{sighting.species}}</p>
 	<p><strong>Datum:</strong> {{sighting.sightingDate}}</p>
 	<p><strong>Position:</strong> {{sighting.coordinatesFormatted}} ({{sighting.balticSea.label}})</p>
+	{{#if sighting.mediaUpload}}
+	<p><strong>📷 Foto angekündigt:</strong> Der Melder hat laut App ein Foto, kann es aber nicht direkt hochladen — es kommt separat per E-Mail nach. Beim Eintreffen bitte anhand der Referenz-ID {{referenceId}} zuordnen.</p>
+	{{/if}}
 	<p><a href="{{adminUrl}}">Sichtung im Admin-Bereich anzeigen</a></p>
 </body>
 </html>`;

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -109,7 +109,7 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	});
 
 	/**
-	 * Foto-Ankündigung (rebuilter iOS-Client `OstSeeTiere/8`, Stand
+	 * Foto-Ankündigung (neu gebauter iOS-Client `OstSeeTiere/8`, Stand
 	 * 2026-07-30): Der Client setzt `aufnahmeHochladen`, kann aber kein Foto
 	 * hochladen — es kommt separat per E-Mail nach. Ohne einen Hinweis in
 	 * dieser Mail lässt sich eine später eintreffende Foto-Mail keiner
@@ -185,7 +185,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390');
+		expect(hash).toBe('2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -109,6 +109,48 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	});
 
 	/**
+	 * Foto-Ankündigung (rebuilter iOS-Client `OstSeeTiere/8`, Stand
+	 * 2026-07-30): Der Client setzt `aufnahmeHochladen`, kann aber kein Foto
+	 * hochladen — es kommt separat per E-Mail nach. Ohne einen Hinweis in
+	 * dieser Mail lässt sich eine später eintreffende Foto-Mail keiner
+	 * Sichtung zuordnen.
+	 */
+	describe('Foto-Ankündigung', () => {
+		function renderWithMediaUpload(mediaUpload: boolean) {
+			return render({
+				referenceId: 'REF-77',
+				adminUrl: 'https://example.com/admin/1',
+				currentDate: '30.07.2026',
+				currentTime: '12:00',
+				spamCheck: { score: 0, isHighRisk: false, indicators: [] },
+				sighting: {
+					species: 'Schweinswal',
+					sightingDate: '30.07.2026',
+					coordinatesFormatted: null,
+					mediaUpload,
+					balticSea: balticSeaEmailContext({})
+				},
+				...emailColorContext()
+			});
+		}
+
+		it('weist beim Empfänger auf das nachfolgende Foto hin und nennt die Referenz-ID', () => {
+			const html = renderWithMediaUpload(true);
+
+			expect(html).toContain('Foto angekündigt');
+			// Referenz-ID steht bereits im Kopfbereich — hier zählt, dass sie
+			// auch innerhalb des Hinweises zum Zuordnen genannt wird.
+			expect(html.match(/REF-77/g)?.length).toBeGreaterThan(1);
+		});
+
+		it('lässt den Hinweis weg, wenn kein Foto angekündigt wurde', () => {
+			const html = renderWithMediaUpload(false);
+
+			expect(html).not.toContain('Foto angekündigt');
+		});
+	});
+
+	/**
 	 * Ein `<!-- … -->` mit `{{#if …}}` darin wird von Handlebars **ausgewertet**,
 	 * nicht zitiert — genau daran ist diese Vorlage beim Umbau einmal
 	 * unbalanciert geworden (Parse-Fehler erst zur Laufzeit). Erklärende Notizen
@@ -143,7 +185,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e');
+		expect(hash).toBe('e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -34,6 +34,10 @@
  * aktuellen Stands und schlägt bei jeder Änderung fehl.
  */
 export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
+	// Stand bis 2026-07-30: ohne Hinweis auf ein per E-Mail nachgereichtes
+	// Foto (rebuilter iOS-Client `OstSeeTiere/8` setzt `aufnahmeHochladen`,
+	// kann aber keine Datei hochladen).
+	'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
 	// Stand bis 2026-07-30: verzweigte über `inBalticSeaGeo` (Bounding Box) und
 	// zeigte einer Meldung aus dem Hamburger Hafen „Ostsee ✓".
 	'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
@@ -146,6 +150,21 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 			{{/if}}
 		</table>
 	</div>
+
+	{{!--
+		Foto-Ankündigung: Der rebuilte iOS-Client (OstSeeTiere/8, Stand
+		2026-07-30) setzt aufnahmeHochladen, kann aber selbst keine Datei
+		hochladen — der Melder wird gebeten, das Foto per E-Mail nachzureichen.
+		Ohne diesen Hinweis lässt sich die später eintreffende Foto-Mail keiner
+		Sichtung zuordnen. Siehe $lib/utils/media/photoAnnouncement.ts.
+	--}}
+	{{#if sighting.mediaUpload}}
+	<div class="alert-info">
+		<p style="margin: 0; font-size: 14px;">
+			<strong>📷 Foto angekündigt:</strong> Der Melder hat laut App ein Foto, kann es aber nicht direkt hochladen — es kommt separat per E-Mail nach. Beim Eintreffen bitte anhand der Referenz-ID <strong>{{referenceId}}</strong> zuordnen.
+		</p>
+	</div>
+	{{/if}}
 
 	<!-- Contact Information -->
 	{{#if sighting.email}}

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -34,8 +34,12 @@
  * aktuellen Stands und schlägt bei jeder Änderung fehl.
  */
 export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
+	// Stand bis 2026-07-30: Foto-Hinweis wortidentisch, aber „rebuilter
+	// iOS-Client" statt der im Projekt sonst üblichen Formulierung „neu
+	// gebauter iOS-Client" (siehe .claude/rules/legacy-api.md).
+	'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
 	// Stand bis 2026-07-30: ohne Hinweis auf ein per E-Mail nachgereichtes
-	// Foto (rebuilter iOS-Client `OstSeeTiere/8` setzt `aufnahmeHochladen`,
+	// Foto (neu gebauter iOS-Client `OstSeeTiere/8` setzt `aufnahmeHochladen`,
 	// kann aber keine Datei hochladen).
 	'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
 	// Stand bis 2026-07-30: verzweigte über `inBalticSeaGeo` (Bounding Box) und
@@ -152,7 +156,7 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 	</div>
 
 	{{!--
-		Foto-Ankündigung: Der rebuilte iOS-Client (OstSeeTiere/8, Stand
+		Foto-Ankündigung: Der neu gebaute iOS-Client (OstSeeTiere/8, Stand
 		2026-07-30) setzt aufnahmeHochladen, kann aber selbst keine Datei
 		hochladen — der Melder wird gebeten, das Foto per E-Mail nachzureichen.
 		Ohne diesen Hinweis lässt sich die später eintreffende Foto-Mail keiner

--- a/src/lib/server/templates/sightingNotificationTemplate.html
+++ b/src/lib/server/templates/sightingNotificationTemplate.html
@@ -167,7 +167,27 @@
 				{{/if}}
 			</div>
 
-			{{#if sighting.notes}}
+			{{!-- Foto-Ankündigung: Der rebuilte iOS-Client (OstSeeTiere/8, Stand 2026-07-30) setzt
+			aufnahmeHochladen, kann aber selbst keine Datei hochladen — der Melder wird gebeten, das Foto
+			per E-Mail nachzureichen. Siehe $lib/utils/media/photoAnnouncement.ts. --}} {{#if
+			sighting.mediaUpload}}
+			<div
+				style="
+					background: {{colors.infoSurface}};
+					border: 1px solid {{colors.infoStrong}};
+					border-radius: 6px;
+					padding: 15px;
+					margin: 15px 0;
+				"
+			>
+				<h3 style="margin-top: 0; color: {{colors.infoStrong}}">📷 Foto angekündigt</h3>
+				<p style="color: {{colors.text}}">
+					Der Melder hat laut App ein Foto, kann es aber nicht direkt hochladen — es kommt separat
+					per E-Mail nach. Beim Eintreffen bitte anhand der Referenz-ID
+					<strong>{{referenceId}}</strong> zuordnen.
+				</p>
+			</div>
+			{{/if}} {{#if sighting.notes}}
 			<div
 				style="
 					background: {{colors.page}};

--- a/src/lib/server/templates/sightingNotificationTemplate.html
+++ b/src/lib/server/templates/sightingNotificationTemplate.html
@@ -167,10 +167,14 @@
 				{{/if}}
 			</div>
 
-			{{!-- Foto-Ankündigung: Der rebuilte iOS-Client (OstSeeTiere/8, Stand 2026-07-30) setzt
-			aufnahmeHochladen, kann aber selbst keine Datei hochladen — der Melder wird gebeten, das Foto
-			per E-Mail nachzureichen. Siehe $lib/utils/media/photoAnnouncement.ts. --}} {{#if
-			sighting.mediaUpload}}
+			<!-- prettier-ignore -->
+			{{!--
+				Foto-Ankündigung: Der neu gebaute iOS-Client (OstSeeTiere/8, Stand
+				2026-07-30) setzt aufnahmeHochladen, kann aber selbst keine Datei
+				hochladen — der Melder wird gebeten, das Foto per E-Mail
+				nachzureichen. Siehe $lib/utils/media/photoAnnouncement.ts.
+			--}}
+			{{#if sighting.mediaUpload}}
 			<div
 				style="
 					background: {{colors.infoSurface}};
@@ -187,7 +191,9 @@
 					<strong>{{referenceId}}</strong> zuordnen.
 				</p>
 			</div>
-			{{/if}} {{#if sighting.notes}}
+			<!-- prettier-ignore -->
+			{{/if}}
+			{{#if sighting.notes}}
 			<div
 				style="
 					background: {{colors.page}};

--- a/src/lib/types/Pagination.ts
+++ b/src/lib/types/Pagination.ts
@@ -15,4 +15,11 @@ export interface Pagination {
 export interface PageData {
 	sightings: FrontendSighting[];
 	pagination: Pagination;
+	/**
+	 * Arbeitslisten-Zähler „Foto angekündigt, fehlt noch" — Sichtungen mit
+	 * `mediaUpload` gesetzt, aber ohne angehängte Datei
+	 * (`$lib/utils/media/photoAnnouncement.ts`). Unabhängig vom aktiven
+	 * Filter, damit er im Dashboard-Kopf immer sichtbar ist.
+	 */
+	pendingPhotoAnnouncements?: number;
 }

--- a/src/lib/utils/media/photoAnnouncement.test.ts
+++ b/src/lib/utils/media/photoAnnouncement.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Der rebuilte iOS-Client (`OstSeeTiere/8`) setzt `aufnahmeHochladen`
+ * (→ `mediaUpload`), kann aber selbst keine Datei hochladen — Melder werden
+ * gebeten, das Foto per E-Mail nachzureichen. Bis dahin liest „Upload: ja" ohne
+ * angehängte Datei wie ein defekter Datensatz.
+ *
+ * `isPhotoAnnouncementPending()` ist die einzige Stelle, an der dieser Zustand
+ * entsteht — analog zu `getBalticSeaStatus()` in `balticSeaStatus.ts`. Admin-
+ * Detailansicht und Admin-Arbeitsliste (DB-Filter) müssen dieselbe Aussage
+ * treffen, sonst laufen sie auseinander wie zuvor der Ostsee-Status.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+	isPhotoAnnouncementPending,
+	MEDIA_UPLOAD_ANNOUNCED_MISSING,
+	PHOTO_ANNOUNCEMENT_LABEL
+} from './photoAnnouncement';
+
+describe('isPhotoAnnouncementPending', () => {
+	it('ist wahr, wenn ein Foto angekündigt ist und keine Datei angehängt wurde', () => {
+		expect(isPhotoAnnouncementPending(1, 0)).toBe(true);
+	});
+
+	it('ist falsch, sobald mindestens eine Datei angehängt ist', () => {
+		expect(isPhotoAnnouncementPending(1, 1)).toBe(false);
+		expect(isPhotoAnnouncementPending(1, 3)).toBe(false);
+	});
+
+	it('ist falsch, wenn kein Foto angekündigt wurde — unabhängig von der Dateizahl', () => {
+		expect(isPhotoAnnouncementPending(0, 0)).toBe(false);
+		expect(isPhotoAnnouncementPending(null, 0)).toBe(false);
+		expect(isPhotoAnnouncementPending(undefined, 0)).toBe(false);
+	});
+
+	it('behandelt einen booleschen mediaUpload-Wert genauso wie das DB-Integer-Flag', () => {
+		expect(isPhotoAnnouncementPending(true, 0)).toBe(true);
+		expect(isPhotoAnnouncementPending(false, 0)).toBe(false);
+	});
+
+	it('exportiert einen stabilen deutschen Hinweistext', () => {
+		expect(PHOTO_ANNOUNCEMENT_LABEL).toBe('Foto angekündigt, folgt per E-Mail');
+	});
+
+	it('exportiert einen stabilen Filterwert für die Admin-Arbeitsliste', () => {
+		expect(MEDIA_UPLOAD_ANNOUNCED_MISSING).toBe('announced_missing');
+	});
+});

--- a/src/lib/utils/media/photoAnnouncement.test.ts
+++ b/src/lib/utils/media/photoAnnouncement.test.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Der rebuilte iOS-Client (`OstSeeTiere/8`) setzt `aufnahmeHochladen`
+ * @fileoverview Der neu gebaute iOS-Client (`OstSeeTiere/8`) setzt `aufnahmeHochladen`
  * (→ `mediaUpload`), kann aber selbst keine Datei hochladen — Melder werden
  * gebeten, das Foto per E-Mail nachzureichen. Bis dahin liest „Upload: ja" ohne
  * angehängte Datei wie ein defekter Datensatz.

--- a/src/lib/utils/media/photoAnnouncement.ts
+++ b/src/lib/utils/media/photoAnnouncement.ts
@@ -1,6 +1,6 @@
 /**
  * „Foto angekündigt, aber noch nicht eingetroffen" — Zustand einer Sichtung
- * vom rebuilten iOS-Client (`OstSeeTiere/8`, Stand 2026-07-30).
+ * vom neu gebauten iOS-Client (`OstSeeTiere/8`, Stand 2026-07-30).
  *
  * Der Client setzt `aufnahmeHochladen` (→ `mediaUpload`), wenn der Melder ein
  * Foto hat, kann darüber aber keine Datei übertragen — der Client kann nicht

--- a/src/lib/utils/media/photoAnnouncement.ts
+++ b/src/lib/utils/media/photoAnnouncement.ts
@@ -1,0 +1,47 @@
+/**
+ * „Foto angekündigt, aber noch nicht eingetroffen" — Zustand einer Sichtung
+ * vom rebuilten iOS-Client (`OstSeeTiere/8`, Stand 2026-07-30).
+ *
+ * Der Client setzt `aufnahmeHochladen` (→ `mediaUpload`), wenn der Melder ein
+ * Foto hat, kann darüber aber keine Datei übertragen — der Client kann nicht
+ * geändert werden. Melder werden gebeten, das Foto per E-Mail nachzureichen.
+ * Ohne diese Einordnung liest „Upload: ja" ohne angehängte Datei wie ein
+ * defekter Datensatz, dabei ist es eine erwartete Zwischenphase.
+ *
+ * **Einzige Stelle, an der dieser Zustand entsteht** — analog zu
+ * `getBalticSeaStatus()` in `$lib/utils/geo/balticSeaStatus.ts`. Angeschlossen
+ * sind die Admin-Detailansicht (`AdminSightingView.svelte`) und der
+ * Datenbank-Filter für die Admin-Arbeitsliste
+ * (`$lib/server/db/mediaUploadFilter.ts`). Die Benachrichtigungs-Mail prüft
+ * dagegen nur das rohe Flag: beim Versand — unmittelbar nach dem Anlegen der
+ * Sichtung — kann noch keine Datei angehängt sein, der Dateizähler wäre dort
+ * immer 0 und träfe keine zusätzliche Aussage.
+ */
+
+/** Zählt als „gesetzt", egal ob DB-Integer (0/1) oder Formular-Boolean. */
+type MediaUploadFlag = number | boolean | null | undefined;
+
+export function isPhotoAnnouncementPending(
+	mediaUpload: MediaUploadFlag,
+	attachedFileCount: number
+): boolean {
+	return !!mediaUpload && attachedFileCount === 0;
+}
+
+export const PHOTO_ANNOUNCEMENT_LABEL = 'Foto angekündigt, folgt per E-Mail';
+
+export const PHOTO_ANNOUNCEMENT_TITLE =
+	'Der Melder hat laut App ein Foto, kann es darüber aber nicht hochladen — es kommt separat per E-Mail. Beim Eintreffen anhand der Referenz-ID zuordnen.';
+
+/**
+ * Wert des `mediaUpload`-Query-Parameters für die Admin-Arbeitsliste
+ * „angekündigt, aber keine Datei angehängt" — dieselbe Aussage wie
+ * `isPhotoAnnouncementPending()`, hier als Filterwert für Admin-Übersicht und
+ * Export (`$lib/server/db/mediaUploadFilter.ts`).
+ *
+ * **Hier und nicht in `mediaUploadFilter.ts` definiert**, weil diese Datei
+ * client-sicher ist und `mediaUploadFilter.ts` `$lib/server/db/schema`
+ * importiert — ein Import von dort in `admin/+page.svelte` würde
+ * SvelteKits Server-only-Grenze verletzen.
+ */
+export const MEDIA_UPLOAD_ANNOUNCED_MISSING = 'announced_missing';

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -112,11 +112,14 @@ export const load: PageServerLoad = async ({ url }) => {
 		.from(sightings)
 		.where(mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING));
 
-	// Abfragen ausführen
-	const data = await paginatedQuery;
-	const countResult = await countQuery;
+	// Abfragen ausführen — voneinander unabhängig, deshalb parallel statt
+	// sequenziell (drei Round-Trips gleichzeitig statt hintereinander).
+	const [data, countResult, pendingPhotoResult] = await Promise.all([
+		paginatedQuery,
+		countQuery,
+		pendingPhotoQuery
+	]);
 	const count = countResult[0]?.count || 0;
-	const pendingPhotoResult = await pendingPhotoQuery;
 	const pendingPhotoAnnouncements = pendingPhotoResult[0]?.count || 0;
 
 	return {

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,6 +1,10 @@
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
+import {
+	MEDIA_UPLOAD_ANNOUNCED_MISSING,
+	mediaUploadCondition
+} from '$lib/server/db/mediaUploadFilter';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
@@ -53,11 +57,11 @@ export const load: PageServerLoad = async ({ url }) => {
 		}
 	}
 
-	// Aufnahme-Filter (Media Upload)
-	if (mediaUpload === '1') {
-		conditions.push(eq(sightings.mediaUpload, 1));
-	} else if (mediaUpload === '0') {
-		conditions.push(eq(sightings.mediaUpload, 0));
+	// Aufnahme-Filter (Media Upload) — inkl. „angekündigt, aber keine Datei
+	// angehängt" (announced_missing), siehe mediaUploadFilter.ts.
+	const mediaCondition = mediaUploadCondition(mediaUpload);
+	if (mediaCondition) {
+		conditions.push(mediaCondition);
 	}
 
 	// Kombinierte WHERE-Bedingung erstellen
@@ -100,10 +104,20 @@ export const load: PageServerLoad = async ({ url }) => {
 	// WHERE-Klausel zur Count-Abfrage hinzufügen
 	const countQuery = whereCondition ? countBaseQuery.where(whereCondition) : countBaseQuery;
 
+	// Arbeitslisten-Zähler „Foto angekündigt, fehlt noch" — unabhängig vom
+	// aktiven Filter, damit er als Hinweis im Dashboard-Kopf sichtbar ist, auch
+	// wenn gerade eine andere Ansicht gefiltert ist.
+	const pendingPhotoQuery = db
+		.select({ count: sql<number>`count(*)` })
+		.from(sightings)
+		.where(mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING));
+
 	// Abfragen ausführen
 	const data = await paginatedQuery;
 	const countResult = await countQuery;
 	const count = countResult[0]?.count || 0;
+	const pendingPhotoResult = await pendingPhotoQuery;
+	const pendingPhotoAnnouncements = pendingPhotoResult[0]?.count || 0;
 
 	return {
 		sightings: data,
@@ -113,6 +127,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			totalPages: Math.ceil(count / perPage),
 			total: count,
 			maxPerPage: paginationConfig.maxSightingsPerPage
-		}
+		},
+		pendingPhotoAnnouncements
 	};
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -22,6 +22,7 @@
 		BALTIC_SEA_STATUS_PRESENTATION,
 		getBalticSeaStatus
 	} from '$lib/utils/geo/balticSeaStatus';
+	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 
 	const logger = createLogger('SichtungenPage');
 
@@ -143,6 +144,18 @@
 
 		url.searchParams.set('page', '1');
 		goto(url);
+	}
+
+	/**
+	 * Springt direkt zur Arbeitsliste „Foto angekündigt, fehlt noch"
+	 * (siehe `$lib/utils/media/photoAnnouncement.ts`). Setzt nur den
+	 * Aufnahme-Filter — andere aktive Filter bleiben erhalten, damit z. B. ein
+	 * bereits gesetzter Datumsbereich nicht verloren geht.
+	 */
+	function showPendingPhotoAnnouncements(): void {
+		mediaUpload = MEDIA_UPLOAD_ANNOUNCED_MISSING;
+		isFilterPanelOpen = true;
+		applyFilters();
 	}
 
 	function resetFilters(): void {
@@ -385,6 +398,31 @@
 <div class="pt-6">
 	<!-- Page Header -->
 	<div class="container mx-auto mb-6 px-4 sm:px-6">
+		<!--
+			Arbeitslisten-Hinweis „Foto angekündigt, fehlt noch"
+			(siehe $lib/utils/media/photoAnnouncement.ts). Echter `btn btn-outline`
+			statt eines mit `onclick` klickbar gemachten `badge`: Nur `.btn` bzw.
+			`summary.btn` bekommen über app.css automatisch die 44px-Touch-Target-
+			Mindestgröße (design-system.md „Feldmodus und Touch-Targets") — ein
+			`badge` bleibt bei ~24px hoch und wäre auf der Mobile-Kartenansicht
+			dieser Seite nicht zuverlässig zu treffen. `btn-outline` statt eines
+			vollton-farbigen `btn-info`, weil Vollton-Sekundärbuttons neben der
+			Primäraktion „Export" optisch mit ihr konkurrieren würden (Button-
+			Hierarchie-Regel); die Statusfarbe trägt stattdessen nur das Icon
+			(`text-info-strong`, AA-geprüft laut tokens.css).
+		-->
+		{#snippet pendingPhotoBadge()}
+			<button
+				type="button"
+				class="btn btn-sm btn-outline"
+				onclick={showPendingPhotoAnnouncements}
+				title="Sichtungen mit angekündigtem, aber noch nicht eingetroffenem Foto anzeigen"
+			>
+				<Icon icon="lucide:camera" class="text-info-strong mr-1 h-4 w-4" aria-hidden="true" />
+				{data.pendingPhotoAnnouncements} Foto{data.pendingPhotoAnnouncements === 1 ? '' : 's'} ausstehend
+			</button>
+		{/snippet}
+
 		<!-- Mobile Layout -->
 		<div class="block space-y-3 sm:hidden">
 			<h1 class="text-2xl font-bold">Sichtungen</h1>
@@ -415,9 +453,14 @@
 						Export
 					</button>
 				</div>
-				{#if data.pagination && data.pagination.total}
-					<div class="text-center">
-						<span class="badge badge-outline text-sm">{data.pagination.total} Ergebnisse</span>
+				{#if (data.pagination && data.pagination.total) || data.pendingPhotoAnnouncements}
+					<div class="flex flex-wrap items-center justify-center gap-2">
+						{#if data.pagination && data.pagination.total}
+							<span class="badge badge-outline text-sm">{data.pagination.total} Ergebnisse</span>
+						{/if}
+						{#if data.pendingPhotoAnnouncements}
+							{@render pendingPhotoBadge()}
+						{/if}
 					</div>
 				{/if}
 			</div>
@@ -494,6 +537,9 @@
 					<Icon icon="lucide:download" class="mr-1 h-4 w-4" />
 					Export
 				</button>
+				{#if data.pendingPhotoAnnouncements}
+					{@render pendingPhotoBadge()}
+				{/if}
 				{#if data.pagination && data.pagination.total}
 					<span class="badge badge-outline whitespace-nowrap"
 						>{data.pagination.total} Ergebnisse</span
@@ -588,6 +634,7 @@
 						<option value="">Alle</option>
 						<option value="1">Mit</option>
 						<option value="0">Ohne</option>
+						<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}>Angekündigt, fehlt noch</option>
 					</select>
 				</div>
 			</div>

--- a/src/routes/admin/page.server.test.ts
+++ b/src/routes/admin/page.server.test.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Admin-Dashboard: Arbeitsliste „Foto angekündigt, fehlt noch".
  *
- * Der rebuilte iOS-Client setzt `aufnahmeHochladen`, kann aber kein Foto
+ * Der neu gebaute iOS-Client setzt `aufnahmeHochladen`, kann aber kein Foto
  * hochladen — es kommt per E-Mail nach (`$lib/utils/media/photoAnnouncement.ts`).
  * `load()` muss zwei Dinge leisten:
  *

--- a/src/routes/admin/page.server.test.ts
+++ b/src/routes/admin/page.server.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Admin-Dashboard: Arbeitsliste „Foto angekündigt, fehlt noch".
+ *
+ * Der rebuilte iOS-Client setzt `aufnahmeHochladen`, kann aber kein Foto
+ * hochladen — es kommt per E-Mail nach (`$lib/utils/media/photoAnnouncement.ts`).
+ * `load()` muss zwei Dinge leisten:
+ *
+ * 1. Der Filterwert `mediaUpload=announced_missing` muss dieselbe Bedingung
+ *    erzeugen wie `mediaUploadCondition()` — sonst driftet die Admin-Liste vom
+ *    zentral getesteten Filter auseinander.
+ * 2. Unabhängig vom aktiven Filter liefert `load()` einen globalen Zähler
+ *    `pendingPhotoAnnouncements`, damit Admins die Arbeitsliste sehen, ohne
+ *    den Filter erst öffnen zu müssen.
+ *
+ * Testansatz wie `statisticsApprovalScope.test.ts`: ein aufzeichnender
+ * `db.select`-Mock, das WHERE-Prädikat wird über den echten `PgDialect` zu SQL
+ * kompiliert.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL, SQLWrapper } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	MEDIA_UPLOAD_ANNOUNCED_MISSING,
+	mediaUploadCondition
+} from '$lib/server/db/mediaUploadFilter';
+
+const dialect = new PgDialect();
+const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
+
+/** Ein `db.select(...)`-Aufruf, wie ihn `load()` erzeugt. */
+type RecordedSelect = { columns: Record<string, unknown> | undefined; whereSql?: string };
+
+let recordedSelects: RecordedSelect[] = [];
+/** Rückgabewerte in Aufrufreihenfolge — `load()` ruft `db.select` dreimal auf. */
+let resolvedRows: unknown[][] = [];
+
+function createRecordingBuilder(record: RecordedSelect) {
+	const builder = {
+		from: () => builder,
+		where: (predicate?: SQL) => {
+			if (predicate) record.whereSql = toSqlText(predicate);
+			return builder;
+		},
+		orderBy: () => builder,
+		limit: () => builder,
+		offset: () => builder,
+		then: (resolve: (rows: unknown[]) => unknown, reject?: (error: unknown) => unknown) =>
+			Promise.resolve(resolvedRows[recordedSelects.indexOf(record)] ?? []).then(resolve, reject)
+	};
+	return builder;
+}
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: (columns?: Record<string, unknown>) => {
+			const record: RecordedSelect = { columns };
+			recordedSelects.push(record);
+			return createRecordingBuilder(record);
+		}
+	}
+}));
+
+vi.mock('$lib/services/configService', () => ({
+	ServerConfigService: {
+		getPaginationConfig: vi
+			.fn()
+			.mockResolvedValue({ defaultPageSize: 20, maxSightingsPerPage: 100 })
+	}
+}));
+
+function makeUrl(params: Record<string, string> = {}): URL {
+	const url = new URL('https://example.com/admin');
+	for (const [key, value] of Object.entries(params)) {
+		url.searchParams.set(key, value);
+	}
+	return url;
+}
+
+const { load } = await import('./+page.server');
+
+describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => {
+	beforeEach(() => {
+		recordedSelects = [];
+		resolvedRows = [[{ id: 1 }], [{ count: 5 }], [{ count: 2 }]];
+	});
+
+	it('liefert pendingPhotoAnnouncements unabhängig vom aktiven Filter', async () => {
+		// `PageServerLoad` erlaubt generisch auch `void` als Rückgabe (Redirects
+		// o.ä.); für diesen Test ist das tatsächlich zurückgegebene Objekt
+		// bekannt, deshalb der Cast statt eines Guards gegen `void`.
+		const result = (await load({
+			url: makeUrl()
+		} as unknown as Parameters<typeof load>[0])) as { pendingPhotoAnnouncements: number };
+
+		expect(result.pendingPhotoAnnouncements).toBe(2);
+	});
+
+	it('das dritte select() trägt exakt die Bedingung von mediaUploadCondition(announced_missing)', async () => {
+		await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(
+			mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING) as unknown as SQLWrapper
+		);
+		const thirdSelect = recordedSelects[2];
+		expect(thirdSelect?.whereSql).toBe(expected);
+	});
+
+	it('?mediaUpload=announced_missing filtert die Hauptliste mit derselben Bedingung', async () => {
+		// Ohne weitere Filter ruft nur die neue Arbeitslisten-Abfrage where()
+		// auf — mit diesem Query-Parameter tut es zusätzlich die Hauptliste.
+		await load({
+			url: makeUrl({ mediaUpload: MEDIA_UPLOAD_ANNOUNCED_MISSING })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(
+			mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING) as unknown as SQLWrapper
+		);
+		// Erster Select = Hauptliste, zweiter = Pagination-Count — beide
+		// müssen jetzt dieselbe Bedingung tragen wie die Arbeitslisten-Abfrage.
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+});

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -2,6 +2,7 @@ import { isValidDateParam } from '../../../admin/dateParam';
 import { eq, gte, lt } from 'drizzle-orm';
 import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
+import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
 
 export function xmlEscape(str: string | null | undefined): string {
 	if (!str) return '';
@@ -68,10 +69,11 @@ export function buildExportConditions(params: ExportFilterParams) {
 			conditions.push(eq(sightingsTable.entryChannel, channelId));
 		}
 	}
-	if (mediaUpload === '1') {
-		conditions.push(eq(sightingsTable.mediaUpload, 1));
-	} else if (mediaUpload === '0') {
-		conditions.push(eq(sightingsTable.mediaUpload, 0));
+	// Inkl. „angekündigt, aber keine Datei angehängt" (announced_missing),
+	// siehe mediaUploadFilter.ts — dieselbe Bedingung wie in der Admin-Liste.
+	const mediaCondition = mediaUploadCondition(mediaUpload);
+	if (mediaCondition) {
+		conditions.push(mediaCondition);
 	}
 
 	return conditions;

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2102,10 +2102,13 @@ components:
     ExportMediaUpload:
       name: mediaUpload
       in: query
-      description: Medienupload-Filter (1=mit Aufnahme, 0=ohne Aufnahme)
+      description: >-
+        Medienupload-Filter (1=mit Aufnahme, 0=ohne Aufnahme,
+        announced_missing=Foto laut App angekündigt, aber keine Datei
+        angehängt — der Melder reicht es separat per E-Mail nach)
       schema:
         type: string
-        enum: ["0", "1"]
+        enum: ["0", "1", "announced_missing"]
         example: "1"
 
     ExportVerified:


### PR DESCRIPTION
## Summary

The rebuilt iOS client (`OstSeeTiere/8`) sets `aufnahmeHochladen` (`mediaUpload`) when a reporter has a photo, but can't upload it through the app — reporters are asked to send the photo by email afterwards. Without any indication of that in the app, "Upload: ja" with no attached file read like a broken record, and there was no way to match an incoming photo email to the right sighting.

- **Admin detail view**: shows a distinct hint ("Foto angekündigt, folgt per E-Mail") instead of the plain Ja/Nein boolean when a photo is announced but no file is attached yet. Once a file *is* attached, the existing media gallery still takes over unchanged.
- **Notification email**: all three template layers — the DB-seeded default (`notificationEmailDefault.ts`), its file fallback (`sightingNotificationTemplate.html`), and the last-resort inline constant in `emailService.ts` — now add a line pointing the recipient to the reference id so an incoming photo email can be matched to the sighting.
- **Admin work list**: a shared `mediaUploadCondition()` (`mediaUpload = 1 AND no attached file`, via `NOT EXISTS` against `sichtungen_dateien`) backs a new `announced_missing` filter value, wired into both the admin dashboard filter and the export API — this also deduplicates what were previously two independently-drifting copies of the plain `mediaUpload` filter. A proactive count badge in the dashboard header links straight to the filtered list.

`isPhotoAnnouncementPending()` in `photoAnnouncement.ts` is the single source of truth for the "announced but missing" state, mirroring the existing `getBalticSeaStatus()` pattern so the three surfaces can't drift apart the way the Baltic-sea status once did.

`openapi.yml` documents the new `mediaUpload=announced_missing` filter value per the project's API-change checklist.

**Database:** the DB-seeded email template default was pushed to the local database via `npm run config:refresh-email-template` and verified directly — `app_config.notification.email.template` now hashes to the new pinned value and contains the photo-announcement line.

## Test plan

- [x] `npm run test:quick` (lint + type-check + svelte-check + unit) — clean; the only 3 failing tests are pre-existing/environmental (`src/tools/import-legacy-inbox.test.ts`, subprocess spawn exit 127 in this sandbox), unrelated to this change and untouched by it.
- [x] New unit tests, test-first: `photoAnnouncement.test.ts`, `mediaUploadFilter.test.ts`, `AdminSightingView.svelte.test.ts`, `admin/page.server.test.ts`, plus additions to `emailService.test.ts` and `notificationEmailDefault.test.ts` covering all three email template layers.
- [x] `static/openapi.yml` validated (`js-yaml` parse check).
- [x] Local DB verified directly (SQL query against `app_config`) to confirm the new template is actually live, not just in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)