### PR TITLE
fix(ui): make the form stepper look like the navigation it already is

### DIFF
--- a/e2e/form-stepper-affordance.spec.ts
+++ b/e2e/form-stepper-affordance.spec.ts
@@ -1,0 +1,209 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { FormPage } from './pages/FormPage';
+
+/**
+ * Der Stepper am Seitenkopf ist seit jeher Navigation — man sah es ihm nur
+ * nicht an. Gemessen im Ruhezustand auf Schritt 2 trugen erreichbarer und
+ * aktueller Schritt dieselbe Farbe (`base-content`), denselben Schriftschnitt
+ * (400) und denselben Cursor (`default`, aus Tailwinds Preflight). Der einzige
+ * Schritt mit einem abweichenden Cursor war der **gesperrte**
+ * (`not-allowed`) — das Zeigegerät meldete also ausschließlich, wo nichts
+ * geht. Ein Hover-Zustand existierte nicht, und die Trefferfläche war 16px
+ * hoch, also die nackte Textzeile.
+ *
+ * Genau daraus entstand der Wunsch des Deutschen Meeresmuseums nach einem
+ * „Zurück-Button auch oberhalb" (Abschnitt B5 der Änderungswünsche; das
+ * Dokument liegt seit #676 außerhalb dieses Repos). Die
+ * Antwort ist kein zweites Bedienelement — das verstieße gegen die
+ * Button-Hierarchie in `design-system.md` —, sondern die fehlende Affordanz.
+ *
+ * Dieser Test hält die drei Zustände auseinander. Er prüft NICHT, ob die
+ * Navigation funktioniert (das tun `stepNavigation.test.ts` und
+ * `form-field-mode.spec.ts`), sondern ob man ihr ansieht, dass es sie gibt.
+ */
+
+const STEP_BUTTON = 'nav[aria-label="Formular-Schritte"]:visible .step-button';
+
+/**
+ * Wartet, bis alle laufenden CSS-Transitions durch sind.
+ *
+ * Ohne das misst dieser Test sich selbst blind: Der Schrittwechsel färbt den
+ * verlassenen Schritt in die Linkfarbe um, und zwar über
+ * `--motion-instant` (120ms). Ein `getComputedStyle` unmittelbar danach liest
+ * einen Zwischenwert. Beim Hover ist es schlimmer als ungenau — dort steht
+ * sofort nach `.hover()` `oklab(0 0 0 / 0)`, also **Deckkraft 0**. Ein
+ * Vergleich gegen den Ruhewert `rgba(0, 0, 0, 0)` wäre damit schon erfüllt,
+ * ohne dass irgendetwas sichtbar geworden ist.
+ *
+ * Nur Transitions, nicht `getAnimations()` insgesamt: eine endlos laufende
+ * Keyframe (Ladeanzeige) würde sonst nie fertig und der Test hinge.
+ */
+async function transitionsSettled(page: Page): Promise<void> {
+	await page.evaluate(async () => {
+		const transitions = document
+			.getAnimations()
+			.filter((a) => typeof CSSTransition !== 'undefined' && a instanceof CSSTransition);
+		await Promise.all(transitions.map((a) => a.finished.catch(() => undefined)));
+	});
+}
+
+/** Bringt das Formular auf Schritt 2 — dort ist Schritt 1 erreichbar, 3 und 4 sind gesperrt. */
+async function gotoStepTwo(page: Page): Promise<FormPage> {
+	const formPage = new FormPage(page);
+	await formPage.goto();
+	await formPage.fillWaterway('Kieler Förde');
+	await formPage.clickNext();
+	await expect(page.locator(`${STEP_BUTTON}[aria-current="step"]`)).toHaveText(/Angaben zum Tier/);
+	await transitionsSettled(page);
+	return formPage;
+}
+
+async function style(el: Locator, prop: string): Promise<string> {
+	return el.evaluate(
+		(node, p) => getComputedStyle(node).getPropertyValue(p),
+		prop
+	) as Promise<string>;
+}
+
+/**
+ * Deckkraft einer berechneten Farbe. Der Browser serialisiert je nach Herkunft
+ * als `rgba(…)` oder als `oklab(… / a)` — beide Formen kommen an derselben
+ * Eigenschaft vor, sobald ein `color-mix()` im Spiel ist.
+ */
+function alphaOf(color: string): number {
+	const mitSchraegstrich = color.match(/\/\s*([\d.]+)\s*\)/);
+	if (mitSchraegstrich) return Number(mitSchraegstrich[1]);
+	const rgba = color.match(/^rgba?\(([^)]+)\)/);
+	if (rgba) {
+		const teile = rgba[1].split(',').map((s) => s.trim());
+		return teile.length === 4 ? Number(teile[3]) : 1;
+	}
+	return 1;
+}
+
+test.describe('Stepper — erkennbar als Navigation', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.setViewportSize({ width: 1024, height: 900 });
+	});
+
+	test('der erreichbare Schritt sieht anders aus als der aktuelle', async ({ page }) => {
+		await gotoStepTwo(page);
+		const erreichbar = page.locator(`${STEP_BUTTON}[aria-disabled="false"]`).first();
+		const aktuell = page.locator(`${STEP_BUTTON}[aria-current="step"]`);
+
+		await expect(erreichbar).toHaveText(/Position & Zeitpunkt/);
+
+		// Farbe UND Unterstreichung — zwei Kanäle, damit die Auszeichnung nicht
+		// allein an der Farbe hängt (WCAG 1.4.1).
+		expect(await style(erreichbar, 'color')).not.toBe(await style(aktuell, 'color'));
+		expect(await style(erreichbar, 'text-decoration-line')).toBe('underline');
+		expect(await style(aktuell, 'text-decoration-line')).toBe('none');
+
+		// Der aktuelle Schritt ist Standort, kein Ziel: fetter, nicht unterstrichen.
+		expect(Number(await style(aktuell, 'font-weight'))).toBeGreaterThan(
+			Number(await style(erreichbar, 'font-weight'))
+		);
+	});
+
+	test('das Zeigegerät meldet erreichbar und gesperrt unterschiedlich', async ({ page }) => {
+		await gotoStepTwo(page);
+		const erreichbar = page.locator(`${STEP_BUTTON}[aria-disabled="false"]`).first();
+		const gesperrt = page.locator(`${STEP_BUTTON}[aria-disabled="true"]`).first();
+
+		// Vor dieser Änderung stand hier zweimal `default` bzw. einmal
+		// `not-allowed` — der Cursor zeigte nur, wo es NICHT weitergeht.
+		expect(await style(erreichbar, 'cursor')).toBe('pointer');
+		expect(await style(gesperrt, 'cursor')).toBe('not-allowed');
+	});
+
+	test('die Trefferfläche erfüllt das Mindestmaß aus --target-min', async ({ page }) => {
+		await gotoStepTwo(page);
+		const buttons = page.locator(STEP_BUTTON);
+		const anzahl = await buttons.count();
+		expect(anzahl).toBe(4);
+
+		for (const density of ['default', 'field'] as const) {
+			await page.evaluate((d) => document.documentElement.setAttribute('data-density', d), density);
+			await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => r(null))));
+
+			// rem → px über die tatsächliche Root-Schriftgröße, nicht über eine
+			// angenommene 16.
+			const sollPx = await page.evaluate(() => {
+				const root = getComputedStyle(document.documentElement);
+				return parseFloat(root.getPropertyValue('--target-min')) * parseFloat(root.fontSize);
+			});
+
+			for (let i = 0; i < anzahl; i++) {
+				const box = await buttons.nth(i).boundingBox();
+				expect(box, `Schritt ${i + 1} muss sichtbar sein`).not.toBeNull();
+				expect(
+					box!.height,
+					`Schritt ${i + 1} (${density}) muss --target-min hoch sein`
+				).toBeGreaterThanOrEqual(sollPx - 0.5);
+			}
+		}
+		await page.evaluate(() => document.documentElement.removeAttribute('data-density'));
+	});
+
+	test('der Hover hebt den erreichbaren Schritt hervor, den gesperrten nicht', async ({ page }) => {
+		await gotoStepTwo(page);
+		const erreichbar = page.locator(`${STEP_BUTTON}[aria-disabled="false"]`).first();
+		const gesperrt = page.locator(`${STEP_BUTTON}[aria-disabled="true"]`).first();
+
+		// Deckkraft statt Farb-String: `not.toBe()` auf der Serialisierung wäre
+		// schon erfüllt, wenn aus `rgba(0, 0, 0, 0)` ein `oklab(0 0 0 / 0)` wird —
+		// eine Fläche mit 0 % Deckkraft käme durch.
+		expect(alphaOf(await style(erreichbar, 'background-color'))).toBe(0);
+		await erreichbar.hover();
+		await transitionsSettled(page);
+		expect(alphaOf(await style(erreichbar, 'background-color'))).toBeGreaterThan(0);
+
+		await gesperrt.hover({ force: true });
+		await transitionsSettled(page);
+		expect(alphaOf(await style(gesperrt, 'background-color'))).toBe(0);
+	});
+
+	test('die Schaltflächen benennen die Aktion, nicht nur den Schritt', async ({ page }) => {
+		await gotoStepTwo(page);
+		const buttons = page.locator(STEP_BUTTON);
+
+		await expect(buttons.nth(0)).toHaveAttribute(
+			'aria-label',
+			'Zurück zu Schritt 1: Position & Zeitpunkt'
+		);
+		await expect(buttons.nth(1)).toHaveAttribute('aria-label', 'Schritt 2: Angaben zum Tier');
+		await expect(buttons.nth(2)).toHaveAttribute(
+			'aria-label',
+			'Weiter zu Schritt 3: Weitere Informationen'
+		);
+	});
+
+	test('die Sperre bleibt fokussierbar, begründet und wirksam', async ({ page }) => {
+		await gotoStepTwo(page);
+		const gesperrt = page.locator(`${STEP_BUTTON}[aria-disabled="true"]`).first();
+
+		// `aria-disabled` statt `disabled` — sonst verlöre die Tastaturbedienung
+		// den Fokus und der begründende `title` wäre unerreichbar
+		// (design-system.md, „Gesperrte Schaltflächen").
+		await expect(gesperrt).not.toHaveAttribute('disabled', /.*/);
+		await expect(gesperrt).toHaveAttribute('title', /vorherigen Schritte/);
+		await gesperrt.focus();
+		await expect(gesperrt).toBeFocused();
+
+		// `force`, weil Playwright `aria-disabled="true"` selbst als nicht
+		// bedienbar wertet und ohne das gar nicht erst klickt — der Test würde
+		// dann nur Playwrights eigene Prüfung bestätigen, nie die der Anwendung.
+		await gesperrt.click({ force: true });
+		await expect(page.locator(`${STEP_BUTTON}[aria-current="step"]`)).toHaveText(
+			/Angaben zum Tier/
+		);
+	});
+
+	test('ein Klick auf den erreichbaren Schritt geht zurück', async ({ page }) => {
+		await gotoStepTwo(page);
+		await page.locator(`${STEP_BUTTON}[aria-disabled="false"]`).first().click();
+		await expect(page.locator(`${STEP_BUTTON}[aria-current="step"]`)).toHaveText(
+			/Position & Zeitpunkt/
+		);
+	});
+});

