### PR TITLE
fix(auth): restart the login instead of dead-ending on an expired oauth flow

### DIFF
--- a/src/lib/server/auth/auth.test.ts
+++ b/src/lib/server/auth/auth.test.ts
@@ -666,6 +666,28 @@ describe('auth.ts', () => {
 			expect(token1).not.toBe(token2);
 			expect(mockCookies.set).toHaveBeenCalledTimes(2);
 		});
+
+		// OWASP verlangt für Session-/CSRF-Token mindestens 128 Bit. Math.random().toString(36)
+		// .substring(7) lieferte gemessen 3–7 base36-Zeichen (~15–36 Bit) und ist zudem kein
+		// kryptografischer Zufall — beides für einen CSRF-State ungeeignet.
+		it('erzeugt einen State mit mindestens 128 Bit kryptografischer Entropie', () => {
+			const token = setCsrfCookie(mockCookies);
+
+			// base64url: 4 Zeichen je 3 Byte → 128 Bit brauchen mindestens 22 Zeichen
+			expect(token.length).toBeGreaterThanOrEqual(22);
+			expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+		});
+
+		it('bleibt zufällig, auch wenn Math.random festgenagelt ist', () => {
+			const mockRandom = vi.spyOn(Math, 'random').mockReturnValue(0.42);
+
+			const token1 = setCsrfCookie(mockCookies);
+			const token2 = setCsrfCookie(mockCookies);
+
+			expect(token1).not.toBe(token2);
+
+			mockRandom.mockRestore();
+		});
 	});
 
 	describe('setPKCECookie', () => {

--- a/src/lib/server/auth/auth.ts
+++ b/src/lib/server/auth/auth.ts
@@ -27,6 +27,7 @@ const getSessionSecret = () => env.SESSION_SECRET ?? '';
 // setPKCECookie) würden dann ohne `secure` gesetzt (Befund 1, #668-Review).
 const getNodeEnv = () => (env.NODE_ENV ?? 'development').trim().toLowerCase();
 import { error, redirect, type Cookies } from '@sveltejs/kit';
+import { randomBytes } from 'crypto';
 import { createRemoteJWKSet, decodeJwt, jwtVerify, SignJWT } from 'jose';
 import { decrypt, encrypt, getPKCEChallengeData } from './crypto.js';
 
@@ -381,7 +382,11 @@ export const requireUserRole = (
  * ```
  */
 export const setCsrfCookie = (cookies: Cookies) => {
-	const csrfState = Math.random().toString(36).substring(7);
+	// 256 Bit aus dem Krypto-Zufallsgenerator. Der frühere Ausdruck
+	// `Math.random().toString(36).substring(7)` lieferte gemessen 3–7 base36-Zeichen
+	// (~15–36 Bit) aus einem nicht-kryptografischen PRNG — unter dem OWASP-Minimum
+	// von 128 Bit und damit als CSRF-State ratbar.
+	const csrfState = randomBytes(32).toString('base64url');
 	cookies.set('csrfState', csrfState, {
 		httpOnly: true,
 		sameSite: 'lax',

--- a/src/routes/api/auth/callback/+server.ts
+++ b/src/routes/api/auth/callback/+server.ts
@@ -26,6 +26,33 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const csrfState = cookies.get('csrfState');
 	const pkceVerifier = getPKCEVerifierFromCookie(cookies);
 
+	// Ein vorhandener State, der nicht passt, ist das einzige echte CSRF-Signal — nur dann
+	// darf hart abgewiesen werden.
+	const stateContradicts = !!csrfState && state !== csrfState;
+
+	// Sonst ist ein fehlendes Flow-Cookie bei vorhandenem code ein abgelaufener oder
+	// verbrauchter Flow, kein Angriff: Die Cookies leben 10 Minuten
+	// (COOKIE_AUTHORIZE_DURATION_SECONDS), Auth0 zeigt bei nicht verifizierbaren
+	// Callback-URIs wie localhost immer einen nicht abschaltbaren Consent-Screen, und der
+	// PKCE-Verifier ist Single-Use — ein zweiter Callback mit demselben code (Reload,
+	// Zurück-Taste, wiederhergestellter Tab) findet ihn nie wieder vor. Alle drei Fälle
+	// landeten bisher auf einer 403-Sackgasse statt in einem neuen Login.
+	const flowUnusable = !csrfState || !pkceVerifier;
+	// Einmaliger Neustart: ohne Marker drehte ein Client, der grundsätzlich keine Cookies
+	// annimmt, endlos zwischen Login und Callback.
+	const alreadyRetried = url.searchParams.get('authRetry') === '1';
+
+	if (!stateContradicts && flowUnusable && code && !alreadyRetried) {
+		logger.warn(
+			{ event: 'security.auth_flow_expired', returnUrl },
+			'Auth callback: Flow-Cookies abgelaufen oder verbraucht — Login wird neu gestartet'
+		);
+		const target = new URL('/api/auth/login', url);
+		target.searchParams.set('returnUrl', sanitizeReturnUrl(returnUrl));
+		target.searchParams.set('authRetry', '1');
+		redirect(302, `${target.pathname}${target.search}`);
+	}
+
 	if (state !== csrfState || !code || !pkceVerifier) {
 		logger.warn(
 			{
@@ -57,7 +84,9 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 			resourceType: 'auth',
 			userEmail: authUser.email
 		});
-		cookies.delete('csrfState', { path: '/' });
+		// Pfad muss mit setCsrfCookie übereinstimmen — ein delete auf '/' adressiert ein
+		// anderes Cookie und ließ das echte bis zum Ablauf stehen.
+		cookies.delete('csrfState', { path: '/api/auth' });
 		// Open-Redirect-Schutz: nur relative Same-Origin-Pfade zulassen
 		redirect(302, sanitizeReturnUrl(returnUrl));
 	} catch (err) {

--- a/src/routes/api/auth/callback/callback.test.ts
+++ b/src/routes/api/auth/callback/callback.test.ts
@@ -169,6 +169,138 @@ describe('GET /api/auth/callback — Audit Logging', () => {
 			expect.any(String)
 		);
 	});
+
+	it('löscht csrfState unter dem Pfad, unter dem es gesetzt wurde (/api/auth)', async () => {
+		mockGetToken.mockResolvedValue({ id_token: 'id-tok', access_token: 'access-tok' });
+		mockVerifyToken.mockResolvedValue({ email: 'user@test.com', sub: 'auth0|123' });
+		mockGetTokenClaims.mockResolvedValue({ 'https://api.test/roles': ['admin'] });
+
+		const cookies = makeCookies();
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?code=auth-code&state=valid-csrf'),
+			cookies
+		} as never).catch(() => {});
+
+		// Gesetzt wird das Cookie in setCsrfCookie mit path: '/api/auth'. Ein delete mit
+		// path: '/' adressiert ein anderes Cookie und lässt das echte 10 Minuten stehen.
+		expect(cookies.delete).toHaveBeenCalledWith('csrfState', { path: '/api/auth' });
+	});
+});
+
+/**
+ * Der abgelaufene Flow ist kein Angriff, sondern der Normalfall: Auth0 zeigt bei
+ * localhost-Callbacks immer einen Consent-Screen (nicht abschaltbar), und die
+ * Flow-Cookies leben nur 10 Minuten. Wer dort zu lange braucht — oder den
+ * Callback-Tab wiederherstellt — landete bisher auf einer 403-Sackgasse.
+ */
+describe('GET /api/auth/callback — abgelaufener oder verbrauchter Flow', () => {
+	const noFlowCookies = () => ({
+		get: vi.fn().mockReturnValue(undefined),
+		delete: vi.fn()
+	});
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetPKCEVerifier.mockReturnValue(null);
+	});
+
+	it('startet den Login neu, wenn beide Flow-Cookies fehlen', async () => {
+		let thrown: unknown;
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?returnUrl=/admin&code=auth-code&state=x'),
+			cookies: noFlowCookies()
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		const r = thrown as { status?: number; location?: string };
+		expect(r?.status).toBe(302);
+		expect(r?.location).toBe('/api/auth/login?returnUrl=%2Fadmin&authRetry=1');
+	});
+
+	it('meldet den abgelaufenen Flow als eigenes Event, nicht als csrf_mismatch', async () => {
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?returnUrl=/admin&code=auth-code&state=x'),
+			cookies: noFlowCookies()
+		} as never).catch(() => {});
+
+		expect(mockLoggerWarn).toHaveBeenCalledWith(
+			expect.objectContaining({ event: 'security.auth_flow_expired' }),
+			expect.any(String)
+		);
+		const csrfCalls = mockLoggerWarn.mock.calls.filter(
+			(call) => (call[0] as { event?: string })?.event === 'security.csrf_mismatch'
+		);
+		expect(csrfCalls).toHaveLength(0);
+	});
+
+	it('dreht keine Endlosschleife: nach einem Neustart wird abgebrochen', async () => {
+		let thrown: unknown;
+		await GET({
+			url: new URL(
+				'http://localhost/api/auth/callback?returnUrl=/admin&code=auth-code&state=x&authRetry=1'
+			),
+			cookies: noFlowCookies()
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		expect((thrown as { status?: number })?.status).toBe(403);
+	});
+
+	it('bleibt bei vorhandenem, aber abweichendem State bei 403 (echter CSRF-Verdacht)', async () => {
+		mockGetPKCEVerifier.mockReturnValue('pkce-verifier');
+
+		let thrown: unknown;
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?returnUrl=/admin&code=auth-code&state=böse'),
+			cookies: {
+				get: vi.fn().mockImplementation((n: string) => (n === 'csrfState' ? 'echt' : undefined)),
+				delete: vi.fn()
+			}
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		expect((thrown as { status?: number })?.status).toBe(403);
+		expect(mockLoggerWarn).toHaveBeenCalledWith(
+			expect.objectContaining({ event: 'security.csrf_mismatch' }),
+			expect.any(String)
+		);
+	});
+
+	// Der PKCE-Verifier wird beim Lesen gelöscht (Single-Use), csrfState überlebt bis zum
+	// Ablauf. Ein zweiter Callback mit demselben code — Reload, Zurück-Taste, doppelt
+	// zugestellter Request — trifft deshalb auf „State passt, Verifier weg". Das ist ein
+	// verbrauchter Flow, kein Angriff.
+	it('startet neu, wenn nur der PKCE-Verifier verbraucht ist und der State noch passt', async () => {
+		let thrown: unknown;
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?returnUrl=/admin&code=auth-code&state=echt'),
+			cookies: {
+				get: vi.fn().mockImplementation((n: string) => (n === 'csrfState' ? 'echt' : undefined)),
+				delete: vi.fn()
+			}
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		const r = thrown as { status?: number; location?: string };
+		expect(r?.status).toBe(302);
+		expect(r?.location).toBe('/api/auth/login?returnUrl=%2Fadmin&authRetry=1');
+	});
+
+	it('startet nicht neu, wenn der code fehlt (kein Auth0-Rücklauf)', async () => {
+		let thrown: unknown;
+		await GET({
+			url: new URL('http://localhost/api/auth/callback?returnUrl=/admin'),
+			cookies: noFlowCookies()
+		} as never).catch((e) => {
+			thrown = e;
+		});
+
+		expect((thrown as { status?: number })?.status).toBe(403);
+	});
 });
 
 describe('sanitizeReturnUrl', () => {

--- a/src/routes/api/auth/login/+server.ts
+++ b/src/routes/api/auth/login/+server.ts
@@ -8,16 +8,25 @@ export async function GET({ url, cookies }: { url: URL; cookies: Cookies }) {
 	const returnUrl = encodeURIComponent(url.searchParams.get('returnUrl') || '/');
 	const challenge = setPKCECookie(cookies);
 	const publicSiteUrl = publicEnv.PUBLIC_SITE_URL ?? 'http://localhost:3000';
+	// Der Callback setzt diesen Marker, wenn er den Login wegen fehlender Flow-Cookies
+	// neu gestartet hat. Er muss bis in die redirect_uri wandern, sonst sieht der Callback
+	// ihn nach dem Auth0-Rücklauf nie wieder und ein Client, der keine Cookies annimmt,
+	// pendelt endlos zwischen Login und Callback. Nur der exakte Wert '1' wird
+	// weitergereicht — sonst wäre die redirect_uri über die Query fremdsteuerbar.
+	const authRetry = url.searchParams.get('authRetry') === '1' ? '&authRetry=1' : '';
 	const query = {
 		scope: 'openid profile email',
 		response_type: 'code',
 		client_id: env.AUTH0_CLIENT_ID ?? '',
-		redirect_uri: `${publicSiteUrl}/api/auth/callback?returnUrl=${returnUrl}`,
+		redirect_uri: `${publicSiteUrl}/api/auth/callback?returnUrl=${returnUrl}${authRetry}`,
 		state: csrfState,
 		audience: env.API_AUDIENCE ?? '',
 		code_challenge: challenge,
 		code_challenge_method: 'S256'
 	};
 
-	throw redirect(302, `https://${env.AUTH0_DOMAIN}/authorize?${new URLSearchParams(query).toString()}`);
+	throw redirect(
+		302,
+		`https://${env.AUTH0_DOMAIN}/authorize?${new URLSearchParams(query).toString()}`
+	);
 }

--- a/src/routes/api/auth/login/login.test.ts
+++ b/src/routes/api/auth/login/login.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSetCsrfCookie, mockSetPKCECookie } = vi.hoisted(() => ({
+	mockSetCsrfCookie: vi.fn().mockReturnValue('csrf-state'),
+	mockSetPKCECookie: vi.fn().mockReturnValue('pkce-challenge')
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		AUTH0_CLIENT_ID: 'client-id',
+		AUTH0_DOMAIN: 'id.test',
+		API_AUDIENCE: 'https://api.test'
+	}
+}));
+
+vi.mock('$env/dynamic/public', () => ({
+	env: { PUBLIC_SITE_URL: 'https://test-site.com' }
+}));
+
+vi.mock('$lib/server/auth/auth', () => ({
+	setCsrfCookie: mockSetCsrfCookie,
+	setPKCECookie: mockSetPKCECookie
+}));
+
+import { GET } from './+server';
+
+/** Führt GET aus und liefert die redirect_uri, die an Auth0 gesendet würde. */
+async function redirectUriFor(query: string): Promise<string> {
+	let thrown: unknown;
+	await GET({
+		url: new URL(`https://test-site.com/api/auth/login${query}`),
+		cookies: { set: vi.fn(), get: vi.fn(), delete: vi.fn() }
+	} as never).catch((e) => {
+		thrown = e;
+	});
+
+	const location = (thrown as { location?: string })?.location ?? '';
+	const authorizeUrl = new URL(location);
+	return authorizeUrl.searchParams.get('redirect_uri') ?? '';
+}
+
+describe('GET /api/auth/login — Schleifenschutz', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSetCsrfCookie.mockReturnValue('csrf-state');
+		mockSetPKCECookie.mockReturnValue('pkce-challenge');
+	});
+
+	// Der Callback setzt authRetry=1, wenn er den Login wegen fehlender Flow-Cookies
+	// neu startet. Trägt die Login-Route den Marker nicht bis in die redirect_uri, sieht
+	// der Callback ihn nach dem Auth0-Rücklauf nie — ein Client, der keine Cookies
+	// annimmt, pendelt dann endlos zwischen Login und Callback.
+	it('trägt authRetry=1 bis in die redirect_uri, damit der Callback es wiedersieht', async () => {
+		const redirectUri = await redirectUriFor('?returnUrl=%2Fadmin&authRetry=1');
+
+		expect(redirectUri).toContain('authRetry=1');
+		expect(new URL(redirectUri).searchParams.get('returnUrl')).toBe('/admin');
+	});
+
+	it('hängt ohne Marker kein authRetry an', async () => {
+		const redirectUri = await redirectUriFor('?returnUrl=%2Fadmin');
+
+		expect(redirectUri).not.toContain('authRetry');
+	});
+
+	// Nur der exakte Wert '1' wird weitergereicht — sonst wäre die redirect_uri ein
+	// Einfallstor für beliebige, vom Aufrufer gesteuerte Query-Parameter.
+	it('reicht nur den Wert 1 weiter, keinen beliebigen Fremdwert', async () => {
+		const redirectUri = await redirectUriFor('?returnUrl=%2Fadmin&authRetry=schadhaft');
+
+		expect(redirectUri).not.toContain('authRetry');
+		expect(redirectUri).not.toContain('schadhaft');
+	});
+});

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1280,11 +1280,27 @@ paths:
           schema:
             type: string
             format: uri
