### PR TITLE
fix(map): let the position picker pan without a position-setting click

### DIFF
--- a/e2e/form-map-pan-zoom.spec.ts
+++ b/e2e/form-map-pan-zoom.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test, type Page } from '@playwright/test';
+import { FormPage } from './pages/FormPage';
+import { blockTileHosts, createMapCanvasProbe, FORM_TILE_HOSTS } from './helpers/mapCanvas';
+
+/**
+ * Derselbe Defekt wie in `e2e/map-pan-zoom.spec.ts`, eine Karte weiter: Das
+ * Ziel-Element von OpenLayers trägt in `OLMap.svelte` ein `tabindex="0"`
+ * (Tastaturbedienung), und `ol/Map.js` baut seine Interactions deshalb mit
+ * `defaultInteractions({ onFocusOnly: true })`. `DragPan` bekommt damit
+ * `focusWithTabindex` vorgeschaltet und reagiert erst, wenn der Fokus im Target
+ * liegt — die Karte war bis zum ersten Klick nicht zu schieben.
+ *
+ * Warum das hier schwerer wiegt als auf der Sichtungskarte: Der Klick, mit dem
+ * man das Ziehen „freischaltet", ist auf dieser Karte kein neutraler Klick.
+ * `OLMap.svelte` hängt an `singleclick` den Handler `handleMapClick` →
+ * `applyPosition` — er **setzt die gemeldete Position**. Wer die Karte nur
+ * zurechtschieben wollte, hatte damit unbemerkt seine Sichtung verlegt.
+ *
+ * ── Was hier bewusst NICHT geändert wurde ────────────────────────────────────
+ * Das Mausrad behält den Fokus-Zwang. Die Karte ist hier ein 556×400 großes
+ * Element mitten in einem langen, scrollbaren Formular; ein bedingungsloser
+ * Rad-Zoom würde das Seiten-Scrollen auf halber Strecke abfangen. Die Tests
+ * unten sichern deshalb **beide** Richtungen ab — Ziehen frei, Rad gebremst.
+ *
+ * ── Messverfahren ────────────────────────────────────────────────────────────
+ * Canvas-Fingerprint, Werkzeug und Begründung in `e2e/helpers/mapCanvas.ts`.
+ * Zwei Voraussetzungen erfüllt dieses Spec dort selbst:
+ *
+ * - **Sichtbarer Inhalt:** Auf dieser Karte gibt es keine Sichtungen — die Rolle
+ *   übernimmt der **Marker**, den `oeffneKarteMitMarker()` über die
+ *   Koordinatenfelder erzeugt (nicht über einen Klick in die Karte, der würde
+ *   genau den Fokus setzen, um den es geht). Weil der Marker das einzige
+ *   gezeichnete Objekt ist, wird dichter abgetastet als auf der Sichtungskarte.
+ * - **Ruhiger Hintergrund:** Die OSM-Kacheln werden abgewiesen.
+ */
+
+/** Startpunkt der Karte in `LocationInput.svelte` — Marker landet in der Mitte. */
+const DEFAULT_CENTER = { latitude: '54.5', longitude: '13.5' };
+
+/** Nur der Marker wird gezeichnet — grobes Raster könnte ihn verfehlen. */
+const karte = (page: Page) =>
+	createMapCanvasProbe(page, { selector: '.ol-map-container', stride: 97 });
+
+/**
+ * Punkt in der Karte — abseits der Zoom-Controls (oben links), der Attribution
+ * (unten rechts) und vor allem abseits des Markers in der Mitte: Ein Zug, der
+ * auf dem Marker beginnt, landet in der `Translate`-Interaktion und verschiebt
+ * ihn, statt die Karte zu schieben.
+ *
+ * **Die Karte wird vorher ins Bild geholt und der Scroll abgewartet.** Das
+ * Formular scrollt an mehreren Stellen von selbst — `PositionPanel.openMap()`
+ * ruft `scrollIntoView`, und jedes fokussierte Feld zieht die Ansicht nach. Wer
+ * die Bounding-Box mitten in diese Bewegung liest, bekommt eine Position, die
+ * beim Ziehen schon nicht mehr stimmt: Beim Entwickeln dieses Tests lag der
+ * Startpunkt einmal bei `y = -36`, also außerhalb des Fensters — die Geste ging
+ * ins Leere und sah aus wie der Defekt, den der Test sucht.
+ */
+async function mapPoint(page: Page, relX = 0.25, relY = 0.78) {
+	const map = page.locator('.ol-map-container');
+	await map.scrollIntoViewIfNeeded();
+
+	let previous: string | null = null;
+	let current: string | null = null;
+	await expect
+		.poll(
+			async () => {
+				const box = await map.boundingBox();
+				previous = current;
+				current = box ? `${Math.round(box.x)}/${Math.round(box.y)}` : null;
+				return current !== null && current === previous;
+			},
+			{ timeout: 10000, intervals: [100, 100, 200, 300], message: 'Karte scrollt noch' }
+		)
+		.toBe(true);
+
+	const box = await map.boundingBox();
+	if (!box) throw new Error('.ol-map-container hat keine Bounding-Box');
+	// Gegenprobe zum Fall oben: Eine Geste außerhalb des Fensters beweist nichts.
+	expect(box.y, 'Karte liegt oberhalb des sichtbaren Bereichs').toBeGreaterThanOrEqual(0);
+	return { x: box.x + box.width * relX, y: box.y + box.height * relY };
+}
+
+/**
+ * Öffnet die Karte und setzt eine Position **über die Koordinatenfelder**.
+ *
+ * Bewusst nicht per Klick in die Karte: Der würde den Fokus ins Ziel-Element
+ * legen und damit genau die Bedingung herstellen, die diese Tests als fehlend
+ * nachweisen wollen. Der Wert ist der Kartenmittelpunkt, damit `setMapCenter`
+ * die Ansicht nicht zusätzlich verschiebt.
+ */
+async function oeffneKarteMitMarker(page: Page): Promise<void> {
+	const disclosure = page.locator('[data-testid="map-disclosure"]');
+	await disclosure.locator('summary').click();
+	await expect(disclosure).toHaveAttribute('open', '');
+
+	// `press('Tab')` gehört dazu: `LocationInput.svelte` übernimmt die Zahl im
+	// `onchange`-Handler, und der feuert an einem `type="number"`-Feld erst beim
+	// Verlassen. Ein reines `fill()` setzt den Wert sichtbar, aber nicht im
+	// Formular — die Karte bliebe auf `data-position="unset"`.
+	await page.locator('#latitude').fill(DEFAULT_CENTER.latitude);
+	await page.locator('#latitude').press('Tab');
+	await page.locator('#longitude').fill(DEFAULT_CENTER.longitude);
+	await page.locator('#longitude').press('Tab');
+
+	// Der Marker hängt an `hasPosition` — erst wenn beide Werte stehen. Der Fokus
+	// liegt jetzt auf dem Feld hinter der Länge, also außerhalb der Karte: genau
+	// der Ausgangszustand, den die Tests unten brauchen.
+	await expect(page.locator('.ol-map-container')).toHaveAttribute('data-position', 'set');
+}
+
+/** Liest die gemeldete Position aus den Koordinatenfeldern. */
+async function position(page: Page): Promise<{ lat: string; lon: string }> {
+	return {
+		lat: await page.locator('#latitude').inputValue(),
+		lon: await page.locator('#longitude').inputValue()
+	};
+}
+
+test.describe('Positions-Karte im Formular — Pan und Zoom', () => {
+	test.beforeEach(async ({ page }) => {
+		await blockTileHosts(page, FORM_TILE_HOSTS);
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await oeffneKarteMitMarker(page);
+	});
+
+	test('Ziehen verschiebt die Karte ohne vorherigen Klick', async ({ page }) => {
+		const probe = karte(page);
+		const start = await mapPoint(page);
+		const before = await probe.hoverAndSettle(start);
+
+		await probe.drag(start, 120, -90);
+
+		await probe.expectToMove(
+			before,
+			'Karte reagierte auf das erste Ziehen nicht — genau der berichtete Befund'
+		);
+	});
+
+	// Der eigentliche Grund, warum der Fokus-Zwang auf dieser Karte teurer ist als
+	// auf der Sichtungskarte: Der „Freischalt-Klick" hätte die Meldung verlegt.
+	test('Ziehen verändert die gemeldete Position nicht', async ({ page }) => {
+		const probe = karte(page);
+		const vorher = await position(page);
+
+		const start = await mapPoint(page);
+		await probe.hoverAndSettle(start);
+		await probe.drag(start, 120, -90);
+
+		// `singleclick` feuert nach einem Zug nicht — die Position muss stehen
+		// bleiben, sonst hätte das Schieben die Sichtung verschoben.
+		await expect(page.locator('#latitude')).toHaveValue(vorher.lat);
+		await expect(page.locator('#longitude')).toHaveValue(vorher.lon);
+	});
+
+	// ── Mausrad: Fokus-Schutz bleibt absichtlich erhalten ──────────────────────
+	//
+	// Anders als beim Ziehen ist das hier **gewolltes** Verhalten: Die Karte sitzt
+	// als 556×400-Element mitten in einem langen Formular. Ein bedingungsloser
+	// Rad-Zoom würde das Seiten-Scrollen genau dort abfangen — siehe die
+	// Begründung an `interactions:` in `src/lib/utils/map/openLayersHelpers.ts`.
+
+	test('Mausrad zoomt nicht, solange die Karte keinen Fokus hat — die Seite scrollt', async ({
+		page
+	}) => {
+		const probe = karte(page);
+		const point = await mapPoint(page);
+		const before = await probe.hoverAndSettle(point);
+
+		// Vorbedingung, nicht Beiwerk: Steht die Seite schon am Ende, hätte das Rad
+		// nichts mehr zu scrollen und die Assertion unten würde aus einem Grund
+		// fehlschlagen, der mit der Karte nichts zu tun hat.
+		const { scrollVorher, reserve } = await page.evaluate(() => ({
+			scrollVorher: window.scrollY,
+			reserve: document.documentElement.scrollHeight - window.innerHeight - window.scrollY
+		}));
+		expect(reserve, 'Kein Scroll-Vorrat unterhalb der Karte — Testaufbau prüfen').toBeGreaterThan(
+			400
+		);
+
+		await page.mouse.wheel(0, 400);
+
+		await probe.expectToStayPut(
+			before,
+			'Mausrad hat ohne Fokus gezoomt — das Formular lässt sich über der Karte nicht mehr scrollen'
+		);
+		expect(
+			await page.evaluate(() => window.scrollY),
+			'Seite ist nicht gescrollt — das Rad wurde über der Karte verschluckt'
+		).toBeGreaterThan(scrollVorher);
+	});
+
+	test('Mausrad zoomt, sobald die Karte den Fokus hat', async ({ page }) => {
+		const probe = karte(page);
+		// Fokus per Tastatur-Weg statt per Klick: Ein Klick in die Karte würde
+		// die gemeldete Position setzen (`handleMapClick`). Genau deshalb ist er
+		// als „Freischalter" ungeeignet.
+		await page.locator('.ol-map-container').focus();
+
+		const point = await mapPoint(page);
+		const before = await probe.hoverAndSettle(point);
+		const vorher = await position(page);
+
+		await page.mouse.wheel(0, -400);
+
+		await probe.expectToMove(before, 'Mausrad-Zoom blieb auch mit Fokus ohne Wirkung');
+		// Zoomen ist keine Positionsangabe.
+		await expect(page.locator('#latitude')).toHaveValue(vorher.lat);
+		await expect(page.locator('#longitude')).toHaveValue(vorher.lon);
+	});
+});

