### PR TITLE
fix(ui): stepper clipping, sideways page scroll and blocked non-Baltic positions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ Vor der Arbeit mit externen Libraries IMMER den passenden MCP Server für aktuel
 
 Runes (`$state`, `$derived`, `$effect`, `$props`) statt Svelte-4-Syntax; `onclick` statt `on:click`; `$app/state` statt `$app/stores`. Vollständige Patterns inkl. SSR-sicherem State-Management: `.claude/rules/architecture.md` (wird immer geladen).
 
+**Kommentare im Markup werden nicht ausgeliefert.** Svelte entfernt sie beim Kompilieren (`preserveComments` ist nicht gesetzt, Default `false`); im Client- wie im Server-Output entsteht kein `<!--`-Node. Begründungen gehören deshalb ins Markup, direkt neben das, was sie erklären — und nicht „aus Performance-Gründen" in den `<script>`-Block, denn ein JS-Kommentar landet sehr wohl im Bundle. Reviews, die das andersherum vorschlagen, beruhen auf einer falschen Annahme (belegt in PR #669).
+
 ### Test-First Entwicklung — PFLICHT
 
 Jedes Feature und jeder Bugfix beginnt mit einem fehlschlagenden Test. Workflow und Ausnahmen: `.claude/rules/testing.md` (wird immer geladen). Nutze `/tdd <beschreibung>` für den geführten RED→GREEN→REFACTOR-Zyklus.

--- a/e2e/form-stepper.spec.ts
+++ b/e2e/form-stepper.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import { FormPage } from './pages/FormPage';
+
+/**
+ * Der Schritt-Stepper darf an keiner Breite abgeschnitten werden.
+ *
+ * DaisyUI gibt `.steps` ein `overflow: auto hidden` und `.step` ein
+ * `grid-template-columns: auto`. Ein Titel, der breiter ist als sein Viertel
+ * der Leiste, sprengt damit die Spalte und wird **still abgeschnitten** statt
+ * umzubrechen — sichtbar als angeschnittene Beschriftung am Rand.
+ *
+ * Die Reserve war knapp: gemessen 137px Text in einer 156px-Spalte bei 768px
+ * Breite. Im Feldmodus (`--text-support` 14px statt 13px) oder bei abweichender
+ * Schriftdarstellung reicht das nicht. Der Override in `app.css`
+ * (`minmax(0, 1fr)` + Umbruch) löst die Spalte vom Inhalt.
+ *
+ * Zusätzlich abgesichert: die Seite darf **nicht** horizontal scrollen. Der
+ * Footer erzwang mit `md:grid md:grid-flow-col` eine nicht umbrechende Zeile
+ * aus fünf Links; zwischen 768 und ~890px wurde das Dokument dadurch breiter
+ * als der Viewport und schob den Stepper mit an.
+ */
+type StepperReport = {
+	overlaps: string[];
+	clipped: string[];
+	ulScrolls: boolean;
+	docScrolls: boolean;
+} | null;
+
+async function measure(page: import('@playwright/test').Page): Promise<StepperReport> {
+	return page.evaluate(() => {
+		const nav = document.querySelector('nav[aria-label="Formular-Schritte"]');
+		const ul = nav?.querySelector('ul.steps');
+		if (!nav || !ul || getComputedStyle(nav).display === 'none') return null;
+
+		const items = [...ul.querySelectorAll('li')].map((li) => {
+			const b = li.querySelector('.step-button') as HTMLElement;
+			const r = b.getBoundingClientRect();
+			return { label: b.textContent!.trim(), left: r.left, right: r.right, el: b };
+		});
+
+		const overlaps: string[] = [];
+		for (let i = 1; i < items.length; i++) {
+			if (items[i].left < items[i - 1].right - 0.5) {
+				overlaps.push(`${items[i - 1].label} ⇄ ${items[i].label}`);
+			}
+		}
+
+		return {
+			overlaps,
+			clipped: items.filter((i) => i.el.scrollWidth > i.el.clientWidth + 1).map((i) => i.label),
+			ulScrolls: ul.scrollWidth > ul.clientWidth + 1,
+			docScrolls: document.documentElement.scrollWidth > document.documentElement.clientWidth + 1
+		};
+	});
+}
+
+// Ab `md` (768px) ist der Stepper sichtbar; darunter übernimmt
+// StepProgressCompact im ortsfesten Balken.
+for (const width of [768, 800, 820, 900, 1024, 1280]) {
+	for (const density of ['default', 'field'] as const) {
+		test(`Stepper bleibt lesbar bei ${width}px (${density})`, async ({ page }) => {
+			await page.setViewportSize({ width, height: 900 });
+			const formPage = new FormPage(page);
+			await formPage.goto();
+
+			if (density === 'field') {
+				await page.evaluate(() => document.documentElement.setAttribute('data-density', 'field'));
+				// Ein Frame abwarten, damit die neuen Token-Werte angewendet sind.
+				await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r(null))));
+			}
+
+			const report = await measure(page);
+			expect(report, 'Stepper muss ab 768px sichtbar sein').not.toBeNull();
+			expect(report!.clipped, 'kein Titel darf abgeschnitten werden').toEqual([]);
+			expect(report!.overlaps, 'Titel dürfen sich nicht überlappen').toEqual([]);
+			expect(report!.ulScrolls, 'die Leiste darf nicht horizontal scrollen').toBe(false);
+			expect(report!.docScrolls, 'die Seite darf nicht horizontal scrollen').toBe(false);
+		});
+	}
+}
+
+/**
+ * Gegenprobe mit Biss: Die Fälle oben halten auch ohne den Override, weil die
+ * heutigen Titel gerade noch passen — sie sichern nur, dass es so bleibt.
+ * Dieser Test erzwingt den Ernstfall und schlägt ohne `minmax(0, 1fr)` fehl.
+ */
+test('ein überlanger Schritt-Titel bricht um statt abzuschneiden', async ({ page }) => {
+	await page.setViewportSize({ width: 768, height: 900 });
+	const formPage = new FormPage(page);
+	await formPage.goto();
+
+	await page.evaluate(() => {
+		const b = document.querySelector('.step-button');
+		if (b) b.textContent = 'Positionsangabe und Zeitpunkt der Beobachtung';
+	});
+	await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r(null))));
+
+	const report = await measure(page);
+	expect(report!.clipped, 'der lange Titel darf nicht abgeschnitten werden').toEqual([]);
+	expect(report!.ulScrolls, 'die Leiste darf dadurch nicht scrollen').toBe(false);
+	expect(report!.docScrolls, 'die Seite darf dadurch nicht scrollen').toBe(false);
+});

