### PR TITLE
fix(security): gate showreports.json search behind reporter consent

### DIFF
--- a/.claude/rules/legacy-api.md
+++ b/.claude/rules/legacy-api.md
@@ -74,6 +74,18 @@ Zusätzlich existiert `/en/rest_sichtungen/antworten.json` (englische Variante).
    Vorname und Schiffsname nur, wenn der Melder das freigegeben hat. Die Felder
    `bm` und `va` nur für eingeloggte Admins.
 
+   **Das gilt seit 2026-07-31 auch für den `search`-Parameter** — und das ist
+   die einzige bewusste Abweichung von der Spezifikation in diesem Endpunkt.
+   Anonyme Aufrufer durchsuchen Vorname/Name nur bei `namensnennung = 1`, den
+   Schiffsnamen nur bei `schiffnamensnennung = 1`, die E-Mail-Adresse gar nicht;
+   eingeloggte Admins bekommen die volle Vier-Feld-Suche der Spezifikation.
+   Grund: Die Ausgabe war immer gegated, die **Trefferzahl** nicht — damit war
+   die Suche ein Membership-Orakel über personenbezogene Daten. Die Einschränkung
+   ist eine Datenschutzmaßnahme, **kein zu behebender Spec-Verstoß**; sie darf
+   nicht mit Verweis auf Regel 1 oder auf `docs/LEGACY_API_SPECIFICATION.md`
+   zurückgebaut werden. Festgeschrieben in `showreports.test.ts`, begründet unter
+   „Deviation: consent-gated search" in der Spezifikation.
+
 ---
 
 ## Statuscodes

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -273,7 +273,39 @@ Returns all reports of a year that are approved and marked as lying in the Balti
 | `location` | Position specification: Latitude and longitude, comma separated. Returns all reports within radius of this position (default radius 100 km)                                                                                  | Latitude, Longitude                                              | No       |
 | `distance` | Distance in meters for radius search, only used with "location"                                                                                                                                                              | Integer                                                          | No       |
 | `bbox`     | Area specification defined by lower left and upper right corner in degrees, separated by commas. Format: Longitude lower left, Latitude lower left, Longitude upper right, Latitude upper right. Compatible with OpenLayers. | Longitude min_x, Latitude min_y, Longitude max_x, Latitude max_y | No       |