--- a/e2e/helpers/mapCanvas.ts
+++ b/e2e/helpers/mapCanvas.ts
@@ -1,0 +1,217 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Messwerkzeug für „hat sich die Karte bewegt?"-Tests.
+ *
+ * Gemessen wird das **gezeichnete Kartenbild** (Canvas-Fingerprint) und nicht
+ * der View-Zustand: An die OpenLayers-Instanz kommt man von außen nicht heran,
+ * und eine Test-Hintertür im Produktionscode wäre der falsche Preis dafür.
+ *
+ * Damit der Fingerprint aussagekräftig ist, muss der Aufrufer zwei Dinge
+ * sicherstellen — beides ist Sache des jeweiligen Specs, weil es von der Karte
+ * abhängt:
+ *
+ * 1. Es muss überhaupt etwas gezeichnet werden. Ein leeres Canvas kann sich
+ *    durch einen Pan nicht verändern; der Test wäre gehaltlos statt
+ *    aussagekräftig. `settledHash()` prüft das und schlägt sonst fehl.
+ * 2. Der Hintergrund darf sich **nicht von selbst** ändern. Nachladende
+ *    OSM-Kacheln würden das Bild auch ohne Geste verändern und einen Test auf
+ *    „hat sich bewegt" fälschlich grün machen — die Kachel-Hosts gehören
+ *    deshalb abgewiesen.
+ *
+ * Diese Datei ist die gemeinsame Quelle für `e2e/map-pan-zoom.spec.ts`
+ * (Sichtungskarte) und `e2e/form-map-pan-zoom.spec.ts` (Positions-Karte im
+ * Meldeformular). Sie entstand, weil beide Specs dieselben rund 130 Zeilen
+ * trugen und bereits auseinanderzudriften begannen.
+ */
+
+export type CanvasState = { hash: number; distinct: number };
+
+export type MapCanvasProbeOptions = {
+	/** CSS-Selektor des Karten-Containers; alle `canvas` darunter werden gelesen. */
+	selector: string;
+	/**
+	 * Abtastschritt in Byte über die Bilddaten. Groß halten, wo viel gezeichnet
+	 * wird (Sichtungskarte); klein, wo das einzige Objekt ein handtellergroßer
+	 * Marker ist und ein grobes Raster ihn zwischen zwei Messungen verfehlen
+	 * könnte.
+	 */
+	stride?: number;
+	/**
+	 * Obergrenze für den gelesenen Ausschnitt. `getImageData` über ein
+	 * Vollbild-Canvas kostet bei 2752×1496 rund 66 MB **pro Messung** — bei einer
+	 * Karte, die pollend gemessen wird, ist das der Unterschied zwischen einem
+	 * flotten und einem unbrauchbaren Testlauf.
+	 */
+	maxWidth?: number;
+	maxHeight?: number;
+};
+
+export type MapCanvasProbe = {
+	/** Rohmessung: Fingerprint plus Anzahl unterschiedlicher Abtastwerte. */
+	state(): Promise<CanvasState | null>;
+	/** Wartet, bis das Bild ruht, und gibt seinen Fingerprint zurück. */
+	settledHash(): Promise<number>;
+	/** Erwartet, dass sich das Kartenbild binnen weniger Sekunden verändert. */
+	expectToMove(before: number, hinweis: string): Promise<void>;
+	/** Erwartet, dass das Kartenbild über ein Zeitfenster unverändert bleibt. */
+	expectToStayPut(before: number, hinweis: string): Promise<void>;
+	/** Zieht mit echten Maus-Events über die Karte. */
+	drag(from: { x: number; y: number }, dx: number, dy: number): Promise<void>;
+	/** Fährt die Maus an die Gestenposition und misst erst danach die Basis. */
+	hoverAndSettle(point: { x: number; y: number }): Promise<number>;
+};
+
+export function createMapCanvasProbe(page: Page, options: MapCanvasProbeOptions): MapCanvasProbe {
+	const { selector, stride = 401, maxWidth = 1200, maxHeight = 800 } = options;
+
+	async function state(): Promise<CanvasState | null> {
+		return page.evaluate(
+			({ selector, stride, maxWidth, maxHeight }) => {
+				const canvases = Array.from(
+					document.querySelectorAll<HTMLCanvasElement>(`${selector} canvas`)
+				);
+				if (canvases.length === 0) return null;
+
+				let hash = 0;
+				const seen = new Set<number>();
+
+				for (const canvas of canvases) {
+					const ctx = canvas.getContext('2d');
+					if (!ctx) continue;
+					const width = Math.min(canvas.width, maxWidth);
+					const height = Math.min(canvas.height, maxHeight);
+					if (width === 0 || height === 0) continue;
+
+					const { data } = ctx.getImageData(0, 0, width, height);
+					for (let i = 0; i < data.length; i += stride) {
+						hash = (hash * 31 + data[i]) | 0;
+						if (seen.size < 64) seen.add(data[i]);
+					}
+				}
+
+				return { hash, distinct: seen.size };
+			},
+			{ selector, stride, maxWidth, maxHeight }
+		);
+	}
+
+	/**
+	 * „Zur Ruhe gekommen" heißt: zwei aufeinanderfolgende Messungen sind gleich —
+	 * sonst würde eine noch laufende Erstdarstellung als Wirkung der Geste
+	 * durchgehen.
+	 */
+	async function settledHash(): Promise<number> {
+		let previous: number | null = null;
+		let current: number | null = null;
+
+		await expect
+			.poll(
+				async () => {
+					const gemessen = await state();
+					previous = current;
+					current = gemessen?.hash ?? null;
+					return current !== null && current === previous;
+				},
+				{
+					timeout: 15000,
+					intervals: [200, 200, 200, 400],
+					message: 'Kartenbild kam nicht zur Ruhe'
+				}
+			)
+			.toBe(true);
+
+		// Gegenprobe (Punkt 1 im Kopfkommentar): Ein einfarbiges Canvas könnte sich
+		// durch einen Pan nicht verändern — der Test wäre dann gehaltlos.
+		//
+		// Der Rückgabewert stammt aus **dieser** Messung und nicht aus der
+		// Schleifenvariablen: Die liegt in einer Closure, die TypeScript nicht
+		// verfolgt (`current` gilt dort weiterhin als `null`), und bräuchte einen
+		// Cast, der die Prüfung nur stillstellt. Das Bild ruht an dieser Stelle
+		// ohnehin — beide Werte sind gleich.
+		const gemessen = await state();
+		expect(
+			gemessen?.distinct ?? 0,
+			'Karte zeichnet nichts — der Fingerprint wäre gehaltlos'
+		).toBeGreaterThan(1);
+		if (!gemessen) throw new Error('Kartenbild ist nicht messbar');
+
+		return gemessen.hash;
+	}
+
+	async function expectToMove(before: number, hinweis: string): Promise<void> {
+		await expect
+			.poll(async () => (await state())?.hash ?? null, {
+				timeout: 4000,
+				intervals: [150, 250, 400, 600],
+				message: hinweis
+			})
+			.not.toBe(before);
+	}
+
+	/**
+	 * `expect.poll` ist hier das falsche Werkzeug: Es prüft, bis eine Bedingung
+	 * erfüllt ist — bei „hat sich nichts geändert" wäre sie sofort erfüllt und der
+	 * Test damit gehaltlos. Stattdessen wird über ein Zeitfenster mehrfach gemessen
+	 * und jede Messung geprüft.
+	 *
+	 * Die 8 × 200 ms sind so bemessen, dass ein **verzögerter** Zoom nicht
+	 * durchrutscht: `MouseWheelZoom` sammelt Rad-Ereignisse hinter einem Timeout
+	 * (80 ms) und zoomt dann animiert (250 ms). Das Fenster deckt beides mehrfach
+	 * ab. Es ist damit kürzer als die 4 s, die `expectToMove` maximal wartet — die
+	 * Zahlen messen Verschiedenes und dürfen nicht aneinander angeglichen werden.
+	 */
+	async function expectToStayPut(before: number, hinweis: string): Promise<void> {
+		for (let versuch = 0; versuch < 8; versuch++) {
+			await page.waitForTimeout(200);
+			const jetzt = (await state())?.hash ?? null;
+			expect(jetzt, `${hinweis} (Messung ${versuch + 1} von 8)`).toBe(before);
+		}
+	}
+
+	async function drag(from: { x: number; y: number }, dx: number, dy: number): Promise<void> {
+		await page.mouse.move(from.x, from.y);
+		await page.mouse.down();
+		// Mehrere Zwischenschritte: OpenLayers braucht `pointermove` mit gedrückter
+		// Taste, ein einzelner Sprung erzeugt keine belastbare Drag-Sequenz.
+		await page.mouse.move(from.x + dx * 0.3, from.y + dy * 0.3, { steps: 5 });
+		await page.mouse.move(from.x + dx, from.y + dy, { steps: 10 });
+		await page.mouse.up();
+	}
+
+	/**
+	 * Die Reihenfolge ist wesentlich: Schon das Bewegen der Maus kann das
+	 * Kartenbild verändern — die Sichtungskarte sucht in ihrem
+	 * `pointermove`-Handler Features unter dem Zeiger und setzt den Hover-Zustand.
+	 * Wer die Basis vorher nimmt, misst hinterher diesen Effekt mit: Ein Test auf
+	 * „hat sich bewegt" würde dann auch ohne Geste grün, einer auf „hat sich nicht
+	 * bewegt" fälschlich rot (genau so ist der Mausrad-Test beim ersten Lauf
+	 * gescheitert).
+	 */
+	async function hoverAndSettle(point: { x: number; y: number }): Promise<number> {
+		await page.mouse.move(point.x, point.y);
+		return settledHash();
+	}
+
+	return { state, settledHash, expectToMove, expectToStayPut, drag, hoverAndSettle };
+}
+
+/**
+ * Weist die Kachel-Hosts ab, damit sich das Kartenbild nicht von selbst ändert.
+ *
+ * OLs `OSM`-Source nutzt den Einzelhost `tile.openstreetmap.org` (kein
+ * Subdomain-Sharding) — ein Muster für `*.tile.openstreetmap.org` würde nie
+ * greifen. `tiles.openseamap.org` nur mitnehmen, wo die Karte den Seezeichen-
+ * Layer überhaupt anlegt.
+ */
+export async function blockTileHosts(page: Page, hosts: string[]): Promise<void> {
+	for (const pattern of hosts) {
+		await page.route(pattern, (route) => route.abort());
+	}
+}
+
+/** Kachel-Hosts der Sichtungskarte (OSM + OpenSeaMap-Layer). */
+export const SIGHTINGS_TILE_HOSTS = ['**://tile.openstreetmap.org/**', '**tiles.openseamap.org/**'];
+
+/** Kachel-Host der Formular-Karte — `createMap()` legt nur einen OSM-Layer an. */
+export const FORM_TILE_HOSTS = ['**://tile.openstreetmap.org/**'];

