### PR TITLE
fix(admin): stop 13 years of legacy mediaUpload rows from faking a work list

### DIFF
--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -134,7 +134,13 @@
 		// Funktion einmal außerhalb des aktuellen Kontexts wiederverwendet wird.
 		const attachedFileCount = currentSighting.uploadedFiles?.length ?? 0;
 
-		if (isPhotoAnnouncementPending(currentSighting.mediaUpload, attachedFileCount)) {
+		if (
+			isPhotoAnnouncementPending(
+				currentSighting.mediaUpload,
+				attachedFileCount,
+				currentSighting.created
+			)
+		) {
 			return {
 				label: 'Upload',
 				value: PHOTO_ANNOUNCEMENT_LABEL,

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -19,13 +19,16 @@ import {
 // Minimales Objekt, wie an anderer Stelle bereits üblich
 // (src/lib/server/export/csvExport.timezone.test.ts) — die Komponente prüft
 // zur Laufzeit nur die tatsächlich gelesenen Felder, nicht das volle Schema.
+// `created` liegt bewusst NACH NEW_IOS_CLIENT_LAUNCH_DATE (2026-07-30): nur
+// Sichtungen ab dann können „wartet auf E-Mail" bedeuten — siehe den
+// eigenen Test unten für Altbestand vor diesem Datum.
 function baseSighting(overrides: Record<string, unknown> = {}): FrontendSighting {
 	return {
 		id: 1,
 		species: 0,
 		totalCount: 1,
-		sightingDate: new Date('2026-07-01T10:00:00Z'),
-		created: new Date('2026-07-01T09:00:00Z'),
+		sightingDate: new Date('2026-07-30T10:00:00Z'),
+		created: new Date('2026-07-30T09:00:00Z'),
 		mediaFile: null,
 		mediaUpload: 0,
 		mediaConsent: 0,
@@ -74,6 +77,23 @@ describe('AdminSightingView — Foto-Ankündigung', () => {
 			})
 		});
 
+		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
+	});
+
+	// Live auf der lokalen DB gefunden: `aufnahmeHochladen` trägt 13 Jahre
+	// Altbestand, dessen Bedeutung nicht „wartet auf E-Mail vom neuen Client"
+	// ist. Eine Sichtung von vor dem Client-Start darf den Hinweis deshalb
+	// trotz gesetztem Flag und fehlender Datei nicht zeigen.
+	it('zeigt keinen Ankündigungs-Hinweis für Altbestand von vor dem Client-Start', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({
+				mediaUpload: 1,
+				uploadedFiles: [],
+				created: new Date('2015-03-12T08:00:00Z')
+			})
+		});
+
+		await expect.element(page.getByRole('row', { name: 'Upload Ja' })).toBeVisible();
 		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
 	});
 });

--- a/src/lib/server/db/mediaUploadFilter.test.ts
+++ b/src/lib/server/db/mediaUploadFilter.test.ts
@@ -56,4 +56,24 @@ describe('mediaUploadCondition', () => {
 		// sonst träfe die Bedingung jede Sichtung gleichermaßen.
 		expect(text).toContain('sichtung_id');
 	});
+
+	/**
+	 * Live auf der lokalen DB gefunden: `aufnahmeHochladen` trägt 13 Jahre
+	 * Altbestand (früheste Zeile 2012-07-01) über alle Eingangskanäle. Ohne
+	 * Untergrenze meldete dieses Prädikat 2.539 „ausstehende" Fotos — Zeilen,
+	 * für die nie eine E-Mail nachkommen wird, weil das Flag dort historisch
+	 * nur „der Melder hatte ein Foto" bedeutete. Siehe
+	 * `$lib/utils/media/photoAnnouncement.ts`.
+	 */
+	it('grenzt "angekündigt, aber keine Datei" zusätzlich auf den Client-Start ein', () => {
+		const condition = mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING);
+		const text = toSqlText(condition as SQL);
+
+		expect(text).toContain('"created" >=');
+	});
+
+	it('lässt "mit"/"ohne Aufnahme" unverändert — keine Datumsgrenze für diese beiden Werte', () => {
+		expect(toSqlText(mediaUploadCondition('1') as SQL)).not.toContain('"created"');
+		expect(toSqlText(mediaUploadCondition('0') as SQL)).not.toContain('"created"');
+	});
 });

--- a/src/lib/server/db/mediaUploadFilter.ts
+++ b/src/lib/server/db/mediaUploadFilter.ts
@@ -8,8 +8,11 @@
  * `approvalFilter.ts`. Beide Aufrufer hängen das Ergebnis an ihre eigene
  * `and(...)`-Bedingungsliste.
  */
