### PR TITLE
fix(media): skip 0-byte source files in legacy upload migration

### DIFF
--- a/src/tools/migrate-old-uploads.test.ts
+++ b/src/tools/migrate-old-uploads.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { isEmptySourceFile } from './migrate-old-uploads';
+
+describe('isEmptySourceFile', () => {
+	it('erkennt eine 0-Byte-Quelldatei als leer', () => {
+		expect(isEmptySourceFile(0)).toBe(true);
+	});
+
+	it('lässt eine Datei mit Inhalt durch', () => {
+		expect(isEmptySourceFile(1)).toBe(false);
+		expect(isEmptySourceFile(1024)).toBe(false);
+	});
+});

--- a/src/tools/migrate-old-uploads.ts
+++ b/src/tools/migrate-old-uploads.ts
@@ -18,6 +18,7 @@ import { and, eq, isNotNull, ne } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { pathToFileURL } from 'node:url';
 import postgres from 'postgres';
 import * as schema from '../lib/server/db/schema';
 import { sightingFiles, sightings } from '../lib/server/db/schema';
@@ -67,6 +68,15 @@ const log = {
  */
 function isImageFile(mimeType: string): boolean {
 	return mimeType.startsWith('image/') && mimeType !== 'image/svg+xml';
+}
+
+/**
+ * Erkennt eine 0-Byte-Quelldatei. `_old_uploads/` enthält vereinzelt bereits
+ * leere Dateien aus dem Altsystem — ungeprüft übernommen landen sie als
+ * kaputte Medien an veröffentlichten Sichtungen (Befund vom 2026-07-31).
+ */
+export function isEmptySourceFile(size: number): boolean {
+	return size === 0;
 }
 
 /**
@@ -313,6 +323,7 @@ async function main() {
 		// Process each sighting
 		let successCount = 0;
 		let errorCount = 0;
+		let emptySkippedCount = 0;
 
 		for (const sighting of sightingsWithUploads) {
 			try {
@@ -341,10 +352,17 @@ async function main() {
 						const targetPath = path.join(targetDir, fileName);
 
 						// Check if source file exists
+						let sourceStats;
 						try {
-							await fs.access(sourcePath);
+							sourceStats = await fs.stat(sourcePath);
 						} catch {
 							log.warning(`Source file not found, skipping: ${sourcePath}`);
+							continue;
+						}
+
+						if (isEmptySourceFile(sourceStats.size)) {
+							log.warning(`Source file is empty (0 bytes), skipping: ${sourcePath}`);
+							emptySkippedCount++;
 							continue;
 						}
 
@@ -400,6 +418,9 @@ async function main() {
 		if (errorCount > 0) {
 			log.warning(`Errors encountered: ${errorCount}`);
 		}
+		if (emptySkippedCount > 0) {
+			log.warning(`Skipped empty (0-byte) source files: ${emptySkippedCount}`);
+		}
 
 		// Summary: Files are preserved in _old_uploads for safety
 		const totalFiles = await fs.readdir(oldUploadPath);
@@ -418,8 +439,16 @@ async function main() {
 	}
 }
 
-// Run the migration
-main().catch((error) => {
-	log.error(`Unhandled error: ${error}`);
-	process.exit(1);
-});
+// `pathToFileURL` statt Zeichenkettenbau, gleiches Muster wie in
+// cleanup-orphaned-uploads.ts: verhindert, dass ein Test-Import von
+// `isEmptySourceFile` die komplette Migration ausführt.
+const isDirectRun =
+	typeof process.argv[1] === 'string' && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+	// Run the migration
+	main().catch((error) => {
+		log.error(`Unhandled error: ${error}`);
+		process.exit(1);
+	});
+}

--- a/src/tools/migrate-old-uploads.ts
+++ b/src/tools/migrate-old-uploads.ts
@@ -16,6 +16,7 @@ import type { SightingFileInsert } from '$lib/types/sightingFile';
 import { createId } from '@paralleldrive/cuid2';
 import { and, eq, isNotNull, ne } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
+import type { Stats } from 'fs';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { pathToFileURL } from 'node:url';
@@ -352,7 +353,7 @@ async function main() {
 						const targetPath = path.join(targetDir, fileName);
 
 						// Check if source file exists
-						let sourceStats;
+						let sourceStats: Stats;
 						try {
 							sourceStats = await fs.stat(sourcePath);
 						} catch {


### PR DESCRIPTION
## Summary
- `migrate-old-uploads.ts` copied whatever `fs.stat` reported for a source file in `_old_uploads/` without checking for size 0, faithfully carrying forward already-broken legacy files.
- Found via a live data audit (2026-07-31): 7 videos + 8 other files (all 0 bytes) had `sichtungen_dateien` rows attached to *published* sightings — real users were served broken media with no visible error. Those 15 rows/files were already cleaned up directly against the shared local DB (data fix, not part of this PR's diff).
- This PR fixes the migration script itself so a future legacy import can't reintroduce the same corruption: source files are now checked for size 0 before EXIF extraction/copy/DB insert, skipped with a warning log, and counted in the run summary.
- Added `isDirectRun` guard (same `pathToFileURL`/`import.meta.url` pattern already used in `cleanup-orphaned-uploads.ts`) so the new unit test can import `isEmptySourceFile` without triggering the actual migration.

## Test plan
- [x] `npx vitest run --project server src/tools/migrate-old-uploads.test.ts` — 2/2 green
- [x] `npm run lint` — clean (2 pre-existing, unrelated warnings elsewhere)
- [x] `npm run type-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)