--- a/e2e/form-stepper-affordance.spec.ts
+++ b/e2e/form-stepper-affordance.spec.ts
@@ -207,3 +207,55 @@ test.describe('Stepper — erkennbar als Navigation', () => {
 		);
 	});
 });
+
+/**
+ * Unterhalb `md` übernimmt `StepProgressCompact.svelte` im ortsfesten Balken.
+ * Dort steht „Zurück" als echter Button daneben, die Segmente brauchen also
+ * keine eigene Link-Optik — wohl aber denselben Cursor-Vertrag.
+ *
+ * Der Anlass für diesen Block: `canNavigateToStep` liefert für den AKTUELLEN
+ * Schritt `true` (`targetIndex <= currentStep`). Oben schließt das CSS ihn über
+ * `:not([aria-current='step'])` aus; unten hing der Cursor an einer Utility, die
+ * das nicht tat — der aktuelle Schritt gab sich damit als Navigationsziel aus,
+ * obwohl ein Klick darauf nichts tut.
+ */
+test.describe('Kompakte Fortschrittsanzeige — derselbe Cursor-Vertrag', () => {
+	const SEGMENT = 'nav[aria-label="Formular-Schritte"]:visible ol button';
+
+	test.beforeEach(async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+	});
+
+	test('nur erreichbare Schritte außer dem aktuellen zeigen den Zeigefinger', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await formPage.fillWaterway('Kieler Förde');
+		await formPage.clickNext();
+		await expect(page.locator(`${SEGMENT}[aria-current="step"]`)).toHaveAttribute(
+			'aria-label',
+			/Angaben zum Tier/
+		);
+
+		const segmente = page.locator(SEGMENT);
+		await expect(segmente).toHaveCount(4);
+
+		// Schritt 1: erreichbar, nicht aktuell → Ziel.
+		expect(await style(segmente.nth(0), 'cursor')).toBe('pointer');
+		// Schritt 2: aktuell → Standort, kein Ziel.
+		expect(await style(segmente.nth(1), 'cursor')).not.toBe('pointer');
+		// Schritt 3 und 4: gesperrt.
+		expect(await style(segmente.nth(2), 'cursor')).toBe('not-allowed');
+		expect(await style(segmente.nth(3), 'cursor')).toBe('not-allowed');
+	});
+
+	test('auf Schritt 1 ist kein Segment ein Ziel', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		const segmente = page.locator(SEGMENT);
+		// Der einzige erreichbare Schritt ist der aktuelle — es gibt nichts
+		// anzuspringen, also darf auch nichts danach aussehen.
+		expect(await style(segmente.nth(0), 'cursor')).not.toBe('pointer');
+		expect(await style(segmente.nth(1), 'cursor')).toBe('not-allowed');
+	});
+});