--- a/e2e/map-pan-zoom.spec.ts
+++ b/e2e/map-pan-zoom.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 import { MapPage } from './pages/MapPage';
 import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
+import { createMapCanvasProbe } from './helpers/mapCanvas';
 
 /**
  * Reproduktion des Berichts „nach Öffnen der Sidebar geht Pan und Zoom in der
@@ -15,15 +16,11 @@ import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
  * fährt einen echten, fokussierten Browser und trennt beides.
  *
  * ── Messverfahren ────────────────────────────────────────────────────────────
- * Gemessen wird das gezeichnete Kartenbild (Canvas-Fingerprint), nicht der
- * View-Zustand: An die OpenLayers-Instanz kommt man von außen nicht heran, und
- * eine Test-Hintertür im Produktionscode wäre der falsche Preis dafür.
- *
- * Damit der Fingerprint aussagekräftig ist, blockiert
- * `mockMapSightingsWithFeatures` die externen Kacheln und liefert feste
- * Sichtungen. Sonst gäbe es zwei Fehlerquellen: ein leeres Canvas könnte sich
- * durch einen Pan gar nicht verändern (Test wäre gehaltlos), und nachladende
- * Kacheln würden es auch ohne Pan verändern (Test wäre fälschlich grün).
+ * Canvas-Fingerprint, Werkzeug und Begründung stehen in
+ * `e2e/helpers/mapCanvas.ts`. Die beiden Voraussetzungen von dort erfüllt
+ * `mockMapSightingsWithFeatures`: Es liefert feste Sichtungen (sonst wäre das
+ * Canvas leer und der Test gehaltlos) und weist die Kachel-Hosts ab (sonst
+ * veränderten nachladende Kacheln das Bild auch ohne Geste).
  *
  * ── Reihenfolge in den Kontrolltests ─────────────────────────────────────────
  * Der Klick passiert **vor** der Basismessung. Ein Klick kann die Ansicht selbst
@@ -31,131 +28,11 @@ import { mockMapSightingsWithFeatures } from './fixtures/mockApi';
  * bestätigte der Test am Ende diesen Nebeneffekt statt des Pans.
  */
 