+        - name: authRetry
+          in: query
+          description: >-
+            Interner Marker. Wird gesetzt, wenn der Login wegen abgelaufener
+            Flow-Cookies bereits einmal neu gestartet wurde, und verhindert eine
+            Endlosschleife zwischen Login und Callback.
+          schema:
+            type: string
+            enum:
+              - '1'
       responses:
         '302':
-          description: Weiterleitung nach erfolgreichem Login
+          description: >-
+            Weiterleitung nach erfolgreichem Login zur returnUrl — oder zurück auf
+            /api/auth/login, wenn die Flow-Cookies abgelaufen oder bereits verbraucht
+            sind (dann mit authRetry=1).
         '403':
-          description: Ungültiger State oder fehlender Code
+          description: >-
+            Fehlender Code, oder vorhandener State-Cookie, der dem übergebenen state
+            widerspricht (CSRF-Verdacht). Ebenso, wenn der Login-Neustart bereits
+            erfolglos versucht wurde (authRetry=1).
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1239,6 +1239,17 @@ paths:
             type: string
             format: uri
             example: "/admin"
+        - name: authRetry
+          in: query
+          description: >-
+            Interner Marker. Wird vom Callback gesetzt, wenn er den Login wegen
+            abgelaufener Flow-Cookies neu gestartet hat, und in die redirect_uri
+            übernommen, damit der Callback ihn nach dem Auth0-Rücklauf wiedersieht.
+            Nur der Wert '1' wird weitergereicht.
+          schema:
+            type: string
+            enum:
+              - '1'
       responses:
         '302':
           description: Weiterleitung zu Auth0


