### PR TITLE
fix(security): refuse to start production with a publicly known SESSION_SECRET

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -77,7 +77,7 @@ HOST_HEADER="x-forwarded-host"
 # Security Settings (CHANGE THESE IN PRODUCTION!)
 # ============================================
 # Generate with: openssl rand -base64 32
-SESSION_SECRET="CHANGE-ME-use-openssl-rand-base64-32"
+SESSION_SECRET="CHANGE-ME"
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY="CHANGE-ME-use-openssl-rand-hex-32"
 COOKIE_NAME="auth-cookie"

--- a/docs/DOCKER_DEPLOYMENT.md
+++ b/docs/DOCKER_DEPLOYMENT.md
@@ -493,7 +493,7 @@ HOST_HEADER=x-forwarded-host
 
 # Security (GENERATE THESE!)
 # openssl rand -base64 32
-SESSION_SECRET=your-generated-session-secret-here
+SESSION_SECRET=<Ausgabe von openssl rand -base64 32>
 # openssl rand -hex 32
 ENCRYPTION_KEY=your-generated-64-char-hex-key-here
 # openssl rand -hex 32 — required for the orphaned-upload cleanup cron
@@ -716,7 +716,7 @@ Create a `.env` file with your configuration. See [ENVIRONMENT.md](./ENVIRONMENT
 DATABASE_POSTGRES_URL=postgresql://postgres:yourpassword@db:5432/ostsee
 
 # Security (REQUIRED - generate secure values!)
-SESSION_SECRET=your-secure-random-string-min-32-chars
+SESSION_SECRET=<Ausgabe von openssl rand -base64 32>
 ENCRYPTION_KEY=your-64-character-hexadecimal-encryption-key
 
 # Auth0 (REQUIRED)
@@ -1337,7 +1337,7 @@ DATABASE_POSTGRES_URL="postgresql://ostsee_app:your-password@localhost:5432/osts
 STORAGE_PROVIDER=local
 
 # Security
-SESSION_SECRET=your-secure-random-string-min-32-chars
+SESSION_SECRET=<Ausgabe von openssl rand -base64 32>
 ENCRYPTION_KEY=your-64-character-hexadecimal-encryption-key
 
 # Auth0 (can use test values for local testing)

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -84,6 +84,11 @@ curl -fsS -X POST -H "Authorization: Bearer $CLEANUP_TOKEN" \
 **Min Length**: 32 characters
 **Description**: Secret key for encrypting session data.
 
+**Important**: Do not use an example value that looks realistic. In production, the startup
+guard verifies that `SESSION_SECRET` is neither a well-known test value nor a default. A
+value that looks authentic will be copied — and the server will refuse to start, rejecting
+it. Generate a unique, random secret for each environment.
+
 **Generate**:
 
 ```bash
@@ -93,8 +98,21 @@ openssl rand -base64 32
 **Example**:
 
 ```bash
-SESSION_SECRET=8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE
+SESSION_SECRET=<Ausgabe von openssl rand -base64 32>
 ```
+
+**Rotation:**
+
+`SESSION_SECRET` lässt sich jederzeit wechseln — der neue Wert wird in die `.env` des
+Hosts geschrieben, danach `docker compose up -d`.
+
+**Nebenwirkung:** Jeder Wechsel beendet **alle** laufenden Sitzungen gleichzeitig. Jedes
+`jwtVerify` gegen das alte Cookie schlägt fehl, das Cookie wird gelöscht, alle Angemeldeten
+landen im Login. Das ist der Notausschalter für den Verdachtsfall („jemand könnte das
+Secret kennen") — und der einzige Weg, eine ausgestellte Session ungültig zu machen.
+
+Staging und Production müssen **verschiedene** Secrets haben. Sonst ist ein Staging-Zugang
+ein Produktions-Zugang.
 
 ---
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -86,8 +86,8 @@ curl -fsS -X POST -H "Authorization: Bearer $CLEANUP_TOKEN" \
 
 **Wichtig**: Der Guard beim Serverstart lehnt in Production zwei öffentlich bekannte Beispielwerte ab
 (den Platzhalter aus `.env.example` und den Beispielwert dieser Dokumentation). Ein abgelehntes
-Secret verhindert, dass der Server startet. Erzeugen Sie für jede Umgebung ein eindeutiges,
-zufälliges Secret.
+Secret verhindert, dass der Server startet. Für jede Umgebung ein eigenes, zufällig erzeugtes
+Secret verwenden.
 
 **Generate**:
 
@@ -133,7 +133,7 @@ openssl rand -hex 32
 **Example**:
 
 ```bash
-ENCRYPTION_KEY=f5fcd0aaabcc4bdd0a87d4b2c03203e5863c0459f89fe99dab1fe8dde1cdf181
+ENCRYPTION_KEY=<Ausgabe von openssl rand -hex 32>
 ```
 
 ---

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -84,10 +84,10 @@ curl -fsS -X POST -H "Authorization: Bearer $CLEANUP_TOKEN" \
 **Min Length**: 32 characters
 **Description**: Secret key for encrypting session data.
 
-**Important**: Do not use an example value that looks realistic. In production, the startup
-guard verifies that `SESSION_SECRET` is neither a well-known test value nor a default. A
-value that looks authentic will be copied — and the server will refuse to start, rejecting
-it. Generate a unique, random secret for each environment.
+**Wichtig**: Der Guard beim Serverstart lehnt in Production zwei öffentlich bekannte Beispielwerte ab
+(den Platzhalter aus `.env.example` und den Beispielwert dieser Dokumentation). Ein abgelehntes
+Secret verhindert, dass der Server startet. Erzeugen Sie für jede Umgebung ein eindeutiges,
+zufälliges Secret.
 
 **Generate**:
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -82,7 +82,10 @@ curl -fsS -X POST -H "Authorization: Bearer $CLEANUP_TOKEN" \
 **Required**: Yes
 **Default**: None
 **Min Length**: 32 characters
-**Description**: Secret key for encrypting session data.
+**Description**: Secret key for signing the session cookie (JWT, HS256). It does not encrypt
+the cookie's contents — anyone who reads the cookie can decode `sub`, email and roles in
+plain text; the signature only proves the server issued it (see
+`docs/SESSION_STORE_SPEC_2026-07-31.md`, Befund B16).
 
 **Wichtig**: Der Guard beim Serverstart lehnt in Production zwei öffentlich bekannte Beispielwerte ab
 (den Platzhalter aus `.env.example` und den Beispielwert dieser Dokumentation). Ein abgelehntes

--- a/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
+++ b/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
@@ -1,0 +1,649 @@
+# Startup-Guard für Produktions-Secrets — Implementierungsplan (PR 1 / Paket A)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ein Produktions-Deployment startet nicht mehr, wenn `SESSION_SECRET` ein öffentlich
+bekannter Wert ist oder `ENCRYPTION_KEY` kein gültiger 32-Byte-Hex-Schlüssel.
+
+**Architecture:** Die Prüflogik zieht aus dem Modul-Scope von `src/hooks.server.ts` in ein
+neues, reines Modul `src/lib/server/config/secretGuard.ts`. Grund: `hooks.server.ts` liegt
+außerhalb von `src/lib/**` und wird von der Server-Test-Konfiguration nicht erfasst
+(`vitest.config.ts:9`, `include: ['src/lib/**/*.ts']`); außerdem führt es beim Import
+Seiteneffekte aus (Middleware-Kette, DB-Modul, Signal-Handler). Ein reines Modul ist testbar,
+`hooks.server.ts` ruft es nur noch auf.
+
+**Tech Stack:** TypeScript, SvelteKit 5, Vitest (Node-Umgebung), `$env/dynamic/private`.
+
+## Global Constraints
+
+- **Test-First ist Projektpflicht** (`.claude/rules/testing.md`): jeder Schritt beginnt mit
+  einem fehlschlagenden Test.
+- **Keine `any`-Typen, explizite Return-Types** für alle Funktionen
+  (`.claude/rules/architecture.md`).
+- **Imports über `$lib`** mit vollständigen Pfaden, nie relativ über Verzeichnisgrenzen.
+- **Kommentare und Doku auf Deutsch**, Bezeichner und Commit-Messages auf Englisch, Subject
+  lowercase (`CLAUDE.md`, Commit Conventions).
+- **Commit-Format:** `<type>(<scope>): <beschreibung>`, hier `fix(security)` bzw. `docs(security)`.
+- **`npm run test:quick` muss vor jedem Commit grün sein.**
+- Der Guard greift **nur** bei `NODE_ENV === 'production'`. Lokale Entwicklung und CI arbeiten
+  bewusst mit dem Platzhalter aus `.env.example` (`.github/workflows/ci.yml:109,261,376`) und
+  dürfen nicht brechen.
+- Die exakten öffentlich bekannten Werte, verbatim:
+  - `your-secret-key-here-min-32-chars` (aus `.env.example:40`, **33 Zeichen** — eine reine
+    Längenprüfung lässt ihn durch)
+  - `8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE` (aus `docs/ENVIRONMENT.md:96`, ebenfalls 33 Zeichen)
+  - `'0'.repeat(64)` für `ENCRYPTION_KEY` (bereits als `PLACEHOLDER_ENCRYPTION_KEY` in
+    `src/hooks.server.ts:21`)
+
+**Spec:** `docs/SESSION_STORE_SPEC_2026-07-31.md`, Abschnitt 4.
+
+---
+
+## Dateistruktur
+
+| Datei                                       | Verantwortung                                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/server/config/secretGuard.ts`      | **neu.** Reine Validierung der beiden Produktions-Secrets. Kein I/O, kein Env-Zugriff — die Werte kommen als Parameter herein. |
+| `src/lib/server/config/secretGuard.test.ts` | **neu.** Vitest, Node-Umgebung.                                                                                                |
+| `src/hooks.server.ts`                       | Ruft den Guard auf; die beiden inline-Guards (Zeilen 20–45) und die Konstante `PLACEHOLDER_ENCRYPTION_KEY` entfallen.          |
+| `docs/ENVIRONMENT.md`                       | Beispielwert entschärfen, Rotations-Abschnitt ergänzen.                                                                        |
+| `docs/RELEASE_PIPELINE.md`                  | „Zwei Dinge, die getrennt sein müssen" wird zu drei.                                                                           |
+
+`src/lib/server/config/` existiert bereits (`accessControl.ts`) — kein neues Verzeichnis.
+
+---
+
+## Task 1: Validierung für `SESSION_SECRET`
+
+**Files:**
+
+- Create: `src/lib/server/config/secretGuard.ts`
+- Test: `src/lib/server/config/secretGuard.test.ts`
+
+**Interfaces:**
+
+- Consumes: nichts
+- Produces:
+
+  ```ts
+  export const PUBLIC_SESSION_SECRETS: ReadonlySet<string>;
+  export const MIN_SESSION_SECRET_LENGTH: number; // 32
+  export function validateSessionSecret(value: string): string | null;
+  ```
+
+  Rückgabe `null` bedeutet gültig; ein String ist die fertige, für Menschen lesbare
+  Fehlermeldung.
+
+- [ ] **Step 1: Write the failing test**
+
+Datei `src/lib/server/config/secretGuard.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+	MIN_SESSION_SECRET_LENGTH,
+	PUBLIC_SESSION_SECRETS,
+	validateSessionSecret
+} from '$lib/server/config/secretGuard';
+
+describe('validateSessionSecret', () => {
+	it('akzeptiert ein ausreichend langes, unbekanntes Secret', () => {
+		expect(validateSessionSecret('a'.repeat(48))).toBeNull();
+	});
+
+	it('lehnt einen leeren Wert ab', () => {
+		expect(validateSessionSecret('')).toMatch(/SESSION_SECRET/);
+	});
+
+	it('lehnt einen zu kurzen Wert ab', () => {
+		const tooShort = 'x'.repeat(MIN_SESSION_SECRET_LENGTH - 1);
+		expect(validateSessionSecret(tooShort)).toMatch(/32/);
+	});
+
+	it('lehnt den Platzhalter aus .env.example ab', () => {
+		expect(validateSessionSecret('your-secret-key-here-min-32-chars')).toMatch(/öffentlich/);
+	});
+
+	it('lehnt den Beispielwert aus docs/ENVIRONMENT.md ab', () => {
+		expect(validateSessionSecret('8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE')).toMatch(/öffentlich/);
+	});
+
+	/* Der Kern des Befunds aus #635: Beide öffentlich bekannten Werte sind 33 Zeichen lang
+	   und bestehen jede reine Längenprüfung. Ohne diesen Test ist die naheliegende
+	   Implementierung (nur `>= 32`) grün und trotzdem falsch. */
+	it('erkennt, dass die öffentlichen Werte die Längenprüfung bestehen würden', () => {
+		for (const known of PUBLIC_SESSION_SECRETS) {
+			expect(known.length).toBeGreaterThanOrEqual(MIN_SESSION_SECRET_LENGTH);
+			expect(validateSessionSecret(known)).not.toBeNull();
+		}
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: FAIL — `Failed to resolve import "$lib/server/config/secretGuard"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Datei `src/lib/server/config/secretGuard.ts`:
+
+```ts
+/**
+ * Prüfung der Produktions-Secrets beim Serverstart.
+ *
+ * Reine Funktionen ohne Env-Zugriff: Die Werte kommen als Parameter herein, damit sie
+ * testbar sind. Der Aufruf und das Werfen passieren in `src/hooks.server.ts`.
+ *
+ * Hintergrund: Issue #635 — ein Deployment, das `.env.example` als Vorlage übernimmt,
+ * lief bisher mit einem Secret, das im öffentlichen Repository steht.
+ */
+
+/**
+ * Werte, die als `SESSION_SECRET` nie gelten dürfen, weil sie öffentlich einsehbar sind.
+ *
+ * Beide sind 33 Zeichen lang und bestehen damit jede reine Mindestlängenprüfung — der
+ * Vergleich gegen diese Menge ist deshalb nicht optional.
+ */
+export const PUBLIC_SESSION_SECRETS: ReadonlySet<string> = new Set([
+	'your-secret-key-here-min-32-chars', // .env.example
+	'8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE' // docs/ENVIRONMENT.md
+]);
+
+export const MIN_SESSION_SECRET_LENGTH = 32;
+
+const GENERATE_HINT = 'Erzeugen mit: openssl rand -base64 32';
+
+/**
+ * Prüft einen `SESSION_SECRET`-Wert.
+ *
+ * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
+ */
+export function validateSessionSecret(value: string): string | null {
+	if (!value) {
+		return `SESSION_SECRET ist in Produktion erforderlich. ${GENERATE_HINT}`;
+	}
+	if (value.length < MIN_SESSION_SECRET_LENGTH) {
+		return (
+			`SESSION_SECRET ist zu kurz (${value.length} Zeichen, mindestens ` +
+			`${MIN_SESSION_SECRET_LENGTH} erforderlich). ${GENERATE_HINT}`
+		);
+	}
+	if (PUBLIC_SESSION_SECRETS.has(value)) {
+		return (
+			'SESSION_SECRET ist ein öffentlich bekannter Beispielwert aus dem Repository. ' +
+			`Wer ihn kennt, kann sich eine Admin-Session ausstellen. ${GENERATE_HINT}`
+		);
+	}
+	return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: PASS, 6 Tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/server/config/secretGuard.ts src/lib/server/config/secretGuard.test.ts
+git commit -m "fix(security): reject publicly known SESSION_SECRET values"
+```
+
+---
+
+## Task 2: Validierung für `ENCRYPTION_KEY`
+
+Der bestehende Guard (`src/hooks.server.ts:36–45`) prüft nur _leer_ und _Platzhalter_.
+`src/lib/server/auth/crypto.ts:103` nutzt `aes-256-gcm`, das exakt 32 Byte Schlüssel verlangt.
+Ein 32-stelliger Hex-Wert (= 16 Byte) kommt heute durch den Guard und lässt
+`crypto.createCipheriv` erst beim ersten Login werfen — auf dem Auth-Pfad, wo der Fehler am
+teuersten ist. #635 verlangt ausdrücklich, diesen Guard mitzuprüfen.
+
+**Files:**
+
+- Modify: `src/lib/server/config/secretGuard.ts`
+- Test: `src/lib/server/config/secretGuard.test.ts`
+
+**Interfaces:**
+
+- Consumes: nichts aus Task 1 (eigenständige Funktion in derselben Datei)
+- Produces:
+
+  ```ts
+  export const PLACEHOLDER_ENCRYPTION_KEY: string; // '0'.repeat(64)
+  export const ENCRYPTION_KEY_LENGTH: number; // 64
+  export function validateEncryptionKey(value: string): string | null;
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+An `src/lib/server/config/secretGuard.test.ts` anhängen. Die drei neuen Namen
+(`ENCRYPTION_KEY_LENGTH`, `PLACEHOLDER_ENCRYPTION_KEY`, `validateEncryptionKey`) in den
+**bestehenden** Import-Block aus Task 1 aufnehmen — kein zweites `import`-Statement aus
+demselben Modul, das würde ESLint anschlagen.
+
+```ts
+describe('validateEncryptionKey', () => {
+	const valid = 'a3f1'.repeat(16); // 64 Hex-Zeichen = 32 Byte
+
+	it('akzeptiert 64 Hex-Zeichen', () => {
+		expect(valid).toHaveLength(ENCRYPTION_KEY_LENGTH);
+		expect(validateEncryptionKey(valid)).toBeNull();
+	});
+
+	it('akzeptiert Grossbuchstaben in der Hex-Darstellung', () => {
+		expect(validateEncryptionKey(valid.toUpperCase())).toBeNull();
+	});
+
+	it('lehnt einen leeren Wert ab', () => {
+		expect(validateEncryptionKey('')).toMatch(/ENCRYPTION_KEY/);
+	});
+
+	it('lehnt den Platzhalter aus .env.example ab', () => {
+		expect(validateEncryptionKey(PLACEHOLDER_ENCRYPTION_KEY)).toMatch(/Platzhalter/);
+	});
+
+	/* Der neue Fall: aes-256-gcm braucht 32 Byte. Ein 32-stelliger Hex-Wert sind 16 Byte
+	   und liess createCipheriv bisher erst beim ersten Login werfen. */
+	it('lehnt einen zu kurzen Hex-Wert ab, der bisher durchkam', () => {
+		expect(validateEncryptionKey('a3f1'.repeat(8))).toMatch(/64/);
+	});
+
+	it('lehnt Nicht-Hex-Zeichen ab', () => {
+		expect(validateEncryptionKey('z'.repeat(64))).toMatch(/hexadezimal/);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: FAIL — `validateEncryptionKey is not a function` bzw. fehlende Exporte.
+
+- [ ] **Step 3: Write minimal implementation**
+
+An `src/lib/server/config/secretGuard.ts` anhängen:
+
+```ts
+/**
+ * Platzhalter-Wert aus `.env.example` (64x "0") — NIE in Produktion nutzen.
+ */
+export const PLACEHOLDER_ENCRYPTION_KEY = '0'.repeat(64);
+
+/**
+ * `crypto.ts` nutzt aes-256-gcm. Das verlangt exakt 32 Byte Schlüssel,
+ * hex-kodiert also 64 Zeichen.
+ */
+export const ENCRYPTION_KEY_LENGTH = 64;
+
+const HEX_ONLY = /^[0-9a-f]+$/i;
+
+/**
+ * Prüft einen `ENCRYPTION_KEY`-Wert.
+ *
+ * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
+ */
+export function validateEncryptionKey(value: string): string | null {
+	const hint = 'Erzeugen mit: openssl rand -hex 32';
+
+	if (!value) {
+		return `ENCRYPTION_KEY ist in Produktion erforderlich. ${hint}`;
+	}
+	if (value === PLACEHOLDER_ENCRYPTION_KEY) {
+		return (
+			'ENCRYPTION_KEY ist der Platzhalter aus der Beispiel-Konfiguration. ' +
+			`Die Verschlüsselung des PKCE-Verifiers wäre damit wirkungslos. ${hint}`
+		);
+	}
+	if (value.length !== ENCRYPTION_KEY_LENGTH) {
+		return (
+			`ENCRYPTION_KEY muss genau ${ENCRYPTION_KEY_LENGTH} Zeichen lang sein ` +
+			`(32 Byte für aes-256-gcm), ist aber ${value.length}. ${hint}`
+		);
+	}
+	if (!HEX_ONLY.test(value)) {
+		return `ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f). ${hint}`;
+	}
+	return null;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: PASS, 12 Tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/server/config/secretGuard.ts src/lib/server/config/secretGuard.test.ts
+git commit -m "fix(security): require ENCRYPTION_KEY to be 64 hex chars"
+```
+
+---
+
+## Task 3: Guard in `hooks.server.ts` verdrahten
+
+**Files:**
+
+- Modify: `src/hooks.server.ts:20-45` (Konstante und beide inline-Guards)
+- Test: `src/lib/server/config/secretGuard.test.ts`
+
+**Interfaces:**
+
+- Consumes: `validateSessionSecret`, `validateEncryptionKey` aus Task 1 und 2
+- Produces:
+
+  ```ts
+  export function assertProductionSecrets(env: {
+  	NODE_ENV: string;
+  	SESSION_SECRET: string;
+  	ENCRYPTION_KEY: string;
+  }): void; // wirft Error bei ungültiger Konfiguration
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+An `src/lib/server/config/secretGuard.test.ts` anhängen (Import von
+`assertProductionSecrets` in den bestehenden Import-Block aufnehmen):
+
+```ts
+describe('assertProductionSecrets', () => {
+	const good = { SESSION_SECRET: 'a'.repeat(48), ENCRYPTION_KEY: 'a3f1'.repeat(16) };
+
+	it('wirft nicht ausserhalb von production', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'development',
+				SESSION_SECRET: 'your-secret-key-here-min-32-chars',
+				ENCRYPTION_KEY: '0'.repeat(64)
+			})
+		).not.toThrow();
+	});
+
+	it('wirft nicht bei gültiger Produktionskonfiguration', () => {
+		expect(() => assertProductionSecrets({ NODE_ENV: 'production', ...good })).not.toThrow();
+	});
+
+	it('wirft in production bei öffentlich bekanntem SESSION_SECRET', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				...good,
+				SESSION_SECRET: 'your-secret-key-here-min-32-chars'
+			})
+		).toThrow(/öffentlich bekannter Beispielwert/);
+	});
+
+	it('wirft in production bei zu kurzem ENCRYPTION_KEY', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				...good,
+				ENCRYPTION_KEY: 'a3f1'.repeat(8)
+			})
+		).toThrow(/64 Zeichen/);
+	});
+
+	/* Beide Fehler zusammen: Die Meldung muss beide nennen, damit ein Betreiber nicht
+	   zweimal deployen muss, um beide zu finden. */
+	it('nennt beide Fehler in einer Meldung', () => {
+		let message = '';
+		try {
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				SESSION_SECRET: '',
+				ENCRYPTION_KEY: ''
+			});
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+		expect(message).toMatch(/SESSION_SECRET/);
+		expect(message).toMatch(/ENCRYPTION_KEY/);
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: FAIL — `assertProductionSecrets is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+An `src/lib/server/config/secretGuard.ts` anhängen:
+
+```ts
+/**
+ * Prüft beim Serverstart alle Produktions-Secrets und wirft mit einer Meldung,
+ * die **alle** gefundenen Probleme nennt.
+ *
+ * Beide Fehler gemeinsam zu melden ist Absicht: Ein Betreiber, der nur den ersten
+ * sieht, deployt zweimal.
+ */
+export function assertProductionSecrets(env: {
+	NODE_ENV: string;
+	SESSION_SECRET: string;
+	ENCRYPTION_KEY: string;
+}): void {
+	if (env.NODE_ENV !== 'production') {
+		return;
+	}
+
+	const problems = [
+		validateSessionSecret(env.SESSION_SECRET),
+		validateEncryptionKey(env.ENCRYPTION_KEY)
+	].filter((problem): problem is string => problem !== null);
+
+	if (problems.length > 0) {
+		throw new Error(
+			`Ungültige Produktions-Konfiguration:\n- ${problems.join('\n- ')}\n` +
+				'Der Server startet aus Sicherheitsgründen nicht.'
+		);
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: PASS, 17 Tests.
+
+- [ ] **Step 5: Replace the inline guards in `hooks.server.ts`**
+
+In `src/hooks.server.ts` den Import ergänzen:
+
+```ts
+import { assertProductionSecrets } from '$lib/server/config/secretGuard';
+```
+
+Die Zeilen 20–45 — also die Konstante `PLACEHOLDER_ENCRYPTION_KEY` samt Kommentar und **beide**
+`if (NODE_ENV === 'production' && …) { throw … }`-Blöcke — vollständig ersetzen durch:
+
+```ts
+// Guard: Der Server startet in Produktion nicht mit fehlenden, zu kurzen oder öffentlich
+// bekannten Secrets. Die Prüflogik steht in secretGuard.ts, damit sie testbar ist —
+// hooks.server.ts liegt ausserhalb von src/lib/** und wird von den Server-Tests nicht erfasst.
+assertProductionSecrets({ NODE_ENV, SESSION_SECRET, ENCRYPTION_KEY });
+```
+
+Die Konstanten `NODE_ENV`, `SESSION_SECRET` und `ENCRYPTION_KEY` (Zeilen 16–18) bleiben, sie
+werden weiter unten noch gebraucht bzw. hier übergeben. Der `logger` (Zeile 23) muss **vor**
+dem Aufruf definiert bleiben — die Reihenfolge der Zeilen 15–23 nicht verändern, nur den Block
+danach ersetzen.
+
+- [ ] **Step 6: Verify the whole suite**
+
+```bash
+npm run test:quick
+```
+
+Erwartet: lint, type-check, svelte-check und Unit-Tests grün. Kein Test darf durch das
+Entfernen der inline-Guards brechen; sie waren nicht abgedeckt.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks.server.ts src/lib/server/config/secretGuard.ts src/lib/server/config/secretGuard.test.ts
+git commit -m "fix(security): move startup secret validation into a tested module"
+```
+
+---
+
+## Task 4: Dokumentation
+
+**Files:**
+
+- Modify: `docs/ENVIRONMENT.md:96` und Abschnitt `### SESSION_SECRET` (ab Zeile 79)
+- Modify: `docs/RELEASE_PIPELINE.md:169-177`
+
+Kein Test — reine Dokumentationsänderung, laut `.claude/rules/testing.md` eine zulässige
+Ausnahme, die im Commit begründet wird.
+
+- [ ] **Step 1: Beispielwert in `docs/ENVIRONMENT.md` entschärfen**
+
+Zeile 96 lautet heute:
+
+```bash
+SESSION_SECRET=8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE
+```
+
+Ersetzen durch:
+
+```bash
+SESSION_SECRET=<Ausgabe von openssl rand -base64 32>
+```
+
+Begründung im Kopf des Abschnitts ergänzen: Ein Wert, der echt aussieht, wird kopiert — und
+seit PR 1 verweigert der Server den Start, wenn er es doch wurde.
+
+- [ ] **Step 2: Rotations-Abschnitt in `docs/ENVIRONMENT.md` ergänzen**
+
+Direkt nach dem `SESSION_SECRET`-Abschnitt einfügen:
+
+```markdown
+**Rotation:**
+
+`SESSION_SECRET` lässt sich jederzeit wechseln — der neue Wert wird in die `.env` des
+Hosts geschrieben, danach `docker compose up -d`.
+
+**Nebenwirkung:** Jeder Wechsel beendet **alle** laufenden Sitzungen gleichzeitig. Jedes
+`jwtVerify` gegen das alte Cookie schlägt fehl, das Cookie wird gelöscht, alle Angemeldeten
+landen im Login. Das ist der Notausschalter für den Verdachtsfall („jemand könnte das
+Secret kennen") — und der einzige Weg, eine ausgestellte Session ungültig zu machen.
+
+Staging und Production müssen **verschiedene** Secrets haben. Sonst ist ein Staging-Zugang
+ein Produktions-Zugang.
+```
+
+- [ ] **Step 3: `docs/RELEASE_PIPELINE.md` erweitern**
+
+Die Überschrift auf Zeile 169 lautet „## Zwei Dinge, die getrennt sein müssen". Sie wird zu
+„## Drei Dinge, die getrennt sein müssen". Nach dem Absatz „**Upload-Verzeichnisse.**"
+(Zeile 175) einfügen:
+
+```markdown
+**`SESSION_SECRET`.** Jeder Stack braucht sein eigenes. Das Secret ist die alleinige
+Grundlage dafür, dass eine Session echt ist — wer es kennt, kann sich eine Admin-Session
+ausstellen, ohne Auth0 zu berühren. Ein geteiltes Secret macht einen Staging-Zugang zu
+einem Produktions-Zugang. Siehe `docs/ENVIRONMENT.md`, Abschnitt `SESSION_SECRET`.
+```
+
+- [ ] **Step 4: Formatierung prüfen**
+
+```bash
+npx prettier --check docs/ENVIRONMENT.md docs/RELEASE_PIPELINE.md
+```
+
+Erwartet: `All matched files use Prettier code style!`. Bei Abweichung `--write` statt
+`--check`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ENVIRONMENT.md docs/RELEASE_PIPELINE.md
+git commit -m "docs(security): document SESSION_SECRET rotation and per-environment separation
+
+Kein Test: reine Dokumentationsaenderung ohne Logik (Ausnahme nach
+.claude/rules/testing.md)."
+```
+
+---
+
+## Task 5: Abnahme
+
+- [ ] **Step 1: Vollständiger Schnelltest**
+
+```bash
+npm run test:quick
+```
+
+Erwartet: grün.
+
+- [ ] **Step 2: Gegenprobe — der Guard greift tatsächlich**
+
+```bash
+NODE_ENV=production SESSION_SECRET="your-secret-key-here-min-32-chars" \
+ENCRYPTION_KEY="$(printf '0%.0s' {1..64})" \
+npx vitest run src/lib/server/config/secretGuard.test.ts
+```
+
+Erwartet: PASS — die Tests prüfen die Funktion direkt, die Umgebungsvariablen sind hier nur
+Kontrolle, dass nichts implizit aus der Umgebung gelesen wird. Schlägt einer der Tests fehl,
+liest `secretGuard.ts` entgegen der Vorgabe aus `$env` statt aus seinen Parametern.
+
+- [ ] **Step 3: Prüfen, dass Entwicklung und CI unberührt sind**
+
+```bash
+grep -n '^SESSION_SECRET=\|^ENCRYPTION_KEY=' .env.example
+```
+
+Erwartet: die unveränderten Platzhalter. `.env.example` wird in PR 1 **nicht** angefasst —
+lokale Entwicklung und CI laufen weiter mit dem Platzhalter, weil der Guard nur bei
+`NODE_ENV === 'production'` greift.
+
+- [ ] **Step 4: PR eröffnen**
+
+```bash
+gh pr create --fill --base main
+```
+
+Im PR-Text auf `docs/SESSION_STORE_SPEC_2026-07-31.md` Abschnitt 4 verweisen und festhalten,
+dass dies Paket A ist — Paket D (Session-Store) folgt separat und entfernt `SESSION_SECRET`
+dann vollständig.
+
+---
+
+## Was dieser PR ausdrücklich **nicht** tut
+
+- Er behebt **nicht** die Ursache aus #635. Wer das echte `SESSION_SECRET` kennt, kann sich
+  weiterhin eine Admin-Session ausstellen. Der Guard schliesst nur den Fall, dass dieses
+  Secret ein öffentlich bekannter Wert ist.
+- Er ändert **nichts** am Verhalten eines laufenden Deployments mit einem echten Secret.
+- Er fasst `.env.example`, `docker-compose.production.yml`, `run-release.sh` und
+  `scripts/docker-entrypoint.sh` nicht an. Der Guard in `hooks.server.ts` ist der einzige
+  Punkt, den jeder Startweg durchläuft — `run-release.sh:275` startet mit `--entrypoint ""`
+  und umgeht das Entrypoint-Skript vollständig.

--- a/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
+++ b/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
@@ -8,11 +8,16 @@
 bekannter Wert ist oder `ENCRYPTION_KEY` kein gültiger 32-Byte-Hex-Schlüssel.
 
 **Architecture:** Die Prüflogik zieht aus dem Modul-Scope von `src/hooks.server.ts` in ein
-neues, reines Modul `src/lib/server/config/secretGuard.ts`. Grund: `hooks.server.ts` liegt
-außerhalb von `src/lib/**` und wird von der Server-Test-Konfiguration nicht erfasst
-(`vitest.config.ts:9`, `include: ['src/lib/**/*.ts']`); außerdem führt es beim Import
-Seiteneffekte aus (Middleware-Kette, DB-Modul, Signal-Handler). Ein reines Modul ist testbar,
-`hooks.server.ts` ruft es nur noch auf.
+neues, reines Modul `src/lib/server/config/secretGuard.ts`.
+
+Grund ist **nicht** der Dateiort — der Server-Test-Include ist
+`src/**/*.{test,spec}.{js,ts}` und würde ein `src/hooks.server.test.ts` erfassen. Der Grund
+sind die Seiteneffekte beim Import: `hooks.server.ts` zieht das DB-Modul, die
+Middleware-Kette und `process.once`-Signal-Handler mit, und die Guards laufen im Modul-Scope —
+ein Test müsste also für jeden Fall das ganze Modul mit anderen Env-Werten neu importieren.
+Dazu zählt die Coverage ohnehin nur `src/lib/**` (`vitest.config.ts`, `coverage.include`).
+Reine Funktionen mit den Werten als Parameter sind ohne all das prüfbar; `hooks.server.ts` ruft
+sie nur noch auf.
 
 **Tech Stack:** TypeScript, SvelteKit 5, Vitest (Node-Umgebung), `$env/dynamic/private`.
 
@@ -26,7 +31,10 @@ Seiteneffekte aus (Middleware-Kette, DB-Modul, Signal-Handler). Ein reines Modul
 - **Kommentare und Doku auf Deutsch**, Bezeichner und Commit-Messages auf Englisch, Subject
   lowercase (`CLAUDE.md`, Commit Conventions).
 - **Commit-Format:** `<type>(<scope>): <beschreibung>`, hier `fix(security)` bzw. `docs(security)`.
-- **`npm run test:quick` muss vor jedem Commit grün sein.**
+- **`npm run test:quick` muss vor jedem Commit grün sein.** Der Pre-Commit-Hook dieses Repos
+  führt `lint` und `type-check` ohnehin bei jedem `git commit` aus; in den Tasks 1, 2 und 4
+  genügt daher der fokussierte `vitest run`, den der jeweilige Schritt nennt. Der vollständige
+  Lauf steht in Task 3 Schritt 6 und Task 5 Schritt 1.
 - Der Guard greift **nur** bei `NODE_ENV === 'production'`. Lokale Entwicklung und CI arbeiten
   bewusst mit dem Platzhalter aus `.env.example` (`.github/workflows/ci.yml:109,261,376`) und
   dürfen nicht brechen.
@@ -43,13 +51,13 @@ Seiteneffekte aus (Middleware-Kette, DB-Modul, Signal-Handler). Ein reines Modul
 
 ## Dateistruktur
 
-| Datei                                       | Verantwortung                                                                                                                  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `src/lib/server/config/secretGuard.ts`      | **neu.** Reine Validierung der beiden Produktions-Secrets. Kein I/O, kein Env-Zugriff — die Werte kommen als Parameter herein. |
-| `src/lib/server/config/secretGuard.test.ts` | **neu.** Vitest, Node-Umgebung.                                                                                                |
-| `src/hooks.server.ts`                       | Ruft den Guard auf; die beiden inline-Guards (Zeilen 20–45) und die Konstante `PLACEHOLDER_ENCRYPTION_KEY` entfallen.          |
-| `docs/ENVIRONMENT.md`                       | Beispielwert entschärfen, Rotations-Abschnitt ergänzen.                                                                        |
-| `docs/RELEASE_PIPELINE.md`                  | „Zwei Dinge, die getrennt sein müssen" wird zu drei.                                                                           |
+| Datei                                       | Verantwortung                                                                                                                   |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/server/config/secretGuard.ts`      | **neu.** Reine Validierung der beiden Produktions-Secrets. Kein I/O, kein Env-Zugriff — die Werte kommen als Parameter herein.  |
+| `src/lib/server/config/secretGuard.test.ts` | **neu.** Vitest, Node-Umgebung.                                                                                                 |
+| `src/hooks.server.ts`                       | Ruft den Guard auf; die beiden inline-Guards (Zeilen 20–22 und 25–45) und die Konstante `PLACEHOLDER_ENCRYPTION_KEY` entfallen. |
+| `docs/ENVIRONMENT.md`                       | Beispielwert entschärfen, Rotations-Abschnitt ergänzen.                                                                         |
+| `docs/RELEASE_PIPELINE.md`                  | „Zwei Dinge, die getrennt sein müssen" wird zu drei.                                                                            |
 
 `src/lib/server/config/` existiert bereits (`accessControl.ts`) — kein neues Verzeichnis.
 
@@ -110,6 +118,16 @@ describe('validateSessionSecret', () => {
 		expect(validateSessionSecret('8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE')).toMatch(/öffentlich/);
 	});
 
+	/* Ein Leerzeichen oder Zeilenumbruch um den Platzhalter darf die Prüfung nicht
+	   aushebeln — sonst ist der Guard still wirkungslos. */
+	it('lehnt den Platzhalter auch mit Leerraum drumherum ab', () => {
+		expect(validateSessionSecret('  your-secret-key-here-min-32-chars\n')).toMatch(/öffentlich/);
+	});
+
+	it('lehnt einen Wert ab, der nur aus Leerraum besteht', () => {
+		expect(validateSessionSecret('   ')).toMatch(/erforderlich/);
+	});
+
 	/* Der Kern des Befunds aus #635: Beide öffentlich bekannten Werte sind 33 Zeichen lang
 	   und bestehen jede reine Längenprüfung. Ohne diesen Test ist die naheliegende
 	   Implementierung (nur `>= 32`) grün und trotzdem falsch. */
@@ -165,7 +183,12 @@ const GENERATE_HINT = 'Erzeugen mit: openssl rand -base64 32';
  *
  * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
  */
-export function validateSessionSecret(value: string): string | null {
+export function validateSessionSecret(raw: string): string | null {
+	/* Trimmen vor dem Vergleich, sonst umgeht ein versehentliches Leerzeichen oder ein
+	   Zeilenumbruch (`openssl rand -base64 32 > datei`) die Prüfung gegen die bekannten
+	   Werte — der Guard wäre dann still wirkungslos. */
+	const value = raw.trim();
+
 	if (!value) {
 		return `SESSION_SECRET ist in Produktion erforderlich. ${GENERATE_HINT}`;
 	}
@@ -191,7 +214,7 @@ export function validateSessionSecret(value: string): string | null {
 npx vitest run src/lib/server/config/secretGuard.test.ts
 ```
 
-Erwartet: PASS, 6 Tests.
+Erwartet: PASS, 8 Tests.
 
 - [ ] **Step 5: Commit**
 
@@ -328,7 +351,7 @@ export function validateEncryptionKey(value: string): string | null {
 npx vitest run src/lib/server/config/secretGuard.test.ts
 ```
 
-Erwartet: PASS, 12 Tests.
+Erwartet: PASS, 14 Tests.
 
 - [ ] **Step 5: Commit**
 
@@ -470,7 +493,7 @@ export function assertProductionSecrets(env: {
 npx vitest run src/lib/server/config/secretGuard.test.ts
 ```
 
-Erwartet: PASS, 17 Tests.
+Erwartet: PASS, 19 Tests.
 
 - [ ] **Step 5: Replace the inline guards in `hooks.server.ts`**
 
@@ -480,8 +503,13 @@ In `src/hooks.server.ts` den Import ergänzen:
 import { assertProductionSecrets } from '$lib/server/config/secretGuard';
 ```
 
-Die Zeilen 20–45 — also die Konstante `PLACEHOLDER_ENCRYPTION_KEY` samt Kommentar und **beide**
-`if (NODE_ENV === 'production' && …) { throw … }`-Blöcke — vollständig ersetzen durch:
+Dann **zwei getrennte** Bereiche anfassen — die Zeile 23 dazwischen (`const logger = …`) muss
+stehen bleiben:
+
+1. **Zeilen 20–22 löschen**: der Kommentar `// Platzhalter-Wert aus der Beispiel-Konfiguration …`,
+   die Konstante `PLACEHOLDER_ENCRYPTION_KEY` und die folgende Leerzeile.
+2. **Zeilen 25–45 ersetzen**: den Kommentar `// Guard: fail fast if SESSION_SECRET …` und
+   **beide** `if (NODE_ENV === 'production' && …) { throw … }`-Blöcke durch:
 
 ```ts
 // Guard: Der Server startet in Produktion nicht mit fehlenden, zu kurzen oder öffentlich
@@ -490,10 +518,8 @@ Die Zeilen 20–45 — also die Konstante `PLACEHOLDER_ENCRYPTION_KEY` samt Komm
 assertProductionSecrets({ NODE_ENV, SESSION_SECRET, ENCRYPTION_KEY });
 ```
 
-Die Konstanten `NODE_ENV`, `SESSION_SECRET` und `ENCRYPTION_KEY` (Zeilen 16–18) bleiben, sie
-werden weiter unten noch gebraucht bzw. hier übergeben. Der `logger` (Zeile 23) muss **vor**
-dem Aufruf definiert bleiben — die Reihenfolge der Zeilen 15–23 nicht verändern, nur den Block
-danach ersetzen.
+Die Konstanten `NODE_ENV`, `SESSION_SECRET` und `ENCRYPTION_KEY` (Zeilen 16–18) bleiben — sie
+werden hier übergeben und weiter unten noch gebraucht.
 
 - [ ] **Step 6: Verify the whole suite**
 
@@ -625,7 +651,31 @@ Erwartet: die unveränderten Platzhalter. `.env.example` wird in PR 1 **nicht** 
 lokale Entwicklung und CI laufen weiter mit dem Platzhalter, weil der Guard nur bei
 `NODE_ENV === 'production'` greift.
 
-- [ ] **Step 4: PR eröffnen**
+- [ ] **Step 4: Die eigentliche Wirkung prüfen — startet der Server wirklich nicht?**
+
+Die Unit-Tests belegen, dass die Funktion wirft. Sie belegen **nicht**, dass ein Modul-Scope-
+`throw` in `hooks.server.ts` den adapter-node-Prozess tatsächlich beendet, statt nur 500er zu
+liefern. Ohne diesen Schritt ist der Guard eine Zusicherung, die nie an einem echten Server
+geprüft wurde.
+
+```bash
+npm run build
+NODE_ENV=production \
+SESSION_SECRET="your-secret-key-here-min-32-chars" \
+ENCRYPTION_KEY="$(printf '0%.0s' {1..64})" \
+DATABASE_POSTGRES_URL="postgres://invalid/invalid" \
+node build/index.js; echo "exit=$?"
+```
+
+Erwartet: Die Meldung „Ungültige Produktions-Konfiguration" mit **beiden** Punkten auf stderr,
+und `exit=` mit einem Wert ungleich 0. Der Prozess darf **nicht** auf einem Port lauschen.
+
+Kommt stattdessen ein laufender Server heraus, ist der Guard wirkungslos und der Aufruf muss
+vor den SvelteKit-Server gezogen werden (dann zusätzlich in `scripts/docker-entrypoint.sh` —
+mit dem Hinweis, dass `run-release.sh:275` das Skript per `--entrypoint ""` umgeht). Das in
+diesem Fall als eigenen Befund festhalten, nicht stillschweigend umbauen.
+
+- [ ] **Step 5: PR eröffnen**
 
 ```bash
 gh pr create --fill --base main
@@ -642,6 +692,9 @@ dann vollständig.
 - Er behebt **nicht** die Ursache aus #635. Wer das echte `SESSION_SECRET` kennt, kann sich
   weiterhin eine Admin-Session ausstellen. Der Guard schliesst nur den Fall, dass dieses
   Secret ein öffentlich bekannter Wert ist.
+- Er beurteilt **nicht die Güte** eines selbstgewählten Secrets. `passwort-passwort-passwort-1234`
+  ist 32 Zeichen lang, unbekannt und kommt durch. Entropie-Schätzung ist unzuverlässig und
+  würde falsche Sicherheit erzeugen; die Doku verweist stattdessen auf `openssl rand`.
 - Er ändert **nichts** am Verhalten eines laufenden Deployments mit einem echten Secret.
 - Er fasst `.env.example`, `docker-compose.production.yml`, `run-release.sh` und
   `scripts/docker-entrypoint.sh` nicht an. Der Guard in `hooks.server.ts` ist der einzige

--- a/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
+++ b/docs/PLAN_SESSION_SECRET_GUARD_2026-07-31.md
@@ -1,9 +1,5 @@
 # Startup-Guard für Produktions-Secrets — Implementierungsplan (PR 1 / Paket A)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
-> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
-> checkbox (`- [ ]`) syntax for tracking.
-
 **Goal:** Ein Produktions-Deployment startet nicht mehr, wenn `SESSION_SECRET` ein öffentlich
 bekannter Wert ist oder `ENCRYPTION_KEY` kein gültiger 32-Byte-Hex-Schlüssel.
 

--- a/docs/RELEASE_PIPELINE.md
+++ b/docs/RELEASE_PIPELINE.md
@@ -166,7 +166,7 @@ Skript nach der Freigabe von Hand auf.
 
 ---
 
-## Zwei Dinge, die getrennt sein müssen
+## Drei Dinge, die getrennt sein müssen
 
 **Datenbanken.** Staging und Production brauchen jeweils eine eigene DB.
 Migrationen laufen beim Container-Start — bei geteilter DB migriert das
@@ -175,6 +175,11 @@ Staging-Deploy die Produktion, und die Freigabe sichert nichts mehr ab.
 **Upload-Verzeichnisse.** Jeder Stack braucht sein eigenes `uploads/`-Volume.
 Medien liegen seit dem 28.07.2026 auf Platte statt in Vercel Blob; ein geteiltes
 Volume würde Staging-Testdaten in den Prod-Bestand schreiben.
+
+**`SESSION_SECRET`.** Jeder Stack braucht sein eigenes. Das Secret ist die alleinige
+Grundlage dafür, dass eine Session echt ist — wer es kennt, kann sich eine Admin-Session
+ausstellen, ohne Auth0 zu berühren. Ein geteiltes Secret macht einen Staging-Zugang zu
+einem Produktions-Zugang. Siehe `docs/ENVIRONMENT.md`, Abschnitt `SESSION_SECRET`.
 
 ---
 

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -200,6 +200,16 @@ Attribute bleiben wie in `setAuthCookie` heute: `httpOnly`, `sameSite: 'none'`, 
 `path: '/'`. Die `SameSite=None`-Anforderung stammt aus der iframe-Einbettung auf
 meeresmuseum.de und bleibt unberührt.
 
+`maxAge` folgt dem Inaktivitätsfenster und wird bei jedem Fortschreiben von `expires_at`
+mitgesetzt. Cookie-Lebensdauer und Zeilen-Lebensdauer dürfen nicht auseinanderlaufen — genau
+diese Diskrepanz ist der Mechanismus hinter #634, nur in der anderen Richtung.
+
+**Warum SHA-256 und kein Passwort-KDF.** Der Token ist 256 Bit Zufall, kein geratener Wert:
+Es gibt kein Wörterbuch, gegen das ein Angreifer den Hash prüfen könnte, und damit nichts, was
+ein absichtlich langsames Verfahren erschweren würde. bcrypt oder Argon2 wären hier pro Request
+messbare Kosten ohne Gegenwert. Ungesalzenes SHA-256 ist die richtige Wahl und keine
+Nachlässigkeit.
+
 Der Cookie-**Name** bleibt (`COOKIE_NAME`, Default `auth-cookie`). Alte JWT-Werte finden nach
 dem Deploy schlicht keine Zeile, werden verworfen und gelöscht. Das ist die Migration:
 einmalig neu einloggen.
@@ -225,9 +235,23 @@ tokens if the Auth0 session remains valid)". Der Redirect ist still, solange die
 lebt, und die App tut ihn **heute schon**. Damit braucht diese Spec weder den
 `offline_access`-Scope noch eine verschlüsselte Refresh-Token-Spalte.
 
-**Aufräumen ohne Cron.** Beim Anlegen einer Session werden abgelaufene Zeilen desselben `sub`
-in derselben Anweisung gelöscht. Ein Timer wäre eine zusätzliche bewegliche Komponente für ein
-Problem, das ein `DELETE` löst.
+**`touchSession` darf nicht bei jedem Request schreiben.** Heute kostet die gleitende
+Verlängerung einen Cookie-Header; ein `UPDATE` pro Request wäre etwas anderes — `handle` läuft
+für jeden Request, auch für Assets. Deshalb: `touchSession` schreibt nur, wenn `last_seen_at`
+älter als ein Schwellwert ist (Vorschlag: 60 Sekunden). Dazwischen wird die Zeile nur gelesen.
+Der Effekt auf die Sitzungsdauer ist vernachlässigbar (bis zu einer Minute Unschärfe im
+Inaktivitätsfenster), der Effekt auf die Schreiblast erheblich.
+
+**Aufräumen ohne Cron.** Beim Anlegen einer Session werden abgelaufene **und widerrufene**
+Zeilen desselben `sub` in derselben Anweisung gelöscht. Ein Timer wäre eine zusätzliche
+bewegliche Komponente für ein Problem, das ein `DELETE` löst.
+
+**Aufbewahrung (DSGVO).** `user_claims` enthält Name und E-Mail, also personenbezogene Daten.
+Sie werden nicht archiviert: Eine widerrufene oder abgelaufene Zeile wird beim nächsten Login
+desselben `sub` gelöscht, nicht nur markiert. `revoked_at` ist ein Übergangszustand für die
+Dauer zwischen Logout und nächster Anmeldung, kein Aufbewahrungsmechanismus. Für den Fall, dass
+ein Benutzer sich nie wieder anmeldet, deckt das nichts ab — dafür genügt ein `DELETE` auf
+abgelaufene Zeilen im bestehenden Wartungsendpunkt `/api/admin/cleanup-orphans`.
 
 ### 5.4 Betroffene Dateien
 
@@ -246,6 +270,23 @@ Problem, das ein `DELETE` löst.
 | `e2e/helpers/adminSession.ts`                                                                                                                                                                                      | schreibt eine `sessions`-Zeile statt ein JWT zu signieren                                                                                                          |
 | `e2e/design-tokens.spec.ts:482`                                                                                                                                                                                    | Fehlermeldung anpassen (nennt heute `SESSION_SECRET`)                                                                                                              |
 | `.env.example`, `docker-compose.production.yml`, `run-release.sh`, `scripts/docker-entrypoint.sh`, `.github/workflows/ci.yml`, `docs/ENVIRONMENT.md`, `docs/DOCKER_DEPLOYMENT.md`, `docs/PRODUCTION_DEPLOYMENT.md` | `SESSION_SECRET` entfernen                                                                                                                                         |
+
+**Zusätzlich betroffen, beim ersten Entwurf übersehen:**
+
+- `src/lib/server/audit/auditService.ts` — neue Events `auth.logout` und `auth.session_revoked`.
+  `.claude/rules/security.md` führt eine verbindliche Tabelle der Audit-Events; sie ist
+  mitzupflegen. `auth.login_success` existiert bereits und bleibt.
+- `static/openapi.yml:1248` — `/api/auth/logout` ist dokumentiert und ändert sein Verhalten
+  (wirkt jetzt wirklich). Ebenso zu prüfen: `securitySchemes` ab Zeile 2058, falls dort das
+  Session-Cookie als JWT beschrieben ist. CLAUDE.md verlangt die Aktualisierung der OpenAPI-Spec
+  nach API-Änderungen.
+- `e2e/helpers/adminSession.ts` braucht einen **eigenen** `postgres`-Client (`postgres@^3.4.9`,
+  bereits Abhängigkeit). Ein Import aus `$lib/server/...` funktioniert dort nicht: Playwright
+  läuft als gewöhnliches Node-Programm ohne SvelteKit-Bundler, also ohne `$lib`-Alias und ohne
+  `$env/dynamic/private`. Präzedenz für genau diesen Weg steht in
+  `.github/workflows/ci.yml` — der PostGIS-Check nutzt bewusst das `postgres`-Paket statt `psql`.
+  Die Verbindungsdaten kommen aus `DATABASE_POSTGRES_URL` in `.env`, das die Fixture über
+  `dotenv` bereits lädt.
 
 **Unverändert bleiben** `requireUserRole`, `isUserInRole`, `isAdminUser`, `isSuperAdminUser`
 und `src/lib/server/config/accessControl.ts`. Sie lesen `locals.user.roles`, und dort steht
@@ -277,11 +318,39 @@ Die vier zugehörigen Tests in `auth.test.ts` entfallen mit.
 - **Nicht gelöst:** Wer Schreibzugriff auf die Datenbank hat, kann sich eine Session-Zeile
   anlegen. Das ist die bewusste Grenze — wer die DB schreiben kann, braucht keine Admin-Session
   mehr, um Schaden anzurichten.
+- **Sitzungen werden nicht kürzer.** Die effektive Lebensdauer ist schon heute Auth0s `exp` —
+  genau das ist der Mechanismus hinter #634. `absolute_expires_at` übernimmt dieselbe Grenze,
+  nur sichtbar und mit Vorwarnung statt still. D verschärft nichts, es macht das Bestehende
+  erklärbar.
+- **CSRF-neutral.** `SameSite=None` bleibt (iframe-Einbettung meeresmuseum.de), der Schutz ruht
+  weiter auf SvelteKits Origin-Prüfung. Der CSRF-Bypass für `/rest_sichtungen` in
+  `hooks.server.ts:53–60` bleibt unberührt — die Legacy-Endpunkte nutzen kein Session-Cookie.
+- **Nicht gelöst:** Eine Abmeldung bei Auth0 beendet unsere Session nicht; sie läuft bis zum
+  Ablauf weiter. Das ist heute genauso, wird durch die Tabelle aber erstmals adressierbar — der
+  `sid`-Claim liegt in `user_claims` und wäre der Anknüpfungspunkt für Auth0s Back-Channel-Logout.
+  Bewusst nicht in dieser Spec.
 - **Nicht gelöst:** Rollenentzug in Auth0 wirkt erst bei der nächsten Anmeldung. Die
   Session-Zeile trägt einen Snapshot. Gegenmittel im Bedarfsfall: gezielter Widerruf, oder
   später die verworfene Management-API-Auffrischung.
 
 ---
+
+### 5.7 Abgleich mit dem OWASP Session Management Cheat Sheet
+
+Auth0 und SvelteKit begründen die _Wahl_ des Ansatzes. Der Maßstab für seine _Ausführung_ ist
+OWASP. Die sechs Kernanforderungen und wo diese Spec sie erfüllt:
+
+| OWASP-Anforderung                                           | Umsetzung                                                                                                         |
+| ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Session-ID mit mindestens 128 Bit Länge und 64 Bit Entropie | 256 Bit aus `crypto.randomBytes` (§5.2)                                                                           |
+| Session-ID ohne Bedeutung, kein Träger von Daten            | opakes Token, alle Daten in der Zeile (§5.2)                                                                      |
+| Serverseitig nicht im Klartext gespeichert                  | SHA-256 in `token_hash` (§5.1, §5.2)                                                                              |
+| Neuvergabe bei Anmeldung (Session Fixation)                 | jeder Login legt eine neue Zeile mit neuem Token an; ein vom Client mitgebrachter Wert wird nie übernommen (§5.3) |
+| Idle- **und** Absolut-Timeout                               | `expires_at` und `absolute_expires_at` (§5.1)                                                                     |
+| Invalidierung bei Logout, serverseitig                      | `destroySession` setzt `revoked_at` (§5.3, behebt B7)                                                             |
+
+Cookie-Attribute (`httpOnly`, `Secure`, `Path`) entsprechen der Empfehlung; `SameSite=None` ist
+eine begründete Abweichung aus der iframe-Einbettung und war schon vorher so.
 
 ## 6. Verhältnis zu #634
 
@@ -342,6 +411,13 @@ auf. Die Tests laufen gegen diese Funktion (`sessionRepository.test.ts`):
   abgelaufen (kein „Cookie lebt, Token tot" mehr)
 - `touchSession` verlängert nicht über `absolute_expires_at` hinaus
 
+### 7.3a Schreiblast und Cookie-Kopplung
+
+- `touchSession` schreibt **nicht**, wenn `last_seen_at` jünger als der Schwellwert ist
+- `touchSession` schreibt, sobald der Schwellwert überschritten ist
+- Ein `createSession` setzt `maxAge` passend zum Inaktivitätsfenster; ein Fortschreiben von
+  `expires_at` setzt das Cookie mit
+
 ### 7.4 Regression zu B7
 
 - Nach `destroySession` ist dasselbe Cookie ungültig — auch wenn der Client es behält
@@ -391,6 +467,7 @@ Betriebliche Schritte bei PR 2:
 
 ## 10. Quellen
 
+- [OWASP — Session Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)
 - [SvelteKit — Auth](https://svelte.dev/docs/kit/auth)
 - [Auth0 — Best Practices for Application Session Management](https://auth0.com/blog/application-session-management-best-practices/)
 - [Auth0 — Sessions](https://auth0.com/docs/manage-users/sessions)

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -1,0 +1,399 @@
+# Session-Store statt signiertem Cookie
+
+**Datum:** 2026-07-31
+**Issues:** [#635](https://github.com/jansinger/ostsee-tiere/issues/635) (Sicherheit), [#634](https://github.com/jansinger/ostsee-tiere/issues/634) (stiller Session-Ablauf)
+**Status:** Entwurf, abgestimmt — noch kein Implementierungsplan
+
+---
+
+## 1. Problem
+
+Die App stellt nach dem Auth0-Callback ihr **eigenes**, symmetrisch mit `SESSION_SECRET`
+signiertes JWT aus und legt es als Cookie ab. Ab da ist Auth0 nicht mehr beteiligt: Jeder
+Request wird gegen dasselbe Secret verifiziert, und `locals.isAdmin` entsteht aus dem
+`roles`-Feld der Token-Payload.
+
+Symmetrisch heißt: dasselbe Secret verifiziert **und** signiert. Wer `SESSION_SECRET` lesen
+kann, stellt sich eine Admin-Session aus — ohne Auth0, ohne Passwort, ohne dass die Identität
+in irgendeiner Benutzerverwaltung existieren muss.
+
+Der Nachweis steht im Repo und läuft täglich in CI: `e2e/helpers/adminSession.ts` signiert ein
+JWT mit `sub: 'e2e|design-tokens'` und `roles: ['admin']` und kommt damit an `/admin`. Diese
+Identität existiert in keinem Auth0-Tenant und in keiner Datenbank.
+
+### 1.1 Belegte Befunde
+
+Alle Zeilenangaben gegen `main` bei Commit `11a4e87` geprüft.
+
+| #   | Befund                                                                                                                                                                                                  | Beleg                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| B1  | Session-JWT wird mit `SESSION_SECRET` (HS256) signiert                                                                                                                                                  | `src/lib/server/auth/auth.ts:263–275`                              |
+| B2  | Verifikation ohne `issuer`/`audience`/`algorithms`-Einschränkung                                                                                                                                        | `src/hooks.server.ts:77–78`, `src/lib/server/auth/auth.ts:229–230` |
+| B3  | `locals.isAdmin` stammt allein aus der Token-Payload                                                                                                                                                    | `src/hooks.server.ts:85`                                           |
+| B4  | Rollen stammen aus dem Auth0-Claim `${API_AUDIENCE}/roles`, einmalig beim Callback                                                                                                                      | `src/routes/api/auth/callback/+server.ts`                          |
+| B5  | Es gibt keine Benutzertabelle. Schema: `sightings`, `sightingFiles`, `appConfig`, `auditLogs`                                                                                                           | `src/lib/server/db/schema.ts`                                      |
+| B6  | `getAuthUser` hat **keinen** Aufrufer im Produktivcode — nur `auth.test.ts` importiert es                                                                                                               | Repo-weite Suche                                                   |
+| B7  | Logout löscht nur das Cookie; das JWT bleibt gültig                                                                                                                                                     | `src/routes/api/auth/logout/+server.ts`                            |
+| B8  | Startup-Guard prüft `SESSION_SECRET` nur auf _leer_, nicht auf Länge oder Platzhalter                                                                                                                   | `src/hooks.server.ts:26`                                           |
+| B9  | Der Platzhalter `your-secret-key-here-min-32-chars` ist **33 Zeichen** lang — eine reine `>= 32`-Prüfung lässt ihn durch                                                                                | `.env.example:40`                                                  |
+| B10 | `docs/ENVIRONMENT.md:96` zeigt als „Example" einen konkreten, echt aussehenden Wert (ebenfalls 33 Zeichen)                                                                                              | `docs/ENVIRONMENT.md:96`                                           |
+| B11 | `scripts/docker-entrypoint.sh:60` prüft nur Präsenz                                                                                                                                                     | `scripts/docker-entrypoint.sh:60`                                  |
+| B12 | `run-release.sh` startet den Container mit `--entrypoint ""` und umgeht das Entrypoint-Skript vollständig                                                                                               | `run-release.sh:275`                                               |
+| B13 | CI erzeugt `.env` aus `.env.example` — CI hat nie ein echtes Secret, wohl aber ein funktionierendes                                                                                                     | `.github/workflows/ci.yml:109,261,376`                             |
+| B14 | Staging und Production sind zwei Hosts mit je eigener Klartext-`.env`; der Abschnitt „Zwei Dinge, die getrennt sein müssen" (Zeile 169) nennt DB (171) und `uploads/` (175), **nicht** `SESSION_SECRET` | `docs/RELEASE_PIPELINE.md:101, 169–177`                            |
+| B15 | Der Staging-Stack ist laut Setup-Checkliste noch nicht eingerichtet                                                                                                                                     | `docs/RELEASE_PIPELINE.md:207`                                     |
+| B16 | Das Cookie ist nur signiert, nicht verschlüsselt: base64-Dekodieren liefert `sub`, E-Mail und Rollen im Klartext                                                                                        | folgt aus B1 (JWS statt JWE)                                       |
+
+### 1.2 Offene Betriebsfrage
+
+Woher `SESSION_SECRET` beim Start des Produktions-Containers kommt und wer diese Quelle lesen
+kann, ist **nicht geklärt** (Stand 2026-07-31). Diese Spec arbeitet mit der ungünstigsten
+Annahme: Klartext in `/opt/ostsee-tiere/.env`, lesbar für jeden mit Shell-Zugang auf dem Host
+und in jedem Backup dieser Datei. Die Klärung ändert die Dringlichkeit von Paket A, nicht das
+Ziel von Paket D.
+
+---
+
+## 2. Einordnung: kein Fehler, sondern ein Muster mit bekanntem Preis
+
+Die Architektur im Repo ist das Mainstream-Muster für zustandslose Sessions. Auth0s eigenes
+`nextjs-auth0` v4 nutzt per Default einen `StatelessSessionStore` — Session-Daten als JWE im
+Cookie, verschlüsselt mit `AUTH0_SECRET`, mit rollierendem Ablauf. **Wer dort `AUTH0_SECRET`
+hat, stellt genauso Sessions aus.** Die Alleinzuständigkeit eines symmetrischen Secrets ist
+dem zustandslosen Ansatz inhärent.
+
+Daraus folgt: Es gibt keinen Weg, der zustandslos bleibt _und_ Fälschung ausschließt. Wer die
+Alleinzuständigkeit beseitigen will, muss den Zustand serverseitig halten.
+
+SvelteKit bezieht in [seiner Auth-Dokumentation](https://svelte.dev/docs/kit/auth) bewusst
+keine Position und beschreibt genau diesen Handel: Session-IDs liegen in der Datenbank, sind
+„immediately revocable", kosten aber eine Query pro Request; JWTs werden „not checked against
+a datastore, which means they cannot be immediately revoked", dafür weniger Latenz und Last.
+Als Integrationspunkt nennt SvelteKit Server-Hooks und `locals` — das macht der Bestand
+bereits richtig und bleibt unverändert.
+
+Für **diese** Anwendungsform — server-gerenderte App mit eigenem Backend — empfiehlt Auth0 den
+zustandsbehafteten Weg. Aus
+[Best Practices for Application Session Management](https://auth0.com/blog/application-session-management-best-practices/):
+Anwendungen sollen Sessions „with a server-side application session" führen, und das Cookie
+soll nur „an anchor (an identifier stored in it)" tragen.
+
+Einen offiziellen Auth0-SDK für SvelteKit gibt es weiterhin nicht. Die Alternative
+[`@auth/sveltekit`](https://authjs.dev/reference/sveltekit) nutzt seinerseits standardmäßig
+JWT-Cookies mit optionalem Datenbank-Adapter — derselbe Handel, plus Framework-Wechsel. Der
+handgeschriebene PKCE-Flow im Repo bleibt angemessen und wird nicht angefasst.
+
+---
+
+## 3. Entscheidung
+
+Zwei Pakete, getrennt ausgeliefert.
+
+**Paket A — Startup-Guard.** Schließt den Fall „Deployment läuft mit einem öffentlich
+bekannten Secret". Klein, sofort mergefähig, kein Verhaltenswechsel.
+
+**Paket D — Session-Store.** Das Cookie wird ein opakes Zufalls-Token, der Session-Zustand
+liegt in einer Tabelle. Beseitigt die Fälschbarkeit vollständig und löst #634 im selben Zug.
+
+A wird von D später wieder entfernt, weil `SESSION_SECRET` mit D verschwindet. Das ist kein
+Argument gegen A, sondern gegen das Warten: A braucht Tage, D braucht Wochen, und dazwischen
+liegt genau das Risiko, um das es geht.
+
+### 3.1 Verworfene Alternativen
+
+| Alternative                                                                    | Warum nicht                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ENV-Allowlist** (`ADMIN_SUBS`, `sub` gegen eine Liste prüfen)                | Verlagert Rollenverwaltung aus Auth0 heraus und schafft eine zweite Quelle für dieselbe Aussage. Dazu: die `sub`-Werte, auf die sie baut, stehen laut B16 im Klartext im Cookie.                                                                                                                                                                                    |
+| **Auth0 Management API pro Request** (`GET /api/v2/users/{id}/roles`, gecacht) | Einziger Weg, bei dem Rollenentzug sofort greift — aber M2M-Client, zweites Secret in derselben `.env`, Auth0-Rate-Limits, und eine unangenehme Entscheidung zum Ausfallverhalten (fail-closed sperrt Admins aus, fail-open hebt den Schutz auf). Löst #634 nicht. Bleibt als **späterer Zusatz zu D** denkbar: Rollen in der Session-Zeile periodisch auffrischen. |
+| **Auth0-Access-Token in der Session halten**, pro Request gegen JWKS prüfen    | Unfälschbar (RS256), aber Cookie-Größe und `offline_access`/Refresh-Flow nötig. Löst #634 nur teilweise.                                                                                                                                                                                                                                                            |
+| **Asymmetrisch signieren (RS256/EdDSA)** — Maßnahme 5 aus #635                 | Bringt hier **nichts**. Signierer und Verifizierer sind derselbe Prozess mit derselben `.env`; der private Schlüssel läge exakt dort, wo heute das Secret liegt. Großer Aufwand, kein Gewinn.                                                                                                                                                                       |
+| **Cookie verschlüsseln statt signieren (JWE)** — Auth0s SDK-Default            | Behebt B16 (Klartext-Claims), aber nicht das Kernproblem: dasselbe Secret ver- und entschlüsselt, Fälschung bleibt möglich.                                                                                                                                                                                                                                         |
+| **Auf `@auth/sveltekit` wechseln**                                             | Derselbe Trade-off, plus Migration des gesamten Auth-Flows.                                                                                                                                                                                                                                                                                                         |
+
+---
+
+## 4. Paket A — Startup-Guard
+
+### 4.1 Code
+
+Alles in `src/hooks.server.ts`, in der Struktur des bestehenden
+`PLACEHOLDER_ENCRYPTION_KEY`-Guards (Zeilen 21, 36–45).
+
+```ts
+// Öffentlich bekannte Werte, die als Secret nie gelten dürfen:
+// .env.example ist die Vorlage jeder Prod-.env, docs/ENVIRONMENT.md zeigt ein Beispiel.
+const PUBLIC_SESSION_SECRETS = new Set([
+	'your-secret-key-here-min-32-chars',
+	'8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE'
+]);
+const MIN_SESSION_SECRET_LENGTH = 32;
+```
+
+Der Guard bei Zeile 26 prüft dann drei Bedingungen statt einer: leer, kürzer als
+`MIN_SESSION_SECRET_LENGTH`, oder Element von `PUBLIC_SESSION_SECRETS`.
+
+**Warum die Menge und nicht nur die Länge:** B9 — der Platzhalter ist 33 Zeichen lang und
+besteht jede reine Längenprüfung. Das ist die Falle, in die die naheliegende Umsetzung läuft.
+
+**Warum `hooks.server.ts` und nicht `docker-entrypoint.sh`:** B11 und B12. Der Modul-Scope von
+`hooks.server.ts` ist der einzige Punkt, den jeder Startweg durchläuft.
+
+**Warum nur `production`:** Lokale Entwicklung und CI arbeiten bewusst mit dem Platzhalter
+(B13). Der Guard darf sie nicht brechen.
+
+### 4.2 Dokumentation
+
+- `docs/ENVIRONMENT.md:96` — den konkreten Beispielwert durch
+  `<Ausgabe von openssl rand -base64 32>` ersetzen. Ein Wert, der echt aussieht, wird kopiert.
+- `docs/ENVIRONMENT.md` — neuer Abschnitt **Rotation**: wie man `SESSION_SECRET` wechselt und
+  dass jeder Wechsel _alle_ Sessions gleichzeitig beendet. Das ist der Notausschalter aus #635,
+  und er nützt nur, wenn dokumentiert ist, dass es ihn gibt.
+- `docs/RELEASE_PIPELINE.md:169` — „Zwei Dinge, die getrennt sein müssen" wird zu drei:
+  DB, `uploads/`, **`SESSION_SECRET`**. Wegen B15 steht die Regel damit da, bevor jemand die
+  `.env` auf den Staging-Host kopiert.
+
+### 4.3 Auswirkung
+
+Kein laufendes Deployment mit einem echten Secret merkt etwas. Ein Deployment mit einem
+öffentlich bekannten Wert startet nicht mehr — das ist der Zweck.
+
+---
+
+## 5. Paket D — Session-Store
+
+### 5.1 Datenmodell
+
+Neue Tabelle in `src/lib/server/db/schema.ts`, nach den dortigen Konventionen (`serial` als PK,
+snake_case-Spaltennamen, `timestamp({ withTimezone: true })`, Indizes als
+`idx_<tabelle>_<spalten>`).
+
+| Spalte                | Typ                       | Zweck                                                                                                                                           |
+| --------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                  | `serial` PK               | intern                                                                                                                                          |
+| `token_hash`          | `varchar(64)` unique      | SHA-256 des Cookie-Werts, hex. **Der Klartext steht nie in der DB.** Ein Lesezugriff auf die Tabelle händigt damit keine lebenden Sessions aus. |
+| `sub`                 | `varchar(255)`, indiziert | Auth0-Identität; ermöglicht „alle Sessions dieses Benutzers beenden"                                                                            |
+| `roles`               | `text[]`                  | Snapshot des Auth0-Claims vom Login. Eigene Spalte statt in `user_claims` vergraben, damit abfragbar bleibt, welche Session privilegiert ist.   |
+| `user_claims`         | `jsonb`                   | Rest der Identität (Name, E-Mail, Bild, `sid`) für `locals.user`                                                                                |
+| `expires_at`          | `timestamptz`, indiziert  | **Gleitend.** Inaktivitätsfenster, wird bei jedem Request fortgeschrieben.                                                                      |
+| `absolute_expires_at` | `timestamptz`             | **Nicht verlängerbar.** Beim Login aus Auth0s `exp` gesetzt.                                                                                    |
+| `revoked_at`          | `timestamptz` nullable    | Logout und gezielter Widerruf                                                                                                                   |
+| `created_at`          | `timestamptz`             | Nachvollziehbarkeit                                                                                                                             |
+| `last_seen_at`        | `timestamptz`             | Nachvollziehbarkeit, Grundlage für „aktive Sessions"                                                                                            |
+
+Indizes: unique auf `token_hash` (Lookup-Pfad), `idx_sessions_sub` (Widerruf pro Benutzer),
+`idx_sessions_expires_at` (Aufräumen).
+
+**Warum zwei Ablaufspalten.** Das ist die Antwort auf die offene Frage in #634 („Soll die
+Session überhaupt an Auth0s `exp` hängen?"): **beides**. Die gleitende Grenze hält den
+arbeitenden Admin drin, die absolute respektiert die Aussage des Identity Providers. Keine der
+beiden allein leistet das. Auth0 kennt auf Tenant-Ebene ebenfalls mehrere Grenzen
+(„Session Lifetime Limits", verlinkt aus [Sessions](https://auth0.com/docs/manage-users/sessions)).
+Die konkreten Werte sind gegen die tatsächlichen Tenant-Einstellungen abzugleichen und nicht
+frei zu wählen — siehe Abschnitt 9.
+
+### 5.2 Cookie
+
+32 Zufallsbytes (`crypto.randomBytes(32)`), base64url-kodiert. Kein JWT, keine Payload, nichts
+zu fälschen — und nichts zu lesen (behebt B16).
+
+Attribute bleiben wie in `setAuthCookie` heute: `httpOnly`, `sameSite: 'none'`, `secure: true`,
+`path: '/'`. Die `SameSite=None`-Anforderung stammt aus der iframe-Einbettung auf
+meeresmuseum.de und bleibt unberührt.
+
+Der Cookie-**Name** bleibt (`COOKIE_NAME`, Default `auth-cookie`). Alte JWT-Werte finden nach
+dem Deploy schlicht keine Zeile, werden verworfen und gelöscht. Das ist die Migration:
+einmalig neu einloggen.
+
+### 5.3 Lebenszyklus
+
+```
+Login (Callback)   → createSession()  : Zeile anlegen, expires_at = now + idle,
+                                        absolute_expires_at = Auth0 exp, Cookie setzen
+Jeder Request      → getSession()     : token_hash nachschlagen; gültig, wenn
+                                        revoked_at IS NULL
+                                        AND expires_at > now
+                                        AND absolute_expires_at > now
+                     touchSession()   : last_seen_at = now,
+                                        expires_at = min(now + idle, absolute_expires_at)
+Logout             → destroySession() : revoked_at = now, Cookie löschen
+Absoluter Ablauf   → Redirect nach /api/auth/login (bestehender Weg)
+```
+
+**Erneuerung ohne Refresh-Tokens.** Auth0 nennt zwei Wege, eine abgelaufene App-Session zu
+erneuern: Refresh-Token oder „a redirect to Auth0's `/authorize` endpoint (which will issue new
+tokens if the Auth0 session remains valid)". Der Redirect ist still, solange die Auth0-Sitzung
+lebt, und die App tut ihn **heute schon**. Damit braucht diese Spec weder den
+`offline_access`-Scope noch eine verschlüsselte Refresh-Token-Spalte.
+
+**Aufräumen ohne Cron.** Beim Anlegen einer Session werden abgelaufene Zeilen desselben `sub`
+in derselben Anweisung gelöscht. Ein Timer wäre eine zusätzliche bewegliche Komponente für ein
+Problem, das ein `DELETE` löst.
+
+### 5.4 Betroffene Dateien
+
+| Datei                                                                                                                                                                                                              | Änderung                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/lib/server/db/schema.ts`                                                                                                                                                                                      | Tabelle `sessions` + `SessionSelect`/`SessionInsert`-Typen                                                                                                         |
+| `drizzle/`                                                                                                                                                                                                         | Migration via `npm run db:generate`, committen (Projektpflicht)                                                                                                    |
+| `src/lib/server/auth/sessionRepository.ts`                                                                                                                                                                         | **neu** — `createSession`, `getSession`, `touchSession`, `destroySession`, `revokeAllForSub` sowie `resolveSessionUser(cookies)`; einziger Ort mit SQL             |
+| `src/lib/server/auth/sessionToken.ts`                                                                                                                                                                              | **neu** — Token erzeugen und hashen; klein und rein, damit „Klartext landet nie in der DB" testbar ist                                                             |
+| `src/lib/server/auth/auth.ts`                                                                                                                                                                                      | `setAuthCookie` → `createSession`; `clearAuthCookie` → `destroySession`; `getAuthUser` **entfällt** (B6); JWKS-Teil (`verifyToken`, PKCE, CSRF) bleibt unverändert |
+| `src/hooks.server.ts`                                                                                                                                                                                              | Verifikationsblock (74–90) wird Session-Lookup; `SESSION_SECRET`-Guard und -Konstante entfallen                                                                    |
+| `src/routes/api/auth/logout/+server.ts`                                                                                                                                                                            | `destroySession` statt `clearAuthCookie` — damit wirkt Logout (behebt B7)                                                                                          |
+| `src/routes/api/auth/callback/+server.ts`                                                                                                                                                                          | `createSession` statt `setAuthCookie`. **Rollenlogik unverändert.**                                                                                                |
+| `src/lib/types/User.ts`                                                                                                                                                                                            | `iss`, `aud`, `iat`, `exp` werden optional — sie stammten aus unserem eigenen Token und kommen jetzt nicht mehr mit                                                |
+| `src/routes/+layout.server.ts`                                                                                                                                                                                     | liefert die Restlaufzeit (`expires_at`) in `data` aus, als Grundlage für #634                                                                                      |
+| `e2e/helpers/adminSession.ts`                                                                                                                                                                                      | schreibt eine `sessions`-Zeile statt ein JWT zu signieren                                                                                                          |
+| `e2e/design-tokens.spec.ts:482`                                                                                                                                                                                    | Fehlermeldung anpassen (nennt heute `SESSION_SECRET`)                                                                                                              |
+| `.env.example`, `docker-compose.production.yml`, `run-release.sh`, `scripts/docker-entrypoint.sh`, `.github/workflows/ci.yml`, `docs/ENVIRONMENT.md`, `docs/DOCKER_DEPLOYMENT.md`, `docs/PRODUCTION_DEPLOYMENT.md` | `SESSION_SECRET` entfernen                                                                                                                                         |
+
+**Unverändert bleiben** `requireUserRole`, `isUserInRole`, `isAdminUser`, `isSuperAdminUser`
+und `src/lib/server/config/accessControl.ts`. Sie lesen `locals.user.roles`, und dort steht
+weiterhin, was Auth0 beim Login gesagt hat. **Rollenverwaltung bleibt vollständig in Auth0.**
+
+`getAuthUser` wird gelöscht statt umgebaut, weil es genau das anbietet, was hier gefährlich
+ist: einen zweiten Weg von Cookie zu Benutzer. Ein künftiger Aufruf wäre eine stille Lücke.
+Die vier zugehörigen Tests in `auth.test.ts` entfallen mit.
+
+### 5.5 Fehlerverhalten
+
+| Fall                             | Verhalten                                                                                                                                                               |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cookie vorhanden, keine Zeile    | Cookie löschen, kein `locals.user`, `security.auth_error` loggen. Deckt sowohl Alt-JWTs nach dem Deploy als auch Fälschungsversuche ab.                                 |
+| Zeile abgelaufen oder widerrufen | wie oben, plus Löschen der Zeile                                                                                                                                        |
+| DB nicht erreichbar              | Kein neues Ausfallszenario: `databaseCheck` läuft als **erstes** in der `sequence()` und liefert bereits 503, wenn die DB fehlt. Ohne DB ist die App schon heute unten. |
+| Schreibfehler bei `touchSession` | Geloggt, nicht geworfen. Ein fehlgeschlagenes Fortschreiben darf keinen Request abbrechen; die Session läuft dann eben früher ab.                                       |
+| `createSession` schlägt fehl     | Der Login schlägt fehl (500). Kein stiller Fallback auf eine Session ohne Zeile.                                                                                        |
+
+### 5.6 Sicherheitsgewinn — was sich tatsächlich ändert
+
+- **Fälschung ist ausgeschlossen**, nicht erschwert: Ein gefälschtes Cookie hat keine Zeile.
+  `SESSION_SECRET` verschwindet als Vertrauensgrundlage — die Ursache wird gelöscht, nicht
+  abgemildert.
+- **Logout wirkt** (behebt B7).
+- **Widerruf existiert:** „alle Sessions beenden" wird eine `UPDATE`-Anweisung statt eines
+  Secret-Wechsels mit Kollateralschaden.
+- **Das Cookie trägt keine Identitätsdaten mehr** (behebt B16).
+- **Nicht gelöst:** Wer Schreibzugriff auf die Datenbank hat, kann sich eine Session-Zeile
+  anlegen. Das ist die bewusste Grenze — wer die DB schreiben kann, braucht keine Admin-Session
+  mehr, um Schaden anzurichten.
+- **Nicht gelöst:** Rollenentzug in Auth0 wirkt erst bei der nächsten Anmeldung. Die
+  Session-Zeile trägt einen Snapshot. Gegenmittel im Bedarfsfall: gezielter Widerruf, oder
+  später die verworfene Management-API-Auffrischung.
+
+---
+
+## 6. Verhältnis zu #634
+
+Diese Spec deckt den **Server-Teil** von #634 ab:
+
+- Echtes, eigenes Ablaufdatum statt geerbtem Auth0-`exp` → `expires_at`
+- Gleitende Verlängerung, die auch den Ablauf mitzieht → `touchSession`
+- Ablesbare Restlaufzeit → `+layout.server.ts` liefert `expires_at` in `data`
+
+**Nicht Teil dieser Spec:** die UI-Ankündigung vor dem Ablauf und der Umgang mit ungespeicherten
+Eingaben. #634 hängt sie an `StatusBlock`/`SubmitStatus` aus PRs #625/#626, die noch nicht in
+`main` sind. Diese Spec bereitet sie vor, indem die Restlaufzeit überhaupt verfügbar wird; die
+Umsetzung bleibt in #634.
+
+---
+
+## 7. Testplan
+
+Test-First ist Projektpflicht (`.claude/rules/testing.md`). Reihenfolge: RED → GREEN →
+REFACTOR, jeder Baustein zuerst als fehlschlagender Test.
+
+### 7.1 Unit (`src/**/*.test.ts`, Node-Umgebung)
+
+`sessionToken.test.ts`
+
+- Zwei Aufrufe erzeugen verschiedene Token
+- Token ist base64url und mindestens 32 Byte Entropie
+- Derselbe Token-Wert ergibt denselben Hash; der Hash ist nicht der Token
+
+`sessionRepository.test.ts` (Drizzle gemockt nach dem Muster aus `testing-patterns.md`)
+
+- `createSession` legt an, speichert **nie** den Klartext-Token
+- `getSession` findet über den Hash
+- `getSession` liefert `null` bei `revoked_at != null`
+- `getSession` liefert `null` bei `expires_at < now`
+- `getSession` liefert `null` bei `absolute_expires_at < now`, auch wenn `expires_at` noch läuft
+- `touchSession` schreibt `expires_at` fort, aber **nie über** `absolute_expires_at` hinaus
+- `destroySession` setzt `revoked_at`
+- `createSession` löscht abgelaufene Zeilen desselben `sub`
+
+### 7.2 Regression zu #635 — der eigentliche Beweis
+
+Damit das ohne den Modul-Scope von `hooks.server.ts` (Startup-Guards, `sequence()`) testbar
+ist, wandert die Ableitung Cookie → Benutzer in eine eigene, aufrufbare Funktion
+`resolveSessionUser(cookies)` in `sessionRepository.ts`. `hooks.server.ts` ruft nur noch sie
+auf. Die Tests laufen gegen diese Funktion (`sessionRepository.test.ts`):
+
+- **Ein selbst signiertes HS256-JWT im Cookie ergibt keinen Benutzer und kein `locals.isAdmin`.**
+  Dieser Test ist die Umkehrung von `e2e/helpers/adminSession.ts` in seiner heutigen Form und
+  muss vor der Umstellung **fehlschlagen**, danach bestehen.
+- Ein zufälliges, unbekanntes Cookie ergibt keinen Benutzer und wird gelöscht
+- Ein gültiges Cookie ergibt `locals.user` mit den Rollen aus der Zeile
+- `locals.isAdmin` folgt weiterhin `roles.includes('admin')`
+
+### 7.3 Regression zu #634
+
+- Eine Session mit abgelaufenem `expires_at`, aber gültigem `absolute_expires_at` gilt als
+  abgelaufen (kein „Cookie lebt, Token tot" mehr)
+- `touchSession` verlängert nicht über `absolute_expires_at` hinaus
+
+### 7.4 Regression zu B7
+
+- Nach `destroySession` ist dasselbe Cookie ungültig — auch wenn der Client es behält
+
+### 7.5 E2E
+
+- `e2e/design-tokens.spec.ts` läuft unverändert grün mit der umgebauten Fixture. Der E2E-Job
+  hat einen PostGIS-Service und führt Migrationen aus (`.github/workflows/ci.yml`), das
+  Schreiben einer Session-Zeile ist dort also möglich.
+- Der Fixture-Kopfkommentar wird neu geschrieben: Sie schreibt jetzt in die Datenbank statt ein
+  Token zu signieren — und kann damit in Produktion nichts mehr ausrichten. Genau diese
+  Eigenschaft war der Anlass für #635.
+
+### 7.6 Vor jedem Commit
+
+`npm run test:quick` (lint + type-check + svelte-check + unit).
+
+---
+
+## 8. Auslieferung
+
+**PR 1 — Paket A.** Guard + Doku. Keine Migration, kein Verhaltenswechsel. Sofort mergefähig.
+
+**PR 2 — Paket D.** Schema + Migration + Repository + Hooks + Callback + Logout + Fixture +
+Entfernen von `SESSION_SECRET`. Ein PR, weil Schema und Auth-Pfad nicht sinnvoll trennbar sind.
+
+Betriebliche Schritte bei PR 2:
+
+1. Migration läuft beim Container-Start automatisch (`docker-migrate.ts`)
+2. Alle bestehenden Sessions werden ungültig — alle Angemeldeten müssen sich einmal neu
+   anmelden. Bei der Größenordnung dieser Anwendung unkritisch, aber ankündigen.
+3. `SESSION_SECRET` kann nach dem Deploy aus den `.env`-Dateien beider Hosts entfernt werden.
+4. Rollback: Der Weg zurück ist ein Code-Rollback plus die Erkenntnis, dass die
+   `sessions`-Tabelle stehen bleibt (additive Migration, nicht destruktiv).
+
+---
+
+## 9. Offene Punkte
+
+| Punkt                                                          | Wer entscheidet                                 | Wann                                                                         |
+| -------------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| Herkunft und Leserechte von `SESSION_SECRET` auf dem Prod-Host | Jan, am Host                                    | vor PR 1 — bestimmt, ob PR 1 dringend oder nur richtig ist                   |
+| Konkrete Werte für Inaktivitätsfenster und absolute Laufzeit   | abzugleichen mit den Auth0-Tenant-Einstellungen | vor PR 2                                                                     |
+| Ob Rollenentzug in Auth0 sofort wirken muss                    | Jan                                             | nach PR 2 — entscheidet, ob die Management-API-Auffrischung nachgezogen wird |
+
+---
+
+## 10. Quellen
+
+- [SvelteKit — Auth](https://svelte.dev/docs/kit/auth)
+- [Auth0 — Best Practices for Application Session Management](https://auth0.com/blog/application-session-management-best-practices/)
+- [Auth0 — Sessions](https://auth0.com/docs/manage-users/sessions)
+- [auth0/nextjs-auth0](https://github.com/auth0/nextjs-auth0) — Stateless-Default, JWE, BYODB
+- [Auth0 Community — kein offizieller SvelteKit-SDK](https://community.auth0.com/t/provide-example-sdk-for-server-side-authentication-with-auth0-for-sveltekit/105041)
+- [`@auth/sveltekit`](https://authjs.dev/reference/sveltekit)

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -44,6 +44,10 @@ Alle Zeilenangaben gegen `main` bei Commit `11a4e87` geprüft.
 | B15 | Der Staging-Stack ist laut Setup-Checkliste noch nicht eingerichtet                                                                                                                                     | `docs/RELEASE_PIPELINE.md:207`                                     |
 | B16 | Das Cookie ist nur signiert, nicht verschlüsselt: base64-Dekodieren liefert `sub`, E-Mail und Rollen im Klartext                                                                                        | folgt aus B1 (JWS statt JWE)                                       |
 
+**Stand nach diesem Branch:** B8, B9 und B10 sind durch den in Abschnitt 4 beschriebenen
+Startup-Guard (`secretGuard.ts`) behoben — sie beschreiben hier bewusst noch den Zustand
+_vor_ dem Guard, als Begründung für dessen Notwendigkeit.
+
 ### 1.2 Offene Betriebsfrage
 
 Woher `SESSION_SECRET` beim Start des Produktions-Containers kommt und wer diese Quelle lesen
@@ -148,7 +152,6 @@ _Platzhalter_. Ein 32-stelliger Hex-Wert (16 Byte) kommt heute durch und lässt
 Länge und Hex-Zeichensatz ergänzt.
 
 **Beide Prüfungen ziehen in ein eigenes Modul** `src/lib/server/config/secretGuard.ts`.
-Sein Import hat Seiteneffekte (DB-Modul, Middleware-Kette, Signal-Handler) und die Guards laufen im Modul-Scope; die Coverage erfasst zudem nur `src/lib/**`
 Sein Import hat Seiteneffekte (DB-Modul, Middleware-Kette, Signal-Handler) und die Guards
 laufen im Modul-Scope — ein Test müsste das Modul je Fall neu importieren; die Coverage erfasst
 zudem nur `src/lib/**` (`vitest.config.ts`, `coverage.include`). Reine Funktionen

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -90,7 +90,9 @@ handgeschriebene PKCE-Flow im Repo bleibt angemessen und wird nicht angefasst.
 Zwei Pakete, getrennt ausgeliefert.
 
 **Paket A — Startup-Guard.** Schließt den Fall „Deployment läuft mit einem öffentlich
-bekannten Secret". Klein, sofort mergefähig, kein Verhaltenswechsel.
+bekannten Secret". Klein, sofort mergefähig — bis auf eine gewollte Ausnahme kein
+Verhaltenswechsel: Ein Deployment mit ungültigem `ENCRYPTION_KEY` startete bisher und brach
+erst beim ersten Login, jetzt verweigert es den Start.
 
 **Paket D — Session-Store.** Das Cookie wird ein opakes Zufalls-Token, der Session-Zustand
 liegt in einer Tabelle. Beseitigt die Fälschbarkeit vollständig und löst #634 im selben Zug.
@@ -116,8 +118,8 @@ liegt genau das Risiko, um das es geht.
 
 ### 4.1 Code
 
-Alles in `src/hooks.server.ts`, in der Struktur des bestehenden
-`PLACEHOLDER_ENCRYPTION_KEY`-Guards (Zeilen 21, 36–45).
+Die Prüflogik liegt in `src/lib/server/config/secretGuard.ts`, `hooks.server.ts` ruft sie nur
+auf — in der Struktur des bestehenden `PLACEHOLDER_ENCRYPTION_KEY`-Guards (Zeilen 21, 36–45).
 
 ```ts
 // Öffentlich bekannte Werte, die als Secret nie gelten dürfen:

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -138,6 +138,18 @@ besteht jede reine Längenprüfung. Das ist die Falle, in die die naheliegende U
 **Warum `hooks.server.ts` und nicht `docker-entrypoint.sh`:** B11 und B12. Der Modul-Scope von
 `hooks.server.ts` ist der einzige Punkt, den jeder Startweg durchläuft.
 
+**Der `ENCRYPTION_KEY`-Guard kommt mit** (#635 verlangt ausdrücklich, ihn mitzuprüfen). Er ist
+unvollständig: `src/lib/server/auth/crypto.ts:103` nutzt `aes-256-gcm`, das exakt 32 Byte
+Schlüssel verlangt — also 64 Hex-Zeichen. Der bestehende Guard prüft nur _leer_ und
+_Platzhalter_. Ein 32-stelliger Hex-Wert (16 Byte) kommt heute durch und lässt
+`createCipheriv` erst beim ersten Login werfen, also auf dem Auth-Pfad. Die Prüfung wird um
+Länge und Hex-Zeichensatz ergänzt.
+
+**Beide Prüfungen ziehen in ein eigenes Modul** `src/lib/server/config/secretGuard.ts`.
+`hooks.server.ts` liegt ausserhalb von `src/lib/**` und wird von der Server-Test-Konfiguration
+nicht erfasst (`vitest.config.ts:9`); ausserdem hat sein Import Seiteneffekte. Reine Funktionen
+mit den Werten als Parameter sind testbar, `hooks.server.ts` ruft nur noch auf.
+
 **Warum nur `production`:** Lokale Entwicklung und CI arbeiten bewusst mit dem Platzhalter
 (B13). Der Guard darf sie nicht brechen.
 

--- a/docs/SESSION_STORE_SPEC_2026-07-31.md
+++ b/docs/SESSION_STORE_SPEC_2026-07-31.md
@@ -146,8 +146,10 @@ _Platzhalter_. Ein 32-stelliger Hex-Wert (16 Byte) kommt heute durch und lässt
 Länge und Hex-Zeichensatz ergänzt.
 
 **Beide Prüfungen ziehen in ein eigenes Modul** `src/lib/server/config/secretGuard.ts`.
-`hooks.server.ts` liegt ausserhalb von `src/lib/**` und wird von der Server-Test-Konfiguration
-nicht erfasst (`vitest.config.ts:9`); ausserdem hat sein Import Seiteneffekte. Reine Funktionen
+Sein Import hat Seiteneffekte (DB-Modul, Middleware-Kette, Signal-Handler) und die Guards laufen im Modul-Scope; die Coverage erfasst zudem nur `src/lib/**`
+Sein Import hat Seiteneffekte (DB-Modul, Middleware-Kette, Signal-Handler) und die Guards
+laufen im Modul-Scope — ein Test müsste das Modul je Fall neu importieren; die Coverage erfasst
+zudem nur `src/lib/**` (`vitest.config.ts`, `coverage.include`). Reine Funktionen
 mit den Werten als Parameter sind testbar, `hooks.server.ts` ruft nur noch auf.
 
 **Warum nur `production`:** Lokale Entwicklung und CI arbeiten bewusst mit dem Platzhalter

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { createLogger } from '$lib/logger.server';
 import { clearAuthCookie, setAuthCookie } from '$lib/server/auth/auth';
+import { assertProductionSecrets } from '$lib/server/config/secretGuard';
 import { closeDb } from '$lib/server/db';
 import { databaseCheck } from '$lib/server/middleware/databaseCheck';
 import { maintenanceMode } from '$lib/server/middleware/maintenanceMode';
@@ -17,32 +18,12 @@ const NODE_ENV = env.NODE_ENV ?? 'development';
 const SESSION_SECRET = env.SESSION_SECRET ?? '';
 const ENCRYPTION_KEY = env.ENCRYPTION_KEY ?? '';
 
-// Platzhalter-Wert aus der Beispiel-Konfiguration (64x "0") — NIE in Produktion nutzen
-const PLACEHOLDER_ENCRYPTION_KEY = '0'.repeat(64);
-
 const logger = createLogger('hooks:server');
 
-// Guard: fail fast if SESSION_SECRET is missing in production
-if (NODE_ENV === 'production' && !SESSION_SECRET) {
-	throw new Error(
-		'SESSION_SECRET environment variable is required in production. ' +
-			'Set it to a strong random secret before starting the server.'
-	);
-}
-
-// Guard: fail fast if ENCRYPTION_KEY is missing or still the default placeholder in production.
-// ENCRYPTION_KEY schützt den PKCE-Verifier im Auth-Flow (AES-256-GCM); ein Platzhalter
-// würde die Verschlüsselung wirkungslos machen.
-if (
-	NODE_ENV === 'production' &&
-	(!ENCRYPTION_KEY || ENCRYPTION_KEY === PLACEHOLDER_ENCRYPTION_KEY)
-) {
-	throw new Error(
-		'ENCRYPTION_KEY environment variable is required in production and must not be the ' +
-			'default placeholder value. Set it to a strong random 32-byte hex secret (64 hex chars) ' +
-			'before starting the server.'
-	);
-}
+// Guard: Der Server startet in Produktion nicht mit fehlenden, zu kurzen oder öffentlich
+// bekannten Secrets. Die Prüflogik steht in secretGuard.ts, damit sie testbar ist —
+// hooks.server.ts liegt ausserhalb von src/lib/** und wird von den Server-Tests nicht erfasst.
+assertProductionSecrets({ NODE_ENV, SESSION_SECRET, ENCRYPTION_KEY });
 
 const setAdditionalHeaders: Handle = createSecurityHeadersHandler(NODE_ENV);
 

--- a/src/lib/server/auth/auth.test.ts
+++ b/src/lib/server/auth/auth.test.ts
@@ -765,6 +765,43 @@ describe('auth.ts', () => {
 		});
 	});
 
+	describe('getNodeEnv (Normalisierung)', () => {
+		/* Befund 1 (#668-Review): secretGuard.ts normalisiert NODE_ENV vor dem Vergleich
+		   (trimmen, Kleinbuchstaben), damit "Production" oder " production " den Startup-Guard
+		   nicht lautlos abschalten. getNodeEnv() hier verglich bisher ungetrimmt und
+		   case-sensitiv gegen 'production' — bei NODE_ENV="Production" greift der Guard, aber
+		   das secure-Flag der Cookies (setCsrfCookie, setPKCECookie) bliebe false. Zwei
+		   Sicherheitsentscheidungen aus derselben Variable liefen damit auseinander. */
+		it('setzt secure:true bei NODE_ENV="Production" (Grossschreibung)', async () => {
+			vi.resetModules();
+			vi.doMock('$env/dynamic/private', () => ({
+				env: {
+					AUTH0_CLIENT_ID: 'test-client-id',
+					AUTH0_CLIENT_SECRET: 'test-client-secret',
+					AUTH0_DOMAIN: 'test-domain.auth0.com',
+					COOKIE_NAME: 'test-auth-cookie',
+					JWKS_URL: 'https://test-domain.auth0.com/.well-known/jwks.json',
+					SESSION_SECRET: 'test-session-secret',
+					ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+					NODE_ENV: 'Production'
+				}
+			}));
+
+			const { setCsrfCookie } = await import('./auth');
+			const mockRandom = vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+
+			const result = setCsrfCookie(mockCookies);
+
+			expect(mockCookies.set).toHaveBeenCalledWith(
+				'csrfState',
+				result,
+				expect.objectContaining({ secure: true })
+			);
+
+			mockRandom.mockRestore();
+		});
+	});
+
 	describe('getPKCEVerifierFromCookie', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();

--- a/src/lib/server/auth/auth.test.ts
+++ b/src/lib/server/auth/auth.test.ts
@@ -722,6 +722,49 @@ describe('auth.ts', () => {
 		});
 	});
 
+	describe('getEncryptionKey (Trimmen)', () => {
+		/* Befund 3 (#635-Review): secretGuard.ts prüft ENCRYPTION_KEY getrimmt, auth.ts liest
+		   ihn bisher ungetrimmt (`env.ENCRYPTION_KEY ?? ''`) und reicht ihn an
+		   `Buffer.from(wert, 'hex')` weiter. Bei Leerraum drumherum (z. B. durch
+		   `openssl rand -hex 32 > datei` oder einen YAML-Blockskalar) sagt der Guard beim
+		   Start "in Ordnung", `createCipheriv` wirft dann erst beim ersten Admin-Login mit
+		   "Invalid key length". Dieser Test belegt, dass setPKCECookie denselben getrimmten
+		   Wert verwendet, den der Guard geprüft hat. */
+		it('trimmt ENCRYPTION_KEY vor der Verwendung, damit Leerraum drumherum den Guard nicht unterläuft', async () => {
+			vi.resetModules();
+			vi.doMock('$env/dynamic/private', () => ({
+				env: {
+					AUTH0_CLIENT_ID: 'test-client-id',
+					AUTH0_CLIENT_SECRET: 'test-client-secret',
+					AUTH0_DOMAIN: 'test-domain.auth0.com',
+					COOKIE_NAME: 'test-auth-cookie',
+					JWKS_URL: 'https://test-domain.auth0.com/.well-known/jwks.json',
+					SESSION_SECRET: 'test-session-secret',
+					// Leerraum drumherum, wie ihn `openssl rand -hex 32 > datei` oder ein
+					// YAML-Blockskalar erzeugen kann.
+					ENCRYPTION_KEY: '  0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n',
+					NODE_ENV: 'test'
+				}
+			}));
+
+			const { setPKCECookie } = await import('./auth');
+			const mockPKCEData = { verifier: 'test-verifier-123', challenge: 'test-challenge-456' };
+			vi.mocked(getPKCEChallengeData).mockReturnValue(mockPKCEData);
+			vi.mocked(encrypt).mockReturnValue({
+				iv: Buffer.from('00', 'hex'),
+				encryptedData: Buffer.from('00', 'hex'),
+				tag: Buffer.from('00', 'hex')
+			});
+
+			setPKCECookie(mockCookies);
+
+			expect(encrypt).toHaveBeenCalledWith(
+				'test-verifier-123',
+				Buffer.from('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'hex')
+			);
+		});
+	});
+
 	describe('getPKCEVerifierFromCookie', () => {
 		beforeEach(() => {
 			vi.clearAllMocks();

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -14,7 +14,11 @@ const getAuth0ClientId = () => env.AUTH0_CLIENT_ID ?? '';
 const getAuth0ClientSecret = () => env.AUTH0_CLIENT_SECRET ?? '';
 const getAuth0Domain = () => env.AUTH0_DOMAIN ?? '';
 const getCookieName = () => env.COOKIE_NAME ?? 'auth-cookie';
-const getEncryptionKey = () => env.ENCRYPTION_KEY ?? '';
+// Getrimmt, damit Leerraum drumherum (z. B. durch `openssl rand -hex 32 > datei` oder einen
+// YAML-Blockskalar) nicht den Wert unterläuft, den secretGuard.ts beim Start bereits getrimmt
+// geprüft hat — sonst sagt der Guard "in Ordnung" und createCipheriv wirft erst beim ersten
+// Admin-Login mit "Invalid key length" (Befund 3, #635-Review).
+const getEncryptionKey = () => (env.ENCRYPTION_KEY ?? '').trim();
 const getJwksUrl = () => env.JWKS_URL ?? '';
 const getSessionSecret = () => env.SESSION_SECRET ?? '';
 const getNodeEnv = () => env.NODE_ENV ?? 'development';

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -21,7 +21,11 @@ const getCookieName = () => env.COOKIE_NAME ?? 'auth-cookie';
 const getEncryptionKey = () => (env.ENCRYPTION_KEY ?? '').trim();
 const getJwksUrl = () => env.JWKS_URL ?? '';
 const getSessionSecret = () => env.SESSION_SECRET ?? '';
-const getNodeEnv = () => env.NODE_ENV ?? 'development';
+// Getrimmt und in Kleinbuchstaben, analog zur Normalisierung in secretGuard.ts
+// (assertProductionSecrets): Sonst kann NODE_ENV="Production" den Startup-Guard auslösen,
+// während hier `getNodeEnv() === 'production'` falsch bliebe — die Cookies (setCsrfCookie,
+// setPKCECookie) würden dann ohne `secure` gesetzt (Befund 1, #668-Review).
+const getNodeEnv = () => (env.NODE_ENV ?? 'development').trim().toLowerCase();
 import { error, redirect, type Cookies } from '@sveltejs/kit';
 import { createRemoteJWKSet, decodeJwt, jwtVerify, SignJWT } from 'jose';
 import { decrypt, encrypt, getPKCEChallengeData } from './crypto.js';

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -65,8 +65,12 @@ describe('validateEncryptionKey', () => {
 		expect(validateEncryptionKey(valid.toUpperCase())).toBeNull();
 	});
 
+	/* "ENCRYPTION_KEY" allein steht in jeder Fehlermeldung dieser Funktion — eine vertauschte
+	   Prüfreihenfolge (leer erst nach der Längenprüfung) bliebe mit dieser Erwartung grün.
+	   "erforderlich" kommt dagegen nur in der Pflicht-Meldung vor (Platzhalter-, Längen- und
+	   Hex-Meldung enthalten das Wort nicht) und trifft damit gezielt den Pflicht-Zweig. */
 	it('lehnt einen leeren Wert ab', () => {
-		expect(validateEncryptionKey('')).toMatch(/ENCRYPTION_KEY/);
+		expect(validateEncryptionKey('')).toMatch(/erforderlich/);
 	});
 
 	it('lehnt den Platzhalter aus .env.example ab', () => {
@@ -143,5 +147,34 @@ describe('assertProductionSecrets', () => {
 		}
 		expect(message).toMatch(/SESSION_SECRET/);
 		expect(message).toMatch(/ENCRYPTION_KEY/);
+	});
+
+	/* Befund 4 (#635-Review): `NODE_ENV !== 'production'` war ein exakter Vergleich. Bei
+	   "Production", " production " oder "PRODUCTION" blieb der Guard lautlos aus — ein
+	   Betreiber, der eine dieser Schreibweisen setzt, bekommt keinen Schutz. */
+	it.each(['Production', ' production ', 'PRODUCTION'])(
+		'greift auch bei der Schreibweise NODE_ENV=%j',
+		(nodeEnv) => {
+			expect(() =>
+				assertProductionSecrets({
+					NODE_ENV: nodeEnv,
+					SESSION_SECRET: '',
+					ENCRYPTION_KEY: ''
+				})
+			).toThrow(/SESSION_SECRET/);
+		}
+	);
+
+	/* "prod" ist keine Schreibvariante von "production", sondern ein eigener Wert. SvelteKit
+	   und die Skripte dieses Projekts setzen durchgehend "production" — eine Zusatzbedeutung
+	   für "prod" zu erfinden wäre eine eigene Entscheidung, die der Guard nicht treffen soll. */
+	it('behandelt NODE_ENV="prod" NICHT als Produktion', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'prod',
+				SESSION_SECRET: '',
+				ENCRYPTION_KEY: ''
+			})
+		).not.toThrow();
 	});
 });

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+	MIN_SESSION_SECRET_LENGTH,
+	PUBLIC_SESSION_SECRETS,
+	validateSessionSecret
+} from '$lib/server/config/secretGuard';
+
+describe('validateSessionSecret', () => {
+	it('akzeptiert ein ausreichend langes, unbekanntes Secret', () => {
+		expect(validateSessionSecret('a'.repeat(48))).toBeNull();
+	});
+
+	it('lehnt einen leeren Wert ab', () => {
+		expect(validateSessionSecret('')).toMatch(/SESSION_SECRET/);
+	});
+
+	it('lehnt einen zu kurzen Wert ab', () => {
+		const tooShort = 'x'.repeat(MIN_SESSION_SECRET_LENGTH - 1);
+		expect(validateSessionSecret(tooShort)).toMatch(/32/);
+	});
+
+	it('lehnt den Platzhalter aus .env.example ab', () => {
+		expect(validateSessionSecret('your-secret-key-here-min-32-chars')).toMatch(/öffentlich/);
+	});
+
+	it('lehnt den Beispielwert aus docs/ENVIRONMENT.md ab', () => {
+		expect(validateSessionSecret('8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE')).toMatch(/öffentlich/);
+	});
+
+	/* Ein Leerzeichen oder Zeilenumbruch um den Platzhalter darf die Prüfung nicht
+	   aushebeln — sonst ist der Guard still wirkungslos. */
+	it('lehnt den Platzhalter auch mit Leerraum drumherum ab', () => {
+		expect(validateSessionSecret('  your-secret-key-here-min-32-chars\n')).toMatch(/öffentlich/);
+	});
+
+	it('lehnt einen Wert ab, der nur aus Leerraum besteht', () => {
+		expect(validateSessionSecret('   ')).toMatch(/erforderlich/);
+	});
+
+	/* Der Kern des Befunds aus #635: Beide öffentlich bekannten Werte sind 33 Zeichen lang
+	   und bestehen jede reine Längenprüfung. Ohne diesen Test ist die naheliegende
+	   Implementierung (nur `>= 32`) grün und trotzdem falsch. */
+	it('erkennt, dass die öffentlichen Werte die Längenprüfung bestehen würden', () => {
+		for (const known of PUBLIC_SESSION_SECRETS) {
+			expect(known.length).toBeGreaterThanOrEqual(MIN_SESSION_SECRET_LENGTH);
+			expect(validateSessionSecret(known)).not.toBeNull();
+		}
+	});
+});

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
 	MIN_SESSION_SECRET_LENGTH,
 	PUBLIC_SESSION_SECRETS,
-	validateSessionSecret
+	validateSessionSecret,
+	ENCRYPTION_KEY_LENGTH,
+	PLACEHOLDER_ENCRYPTION_KEY,
+	validateEncryptionKey
 } from '$lib/server/config/secretGuard';
 
 describe('validateSessionSecret', () => {
@@ -45,5 +48,36 @@ describe('validateSessionSecret', () => {
 			expect(known.length).toBeGreaterThanOrEqual(MIN_SESSION_SECRET_LENGTH);
 			expect(validateSessionSecret(known)).not.toBeNull();
 		}
+	});
+});
+
+describe('validateEncryptionKey', () => {
+	const valid = 'a3f1'.repeat(16); // 64 Hex-Zeichen = 32 Byte
+
+	it('akzeptiert 64 Hex-Zeichen', () => {
+		expect(valid).toHaveLength(ENCRYPTION_KEY_LENGTH);
+		expect(validateEncryptionKey(valid)).toBeNull();
+	});
+
+	it('akzeptiert Grossbuchstaben in der Hex-Darstellung', () => {
+		expect(validateEncryptionKey(valid.toUpperCase())).toBeNull();
+	});
+
+	it('lehnt einen leeren Wert ab', () => {
+		expect(validateEncryptionKey('')).toMatch(/ENCRYPTION_KEY/);
+	});
+
+	it('lehnt den Platzhalter aus .env.example ab', () => {
+		expect(validateEncryptionKey(PLACEHOLDER_ENCRYPTION_KEY)).toMatch(/Platzhalter/);
+	});
+
+	/* Der neue Fall: aes-256-gcm braucht 32 Byte. Ein 32-stelliger Hex-Wert sind 16 Byte
+	   und liess createCipheriv bisher erst beim ersten Login werfen. */
+	it('lehnt einen zu kurzen Hex-Wert ab, der bisher durchkam', () => {
+		expect(validateEncryptionKey('a3f1'.repeat(8))).toMatch(/64/);
+	});
+
+	it('lehnt Nicht-Hex-Zeichen ab', () => {
+		expect(validateEncryptionKey('z'.repeat(64))).toMatch(/hexadezimal/);
 	});
 });

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -44,12 +44,13 @@ describe('validateSessionSecret', () => {
 	/* Der Kern des Befunds aus #635: Beide öffentlich bekannten Werte sind 33 Zeichen lang
 	   und bestehen jede reine Längenprüfung. Ohne diesen Test ist die naheliegende
 	   Implementierung (nur `>= 32`) grün und trotzdem falsch. */
-	it('erkennt, dass die öffentlichen Werte die Längenprüfung bestehen würden', () => {
-		for (const known of PUBLIC_SESSION_SECRETS) {
+	it.each([...PUBLIC_SESSION_SECRETS])(
+		'erkennt, dass %s die Längenprüfung bestehen würde',
+		(known) => {
 			expect(known.length).toBeGreaterThanOrEqual(MIN_SESSION_SECRET_LENGTH);
 			expect(validateSessionSecret(known)).not.toBeNull();
 		}
-	});
+	);
 });
 
 describe('validateEncryptionKey', () => {

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -81,6 +81,13 @@ describe('validateEncryptionKey', () => {
 	it('lehnt Nicht-Hex-Zeichen ab', () => {
 		expect(validateEncryptionKey('z'.repeat(64))).toMatch(/hexadezimal/);
 	});
+
+	/* Ohne Trimmen erkennt die Längenprüfung den Platzhalter nicht als Platzhalter, sondern
+	   als "66 statt 64 Zeichen" — eine irreführende Fehlermeldung, analog zu
+	   validateSessionSecret oben. */
+	it('lehnt den Platzhalter auch mit Leerraum drumherum ab', () => {
+		expect(validateEncryptionKey(`  ${PLACEHOLDER_ENCRYPTION_KEY}\n`)).toMatch(/Platzhalter/);
+	});
 });
 
 describe('assertProductionSecrets', () => {

--- a/src/lib/server/config/secretGuard.test.ts
+++ b/src/lib/server/config/secretGuard.test.ts
@@ -5,7 +5,8 @@ import {
 	validateSessionSecret,
 	ENCRYPTION_KEY_LENGTH,
 	PLACEHOLDER_ENCRYPTION_KEY,
-	validateEncryptionKey
+	validateEncryptionKey,
+	assertProductionSecrets
 } from '$lib/server/config/secretGuard';
 
 describe('validateSessionSecret', () => {
@@ -79,5 +80,60 @@ describe('validateEncryptionKey', () => {
 
 	it('lehnt Nicht-Hex-Zeichen ab', () => {
 		expect(validateEncryptionKey('z'.repeat(64))).toMatch(/hexadezimal/);
+	});
+});
+
+describe('assertProductionSecrets', () => {
+	const good = { SESSION_SECRET: 'a'.repeat(48), ENCRYPTION_KEY: 'a3f1'.repeat(16) };
+
+	it('wirft nicht ausserhalb von production', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'development',
+				SESSION_SECRET: 'your-secret-key-here-min-32-chars',
+				ENCRYPTION_KEY: '0'.repeat(64)
+			})
+		).not.toThrow();
+	});
+
+	it('wirft nicht bei gültiger Produktionskonfiguration', () => {
+		expect(() => assertProductionSecrets({ NODE_ENV: 'production', ...good })).not.toThrow();
+	});
+
+	it('wirft in production bei öffentlich bekanntem SESSION_SECRET', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				...good,
+				SESSION_SECRET: 'your-secret-key-here-min-32-chars'
+			})
+		).toThrow(/öffentlich bekannter Beispielwert/);
+	});
+
+	it('wirft in production bei zu kurzem ENCRYPTION_KEY', () => {
+		expect(() =>
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				...good,
+				ENCRYPTION_KEY: 'a3f1'.repeat(8)
+			})
+		).toThrow(/64 Zeichen/);
+	});
+
+	/* Beide Fehler zusammen: Die Meldung muss beide nennen, damit ein Betreiber nicht
+	   zweimal deployen muss, um beide zu finden. */
+	it('nennt beide Fehler in einer Meldung', () => {
+		let message = '';
+		try {
+			assertProductionSecrets({
+				NODE_ENV: 'production',
+				SESSION_SECRET: '',
+				ENCRYPTION_KEY: ''
+			});
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+		expect(message).toMatch(/SESSION_SECRET/);
+		expect(message).toMatch(/ENCRYPTION_KEY/);
 	});
 });

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -1,0 +1,53 @@
+/**
+ * Prüfung der Produktions-Secrets beim Serverstart.
+ *
+ * Reine Funktionen ohne Env-Zugriff: Die Werte kommen als Parameter herein, damit sie
+ * testbar sind. Der Aufruf und das Werfen passieren in `src/hooks.server.ts`.
+ *
+ * Hintergrund: Issue #635 — ein Deployment, das `.env.example` als Vorlage übernimmt,
+ * lief bisher mit einem Secret, das im öffentlichen Repository steht.
+ */
+
+/**
+ * Werte, die als `SESSION_SECRET` nie gelten dürfen, weil sie öffentlich einsehbar sind.
+ *
+ * Beide sind 33 Zeichen lang und bestehen damit jede reine Mindestlängenprüfung — der
+ * Vergleich gegen diese Menge ist deshalb nicht optional.
+ */
+export const PUBLIC_SESSION_SECRETS: ReadonlySet<string> = new Set([
+	'your-secret-key-here-min-32-chars', // .env.example
+	'8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE' // docs/ENVIRONMENT.md
+]);
+
+export const MIN_SESSION_SECRET_LENGTH = 32;
+
+const GENERATE_HINT = 'Erzeugen mit: openssl rand -base64 32';
+
+/**
+ * Prüft einen `SESSION_SECRET`-Wert.
+ *
+ * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
+ */
+export function validateSessionSecret(raw: string): string | null {
+	/* Trimmen vor dem Vergleich, sonst umgeht ein versehentliches Leerzeichen oder ein
+	   Zeilenumbruch (`openssl rand -base64 32 > datei`) die Prüfung gegen die bekannten
+	   Werte — der Guard wäre dann still wirkungslos. */
+	const value = raw.trim();
+
+	if (!value) {
+		return `SESSION_SECRET ist in Produktion erforderlich. ${GENERATE_HINT}`;
+	}
+	if (value.length < MIN_SESSION_SECRET_LENGTH) {
+		return (
+			`SESSION_SECRET ist zu kurz (${value.length} Zeichen, mindestens ` +
+			`${MIN_SESSION_SECRET_LENGTH} erforderlich). ${GENERATE_HINT}`
+		);
+	}
+	if (PUBLIC_SESSION_SECRETS.has(value)) {
+		return (
+			'SESSION_SECRET ist ein öffentlich bekannter Beispielwert aus dem Repository. ' +
+			`Wer ihn kennt, kann sich eine Admin-Session ausstellen. ${GENERATE_HINT}`
+		);
+	}
+	return null;
+}

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -93,3 +93,32 @@ export function validateEncryptionKey(value: string): string | null {
 	}
 	return null;
 }
+
+/**
+ * Prüft beim Serverstart alle Produktions-Secrets und wirft mit einer Meldung,
+ * die **alle** gefundenen Probleme nennt.
+ *
+ * Beide Fehler gemeinsam zu melden ist Absicht: Ein Betreiber, der nur den ersten
+ * sieht, deployt zweimal.
+ */
+export function assertProductionSecrets(env: {
+	NODE_ENV: string;
+	SESSION_SECRET: string;
+	ENCRYPTION_KEY: string;
+}): void {
+	if (env.NODE_ENV !== 'production') {
+		return;
+	}
+
+	const problems = [
+		validateSessionSecret(env.SESSION_SECRET),
+		validateEncryptionKey(env.ENCRYPTION_KEY)
+	].filter((problem): problem is string => problem !== null);
+
+	if (problems.length > 0) {
+		throw new Error(
+			`Ungültige Produktions-Konfiguration:\n- ${problems.join('\n- ')}\n` +
+				'Der Server startet aus Sicherheitsgründen nicht.'
+		);
+	}
+}

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -70,8 +70,13 @@ const HEX_ONLY = /^[0-9a-f]+$/i;
  *
  * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
  */
-export function validateEncryptionKey(value: string): string | null {
+export function validateEncryptionKey(raw: string): string | null {
 	const hint = 'Erzeugen mit: openssl rand -hex 32';
+
+	/* Trimmen vor dem Vergleich, analog zu validateSessionSecret: sonst umgeht umgebender
+	   Leerraum die Platzhalter-Prüfung und die Fehlermeldung nennt die falsche Ursache
+	   (Längenfehler statt Platzhalter). */
+	const value = raw.trim();
 
 	if (!value) {
 		return `ENCRYPTION_KEY ist in Produktion erforderlich. ${hint}`;

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -103,7 +103,10 @@ export function validateEncryptionKey(raw: string): string | null {
 		);
 	}
 	if (!HEX_ONLY.test(value)) {
-		return `ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f). ${ENCRYPTION_KEY_HINT}`;
+		return (
+			'ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f, Grossbuchstaben A-F sind ' +
+			`ebenfalls erlaubt). ${ENCRYPTION_KEY_HINT}`
+		);
 	}
 	return null;
 }

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -11,17 +11,28 @@
 /**
  * Werte, die als `SESSION_SECRET` nie gelten dürfen, weil sie öffentlich einsehbar sind.
  *
- * Beide sind 33 Zeichen lang und bestehen damit jede reine Mindestlängenprüfung — der
- * Vergleich gegen diese Menge ist deshalb nicht optional.
+ * Alle sind mindestens 32 Zeichen lang und bestehen damit jede reine Mindestlängenprüfung —
+ * der Vergleich gegen diese Menge ist deshalb nicht optional.
  */
 export const PUBLIC_SESSION_SECRETS: ReadonlySet<string> = new Set([
 	'your-secret-key-here-min-32-chars', // .env.example
-	'8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE' // docs/ENVIRONMENT.md
+	'8K7h3L9mN2pQ4rS6tU8vW0xY2zA4bC6dE', // docs/ENVIRONMENT.md
+	// .env.docker (committet, per docker-compose.production.yml als Vorlage verlinkt) —
+	// der Wert wurde bereits ausgeliefert, laufende Deployments können ihn übernommen
+	// haben; ihn nur aus der Vorlage zu entfernen erreicht die nicht.
+	'CHANGE-ME-use-openssl-rand-base64-32',
+	// docs/DOCKER_DEPLOYMENT.md — aus demselben Grund: bereits ausgeliefert, zusätzlich
+	// zur Bereinigung der Vorlage muss der Wert selbst blockiert werden.
+	'your-generated-session-secret-here',
+	'your-secure-random-string-min-32-chars'
 ]);
 
 export const MIN_SESSION_SECRET_LENGTH = 32;
 
 const GENERATE_HINT = 'Erzeugen mit: openssl rand -base64 32';
+
+/** Analog zu `GENERATE_HINT`, aber für `ENCRYPTION_KEY` (Befund 6: einheitliche Behandlung). */
+const ENCRYPTION_KEY_HINT = 'Erzeugen mit: openssl rand -hex 32';
 
 /**
  * Prüft einen `SESSION_SECRET`-Wert.
@@ -71,30 +82,28 @@ const HEX_ONLY = /^[0-9a-f]+$/i;
  * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
  */
 export function validateEncryptionKey(raw: string): string | null {
-	const hint = 'Erzeugen mit: openssl rand -hex 32';
-
 	/* Trimmen vor dem Vergleich, analog zu validateSessionSecret: sonst umgeht umgebender
 	   Leerraum die Platzhalter-Prüfung und die Fehlermeldung nennt die falsche Ursache
 	   (Längenfehler statt Platzhalter). */
 	const value = raw.trim();
 
 	if (!value) {
-		return `ENCRYPTION_KEY ist in Produktion erforderlich. ${hint}`;
+		return `ENCRYPTION_KEY ist in Produktion erforderlich. ${ENCRYPTION_KEY_HINT}`;
 	}
 	if (value === PLACEHOLDER_ENCRYPTION_KEY) {
 		return (
 			'ENCRYPTION_KEY ist der Platzhalter aus der Beispiel-Konfiguration. ' +
-			`Die Verschlüsselung des PKCE-Verifiers wäre damit wirkungslos. ${hint}`
+			`Die Verschlüsselung des PKCE-Verifiers wäre damit wirkungslos. ${ENCRYPTION_KEY_HINT}`
 		);
 	}
 	if (value.length !== ENCRYPTION_KEY_LENGTH) {
 		return (
 			`ENCRYPTION_KEY muss genau ${ENCRYPTION_KEY_LENGTH} Zeichen lang sein ` +
-			`(32 Byte für aes-256-gcm), ist aber ${value.length}. ${hint}`
+			`(32 Byte für aes-256-gcm), ist aber ${value.length}. ${ENCRYPTION_KEY_HINT}`
 		);
 	}
 	if (!HEX_ONLY.test(value)) {
-		return `ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f). ${hint}`;
+		return `ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f). ${ENCRYPTION_KEY_HINT}`;
 	}
 	return null;
 }
@@ -111,7 +120,13 @@ export function assertProductionSecrets(env: {
 	SESSION_SECRET: string;
 	ENCRYPTION_KEY: string;
 }): void {
-	if (env.NODE_ENV !== 'production') {
+	/* Groß-/Kleinschreibung und umgebender Leerraum dürfen den Guard nicht abschalten
+	   ("Production", " production ", "PRODUCTION" sind gemeint). Eine Kurzform wie "prod"
+	   gilt bewusst NICHT als Produktion: SvelteKit und die Skripte dieses Projekts setzen
+	   durchgehend "production" — eine Zusatzbedeutung zu erfinden wäre eine eigene
+	   Entscheidung, die dieser Guard nicht treffen soll. */
+	const normalizedNodeEnv = env.NODE_ENV.trim().toLowerCase();
+	if (normalizedNodeEnv !== 'production') {
 		return;
 	}
 

--- a/src/lib/server/config/secretGuard.ts
+++ b/src/lib/server/config/secretGuard.ts
@@ -51,3 +51,45 @@ export function validateSessionSecret(raw: string): string | null {
 	}
 	return null;
 }
+
+/**
+ * Platzhalter-Wert aus `.env.example` (64x "0") — NIE in Produktion nutzen.
+ */
+export const PLACEHOLDER_ENCRYPTION_KEY = '0'.repeat(64);
+
+/**
+ * `crypto.ts` nutzt aes-256-gcm. Das verlangt exakt 32 Byte Schlüssel,
+ * hex-kodiert also 64 Zeichen.
+ */
+export const ENCRYPTION_KEY_LENGTH = 64;
+
+const HEX_ONLY = /^[0-9a-f]+$/i;
+
+/**
+ * Prüft einen `ENCRYPTION_KEY`-Wert.
+ *
+ * @returns `null` wenn gültig, sonst die vollständige Fehlermeldung.
+ */
+export function validateEncryptionKey(value: string): string | null {
+	const hint = 'Erzeugen mit: openssl rand -hex 32';
+
+	if (!value) {
+		return `ENCRYPTION_KEY ist in Produktion erforderlich. ${hint}`;
+	}
+	if (value === PLACEHOLDER_ENCRYPTION_KEY) {
+		return (
+			'ENCRYPTION_KEY ist der Platzhalter aus der Beispiel-Konfiguration. ' +
+			`Die Verschlüsselung des PKCE-Verifiers wäre damit wirkungslos. ${hint}`
+		);
+	}
+	if (value.length !== ENCRYPTION_KEY_LENGTH) {
+		return (
+			`ENCRYPTION_KEY muss genau ${ENCRYPTION_KEY_LENGTH} Zeichen lang sein ` +
+			`(32 Byte für aes-256-gcm), ist aber ${value.length}. ${hint}`
+		);
+	}
+	if (!HEX_ONLY.test(value)) {
+		return `ENCRYPTION_KEY muss hexadezimal sein (nur 0-9 und a-f). ${hint}`;
+	}
+	return null;
+}


### PR DESCRIPTION
Erster Teil der Antwort auf #635 („Paket A"). Dazu die abgestimmte Spezifikation für den zweiten Teil, der separat kommt.

## Warum

`SESSION_SECRET` signiert das Session-Cookie symmetrisch (HS256). Wer den Wert kennt, stellt sich eine Admin-Session aus — ohne Auth0, ohne Passwort, ohne dass die Identität irgendwo existiert. Der bestehende Guard in `hooks.server.ts` prüfte nur auf **leer**.

Das ließ den schlimmsten Fall offen: ein Deployment, das mit einem Secret läuft, das **im öffentlichen Repository steht**. Und die Falle war schärfer als gedacht — der Platzhalter aus `.env.example` ist 33 Zeichen lang und hätte jede reine Mindestlängenprüfung bestanden.

## Was sich ändert

Ein Startup-Guard verweigert in Produktion den Serverstart bei:

- leerem `SESSION_SECRET`, kürzer als 32 Zeichen, oder einem von fünf öffentlich bekannten Werten aus `.env.example`, `.env.docker` und der Deployment-Doku
- `ENCRYPTION_KEY`, der nicht exakt 64 Hex-Zeichen hat — `crypto.ts` nutzt `aes-256-gcm` und braucht 32 Byte. Der alte Guard prüfte nur leer und Platzhalter; ein 32-stelliger Wert kam durch und ließ `createCipheriv` erst beim ersten Login werfen. #635 verlangte ausdrücklich, diesen Guard mitzuprüfen.

Die Prüflogik liegt in `src/lib/server/config/secretGuard.ts` statt im Modul-Scope von `hooks.server.ts` — dessen Import zieht DB-Modul, Middleware-Kette und Signal-Handler mit, ein Test müsste das Modul je Fall neu importieren. Reine Funktionen mit den Werten als Parameter sind ohne all das prüfbar. 28 Tests.

Dazu: Rotation dokumentiert (inklusive der Nebenwirkung, dass ein Wechsel *alle* Sitzungen beendet), Beispielwerte aus der Doku entfernt, `RELEASE_PIPELINE.md` auf „Drei Dinge, die getrennt sein müssen" — `SESSION_SECRET` gehört neben DB und `uploads/`, und der Staging-Host ist laut Checkliste noch nicht aufgesetzt.

## Was das ausdrücklich **nicht** tut

**Die Ursache bleibt.** Wer das *echte* Secret kennt, kann sich weiterhin eine Admin-Session ausstellen. Dieser PR schließt nur den Fall, dass dieses Secret ein öffentlich bekannter Wert ist.

Der Guard beurteilt auch nicht die Güte eines selbstgewählten Secrets — `passwort-passwort-passwort-1234` kommt durch. Entropie-Schätzung wäre unzuverlässig und würde falsche Sicherheit erzeugen.

Die vollständige Lösung steht in `docs/SESSION_STORE_SPEC_2026-07-31.md`: ein serverseitiger Session-Store mit opakem Cookie, der `SESSION_SECRET` als Vertrauensgrundlage ganz beseitigt und #634 (stiller Session-Ablauf) im selben Zug löst. Das ist Auth0s dokumentierte Empfehlung für diese Anwendungsform — und der Guard aus diesem PR wird davon später wieder entfernt. Kein verlorener Aufwand: A braucht Tage, D braucht Wochen, dazwischen liegt genau das Risiko.

## Für Reviewer

**Verifiziert, nicht nur getestet:** Ein echter Serverstart mit dem Platzhalter-Secret endete mit **Exit-Code 1, bevor ein Port geöffnet wurde** — der Throw greift in `Server.init()`. Unit-Tests hätten nur belegt, dass die Funktion wirft, nicht dass ein Modul-Scope-`throw` den adapter-node-Prozess beendet statt 500er zu liefern.

**Der teuerste Fund kam aus dem Abschluss-Review:** `.env.docker` liegt committet im Repo mit einem 36-Zeichen-Platzhalter, und `docker-compose.production.yml` weist an, die Datei nach `.env` zu kopieren. Ein Betreiber hätte den vom Guard angemahnten `ENCRYPTION_KEY` ersetzt und wäre mit öffentlich bekanntem Signierschlüssel gestartet — der Guard hätte dabei vom offenen Loch abgelenkt. Behoben doppelt: Vorlage gekürzt **und** Altwert geblockt, weil laufende Deployments ihn übernommen haben können.

**Lokale Entwicklung und CI sind unberührt.** Der Guard greift nur bei `NODE_ENV === 'production'`; `.env.example` ist unverändert, CI arbeitet weiter mit dem Platzhalter.

**Vor dem Deploy prüfen:** ob auf einem Host ein `ENCRYPTION_KEY` läuft, der nicht 64 Hex-Zeichen hat. Der startet danach nicht mehr — der Login war dort allerdings ohnehin kaputt.

**Ungeprüft:** Verhalten unter `adapter-vercel`. Dort würde der Throw beim Cold Start greifen, nicht als Startabbruch.

`npm run test:quick`: 2770 Tests grün.

Closes #635 nicht — das Issue bleibt für Paket D offen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