-/** Ein Wert, der sich ändert, sobald sich das Kartenbild ändert. */
-async function canvasState(page: Page): Promise<{ hash: number; distinct: number } | null> {
-	return page.evaluate(() => {
-		const canvases = [...document.querySelectorAll<HTMLCanvasElement>('#map canvas')];
-		if (canvases.length === 0) return null;
-
-		let hash = 0;
-		const seen = new Set<number>();
-
-		for (const canvas of canvases) {
-			const ctx = canvas.getContext('2d');
-			if (!ctx) continue;
-			// Ausschnitt statt Vollbild: bei 2752x1496 wären es 66 MB pro Messung.
-			const width = Math.min(canvas.width, 1200);
-			const height = Math.min(canvas.height, 800);
-			if (width === 0 || height === 0) continue;
-
-			const { data } = ctx.getImageData(0, 0, width, height);
-			for (let i = 0; i < data.length; i += 401) {
-				hash = (hash * 31 + data[i]) | 0;
-				if (seen.size < 64) seen.add(data[i]);
-			}
-		}
-
-		return { hash, distinct: seen.size };
-	});
-}
-
-/**
- * Wartet, bis das Kartenbild zur Ruhe gekommen ist, und gibt seinen Fingerprint
- * zurück. „Zur Ruhe gekommen" heißt: zwei aufeinanderfolgende Messungen sind
- * gleich — sonst würde eine noch laufende Erstdarstellung als Pan-Wirkung
- * durchgehen.
- */
-async function settledCanvasHash(page: Page): Promise<number> {
-	let previous: number | null = null;
-	let current: number | null = null;
-
-	await expect
-		.poll(
-			async () => {
-				const state = await canvasState(page);
-				previous = current;
-				current = state?.hash ?? null;
-				return current !== null && current === previous;
-			},
-			{
-				timeout: 15000,
-				intervals: [200, 200, 200, 400],
-				message: 'Kartenbild kam nicht zur Ruhe'
-			}
-		)
-		.toBe(true);
-
-	// Gegenprobe: Ein einfarbiges Canvas könnte sich durch einen Pan nicht
-	// verändern — der Test wäre dann gehaltlos statt aussagekräftig.
-	const state = await canvasState(page);
-	expect(
-		state?.distinct ?? 0,
-		'Karte zeichnet nichts — Fingerprint wäre gehaltlos'
-	).toBeGreaterThan(1);
-
-	return current as number;
-}
-
-/** Erwartet, dass sich das Kartenbild binnen weniger Sekunden verändert. */
-async function expectMapToMove(page: Page, before: number, hinweis: string): Promise<void> {
-	await expect
-		.poll(async () => (await canvasState(page))?.hash ?? null, {
-			timeout: 4000,
-			intervals: [150, 250, 400, 600],
-			message: hinweis
-		})
-		.not.toBe(before);
-}
-
-/**
- * Erwartet, dass das Kartenbild **unverändert** bleibt.
- *
- * Hier ist `expect.poll` das falsche Werkzeug: Es prüft, bis eine Bedingung
- * erfüllt ist — bei „hat sich nichts geändert" wäre sie sofort erfüllt und der
- * Test damit gehaltlos. Stattdessen wird über ein Zeitfenster mehrfach gemessen
- * und jede Messung geprüft. Das Fenster ist bewusst länger als die
- * `expectMapToMove`-Toleranz, damit ein verzögerter Zoom nicht durchrutscht:
- * `MouseWheelZoom` arbeitet intern mit einem Timeout und einer Animation.
- */
-async function expectMapToStayPut(page: Page, before: number, hinweis: string): Promise<void> {
-	for (let versuch = 0; versuch < 8; versuch++) {
-		await page.waitForTimeout(200);
-		const jetzt = (await canvasState(page))?.hash ?? null;
-		expect(jetzt, `${hinweis} (Messung ${versuch + 1} von 8)`).toBe(before);
-	}
-}
-
-/** Zieht mit echten Maus-Events über die Karte. */
-async function dragMap(page: Page, from: { x: number; y: number }, dx: number, dy: number) {
-	await page.mouse.move(from.x, from.y);
-	await page.mouse.down();
-	// Mehrere Zwischenschritte: OpenLayers braucht `pointermove` mit gedrückter
-	// Taste, ein einzelner Sprung erzeugt keine belastbare Drag-Sequenz.
-	await page.mouse.move(from.x + dx * 0.3, from.y + dy * 0.3, { steps: 5 });
-	await page.mouse.move(from.x + dx, from.y + dy, { steps: 10 });
-	await page.mouse.up();
-}
-
 /** Punkt in der Karte, abseits der Controls links und der Panel-Reiter rechts. */
 async function mapPoint(page: Page, relX = 0.45, relY = 0.5) {
 	const box = await page.locator('#map').boundingBox();
 	if (!box) throw new Error('#map hat keine Bounding-Box');
 	return { x: box.x + box.width * relX, y: box.y + box.height * relY };
-}
-
-/**
- * Fährt die Maus an die Gestenposition und misst **erst danach** die Basis.
- *
- * Die Reihenfolge ist wesentlich: Der Controller hat einen `pointermove`-Handler,
- * der Features unter dem Zeiger sucht und den Hover-Zustand setzt. Schon das
- * Bewegen der Maus verändert damit das Kartenbild. Wer die Basis vorher nimmt,
- * misst hinterher diesen Hover-Effekt mit — ein Test auf „hat sich bewegt" würde
- * dann auch ohne Pan grün, und ein Test auf „hat sich nicht bewegt" fälschlich rot
- * (genau so ist der Mausrad-Test beim ersten Lauf gescheitert).
- */
-async function hoverAndSettle(page: Page, point: { x: number; y: number }): Promise<number> {
-	await page.mouse.move(point.x, point.y);
-	return settledCanvasHash(page);
 }
 
 test.describe('Sichtungskarte — Pan und Zoom', () => {
@@ -169,45 +46,46 @@ test.describe('Sichtungskarte — Pan und Zoom', () => {
 	});
 
 	test('Ziehen verschiebt die Karte ohne vorherigen Klick', async ({ page }) => {
+		const probe = createMapCanvasProbe(page, { selector: '#map' });
 		const start = await mapPoint(page);
-		const before = await hoverAndSettle(page, start);
+		const before = await probe.hoverAndSettle(start);
 
-		await dragMap(page, start, -160, 110);
+		await probe.drag(start, -160, 110);
 
-		await expectMapToMove(
-			page,
+		await probe.expectToMove(
 			before,
 			'Karte reagierte auf das erste Ziehen nicht — genau der berichtete Befund'
 		);
 	});
 
 	test('Ziehen verschiebt die Karte nach einem Klick in die Karte', async ({ page }) => {
+		const probe = createMapCanvasProbe(page, { selector: '#map' });
 		// Kontrollfall. Der Klick landet bewusst nicht auf einer Sichtung, damit
 		// kein Popup mit `autoPan` die Ansicht bewegt.
 		const klickPunkt = await mapPoint(page, 0.2, 0.85);
 		await page.mouse.click(klickPunkt.x, klickPunkt.y);
 
 		const start = await mapPoint(page);
-		const before = await hoverAndSettle(page, start);
+		const before = await probe.hoverAndSettle(start);
 
-		await dragMap(page, start, -160, 110);
+		await probe.drag(start, -160, 110);
 
-		await expectMapToMove(page, before, 'Karte reagierte auch nach einem Klick nicht auf Ziehen');
+		await probe.expectToMove(before, 'Karte reagierte auch nach einem Klick nicht auf Ziehen');
 	});
 
 	test('Ziehen verschiebt die Karte nach dem Öffnen des Filter-Panels', async ({ page }) => {
+		const probe = createMapCanvasProbe(page, { selector: '#map' });
 		// Die Formulierung des Berichts: erst Sidebar öffnen, dann pannen.
 		await mapPage.openFilter();
 		await expect(mapPage.getFilterPanel()).toHaveJSProperty('inert', false);
 
 		// Links vom 320-px-Panel ziehen, damit die Geste auf der Karte landet.
 		const start = await mapPoint(page, 0.3, 0.5);
-		const before = await hoverAndSettle(page, start);
+		const before = await probe.hoverAndSettle(start);
 
-		await dragMap(page, start, -140, 100);
+		await probe.drag(start, -140, 100);
 
-		await expectMapToMove(
-			page,
+		await probe.expectToMove(
 			before,
 			'Karte reagierte nach dem Öffnen des Filter-Panels nicht auf Ziehen'
 		);
@@ -223,29 +101,30 @@ test.describe('Sichtungskarte — Pan und Zoom', () => {
 	// `optimizedMapController.ts`.
 
 	test('Mausrad zoomt nicht, solange die Karte keinen Fokus hat', async ({ page }) => {
+		const probe = createMapCanvasProbe(page, { selector: '#map' });
 		const point = await mapPoint(page);
-		const before = await hoverAndSettle(page, point);
+		const before = await probe.hoverAndSettle(point);
 
 		await page.mouse.wheel(0, -400);
 
-		await expectMapToStayPut(
-			page,
+		await probe.expectToStayPut(
 			before,
 			'Mausrad hat ohne Fokus gezoomt — der Scroll-Hijacking-Schutz ist weg'
 		);
 	});
 
 	test('Mausrad zoomt nach einem Klick in die Karte', async ({ page }) => {
+		const probe = createMapCanvasProbe(page, { selector: '#map' });
 		// Der Klick setzt den Fokus auf das `#map`-Div (`tabindex="0"`) und schaltet
 		// damit `focusWithTabindex` frei.
 		const klickPunkt = await mapPoint(page, 0.2, 0.85);
 		await page.mouse.click(klickPunkt.x, klickPunkt.y);
 
 		const point = await mapPoint(page);
-		const before = await hoverAndSettle(page, point);
+		const before = await probe.hoverAndSettle(point);
 
 		await page.mouse.wheel(0, -400);
 
-		await expectMapToMove(page, before, 'Mausrad-Zoom blieb auch mit Fokus ohne Wirkung');
+		await probe.expectToMove(before, 'Mausrad-Zoom blieb auch mit Fokus ohne Wirkung');
 	});
 });

--- a/src/lib/utils/map/openLayersHelpers.ts
+++ b/src/lib/utils/map/openLayersHelpers.ts
@@ -10,8 +10,10 @@ const logger = createLogger('utils:map:openLayersHelpers');
 
 import Collection from 'ol/Collection';
 import { Control, defaults as defaultControls } from 'ol/control';
+import { all, noModifierKeys, primaryAction } from 'ol/events/condition';
 import OLFeature from 'ol/Feature';
 import OLPoint from 'ol/geom/Point';
+import { defaults as defaultInteractions, DragPan } from 'ol/interaction';
 import Translate from 'ol/interaction/Translate';
 import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer';
 import OLMap from 'ol/Map';
@@ -203,7 +205,70 @@ export function createMap(
 		target: target,
 		layers: [osmLayer],
 		view: view,
-		controls: controls
+		controls: controls,
+
+		/**
+		 * Interactions wie OpenLayers sie selbst baut — **nur DragPan** ist vom
+		 * Fokus-Zwang ausgenommen. Der Ausdruck ist derselbe wie in
+		 * `src/lib/map/optimizedMapController.ts`; die Begründung für das Mausrad
+		 * ist es **nicht**, siehe unten. Wer eine der beiden Stellen ändert, muss
+		 * deshalb nicht automatisch die andere mitziehen.
+		 *
+		 * `onFocusOnly: true` ist kein Zusatz, sondern die Wiederherstellung des
+		 * Verhaltens, das `ol/Map` beim Weglassen der Option verwendet: Map.js ruft
+		 * `defaultInteractions({ onFocusOnly: true })` auf. Ruft man `defaults()`
+		 * dagegen selbst auf, ist der Default `false` — wer das übersieht, hebt den
+		 * Fokus-Schutz still für **alle** Interactions auf.
+		 *
+		 * Was `onFocusOnly` bewirkt: `DragPan` und `MouseWheelZoom` — und nur diese
+		 * beiden — bekommen `all(focusWithTabindex, …)` vorgeschaltet.
+		 * `focusWithTabindex` verlangt, **nur wenn das Ziel-Element ein `tabindex`
+		 * trägt**, dass `document.activeElement` innerhalb des Ziels liegt.
+		 *
+		 * Genau dieses `tabindex="0"` setzt `OLMap.svelte` bewusst auf den
+		 * Karten-Container, damit KeyboardPan und KeyboardZoom greifen. Nebenwirkung
+		 * war der bekannte Defekt „die Karte reagiert erst nach einem Klick": ohne
+		 * Fokus war `activeElement` der `<body>`, die Condition damit `false` und die
+		 * Geste verpuffte — bei einwandfreien, trusted Events.
+		 *
+		 * **Auf dieser Karte wiegt das schwerer als auf der Sichtungskarte.** Der
+		 * Klick, mit dem man das Ziehen freischalten müsste, ist hier kein neutraler
+		 * Klick: `OLMap.svelte` hängt an `singleclick` den Handler `handleMapClick`
+		 * → `applyPosition`, der die **gemeldete Position setzt**. Wer die Karte nur
+		 * zurechtschieben wollte, hätte damit unbemerkt seine Sichtung verlegt.
+		 * Ziehen ist deshalb bedingungslos frei — eine eindeutige Absicht, die mit
+		 * nichts konkurriert. `kinetic` bleibt bewusst weg: `defaults()` setzt dort
+		 * eine Schwung-Animation, die beim Setzen einer Position eher stört.
+		 *
+		 * **Das Mausrad behält den Fokus-Zwang** — und zwar aus einem Grund, den die
+		 * Sichtungskarte nicht hat. Dort trägt die Bremse allein die iframe-
+		 * Einbettung auf meeresmuseum.de; fiele die weg, könnte das Rad frei zoomen,
+		 * weil die Karte die Seite füllt. Hier ist sie ein rund 556×400 großes
+		 * Element mitten in einem langen, scrollbaren Formular. Ein bedingungsloser
+		 * Rad-Zoom würde das Seiten-Scrollen auf halber Strecke abfangen
+		 * (`MouseWheelZoom` ruft `preventDefault()`), und der Melder käme über der
+		 * Karte nicht mehr zum nächsten Feld — unabhängig von jedem iframe.
+		 *
+		 * Vertretbar ist die Bremse, weil Zoomen im Gegensatz zum Schieben
+		 * **Ersatzwege hat, die keinen Fokus brauchen**: die Zoom-Buttons oben links
+		 * sind immer bedienbar. Und wer den Fokus doch will, kommt per Tab hinein —
+		 * ohne den Klick, der eine Position setzen würde. Beim Schieben gab es diesen
+		 * Ersatz nicht; das ist der ganze Unterschied.
+		 *
+		 * **Zur Reihenfolge:** `.extend()` hängt den eigenen DragPan ans Ende der
+		 * Collection, und `Map.handleMapBrowserEvent` läuft sie rückwärts durch — er
+		 * wird also zuerst gefragt. Das ist unkritisch, weil `addMarker()` seine
+		 * `Translate`-Interaktion später per `addInteraction` anhängt und damit
+		 * dahinter landet: Ein Zug, der auf dem Marker beginnt, verschiebt weiterhin
+		 * den Marker und nicht die Karte. Wer `addMarker()` vor die Karten-Erzeugung
+		 * zieht, dreht genau das um.
+		 *
+		 * Abgesichert in `e2e/form-map-pan-zoom.spec.ts` — beide Richtungen, also
+		 * auch der Rad-Schutz als Gegenprobe.
+		 */
+		interactions: defaultInteractions({ onFocusOnly: true, dragPan: false }).extend([
+			new DragPan({ condition: all(noModifierKeys, primaryAction) })
+		])
 	});
 
 	// Wichtig: Karte neu rendern, wenn das Ziel-Element sichtbar ist


### PR DESCRIPTION
## Problem

Die Positions-Karte im Meldeformular hatte denselben Defekt, der gerade für die Sichtungskarte behoben wurde: **Ziehen wirkte erst nach einem Klick in die Karte.**

Mechanismus, in `node_modules/ol` (10.9.0) verifiziert:

- [`OLMap.svelte:209`](src/lib/components/map/OLMap.svelte#L209) setzt `tabindex="0"` auf das OL-Ziel-Element (für KeyboardPan/KeyboardZoom).
- `createMap()` übergab kein `interactions`, also greift `ol/Map.js:468` → `defaultInteractions({ onFocusOnly: true })`.
- `onFocusOnly` schaltet `focusWithTabindex` vor die Condition von `DragPan` und `MouseWheelZoom`. Da das Ziel ein `tabindex` trägt, verlangt das `document.activeElement` **innerhalb** der Karte — ohne Fokus verpuffte jede Geste.

**Warum das hier schwerer wiegt als auf der Sichtungskarte:** Der Klick, der das Ziehen freischaltet, ist auf dieser Karte kein neutraler Klick. [`OLMap.svelte:167`](src/lib/components/map/OLMap.svelte#L167) hängt an `singleclick` den Handler `handleMapClick` → `applyPosition` — er **setzt die gemeldete Position**. Wer die Karte nur zurechtschieben wollte, hat damit unbemerkt seine Sichtung verlegt.

## Änderung

```ts
interactions: defaultInteractions({ onFocusOnly: true, dragPan: false }).extend([
    new DragPan({ condition: all(noModifierKeys, primaryAction) })
])
```

**Ziehen ist frei, das Mausrad behält den Fokus-Zwang.** Diese Asymmetrie ist der Kern der Entscheidung und im Code ausführlich begründet:

- **Pan** hatte keinen Ersatzweg. Der einzige Weg zum Freischalten war der Klick — und der verlegt die Meldung. Deshalb bedingungslos frei.
- **Zoom** hat Ersatzwege, die keinen Fokus brauchen: die `+`/`−`-Controls sind immer bedienbar, und Tab erreicht die Karte, ohne eine Position zu setzen. Ein bedingungsloser Rad-Zoom auf einem 556×400-Element mitten im Formular würde dagegen das Seiten-Scrollen abfangen (`MouseWheelZoom` ruft `preventDefault()`) — Kosten ohne Gegenwert.

Dieser Grund gilt unabhängig vom iframe-Argument, das die Bremse auf der Sichtungskarte trägt. Der Ausdruck ist dort inzwischen identisch, die Begründung nicht — im Kommentar explizit vermerkt, damit niemand die beiden Stellen für gekoppelt hält.

## Tests

Neu: [`e2e/form-map-pan-zoom.spec.ts`](e2e/form-map-pan-zoom.spec.ts) — vier Tests, beide Richtungen:

| Test | Sichert |
| --- | --- |
| Ziehen ohne vorherigen Klick verschiebt die Karte | der eigentliche Fix |
| Ziehen verändert die gemeldete Position nicht | dass Schieben keine Sichtung verlegt |
| Mausrad zoomt ohne Fokus nicht — die Seite scrollt | die bewusst behaltene Bremse |
| Mausrad zoomt mit Fokus (per Tab, nicht per Klick) | dass die Bremse lösbar ist |

Gemessen wird der Canvas-Fingerprint. Der sichtbare Inhalt ist hier der **Marker**, gesetzt über die Koordinatenfelder statt per Kartenklick — ein Klick würde genau den Fokus herstellen, um den es geht.

Test-First eingehalten: Der Test war zuerst rot (nur der Ziehen-Test, die drei Gegenproben grün). Nach dem Fix grün. **Gegenprobe zusätzlich gefahren:** Fix wieder entfernt → Test wieder rot; nach dem Refactoring unten erneut geprüft.

## Refactoring aus dem Review

`canvasState`, `settledCanvasHash`, `expectMapToMove`, `expectMapToStayPut`, `dragMap` und `hoverAndSettle` lagen als ~130 nahezu wörtlich identische Zeilen in beiden Map-Specs. Sie stehen jetzt parametrisiert in [`e2e/helpers/mapCanvas.ts`](e2e/helpers/mapCanvas.ts) (Selektor, Abtastschritt, `getImageData`-Obergrenze); `e2e/map-pan-zoom.spec.ts` nutzt sie mit.

Dass die Kopien bereits zu driften begannen, war im Review konkret nachweisbar: Beide trugen denselben falschen Kommentar („Fenster ist länger als die `expectMapToMove`-Toleranz" — tatsächlich 1600 ms gegen 4000 ms). In der gemeinsamen Fassung steht jetzt die richtige Begründung (das Fenster muss `MouseWheelZoom`s 80-ms-Timeout plus 250-ms-Animation überdauern, nicht die Toleranz der Gegenfunktion).

## Verifikation

- `npm run test:quick` — 2798 Tests in 187 Dateien grün; Lint nur zwei vorbestehende `any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`.
- E2E: `form-map-pan-zoom`, `map-pan-zoom`, `form-position`, `form-position-photo` — 21 Tests grün.
- `e2e/` liegt außerhalb von `type-check` und ESLint (bekannte Lücke, Pendant zum `scripts/`-Problem). Die drei berührten Dateien wurden deshalb einmal separat mit `tsc --strict` geprüft; zwei dabei gefundene Typfehler sind behoben.

## Hinweis für Reviewer

Ein früher Testlauf sah wie ein fehlgeschlagener Fix aus. Ursache war der Test, nicht die App: Das Formular scrollt an mehreren Stellen von selbst (`PositionPanel.openMap()` ruft `scrollIntoView`), und die Bounding-Box wurde mitten in diese Bewegung gelesen — der Startpunkt lag einmal bei `y = -36`, also außerhalb des Fensters. `mapPoint()` wartet den Scroll jetzt ab und prüft `box.y >= 0`; ohne diesen Wächter wäre der Test sporadisch aus dem falschen Grund grün gewesen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)