### PR TITLE
feat(db): record timestamp and text version for all consents

### DIFF
--- a/drizzle/0002_nervous_deadpool.sql
+++ b/drizzle/0002_nervous_deadpool.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "sichtungen" ADD COLUMN "namensnennung_am" timestamp;--> statement-breakpoint
+ALTER TABLE "sichtungen" ADD COLUMN "namensnennung_version" varchar(32);--> statement-breakpoint
+ALTER TABLE "sichtungen" ADD COLUMN "schiffnamensnennung_am" timestamp;--> statement-breakpoint
+ALTER TABLE "sichtungen" ADD COLUMN "schiffnamensnennung_version" varchar(32);--> statement-breakpoint
+ALTER TABLE "sichtungen" ADD COLUMN "datenschutz_einverstaendnis_am" timestamp;--> statement-breakpoint
+ALTER TABLE "sichtungen" ADD COLUMN "datenschutz_einverstaendnis_version" varchar(32);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,998 @@
+{
+  "id": "55e424b5-354d-4bc2-bdd6-baa5536a7f9f",
+  "prevId": "f0109c2a-9469-479b-b7c0-8b57cd7f78d0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_app_config_key": {
+          "name": "idx_app_config_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_category": {
+          "name": "idx_app_config_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_config_key_unique": {
+          "name": "app_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_timestamp": {
+          "name": "idx_audit_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action_timestamp": {
+          "name": "idx_audit_logs_action_timestamp",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_email_timestamp": {
+          "name": "idx_audit_logs_user_email_timestamp",
+          "columns": [
+            {
+              "expression": "user_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtungen_dateien": {
+      "name": "sichtungen_dateien",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sichtung_id": {
+          "name": "sichtung_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_name": {
+          "name": "datei_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_pfad": {
+          "name": "datei_pfad",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_typ": {
+          "name": "mime_typ",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hochgeladen_am": {
+          "name": "hochgeladen_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exif_daten": {
+          "name": "exif_daten",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erstellt_am": {
+          "name": "erstellt_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sichtungen_dateien_sichtung_id": {
+          "name": "idx_sichtungen_dateien_sichtung_id",
+          "columns": [
+            {
+              "expression": "sichtung_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_referenz_id": {
+          "name": "idx_sichtungen_dateien_referenz_id",
+          "columns": [
+            {
+              "expression": "referenz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_uid": {
+          "name": "idx_sichtungen_dateien_uid",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sichtungen_dateien_sichtung_id_sichtungen_id_fk": {
+          "name": "sichtungen_dateien_sichtung_id_sichtungen_id_fk",
+          "tableFrom": "sichtungen_dateien",
+          "tableTo": "sichtungen",
+          "columnsFrom": [
+            "sichtung_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtungen": {
+      "name": "sichtungen",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('sichtungen_seq'::regclass)"
+        },
+        "gps_breite": {
+          "name": "gps_breite",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gps_laenge": {
+          "name": "gps_laenge",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fahrwasser": {
+          "name": "fahrwasser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seezeichen": {
+          "name": "seezeichen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtungsdatum": {
+          "name": "sichtungsdatum",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vonwo": {
+          "name": "vonwo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vonwo_text": {
+          "name": "vonwo_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entfernung": {
+          "name": "entfernung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_schiffe": {
+          "name": "anzahl_schiffe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anzahl_gesamt": {
+          "name": "anzahl_gesamt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_jung": {
+          "name": "anzahl_jung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung": {
+          "name": "verteilung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung_text": {
+          "name": "verteilung_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahme": {
+          "name": "aufnahme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahmeHochladen": {
+          "name": "aufnahmeHochladen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten": {
+          "name": "verhalten",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten_text": {
+          "name": "verhalten_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaktion": {
+          "name": "reaktion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sonstige_auffaelligkeiten": {
+          "name": "sonstige_auffaelligkeiten",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seegang": {
+          "name": "seegang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windrichtung": {
+          "name": "windrichtung",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "windstaerke": {
+          "name": "windstaerke",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtweite": {
+          "name": "sichtweite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffsname": {
+          "name": "schiffsname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heimathafen": {
+          "name": "heimathafen",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstyp": {
+          "name": "bootstyp",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootsantrieb": {
+          "name": "bootsantrieb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bootsantrieb_text": {
+          "name": "bootsantrieb_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vorname": {
+          "name": "vorname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strasse": {
+          "name": "strasse",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plz": {
+          "name": "plz",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ort": {
+          "name": "ort",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telefon": {
+          "name": "telefon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung": {
+          "name": "namensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "namensnennung_am": {
+          "name": "namensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung_version": {
+          "name": "namensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung": {
+          "name": "schiffnamensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffnamensnennung_am": {
+          "name": "schiffnamensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung_version": {
+          "name": "schiffnamensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bemerkungen": {
+          "name": "bemerkungen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eingangskanal": {
+          "name": "eingangskanal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freigegeben_am": {
+          "name": "freigegeben_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geprueft": {
+          "name": "geprueft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ostsee": {
+          "name": "ostsee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "kommentar_intern": {
+          "name": "kommentar_intern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ostsee_geo": {
+          "name": "ostsee_geo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund": {
+          "name": "totfund",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_groesse": {
+          "name": "totfund_groesse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totfund_zustand": {
+          "name": "totfund_zustand",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_geschlecht": {
+          "name": "totfund_geschlecht",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_telefon": {
+          "name": "totfund_telefon",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tierart": {
+          "name": "tierart",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis": {
+          "name": "datenschutz_einverstaendnis",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis_am": {
+          "name": "datenschutz_einverstaendnis_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datenschutz_einverstaendnis_version": {
+          "name": "datenschutz_einverstaendnis_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung": {
+          "name": "medien_einwilligung",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "medien_einwilligung_am": {
+          "name": "medien_einwilligung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung_version": {
+          "name": "medien_einwilligung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data": {
+          "name": "weather_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_fetched_at": {
+          "name": "weather_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_provider": {
+          "name": "weather_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open-meteo'"
+        },
+        "weather_api_version": {
+          "name": "weather_api_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data_type": {
+          "name": "weather_data_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'historical'"
+        }
+      },
+      "indexes": {
+        "geom_sichtungen": {
+          "name": "geom_sichtungen",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_geometry_ops_2d"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_sichtungsdatum": {
+          "name": "idx_sichtungsdatum",
+          "columns": [
+            {
+              "expression": "sichtungsdatum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungsdatum_berlin_tag": {
+          "name": "idx_sichtungsdatum_berlin_tag",
+          "columns": [
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_year_sichtungen": {
+          "name": "idx_year_sichtungen",
+          "columns": [
+            {
+              "expression": "EXTRACT(year FROM \"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_data_gin": {
+          "name": "idx_weather_data_gin",
+          "columns": [
+            {
+              "expression": "weather_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_weather_fetched": {
+          "name": "idx_weather_fetched",
+          "columns": [
+            {
+              "expression": "weather_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_provider": {
+          "name": "idx_weather_provider",
+          "columns": [
+            {
+              "expression": "weather_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_position_date_weather": {
+          "name": "idx_position_date_weather",
+          "columns": [
+            {
+              "expression": "ROUND(\"gps_breite\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ROUND(\"gps_laenge\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sichtungen\".\"weather_data\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.sichtungen_seq": {
+      "name": "sichtungen_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1840",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1785252001790,
       "tag": "0001_first_wallop",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785506723798,
+      "tag": "0002_nervous_deadpool",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -82,7 +82,7 @@
 		<div class="space-y-4">
 			<div class="card bg-base-200 p-4">
 				<!-- Technische Informationen -->
-				<div class="text-sm text-base-content/70">
+				<div class="text-base-content/70 text-sm">
 					<p>Datensatz ID: {sighting.id}</p>
 					<p>Gemeldet: {formatLocalDateTime(sighting.created)}</p>
 					<p>Verifiziert: <BooleanStatus value={sighting.verified} /></p>
@@ -106,7 +106,7 @@
 			<Environment adminMode={true} />
 			<!-- Verhalten und Reaktion -->
 			<Behavior adminMode={true} />
-			<Media />
+			<Media adminMode={true} />
 			<!-- Administratives -->
 			<Administrative />
 		</div>

--- a/src/lib/form/consent/consentTextVersions.test.ts
+++ b/src/lib/form/consent/consentTextVersions.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Bindet die Fassungskennungen an die tatsächlichen Einwilligungstexte.
+ *
+ * Die Kennung ist der zweite Teil des Nachweises nach Art. 7 Abs. 1 DSGVO: Der
+ * Zeitstempel sagt **wann**, die Kennung sagt **wozu** eingewilligt wurde. Sie
+ * taugt dafür aber nur, solange sie sich mit dem Text ändert — eine Kennung, die
+ * beim Umformulieren stehen bleibt, weist der Einwilligung rückwirkend einen
+ * Text zu, den die Meldenden nie gesehen haben.
+ *
+ * Ein Kommentar allein trägt diese Zusicherung nicht. Deshalb pinnt dieser Test
+ * den Hash jedes Textes — wie `notificationEmailDefault.test.ts` es für die
+ * E-Mail-Vorlage tut.
+ *
+ * **Geltungsbereich — bewusst enger, als es zunächst wirkt:** Gepinnt wird
+ * ausschließlich `meta.helpText` aus `sightingSchema.ts`. **Nicht** erfasst sind
+ * `.label()` und der gesamte umgebende Text in
+ * `src/lib/report/components/form/RequiredConsent.svelte` — Überschrift,
+ * Verarbeitungs-Kacheln, Widerrufshinweis, Verweis auf die
+ * Datenschutzerklärung. Gerade bei `privacyConsent` ist das ein erheblicher Teil
+ * dessen, was die meldende Person tatsächlich liest: Wer dort umformuliert,
+ * lässt diesen Test grün.
+ *
+ * Der Hash über die gerenderte Einwilligungsfläche zu ziehen wäre die
+ * vollständige Lösung; sie braucht einen Browser-Test und ist hier bewusst
+ * nicht gebaut. Bis dahin gilt: **Eine Änderung an `RequiredConsent.svelte`
+ * erfordert die Fassungskennung genauso wie eine am `helpText`** — nur erinnert
+ * daran kein Test.
+ *
+ * **Schlägt der Test fehl, wurde ein Einwilligungstext geändert. Dann beides tun:**
+ *   1. die Fassungskennung in `consentVersions.ts` bzw. `mediaConsentVersion.ts`
+ *      auf das Datum der Änderung setzen,
+ *   2. den neuen Hash aus der Fehlermeldung hier eintragen.
+ *
+ * Wer nur (2) macht, hat den Nachweis entwertet: Alle Altbestände tragen dann
+ * eine Kennung, hinter der ein anderer Wortlaut steht.
+ */
+import { createHash } from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { sightingSchema } from '$lib/form/validation/sightingSchema';
+import { MEDIA_CONSENT_VERSION } from './mediaConsentVersion';
+import {
+	NAME_CONSENT_VERSION,
+	PRIVACY_CONSENT_VERSION,
+	SHIP_NAME_CONSENT_VERSION
+} from './consentVersions';
+
+function helpTextOf(field: string): string {
+	const described = sightingSchema.describe().fields[field];
+	if (!described || !('meta' in described)) {
+		throw new Error(`Feld ${field} hat keine Beschreibung`);
+	}
+	const helpText = ((described.meta ?? {}) as { helpText?: string }).helpText;
+	if (!helpText) {
+		throw new Error(`Feld ${field} hat keinen Einwilligungstext`);
+	}
+	return helpText;
+}
+
+const PINNED_CONSENT_TEXTS = [
+	{
+		field: 'nameConsent',
+		version: NAME_CONSENT_VERSION,
+		hash: 'eb46f8a140808245a3f8de9a65917a69452ae212a80a738339405e091b0210d1'
+	},
+	{
+		field: 'shipNameConsent',
+		version: SHIP_NAME_CONSENT_VERSION,
+		hash: 'ad612652de32e9a21b272fd878dfc2509a5ae96308a1dd05365e484c5ff256b6'
+	},
+	{
+		field: 'privacyConsent',
+		version: PRIVACY_CONSENT_VERSION,
+		hash: '73445d9c1ac5e29d803efe505d830951dd296cbeff21ccc0042a223003527c01'
+	},
+	{
+		field: 'mediaConsent',
+		version: MEDIA_CONSENT_VERSION,
+		hash: '55294e0730f56023ef0e4eb3a3c907bf799996ddffecdaaa3af07e72ff4847f9'
+	}
+] as const;
+
+describe('Fassungskennungen der Einwilligungstexte', () => {
+	it.each(PINNED_CONSENT_TEXTS)(
+		'$field entspricht dem gepinnten Hash der Fassung $version',
+		({ field, hash }) => {
+			const actual = createHash('sha256').update(helpTextOf(field), 'utf8').digest('hex');
+
+			expect(actual).toBe(hash);
+		}
+	);
+
+	it.each(PINNED_CONSENT_TEXTS)(
+		'$field trägt eine Fassungskennung im Format JJJJ-MM-TT',
+		({ version }) => {
+			expect(version).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		}
+	);
+
+	it('vergibt keine Kennung, die in der Zukunft liegt', () => {
+		// Eine Fassung kann nicht ab einem Datum gelten, das noch nicht erreicht
+		// ist — das wäre kein Nachweis, sondern eine Ankündigung.
+		//
+		// Berliner Datum, nicht UTC: Zwischen 00:00 und 02:00 Ortszeit liegt das
+		// UTC-Datum einen Tag zurück, und eine an diesem Tag korrekt vergebene
+		// Kennung fiele als „Zukunft" durch. Konvention wie in `sqlTimeZone.ts`.
+		const today = new Intl.DateTimeFormat('en-CA', {
+			timeZone: 'Europe/Berlin',
+			year: 'numeric',
+			month: '2-digit',
+			day: '2-digit'
+		}).format(new Date());
+		for (const { field, version } of PINNED_CONSENT_TEXTS) {
+			expect(version <= today, `${field}: ${version} liegt in der Zukunft`).toBe(true);
+		}
+	});
+});

--- a/src/lib/form/consent/consentVersions.ts
+++ b/src/lib/form/consent/consentVersions.ts
@@ -1,0 +1,31 @@
+/**
+ * Fassungen der übrigen Einwilligungstexte des Sichtungsformulars.
+ *
+ * Art. 7 Abs. 1 DSGVO verlangt, dass sich eine Einwilligung nachweisen lässt.
+ * Ein gespeichertes „ja“ allein belegt weder **wann** noch **wozu** zugestimmt
+ * wurde — deshalb wandern diese Kennungen zusammen mit dem Zeitpunkt in die
+ * Sichtung (siehe `mapFormToSighting`).
+ *
+ * Die Medien-Einwilligung führt denselben Nachweis seit dem 2026-07-28, hat aber
+ * einen eigenen Lebenszyklus und bleibt deshalb in `mediaConsentVersion.ts`.
+ *
+ * **Regel:** Wird der Wortlaut einer Einwilligung in `sightingSchema.ts`
+ * inhaltlich geändert, muss die zugehörige Kennung auf das Datum der Änderung
+ * gesetzt werden. Altbestände behalten dadurch die Fassung, der sie tatsächlich
+ * zugestimmt haben. `consentTextVersions.test.ts` erzwingt das über gepinnte
+ * Hashes der Texte — ein Kommentar allein trägt diese Zusicherung nicht.
+ *
+ * Die Datumswerte stammen aus der Historie des Wortlauts, nicht aus dem Tag der
+ * Einführung dieser Spalten: `nameConsent` und `shipNameConsent` sind seit
+ * f7f9c10d (2025-08-12) unverändert, `privacyConsent` wurde zuletzt mit der
+ * Medien-Einwilligung überarbeitet (6ec70dc4, 2026-07-28).
+ */
+
+/** Fassung des Textes zu `nameConsent` (Veröffentlichung von Vor- und Nachname). */
+export const NAME_CONSENT_VERSION = '2025-08-12';
+
+/** Fassung des Textes zu `shipNameConsent` (Veröffentlichung des Schiffsnamens). */
+export const SHIP_NAME_CONSENT_VERSION = '2025-08-12';
+
+/** Fassung des Textes zu `privacyConsent` (Pflicht-Einwilligung der Meldung). */
+export const PRIVACY_CONSENT_VERSION = '2026-07-28';

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -8,6 +8,13 @@
 	import type { ValidationPreset } from '$lib/types';
 	import SectionCard from './SectionCard.svelte';
 
+	// Im Admin-Bearbeitungsformular bleibt die Medien-Einwilligung sichtbar, aber
+	// gesperrt: Sie ist eine Aussage der meldenden Person, kein Attribut des
+	// Datensatzes. Ein Admin könnte sie weder stellvertretend erteilen noch
+	// nachweisen — `updateSighting` schreibt die Nachweisspalten bewusst nicht
+	// mehr mit (Art. 7 Abs. 1 DSGVO).
+	let { adminMode = false }: { adminMode?: boolean } = $props();
+
 	// Generiere eine einfache referenceId für Upload (temporäre Lösung)
 	const { form } = getFormContext();
 	let referenceId = $derived($form.referenceId);
@@ -65,7 +72,19 @@
 		</ul>
 	</div>
 	<UploadNotice />
-	<FormField name="mediaConsent" />
+	<FormField name="mediaConsent" disabled={adminMode} />
+	{#if adminMode}
+		<!--
+			Bewusst ohne `aria-describedby`: Ein `disabled` Control ist nicht
+			fokussierbar, eine Beschreibung daran würde im Formularmodus nie
+			vorgelesen. Der sichtbare Text in Dokumentreihenfolge ist hier der
+			wirksame Weg. Die Feld-Pipeline (`FieldRenderer`) bietet ohnehin keinen
+			Hook für eine zusätzliche Beschreibung.
+		-->
+		<p class="text-support text-base-content/70 mt-1">
+			Diese Einwilligung kann nur die meldende Person selbst erteilen oder zurückziehen.
+		</p>
+	{/if}
 	{#if uploadConfig}
 		<DropzoneEnhanced
 			{referenceId}

--- a/src/lib/report/components/sections/Media.svelte.test.ts
+++ b/src/lib/report/components/sections/Media.svelte.test.ts
@@ -1,0 +1,68 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import Media from './Media.svelte';
+
+/**
+ * Die Medien-Einwilligung ist eine Aussage der meldenden Person, kein Attribut
+ * des Datensatzes. Ein Admin kann sie deshalb nicht stellvertretend erteilen —
+ * und ein Häkchen, das er setzen kann, hätte auch keinen Nachweis: Der
+ * Zeitstempel würde die Bearbeitungszeit tragen und damit eine Zustimmung
+ * behaupten, die nie stattgefunden hat.
+ *
+ * Im Admin-Formular bleibt das Feld deshalb sichtbar (der Zustand ist für die
+ * Sachbearbeitung relevant), aber gesperrt. Im öffentlichen Formular muss es
+ * bedienbar bleiben — sonst kann niemand mehr einwilligen.
+ */
+function renderMedia(props: { adminMode?: boolean } = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
+	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
+	render(Media, { props, context: new Map([[formContextKey, context]]) });
+}
+
+function consentInput(): HTMLInputElement {
+	const element = document.querySelector<HTMLInputElement>('[data-testid="field-mediaConsent"]');
+	if (!element) throw new Error('Feld "mediaConsent" nicht im DOM');
+	return element;
+}
+
+describe('Media — Einwilligung zur Veröffentlichung', () => {
+	it('ist im öffentlichen Formular bedienbar', () => {
+		renderMedia();
+
+		expect(consentInput().disabled).toBe(false);
+	});
+
+	it('ist im Admin-Formular gesperrt', () => {
+		renderMedia({ adminMode: true });
+
+		expect(consentInput().disabled).toBe(true);
+	});
+
+	it('zeigt im Admin-Formular weiterhin den Zustand an', () => {
+		// Sperren heißt nicht verstecken — die Sachbearbeitung muss sehen, ob
+		// eine Veröffentlichung erlaubt ist.
+		renderMedia({ adminMode: true });
+
+		expect(consentInput()).toBeTruthy();
+	});
+
+	it('begründet die Sperre sichtbar', () => {
+		// Der Grund darf nicht nur in einem `title` stecken: An einem
+		// `disabled`-Element ist der per Tastatur nicht erreichbar.
+		renderMedia({ adminMode: true });
+
+		expect(document.body.textContent).toMatch(/meldende|melderin|melder|betroffene/i);
+	});
+});

--- a/src/lib/server/db/mapFormToSighting.ts
+++ b/src/lib/server/db/mapFormToSighting.ts
@@ -1,3 +1,8 @@
+import {
+	NAME_CONSENT_VERSION,
+	PRIVACY_CONSENT_VERSION,
+	SHIP_NAME_CONSENT_VERSION
+} from '$lib/form/consent/consentVersions';
 import { MEDIA_CONSENT_VERSION } from '$lib/form/consent/mediaConsentVersion';
 import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
@@ -303,10 +308,19 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 		city: formData.city,
 
 		// === DATENSCHUTZ-EINWILLIGUNGEN ===
-		// DSGVO-konforme Einwilligungen (boolean zu int)
+		// DSGVO-konforme Einwilligungen (boolean zu int). Zu jeder erteilten
+		// Einwilligung gehören Zeitpunkt und Textfassung — sie sind der Nachweis
+		// nach Art. 7 Abs. 1 DSGVO. Zu einer abgelehnten Einwilligung gehört
+		// nichts davon: Ein Zeitstempel würde eine Zustimmung vortäuschen.
 		shipNameConsent: formData.shipNameConsent ? 1 : 0,
+		shipNameConsentAt: formData.shipNameConsent ? new Date() : null,
+		shipNameConsentVersion: formData.shipNameConsent ? SHIP_NAME_CONSENT_VERSION : null,
 		nameConsent: formData.nameConsent ? 1 : 0,
+		nameConsentAt: formData.nameConsent ? new Date() : null,
+		nameConsentVersion: formData.nameConsent ? NAME_CONSENT_VERSION : null,
 		privacyConsent: formData.privacyConsent ? 1 : 0,
+		privacyConsentAt: formData.privacyConsent ? new Date() : null,
+		privacyConsentVersion: formData.privacyConsent ? PRIVACY_CONSENT_VERSION : null,
 		// Einwilligung zur Veröffentlichung von Aufnahmen. Zeitpunkt und
 		// Textfassung nur dann, wenn tatsächlich zugestimmt wurde — ein
 		// Nachweis für eine nicht erteilte Einwilligung wäre sinnlos.

--- a/src/lib/server/db/mapFormToSightingConsentProof.test.ts
+++ b/src/lib/server/db/mapFormToSightingConsentProof.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Nachweis der Einwilligungen nach Art. 7 Abs. 1 DSGVO.
+ *
+ * Der Verantwortliche muss eine Einwilligung **nachweisen** können. Ein
+ * gespeichertes „ja" allein belegt weder **wann** eingewilligt wurde noch
+ * **welchem Text** zugestimmt wurde. `mediaConsent` führt diesen Nachweis seit
+ * dem 2026-07-28 (siehe `mapFormToSightingMediaConsent.test.ts`); diese Tests
+ * ziehen die übrigen drei Einwilligungen nach.
+ *
+ * Besonders `nameConsent` hat sichtbare Folgen: `/api/sightings` (Feld `na`)
+ * veröffentlicht Vor- und Nachnamen, sobald das Flag gesetzt ist.
+ */
+import type { SightingFormValues } from '$lib/types/Form';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../geo/checkBalticSeaFile', () => ({
+	checkBalticSeaFile: vi.fn()
+}));
+
+vi.mock('drizzle-orm', () => ({
+	sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+		type: 'sql',
+		strings,
+		values
+	}))
+}));
+
+import {
+	NAME_CONSENT_VERSION,
+	PRIVACY_CONSENT_VERSION,
+	SHIP_NAME_CONSENT_VERSION
+} from '$lib/form/consent/consentVersions';
+import { checkBalticSeaFile } from '../geo/checkBalticSeaFile';
+import { mapFormToSighting } from './mapFormToSighting';
+
+function buildForm(overrides: Partial<SightingFormValues> = {}): SightingFormValues {
+	return {
+		sightingDate: '2026-07-31',
+		sightingTime: '10:30',
+		latitude: '54.5',
+		longitude: '13.2',
+		species: 1,
+		totalCount: 1,
+		referenceId: 'ref-consent-proof',
+		...overrides
+	} as SightingFormValues;
+}
+
+/**
+ * Die drei Einwilligungen unterscheiden sich fachlich, der Nachweis funktioniert
+ * bei allen gleich. Der Tabellenlauf hält sie deshalb zusammen — eine neue
+ * Einwilligung ohne Nachweisspalten fällt hier sofort auf.
+ */
+const CONSENTS = [
+	{
+		field: 'nameConsent',
+		atColumn: 'nameConsentAt',
+		versionColumn: 'nameConsentVersion',
+		version: NAME_CONSENT_VERSION
+	},
+	{
+		field: 'shipNameConsent',
+		atColumn: 'shipNameConsentAt',
+		versionColumn: 'shipNameConsentVersion',
+		version: SHIP_NAME_CONSENT_VERSION
+	},
+	{
+		field: 'privacyConsent',
+		atColumn: 'privacyConsentAt',
+		versionColumn: 'privacyConsentVersion',
+		version: PRIVACY_CONSENT_VERSION
+	}
+] as const;
+
+describe('mapFormToSighting — Nachweis der Einwilligungen', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(checkBalticSeaFile).mockReturnValue({
+			inBaltic: true,
+			inChartArea: true,
+			longitude: 13.2,
+			latitude: 54.5
+		});
+	});
+
+	describe.each(CONSENTS)('$field', ({ field, atColumn, versionColumn, version }) => {
+		it('hält den Zeitpunkt der Einwilligung als Nachweis fest', () => {
+			const before = Date.now();
+			const result = mapFormToSighting(buildForm({ [field]: true }));
+
+			const at = result[atColumn as keyof typeof result] as Date | null;
+			expect(at).toBeInstanceOf(Date);
+			expect(at!.getTime()).toBeGreaterThanOrEqual(before);
+		});
+
+		it('hält fest, welcher Einwilligungstext gegolten hat', () => {
+			const result = mapFormToSighting(buildForm({ [field]: true }));
+
+			expect(result[versionColumn as keyof typeof result]).toBe(version);
+		});
+
+		it('vermerkt eine abgelehnte Einwilligung ohne Zeitpunkt und Version', () => {
+			// Ein Nachweis für eine nicht erteilte Einwilligung wäre sinnlos —
+			// und ein gesetzter Zeitstempel würde eine Zustimmung vortäuschen.
+			const result = mapFormToSighting(buildForm({ [field]: false }));
+
+			expect(result[atColumn as keyof typeof result]).toBeNull();
+			expect(result[versionColumn as keyof typeof result]).toBeNull();
+		});
+
+		it('behandelt eine gar nicht getroffene Auswahl wie eine Ablehnung', () => {
+			// Feld fehlt vollständig — etwa aus einem Legacy-Client, der es nicht
+			// kennt. Ohne Auswahl gibt es nichts nachzuweisen.
+			const result = mapFormToSighting(buildForm());
+
+			expect(result[atColumn as keyof typeof result]).toBeNull();
+			expect(result[versionColumn as keyof typeof result]).toBeNull();
+		});
+	});
+
+	/**
+	 * Die tragende Invariante des Nachweises:
+	 *
+	 *   `_am` und `_version` sind genau dann gesetzt, wenn das Flag 1 ist.
+	 *
+	 * Beide Verletzungsrichtungen sind Fehler. Flag 1 ohne Nachweis behauptet
+	 * etwas ohne Beleg. Nachweis ohne Flag stellt ein Datum hin, das jemanden
+	 * zum Veröffentlichen verleitet, obwohl gerade keine Erlaubnis vorliegt.
+	 *
+	 * Der Test sitzt bewusst auf dem Schreibpfad und nicht als DB-Constraint:
+	 * Der Altbestand (Flag 1, Nachweis NULL) verletzt die Invariante
+	 * zwangsläufig und ist genau so gewollt — dort gibt es keinen Nachweis.
+	 */
+	describe('Invariante: Nachweis genau dann, wenn das Flag steht', () => {
+		const PROOF_COLUMNS = [
+			['nameConsent', 'nameConsentAt', 'nameConsentVersion'],
+			['shipNameConsent', 'shipNameConsentAt', 'shipNameConsentVersion'],
+			['privacyConsent', 'privacyConsentAt', 'privacyConsentVersion'],
+			['mediaConsent', 'mediaConsentAt', 'mediaConsentVersion']
+		] as const;
+
+		it.each([
+			['alle erteilt', true],
+			['alle abgelehnt', false]
+		])('hält die Invariante, wenn %s sind', (_label, granted) => {
+			const result = mapFormToSighting(
+				buildForm({
+					nameConsent: granted,
+					shipNameConsent: granted,
+					privacyConsent: granted,
+					mediaConsent: granted
+				})
+			);
+
+			for (const [flagColumn, atColumn, versionColumn] of PROOF_COLUMNS) {
+				const flag = result[flagColumn as keyof typeof result];
+				const at = result[atColumn as keyof typeof result];
+				const version = result[versionColumn as keyof typeof result];
+
+				expect(at != null, `${atColumn} passt nicht zu ${flagColumn}=${flag}`).toBe(flag === 1);
+				expect(version != null, `${versionColumn} passt nicht zu ${flagColumn}=${flag}`).toBe(
+					flag === 1
+				);
+			}
+		});
+
+		it('hält die Invariante auch bei gemischter Auswahl', () => {
+			const result = mapFormToSighting(
+				buildForm({
+					privacyConsent: true,
+					mediaConsent: true,
+					nameConsent: false
+					// shipNameConsent gar nicht gesetzt
+				})
+			);
+
+			for (const [flagColumn, atColumn, versionColumn] of PROOF_COLUMNS) {
+				const flag = result[flagColumn as keyof typeof result];
+				expect(result[atColumn as keyof typeof result] != null).toBe(flag === 1);
+				expect(result[versionColumn as keyof typeof result] != null).toBe(flag === 1);
+			}
+		});
+	});
+
+	it('führt die Einwilligungen getrennt — eine erteilte belegt die andere nicht', () => {
+		const result = mapFormToSighting(
+			buildForm({ privacyConsent: true, nameConsent: false, shipNameConsent: false })
+		);
+
+		expect(result.privacyConsent).toBe(1);
+		expect(result.privacyConsentAt).toBeInstanceOf(Date);
+		expect(result.nameConsent).toBe(0);
+		expect(result.nameConsentAt).toBeNull();
+		expect(result.shipNameConsent).toBe(0);
+		expect(result.shipNameConsentAt).toBeNull();
+	});
+});

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -68,8 +68,16 @@ export const sightings = pgTable(
 		phone: varchar('telefon', { length: 64 }),
 		fax: varchar('fax', { length: 64 }),
 		email: varchar('email', { length: 64 }),
+		// Einwilligung zur Veröffentlichung von Vor- und Nachname. `/api/sightings`
+		// gibt den Namen aus, sobald das Flag steht — Zeitpunkt und Textfassung
+		// sind der Nachweis nach Art. 7 Abs. 1 DSGVO. Altbestand: NULL, dort gibt
+		// es keinen Nachweis, und ein rückdatierter Wert wäre eine Erfindung.
 		nameConsent: integer('namensnennung').default(0).notNull(),
+		nameConsentAt: timestamp('namensnennung_am', { mode: 'date' }),
+		nameConsentVersion: varchar('namensnennung_version', { length: 32 }),
 		shipNameConsent: integer('schiffnamensnennung').default(0).notNull(),
+		shipNameConsentAt: timestamp('schiffnamensnennung_am', { mode: 'date' }),
+		shipNameConsentVersion: varchar('schiffnamensnennung_version', { length: 32 }),
 		notes: text('bemerkungen'),
 		created: timestamp('created', { mode: 'date' }).notNull(),
 		entryChannel: integer('eingangskanal').default(0).notNull(),
@@ -85,7 +93,11 @@ export const sightings = pgTable(
 		deadSex: smallint('totfund_geschlecht').default(0).notNull(),
 		deadPhoneContact: smallint('totfund_telefon').default(0).notNull(),
 		species: smallint('tierart').default(0).notNull(),
+		// Pflicht-Einwilligung der Meldung. Zeitpunkt und Textfassung sind auch
+		// hier der Nachweis nach Art. 7 Abs. 1 DSGVO.
 		privacyConsent: smallint('datenschutz_einverstaendnis').default(0).notNull(),
+		privacyConsentAt: timestamp('datenschutz_einverstaendnis_am', { mode: 'date' }),
+		privacyConsentVersion: varchar('datenschutz_einverstaendnis_version', { length: 32 }),
 		// Einwilligung zur **Veröffentlichung** hochgeladener Aufnahmen.
 		// Upload und fachliche Prüfung sind dagegen Teil der Meldung selbst und
 		// von `privacyConsent` gedeckt (Entscheidung 2026-07-28).

--- a/src/lib/server/db/sightingRepository.test.ts
+++ b/src/lib/server/db/sightingRepository.test.ts
@@ -4,6 +4,12 @@
  * Testet alle Funktionen des Repository-Patterns für Sichtungen
  * mit besonderem Fokus auf Sicherheit und Edge Cases
  */
+import {
+	NAME_CONSENT_VERSION,
+	PRIVACY_CONSENT_VERSION,
+	SHIP_NAME_CONSENT_VERSION
+} from '$lib/form/consent/consentVersions';
+import { MEDIA_CONSENT_VERSION } from '$lib/form/consent/mediaConsentVersion';
 import { db } from '$lib/server/db';
 import * as schema from '$lib/server/db/schema';
 import type { UploadedFileInfo } from '$lib/types';
@@ -33,12 +39,31 @@ vi.mock('$lib/server/db', () => {
 });
 
 vi.mock('./mapFormToSighting', () => ({
-	mapFormToSighting: vi.fn((formData) => ({
-		id: 1,
-		...formData,
-		created: new Date().toISOString(),
-		approvedAt: null
-	}))
+	// Der Mock muss die Nachweisspalten der Einwilligungen mit erzeugen — sonst
+	// prüft der Test „Nachweisspalten vom Update ausschließen" ins Leere: Was der
+	// Mapper nie liefert, kann das Update auch nicht schreiben.
+	mapFormToSighting: vi.fn((formData) => {
+		const proof = (granted: unknown, version: string) =>
+			granted ? { at: new Date(), version } : { at: null, version: null };
+		const name = proof(formData.nameConsent, NAME_CONSENT_VERSION);
+		const ship = proof(formData.shipNameConsent, SHIP_NAME_CONSENT_VERSION);
+		const privacy = proof(formData.privacyConsent, PRIVACY_CONSENT_VERSION);
+		const media = proof(formData.mediaConsent, MEDIA_CONSENT_VERSION);
+		return {
+			id: 1,
+			...formData,
+			created: new Date().toISOString(),
+			approvedAt: null,
+			nameConsentAt: name.at,
+			nameConsentVersion: name.version,
+			shipNameConsentAt: ship.at,
+			shipNameConsentVersion: ship.version,
+			privacyConsentAt: privacy.at,
+			privacyConsentVersion: privacy.version,
+			mediaConsentAt: media.at,
+			mediaConsentVersion: media.version
+		};
+	})
 }));
 
 vi.mock('$lib/server/storage/factory', () => ({
@@ -375,6 +400,92 @@ describe('sightingRepository', () => {
 			expect(updatePayload).toBeDefined();
 			expect(updatePayload).not.toHaveProperty('verified');
 			expect(updatePayload).not.toHaveProperty('approvedAt');
+		});
+
+		/**
+		 * Test: Der Nachweis einer Einwilligung ist ein historisches Ereignis —
+		 * „Person X hat am T der Fassung V zugestimmt". Ein Admin, der einen
+		 * Datensatz bearbeitet, ist nicht die betroffene Person und kann diesen
+		 * Nachweis nicht erneuern. Liefe er über `mapFormToSighting`, trüge jede
+		 * Bearbeitung den Bearbeitungszeitpunkt ein und behauptete damit eine
+		 * Einwilligung, die es nie gab.
+		 */
+		it('sollte die Nachweisspalten der Einwilligungen vom Update ausschließen', async () => {
+			// Arrange
+			const mockDb = db as any;
+			const setMock = vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					returning: vi.fn().mockResolvedValue([mockFormData])
+				})
+			});
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			// Act: Das Admin-Formular schickt die geladenen Einwilligungen mit
+			await updateSighting(42, {
+				...mockFormData,
+				nameConsent: true,
+				shipNameConsent: true,
+				privacyConsent: true,
+				mediaConsent: true
+			} as any);
+
+			// Assert
+			const updatePayload = setMock.mock.calls[0]?.[0];
+			expect(updatePayload).toBeDefined();
+			for (const column of [
+				'nameConsentAt',
+				'nameConsentVersion',
+				'shipNameConsentAt',
+				'shipNameConsentVersion',
+				'privacyConsentAt',
+				'privacyConsentVersion',
+				'mediaConsentAt',
+				'mediaConsentVersion'
+			]) {
+				expect(updatePayload).not.toHaveProperty(column);
+			}
+		});
+
+		/**
+		 * Test: Auch die Flags selbst gehören nicht ins Update.
+		 *
+		 * Nur den Nachweis auszuschließen und das Flag schreibbar zu lassen
+		 * erzeugt über `PUT /api/sightings/[id]` genau die Kombination, die der
+		 * Anlege-Pfad als Fehler definiert: Flag 1 bei NULL-Nachweis. Die
+		 * Invariante hinge dann allein daran, dass die Admin-Oberfläche kein
+		 * Einwilligungsfeld anbietet — eine UI-Sperre als einzige Absicherung
+		 * einer Datenregel.
+		 *
+		 * Es geht dabei nichts verloren: Einziger Aufrufer ist das
+		 * Admin-Bearbeitungsformular, und das rendert `nameConsent`,
+		 * `shipNameConsent` und `privacyConsent` gar nicht; `mediaConsent` ist
+		 * dort gesperrt. Eine nachträglich erteilte Einwilligung braucht ohnehin
+		 * einen eigenen Weg mit eigenem Nachweis.
+		 */
+		it('sollte auch die Einwilligungs-Flags vom Update ausschließen', async () => {
+			// Arrange
+			const mockDb = db as any;
+			const setMock = vi.fn().mockReturnValue({
+				where: vi.fn().mockReturnValue({
+					returning: vi.fn().mockResolvedValue([mockFormData])
+				})
+			});
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			// Act: Ein Aufruf am UI vorbei versucht, eine Einwilligung zu setzen
+			await updateSighting(42, {
+				...mockFormData,
+				nameConsent: true,
+				shipNameConsent: true,
+				privacyConsent: true,
+				mediaConsent: true
+			} as any);
+
+			// Assert
+			const updatePayload = setMock.mock.calls[0]?.[0];
+			for (const flag of ['nameConsent', 'shipNameConsent', 'privacyConsent', 'mediaConsent']) {
+				expect(updatePayload).not.toHaveProperty(flag);
+			}
 		});
 
 		/**

--- a/src/lib/server/db/sightingRepository.test.ts
+++ b/src/lib/server/db/sightingRepository.test.ts
@@ -52,7 +52,10 @@ vi.mock('./mapFormToSighting', () => ({
 		return {
 			id: 1,
 			...formData,
-			created: new Date().toISOString(),
+			// `Date`, nicht `toISOString()`: Die echte Implementierung liefert hier
+			// ein Date-Objekt (`mapFormToSighting.ts`). Ein String im Mock ließe
+			// Typ- und Serialisierungsfehler im Insert/Update-Payload durchrutschen.
+			created: new Date(),
 			approvedAt: null,
 			nameConsentAt: name.at,
 			nameConsentVersion: name.version,

--- a/src/lib/server/db/sightingRepository.ts
+++ b/src/lib/server/db/sightingRepository.ts
@@ -139,11 +139,40 @@ export const updateSighting = async (
 	// von PATCH /api/sightings/[id]/verify gesetzt — beide immer gemeinsam. Würde
 	// das Bearbeitungsformular `verified` mitschreiben, liefen die Spalten
 	// auseinander und die Sichtung wäre "geprüft", aber nicht veröffentlicht.
+	//
+	// Die Einwilligungen gehören vollständig — Flag UND Nachweis — nicht ins
+	// Update. Sie sind eine Aussage der meldenden Person, kein Attribut des
+	// Datensatzes: Ein Admin ist nicht die betroffene Person und kann nicht für
+	// sie einwilligen. `mapFormToSighting` stempelt die `…ConsentAt`-Spalten auf
+	// `new Date()` — beim Anlegen richtig, beim Bearbeiten eine Erfindung.
+	//
+	// Nur den Nachweis auszuschließen und das Flag schreibbar zu lassen, würde
+	// über diesen Pfad genau die Kombination erzeugen, die der Anlege-Pfad als
+	// Fehler definiert (Flag 1 bei NULL-Nachweis, siehe
+	// `mapFormToSightingConsentProof.test.ts`). Die Invariante hinge dann allein
+	// daran, dass die Admin-Oberfläche kein Einwilligungsfeld anbietet.
+	//
+	// Es geht nichts verloren: Einziger Aufrufer ist PUT /api/sightings/[id]
+	// hinter dem Admin-Bearbeitungsformular, und das rendert die drei übrigen
+	// Einwilligungen nicht und zeigt `mediaConsent` gesperrt. Eine nachträglich
+	// erteilte Einwilligung braucht einen eigenen Weg mit eigenem Nachweis.
 	const {
 		id: _id,
 		created: _created,
 		approvedAt: _approvedAt,
 		verified: _verified,
+		nameConsent: _nameConsent,
+		shipNameConsent: _shipNameConsent,
+		privacyConsent: _privacyConsent,
+		mediaConsent: _mediaConsent,
+		nameConsentAt: _nameConsentAt,
+		nameConsentVersion: _nameConsentVersion,
+		shipNameConsentAt: _shipNameConsentAt,
+		shipNameConsentVersion: _shipNameConsentVersion,
+		privacyConsentAt: _privacyConsentAt,
+		privacyConsentVersion: _privacyConsentVersion,
+		mediaConsentAt: _mediaConsentAt,
+		mediaConsentVersion: _mediaConsentVersion,
 		...rest
 	} = sightingData;
 	const updateData = rest as UpdateSighting;

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2355,11 +2355,74 @@ components:
           description: Einverständnis zur Namensveröffentlichung
           enum: [0, 1]
           example: 1
+        nameConsentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: >-
+            Zeitpunkt der Einwilligung zur Namensveröffentlichung (Nachweis nach
+            Art. 7 Abs. 1 DSGVO). `null`, wenn nicht eingewilligt wurde oder der
+            Datensatz aus dem Altbestand vor Einführung des Nachweises stammt.
+          example: "2026-07-31T10:30:00Z"
+        nameConsentVersion:
+          type: string
+          nullable: true
+          description: >-
+            Fassung des Einwilligungstextes, dem zugestimmt wurde. `null` unter
+            denselben Bedingungen wie `nameConsentAt`.
+          maxLength: 32
+          example: "2025-08-12"
         shipNameConsent:
           type: integer
           description: Einverständnis zur Schiffsnamen-Veröffentlichung
           enum: [0, 1]
           example: 1
+        shipNameConsentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Zeitpunkt der Einwilligung zur Schiffsnamen-Veröffentlichung
+          example: "2026-07-31T10:30:00Z"
+        shipNameConsentVersion:
+          type: string
+          nullable: true
+          description: Fassung des zugestimmten Einwilligungstextes
+          maxLength: 32
+          example: "2025-08-12"
+        privacyConsent:
+          type: integer
+          description: Pflicht-Einwilligung zur Datenverarbeitung
+          enum: [0, 1]
+          example: 1
+        privacyConsentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Zeitpunkt der Pflicht-Einwilligung
+          example: "2026-07-31T10:30:00Z"
+        privacyConsentVersion:
+          type: string
+          nullable: true
+          description: Fassung des zugestimmten Einwilligungstextes
+          maxLength: 32
+          example: "2026-07-28"
+        mediaConsent:
+          type: integer
+          description: Einwilligung zur Veröffentlichung hochgeladener Aufnahmen
+          enum: [0, 1]
+          example: 1
+        mediaConsentAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Zeitpunkt der Medien-Einwilligung
+          example: "2026-07-31T10:30:00Z"
+        mediaConsentVersion:
+          type: string
+          nullable: true
+          description: Fassung des zugestimmten Einwilligungstextes
+          maxLength: 32
+          example: "2026-07-28"
         internalComment:
           type: string
           nullable: true


### PR DESCRIPTION
## Warum

Art. 7 Abs. 1 DSGVO verlangt, dass der Verantwortliche eine Einwilligung **nachweisen** kann. Erfüllt war das nur für `mediaConsent`. `nameConsent`, `shipNameConsent` und `privacyConsent` waren blosse Flags — sie belegen weder **wann** eingewilligt wurde noch **welchem Text** zugestimmt wurde.

Das wiegt schwerer, seit der Datenschutzabsatz auf Schritt 4 sich ausdrücklich darauf stützt („Ihr Name erscheint nur, wenn Sie das unten ausdrücklich erlauben"), und weil die Einwilligung sichtbare Folgen hat: `/api/sightings` veröffentlicht Vor- und Nachnamen, sobald das Flag steht.

## Was drin ist

**Nachweisspalten** für die drei übrigen Einwilligungen, nach dem Muster von `mediaConsent` (Migration `0002`, additiv und nullable).

**Altbestand bleibt `NULL`** — ohne Backfill. „Kein Nachweis" ist ehrlich, ein rückdatierter Wert wäre eine Erfindung.

**Fassungskennungen sind per SHA-256 an die Texte gepinnt** (`consentTextVersions.test.ts`, nach dem Muster von `notificationEmailDefault.test.ts`). Wer einen Einwilligungstext umformuliert, bekommt einen roten Test und muss Kennung und Hash setzen — sonst tragen alle Altbestände eine Kennung, hinter der ein anderer Wortlaut steht. Die Datumswerte stammen aus der Wortlaut-Historie, nicht aus dem Tag der Einführung: `nameConsent`/`shipNameConsent` = 2025-08-12 (f7f9c10d), `privacyConsent`/`mediaConsent` = 2026-07-28 (6ec70dc4).

**Die Invariante** — `_am` und `_version` sind genau dann gesetzt, wenn das Flag 1 ist — ist auf dem Schreibpfad abgesichert, nicht als DB-Constraint: Der Altbestand verletzt sie zwangsläufig und soll das auch.

**`updateSighting` schliesst Einwilligungen vollständig aus**, Flag wie Nachweis. Ein Admin ist nicht die betroffene Person. Nur den Nachweis auszuschliessen hätte über `PUT /api/sightings/[id]` genau die Kombination erzeugt, die der Anlege-Pfad verbietet (Flag gesetzt, Nachweis `NULL`) — die Invariante hinge dann allein an der UI.

**`mediaConsent` ist im Admin-Bearbeitungsformular gesperrt**, nicht entfernt: Der Zustand bleibt für die Sachbearbeitung sichtbar, mit sichtbarer Begründung. Es war das einzige dort editierbare Einwilligungsfeld.

**OpenAPI** nachgezogen — `GET`/`PUT /api/sightings/[id]` selektieren ohne Projektion, die Spalten stehen also in der Antwort. Dabei die vorher undokumentierten `privacyConsent` und `mediaConsent*` mitgenommen.

## Bewusste Grenzen

- Die Hash-Pinnung deckt nur `meta.helpText` ab. Der umgebende Text in `RequiredConsent.svelte` — Überschrift, Verarbeitungs-Kacheln, Widerrufshinweis — ist ein erheblicher Teil dessen, was bei `privacyConsent` gelesen wird, und **nicht** gesichert. Im Docstring benannt; die vollständige Lösung bräuchte einen Browser-Test.
- Der Sperrgrund im Admin-Formular hat bewusst kein `aria-describedby`: An einem `disabled` Control würde er nie vorgelesen.

## Offen

Für die Datenschutzbeauftragte des Museums: ob für den Altbestand (7.698 Zeilen mit `namensnennung = 1`) ein Nachweis nachzuholen ist, oder ob `NULL` plus Notiz im Verarbeitungsverzeichnis genügt. Ebenso, ob es einen Weg für nachträglich (z. B. telefonisch) erteilte Einwilligungen braucht — der gehörte dann als eigene, benannte Aktion in `audit_logs`, nicht als Checkbox.

## Verifikation

- `npm run test:quick` — 189 Dateien, 2818 Tests grün; Lint, Type-Check, Svelte-Check sauber
- `npm run test:unit:client` — 22 Dateien, 233 Tests grün

Die zwei Lint-Warnungen in `src/tests/contract/helpers/createEvent.ts` sind vorbestehend und unberührt.

Test-First eingehalten; jede Verhaltensänderung hatte einen rot laufenden Test. Bei einem davon war der erste Testlauf **vakuum-grün** — der `mapFormToSighting`-Mock in `sightingRepository.test.ts` erzeugte die geprüften Spalten gar nicht. Der Mock erzeugt sie jetzt mit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)