### PR TITLE
fix(ci): push the release branch as deploy key, not as the bot

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,6 +40,13 @@ jobs:
           ref: ${{ needs.release-please.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
+          # Ohne ssh-key klont checkout per HTTPS und der Push geht als
+          # github-actions[bot] raus. Das Ruleset auf `release` sperrt jeden
+          # Update und erlaubt als Ausnahme nur Deploy Keys — der Bot ist keiner
+          # und wird mit GH013 abgewiesen. Mit ssh-key zeigt origin auf
+          # git@github.com und der Push authentifiziert sich als Deploy Key,
+          # womit der Bypass greift.
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       # Fast-forward statt Force-Push: `release` soll den Release-Tag immer nur
       # nach VORNE bewegen. Ein Force-Push würde einen Direkt-Hotfix auf


### PR DESCRIPTION
## Problem

Der Release-Lauf für v2.6.0 ist beim Push auf `release` gescheitert:

```
remote: - Cannot update this protected ref.
 ! [remote rejected] release -> release (push declined due to repository rule violations)
```

Das Ruleset `release` (ID 19995400) sperrt jedes Update auf `refs/heads/release` und lässt als einzige Ausnahme **Deploy Keys** zu. Der Checkout in `update-release-branch` hatte aber kein `ssh-key`, klonte also per HTTPS und pushte als `github-actions[bot]` — kein Deploy Key, also GH013.

Der schreibberechtigte Deploy Key (`read_only: false`) und das Secret `DEPLOY_KEY` existieren beide seit 2025-08-15, der Bypass war eingetragen. Nur die Workflow-Seite wurde nie nachgezogen: `ssh-key` kam in keinem einzigen Workflow vor.

## Folgeschaden an v2.6.0

| | Status |
|---|---|
| Tag + GitHub Release v2.6.0 | ✅ erstellt |
| `release`-Branch | ❌ steht noch auf `9a071bf` statt `6702ecb` |
| GHCR-Image v2.6.0 | ❌ nie gebaut (`docker-publish` hängt an `needs: update-release-branch`) |

## Fix

`ssh-key: ${{ secrets.DEPLOY_KEY }}` am Checkout. Damit zeigt `origin` auf `git@github.com` und der Push authentifiziert sich als Deploy Key — der Bypass greift.

## Geprüft

- Kein Workflow triggert auf `push: branches: [release]` (CI läuft nur auf `main` und auf PRs gegen `main`/`release`). Der Deploy-Key-Push ist im Gegensatz zum bisherigen `GITHUB_TOKEN`-Push trigger-fähig, startet hier aber nichts.
- Fast-Forward bleibt möglich: `origin/release` ist Vorfahre von `v2.6.0`, keine Divergenz.
- **Nicht prüfbar von außen:** ob `DEPLOY_KEY` den privaten Schlüssel zu genau diesem Deploy Key enthält. Falls nicht, bricht der nächste Lauf sichtbar beim Checkout mit `Permission denied (publickey)` ab.

## Kein Test

Workflow-Konfiguration ohne Business-Logik — laut `.claude/rules/testing.md` eine dokumentierte Ausnahme.

## Nach dem Merge

Ein `gh run rerun` des alten Laufs hilft nicht: der Rerun nimmt die Workflow-Datei aus dem Commit des alten Laufs und würde erneut scheitern.

`release` heilt sich beim nächsten Release von selbst — `git merge --ff-only` springt von `9a071bf` direkt aufs neue Tag. Wird das v2.6.0-Image vorher auf Staging gebraucht, geht das unabhängig vom Release-Branch:

```bash
gh workflow run docker-publish.yml -f tag=v2.6.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)