--- a/e2e/homepage.test.ts
+++ b/e2e/homepage.test.ts
@@ -40,7 +40,7 @@ test.describe('Form Navigation', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		await expect(page.locator('.step-button[aria-label="Position & Zeitpunkt"]')).toBeVisible();
+		await expect(page.locator('.step-button', { hasText: 'Position & Zeitpunkt' })).toBeVisible();
 		await expect(formPage.getActiveStepButton()).toBeVisible();
 	});
 
@@ -69,20 +69,19 @@ test.describe('Form Navigation', () => {
 			'Weitere Informationen',
 			'Kontaktdaten'
 		] as const;
+		// Anker ist der sichtbare Titel, nicht der `aria-label`: Der Label-Text
+		// benennt seit der Stepper-Affordanz die Aktion („Zurück zu Schritt 1: …")
+		// und hat mit `stepLabels.test.ts` plus `form-stepper-affordance.spec.ts`
+		// eigene Tests. Ein exakter Attribut-Selektor hier koppelte diese Tests an
+		// eine Formulierung, die sie gar nicht prüfen wollen.
 		for (const name of stepNames) {
-			await expect(page.locator(`.step-button[aria-label="${name}"]`)).toBeVisible();
+			await expect(page.locator('.step-button', { hasText: name })).toBeVisible();
 		}
 
 		// On Step 1: current step should be navigable
-		await expect(page.locator('.step-button[aria-label="Position & Zeitpunkt"]')).toHaveAttribute(
-			'aria-disabled',
-			'false'
-		);
-
-		await expect(page.locator('.step-button[aria-label="Position & Zeitpunkt"]')).toHaveAttribute(
-			'aria-label',
-			/Position & Zeitpunkt/i
-		);
+		const ersterSchritt = page.locator('.step-button', { hasText: 'Position & Zeitpunkt' });
+		await expect(ersterSchritt).toHaveAttribute('aria-disabled', 'false');
+		await expect(ersterSchritt).toHaveAttribute('aria-label', /Position & Zeitpunkt/i);
 	});
 
 	test('active step starts on Position & Zeitpunkt', async ({ page }) => {

--- a/src/app.css
+++ b/src/app.css
@@ -515,13 +515,33 @@ label:has(> .toggle) {
    statt 13px), bei abweichender Schriftdarstellung oder anderer Sprache kippt
    das — und zwar still, weil abgeschnitten wird statt umzubrechen.
 
-   `minmax(0, 1fr)` bindet die Spalte an die Leiste statt an den Inhalt, der
-   Rest lässt den Titel darin umbrechen. Damit hängt die Darstellung nicht mehr
-   an der Länge der Beschriftung. */
+   `minmax(0, 1fr)` bindet die Spalte an die Leiste statt an den Inhalt; die
+   Umbruch-Eigenschaften am `.step-button` unten (`width`, `min-width`,
+   `white-space`, `overflow-wrap`, `hyphens`) lassen den Titel darin umbrechen.
+   Damit hängt die Darstellung nicht mehr an der Länge der Beschriftung. */
 .steps .step {
 	grid-template-columns: minmax(0, 1fr);
 }
 
+/* ===== Der Stepper muss aussehen wie Navigation =====
+
+   Er WAR immer welche — besuchte Schritte lassen sich seit jeher anspringen
+   (`canNavigateToStep`). Nur sah man es ihm nicht an: Im Ruhezustand trugen
+   erreichbarer und aktueller Schritt dieselbe Farbe (`base-content`), denselben
+   Schnitt (400) und denselben Cursor. `default` übrigens, aus Tailwinds
+   Preflight — der EINZIGE Schritt mit abweichendem Cursor war der gesperrte
+   (`not-allowed`). Das Zeigegerät meldete also ausschließlich, wo nichts geht.
+
+   Daraus entstand der Wunsch des Deutschen Meeresmuseums nach einem
+   „Zurück-Button auch oberhalb" (B5 der Änderungswünsche; das Dokument liegt
+   seit #676 außerhalb dieses Repos). Die Antwort ist
+   kein zweites Bedienelement — das verstieße gegen die Button-Hierarchie in
+   design-system.md („Gleiche Aktion = gleiche Variante") —, sondern die
+   fehlende Affordanz. Abgesichert durch `e2e/form-stepper-affordance.spec.ts`.
+
+   Die Zustände kommen aus `aria-disabled` und `aria-current` statt aus eigenen
+   Klassen: Beide stehen ohnehin im Markup, weil die Barrierefreiheit sie
+   braucht. Eine parallele Klasse könnte davon abweichen — dieses Paar nicht. */
 .steps .step-button {
 	width: 100%;
 	min-width: 0;
@@ -529,6 +549,57 @@ label:has(> .toggle) {
 	white-space: normal;
 	overflow-wrap: break-word;
 	hyphens: auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	/* WCAG 2.5.5: Bis hierher war das Ziel die nackte Textzeile, gemessen 16px
+	   hoch. Der zentrale Touch-Target-Block oben greift nicht, weil er auf
+	   `.btn` zielt und dies keiner ist. Der Wert kommt aus dem Token, im
+	   Feldmodus also automatisch 56px. */
+	min-height: var(--target-min);
+	border-radius: var(--radius-field);
+	transition:
+		color var(--motion-instant) var(--motion-ease),
+		background-color var(--motion-instant) var(--motion-ease),
+		text-decoration-thickness var(--motion-instant) var(--motion-ease);
+}
+
+/* Erreichbar, aber nicht der aktuelle Schritt: liest sich als Link.
+   Farbe UND Unterstreichung, damit die Auszeichnung nicht allein an der Farbe
+   hängt (WCAG 1.4.1). `primary` ist keine Statusfarbe, die `-strong`-Pflicht
+   gilt hier nicht — im Browser gemessen 9,24:1. Bezugsfläche ist `base-100`:
+   Der Stepper sitzt im Formular-Container `div.bg-base-100`, nicht auf dem
+   Seitenhintergrund. */
+.steps .step-button[aria-disabled='false']:not([aria-current='step']) {
+	cursor: pointer;
+	color: var(--color-primary);
+	text-decoration-line: underline;
+	text-decoration-thickness: 1px;
+	text-underline-offset: 3px;
+}
+
+/* `:focus-visible` mit auf dieselbe Fläche: Wer per Tastatur ankommt, soll
+   dasselbe sehen wie mit der Maus. Der globale Fokusring aus dem
+   Accessibility-Block bleibt zusätzlich — er umschließt seit der `min-height`
+   oben eine 44px-Fläche statt einer 16px-Textzeile.
+   Gemessen 7,73:1 für den Titel auf dieser Fläche. */
+.steps .step-button[aria-disabled='false']:not([aria-current='step']):hover,
+.steps .step-button[aria-disabled='false']:not([aria-current='step']):focus-visible {
+	background-color: color-mix(in oklab, var(--color-primary) 10%, transparent);
+	text-decoration-thickness: 2px;
+}
+
+/* Der aktuelle Schritt ist Standort, kein Ziel: kräftiger, aber nicht
+   unterstrichen und nicht in der Linkfarbe. */
+.steps .step-button[aria-current='step'] {
+	font-weight: 600;
+}
+
+/* Gesperrt: der `li` trägt bereits die Abblendung, hier fehlte nur der Cursor.
+   Er stand vorher als Utility an der Aufrufstelle — beide Zustände gehören an
+   dieselbe Stelle, sonst driften sie auseinander. */
+.steps .step-button[aria-disabled='true'] {
+	cursor: not-allowed;
 }
 
 /* ===== Print ===== */

--- a/src/lib/report/components/form/FormSteps.svelte
+++ b/src/lib/report/components/form/FormSteps.svelte
@@ -2,6 +2,7 @@
 	import { canNavigateToStep } from '$lib/form/validation/stepNavigation';
 	import { getFormContext } from '$lib/report/formContext';
 	import type { FormStep } from '$lib/report/types';
+	import { stepNavigationLabel } from './stepLabels';
 
 	/**
 	 * Step navigation component - currentStep is managed by parent
@@ -31,6 +32,12 @@
   The step title is rendered as visible <li> content (shown below the
   circle). Navigation is a real <button> for proper keyboard/AT support;
   aria-current marks the active step (WAI stepper pattern).
+
+  Wie die drei Zustände AUSSEHEN, steht in app.css („Der Stepper muss aussehen
+  wie Navigation") und hängt allein an aria-disabled und aria-current — hier
+  gibt es bewusst keine parallelen Zustandsklassen, die davon abweichen
+  könnten. Deshalb steht auch der gesperrte Cursor dort und nicht mehr als
+  `class:cursor-not-allowed` an dieser Stelle.
 -->
 <!--
   Ab `md`. Unterhalb davon zeigt `StepProgressCompact.svelte` denselben Zustand
@@ -51,9 +58,8 @@
 				<button
 					type="button"
 					class="text-support step-button px-1"
-					class:cursor-not-allowed={!navigable}
 					aria-disabled={!navigable ? 'true' : 'false'}
-					aria-label={step.title}
+					aria-label={stepNavigationLabel(index, currentStep, step.title)}
 					aria-current={currentStep === index ? 'step' : undefined}
 					title={navigable
 						? step.description

--- a/src/lib/report/components/form/StepProgressCompact.svelte
+++ b/src/lib/report/components/form/StepProgressCompact.svelte
@@ -3,6 +3,7 @@
 	import { canNavigateToStep } from '$lib/form/validation/stepNavigation';
 	import { getFormContext } from '$lib/report/formContext';
 	import type { FormStep } from '$lib/report/types';
+	import { stepNavigationLabel } from './stepLabels';
 
 	/**
 	 * Kompakte Fortschrittsanzeige für den ortsfesten Balken unterhalb `md`.
@@ -67,10 +68,11 @@
 				<button
 					type="button"
 					class="flex min-h-[var(--target-min)] w-full items-center px-0.5"
+					class:cursor-pointer={navigable}
 					class:cursor-not-allowed={!navigable}
 					aria-current={currentStep === index ? 'step' : undefined}
 					aria-disabled={!navigable ? 'true' : 'false'}
-					aria-label="Schritt {index + 1}: {step.title}"
+					aria-label={stepNavigationLabel(index, currentStep, step.title)}
 					title={navigable
 						? step.description
 						: 'Bitte füllen Sie zuerst die vorherigen Schritte aus'}

--- a/src/lib/report/components/form/StepProgressCompact.svelte
+++ b/src/lib/report/components/form/StepProgressCompact.svelte
@@ -65,10 +65,19 @@
 		{#each steps as step, index (step.id)}
 			{@const navigable = canNavigateTo(index)}
 			<li class="flex-1">
+				<!--
+					`index !== currentStep` ist nicht redundant: `canNavigateToStep`
+					liefert für den aktuellen Schritt `true` (`targetIndex <= currentStep`),
+					ein Klick darauf tut aber nichts. Ohne die Bedingung gäbe der aktuelle
+					Schritt sich als Navigationsziel aus. Der Stepper am Seitenkopf schließt
+					denselben Fall über `:not([aria-current='step'])` im CSS aus — hier
+					steht der Cursor an der Aufrufstelle, weil diese Komponente sonst
+					keinen eigenen CSS-Block hat.
+				-->
 				<button
 					type="button"
 					class="flex min-h-[var(--target-min)] w-full items-center px-0.5"
-					class:cursor-pointer={navigable}
+					class:cursor-pointer={navigable && index !== currentStep}
 					class:cursor-not-allowed={!navigable}
 					aria-current={currentStep === index ? 'step' : undefined}
 					aria-disabled={!navigable ? 'true' : 'false'}

--- a/src/lib/report/components/form/stepLabels.test.ts
+++ b/src/lib/report/components/form/stepLabels.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { stepNavigationLabel } from './stepLabels';
+
+describe('stepNavigationLabel', () => {
+	it('benennt beim zurückliegenden Schritt die Richtung', () => {
+		expect(stepNavigationLabel(0, 2, 'Position & Zeitpunkt')).toBe(
+			'Zurück zu Schritt 1: Position & Zeitpunkt'
+		);
+	});
+
+	it('benennt beim vorausliegenden Schritt die Richtung', () => {
+		expect(stepNavigationLabel(3, 1, 'Kontaktdaten')).toBe('Weiter zu Schritt 4: Kontaktdaten');
+	});
+
+	it('nennt beim aktuellen Schritt keine Richtung', () => {
+		// Dass es der aktuelle Schritt ist, trägt bereits `aria-current="step"`.
+		// Ein „Zurück zu" im Label würde dem widersprechen.
+		expect(stepNavigationLabel(1, 1, 'Angaben zum Tier')).toBe('Schritt 2: Angaben zum Tier');
+	});
+
+	it('zählt für die Anzeige ab 1, nicht ab 0', () => {
+		expect(stepNavigationLabel(0, 0, 'Position & Zeitpunkt')).toContain('Schritt 1');
+	});
+
+	it('unterscheidet sich vom sichtbaren Titel', () => {
+		// Der bisherige `aria-label` war wortgleich mit dem Titel und damit ohne
+		// Nutzen. Diese Zusicherung hält den Regressionsweg zu.
+		const title = 'Weitere Informationen';
+		expect(stepNavigationLabel(2, 0, title)).not.toBe(title);
+	});
+});

--- a/src/lib/report/components/form/stepLabels.ts
+++ b/src/lib/report/components/form/stepLabels.ts
@@ -1,0 +1,23 @@
+/**
+ * Beschriftung der Schaltflächen in beiden Fortschrittsanzeigen
+ * (`FormSteps.svelte` am Seitenkopf, `StepProgressCompact.svelte` im
+ * ortsfesten Balken).
+ *
+ * Warum das eine eigene Funktion ist und nicht zweimal im Markup steht: Es ist
+ * dieselbe Entscheidung wie bei `canNavigateToStep` — beide Anzeigen zeigen
+ * denselben Zustand, und ein zweites Regelwerk würde irgendwann auseinander
+ * laufen. Der bisherige `aria-label` in `FormSteps.svelte` war wortgleich mit
+ * dem sichtbaren Titel; für eine Schaltfläche, deren Bedienbarkeit ohnehin
+ * schwer zu erkennen ist, war das die verschenkte Gelegenheit, die Aktion zu
+ * benennen.
+ *
+ * Die Richtung steht bewusst nur an den anderen Schritten: Dass man beim
+ * aktuellen ist, sagt bereits `aria-current="step"`. Ein „Zurück zu" am
+ * aktuellen Schritt würde dem widersprechen.
+ */
+export function stepNavigationLabel(index: number, currentStep: number, title: string): string {
+	const step = `Schritt ${index + 1}: ${title}`;
+	if (index < currentStep) return `Zurück zu ${step}`;
+	if (index > currentStep) return `Weiter zu ${step}`;
+	return step;
+}


### PR DESCRIPTION
## Anlass

Das Deutsche Meeresmuseum wünscht sich einen „Zurück-Button auch oberhalb im Formular" (Abschnitt B5 der Änderungswünsche). Die Funktion existiert seit jeher — besuchte Schritte lassen sich über `canNavigateToStep` direkt anspringen. **Man sah es dem Stepper nur nicht an.**

Am Stepper auf Schritt 2 gemessen (1200px, Ruhezustand):

| Merkmal | erreichbar (Schritt 1) | aktuell (Schritt 2) | gesperrt (3, 4) |
| --- | --- | --- | --- |
| Cursor | **`default`** | `default` | `not-allowed` |
| Textfarbe | `base-content` | `base-content` | `base-content` |
| Schriftschnitt | 400 | **400** | 400 |
| Unterstreichung | keine | keine | keine |
| Hover-Zustand | **keiner definiert** | — | — |
| Trefferfläche | **156 × 16 px** | 156 × 16 px | 156 × 16 px |

Drei eigenständige Mängel darin:

1. **Der einzige Schritt mit nicht-Standard-Cursor war der gesperrte.** Tailwind v4 setzt im Preflight `button { cursor: default }`; `cursor-not-allowed` stand nur an den unerreichbaren. Die Affordanz war nicht schwach, sie war invertiert.
2. **Erreichbar und aktuell waren pixelgleich** — der Unterschied lag allein im Kreis darüber, und der ist bei beiden gefüllt.
3. **Die Trefferfläche war 16 px hoch**, deutlich unter `--target-min` (44 px). Der zentrale Touch-Target-Block in `app.css` greift nicht, weil er auf `.btn` zielt. Die kompakte Variante unterhalb `md` machte das bereits richtig.

Ein zweiter „Zurück"-Button für dieselbe Aktion widerspräche der Button-Hierarchie in `design-system.md`. Dieser PR rüstet stattdessen die fehlende Affordanz nach.

## Änderung

**`src/app.css`** — die Zustände hängen an `aria-disabled` und `aria-current` statt an eigenen Klassen: beide stehen ohnehin im Markup, weil die Barrierefreiheit sie braucht, und eine parallele Klasse könnte davon abweichen.

- erreichbar → `text-primary` + dünne Unterstreichung + `cursor: pointer`. Zwei Kanäle statt nur Farbe (WCAG 1.4.1). Im Browser gemessen **9,24:1** auf `base-100`, **7,73:1** auf der Hover-Fläche. `primary` ist keine Statusfarbe, die `-strong`-Pflicht greift hier nicht.
- aktuell → `font-weight: 600`, keine Unterstreichung, keine Linkfarbe.
- gesperrt → `cursor: not-allowed` (von der Aufrufstelle hierher gewandert, damit beide Cursor-Zustände an einer Stelle stehen).
- Hover **und** `:focus-visible` → dieselbe weiche Primärfläche; der globale Fokusring umschließt dadurch eine 44-px-Fläche statt einer Textzeile.
- `min-height: var(--target-min)` — im Feldmodus automatisch 56 px.

**`stepLabels.ts`** (neu) — eine reine Funktion, von **beiden** Fortschrittsanzeigen benutzt. Dieselbe Begründung wie bei `canNavigateToStep`: kein zweites Regelwerk. Der `aria-label` benennt jetzt die Aktion („Zurück zu Schritt 1: Position & Zeitpunkt") statt den sichtbaren Titel zu wiederholen.

**`FormSteps.svelte` / `StepProgressCompact.svelte`** — neuer Label-Aufruf, Cursor-Utilities angepasst.

**Nicht angefasst:** `canNavigateToStep`, das `aria-disabled` (kein `disabled` — sonst verlöre die Tastaturbedienung den Fokus und der begründende `title` wäre unerreichbar) und die Layout-Korrekturen aus #673.

## Tests

Test-First. Beide neuen Suites waren vor der Änderung rot — bei der E2E-Suite 5 von 7 Fällen; die anderen zwei sichern bestehendes Verhalten (Sperre wirksam, Klick geht zurück).

- `src/lib/report/components/form/stepLabels.test.ts` (5 Fälle)
- `e2e/form-stepper-affordance.spec.ts` (7 Fälle): drei Zustände optisch getrennt, Cursor, Trefferfläche in beiden Dichten, Hover, `aria-label`, Wirksamkeit der Sperre inkl. `click({ force: true })`

Zwei Dinge, die der Review am Spec aufgedeckt hat und die eingearbeitet sind:

- **Der Test misst sich sonst blind.** Unmittelbar nach `.hover()` steht dort `oklab(0 0 0 / 0)` — Deckkraft **0**, mitten in der Transition. Ein `not.toBe()` gegen den Ruhewert `rgba(0, 0, 0, 0)` wäre damit schon durch die geänderte Serialisierungsform erfüllt, eine Fläche mit 0 % Deckkraft käme durch. Der Test wartet jetzt über `document.getAnimations()` auf das Ende der Transitions (gefiltert auf `CSSTransition`, damit eine Endlos-Keyframe ihn nicht hängen lässt) und prüft die **Deckkraft**. Per Mutation gegengeprüft: Mix auf 0 % → Test rot.
- **`e2e/homepage.test.ts` hing an vier exakten `aria-label`-Selektoren** und brach durch die Label-Umstellung. Sie ankern jetzt am sichtbaren Titel — worum es ihnen ohnehin ging; die Label-Formulierung hat eigene Tests.

**Lauf nach dem Rebase auf `main` (3f0d9ac):** `npm run test:quick` grün (195 Dateien, 2905 Tests; ESLint 0 Fehler, die 2 Warnungen in `src/tests/contract/helpers/createEvent.ts` sind älter). E2E über `form-stepper-affordance`, `form-stepper`, `homepage`, `form-field-mode`, `form-a11y` und `design-tokens`: **124 passed**. Die sechs Breiten × zwei Dichten aus #673 bleiben grün.

> Hinweis für Nachprüfende im Worktree: Der Dev-Server sieht eigene Änderungen nicht (`docs/WORKTREES.md`), und Playwright verwendet ihn per `reuseExistingServer` weiter. Nach CSS-Änderungen muss er neu gestartet werden, sonst testet der Lauf alten Code — genau darauf ist der erste Mutationstest hier hereingefallen.

## Dokumentation

**Dieser PR ändert bewusst keine Dokumentation.** Der ursprüngliche Stand trug einen Nachtrag zu Abschnitt B5 in `docs/MEERESMUSEUM_AENDERUNGSWUENSCHE_2026-07-31.md`. #676 hat dieses Dokument aus dem öffentlichen Repo entfernt, weil es eine Person der Partnerinstitution nennt und interne Zahlen trägt; `.gitignore` hält den Pfad seither zu. Beim Rebase war das der einzige Konflikt (ändern/löschen) — die Löschung wurde übernommen, der Nachtrag gehört in das Dokument **außerhalb** des Repos und ist dorthin ausgeleitet.

Die Code-Kommentare verweisen weiterhin auf „B5 der Änderungswünsche", jetzt mit dem Zusatz, dass das Dokument seit #676 außerhalb dieses Repos liegt — damit ein späterer `grep` nicht ins Leere läuft. Personenbezug enthalten sie keinen; „Deutsches Meeresmuseum" steht ohnehin im Untertitel des Formulars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