-import { and, eq, sql, type SQL } from 'drizzle-orm';
-import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+import { and, eq, gte, sql, type SQL } from 'drizzle-orm';
+import {
+	MEDIA_UPLOAD_ANNOUNCED_MISSING,
+	NEW_IOS_CLIENT_LAUNCH_DATE
+} from '$lib/utils/media/photoAnnouncement';
 import { sightingFiles, sightings } from '$lib/server/db/schema';
 
 /**
@@ -41,7 +44,13 @@ export function mediaUploadCondition(mediaUpload: string | null | undefined): SQ
 	if (mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
 		return and(
 			eq(sightings.mediaUpload, 1),
-			sql`NOT EXISTS (SELECT 1 FROM ${sightingFiles} WHERE ${sightingFiles.sightingId} = ${sightings.id})`
+			sql`NOT EXISTS (SELECT 1 FROM ${sightingFiles} WHERE ${sightingFiles.sightingId} = ${sightings.id})`,
+			// `aufnahmeHochladen` trägt 13 Jahre Altbestand über alle
+			// Eingangskanäle (früheste Zeile 2012-07-01) — dort bedeutete das
+			// Flag nur „der Melder hatte ein Foto", nicht „der neue Client
+			// konnte es nicht hochladen". Ohne diese Grenze meldete die
+			// Arbeitsliste 2.539 nie einlösbare „ausstehende" Fotos.
+			gte(sightings.created, NEW_IOS_CLIENT_LAUNCH_DATE)
 		);
 	}
 	return undefined;

--- a/src/lib/utils/media/photoAnnouncement.test.ts
+++ b/src/lib/utils/media/photoAnnouncement.test.ts
@@ -8,33 +8,64 @@
  * entsteht — analog zu `getBalticSeaStatus()` in `balticSeaStatus.ts`. Admin-
  * Detailansicht und Admin-Arbeitsliste (DB-Filter) müssen dieselbe Aussage
  * treffen, sonst laufen sie auseinander wie zuvor der Ostsee-Status.
+ *
+ * **Bug, live auf der lokalen DB gefunden (2026-07-30):** `aufnahmeHochladen`
+ * ist kein neues Feld — die Spalte trägt 13 Jahre Altbestand (früheste Zeile
+ * 2012-07-01) über alle Eingangskanäle hinweg (Web, E-Mail, Post, Telefon und
+ * auch die frühere „App"). Ohne Untergrenze meldete die Admin-Arbeitsliste
+ * 2.539 „ausstehende" Fotos — Altdaten, die nie eine E-Mail nachreichen
+ * werden, weil `aufnahmeHochladen=1` dort historisch nur „der Melder hatte
+ * ein Foto" bedeutete, nicht „der neue Client konnte es nicht hochladen".
+ * Nur Sichtungen ab dem Start dieses Clients (`NEW_IOS_CLIENT_LAUNCH_DATE`)
+ * können diese Aussage tragen.
  */
 import { describe, expect, it } from 'vitest';
 import {
 	isPhotoAnnouncementPending,
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
+	NEW_IOS_CLIENT_LAUNCH_DATE,
 	PHOTO_ANNOUNCEMENT_LABEL
 } from './photoAnnouncement';
 
