### PR TITLE
docs(api): warn that verifying the perimeter can trigger fail2ban

### DIFF
--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -132,9 +132,20 @@ Deshalb: Anfragen entzerren, oder vorher wissen, wie man sich wieder befreit.
     fail2ban-client set <jail> unbanip <ip>   # Sperre aufheben
 
 Ob der Dienst noch läuft oder wirklich nur die Sperre greift, klärt ein Aufruf
-**auf dem Server selbst** — der geht nicht über den Perimeter:
+**auf dem Server selbst**. fail2ban sperrt nach Quelladresse und hat
+`127.0.0.1` standardmäßig in seiner `ignoreip`-Liste, ein lokaler Aufruf kommt
+also durch:
 
-    curl -s http://127.0.0.1:<port>/health
+    curl -s -H 'Host: schweinswalsichtung.de' http://127.0.0.1/health
+
+Der `Host`-Kopf ist nötig, damit nginx die Anfrage der richtigen Domain
+zuordnet.
+
+Nicht funktionieren würde ein Aufruf direkt gegen den Anwendungsport: `PORT`
+setzt Passenger nur in der Umgebung des Anwendungsprozesses, nicht in deiner
+Shell — und Passenger fängt `server.listen()` ohnehin ab und verbindet die
+Anwendung über einen eigenen Socket. Ob überhaupt ein TCP-Port lauscht, zeigt
+`ss -ltnp | grep node`.
 
 Startet der Dienst gar nicht erst, steht der Grund im Passenger-Log. Er bricht
 den Start ab, wenn `LEGACY_INBOX_DATA_DIR` fehlt oder das Datenverzeichnis

--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -112,6 +112,30 @@ Bereinigung der Ostsee-Geometrie beginnt der Kartenbereich bei 53,55° N, und
 
 Erwartet: `{"inbaltic":true,"inchartarea":true}` (Kieler Bucht, offenes Wasser).
 
+### Beim Prüfen nicht selbst aussperren
+
+Der Dienst liefert keine statischen Dateien aus — jede Anfrage landet beim
+Node-Prozess, unbekannte Pfade beantwortet er mit `404`. Wer die Absicherung
+nachprüfen will (etwa ob das Datenverzeichnis oder ein Git-Klon über die Domain
+erreichbar ist), erzeugt damit zwangsläufig eine Serie von 404ern auf Pfade wie
+`/.git/config`.
+
+Genau das ist die Signatur eines Schwachstellen-Scanners, und Plesks fail2ban
+reagiert darauf. Am 2026-07-30 wurde bei einer solchen Prüfung die eigene
+Adresse nach zwölf Anfragen gesperrt — erkennbar daran, dass anschließend auch
+`/health` nicht mehr antwortet, obwohl der Dienst läuft.
+
+Deshalb: Anfragen entzerren, oder vorher wissen, wie man sich wieder befreit.
+
+    fail2ban-client status                    # welche Jails gibt es
+    fail2ban-client status <jail>             # gesperrte Adressen
+    fail2ban-client set <jail> unbanip <ip>   # Sperre aufheben
+
+Ob der Dienst noch läuft oder wirklich nur die Sperre greift, klärt ein Aufruf
+**auf dem Server selbst** — der geht nicht über den Perimeter:
+
+    curl -s http://127.0.0.1:<port>/health
+
 Startet der Dienst gar nicht erst, steht der Grund im Passenger-Log. Er bricht
 den Start ab, wenn `LEGACY_INBOX_DATA_DIR` fehlt oder das Datenverzeichnis
 nicht beschreibbar ist (`legacy-inbox/src/startPruefung.js`) — ein Rechte- oder


### PR DESCRIPTION
Beim ersten Absicherungstest des Dienstes ist genau das passiert, wovor dieser Abschnitt jetzt warnt.

Der Dienst liefert keine statischen Dateien aus — jede Anfrage landet beim Node-Prozess, unbekannte Pfade beantwortet er mit `404`. Wer nachprüfen will, ob das Datenverzeichnis oder der Git-Klon über die Domain erreichbar ist, erzeugt damit zwangsläufig eine Serie von 404ern auf Pfade wie `/.git/config`. Das ist die Signatur eines Schwachstellen-Scanners, und Plesks fail2ban reagiert darauf.

Nach zwölf Anfragen war die eigene Adresse gesperrt. Das Tückische daran ist das Symptom: Danach antwortet auch `/health` nicht mehr, was sich wie ein Ausfall des Dienstes liest — obwohl er einwandfrei läuft.

Der Abschnitt nennt deshalb beides: wie man die Sperre erkennt und aufhebt, und wie man vom Server selbst prüft, ob der Dienst noch läuft (dieser Weg geht nicht über den Perimeter).

Nebenbei ist das Testergebnis selbst festgehalten: Alle geprüften Pfade — Datenverzeichnis, einzelne Sichtungsdateien, `/repo/.git/config`, `app.js`, `package.json` — antworteten mit der 404 des Dienstes. Es gibt auf dieser Domain kein statisches Ausliefern.

Reine Dokumentationsänderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)