### PR TITLE
fix(test): exclude vitest helper test from playwright e2e collection

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
 		ignoreHTTPSErrors: true
 	},
 	testDir: 'e2e',
+	/* e2e/helpers/*.test.ts are vitest unit tests (collected separately by vitest.config.ts's
+	 * `server` project) that happen to live under e2e/ — Playwright's default glob would
+	 * otherwise pick them up too and crash at collection time. */
+	testIgnore: ['**/helpers/**'],
 	/* Run tests in files in parallel */
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Summary
- `npm run test:e2e` crashed at collection time because Playwright's default glob picked up `e2e/helpers/bannedClasses.test.ts`, a vitest unit test that lives under `e2e/` but is meant to run via `test:quick`, not Playwright.
- Added `testIgnore: ['**/helpers/**']` to `playwright.config.ts` so Playwright only collects genuine e2e specs, while vitest still picks up the helper test as before.

## Test plan
- [x] `npm run test:e2e -- --list` → 249 tests in 26 files, no collection crash; `basic.test.ts`/`homepage.test.ts` (genuine Playwright `.test.ts` files) still included
- [x] `npx vitest run --project server e2e/helpers/bannedClasses.test.ts` → still collected, 74 tests pass
- [x] `npm run test:e2e` full run → 244 passed / 5 failed (failures are pre-existing flakiness in `design-tokens.spec.ts`/`form-field-mode.spec.ts` around shared admin-page state, reproduced independently of this change — not caused by it)
- [x] `npm run test:unit:all` → 237 files / 3299 tests, all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)