+const AFTER_LAUNCH = '2026-07-30T12:00:00Z';
+const BEFORE_LAUNCH = '2026-07-29T23:59:59Z';
+const LEGACY_DATE = '2015-03-12T08:00:00Z';
+
 describe('isPhotoAnnouncementPending', () => {
-	it('ist wahr, wenn ein Foto angekündigt ist und keine Datei angehängt wurde', () => {
-		expect(isPhotoAnnouncementPending(1, 0)).toBe(true);
+	it('ist wahr, wenn ein Foto angekündigt ist, keine Datei angehängt wurde und die Sichtung nach dem Client-Start liegt', () => {
+		expect(isPhotoAnnouncementPending(1, 0, AFTER_LAUNCH)).toBe(true);
 	});
 
 	it('ist falsch, sobald mindestens eine Datei angehängt ist', () => {
-		expect(isPhotoAnnouncementPending(1, 1)).toBe(false);
-		expect(isPhotoAnnouncementPending(1, 3)).toBe(false);
+		expect(isPhotoAnnouncementPending(1, 1, AFTER_LAUNCH)).toBe(false);
+		expect(isPhotoAnnouncementPending(1, 3, AFTER_LAUNCH)).toBe(false);
 	});
 
 	it('ist falsch, wenn kein Foto angekündigt wurde — unabhängig von der Dateizahl', () => {
-		expect(isPhotoAnnouncementPending(0, 0)).toBe(false);
-		expect(isPhotoAnnouncementPending(null, 0)).toBe(false);
-		expect(isPhotoAnnouncementPending(undefined, 0)).toBe(false);
+		expect(isPhotoAnnouncementPending(0, 0, AFTER_LAUNCH)).toBe(false);
+		expect(isPhotoAnnouncementPending(null, 0, AFTER_LAUNCH)).toBe(false);
+		expect(isPhotoAnnouncementPending(undefined, 0, AFTER_LAUNCH)).toBe(false);
 	});
 
 	it('behandelt einen booleschen mediaUpload-Wert genauso wie das DB-Integer-Flag', () => {
-		expect(isPhotoAnnouncementPending(true, 0)).toBe(true);
-		expect(isPhotoAnnouncementPending(false, 0)).toBe(false);
+		expect(isPhotoAnnouncementPending(true, 0, AFTER_LAUNCH)).toBe(true);
+		expect(isPhotoAnnouncementPending(false, 0, AFTER_LAUNCH)).toBe(false);
+	});
+
+	// Der eigentliche Befund: Altbestand darf nicht als „wartet auf E-Mail" gelesen werden.
+	it('ist falsch für eine Sichtung von vor dem Client-Start, selbst mit gesetztem Flag und ohne Datei', () => {
+		expect(isPhotoAnnouncementPending(1, 0, LEGACY_DATE)).toBe(false);
+		expect(isPhotoAnnouncementPending(1, 0, BEFORE_LAUNCH)).toBe(false);
+	});
+
+	it('ist falsch ohne verwertbares Erstellungsdatum — keine Aussage ohne Zeitbezug', () => {
+		expect(isPhotoAnnouncementPending(1, 0, null)).toBe(false);
+		expect(isPhotoAnnouncementPending(1, 0, undefined)).toBe(false);
+	});
+
+	it('akzeptiert sowohl Date-Objekte als auch ISO-Strings', () => {
+		expect(isPhotoAnnouncementPending(1, 0, new Date(AFTER_LAUNCH))).toBe(true);
+		expect(isPhotoAnnouncementPending(1, 0, new Date(LEGACY_DATE))).toBe(false);
 	});
 
 	it('exportiert einen stabilen deutschen Hinweistext', () => {
@@ -43,5 +74,10 @@ describe('isPhotoAnnouncementPending', () => {
 
 	it('exportiert einen stabilen Filterwert für die Admin-Arbeitsliste', () => {
 		expect(MEDIA_UPLOAD_ANNOUNCED_MISSING).toBe('announced_missing');
+	});
+
+	it('exportiert das Startdatum des neuen Clients als Date', () => {
+		expect(NEW_IOS_CLIENT_LAUNCH_DATE).toBeInstanceOf(Date);
+		expect(NEW_IOS_CLIENT_LAUNCH_DATE.toISOString()).toBe('2026-07-30T00:00:00.000Z');
 	});
 });

--- a/src/lib/utils/media/photoAnnouncement.ts
+++ b/src/lib/utils/media/photoAnnouncement.ts
@@ -8,6 +8,15 @@
  * Ohne diese Einordnung liest „Upload: ja" ohne angehängte Datei wie ein
  * defekter Datensatz, dabei ist es eine erwartete Zwischenphase.
  *
+ * **`aufnahmeHochladen` ist kein neues Feld.** Auf der lokalen Datenbank
+ * (13 Jahre Altbestand, früheste Zeile 2012-07-01) tragen 3.405 Sichtungen
+ * dieses Flag, über alle Eingangskanäle hinweg — Web, E-Mail, Post, Telefon
+ * und auch die frühere „App". Ohne Untergrenze meldete die Admin-Arbeitsliste
+ * 2.539 „ausstehende" Fotos: Altdaten, für die nie eine E-Mail nachkommen
+ * wird, weil das Flag dort historisch nur „der Melder hatte ein Foto"
+ * bedeutete — nicht „der neue Client konnte es nicht hochladen". Nur
+ * Sichtungen ab `NEW_IOS_CLIENT_LAUNCH_DATE` können diese Aussage tragen.
+ *
  * **Einzige Stelle, an der dieser Zustand entsteht** — analog zu
  * `getBalticSeaStatus()` in `$lib/utils/geo/balticSeaStatus.ts`. Angeschlossen
  * sind die Admin-Detailansicht (`AdminSightingView.svelte`) und der
@@ -21,10 +30,28 @@
 /** Zählt als „gesetzt", egal ob DB-Integer (0/1) oder Formular-Boolean. */
 type MediaUploadFlag = number | boolean | null | undefined;
 
+/**
+ * Der neu gebaute iOS-Client (`OstSeeTiere/8`) ist seit diesem Tag
+ * angebunden (`.claude/rules/legacy-api.md`). Nur Sichtungen ab diesem
+ * Zeitpunkt können „wartet auf eine per E-Mail nachgereichte Foto" bedeuten
+ * — jede ältere Zeile mit `mediaUpload=1` ist Altbestand mit einer anderen,
+ * unbekannten Bedeutung des Flags (siehe Modul-Kommentar oben).
+ */
+export const NEW_IOS_CLIENT_LAUNCH_DATE = new Date('2026-07-30T00:00:00.000Z');
+
+function isFromNewClientEra(createdAt: Date | string | null | undefined): boolean {
+	if (createdAt === null || createdAt === undefined) return false;
+	const timestamp = createdAt instanceof Date ? createdAt : new Date(createdAt);
+	if (Number.isNaN(timestamp.getTime())) return false;
+	return timestamp >= NEW_IOS_CLIENT_LAUNCH_DATE;
+}
+
 export function isPhotoAnnouncementPending(
 	mediaUpload: MediaUploadFlag,
-	attachedFileCount: number
+	attachedFileCount: number,
+	createdAt: Date | string | null | undefined
 ): boolean {
+	if (!isFromNewClientEra(createdAt)) return false;
 	return !!mediaUpload && attachedFileCount === 0;
 }
 

--- a/src/lib/utils/media/photoAnnouncement.ts
+++ b/src/lib/utils/media/photoAnnouncement.ts
@@ -33,7 +33,7 @@ type MediaUploadFlag = number | boolean | null | undefined;
 /**
  * Der neu gebaute iOS-Client (`OstSeeTiere/8`) ist seit diesem Tag
  * angebunden (`.claude/rules/legacy-api.md`). Nur Sichtungen ab diesem
- * Zeitpunkt können „wartet auf eine per E-Mail nachgereichte Foto" bedeuten
+ * Zeitpunkt können „wartet auf ein per E-Mail nachgereichtes Foto" bedeuten
  * — jede ältere Zeile mit `mediaUpload=1` ist Altbestand mit einer anderen,
  * unbekannten Bedeutung des Flags (siehe Modul-Kommentar oben).
  */


### PR DESCRIPTION
## Summary

Follow-up to #660 (already merged), found while sanity-checking the new "photo announced, waiting on email" feature against the local database.

Locally, the admin dashboard showed **2539** sightings as "photo announced, waiting on email." That's wrong: `aufnahmeHochladen` (`mediaUpload`) isn't a field the new client introduced — it's a 13-year-old legacy flag (earliest row 2012-07-01) set across every entry channel (web, email, mail, phone, and the older app), where historically it only ever meant "the reporter had a photo," never "the app specifically couldn't upload it." Treating every old row with the flag set and no linked `sichtungen_dateien` file as "pending" manufactured a queue of 2539 items that can never actually clear — nobody's mailing in a photo for a sighting from 2015. Cross-checked `uploads/`: zero files newer than 2026-07-28 either.

`isPhotoAnnouncementPending()` and `mediaUploadCondition('announced_missing')` (the single source of truth both the admin detail view and the admin work-list/dashboard-badge/export filter route through, per #660) now both gate on a new `NEW_IOS_CLIENT_LAUNCH_DATE` constant (2026-07-30, per `.claude/rules/legacy-api.md`'s documented go-live date) — only sightings created on or after that date can plausibly still be waiting on a follow-up email.

## Verification

Directly against the local database (query, not just unit tests with fabricated dates):

```
Total mediaUpload=1:                                    3405
...with no sichtungen_dateien row (old, unguarded):      2539
...of those, created in the last 2 days:                    0
Corrected count (created >= launch date):                   0
```
0 matches reality — no genuine new-client submission has landed yet.

## Test plan

- [x] Test-first: extended `photoAnnouncement.test.ts` and `mediaUploadFilter.test.ts` with cases for pre-launch vs. post-launch `created` dates, plus a component-level regression test in `AdminSightingView.svelte.test.ts` for a 2015 legacy sighting.
- [x] `npm run test:quick` (lint + type-check + svelte-check + unit) — clean, 2741/2741.
- [x] Verified directly against the local database as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)