### PR TITLE
docs(api): name the nginx directive that actually works under passenger

### DIFF
--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -80,8 +80,9 @@ Passenger, und `proxy_set_header` gehört zu nginx' Proxy-Modul — es wirkt nur
 auf Anfragen, die per `proxy_pass` weitergereicht werden. Bei einer
 Passenger-Anwendung läuft die Direktive wirkungslos ins Leere, **ohne
 Fehlermeldung**: nginx startet, die Anwendung startet, alles sieht richtig
-aus, und der Dienst sieht trotzdem nur `127.0.0.1`. Am 2026-07-30 auf hawking
-genau so passiert.
+aus, und der Dienst sieht trotzdem nur `127.0.0.1`. Bei der ersten
+Inbetriebnahme am 2026-07-30 genau so passiert — die Direktive ist also keine
+theoretische Vorsichtsmaßnahme.
 
 Nach dem Eintragen von außen prüfen — nicht vom Server selbst, sonst ist
 `127.0.0.1` die korrekte Antwort. Die empfangene Adresse steht im Umschlag

--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -73,7 +73,19 @@ gesamten Aufbaus.
 **5.** `X-Real-IP` in den nginx-Zusatzdirektiven der Domain setzen — sonst kennt
 der Dienst nur die Adresse des Proxys und zählt alle Melder als einen:
 
-    proxy_set_header X-Real-IP $remote_addr;
+    passenger_set_header X-Real-IP $remote_addr;
+
+**Nicht `proxy_set_header`.** Plesk bedient Node-Anwendungen über Phusion
+Passenger, und `proxy_set_header` gehört zu nginx' Proxy-Modul — es wirkt nur
+auf Anfragen, die per `proxy_pass` weitergereicht werden. Bei einer
+Passenger-Anwendung läuft die Direktive wirkungslos ins Leere, **ohne
+Fehlermeldung**: nginx startet, die Anwendung startet, alles sieht richtig
+aus, und der Dienst sieht trotzdem nur `127.0.0.1`. Am 2026-07-30 auf hawking
+genau so passiert.
+
+Nach dem Eintragen von außen prüfen — nicht vom Server selbst, sonst ist
+`127.0.0.1` die korrekte Antwort. Die empfangene Adresse steht im Umschlag
+unter `quelle.ip`.
 
 `X-Forwarded-For` wird bewusst **nicht** ausgewertet: Die Kopfzeile kommt vom
 Client, und ein zufälliger Wert je Request würde das Rate-Limit aushebeln.

--- a/legacy-inbox/src/routes/createSighting.js
+++ b/legacy-inbox/src/routes/createSighting.js
@@ -140,7 +140,12 @@ export async function createSighting(req, res, { konfiguration, store, rateLimit
  * Request zählte dann als neue IP.
  *
  * Stattdessen X-Real-IP, das nginx setzt und das ein Client nicht durchreichen
- * kann (Plesk-Direktive siehe README), sonst die Adresse der Verbindung selbst.
+ * kann, sonst die Adresse der Verbindung selbst.
+ *
+ * Unter Plesk muss die Kopfzeile mit `passenger_set_header` gesetzt werden,
+ * nicht mit `proxy_set_header` — letzteres wirkt nur auf `proxy_pass` und
+ * bleibt bei einer Passenger-Anwendung wirkungslos, ohne Fehlermeldung. Steht
+ * hier `127.0.0.1`, ist das der erste Verdacht. Einzelheiten in der README.
  */
 function ermittleIp(req) {
 	const vomProxy = req.headers['x-real-ip'];


### PR DESCRIPTION
Die README nannte für `X-Real-IP` die Direktive `proxy_set_header`. Die ist für dieses Setup falsch.

Plesk bedient Node-Anwendungen über Phusion Passenger. `proxy_set_header` gehört zu nginx' Proxy-Modul und wirkt ausschließlich auf Anfragen, die per `proxy_pass` weitergereicht werden — bei einer Passenger-Anwendung tut die Direktive schlicht nichts.

## Warum das unangenehmer ist als ein gewöhnlicher Doku-Fehler

Es scheitert lautlos. nginx startet, die Anwendung startet, die Konfiguration sieht korrekt aus, und der Dienst sieht trotzdem nur `127.0.0.1`. Damit fallen **alle** Melder auf denselben Zähler, und das Rate-Limit pro IP — 100 pro Stunde — greift nach hundert Meldungen für alle gleichzeitig.

Auf einem unauthentifizierten Endpunkt ist das die Schutzschicht, auf die es ankommt.

Verifiziert auf dem Zielhost: mit `passenger_set_header X-Real-IP $remote_addr;` kommt die echte Adresse an.

## Änderung

- README: korrekte Direktive, dazu die Begründung, warum die naheliegende nicht funktioniert — damit sie niemand „zurückkorrigiert"
- README: der Hinweis, dass von **außen** geprüft werden muss. Ein `curl` auf dem Server selbst liefert `127.0.0.1` als völlig korrekte Antwort und sieht wie derselbe Fehler aus
- `createSighting.js`: derselbe Hinweis an `ermittleIp()`, weil dort hinschaut, wer den Fehler sucht

Kein Verhaltensänderung im Code, 99 Tests des Dienstes weiterhin grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)