### PR TITLE
fix(build): let the vite config's dep-hash helper into the docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -109,6 +109,12 @@ sbom/*.xml
 
 # Scripts (except Docker scripts)
 src/tools
+# Ausnahme: kein Script, sondern eine Build-Zeit-Abhängigkeit. vite.config.ts
+# und vite.config.ci.ts importieren stableDepHash auf Modulebene — fehlt die
+# Datei im Kontext, bricht schon das Laden der Vite-Config ab (UNRESOLVED_IMPORT),
+# lange bevor irgendetwas gebaut wird. Der zugehörige Test bleibt über das
+# *.test.ts-Muster weiter draußen.
+!src/tools/vite-stable-dep-hash.ts
 scripts/*
 !scripts/docker-*.sh
 !scripts/docker-migrate.ts


### PR DESCRIPTION
## Problem

Der Docker-Build für v2.6.1 bricht im `builder`-Stage ab:

```
[UNRESOLVED_IMPORT] Could not resolve './src/tools/vite-stable-dep-hash' in vite.config.ts
```

Nicht der Code fehlt — die Datei ist committet und nicht gitignoriert. Sie kommt nur nie im Build-Kontext an: `.dockerignore` schließt unter „Scripts (except Docker scripts)" das **gesamte** Verzeichnis `src/tools` aus.

Seit `vite.config.ts` (und `vite.config.ci.ts`) `stableDepHash` importieren, ist das ein Build-Blocker statt einer Optimierung. Der Import steht auf Modulebene, also scheitert schon das *Laden* der Vite-Config — vor jedem Build-Schritt.

## Folge für v2.6.1

Tag und GitHub Release existieren, `release` steht korrekt auf `4fdb89a` (der Deploy-Key-Fix aus #664 greift). Nur das GHCR-Image wurde nie gebaut.

## Fix

Eine Ausnahme für genau diese eine Datei:

```
src/tools
!src/tools/vite-stable-dep-hash.ts
```

## Verifikation

Ein Testbuild gegen den **echten** Repo-Kontext, der auflistet was ankommt:

```
--- src/tools im Kontext ---
/ctx/src/tools/vite-stable-dep-hash.ts
--- Ende ---
```

Genau eine Datei. `vite-stable-dep-hash.test.ts` bleibt über das bestehende `*.test.ts`-Muster draußen, ebenso der Rest von `src/tools` inklusive der 8,3 MB großen `iho.json` — der Kontext wächst also praktisch nicht.

Beide BuildKit-Driver liefern dasselbe — der `docker`-Driver und der `docker-container`-Driver, den CI über `setup-buildx-action` hochzieht.

**Was offen bleibt:** ein voller `--target builder`-Lauf lokal kommt am Config-Laden vorbei und verbringt sieben Sekunden in `vite build`, bevor ihn der OOM-Killer abschießt — die VM auf dieser Maschine ist zu klein. Dass der Build *durchläuft*, ist hier also nicht bewiesen. Bewiesen ist nur, dass der Fehler, um den es geht, weg ist: der trat nach 0,8 s beim Laden der Config auf.

## Kein Test

Build-Kontext-Konfiguration ohne Business-Logik — dokumentierte Ausnahme laut `.claude/rules/testing.md`. Die Logik von `stableDepHash` selbst deckt `src/tools/vite-stable-dep-hash.test.ts` bereits ab.

## Nach dem Merge

Ein `gh workflow run docker-publish.yml -f tag=v2.6.1` hilft **nicht**: der Dispatch checkt das Tag `v2.6.1` aus, und dort fehlt dieser Fix weiterhin — der Build würde erneut an derselben Stelle scheitern.

Sauber ist der nächste Release: sobald dieser Fix auf `main` liegt, schneidet release-please v2.6.2, und der Build läuft durch. v2.6.1 bleibt dann ein Release ohne Image — sichtbar, aber harmlos, weil Staging ohnehin dem `staging`-Zeiger folgt und der erst mit einem erfolgreichen Build gesetzt wird.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