### PR DESCRIPTION
## Problem

Ein Admin-Login, der etwas zu spät von Auth0 zurückkam, antwortete mit `403 Invalid state` — derselben Antwort, die ein CSRF-Angriff bekommt. Aus dieser Seite führte kein Weg heraus außer `/api/auth/login` von Hand einzutippen.

Ausgangspunkt war diese Logzeile:

```
{"event":"security.csrf_mismatch","stateMatch":false,"hasCode":true,"hasPkce":false}
```

`hasPkce:false` **und** `stateMatch:false` bei vorhandenem `code` heißt: beide Flow-Cookies fehlten. Dass sie blockiert würden, ist ausgeschlossen — im Browser gemessen liefert Chrome sie bei einem normalen Top-Level-Callback korrekt aus (`hasPkce:true`).

Zwei Alltagswege führen dorthin, keiner davon ein Angriff:

- Die Flow-Cookies leben 10 Minuten (`COOKIE_AUTHORIZE_DURATION_SECONDS`). Auth0 zeigt bei `localhost`-Callbacks **immer** einen Consent-Screen — laut Auth0-Doku nicht abschaltbar, weil `localhost` ein „non-verifiable callback URI" ist. Der sitzt mitten im Zeitfenster.
- `getPKCEVerifierFromCookie` löscht `extendedState` beim Lesen (Single-Use). Ein zweiter Callback mit demselben `code` — Reload, Zurück-Taste, wiederhergestellter Tab, doppelt zugestellter Request — findet ihn nie wieder vor.