-| `search`   | Searches for given text in fields Email, Name, First name and Ship name. Partial string search (%<text>%).                                                                                                                   | String                                                           | No       |
+| `search`   | Searches for given text in fields Email, Name, First name and Ship name. Partial string search (%<text>%). **Restricted for anonymous callers — see [Deviation: consent-gated search](#deviation-consent-gated-search).**    | String                                                           | No       |
+
+### Deviation: consent-gated search
+
+This is the **one deliberate deviation** from the original specification in this
+endpoint. Introduced 2026-07-31 after a data-protection review.
+
+| Caller              | Fields searched                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Anonymous (default) | First name + Last name **only if `namensnennung = 1`**, Ship name **only if `schiffnamensnennung = 1`**. Email is **not** searched at all. |
+| Logged-in admin     | Email, First name, Last name, Ship name — unrestricted, exactly as specified above.                                                        |
+
+**Why.** The _response_ has always been consent-gated: `na` is only emitted when
+the reporter released their name, `sh` only when they released the ship name.
+The _result count_ was not. A `search=` request therefore let any anonymous
+caller confirm whether a given email address or name exists in the database —
+including for reporters who never consented to being named. That is a membership
+oracle over personal data and contradicts the promise made in the reporting form
+("Ihre Kontaktdaten verwenden wir ausschließlich für Rückfragen zu Ihrer
+Meldung"). Email is dropped entirely rather than gated, because the field is
+never part of any response and searching it serves no legitimate purpose for a
+public client.
+
+The gating mirrors `/api/map/sightings`, so both public surfaces expose the same
+subset. Additionally, LIKE wildcards (`%`, `_`, `\`) in the search term are
+escaped and matched literally; previously `search=%` matched every record.
+
+**Impact on clients.** A client searching by email, or by the name of a reporter
+without consent, now receives an empty array instead of results. No field name,
+URL path, data type or response structure changed. Admin clients are unaffected.
+
+Pinned by `src/routes/sichtungen/showreports.json/showreports.test.ts`
+(`Datenschutz - Suche über personenbezogene Felder`).
 
 ### Response Format
 

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -8,6 +8,11 @@
  *
  * CRITICAL: Response format uses abbreviated field names as specified in PDF!
  *
+ * Einzige bewusste Abweichung von der Spezifikation: der Umfang der `search`-Suche
+ * für nicht angemeldete Aufrufer (Datenschutz, siehe Kommentar am Suchfilter und
+ * "Deviation: consent-gated search" in docs/LEGACY_API_SPECIFICATION.md).
+ * Feldnamen, URL-Pfade, Datentypen und Response-Struktur sind unverändert.
+ *
  * @author Ostsee-Tiere Team
  * @since 1.10.0
  */
@@ -20,6 +25,7 @@ import {
 } from '$lib/legacy-api/date-utils.js';
 import { createLogger } from '$lib/logger.server';
 import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
+import { isAdminUser } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
@@ -68,6 +74,11 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		const bbox = searchParams.get('bbox');
 		const search = searchParams.get('search');
 
+		// Steuert den Umfang der Suche (siehe Kommentar am Suchfilter weiter unten).
+		// `isAdminUser` statt `locals.isAdmin`, damit hier dieselbe Rollenprüfung
+		// greift wie in den übrigen Routen.
+		const isAdmin = isAdminUser(event.locals.user);
+
 		logger.debug(
 			{
 				year,
@@ -75,6 +86,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 				distance,
 				bbox,
 				search: search ? '***masked***' : null, // Privacy: mask search terms
+				isAdmin,
 				ip: clientIp
 			},
 			'PDF-compliant legacy sightings retrieval request'
@@ -262,25 +274,52 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			}
 		}
 
-		// Search filter - PDF specification: searches in Email, Name, First name, Ship name
+		// Search filter - PDF specification: searches in Email, Name, First name, Ship name.
+		//
+		// BEWUSSTE ABWEICHUNG VON DER SPEZIFIKATION für nicht angemeldete Aufrufer
+		// (dokumentiert in docs/LEGACY_API_SPECIFICATION.md):
+		// Die *Ausgabe* war immer consent-gated (`na` nur bei `namensnennung`,
+		// `sh` nur bei `schiffnamensnennung`), die *Trefferzahl* nicht. Damit konnte
+		// ein anonymer Aufrufer prüfen, ob eine E-Mail-Adresse oder ein Name im
+		// Bestand existiert — auch bei Meldern, die der Namensnennung nie zugestimmt
+		// haben. Das widerspricht der Zusage im Meldeformular (Step4Contact.svelte).
+		//
+		// Deshalb gestuft: anonym ohne `email` und nur mit Einwilligung (identisch zu
+		// /api/map/sightings), für angemeldete Admins die volle Vier-Feld-Suche der
+		// Spezifikation — Admins sehen diese Felder ohnehin.
 		if (search && search.trim().length > 0) {
-			const searchTerm = `%${search.trim()}%`;
+			// LIKE-Wildcards im Suchbegriff escapen, damit % und _ literal gesucht
+			// werden. Ohne das matcht `search=%` jeden Datensatz und `_` jedes
+			// Einzelzeichen — beides verstärkt das oben beschriebene Orakel.
+			const escapedSearch = search.trim().replace(/[%_\\]/g, '\\$&');
+			const searchTerm = `%${escapedSearch}%`;
 
 			whereConditions.push(
-				sql`(
-					${sightings.email} ILIKE ${searchTerm} OR 
-					${sightings.firstName} ILIKE ${searchTerm} OR 
-					${sightings.lastName} ILIKE ${searchTerm} OR
-					${sightings.shipName} ILIKE ${searchTerm}
+				isAdmin
+					? sql`(
+					${sightings.email} ILIKE ${searchTerm} ESCAPE '\\' OR
+					${sightings.firstName} ILIKE ${searchTerm} ESCAPE '\\' OR
+					${sightings.lastName} ILIKE ${searchTerm} ESCAPE '\\' OR
+					${sightings.shipName} ILIKE ${searchTerm} ESCAPE '\\'
+				)`
+					: sql`(
+					(${sightings.nameConsent} = 1 AND (
+						${sightings.firstName} ILIKE ${searchTerm} ESCAPE '\\' OR
+						${sightings.lastName} ILIKE ${searchTerm} ESCAPE '\\'
+					)) OR
+					(${sightings.shipNameConsent} = 1 AND
+						${sightings.shipName} ILIKE ${searchTerm} ESCAPE '\\'
+					)
 				)`
 			);
 
 			logger.debug(
 				{
 					searchLength: search.length,
+					scope: isAdmin ? 'admin' : 'public',
 					ip: clientIp
 				},
-				'Applied search filter (PDF compliant)'
+				'Applied search filter (consent-gated for anonymous callers)'
 			);
 		}
 
@@ -374,7 +413,14 @@ export async function GET(event: RequestEvent): Promise<Response> {
 
 		return json(pdfCompliantSightings, {
 			headers: {
-				'Cache-Control': 'public, max-age=300', // Cache for 5 minutes
+				// Seit der Consent-Gatung der Suche hängt die Antwort von der Session ab:
+				// Ein Admin bekommt unter derselben URL mehr Treffer als ein anonymer
+				// Aufrufer. `public` würde einem Shared Cache erlauben, die Admin-Antwort
+				// zu speichern und anonym auszuliefern — also genau das Membership-Orakel
+				// wiederherzustellen, das die Gatung schließt. Cache-Header sind nicht
+				// Teil des Legacy-Vertrags (docs/LEGACY_API_SPECIFICATION.md).
+				'Cache-Control': isAdmin ? 'private, max-age=0, no-store' : 'public, max-age=300',
+				Vary: 'Cookie',
 				'Content-Type': 'application/json'
 			}
 		});

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -11,6 +11,25 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { GET, POST, PUT, DELETE } from './+server';
 import type { RequestEvent } from '@sveltejs/kit';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+// Die WHERE-Bedingung wird aus dem DB-Mock herausgereicht, damit die Tests die
+// tatsächlich erzeugte SQL prüfen können statt nur den HTTP-Status. Ohne das
+// bleibt der Suchfilter unsichtbar — genau so konnte die ungegatete Suche
+// über personenbezogene Felder unbemerkt bleiben.
+const captured = vi.hoisted(() => ({ where: null as unknown }));
+
+const dialect = new PgDialect();
+
+/** Rendert die zuletzt erfasste WHERE-Bedingung als SQL-Text mit Parametern. */
+function capturedWhereQuery(): { text: string; params: unknown[] } {
+	if (!captured.where) {
+		throw new Error('Keine WHERE-Bedingung erfasst — wurde die Query ausgeführt?');
+	}
+	const query = dialect.sqlToQuery(captured.where as SQL);
+	return { text: query.sql, params: query.params };
+}
 
 // Mock database - simplified approach using partial database operations
 const mockSightingData = [
@@ -74,11 +93,14 @@ vi.mock('$lib/server/db', () => {
 		db: {
 			select: vi.fn(() => ({
 				from: vi.fn(() => ({
-					where: vi.fn(() => ({
-						orderBy: vi.fn(() => ({
-							limit: vi.fn(() => Promise.resolve(mockSightingData))
-						}))
-					}))
+					where: vi.fn((condition: unknown) => {
+						captured.where = condition;
+						return {
+							orderBy: vi.fn(() => ({
+								limit: vi.fn(() => Promise.resolve(mockSightingData))
+							}))
+						};
+					})
 				}))
 			}))
 		}
@@ -96,7 +118,10 @@ vi.mock('$lib/logger', () => ({
 }));
 
 // Helper to create mock request event
-function createMockRequestEvent(searchParams: Record<string, string> = {}): RequestEvent {
+function createMockRequestEvent(
+	searchParams: Record<string, string> = {},
+	locals: App.Locals = {}
+): RequestEvent {
 	const url = new URL('https://example.com/sichtungen/showreports.json');
 	Object.entries(searchParams).forEach(([key, value]) => {
 		url.searchParams.set(key, value);
@@ -104,13 +129,23 @@ function createMockRequestEvent(searchParams: Record<string, string> = {}): Requ
 
 	return {
 		url,
+		locals,
 		getClientAddress: () => '127.0.0.1'
 	} as any;
+}
+
+/** Request-Event eines eingeloggten Admins (Rolle wie in `hooks.server.ts` gesetzt). */
+function createAdminRequestEvent(searchParams: Record<string, string> = {}): RequestEvent {
+	return createMockRequestEvent(searchParams, {
+		user: { sub: 'auth0|admin', roles: ['admin'] } as NonNullable<App.Locals['user']>,
+		isAdmin: true
+	});
 }
 
 describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		captured.where = null;
 	});
 
 	describe('PDF Compliance - Response Format', () => {
@@ -365,6 +400,65 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 		});
 	});
 
+	describe('Datenschutz - Suche über personenbezogene Felder', () => {
+		// Hintergrund: Die Ausgabe war schon immer consent-gegated (`na`, `sh`),
+		// die Trefferzahl nicht. Ein anonymer Aufrufer konnte damit prüfen, ob eine
+		// E-Mail-Adresse oder ein Name im Bestand existiert — auch bei Meldern ohne
+		// Einwilligung. Vgl. `/api/map/sightings`, das dieselbe Consent-Gatung umsetzt.
+
+		it('durchsucht für anonyme Aufrufer die E-Mail-Adresse nicht', async () => {
+			await GET(createMockRequestEvent({ search: 'melder@example.com' }));
+
+			const { text } = capturedWhereQuery();
+			expect(text).not.toContain('"email"');
+		});
+
+		it('durchsucht Name und Schiffsname für anonyme Aufrufer nur mit Einwilligung', async () => {
+			await GET(createMockRequestEvent({ search: 'Private' }));
+
+			const { text } = capturedWhereQuery();
+			// Die Felder werden weiterhin durchsucht ...
+			expect(text).toContain('"vorname"');
+			expect(text).toContain('"name"');
+			expect(text).toContain('"schiffsname"');
+			// ... aber ausschließlich innerhalb des Consent-Gates.
+			expect(text).toMatch(/"namensnennung"\s*=\s*1/);
+			expect(text).toMatch(/"schiffnamensnennung"\s*=\s*1/);
+		});
+
+		it('behandelt LIKE-Wildcards im Suchbegriff als Literale', async () => {
+			// Ohne Escaping matcht `search=%` jeden Datensatz und `_` jedes
+			// Einzelzeichen — das verstärkt das Membership-Orakel zusätzlich.
+			await GET(createMockRequestEvent({ search: '50%_x' }));
+
+			const { text, params } = capturedWhereQuery();
+			expect(params).toContain('%50\\%\\_x%');
+			expect(text).toContain('ESCAPE');
+		});
+
+		it('durchsucht für eingeloggte Admins weiterhin alle vier Felder der Spezifikation', async () => {
+			await GET(createAdminRequestEvent({ search: 'Schneider' }));
+
+			const { text } = capturedWhereQuery();
+			expect(text).toContain('"email"');
+			expect(text).toContain('"vorname"');
+			expect(text).toContain('"name"');
+			expect(text).toContain('"schiffsname"');
+			// Kein Consent-Gate: Admins sehen ohnehin alle Felder.
+			expect(text).not.toContain('"namensnennung"');
+			expect(text).not.toContain('"schiffnamensnennung"');
+		});
+
+		it('erzeugt ohne search-Parameter keine Bedingung auf personenbezogene Felder', async () => {
+			await GET(createMockRequestEvent());
+
+			const { text } = capturedWhereQuery();
+			expect(text).not.toContain('"email"');
+			expect(text).not.toContain('"vorname"');
+			expect(text).not.toContain('"schiffsname"');
+		});
+	});
+
 	describe('PDF Compliance - Cache and Headers', () => {
 		it('should set proper cache headers', async () => {
 			const event = createMockRequestEvent();
@@ -373,6 +467,23 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			expect(response.status).toBe(200);
 			expect(response.headers.get('Cache-Control')).toBe('public, max-age=300');
 			expect(response.headers.get('Content-Type')).toBe('application/json');
+		});
+
+		it('markiert die Admin-Antwort als nicht öffentlich cachebar', async () => {
+			// Die Antwort hängt seit der Consent-Gatung von der Session ab: Ein Admin
+			// bekommt unter derselben URL mehr Treffer. Mit `public` dürfte ein Shared
+			// Cache die Admin-Antwort an anonyme Aufrufer weiterreichen — genau das
+			// Orakel, das die Gatung schließt.
+			const response = await GET(createAdminRequestEvent({ search: 'Schneider' }));
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get('Cache-Control')).toBe('private, max-age=0, no-store');
+		});
+
+		it('meldet die Abhängigkeit von der Session per Vary', async () => {
+			const anonymous = await GET(createMockRequestEvent({ search: 'Schneider' }));
+
+			expect(anonymous.headers.get('Vary')).toBe('Cookie');
 		});
 	});
 

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1859,7 +1859,8 @@ paths:
             nur bei vorliegender Schiffsnamensfreigabe durchsucht; die
             E-Mail-Adresse wird nicht durchsucht. Angemeldete Admins durchsuchen
             zusätzlich die E-Mail-Adresse und ohne Freigabe-Filter.
-            LIKE-Platzhalter (% und _) werden literal gesucht.
+            LIKE-Platzhalter (%, _ und der Escape-Backslash \) werden literal
+            gesucht.
           schema:
             type: string
             maxLength: 100

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1853,7 +1853,13 @@ paths:
             example: "9,53,31,66"
         - name: search
           in: query
-          description: 'Suchtext in Name, E-Mail, Schiffsname (Teilstring-Suche)'
+          description: >
+            Suchtext (Teilstring-Suche). Für nicht angemeldete Aufrufer werden
+            Vorname/Name nur bei vorliegender Namensfreigabe und der Schiffsname
+            nur bei vorliegender Schiffsnamensfreigabe durchsucht; die
+            E-Mail-Adresse wird nicht durchsucht. Angemeldete Admins durchsuchen
+            zusätzlich die E-Mail-Adresse und ohne Freigabe-Filter.
+            LIKE-Platzhalter (% und _) werden literal gesucht.
           schema:
             type: string
             maxLength: 100


### PR DESCRIPTION
## Problem

Der öffentliche Legacy-Endpunkt `GET /sichtungen/showreports.json` erlaubte über den nicht authentifizierten `?search=`-Parameter ein **Membership-Orakel über personenbezogene Daten**.

Die *Ausgabe* war immer consent-gegated (`na` nur bei `namensnennung`, `sh` nur bei `schiffnamensnennung`). Die *Trefferzahl* war es nicht. Ein anonymer Aufrufer konnte damit prüfen, ob eine bestimmte E-Mail-Adresse oder ein Name im Bestand existiert — auch bei Meldern, die der Namensnennung nie zugestimmt haben. Das widerspricht der Zusage im Meldeformular (`Step4Contact.svelte`): „Ihre Kontaktdaten verwenden wir ausschließlich für Rückfragen zu Ihrer Meldung."

Zusätzlich wurden LIKE-Wildcards nicht escaped: `search=%` matchte jeden Datensatz.

## Änderung

Die Suche ist jetzt gestuft:

| Aufrufer | Durchsuchte Felder |
|---|---|
| Anonym | Vor-/Nachname nur bei `namensnennung = 1`, Schiffsname nur bei `schiffnamensnennung = 1`. **E-Mail gar nicht.** |
| Eingeloggter Admin | E-Mail, Vorname, Name, Schiffsname — unverändert wie in der Spezifikation |

Die Gatung ist zeichengleich zu `/api/map/sightings`, damit beide öffentlichen Flächen dieselbe Teilmenge freigeben. E-Mail entfällt anonym vollständig statt gegated zu werden — das Feld ist in keiner Response enthalten, es zu durchsuchen hat für einen öffentlichen Client keinen legitimen Zweck.

`Cache-Control` war bisher unbedingt `public, max-age=300`. Da die Antwort jetzt von der Session abhängt, hätte ein Shared Cache die Admin-Antwort speichern und anonym ausliefern können — also genau das Orakel wiederherstellen. Admin-Antworten sind deshalb `private, no-store`, dazu `Vary: Cookie`.

## Vertragstreue

Feldnamen, URL-Pfade, Datentypen und Response-Struktur sind **unverändert**. Die Einschränkung des Suchumfangs ist die einzige bewusste Abweichung von `docs/LEGACY_API_SPECIFICATION.md` und dort unter „Deviation: consent-gated search" mit Begründung und Client-Auswirkung dokumentiert. Cache-Header sind nicht Teil des Vertrags.

`.claude/rules/legacy-api.md` (Regel 6) benennt die Abweichung explizit als Datenschutzmaßnahme und **nicht** als zu behebenden Spec-Verstoß — sonst baut sie ein späterer Durchgang unter Verweis auf Regel 1 zurück.

**Client-Auswirkung:** Wer per E-Mail sucht oder nach dem Namen eines Melders ohne Einwilligung, bekommt jetzt ein leeres Array statt Treffern. Admin-Clients sind nicht betroffen.

## Verifikation

`npm run test:quick` vollständig grün: **2.798 Tests in 187 Dateien**, ESLint ohne Fehler, `tsc --noEmit` und `svelte-check` sauber, `openapi.yml` lädt.

Test-First: 5 neue Datenschutz-Tests plus 2 Cache-Header-Tests, RED vor der Implementierung verifiziert. Der DB-Mock reicht die WHERE-Bedingung jetzt heraus und die Tests rendern sie über `PgDialect` zu echtem SQL — vorher verschluckte der Mock den Filter vollständig, weshalb die ungegatete Suche unbemerkt bleiben konnte.

Gegen die lokale PostgreSQL (19.883 Zeilen) gemessen:

| Prüfung | vorher | nachher |
|---|---|---|
| `search=Schmi` | 113 Treffer | 61 anonym / 113 als Admin |
| `search=%` | 7.446 | 0 |
| `search=@gmx` | 3.878 | 0 anonym |

`namensnennung`/`schiffnamensnennung` halten im Bestand ausschließlich 0 und 1 — der `= 1`-Vergleich ist damit deckungsgleich mit dem Truthiness-Check im Response-Mapping.

Security-Review ohne Befund: Parametrisierung intakt, Escaping nicht umgehbar (auch nicht per Trailing-Backslash), `isAdminUser(undefined)` schlägt fail-closed fehl, `location`/`bbox`/`year` können das Gate nicht aufweiten.

## Offen

Die Escaping- und Gate-Logik steht jetzt fast identisch in zwei Routen. Ein gemeinsamer `escapeLikePattern()`-Helper wäre sinnvoll, würde diesen PR aber über den Datenschutz-Fix hinaus ausweiten — bewusst nicht enthalten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
