### PR TITLE
fix(test): stop concurrent admin-session seeding from deleting live rows

### DIFF
--- a/e2e/helpers/adminSession.ts
+++ b/e2e/helpers/adminSession.ts
@@ -104,10 +104,17 @@ export async function seedAdminSession(context: BrowserContext, baseURL: string)
 
 	const sql = postgres(databaseUrl, { max: 1 });
 	try {
-		/* Alte Zeilen derselben Testidentität wegräumen. Ohne das sammelt jeder Lauf eine
-		   weitere Zeile an — in einer Datenbank, die sich laut docs/WORKTREES.md alle
-		   Worktrees teilen. */
-		await sql`DELETE FROM sessions WHERE sub = ${ADMIN_SUB}`;
+		/* Alte Zeilen derselben Testidentität wegräumen, aber nur abgelaufene — nicht
+		   unconditional. `fullyParallel: true` ruft diese Funktion für dieselbe ADMIN_SUB
+		   aus mehreren Workern gleichzeitig auf (design-tokens.spec.ts hat vier
+		   auth-Routen mit je drei Tests); ein unconditional DELETE hier löschte die gerade
+		   erst eingefügte, noch gültige Zeile eines parallel laufenden Tests, dessen
+		   nachfolgender page.goto() dann auf einen Login-Redirect lief statt auf die Seite,
+		   die der Scan messen sollte — sichtbar als flaky Design-Token-Verstoß auf
+		   wechselnden Admin-Routen. Dieselbe Bedingung wie in sessionRepository.ts
+		   createSession(): mehrere gültige Sessions pro sub sind kein Sonderfall, sondern
+		   der Normalzustand, weil resolveSessionUser ausschließlich über token_hash sucht. */
+		await sql`DELETE FROM sessions WHERE sub = ${ADMIN_SUB} AND expires_at < NOW()`;
 
 		await sql`
 			INSERT INTO sessions (token_hash, sub, roles, user_claims, expires_at, absolute_expires_at)

--- a/e2e/helpers/adminSession.ts
+++ b/e2e/helpers/adminSession.ts
@@ -104,17 +104,22 @@ export async function seedAdminSession(context: BrowserContext, baseURL: string)
 
 	const sql = postgres(databaseUrl, { max: 1 });
 	try {
-		/* Alte Zeilen derselben Testidentität wegräumen, aber nur abgelaufene — nicht
-		   unconditional. `fullyParallel: true` ruft diese Funktion für dieselbe ADMIN_SUB
-		   aus mehreren Workern gleichzeitig auf (design-tokens.spec.ts hat vier
+		/* Alte Zeilen derselben Testidentität wegräumen, aber nur abgelaufene/widerrufene —
+		   nicht unconditional. `fullyParallel: true` ruft diese Funktion für dieselbe
+		   ADMIN_SUB aus mehreren Workern gleichzeitig auf (design-tokens.spec.ts hat vier
 		   auth-Routen mit je drei Tests); ein unconditional DELETE hier löschte die gerade
 		   erst eingefügte, noch gültige Zeile eines parallel laufenden Tests, dessen
 		   nachfolgender page.goto() dann auf einen Login-Redirect lief statt auf die Seite,
 		   die der Scan messen sollte — sichtbar als flaky Design-Token-Verstoß auf
 		   wechselnden Admin-Routen. Dieselbe Bedingung wie in sessionRepository.ts
-		   createSession(): mehrere gültige Sessions pro sub sind kein Sonderfall, sondern
-		   der Normalzustand, weil resolveSessionUser ausschließlich über token_hash sucht. */
-		await sql`DELETE FROM sessions WHERE sub = ${ADMIN_SUB} AND expires_at < NOW()`;
+		   createSession() (dort revoked_at, expires_at, absolute_expires_at): mehrere
+		   gültige Sessions pro sub sind kein Sonderfall, sondern der Normalzustand, weil
+		   resolveSessionUser ausschließlich über token_hash sucht. */
+		await sql`
+			DELETE FROM sessions
+			WHERE sub = ${ADMIN_SUB}
+				AND (revoked_at IS NOT NULL OR expires_at < NOW() OR absolute_expires_at < NOW())
+		`;
 
 		await sql`
 			INSERT INTO sessions (token_hash, sub, roles, user_claims, expires_at, absolute_expires_at)


### PR DESCRIPTION
## Summary

- `e2e/helpers/adminSession.ts`'s `seedAdminSession()` ran an unconditional `DELETE FROM sessions WHERE sub = ADMIN_SUB` before every insert. `design-tokens.spec.ts` calls it once per admin-route test (4 routes × 3 tests), and with `fullyParallel: true` these calls race across workers — one test's DELETE could remove another concurrently-running test's just-inserted, still-valid session row before that test navigated, invalidating its cookie and bouncing it to the login page mid-scan. That's exactly what surfaced as flaky "design-token violation" failures on a different admin route each run.
- Narrowed the cleanup to only remove already-expired rows (`AND expires_at < NOW()`), matching the condition `sessionRepository.ts`'s `createSession()` already uses in production for the same reason: multiple valid sessions per `sub` are the normal case, since session lookups key on `token_hash`, not `sub`.

## Why no accompanying test

Reproducing the race deterministically would need a vitest test opening a real concurrent connection to Postgres, which `testing-patterns.md` explicitly rules out ("keine Tests die von externen Services abhängen"). Verification is via repeated E2E runs instead (see test plan).

## Test plan

- [x] `design-tokens.spec.ts` + `form-field-mode.spec.ts` run back-to-back 6× — 486/486 passed, zero flakes (previously flaky on a subset each run)
- [x] Full `npm run test:e2e` — 248 passed, 1 unrelated pre-existing flake in `form-map-pan-zoom.spec.ts` that did not reproduce across 3 isolated re-runs
- [x] `npm run lint` / `npm run type-check` (pre-commit hook, pre-existing warnings only in unrelated file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)