## Lösung

Der Callback unterscheidet jetzt drei Fälle statt einem:

| Fall | Vorher | Jetzt |
|---|---|---|
| State-Cookie vorhanden, widerspricht | 403 | 403 + `csrf_mismatch` (unverändert) |
| Flow-Cookie fehlt, `code` vorhanden | 403 | 302 → Login, `auth_flow_expired` |
| Neustart schon versucht (`authRetry=1`) | — | 403, Schleifenschutz |

Ein Neustart vergibt nie eine Session — die CSRF-Zusage bleibt unverändert.

## Zwei Defekte, die beim Nachverfolgen auffielen

- `cookies.delete('csrfState')` übergab `path: '/'`, gesetzt wird das Cookie aber unter `/api/auth`. Es adressierte damit ein anderes Cookie; das echte überlebte jeden erfolgreichen Login bis zum Ablauf.
- Der CSRF-State kam aus `Math.random().toString(36).substring(7)` — über 200.000 Läufe gemessen 3–7 base36-Zeichen, ~26 Bit, aus einem nicht-kryptografischen PRNG. Jetzt `randomBytes(32)` als base64url, über dem OWASP-Minimum von 128 Bit.

## Verifikation

Test-First (RED→GREEN), 7 neue Tests. Gegen einen laufenden Dev-Server nachgestellt:

