### PR TITLE
fix(test): playwright test collection + document local upload cleanup

### DIFF
--- a/.claude/rules/upload.md
+++ b/.claude/rules/upload.md
@@ -188,6 +188,29 @@ Beim Freischalten von Videos gehört deshalb geprüft, dass
 `POST /api/admin/cleanup-orphans` tatsächlich läuft — vorher wächst der Bestand
 um Größenordnungen schneller nach als zuvor.
 
+**Lokale Entwicklung: kein Cron — nach Browser-Verifikation manuell aufräumen.**
+Der Cron oben ist ein Deployment-Schritt und läuft lokal nie. Die Foto-/
+Video-Dropzone lässt sich nicht sinnvoll ohne echten Browser prüfen — die
+vorgeschriebene visuelle Verifikation von UI-Änderungen lädt dabei reale
+Dateien in die geteilte lokale DB und nach `uploads/` hoch
+(`docs/WORKTREES.md` § Geteilte Ressourcen), jede Zeile mit `sichtung_id
+IS NULL`, bis jemand aufräumt. Befund vom 2026-07-31: sieben Waisenzeilen aus
+genau solchen Sessions, teils mit echten Fotos außerhalb der E2E-Fixtures
+(`IMG_7293.jpeg`). Die automatisierten E2E-Specs sind nicht die Ursache — sie
+mocken `/api/files/upload` (`e2e/fixtures/mockApi.ts`) oder lösen die
+Größenprüfung vor jedem Storage-Schreibzugriff aus.
+
+Nach jeder manuellen Verifikationssession, die Dateien hochgeladen hat:
+
+```bash
+npm run media:cleanup-orphans -- --older-than=1h
+```
+
+`1h` statt der Standardfrist (24h, s.o.): Ein manueller Testupload muss nicht
+die Absende-Frist eines echten Formularlaufs abwarten. `--older-than` erlaubt
+nur ganze Stunden/Tage — für Uploads der letzten Minuten vorher `--dry-run`
+gegenprüfen oder eine Stunde warten, sonst räumt der Lauf noch nichts weg.
+
 ---
 
 ## Best Practices

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -108,6 +108,10 @@ Uploads.
 - `npm run db:push` aus einem Worktree ändert das Schema für alle
 - `npm run media:cleanup-orphans` löscht Dateien für alle
 - Migrations-Branches deshalb bevorzugt gegen die Docker-DB (Port 5433) testen
+- Manuelle Browser-Verifikation von Foto-/Video-Upload (Pflicht bei
+  UI-Änderungen) schreibt echte Zeilen und Dateien in genau diese geteilte DB —
+  Aufräumbefehl und Hintergrund: `.claude/rules/upload.md` §
+  „Aufbewahrung unverknüpfter Uploads"
 
 ## Code-Graph-Tools
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
 		ignoreHTTPSErrors: true
 	},
 	testDir: 'e2e',
+	/* e2e/helpers/bannedClasses.test.ts ist ein Vitest-Unit-Test (läuft über
+	   test:unit, siehe vitest.config.ts) und hat kein Playwright-`test()`.
+	   Ohne testIgnore sammelt Playwright die Datei trotzdem ein und bricht
+	   beim ersten `describe()` mit "Cannot read properties of undefined
+	   (reading 'config')" ab — noch bevor ein einziger E2E-Test läuft. */
+	testIgnore: '**/helpers/**',
 	/* Run tests in files in parallel */
 	fullyParallel: true,
 	/* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Summary

- `playwright.config.ts` had no `testIgnore` for `e2e/helpers/**`, so `npm run test:e2e` tried to collect `e2e/helpers/bannedClasses.test.ts` (a Vitest unit test) and aborted with `Cannot read properties of undefined (reading 'config')` before running a single E2E spec. Fixed with `testIgnore: '**/helpers/**'` — `npx playwright test --list` now reports 249 tests across 26 files.
- Investigated orphaned rows in `sichtungen_dateien` (`sichtung_id IS NULL`) found in the shared local database. Traced the cause: not the automated E2E specs (`form-position-photo.spec.ts` mocks `/api/files/upload` in `beforeEach` since PR #590; `form-a11y.spec.ts`'s real-endpoint upload is deliberately oversized and rejected before any storage write; `videoUpload.spec.ts` never uploads a file). The rows instead came from manual browser verification of the photo/video upload flow — one filename (`IMG_7293.jpeg`) isn't even an E2E fixture, and a new row appeared live during the investigation from an active dev server in another worktree.
- Documented the finding and the local cleanup follow-up (`npm run media:cleanup-orphans -- --older-than=1h`, since the default retention is 24h) in `.claude/rules/upload.md`, cross-referenced from `docs/WORKTREES.md`'s shared-resources section.

## Why

`npm run test:e2e` was silently broken at the collection step for anyone running the full suite locally. Separately, the shared local Postgres/`uploads/` (which the project treats as effectively production, per project memory) was accumulating real orphaned uploads from manual verification sessions with no documented cleanup step — this closes that gap without introducing any new automation (no cron/launchd was set up; the fix is guidance in the docs where cleanup commands already live).

## Test plan

- [x] `npx playwright test --list` — collects 249 tests / 26 files (previously aborted with 0 tests)
- [x] `npm run lint` / `npm run type-check` — pass (pre-commit hook, pre-existing unrelated warnings only)
- [ ] `npm run test:e2e` — not run in full (would require the dev server + DB, out of scope for this doc/config fix)

Docs-only + one-line config change; no code paths affected beyond Playwright's file collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)