### PR TITLE
refactor(api): share LIKE escaping and consent gate between both public search surfaces

### DIFF
--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -300,6 +300,11 @@ The gating mirrors `/api/map/sightings`, so both public surfaces expose the same
 subset. Additionally, LIKE wildcards (`%`, `_`, `\`) in the search term are
 escaped and matched literally; previously `search=%` matched every record.
 
+Both surfaces build the predicate from `src/lib/server/db/consentGatedSearch.ts`
+rather than each spelling it out, so the "same subset" claim above cannot drift
+apart in a later edit. The one intended difference stays explicit: this endpoint
+passes `ILIKE` (case-insensitive, as specified), the map passes `LIKE`.
+
 **Impact on clients.** A client searching by email, or by the name of a reporter
 without consent, now receives an empty array instead of results. No field name,
 URL path, data type or response structure changed. Admin clients are unaffected.

--- a/src/lib/server/db/consentGatedSearch.test.ts
+++ b/src/lib/server/db/consentGatedSearch.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Tests für die geteilte, consent-gegatete Personensuche.
+ *
+ * Der Nutzen des Moduls ist, dass die beiden öffentlichen Flächen
+ * (`/sichtungen/showreports.json` und `/api/map/sightings`) **dieselbe**
+ * Teilmenge freigeben — genau damit begründet
+ * `docs/LEGACY_API_SPECIFICATION.md` die Abweichung von der Spezifikation.
+ * Diese Tests schreiben deshalb nicht nur das Escaping fest, sondern auch,
+ * dass das Consent-Gate zu beiden Operatoren identisch aufgebaut ist.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { consentGatedNameSearch, containsPattern, escapeLikePattern } from './consentGatedSearch';
+
+const dialect = new PgDialect();
+
+function render(fragment: SQL): { text: string; params: unknown[] } {
+	const query = dialect.sqlToQuery(fragment);
+	return { text: query.sql, params: query.params };
+}
+
+describe('escapeLikePattern', () => {
+	it('escaped die LIKE-Wildcards % und _', () => {
+		// Ohne Escaping matcht `%` jeden Datensatz und `_` jedes Einzelzeichen —
+		// das verstärkt das Membership-Orakel über personenbezogene Felder.
+		expect(escapeLikePattern('50%_x')).toBe('50\\%\\_x');
+	});
+
+	it('escaped den Escape-Zeichen-Backslash selbst', () => {
+		// Sonst könnte ein Suchbegriff das nachfolgende Zeichen entwerten.
+		expect(escapeLikePattern('a\\b')).toBe('a\\\\b');
+	});
+
+	it('lässt gewöhnliche Suchbegriffe unverändert', () => {
+		expect(escapeLikePattern('Schneider')).toBe('Schneider');
+	});
+
+	it('trimmt nicht — das Trimmen gehört zu containsPattern', () => {
+		expect(escapeLikePattern('  Wal  ')).toBe('  Wal  ');
+	});
+});
+
+describe('containsPattern', () => {
+	it('umschließt den escapten Begriff mit %', () => {
+		expect(containsPattern('50%_x')).toBe('%50\\%\\_x%');
+	});
+
+	it('trimmt den Suchbegriff', () => {
+		// Beide Flächen müssen denselben Begriff suchen. Das Map-Frontend trimmt
+		// bereits (urlFilterState.ts), handgebaute URLs bisher nicht.
+		expect(containsPattern('  Wal  ')).toBe('%Wal%');
+	});
+
+	it('erzeugt für einen reinen Whitespace-Begriff das leere Contains-Muster', () => {
+		expect(containsPattern('   ')).toBe('%%');
+	});
+});
+
+describe('consentGatedNameSearch', () => {
+	it('durchsucht Vor- und Nachname nur bei namensnennung = 1', () => {
+		const { text } = render(consentGatedNameSearch('%Private%', 'LIKE'));
+
+		expect(text).toContain('"vorname"');
+		expect(text).toContain('"name"');
+		expect(text).toMatch(/"namensnennung"\s*=\s*1/);
+	});
+
+	it('durchsucht den Schiffsnamen nur bei schiffnamensnennung = 1', () => {
+		const { text } = render(consentGatedNameSearch('%Yacht%', 'LIKE'));
+
+		expect(text).toContain('"schiffsname"');
+		expect(text).toMatch(/"schiffnamensnennung"\s*=\s*1/);
+	});
+
+	it('durchsucht die E-Mail-Adresse nie', () => {
+		// Das Feld ist in keiner öffentlichen Response enthalten; eine Suche
+		// darüber hätte für öffentliche Clients keinen legitimen Zweck.
+		const { text } = render(consentGatedNameSearch('%melder@example.com%', 'ILIKE'));
+
+		expect(text).not.toContain('"email"');
+	});
+
+	it('gibt das Suchmuster als Parameter aus, nicht als SQL-Literal', () => {
+		const { params } = render(consentGatedNameSearch('%50\\%\\_x%', 'LIKE'));
+
+		expect(params).toContain('%50\\%\\_x%');
+	});
+
+	it('setzt die ESCAPE-Klausel für jedes Feld', () => {
+		const { text } = render(consentGatedNameSearch('%x%', 'LIKE'));
+
+		// Drei Felder: vorname, name, schiffsname.
+		expect(text.match(/ESCAPE/g)).toHaveLength(3);
+	});
+
+	it('erzeugt mit ILIKE case-insensitive Vergleiche', () => {
+		// Die Legacy-Route ist vertraglich case-insensitiv.
+		const { text } = render(consentGatedNameSearch('%x%', 'ILIKE'));
+
+		expect(text.match(/ILIKE/g)).toHaveLength(3);
+		// Kein Feld darf auf das case-sensitive LIKE zurückfallen.
+		expect(text).not.toMatch(/(?<!I)LIKE/);
+	});
+
+	it('erzeugt mit LIKE case-sensitive Vergleiche', () => {
+		const { text } = render(consentGatedNameSearch('%x%', 'LIKE'));
+
+		expect(text).not.toContain('ILIKE');
+		expect(text.match(/LIKE/g)).toHaveLength(3);
+	});
+
+	it('unterscheidet sich zwischen LIKE und ILIKE ausschließlich im Operator', () => {
+		// Kern der Zusammenführung: Die Gate-Struktur darf zwischen den beiden
+		// öffentlichen Flächen nicht auseinanderlaufen.
+		const withLike = render(consentGatedNameSearch('%x%', 'LIKE'));
+		const withIlike = render(consentGatedNameSearch('%x%', 'ILIKE'));
+
+		expect(withIlike.text.replace(/ILIKE/g, 'LIKE')).toBe(withLike.text);
+		expect(withIlike.params).toEqual(withLike.params);
+	});
+});

--- a/src/lib/server/db/consentGatedSearch.ts
+++ b/src/lib/server/db/consentGatedSearch.ts
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Consent-gegatete Suche über personenbezogene Felder
+ *
+ * Die *Ausgabe* personenbezogener Felder war immer an die Einwilligung des
+ * Melders gebunden (`namensnennung`, `schiffnamensnennung`), die *Trefferzahl*
+ * einer Suche nicht. Damit konnte ein anonymer Aufrufer prüfen, ob ein Name
+ * im Bestand existiert — auch bei Meldern, die nie zugestimmt haben. Seit
+ * 2026-07-31 ist die Suche deshalb auf beiden öffentlichen Flächen gegated:
+ *
+ * - `/sichtungen/showreports.json` (Legacy-API, anonymer Zweig)
+ * - `/api/map/sightings` (moderne Karte)
+ *
+ * Begründet wird die Einschränkung in `docs/LEGACY_API_SPECIFICATION.md`
+ * („Deviation: consent-gated search") **ausdrücklich damit, dass beide Flächen
+ * dieselbe Teilmenge freigeben**. Genau deshalb steht das Prädikat hier
+ * **einmal** statt zweimal fast zeichengleich in den Routen — analog zu
+ * `approvedOnly()` in `approvalFilter.ts`. Eine Fläche, die das Gate umgeht,
+ * fällt beim Review auf, weil sie diesen Import nicht hat.
+ *
+ * Die E-Mail-Adresse wird bewusst gar nicht durchsucht statt nur gegated: Sie
+ * ist in keiner öffentlichen Response enthalten, eine Suche darüber hat für
+ * öffentliche Clients also keinen legitimen Zweck.
+ *
+ * **Nicht** hier abgebildet ist der Admin-Zweig der Legacy-Route: Eingeloggte
+ * Admins bekommen die volle Vier-Feld-Suche der Spezifikation (inklusive
+ * E-Mail) ohne Gate, weil sie diese Felder ohnehin sehen.
+ */
+
+import { sightings } from '$lib/server/db/schema';
+import { sql, type Column, type SQL } from 'drizzle-orm';
+
+/**
+ * Vergleichsoperator der Mustersuche.
+ *
+ * Der Unterschied zwischen den beiden Flächen ist bewusst und darf nicht
+ * eingeebnet werden: Die Legacy-API ist vertraglich case-insensitiv (`ILIKE`,
+ * siehe `docs/LEGACY_API_SPECIFICATION.md`), die Karte sucht case-sensitiv
+ * (`LIKE`). Der Operator ist deshalb ein Pflichtargument ohne Default — er
+ * muss an jeder Aufrufstelle sichtbar entschieden werden.
+ */
+export type LikeOperator = 'LIKE' | 'ILIKE';
+
+/**
+ * Escaped die LIKE-Wildcards `%`, `_` und den Escape-Backslash selbst, damit
+ * ein Suchbegriff literal gesucht wird.
+ *
+ * Ohne das matcht `search=%` jeden Datensatz und `_` jedes Einzelzeichen —
+ * beides verstärkt das oben beschriebene Membership-Orakel.
+ *
+ * Trimmt bewusst nicht; das gehört zu {@link containsPattern}.
+ */
+export function escapeLikePattern(term: string): string {
+	return term.replace(/[%_\\]/g, '\\$&');
+}
+
+/**
+ * Baut das Contains-Muster `%<Begriff>%`, das beide Flächen verwenden:
+ * getrimmt und mit escapten Wildcards.
+ *
+ * Das Trimmen liegt hier, damit beide Flächen denselben Begriff suchen — sonst
+ * liefert `search=%20Wal%20` je nach Route eine andere Treffermenge und die
+ * Zusage „dieselbe Teilmenge" wäre nur noch ungefähr wahr.
+ */
+export function containsPattern(term: string): string {
+	return `%${escapeLikePattern(term.trim())}%`;
+}
+
+/**
+ * Das gemeinsame Consent-Gate als ein SQL-Fragment.
+ *
+ * Vor- und Nachname nur bei `namensnennung = 1`, der Schiffsname nur bei
+ * `schiffnamensnennung = 1`, die E-Mail-Adresse nie.
+ *
+ * @param pattern Contains-Muster aus {@link containsPattern} — bereits escaped.
+ * @param operator `ILIKE` (Legacy-API) oder `LIKE` (Karte), siehe {@link LikeOperator}.
+ */
+export function consentGatedNameSearch(pattern: string, operator: LikeOperator): SQL {
+	// Beide Operatoren stehen literal im Quelltext statt per `sql.raw` — so
+	// bleibt die erzeugte SQL greppbar und es gibt keinen Pfad, über den ein
+	// Bezeichner ungeprüft in die Anweisung gelangt.
+	const matches = (column: Column): SQL =>
+		operator === 'ILIKE'
+			? sql`${column} ILIKE ${pattern} ESCAPE '\\'`
+			: sql`${column} LIKE ${pattern} ESCAPE '\\'`;
+
+	return sql`(
+		(${sightings.nameConsent} = 1 AND (
+			${matches(sightings.firstName)} OR
+			${matches(sightings.lastName)}
+		)) OR
+		(${sightings.shipNameConsent} = 1 AND
+			${matches(sightings.shipName)}
+		)
+	)`;
+}

--- a/src/routes/api/map/sightings/+server.ts
+++ b/src/routes/api/map/sightings/+server.ts
@@ -36,8 +36,11 @@ export const GET: RequestHandler = async ({ url }) => {
 			conditions.push(lt(sightingsTable.sightingDate, endExclusive));
 		}
 
-		// Suchfilter hinzufügen, wenn vorhanden
-		if (search) {
+		// Suchfilter hinzufügen, wenn vorhanden. Der Guard prüft den getrimmten
+		// Begriff — gleichlautend mit der Legacy-Route, die bei reinem Whitespace
+		// ebenfalls nicht filtert. Andernfalls entstünde hier `%%`, was jede Zeile
+		// ausschlösse, in der alle durchsuchten Felder NULL sind.
+		if (search?.trim()) {
 			// Fahrwasser und Seezeichen sind nicht personenbezogen und bleiben frei
 			// durchsuchbar; Name und Schiffsname nur mit Einwilligung des Melders.
 			// Das Gate ist mit der Legacy-API geteilt, damit beide öffentlichen

--- a/src/routes/api/map/sightings/+server.ts
+++ b/src/routes/api/map/sightings/+server.ts
@@ -3,6 +3,7 @@ import { sightingsToGeoJSON, type DBSighting } from '$lib/map/mapUtils';
 import { db } from '$lib/server/db';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
 import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
+import { consentGatedNameSearch, containsPattern } from '$lib/server/db/consentGatedSearch';
 import { json } from '@sveltejs/kit';
 import { and, gte, lt, sql } from 'drizzle-orm';
 import { publicMapSightingConditions } from './publicMapConditions';
@@ -37,20 +38,16 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		// Suchfilter hinzufügen, wenn vorhanden
 		if (search) {
-			// LIKE-Wildcards im Suchbegriff escapen, damit % und _ literal gesucht werden
-			const escapedSearch = search.replace(/[%_\\]/g, '\\$&');
-			// Suche nur in nicht-personenbezogenen Feldern oder mit Consent
+			// Fahrwasser und Seezeichen sind nicht personenbezogen und bleiben frei
+			// durchsuchbar; Name und Schiffsname nur mit Einwilligung des Melders.
+			// Das Gate ist mit der Legacy-API geteilt, damit beide öffentlichen
+			// Flächen dieselbe Teilmenge freigeben — siehe consentGatedSearch.ts.
+			const pattern = containsPattern(search);
 			conditions.push(
 				sql`(
-          ${sightingsTable.waterway} LIKE ${`%${escapedSearch}%`} ESCAPE '\\' OR
-          ${sightingsTable.seaMark} LIKE ${`%${escapedSearch}%`} ESCAPE '\\' OR
-          (${sightingsTable.nameConsent} = 1 AND (
-            ${sightingsTable.firstName} LIKE ${`%${escapedSearch}%`} ESCAPE '\\' OR
-            ${sightingsTable.lastName} LIKE ${`%${escapedSearch}%`} ESCAPE '\\'
-          )) OR
-          (${sightingsTable.shipNameConsent} = 1 AND
-            ${sightingsTable.shipName} LIKE ${`%${escapedSearch}%`} ESCAPE '\\'
-          )
+          ${sightingsTable.waterway} LIKE ${pattern} ESCAPE '\\' OR
+          ${sightingsTable.seaMark} LIKE ${pattern} ESCAPE '\\' OR
+          ${consentGatedNameSearch(pattern, 'LIKE')}
         )`
 			);
 		}

--- a/src/routes/api/map/sightings/searchFilter.test.ts
+++ b/src/routes/api/map/sightings/searchFilter.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Datenschutz-Zusicherungen des Suchfilters der öffentlichen Karte.
+ *
+ * Gegenstück zum Block „Datenschutz - Suche über personenbezogene Felder" in
+ * `src/routes/sichtungen/showreports.json/showreports.test.ts`. Beide öffentlichen
+ * Flächen geben laut `docs/LEGACY_API_SPECIFICATION.md` („Deviation: consent-gated
+ * search") dieselbe Teilmenge frei — bisher war jedoch nur die Legacy-Seite durch
+ * einen Test festgeschrieben. Ohne diesen Test hier könnte die Karte die Gatung
+ * verlieren, ohne dass eine Zusicherung bricht.
+ *
+ * Anders als `coordinateFilter.test.ts` läuft dieser Test gegen das **echte**
+ * Drizzle: geprüft wird das erzeugte SQL, nicht eine Marker-Struktur.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+
+const captured = vi.hoisted(() => ({ where: null as unknown }));
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn(() => ({
+			from: vi.fn(() => ({
+				where: vi.fn((condition: unknown) => {
+					captured.where = condition;
+					return { orderBy: vi.fn(() => Promise.resolve([])) };
+				})
+			}))
+		}))
+	}
+}));
+
+vi.mock('$lib/map/mapUtils', () => ({
+	sightingsToGeoJSON: vi.fn(() => ({ type: 'FeatureCollection', features: [] }))
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { GET } from './+server';
+
+const dialect = new PgDialect();
+
+/** Ruft den Endpunkt auf und rendert die erzeugte WHERE-Bedingung als SQL. */
+async function queryFor(search?: string): Promise<{ text: string; params: unknown[] }> {
+	const url = new URL('http://localhost/api/map/sightings');
+	if (search !== undefined) url.searchParams.set('search', search);
+
+	await GET({ url } as Parameters<typeof GET>[0]);
+
+	if (!captured.where) {
+		throw new Error('Keine WHERE-Bedingung erfasst — wurde die Query ausgeführt?');
+	}
+	const query = dialect.sqlToQuery(captured.where as SQL);
+	return { text: query.sql, params: query.params };
+}
+
+describe('GET /api/map/sightings — Datenschutz der Suche', () => {
+	beforeEach(() => {
+		captured.where = null;
+	});
+
+	it('durchsucht Name und Schiffsname nur mit Einwilligung', async () => {
+		const { text } = await queryFor('Private');
+
+		// Die Felder werden durchsucht ...
+		expect(text).toContain('"vorname"');
+		expect(text).toContain('"name"');
+		expect(text).toContain('"schiffsname"');
+		// ... aber ausschließlich innerhalb des Consent-Gates.
+		expect(text).toMatch(/"namensnennung"\s*=\s*1/);
+		expect(text).toMatch(/"schiffnamensnennung"\s*=\s*1/);
+	});
+
+	it('durchsucht die E-Mail-Adresse nicht', async () => {
+		const { text } = await queryFor('melder@example.com');
+
+		expect(text).not.toContain('"email"');
+	});
+
+	it('durchsucht die nicht-personenbezogenen Felder ohne Gate', async () => {
+		// Fahrwasser und Seezeichen sind keine personenbezogenen Daten und
+		// bleiben für die Kartensuche frei durchsuchbar.
+		const { text } = await queryFor('Förde');
+
+		expect(text).toContain('"fahrwasser"');
+		expect(text).toContain('"seezeichen"');
+	});
+
+	it('behandelt LIKE-Wildcards im Suchbegriff als Literale', async () => {
+		const { text, params } = await queryFor('50%_x');
+
+		expect(params).toContain('%50\\%\\_x%');
+		expect(text).toContain('ESCAPE');
+	});
+
+	it('trimmt den Suchbegriff wie die Legacy-Route', async () => {
+		const { params } = await queryFor('  Wal  ');
+
+		expect(params).toContain('%Wal%');
+	});
+
+	it('sucht case-sensitiv (LIKE) — die Legacy-Route ist separat auf ILIKE festgelegt', async () => {
+		const { text } = await queryFor('Wal');
+
+		expect(text).not.toContain('ilike');
+	});
+
+	it('erzeugt ohne search-Parameter keine Bedingung auf personenbezogene Felder', async () => {
+		const { text } = await queryFor();
+
+		expect(text).not.toContain('"vorname"');
+		expect(text).not.toContain('"schiffsname"');
+		expect(text).not.toContain('"namensnennung"');
+	});
+});

--- a/src/routes/api/map/sightings/searchFilter.test.ts
+++ b/src/routes/api/map/sightings/searchFilter.test.ts
@@ -105,7 +105,22 @@ describe('GET /api/map/sightings — Datenschutz der Suche', () => {
 	it('sucht case-sensitiv (LIKE) — die Legacy-Route ist separat auf ILIKE festgelegt', async () => {
 		const { text } = await queryFor('Wal');
 
-		expect(text).not.toContain('ilike');
+		// Drizzle rendert den Operator groß. Beide Zusicherungen zusammen sind
+		// nötig: `toContain('LIKE')` allein wäre auch bei ILIKE erfüllt.
+		expect(text).not.toContain('ILIKE');
+		expect(text).toContain('LIKE');
+	});
+
+	it('wendet bei einem Suchbegriff aus reinem Whitespace keinen Filter an', async () => {
+		// Gleichlauf mit der Legacy-Route, die in diesem Fall gar nicht filtert.
+		// Ohne den Gleichlauf entstünde `%%`, was jede Zeile ausschlösse, in der
+		// alle durchsuchten Felder NULL sind (`NULL LIKE '%%'` ist NULL, nicht
+		// wahr) — die Zusage "dieselbe Teilmenge" wäre damit verletzt.
+		const { text } = await queryFor('   ');
+
+		expect(text).not.toContain('"fahrwasser"');
+		expect(text).not.toContain('"vorname"');
+		expect(text).not.toContain('"namensnennung"');
 	});
 
 	it('erzeugt ohne search-Parameter keine Bedingung auf personenbezogene Felder', async () => {

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -27,6 +27,7 @@ import { createLogger } from '$lib/logger.server';
 import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 import { isAdminUser } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
+import { consentGatedNameSearch, containsPattern } from '$lib/server/db/consentGatedSearch';
 import { sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
@@ -288,11 +289,12 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		// /api/map/sightings), für angemeldete Admins die volle Vier-Feld-Suche der
 		// Spezifikation — Admins sehen diese Felder ohnehin.
 		if (search && search.trim().length > 0) {
-			// LIKE-Wildcards im Suchbegriff escapen, damit % und _ literal gesucht
-			// werden. Ohne das matcht `search=%` jeden Datensatz und `_` jedes
-			// Einzelzeichen — beides verstärkt das oben beschriebene Orakel.
-			const escapedSearch = search.trim().replace(/[%_\\]/g, '\\$&');
-			const searchTerm = `%${escapedSearch}%`;
+			// Wildcards werden escaped, damit `%` und `_` literal gesucht werden —
+			// ohne das matcht `search=%` jeden Datensatz und verstärkt das oben
+			// beschriebene Orakel. Das Consent-Gate für den anonymen Zweig ist mit
+			// /api/map/sightings geteilt, damit beide öffentlichen Flächen dieselbe
+			// Teilmenge freigeben — siehe consentGatedSearch.ts.
+			const searchTerm = containsPattern(search);
 
 			whereConditions.push(
 				isAdmin
@@ -302,15 +304,7 @@ export async function GET(event: RequestEvent): Promise<Response> {
 					${sightings.lastName} ILIKE ${searchTerm} ESCAPE '\\' OR
 					${sightings.shipName} ILIKE ${searchTerm} ESCAPE '\\'
 				)`
-					: sql`(
-					(${sightings.nameConsent} = 1 AND (
-						${sightings.firstName} ILIKE ${searchTerm} ESCAPE '\\' OR
-						${sightings.lastName} ILIKE ${searchTerm} ESCAPE '\\'
-					)) OR
-					(${sightings.shipNameConsent} = 1 AND
-						${sightings.shipName} ILIKE ${searchTerm} ESCAPE '\\'
-					)
-				)`
+					: consentGatedNameSearch(searchTerm, 'ILIKE')
 			);
 
 			logger.debug(


### PR DESCRIPTION
Folgearbeit zu #671. Dort wurde die Suche über personenbezogene Felder in `/sichtungen/showreports.json` consent-gegated, das Prädikat blieb aber fast zeichengleich doppelt — einmal dort, einmal in `/api/map/sightings`. Die Duplizierung war bewusst ausgeklammert, um den Datenschutz-Fix nicht auszuweiten.

Das ist deshalb heikel, weil `docs/LEGACY_API_SPECIFICATION.md` („Deviation: consent-gated search") die Einschränkung **damit begründet**, dass beide öffentlichen Flächen dieselbe Teilmenge freigeben. Zwei Fassungen, die auseinanderlaufen können, entwerten genau diese Begründung.

## Änderung

Neues Modul `src/lib/server/db/consentGatedSearch.ts` — aufgebaut wie `approvedOnly()` in `approvalFilter.ts`: Prädikat einmal definieren, wer es umgeht, fällt im Review durch den fehlenden Import auf.

| Export | Zweck |
| --- | --- |
| `escapeLikePattern(term)` | escaped `%`, `_`, `\`; kein Trim, kein Umschließen |
| `containsPattern(term)` | `%<getrimmt, escaped>%` — das Muster beider Routen |
| `consentGatedNameSearch(pattern, operator)` | das geteilte Gate als ein SQL-Fragment |

**Der ILIKE/LIKE-Unterschied bleibt explizit.** Der Operator ist Pflichtargument ohne Default, und beide Zweige stehen literal im Quelltext statt per `sql.raw` — die erzeugte SQL bleibt greppbar, und kein Bezeichner gelangt ungeprüft in die Anweisung. Ein Test schreibt fest, dass sich die Varianten ausschließlich im Operator unterscheiden.

**Nicht geteilt:** der Admin-Zweig der Legacy-Route. Er durchsucht `email` und hat kein Gate — also keine Gemeinsamkeit mit dem Fragment. Er behält sein eigenes Prädikat und nutzt nur `containsPattern` mit.

## Verhaltensänderungen

Zwei, beide klein und beide in Richtung Gleichlauf:

1. **Die Map-Route trimmt jetzt.** Ihr Frontend tat das ohnehin schon (`urlFilterState.ts:138`), betroffen sind nur handgebaute URLs.
2. **Der Whitespace-Guard ist angeglichen.** Bei `?search=%20` filterte die Legacy-Route gar nicht, die Karte hätte `%%` gebaut — das schließt jede Zeile aus, deren durchsuchte Felder alle NULL sind (`NULL LIKE '%%'` ist NULL, nicht wahr). Kein Leck, das neue Verhalten ist weniger restriktiv als das alte `%   %`, aber es widersprach der Zusage „dieselbe Teilmenge". Beide Routen prüfen jetzt `search?.trim()`.

Keine Feldnamen, URL-Pfade, Datentypen oder Response-Strukturen geändert. Der Legacy-Vertrag ist unberührt.

## Tests

- `consentGatedSearch.test.ts` — Escaping, Trimmen, Parametrisierung, Operator-Unterscheidung, E-Mail wird nie durchsucht
- `searchFilter.test.ts` — **neu für die Map-Seite.** Die Doku behauptete, beide Flächen gaten gleich, festgeschrieben war aber nur die Legacy-Seite; die Karte hätte das Gate verlieren können, ohne dass eine Zusicherung bricht. Läuft anders als das benachbarte `coordinateFilter.test.ts` gegen das echte Drizzle und prüft die erzeugte SQL.
- Der bestehende Block `Datenschutz - Suche über personenbezogene Felder` ist unangetastet und grün.

Ein Review-Befund war eine vakuöse Assertion in meinem eigenen neuen Test (`not.toContain('ilike')` kann nie fehlschlagen, weil Drizzle groß rendert). Behoben und per Mutation verifiziert: Ein Flip der Aufrufstelle auf `'ILIKE'` lässt den Test jetzt rot werden.

**Verifikation:** `npm run test:quick` → Exit 0, 189 Dateien / 2820 Tests grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