```
Callback #1 (Flow intakt)        → HTTP 500   CSRF-Gate passiert
Callback #2 (selber code/state)  → HTTP 302   /api/auth/login?returnUrl=%2Fadmin&authRetry=1
  Log: security.auth_flow_expired
Echter CSRF (State widerspricht) → HTTP 403
Neustart schon versucht          → HTTP 403
```

`npm run test:quick`: 192 Dateien, 2866 Tests grün. `static/openapi.yml` mitgezogen (neuer `authRetry`-Parameter, geschärfte 302/403-Beschreibungen).

## Nicht in diesem PR

- Der parallel gemeldete `/admin`-500 war **unabhängig**: der lokalen DB fehlten sechs Spalten aus PR #672, weil Migration `0002` nie angewandt war. Durch Anwenden der Migration behoben, keine Code-Änderung.
- Dabei fiel eine Falle im Migrator auf: `docker-migrate.ts` erkennt „Journal leer + `sichtungen` existiert" als Baseline und trägt alle Migrationen als angewandt ein, *ohne sie auszuführen*. Bei einer push-gebauten DB, die nicht aktuell ist, zementiert das den Fehler lautlos. Ein Drift-Check vor dem Baselinen wäre die strukturelle Absicherung — separat zu behandeln.
- `getToken()` sendet `redirect_uri` ohne `?returnUrl=`, `/authorize` mit. Formal ein RFC-6749-Verstoß, steht aber seit dem ersten Auth-Commit so drin und wird von Auth0 toleriert. Kein Fehlerbild, deshalb nicht mitgebündelt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)