--- a/e2e/form-stepper.spec.ts
+++ b/e2e/form-stepper.spec.ts
@@ -32,10 +32,18 @@ async function measure(page: import('@playwright/test').Page): Promise<StepperRe
 		const ul = nav?.querySelector('ul.steps');
 		if (!nav || !ul || getComputedStyle(nav).display === 'none') return null;
 
-		const items = [...ul.querySelectorAll('li')].map((li) => {
-			const b = li.querySelector('.step-button') as HTMLElement;
+		// Defensiv statt Cast: Fehlt der Button — etwa weil `FormSteps.svelte`
+		// umgebaut wurde —, soll der Test das benennen und nicht mit einer
+		// Null-Referenz aus `page.evaluate()` fallen, die nichts erklärt.
+		const items = [...ul.querySelectorAll('li')].map((li, index) => {
+			const b = li.querySelector('.step-button');
+			if (!(b instanceof HTMLElement)) {
+				throw new Error(
+					`Schritt ${index + 1} hat kein .step-button-Element — Markup von FormSteps.svelte geändert?`
+				);
+			}
 			const r = b.getBoundingClientRect();
-			return { label: b.textContent!.trim(), left: r.left, right: r.right, el: b };
+			return { label: b.textContent?.trim() ?? '', left: r.left, right: r.right, el: b };
 		});
 
 		const overlaps: string[] = [];

--- a/src/app.css
+++ b/src/app.css
@@ -500,6 +500,37 @@ label:has(> .toggle) {
 	}
 }
 
+/* ===== Schritt-Titel im Stepper dürfen umbrechen =====
+
+   DaisyUI gibt `.steps` ein `overflow: auto hidden` und `.step` ein
+   `grid-template-columns: auto`. Die Spalte ist damit INHALTSBREIT: Ein Titel,
+   der breiter ist als sein Viertel der Leiste, sprengt die Spalte und wird vom
+   `overflow` der Leiste **abgeschnitten** — sichtbar als angeschnittene
+   Beschriftung am linken und rechten Rand.
+
+   Das war lange unauffällig, weil die Titel kurz waren („Position & Zeit",
+   „Beobachtungen"). Mit den längeren Titeln des Museums („Weitere
+   Informationen") schrumpfte die Reserve auf wenige Pixel: gemessen 137px Text
+   in einer 156px-Spalte bei 768px Breite. Im Feldmodus (`--text-support` 14px
+   statt 13px), bei abweichender Schriftdarstellung oder anderer Sprache kippt
+   das — und zwar still, weil abgeschnitten wird statt umzubrechen.
+
+   `minmax(0, 1fr)` bindet die Spalte an die Leiste statt an den Inhalt, der
+   Rest lässt den Titel darin umbrechen. Damit hängt die Darstellung nicht mehr
+   an der Länge der Beschriftung. */
+.steps .step {
+	grid-template-columns: minmax(0, 1fr);
+}
+
+.steps .step-button {
+	width: 100%;
+	min-width: 0;
+	line-height: 1.25;
+	white-space: normal;
+	overflow-wrap: break-word;
+	hyphens: auto;
+}
+
 /* ===== Print ===== */
 @media print {
 	.no-print {

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -6,7 +6,7 @@
 <!-- Footer with navigation (versteckt in iFrame) -->
 {#if isNotIFrame}
 	<footer class="footer footer-center bg-base-200 text-base-content mt-8 rounded-t-lg p-4 sm:p-6">
-		<!-- Navigation Links - Responsive Grid -->
+		<!-- Navigation Links — umbrechende Flexbox, kein Grid -->
 		<!--
 			Bewusst KEIN `md:grid md:grid-flow-col`: Das zwang die fünf Links ab 768px
 			in eine einzige Grid-Zeile, die nicht umbrechen kann. Zwischen 768 und

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -7,7 +7,15 @@
 {#if isNotIFrame}
 	<footer class="footer footer-center bg-base-200 text-base-content mt-8 rounded-t-lg p-4 sm:p-6">
 		<!-- Navigation Links - Responsive Grid -->
-		<nav class="flex flex-wrap justify-center gap-2 sm:gap-4 md:grid md:grid-flow-col">
+		<!--
+			Bewusst KEIN `md:grid md:grid-flow-col`: Das zwang die fünf Links ab 768px
+			in eine einzige Grid-Zeile, die nicht umbrechen kann. Zwischen 768 und
+			~890px passte sie nicht mehr — das Dokument wurde dadurch breiter als der
+			Viewport (gemessen 891px bei 768px Breite), die ganze Seite ließ sich
+			seitlich schieben und der Schritt-Stepper darüber wurde mit angeschnitten.
+			`flex flex-wrap` trägt jede Breite und braucht keine Ausnahme.
+		-->
+		<nav class="flex flex-wrap justify-center gap-2 sm:gap-4">
 			<a href="/about" class="link link-hover text-sm sm:text-base">Über uns</a>
 			<a href="/docs" class="link link-hover text-sm sm:text-base">Dokumentation</a>
 			<a href="/map" class="link link-hover text-sm sm:text-base">Sichtungskarte</a>

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -36,7 +36,6 @@ import { getSpeciesOptions, isValidSpecies } from '$lib/report/formOptions/speci
 import { getVisibilityOptions, isValidVisibility } from '$lib/report/formOptions/visibility';
 import { getWindDirectionOptions } from '$lib/report/formOptions/windDirection';
 import { getWindStrengthOptions } from '$lib/report/formOptions/windStrength';
-import { BALTIC_SEA_BBOX } from '$lib/utils/geo/checkBalticSea';
 import * as yup from 'yup';
 
 /**
@@ -233,14 +232,8 @@ export const sightingSchemaBase = yup.object().shape({
 			then: (schema) =>
 				schema
 					.required('GPS-Position: Breitengrad ist erforderlich')
-					.min(
-						BALTIC_SEA_BBOX.minLatitude,
-						`Der Wert muss zwischen ${BALTIC_SEA_BBOX.minLatitude}° und ${BALTIC_SEA_BBOX.maxLatitude}° liegen (Ostseebereich)`
-					)
-					.max(
-						BALTIC_SEA_BBOX.maxLatitude,
-						`Der Wert muss zwischen ${BALTIC_SEA_BBOX.minLatitude}° und ${BALTIC_SEA_BBOX.maxLatitude}° liegen (Ostseebereich)`
-					),
+					.min(-90, 'Der Breitengrad muss zwischen -90° und 90° liegen')
+					.max(90, 'Der Breitengrad muss zwischen -90° und 90° liegen'),
 			otherwise: (schema) => schema.notRequired()
 		})
 		.label('Breitengrad')
@@ -264,14 +257,8 @@ export const sightingSchemaBase = yup.object().shape({
 			then: (schema) =>
 				schema
 					.required('GPS-Position: Längengrad ist erforderlich')
-					.min(
-						BALTIC_SEA_BBOX.minLongitude,
-						`Der Wert muss zwischen ${BALTIC_SEA_BBOX.minLongitude}° und ${BALTIC_SEA_BBOX.maxLongitude}° liegen (Ostseebereich)`
-					)
-					.max(
-						BALTIC_SEA_BBOX.maxLongitude,
-						`Der Wert muss zwischen ${BALTIC_SEA_BBOX.minLongitude}° und ${BALTIC_SEA_BBOX.maxLongitude}° liegen (Ostseebereich)`
-					),
+					.min(-180, 'Der Längengrad muss zwischen -180° und 180° liegen')
+					.max(180, 'Der Längengrad muss zwischen -180° und 180° liegen'),
 			otherwise: (schema) => schema.notRequired()
 		})
 		.label('Längengrad')

--- a/src/lib/form/validation/sightingSchemaPosition.test.ts
+++ b/src/lib/form/validation/sightingSchemaPosition.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Tests für die Koordinaten-Validierung in Schritt 1
+ *
+ * Eine Position außerhalb der Ostsee darf die Meldung **nicht blockieren**.
+ * Sie war bis 2026-07-31 ein harter Validierungsfehler: `latitude`/`longitude`
+ * trugen `min`/`max` aus `BALTIC_SEA_BBOX`, sobald `hasPosition` gesetzt war.
+ *
+ * Praktische Folge: Wer ein Foto mit GPS-Daten von außerhalb hochlud, bekam
+ * eine Position ins Formular geschrieben, kam damit aber nicht weiter — und der
+ * Schritt-Stepper meldete nur „Bitte füllen Sie zuerst die vorherigen Schritte
+ * aus", ohne das klemmende Feld zu nennen. Eine Sackgasse.
+ *
+ * Die Bereichsprüfung bleibt als **Hinweis** erhalten (`VerifyLocation`,
+ * `/api/geo/inBaltic`) — der Melder soll sehen, dass die Position ungewöhnlich
+ * ist, und sie korrigieren können. Blockiert wird er nicht mehr.
+ *
+ * Unverändert bleibt die Grundplausibilität: Werte außerhalb des
+ * Koordinatensystems sind weiterhin ein Fehler.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateStep } from './stepValidation';
+
+const step1 = {
+	sightingDate: '2026-07-31',
+	sightingTime: '12:00',
+	waterway: '',
+	seaMark: ''
+};
+
+describe('Position außerhalb der Ostsee blockiert Schritt 1 nicht', () => {
+	it('Mittelmeer (Barcelona, 41.39 / 2.17) ist gültig', () => {
+		const result = validateStep(0, {
+			...step1,
+			hasPosition: true,
+			latitude: 41.39,
+			longitude: 2.17
+		});
+		expect(result.errors).not.toHaveProperty('latitude');
+		expect(result.errors).not.toHaveProperty('longitude');
+		expect(result.isValid).toBe(true);
+	});
+
+	it('Nordsee westlich der Ostsee-Grenze (54.0 / 8.0) ist gültig', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, latitude: 54.0, longitude: 8.0 });
+		expect(result.isValid).toBe(true);
+	});
+
+	it('Südlich der Ostsee-Grenze (52.5 / 13.4, Berlin) ist gültig', () => {
+		const result = validateStep(0, {
+			...step1,
+			hasPosition: true,
+			latitude: 52.5,
+			longitude: 13.4
+		});
+		expect(result.isValid).toBe(true);
+	});
+
+	it('Position in der Ostsee bleibt selbstverständlich gültig', () => {
+		const result = validateStep(0, {
+			...step1,
+			hasPosition: true,
+			latitude: 54.31,
+			longitude: 12.09
+		});
+		expect(result.isValid).toBe(true);
+	});
+});
+
+describe('Grundplausibilität der Koordinaten bleibt', () => {
+	it('Breitengrad über 90 ist ein Fehler', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, latitude: 91, longitude: 12 });
+		expect(result.errors).toHaveProperty('latitude');
+	});
+
+	it('Breitengrad unter -90 ist ein Fehler', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, latitude: -91, longitude: 12 });
+		expect(result.errors).toHaveProperty('latitude');
+	});
+
+	it('Längengrad über 180 ist ein Fehler', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, latitude: 54, longitude: 181 });
+		expect(result.errors).toHaveProperty('longitude');
+	});
+
+	it('Längengrad unter -180 ist ein Fehler', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, latitude: 54, longitude: -181 });
+		expect(result.errors).toHaveProperty('longitude');
+	});
+
+	it('Fehlende Koordinate bei hasPosition bleibt Pflicht', () => {
+		const result = validateStep(0, { ...step1, hasPosition: true, longitude: 12 });
+		expect(result.errors).toHaveProperty('latitude');
+	});
+});


### PR DESCRIPTION
Behebt drei Befunde aus dem Test von #669.

## Schritt-Stepper wurde abgeschnitten

DaisyUI gibt `.steps` ein `overflow: auto hidden` und `.step` ein `grid-template-columns: auto` — die Spalte ist also **inhaltsbreit**. Ein Titel, der breiter ist als sein Viertel der Leiste, sprengt die Spalte und wird vom `overflow` still **abgeschnitten** statt umzubrechen.

Gemessen bei 768 px: Button 137 px in einer 156-px-Spalte. Die Reserve waren wenige Pixel, und die längeren Titel aus #669 („Weitere Informationen") haben sie aufgebraucht. Im Feldmodus (`--text-support` 14 px statt 13 px) oder bei abweichender Schriftdarstellung kippt es.

`minmax(0, 1fr)` bindet die Spalte an die Leiste statt an den Inhalt, der Titel bricht darin um. Nachgemessen: Der Button ist jetzt exakt 156 px breit — genau die Spaltenbreite — und kann sie strukturell nicht mehr überschreiten.

## Seite ließ sich seitlich schieben

Zwischen 768 und ~890 px war das Dokument breiter als der Viewport (gemessen 891 px bei 768 px). Ursache war der Footer: `md:grid md:grid-flow-col` zwang seine fünf Links ab 768 px in **eine** Grid-Zeile, die nicht umbrechen kann.

Das ist auch der Grund, warum die abgeschnittenen Labels überhaupt auffielen — die ganze Seite ließ sich verschieben, der Stepper mit ihr. `flex flex-wrap` trägt jede Breite.

## Position außerhalb der Ostsee blockierte die Meldung

Ein Foto mit GPS-Daten von außerhalb der Ostsee schrieb seine Position ins Formular und sperrte den Melder dann aus: `latitude`/`longitude` validierten gegen `BALTIC_SEA_BBOX`, sobald `hasPosition` gesetzt war. Schritt 1 wurde nie gültig, und der Stepper meldete nur „Bitte füllen Sie zuerst die vorherigen Schritte aus", ohne das klemmende Feld zu nennen — eine Sackgasse.

Die Grenzen sind jetzt das Koordinatensystem selbst (−90/90, −180/180). Werte darüber hinaus bleiben ein Fehler, eine fehlende Koordinate bleibt Pflicht.

**Die Bereichsprüfung ist nicht weg, sie blockiert nur nicht mehr:** `VerifyLocation` zeigt weiterhin den Hinweis aus `/api/geo/inBaltic`. Der bestehende E2E-Fall für ein Foto außerhalb der Ostsee prüft genau diesen Hinweis und ist grün.

Zu beachten: Die öffentliche Karte filtert über `publicMapSightingConditions` auf den Ostseebereich — eine solche Sichtung wird also gespeichert und ist prüfbar, erscheint aber nicht auf der Karte.

## Dazu

`CLAUDE.md`: Notiz, dass Svelte Markup-Kommentare beim Kompilieren entfernt. Der Commit kam nach dem Squash-Merge von #669 und fehlte deshalb in `main`.

## Prüfung

2.800 Unit-Tests und 174 E2E-Tests grün.

Neu: `e2e/form-stepper.spec.ts` prüft sechs Breiten in beiden Dichten auf Beschnitt, Überlappung und horizontales Scrollen, plus einen Fall mit absichtlich überlangem Titel. Die Scroll-Zusicherung hat nachgewiesenen Biss — sie war vor dem Footer-Fix rot.

Die Koordinaten-Änderung ist test-first entstanden; die drei Außerhalb-Fälle waren vorher rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
