### PR TITLE
fix(map): let the mouse wheel zoom without a click outside the iframe

### DIFF
--- a/e2e/map-pan-zoom.spec.ts
+++ b/e2e/map-pan-zoom.spec.ts
@@ -290,10 +290,16 @@ test.describe('Sichtungskarte im iframe — Mausrad', () => {
 			route.fulfill({
 				status: 200,
 				contentType: 'text/html',
+				// Die Rahmenseite ist bewusst **scrollbar**: Der Rahmen füllt den Viewport,
+				// darunter steht Platz. Nur so lässt sich überhaupt messen, ob ein Rad über
+				// der Karte an die einbettende Seite durchgereicht wird — mit `overflow:hidden`
+				// bliebe der Scroll-Wert zwangsläufig bei 0 und die Aussage wäre leer.
 				body: `<!doctype html><html><head><meta charset="utf-8"><style>
-					html,body{margin:0;height:100%;overflow:hidden}
-					iframe{border:0;width:100%;height:100%;display:block}
-				</style></head><body><iframe src="/map" title="Sichtungskarte"></iframe></body></html>`
+					html,body{margin:0}
+					iframe{border:0;width:100%;height:100vh;display:block}
+					.nach-der-karte{height:600px}
+				</style></head><body><iframe src="/map" title="Sichtungskarte"></iframe>
+				<div class="nach-der-karte">Inhalt der einbettenden Seite</div></body></html>`
 			})
 		);
 
@@ -324,14 +330,22 @@ test.describe('Sichtungskarte im iframe — Mausrad', () => {
 		return { x: box.x + box.width * relX, y: box.y + box.height * relY };
 	}
 
-	test('Mausrad zoomt nicht ohne Fokus, damit die einbettende Seite scrollen kann', async ({
-		page
-	}) => {
+	test('Mausrad ohne Fokus scrollt die einbettende Seite, statt zu zoomen', async ({ page }) => {
 		const { mapFrame, box } = await embedMap(page);
 
 		const before = await hoverAndSettle(page, pointInFrame(box), mapFrame);
+		expect(await page.evaluate(() => window.scrollY), 'Rahmenseite startet nicht oben').toBe(0);
 
-		await page.mouse.wheel(0, -400);
+		// Nach unten, denn oben am Dokumentanfang gäbe es nichts zu scrollen.
+		await page.mouse.wheel(0, 400);
+
+		// Der eigentliche Punkt: Das Rad landet bei der einbettenden Seite.
+		await expect
+			.poll(async () => page.evaluate(() => window.scrollY), {
+				timeout: 4000,
+				message: 'Rahmenseite hat nicht gescrollt — die Karte hat das Rad verschluckt'
+			})
+			.toBeGreaterThan(0);
 
 		await expectMapToStayPut(
 			mapFrame,
@@ -341,14 +355,18 @@ test.describe('Sichtungskarte im iframe — Mausrad', () => {
 	});
 
 	/**
-	 * Positiv-Kontrolle zum Test darüber.
+	 * Positiv-Kontrolle zum Test darüber — und dessen Spiegelbild.
 	 *
 	 * `expectMapToStayPut` ist mit **jedem** Grund zufrieden, aus dem sich das
 	 * Kartenbild nicht ändert — auch damit, dass das Mausrad den Frame nie erreicht
 	 * oder die Karte dort gar nicht zoomen kann. Erst dieser Test zeigt, dass beides
-	 * funktioniert und oben wirklich die Condition gebremst hat.
+	 * funktioniert und oben wirklich die Condition gebremst hat. Gleiche Geste,
+	 * gleiche Rahmenseite, vertauschtes Ergebnis: hier zoomt die Karte und die
+	 * einbettende Seite bleibt stehen, weil `MouseWheelZoom` `preventDefault()` ruft.
 	 */
-	test('Mausrad zoomt im iframe nach einem Klick in die Karte', async ({ page }) => {
+	test('Mausrad nach einem Klick in die Karte zoomt und lässt die Rahmenseite stehen', async ({
+		page
+	}) => {
 		const { mapFrame, box } = await embedMap(page);
 
 		// Abseits der Sichtungen klicken, damit kein Popup mit `autoPan` die Ansicht bewegt.
@@ -357,12 +375,17 @@ test.describe('Sichtungskarte im iframe — Mausrad', () => {
 
 		const before = await hoverAndSettle(page, pointInFrame(box), mapFrame);
 
-		await page.mouse.wheel(0, -400);
+		await page.mouse.wheel(0, 400);
 
 		await expectMapToMove(
 			mapFrame,
 			before,
 			'Mausrad-Zoom blieb im iframe auch mit Fokus ohne Wirkung — der Test darüber wäre damit gehaltlos'
 		);
+
+		expect(
+			await page.evaluate(() => window.scrollY),
+			'Rahmenseite ist trotz Karten-Zoom mitgescrollt'
+		).toBe(0);
 	});
 });

--- a/e2e/map-pan-zoom.spec.ts
+++ b/e2e/map-pan-zoom.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type Frame, type Page } from '@playwright/test';
 import { MapPage } from './pages/MapPage';
 import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
 
@@ -31,9 +31,16 @@ import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
  * bestätigte der Test am Ende diesen Nebeneffekt statt des Pans.
  */
 
+/**
+ * Wo die Karte lebt: im Hauptdokument (`Page`) oder — für den iframe-Fall — im
+ * eingebetteten Frame. Nur das Messen ist frame-abhängig; Maus-Eingaben laufen
+ * immer über die `Page`, weil Playwright Koordinaten am Viewport misst.
+ */
+type MapScope = Page | Frame;
+
 /** Ein Wert, der sich ändert, sobald sich das Kartenbild ändert. */
-async function canvasState(page: Page): Promise<{ hash: number; distinct: number } | null> {
-	return page.evaluate(() => {
+async function canvasState(scope: MapScope): Promise<{ hash: number; distinct: number } | null> {
+	return scope.evaluate(() => {
 		const canvases = [...document.querySelectorAll<HTMLCanvasElement>('#map canvas')];
 		if (canvases.length === 0) return null;
 
@@ -65,14 +72,14 @@ async function canvasState(page: Page): Promise<{ hash: number; distinct: number
  * gleich — sonst würde eine noch laufende Erstdarstellung als Pan-Wirkung
  * durchgehen.
  */
-async function settledCanvasHash(page: Page): Promise<number> {
+async function settledCanvasHash(scope: MapScope): Promise<number> {
 	let previous: number | null = null;
 	let current: number | null = null;
 
 	await expect
 		.poll(
 			async () => {
-				const state = await canvasState(page);
+				const state = await canvasState(scope);
 				previous = current;
 				current = state?.hash ?? null;
 				return current !== null && current === previous;
@@ -87,7 +94,7 @@ async function settledCanvasHash(page: Page): Promise<number> {
 
 	// Gegenprobe: Ein einfarbiges Canvas könnte sich durch einen Pan nicht
 	// verändern — der Test wäre dann gehaltlos statt aussagekräftig.
-	const state = await canvasState(page);
+	const state = await canvasState(scope);
 	expect(
 		state?.distinct ?? 0,
 		'Karte zeichnet nichts — Fingerprint wäre gehaltlos'
@@ -97,9 +104,9 @@ async function settledCanvasHash(page: Page): Promise<number> {
 }
 
 /** Erwartet, dass sich das Kartenbild binnen weniger Sekunden verändert. */
-async function expectMapToMove(page: Page, before: number, hinweis: string): Promise<void> {
+async function expectMapToMove(scope: MapScope, before: number, hinweis: string): Promise<void> {
 	await expect
-		.poll(async () => (await canvasState(page))?.hash ?? null, {
+		.poll(async () => (await canvasState(scope))?.hash ?? null, {
 			timeout: 4000,
 			intervals: [150, 250, 400, 600],
 			message: hinweis
@@ -117,10 +124,10 @@ async function expectMapToMove(page: Page, before: number, hinweis: string): Pro
  * `expectMapToMove`-Toleranz, damit ein verzögerter Zoom nicht durchrutscht:
  * `MouseWheelZoom` arbeitet intern mit einem Timeout und einer Animation.
  */
-async function expectMapToStayPut(page: Page, before: number, hinweis: string): Promise<void> {
+async function expectMapToStayPut(scope: MapScope, before: number, hinweis: string): Promise<void> {
 	for (let versuch = 0; versuch < 8; versuch++) {
-		await page.waitForTimeout(200);
-		const jetzt = (await canvasState(page))?.hash ?? null;
+		await scope.waitForTimeout(200);
+		const jetzt = (await canvasState(scope))?.hash ?? null;
 		expect(jetzt, `${hinweis} (Messung ${versuch + 1} von 8)`).toBe(before);
 	}
 }
@@ -153,9 +160,13 @@ async function mapPoint(page: Page, relX = 0.45, relY = 0.5) {
  * dann auch ohne Pan grün, und ein Test auf „hat sich nicht bewegt" fälschlich rot
  * (genau so ist der Mausrad-Test beim ersten Lauf gescheitert).
  */
-async function hoverAndSettle(page: Page, point: { x: number; y: number }): Promise<number> {
+async function hoverAndSettle(
+	page: Page,
+	point: { x: number; y: number },
+	scope: MapScope = page
+): Promise<number> {
 	await page.mouse.move(point.x, point.y);
-	return settledCanvasHash(page);
+	return settledCanvasHash(scope);
 }
 
 test.describe('Sichtungskarte — Pan und Zoom', () => {
@@ -213,31 +224,32 @@ test.describe('Sichtungskarte — Pan und Zoom', () => {
 		);
 	});
 
-	// ── Mausrad: Fokus-Schutz bleibt absichtlich erhalten ──────────────────────
+	// ── Mausrad: freigeschaltet, solange die App nicht eingebettet ist ─────────
 	//
-	// Anders als beim Ziehen ist das beim Mausrad **gewolltes** Verhalten und keine
-	// Einschränkung: Die App wird auf meeresmuseum.de in einem iframe eingebettet.
-	// Wer dort die Seite scrollen will, würde ohne diesen Schutz stattdessen die
-	// Karte zoomen. `MouseWheelZoom` behält deshalb die OpenLayers-Default-Condition
-	// `focusWithTabindex` — siehe die Begründung an `interactions:` in
+	// Der Fokus-Zwang des Mausrads stammt aus derselben Quelle wie der beim Ziehen
+	// (`focusWithTabindex`, ausgelöst durch das `tabindex="0"` am `#map`-Div) und
+	// war für Nutzer derselbe Defekt: erst klicken, dann zoomen. Er hat nur **im
+	// iframe** einen Sinn — dort würde ein ungebremstes Mausrad das Scrollen der
+	// einbettenden Seite verschlucken. Auf der eigenen Seite gibt es nichts zu
+	// schützen, dort zoomt das Rad sofort. Siehe `interactions:` in
 	// `optimizedMapController.ts`.
 
-	test('Mausrad zoomt nicht, solange die Karte keinen Fokus hat', async ({ page }) => {
+	test('Mausrad zoomt ohne vorherigen Klick', async ({ page }) => {
 		const point = await mapPoint(page);
 		const before = await hoverAndSettle(page, point);
 
 		await page.mouse.wheel(0, -400);
 
-		await expectMapToStayPut(
+		await expectMapToMove(
 			page,
 			before,
-			'Mausrad hat ohne Fokus gezoomt — der Scroll-Hijacking-Schutz ist weg'
+			'Mausrad-Zoom blieb ohne Klick wirkungslos — genau der berichtete Befund'
 		);
 	});
 
-	test('Mausrad zoomt nach einem Klick in die Karte', async ({ page }) => {
-		// Der Klick setzt den Fokus auf das `#map`-Div (`tabindex="0"`) und schaltet
-		// damit `focusWithTabindex` frei.
+	test('Mausrad zoomt auch nach einem Klick in die Karte', async ({ page }) => {
+		// Kontrollfall: Der Klick setzt den Fokus auf das `#map`-Div und darf am
+		// Ergebnis nichts ändern.
 		const klickPunkt = await mapPoint(page, 0.2, 0.85);
 		await page.mouse.click(klickPunkt.x, klickPunkt.y);
 
@@ -247,5 +259,110 @@ test.describe('Sichtungskarte — Pan und Zoom', () => {
 		await page.mouse.wheel(0, -400);
 
 		await expectMapToMove(page, before, 'Mausrad-Zoom blieb auch mit Fokus ohne Wirkung');
+	});
+});
+
+/**
+ * Der Gegenfall zum Mausrad-Test oben.
+ *
+ * Die App wird auf meeresmuseum.de in einem iframe eingebettet. Zoomte die Karte
+ * dort ohne Fokus, könnte niemand mehr an ihr vorbeiscrollen — sie füllt den
+ * Rahmen, und `MouseWheelZoom` ruft `preventDefault()`, sodass das Scrollen nicht
+ * an die einbettende Seite durchgereicht wird. Deshalb bleibt im iframe der
+ * Fokus-Zwang.
+ *
+ * Die Rahmenseite kommt aus einer gerouteten Antwort und nicht aus `setContent`, weil
+ * letzteres das Dokument auf `about:blank` stehen lässt — ein `<iframe src="/map">`
+ * hätte dort keine Basis-URL zum Auflösen. Für `isNotIFrame` spielt die Herkunft keine
+ * Rolle: `window === window.top` funktioniert auch über Origin-Grenzen, und die
+ * Produktions-Einbettung auf meeresmuseum.de ist ohnehin cross-origin.
+ */
+test.describe('Sichtungskarte im iframe — Mausrad', () => {
+	const HOST_ROUTE = '/e2e/iframe-host';
+
+	type Box = { x: number; y: number; width: number; height: number };
+
+	/** Baut die Rahmenseite, wartet auf die Karte im Frame und gibt beides zurück. */
+	async function embedMap(page: Page): Promise<{ mapFrame: Frame; box: Box }> {
+		await mockMapSightingsWithFeatures(page);
+
+		await page.route(`**${HOST_ROUTE}`, (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'text/html',
+				body: `<!doctype html><html><head><meta charset="utf-8"><style>
+					html,body{margin:0;height:100%;overflow:hidden}
+					iframe{border:0;width:100%;height:100%;display:block}
+				</style></head><body><iframe src="/map" title="Sichtungskarte"></iframe></body></html>`
+			})
+		);
+
+		await page.goto(HOST_ROUTE);
+
+		// Der Filter-Reiter beweist, dass `SightingsMapView` im Frame steht.
+		await expect(
+			page.frameLocator('iframe').getByRole('button', { name: /^filter$/i })
+		).toBeVisible({ timeout: 20000 });
+
+		const mapFrame = page.frames().find((f) => f.url().includes('/map'));
+		if (!mapFrame) throw new Error('iframe mit /map nicht gefunden');
+
+		// Gegenprobe zur Voraussetzung: Ohne echte Einbettung wäre der Test gehaltlos.
+		expect(
+			await mapFrame.evaluate(() => window === window.top),
+			'Frame hält sich nicht für eingebettet'
+		).toBe(false);
+
+		const box = await page.locator('iframe').boundingBox();
+		if (!box) throw new Error('iframe hat keine Bounding-Box');
+
+		return { mapFrame, box };
+	}
+
+	/** Punkt innerhalb des eingebetteten Kartenbilds, in Viewport-Koordinaten. */
+	function pointInFrame(box: Box, relX = 0.45, relY = 0.5) {
+		return { x: box.x + box.width * relX, y: box.y + box.height * relY };
+	}
+
+	test('Mausrad zoomt nicht ohne Fokus, damit die einbettende Seite scrollen kann', async ({
+		page
+	}) => {
+		const { mapFrame, box } = await embedMap(page);
+
+		const before = await hoverAndSettle(page, pointInFrame(box), mapFrame);
+
+		await page.mouse.wheel(0, -400);
+
+		await expectMapToStayPut(
+			mapFrame,
+			before,
+			'Karte hat im iframe ohne Fokus gezoomt — der Scroll-Hijacking-Schutz ist weg'
+		);
+	});
+
+	/**
+	 * Positiv-Kontrolle zum Test darüber.
+	 *
+	 * `expectMapToStayPut` ist mit **jedem** Grund zufrieden, aus dem sich das
+	 * Kartenbild nicht ändert — auch damit, dass das Mausrad den Frame nie erreicht
+	 * oder die Karte dort gar nicht zoomen kann. Erst dieser Test zeigt, dass beides
+	 * funktioniert und oben wirklich die Condition gebremst hat.
+	 */
+	test('Mausrad zoomt im iframe nach einem Klick in die Karte', async ({ page }) => {
+		const { mapFrame, box } = await embedMap(page);
+
+		// Abseits der Sichtungen klicken, damit kein Popup mit `autoPan` die Ansicht bewegt.
+		const klickPunkt = pointInFrame(box, 0.2, 0.85);
+		await page.mouse.click(klickPunkt.x, klickPunkt.y);
+
+		const before = await hoverAndSettle(page, pointInFrame(box), mapFrame);
+
+		await page.mouse.wheel(0, -400);
+
+		await expectMapToMove(
+			mapFrame,
+			before,
+			'Mausrad-Zoom blieb im iframe auch mit Fokus ohne Wirkung — der Test darüber wäre damit gehaltlos'
+		);
 	});
 });

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -758,6 +758,7 @@
 			und AT-Reihenfolge — aria-hidden allein ließe die Zoom-Buttons
 			fokussierbar (WCAG 4.1.2, axe "aria-hidden-focus").
 		-->
+		<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 		<div
 			id={mapContainerId}
 			class="sightings-map-target h-full w-full"

--- a/src/lib/map/optimizedMapController.ts
+++ b/src/lib/map/optimizedMapController.ts
@@ -5,7 +5,7 @@ import { defaults as defaultControls } from 'ol/control';
 import type { EventsKey } from 'ol/events';
 import { all, noModifierKeys, primaryAction } from 'ol/events/condition';
 import * as olExtent from 'ol/extent';
-import { defaults as defaultInteractions, DragPan } from 'ol/interaction';
+import { defaults as defaultInteractions, DragPan, MouseWheelZoom } from 'ol/interaction';
 import GeoJSON from 'ol/format/GeoJSON';
 import type { Geometry } from 'ol/geom';
 import { Point as OlPoint } from 'ol/geom';
@@ -21,6 +21,7 @@ import { LocationControl } from './controls/LocationControl.js';
 import { geolocationErrorMessage } from './controls/locationControlState.js';
 import { ZoomAllControl } from './controls/ZoomAllControl.js';
 import { getDefaultSightingYear } from '$lib/utils/date/defaultYear';
+import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 import { clampExtentToBaltic, type Extent } from './extentUtils';
 import { areExtentsColocated, type MapTranslations } from './mapUtils';
 import {
@@ -285,49 +286,51 @@ export class SichtungenMap {
 			}).extend(this.createCustomControls()),
 
 			/**
-			 * Interactions wie OpenLayers sie selbst baut — **nur DragPan** ist vom
-			 * Fokus-Zwang ausgenommen.
+			 * `DragPan` und `MouseWheelZoom` werden aus den Defaults herausgenommen und
+			 * selbst gebaut — sie sind die beiden einzigen Interactions, auf die die
+			 * Option `onFocusOnly` überhaupt wirkt (`ol/interaction/defaults.js`).
+			 * Damit ist hier vollständig beschrieben, wer einen Fokus braucht und wer
+			 * nicht; ein `onFocusOnly` an `defaults()` hätte keinen Adressaten mehr.
 			 *
-			 * `onFocusOnly: true` ist hier kein Zusatz, sondern die Wiederherstellung
-			 * des Verhaltens, das `ol/Map` beim Weglassen der Option verwendet: Map.js
-			 * ruft `defaultInteractions({ onFocusOnly: true })` auf. Ruft man
-			 * `defaults()` dagegen selbst auf, ist der Default `false` — wer das
-			 * übersieht, hebt den Fokus-Schutz still für **alle** Interactions auf. Genau
-			 * das ist beim ersten Anlauf dieses Fixes passiert und im Test aufgefallen.
+			 * Worum es geht: `onFocusOnly` schaltet `focusWithTabindex` vor die
+			 * Condition. Das verlangt — **nur wenn das Map-Target ein `tabindex`
+			 * trägt** — dass der Fokus im Target liegt. `SightingsMapView.svelte` setzt
+			 * genau dieses `tabindex="0"` auf `#map`, damit KeyboardPan und KeyboardZoom
+			 * greifen (Tastaturbedienung, Befund K3). Die Nebenwirkung war der
+			 * wiederholt gemeldete Defekt „die Karte reagiert erst nach einem Klick":
+			 * ohne Fokus lieferte `document.activeElement === <body>`, die Condition
+			 * `false` und die Geste verpuffte — bei einwandfreien, trusted Events. Eine
+			 * Barrierefreiheits-Verbesserung hatte damit die Maussteuerung gebrochen.
 			 *
-			 * Was `onFocusOnly` bewirkt: `DragPan` und `MouseWheelZoom` bekommen
-			 * `all(focusWithTabindex, …)` vorgeschaltet. `focusWithTabindex` verlangt —
-			 * **nur wenn das Map-Target ein `tabindex`-Attribut trägt** — dass der Fokus
-			 * innerhalb des Targets liegt. Der Sinn ist Scroll-Hijacking-Schutz auf
-			 * Seiten, die eine Karte einbetten.
+			 * Ziehen ist deshalb bedingungslos frei: eine eindeutige Absicht, die mit
+			 * nichts konkurriert. Der eigene `DragPan` bekommt die Standard-Condition
+			 * `all(noModifierKeys, primaryAction)` ohne Fokus-Prüfung. `kinetic` bleibt
+			 * bewusst weg: `defaults()` setzt dort eine Schwung-Animation, die auf einer
+			 * Datenkarte eher stört als hilft.
 			 *
-			 * Genau dieses `tabindex="0"` setzt `SightingsMapView.svelte` bewusst auf
-			 * `#map`, damit KeyboardPan und KeyboardZoom greifen (Tastaturbedienung,
-			 * Befund K3). Nebenwirkung: Maus-Pan war damit tot, bis der Nutzer einmal in
-			 * die Karte klickte — die Barrierefreiheits-Verbesserung hat die Maussteuerung
-			 * gebrochen.
+			 * Das Mausrad hängt dagegen an der Einbettung, nicht am Fokus:
 			 *
-			 * Nachgewiesen in `e2e/map-pan-zoom.spec.ts`: Beim ersten Ziehen war
-			 * `document.activeElement` der `<body>`, die Condition damit `false` und
-			 * `DragPan.handleDownEvent` gab `false` zurück — bei identischen, trusted
-			 * Pointer-Events. Nach einem Klick war `activeElement` das `#map`-Div und
-			 * dasselbe Ziehen funktionierte.
+			 * - **Eigene Seite** (`isNotIFrame`): Das Rad zoomt sofort. Die Karte ist der
+			 *   Inhalt der Seite, und wer über ihr scrollt, will zoomen. Vorher scrollte
+			 *   die Geste stattdessen die Seite zum Footer und schob die Karte aus dem
+			 *   Bild. Der Preis: `/map` hat unterhalb der Karte rund 150 px Footer, und
+			 *   der ist über der Karte nicht mehr per Rad erreichbar — nur noch über
+			 *   Scrollbar, Tastatur oder die Navbar-Leiste. Bewusst in Kauf genommen;
+			 *   wer Impressum und Datenschutz dort prominenter braucht, holt sie in die
+			 *   Kartenleiste statt den Zoom wieder zu bremsen.
+			 * - **Im iframe** (meeresmuseum.de): Der Fokus-Zwang bleibt. `MouseWheelZoom`
+			 *   ruft `preventDefault()`; ohne die Bremse käme niemand mehr an der Karte
+			 *   vorbei, weil sie den Rahmen füllt und das Scrollen nicht mehr an die
+			 *   einbettende Seite durchgereicht würde. Ein Klick oder ein Tab in die
+			 *   Karte schaltet den Zoom frei — wie bei eingebetteten Kartendiensten üblich.
 			 *
-			 * Warum nur DragPan ausgenommen ist: Ein Drag ist eine eindeutige Absicht,
-			 * es gibt keine konkurrierende Deutung — der Fokus-Schutz kostet dort nur
-			 * Bedienbarkeit. Das Mausrad ist der Gegenfall: Die App wird auf
-			 * meeresmuseum.de in einem iframe eingebettet, und wer dort die **Seite**
-			 * scrollen will, würde ohne Schutz stattdessen die Karte zoomen. Mausrad-Zoom
-			 * setzt deshalb weiterhin einen Klick oder Tab in die Karte voraus, wie bei
-			 * Kartendiensten üblich.
-			 *
-			 * Der ausgetauschte DragPan bekommt **kein** `onFocusOnly` und damit die
-			 * Standard-Condition `all(noModifierKeys, primaryAction)` ohne Fokus-Prüfung.
-			 * `kinetic` wird bewusst nicht mitgegeben: `defaults()` setzt dort eine
-			 * Schwung-Animation, die auf einer Datenkarte eher stört als hilft.
+			 * Beides ist in `e2e/map-pan-zoom.spec.ts` abgesichert, der iframe-Fall über
+			 * eine eigene Rahmenseite. Wer `tabindex` an einem anderen OL-Target ergänzt,
+			 * muss dieselbe Abwägung mitsetzen.
 			 */
-			interactions: defaultInteractions({ onFocusOnly: true, dragPan: false }).extend([
-				new DragPan({ condition: all(noModifierKeys, primaryAction) })
+			interactions: defaultInteractions({ dragPan: false, mouseWheelZoom: false }).extend([
+				new DragPan({ condition: all(noModifierKeys, primaryAction) }),
+				new MouseWheelZoom({ onFocusOnly: !isNotIFrame })
 			])
 		});
 


### PR DESCRIPTION
## Warum

Gemeldet: „Man muss immer noch erst einmal in die Karte klicken, bevor sie sich bedienen lässt." Betroffen war nur noch **das Mausrad** — Ziehen war am 30.07. bereits repariert.

Ursache ist dieselbe: `SightingsMapView.svelte` setzt `tabindex="0"` auf `#map`, damit `KeyboardPan`/`KeyboardZoom` greifen. Sobald ein OL-Target ein `tabindex` trägt, schaltet `onFocusOnly` bei `DragPan` und `MouseWheelZoom` die Bedingung `focusWithTabindex` davor — die Geste wirkt nur mit Fokus in der Karte, und der liegt beim Seitenaufruf auf dem `<body>`.

Damals wurde nur `DragPan` befreit; für das Rad blieb `onFocusOnly: true` mit der Begründung „Scroll-Hijacking-Schutz". Auf `/map` war das Ergebnis schlechter als angenommen: Das Dokument ist wegen des Footers ~150 px höher als der Viewport, die Radbewegung hat also nicht „nichts" gemacht, sondern **die Seite zum Footer gescrollt und die Karte aus dem Bild geschoben**.

## Was sich ändert

`optimizedMapController.ts` — beide betroffenen Interactions werden jetzt selbst gebaut. Sie sind die einzigen, die `onFocusOnly` überhaupt erreicht (`ol/interaction/defaults.js`), damit steht an einer Stelle vollständig, wer Fokus braucht:

```ts
interactions: defaultInteractions({ dragPan: false, mouseWheelZoom: false }).extend([
    new DragPan({ condition: all(noModifierKeys, primaryAction) }),
    new MouseWheelZoom({ onFocusOnly: !isNotIFrame })
])
```

Der Fokus-Zwang hängt damit an der Einbettung statt am `tabindex`:

- **Eigene Seite:** Das Rad zoomt sofort.
- **Im meeresmuseum.de-iframe:** Der Zwang bleibt. `MouseWheelZoom` ruft `preventDefault()`; ohne die Bremse käme niemand mehr an der Karte vorbei zur einbettenden Seite.

Dazu die gemeldete a11y-Warnung: `role="application"` gilt Svelte als nicht-interaktiv, ein `tabindex ≥ 0` löst deshalb `a11y_no_noninteractive_tabindex` aus. `OLMap.svelte` hatte dafür längst ein `svelte-ignore`, `SightingsMapView.svelte` fehlte es. Am Markup ändert sich nichts — die Karte ist mit `tabindex` echt tastaturbedienbar.

## Tests

`e2e/map-pan-zoom.spec.ts` war auf das alte Verhalten festgeschrieben („Mausrad zoomt **nicht** ohne Fokus"). Der Test ist umgedreht — RED vor der Änderung, GREEN danach — und um ein iframe-Paar ergänzt: einer weist den Schutz dort nach, einer ist die Positiv-Kontrolle dazu (`expectMapToStayPut` wäre sonst auch dann grün, wenn das Rad den Frame nie erreicht).

Grün: 7/7 in dieser Spec, 29/29 über alle Karten-E2E, 2791 Unit-Tests, `lint`/`type-check`/`check` sauber.

## Bewusst offen gelassen

- **Der Footer auf `/map`** ist über der Karte nicht mehr per Rad erreichbar — nur noch über Scrollbar, Tastatur oder die Navbar-Leiste. Im Code kommentiert. Wer Impressum/Datenschutz dort prominenter braucht, holt sie in die Kartenleiste, statt den Zoom wieder zu bremsen.
- **Dieselbe Klasse Defekt lebt noch in der Positionskarte des Meldeformulars** (`OLMap.svelte:209` setzt `tabindex="0"`, `openLayersHelpers.ts` baut die Map ohne `interactions`-Option). Dort ist es heikler, weil der freischaltende Klick zugleich die gemeldete Position setzt — und unbedingter Rad-Zoom auf einer kleinen Inline-Karte mitten in einem langen Formular wäre die falsche Antwort. Gehört in einen eigenen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
