### PR TITLE
test(db): schwach getestete DB/Media-Dateien absichern

### DIFF
--- a/src/lib/server/db/configRepository.test.ts
+++ b/src/lib/server/db/configRepository.test.ts
@@ -1,0 +1,669 @@
+/**
+ * Unit Tests für configRepository.ts
+ *
+ * Fokus: In-Memory-Cache-Verhalten von `get()`, Kurzschluss bei fehlender
+ * Datenbank, der bewusste Fehler-Vertrag von `set()` für unbekannte Keys,
+ * Bulk-Operationen (`upsertMany`, `insertManyIfAbsent`) sowie die typisierten
+ * Helper (`getString`/`getNumber`/`getBoolean`/`getObject`/`getArray`).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { db, getDb, isDatabaseAvailable } from './index';
+import { ConfigRepository, type ConfigItem } from './configRepository';
+
+// Mock dependencies - siehe sightingRepository.test.ts für das Grundpattern.
+// Hier zusätzlich isDatabaseAvailable und getDb, da configRepository beide nutzt.
+// configRepository.ts importiert relativ aus './index' - daher wird hier
+// derselbe Modulspezifizierer gemockt (kein zusätzlicher '$lib/server/db'-Mock nötig).
+vi.mock('./index', () => {
+	const db: Record<string, any> = {
+		select: vi.fn(),
+		insert: vi.fn(),
+		update: vi.fn(),
+		delete: vi.fn()
+	};
+	return {
+		db,
+		getDb: vi.fn(() => db),
+		isDatabaseAvailable: vi.fn(() => true)
+	};
+});
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn(() => ({
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	}))
+}));
+
+describe('ConfigRepository', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(isDatabaseAvailable).mockReturnValue(true);
+		vi.mocked(getDb).mockReturnValue(db as any);
+		ConfigRepository.clearCache();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		ConfigRepository.clearCache();
+	});
+
+	describe('get', () => {
+		it('gibt null zurück ohne DB-Query wenn die Datenbank nicht konfiguriert ist', async () => {
+			vi.mocked(isDatabaseAvailable).mockReturnValue(false);
+			const mockDb = db as any;
+
+			const result = await ConfigRepository.get('some.key');
+
+			expect(result).toBeNull();
+			expect(mockDb.select).not.toHaveBeenCalled();
+		});
+
+		it('lädt den Wert aus der Datenbank wenn kein Cache-Eintrag existiert', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ value: 'hello' }])
+					})
+				})
+			});
+
+			const result = await ConfigRepository.get('greeting');
+
+			expect(result).toBe('hello');
+			expect(mockDb.select).toHaveBeenCalledTimes(1);
+		});
+
+		it('gibt null zurück wenn der Key nicht existiert', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([])
+					})
+				})
+			});
+
+			const result = await ConfigRepository.get('missing.key');
+
+			expect(result).toBeNull();
+		});
+
+		it('fragt innerhalb der Cache-TTL nicht erneut die Datenbank ab', async () => {
+			vi.useFakeTimers();
+			try {
+				const mockDb = db as any;
+				mockDb.select.mockReturnValue({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([{ value: 'cached-value' }])
+						})
+					})
+				});
+
+				const first = await ConfigRepository.get('cached.key');
+				expect(first).toBe('cached-value');
+				expect(mockDb.select).toHaveBeenCalledTimes(1);
+
+				// 30s später - noch innerhalb der 60s TTL
+				vi.advanceTimersByTime(30_000);
+
+				const second = await ConfigRepository.get('cached.key');
+				expect(second).toBe('cached-value');
+				// Kein zweiter DB-Aufruf
+				expect(mockDb.select).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('fragt nach Ablauf der Cache-TTL erneut die Datenbank ab', async () => {
+			vi.useFakeTimers();
+			try {
+				const mockDb = db as any;
+				mockDb.select.mockReturnValue({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([{ value: 'stale-value' }])
+						})
+					})
+				});
+
+				await ConfigRepository.get('ttl.key');
+				expect(mockDb.select).toHaveBeenCalledTimes(1);
+
+				// 60.001ms später - TTL abgelaufen
+				vi.advanceTimersByTime(60_001);
+
+				await ConfigRepository.get('ttl.key');
+				expect(mockDb.select).toHaveBeenCalledTimes(2);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('fragt nach clearCache() erneut die Datenbank ab', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ value: 'v1' }])
+					})
+				})
+			});
+
+			await ConfigRepository.get('clear.key');
+			expect(mockDb.select).toHaveBeenCalledTimes(1);
+
+			ConfigRepository.clearCache();
+
+			await ConfigRepository.get('clear.key');
+			expect(mockDb.select).toHaveBeenCalledTimes(2);
+		});
+
+		it('fragt nach set() für denselben Key erneut die Datenbank ab (Cache-Invalidierung)', async () => {
+			const mockDb = db as any;
+			mockDb.select
+				.mockReturnValueOnce({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([{ value: 'before' }])
+						})
+					})
+				})
+				// set() prüft zunächst per select ob der Key existiert
+				.mockReturnValueOnce({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([{ id: 1 }])
+						})
+					})
+				})
+				// erneuter get() nach dem Update
+				.mockReturnValueOnce({
+					from: vi.fn().mockReturnValue({
+						where: vi.fn().mockReturnValue({
+							limit: vi.fn().mockResolvedValue([{ value: 'after' }])
+						})
+					})
+				});
+			mockDb.update.mockReturnValue({
+				set: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue(undefined)
+				})
+			});
+
+			const before = await ConfigRepository.get('invalidate.key');
+			expect(before).toBe('before');
+
+			await ConfigRepository.set('invalidate.key', 'after');
+
+			const after = await ConfigRepository.get('invalidate.key');
+			expect(after).toBe('after');
+			expect(mockDb.select).toHaveBeenCalledTimes(3);
+		});
+
+		it('loggt den Fehler und wirft ihn erneut wenn die DB-Query fehlschlägt', async () => {
+			const mockDb = db as any;
+			const dbError = new Error('connection lost');
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockRejectedValue(dbError)
+					})
+				})
+			});
+
+			await expect(ConfigRepository.get('error.key')).rejects.toThrow('connection lost');
+		});
+	});
+
+	describe('set', () => {
+		it('aktualisiert einen bestehenden Eintrag', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ id: 5 }])
+					})
+				})
+			});
+			const setMock = vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined)
+			});
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			await ConfigRepository.set('existing.key', 'new-value', 'user-1');
+
+			expect(mockDb.update).toHaveBeenCalledTimes(1);
+			expect(setMock).toHaveBeenCalledWith(
+				expect.objectContaining({ value: 'new-value', updatedBy: 'user-1' })
+			);
+		});
+
+		it('wirft einen Fehler wenn der Key noch nicht existiert - set() legt keine neuen Keys an', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([])
+					})
+				})
+			});
+
+			await expect(ConfigRepository.set('unknown.key', 'value')).rejects.toThrow(
+				"Configuration key 'unknown.key' does not exist. Use upsert() to create new configurations."
+			);
+			expect(mockDb.update).not.toHaveBeenCalled();
+		});
+
+		it('loggt den Fehler und wirft ihn erneut wenn das Update fehlschlägt', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ id: 1 }])
+					})
+				})
+			});
+			mockDb.update.mockReturnValue({
+				set: vi.fn().mockReturnValue({
+					where: vi.fn().mockRejectedValue(new Error('update failed'))
+				})
+			});
+
+			await expect(ConfigRepository.set('broken.key', 'value')).rejects.toThrow('update failed');
+		});
+	});
+
+	describe('upsert', () => {
+		it('fügt einen neuen Eintrag ein wenn der Key nicht existiert', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([])
+					})
+				})
+			});
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const item: ConfigItem = {
+				key: 'new.key',
+				value: 'value',
+				category: 'display'
+			};
+
+			await ConfigRepository.upsert(item, 'user-1');
+
+			expect(mockDb.insert).toHaveBeenCalledTimes(1);
+			expect(valuesMock).toHaveBeenCalledWith(
+				expect.objectContaining({ key: 'new.key', value: 'value', category: 'display' })
+			);
+		});
+
+		it('aktualisiert einen bestehenden Eintrag', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ id: 9 }])
+					})
+				})
+			});
+			const setMock = vi.fn().mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined)
+			});
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			const item: ConfigItem = {
+				key: 'existing.key',
+				value: 'updated',
+				category: 'security'
+			};
+
+			await ConfigRepository.upsert(item);
+
+			expect(mockDb.update).toHaveBeenCalledTimes(1);
+			expect(mockDb.insert).not.toHaveBeenCalled();
+		});
+
+		it('loggt den Fehler und wirft ihn erneut wenn der Upsert fehlschlägt', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([])
+					})
+				})
+			});
+			mockDb.insert.mockReturnValue({
+				values: vi.fn().mockRejectedValue(new Error('upsert insert failed'))
+			});
+
+			await expect(
+				ConfigRepository.upsert({ key: 'broken', value: 'v', category: 'display' })
+			).rejects.toThrow('upsert insert failed');
+		});
+	});
+
+	describe('upsertMany', () => {
+		it('kehrt bei leerem Array früh zurück ohne DB-Call', async () => {
+			const mockDb = db as any;
+
+			await ConfigRepository.upsertMany([]);
+
+			expect(mockDb.insert).not.toHaveBeenCalled();
+		});
+
+		it('ruft insert().values().onConflictDoUpdate() mit der erwarteten Struktur auf', async () => {
+			const mockDb = db as any;
+			const onConflictDoUpdateMock = vi.fn().mockResolvedValue(undefined);
+			const valuesMock = vi.fn().mockReturnValue({ onConflictDoUpdate: onConflictDoUpdateMock });
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const items: ConfigItem[] = [
+				{ key: 'a', value: 'va', category: 'display' },
+				{ key: 'b', value: 'vb', category: 'security' }
+			];
+
+			await ConfigRepository.upsertMany(items, 'user-1');
+
+			expect(mockDb.insert).toHaveBeenCalledTimes(1);
+			expect(valuesMock).toHaveBeenCalledWith([
+				expect.objectContaining({
+					key: 'a',
+					value: 'va',
+					category: 'display',
+					updatedBy: 'user-1'
+				}),
+				expect.objectContaining({
+					key: 'b',
+					value: 'vb',
+					category: 'security',
+					updatedBy: 'user-1'
+				})
+			]);
+			expect(onConflictDoUpdateMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					target: expect.anything(),
+					set: expect.objectContaining({
+						value: expect.anything(),
+						description: expect.anything(),
+						category: expect.anything(),
+						updatedAt: expect.anything(),
+						updatedBy: expect.anything()
+					})
+				})
+			);
+		});
+
+		it('loggt den Fehler und wirft ihn erneut wenn der Bulk-Upsert fehlschlägt', async () => {
+			const mockDb = db as any;
+			mockDb.insert.mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					onConflictDoUpdate: vi.fn().mockRejectedValue(new Error('bulk failed'))
+				})
+			});
+
+			await expect(
+				ConfigRepository.upsertMany([{ key: 'a', value: 'v', category: 'display' }])
+			).rejects.toThrow('bulk failed');
+		});
+	});
+
+	describe('insertManyIfAbsent', () => {
+		it('kehrt bei leerem Array früh zurück ohne DB-Call und liefert 0', async () => {
+			const mockDb = db as any;
+
+			const result = await ConfigRepository.insertManyIfAbsent([]);
+
+			expect(result).toBe(0);
+			expect(mockDb.insert).not.toHaveBeenCalled();
+		});
+
+		it('gibt die Anzahl tatsächlich eingefügter Zeilen zurück (Teil-Konflikt)', async () => {
+			const mockDb = db as any;
+			// 3 Items werden übergeben, aber nur 1 wird tatsächlich eingefügt (2 existierten schon)
+			const returningMock = vi.fn().mockResolvedValue([{ key: 'c' }]);
+			const onConflictDoNothingMock = vi.fn().mockReturnValue({ returning: returningMock });
+			const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing: onConflictDoNothingMock });
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const items: ConfigItem[] = [
+				{ key: 'a', value: 'va', category: 'display' },
+				{ key: 'b', value: 'vb', category: 'display' },
+				{ key: 'c', value: 'vc', category: 'display' }
+			];
+
+			const result = await ConfigRepository.insertManyIfAbsent(items);
+
+			expect(result).toBe(1);
+			expect(onConflictDoNothingMock).toHaveBeenCalled();
+		});
+
+		it('loggt den Fehler und wirft ihn erneut wenn der Bulk-Insert fehlschlägt', async () => {
+			const mockDb = db as any;
+			mockDb.insert.mockReturnValue({
+				values: vi.fn().mockReturnValue({
+					onConflictDoNothing: vi.fn().mockReturnValue({
+						returning: vi.fn().mockRejectedValue(new Error('insert failed'))
+					})
+				})
+			});
+
+			await expect(
+				ConfigRepository.insertManyIfAbsent([{ key: 'a', value: 'v', category: 'display' }])
+			).rejects.toThrow('insert failed');
+		});
+	});
+
+	describe('getByCategory', () => {
+		it('lädt Konfigurationen einer Kategorie', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockResolvedValue([
+						{
+							id: 1,
+							key: 'a',
+							value: 'va',
+							description: null,
+							category: 'display',
+							updatedAt: new Date(),
+							updatedBy: null
+						}
+					])
+				})
+			});
+
+			const result = await ConfigRepository.getByCategory('display');
+
+			expect(result).toHaveLength(1);
+			expect(result[0]?.key).toBe('a');
+		});
+
+		it('loggt den Fehler und wirft ihn erneut bei DB-Fehler', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockRejectedValue(new Error('category query failed'))
+				})
+			});
+
+			await expect(ConfigRepository.getByCategory('display')).rejects.toThrow(
+				'category query failed'
+			);
+		});
+	});
+
+	describe('getAll', () => {
+		it('lädt alle Konfigurationen sortiert nach Kategorie und Key', async () => {
+			const mockDb = db as any;
+			const orderByMock = vi.fn().mockResolvedValue([
+				{
+					id: 1,
+					key: 'a',
+					value: 'va',
+					description: null,
+					category: 'display',
+					updatedAt: new Date(),
+					updatedBy: null
+				}
+			]);
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({ orderBy: orderByMock })
+			});
+
+			const result = await ConfigRepository.getAll();
+
+			expect(result).toHaveLength(1);
+			expect(orderByMock).toHaveBeenCalled();
+		});
+
+		it('loggt den Fehler und wirft ihn erneut bei DB-Fehler', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					orderBy: vi.fn().mockRejectedValue(new Error('getAll failed'))
+				})
+			});
+
+			await expect(ConfigRepository.getAll()).rejects.toThrow('getAll failed');
+		});
+	});
+
+	describe('delete', () => {
+		it('löscht einen Eintrag und den zugehörigen Cache-Eintrag', async () => {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([{ value: 'v' }])
+					})
+				})
+			});
+			mockDb.delete.mockReturnValue({
+				where: vi.fn().mockResolvedValue(undefined)
+			});
+
+			// Cache befüllen
+			await ConfigRepository.get('delete.key');
+			expect(mockDb.select).toHaveBeenCalledTimes(1);
+
+			await ConfigRepository.delete('delete.key');
+
+			// Nach delete() muss get() erneut die DB treffen
+			await ConfigRepository.get('delete.key');
+			expect(mockDb.select).toHaveBeenCalledTimes(2);
+		});
+
+		it('loggt den Fehler und wirft ihn erneut bei DB-Fehler', async () => {
+			const mockDb = db as any;
+			mockDb.delete.mockReturnValue({
+				where: vi.fn().mockRejectedValue(new Error('delete failed'))
+			});
+
+			await expect(ConfigRepository.delete('broken.key')).rejects.toThrow('delete failed');
+		});
+	});
+
+	describe('typisierte Helper', () => {
+		function mockGetOnce(value: unknown) {
+			const mockDb = db as any;
+			mockDb.select.mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue(value === null ? [] : [{ value }])
+					})
+				})
+			});
+		}
+
+		describe('getString', () => {
+			it('gibt den Default zurück wenn kein Wert existiert', async () => {
+				mockGetOnce(null);
+				const result = await ConfigRepository.getString('missing', 'default-value');
+				expect(result).toBe('default-value');
+			});
+
+			it('konvertiert einen vorhandenen Wert zu String', async () => {
+				mockGetOnce(42);
+				const result = await ConfigRepository.getString('present', 'default-value');
+				expect(result).toBe('42');
+			});
+		});
+
+		describe('getNumber', () => {
+			it('gibt den Default zurück wenn kein Wert existiert', async () => {
+				mockGetOnce(null);
+				const result = await ConfigRepository.getNumber('missing', 7);
+				expect(result).toBe(7);
+			});
+
+			it('konvertiert einen vorhandenen Wert zu Number', async () => {
+				mockGetOnce('123');
+				const result = await ConfigRepository.getNumber('present', 7);
+				expect(result).toBe(123);
+			});
+		});
+
+		describe('getBoolean', () => {
+			it('gibt den Default zurück wenn kein Wert existiert', async () => {
+				mockGetOnce(null);
+				const result = await ConfigRepository.getBoolean('missing', true);
+				expect(result).toBe(true);
+			});
+
+			it('konvertiert einen vorhandenen Wert zu Boolean', async () => {
+				mockGetOnce(false);
+				const result = await ConfigRepository.getBoolean('present', true);
+				expect(result).toBe(false);
+			});
+		});
+
+		describe('getObject', () => {
+			it('gibt den Default zurück wenn kein Wert existiert', async () => {
+				mockGetOnce(null);
+				const result = await ConfigRepository.getObject('missing', { foo: 'bar' });
+				expect(result).toEqual({ foo: 'bar' });
+			});
+
+			it('gibt den vorhandenen Wert zurück wenn er ein Objekt ist', async () => {
+				mockGetOnce({ foo: 'baz' });
+				const result = await ConfigRepository.getObject('present', { foo: 'bar' });
+				expect(result).toEqual({ foo: 'baz' });
+			});
+
+			it('lehnt Arrays ab und gibt den Default zurück', async () => {
+				mockGetOnce(['not', 'an', 'object']);
+				const result = await ConfigRepository.getObject('present', { foo: 'bar' });
+				expect(result).toEqual({ foo: 'bar' });
+			});
+		});
+
+		describe('getArray', () => {
+			it('gibt den Default zurück wenn kein Wert existiert', async () => {
+				mockGetOnce(null);
+				const result = await ConfigRepository.getArray('missing', [1, 2, 3]);
+				expect(result).toEqual([1, 2, 3]);
+			});
+
+			it('gibt den vorhandenen Wert zurück wenn er ein Array ist', async () => {
+				mockGetOnce(['a', 'b']);
+				const result = await ConfigRepository.getArray('present', [1, 2, 3]);
+				expect(result).toEqual(['a', 'b']);
+			});
+
+			it('gibt den Default zurück wenn der Wert kein Array ist', async () => {
+				mockGetOnce({ not: 'an array' });
+				const result = await ConfigRepository.getArray('present', [1, 2, 3]);
+				expect(result).toEqual([1, 2, 3]);
+			});
+		});
+	});
+});

--- a/src/lib/server/db/index.test.ts
+++ b/src/lib/server/db/index.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Unit Tests für den Lazy-Init-Proxy in `src/lib/server/db/index.ts`.
+ *
+ * Das Modul hält Singleton-State auf Modulebene (`_realDb`, `_client`,
+ * `_initError`, `_lastConnectionTest`). Damit Tests sich nicht gegenseitig
+ * beeinflussen, wird das Modul in jedem Test frisch geladen: `vi.resetModules()`
+ * gefolgt von einem dynamischen `await import('./index')`. Die `vi.mock`-Fabriken
+ * für `postgres`, `drizzle-orm/postgres-js` und `$env/dynamic/private` bleiben
+ * über `vi.resetModules()` hinweg registriert (nur der Modul-Cache wird
+ * geleert) — über `vi.hoisted()` referenzierte Mock-Funktionen lassen sich
+ * daher pro Test neu konfigurieren, ohne die Registrierung zu verlieren.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPostgres, mockDrizzle, envState } = vi.hoisted(() => {
+	return {
+		mockPostgres: vi.fn(),
+		mockDrizzle: vi.fn(),
+		envState: {} as Record<string, string | undefined>
+	};
+});
+
+vi.mock('postgres', () => ({ default: mockPostgres }));
+vi.mock('drizzle-orm/postgres-js', () => ({ drizzle: mockDrizzle }));
+vi.mock('$env/dynamic/private', () => ({ env: envState }));
+
+function createMockClient(end: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined)) {
+	return { end };
+}
+
+function createMockDb(execute: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined)) {
+	return { execute };
+}
+
+const ORIGINAL_PROCESS_ENV_URL = process.env.DATABASE_POSTGRES_URL;
+
+describe('src/lib/server/db/index.ts', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+
+		// Sauberer Env-Zustand: weder $env/dynamic/private noch process.env gesetzt
+		for (const key of Object.keys(envState)) {
+			delete envState[key];
+		}
+		delete process.env.DATABASE_POSTGRES_URL;
+
+		// Default-Verhalten: postgres() liefert einen Mock-Client, drizzle() eine Mock-DB
+		mockPostgres.mockImplementation(() => createMockClient());
+		mockDrizzle.mockImplementation(() => createMockDb());
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_PROCESS_ENV_URL === undefined) {
+			delete process.env.DATABASE_POSTGRES_URL;
+		} else {
+			process.env.DATABASE_POSTGRES_URL = ORIGINAL_PROCESS_ENV_URL;
+		}
+	});
+
+	describe('_initError bei fehlender DATABASE_POSTGRES_URL', () => {
+		it('getDatabaseError() liefert die DB_NOT_CONFIGURED-Meldung wenn keine URL gesetzt ist', async () => {
+			const { getDatabaseError } = await import('./index');
+
+			expect(getDatabaseError()).toBe(
+				'Database is not configured. Set DATABASE_POSTGRES_URL environment variable.'
+			);
+			expect(mockPostgres).not.toHaveBeenCalled();
+		});
+
+		it('isDatabaseAvailable() gibt false zurück ohne postgres() aufzurufen', async () => {
+			const { isDatabaseAvailable } = await import('./index');
+
+			expect(isDatabaseAvailable()).toBe(false);
+			expect(mockPostgres).not.toHaveBeenCalled();
+		});
+
+		it('getDatabaseError() liefert null wenn DATABASE_POSTGRES_URL über $env/dynamic/private gesetzt ist', async () => {
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+			const { getDatabaseError, isDatabaseAvailable } = await import('./index');
+
+			expect(isDatabaseAvailable()).toBe(true);
+			expect(getDatabaseError()).toBeNull();
+			expect(mockPostgres).toHaveBeenCalledTimes(1);
+		});
+
+		it('fällt auf process.env zurück wenn $env/dynamic/private die URL nicht liefert', async () => {
+			process.env.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+			const { isDatabaseAvailable } = await import('./index');
+
+			expect(isDatabaseAvailable()).toBe(true);
+			expect(mockPostgres).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('closeDb()', () => {
+		it('ist idempotent: mehrfacher Aufruf ohne aktive Verbindung wirft nicht und kehrt sofort zurück', async () => {
+			const { closeDb } = await import('./index');
+
+			await expect(closeDb()).resolves.toBeUndefined();
+			await expect(closeDb()).resolves.toBeUndefined();
+		});
+
+		it('schließt eine aktive Verbindung über client.end()', async () => {
+			const end = vi.fn().mockResolvedValue(undefined);
+			mockPostgres.mockImplementation(() => createMockClient(end));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { isDatabaseAvailable, closeDb } = await import('./index');
+			// Verbindung initialisieren, damit _client gesetzt ist
+			isDatabaseAvailable();
+
+			await closeDb();
+
+			expect(end).toHaveBeenCalledTimes(1);
+		});
+
+		it('setzt State zurück BEVOR client.end() awaited wird — paralleler zweiter Aufruf schließt nicht doppelt', async () => {
+			let resolveEnd!: () => void;
+			const endPromise = new Promise<void>((resolve) => {
+				resolveEnd = resolve;
+			});
+			const end = vi.fn().mockReturnValue(endPromise);
+			mockPostgres.mockImplementation(() => createMockClient(end));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { isDatabaseAvailable, closeDb } = await import('./index');
+			isDatabaseAvailable();
+
+			// Erster Aufruf: client.end() wird gestartet, aber die Promise ist noch offen
+			const firstClose = closeDb();
+
+			// Zweiter, paralleler Aufruf während der erste noch auf client.end() wartet:
+			// _client wurde vom ersten Aufruf bereits synchron auf null gesetzt,
+			// daher darf der zweite Aufruf sofort zurückkehren, ohne end() erneut aufzurufen.
+			const secondClose = closeDb();
+
+			expect(end).toHaveBeenCalledTimes(1);
+
+			resolveEnd();
+			await Promise.all([firstClose, secondClose]);
+
+			expect(end).toHaveBeenCalledTimes(1);
+		});
+
+		it('erlaubt einen erneuten Verbindungsaufbau nach dem Schließen', async () => {
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { isDatabaseAvailable, closeDb } = await import('./index');
+			isDatabaseAvailable();
+			await closeDb();
+
+			// _realDb wurde auf null gesetzt, initializeDb() muss also erneut laufen
+			expect(isDatabaseAvailable()).toBe(true);
+			expect(mockPostgres).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('testDatabaseConnection()', () => {
+		it('gibt false zurück ohne Query-Versuch, wenn die DB nicht konfiguriert ist', async () => {
+			const { testDatabaseConnection } = await import('./index');
+
+			await expect(testDatabaseConnection()).resolves.toBe(false);
+			expect(mockDrizzle).not.toHaveBeenCalled();
+		});
+
+		it('gibt true zurück wenn die Query erfolgreich ist', async () => {
+			const execute = vi.fn().mockResolvedValue(undefined);
+			mockDrizzle.mockImplementation(() => createMockDb(execute));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { testDatabaseConnection } = await import('./index');
+
+			await expect(testDatabaseConnection()).resolves.toBe(true);
+			expect(execute).toHaveBeenCalledTimes(1);
+		});
+
+		it('fängt Query-Fehler ab und gibt false zurück statt zu werfen', async () => {
+			const execute = vi.fn().mockRejectedValue(new Error('Verbindung abgelehnt'));
+			mockDrizzle.mockImplementation(() => createMockDb(execute));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { testDatabaseConnection } = await import('./index');
+
+			await expect(testDatabaseConnection()).resolves.toBe(false);
+		});
+
+		it('cached das Ergebnis für 10 Sekunden — zweiter Aufruf führt keine neue Query aus', async () => {
+			const execute = vi.fn().mockResolvedValue(undefined);
+			mockDrizzle.mockImplementation(() => createMockDb(execute));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			vi.useFakeTimers();
+			try {
+				const { testDatabaseConnection } = await import('./index');
+
+				await expect(testDatabaseConnection()).resolves.toBe(true);
+				expect(execute).toHaveBeenCalledTimes(1);
+
+				// Innerhalb der 10s-Cache-Frist: keine neue Query
+				vi.advanceTimersByTime(9000);
+				await expect(testDatabaseConnection()).resolves.toBe(true);
+				expect(execute).toHaveBeenCalledTimes(1);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('führt nach Ablauf der Cache-Frist eine neue Query aus', async () => {
+			const execute = vi.fn().mockResolvedValue(undefined);
+			mockDrizzle.mockImplementation(() => createMockDb(execute));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			vi.useFakeTimers();
+			try {
+				const { testDatabaseConnection } = await import('./index');
+
+				await expect(testDatabaseConnection()).resolves.toBe(true);
+				expect(execute).toHaveBeenCalledTimes(1);
+
+				// Cache-Frist überschritten (10s)
+				vi.advanceTimersByTime(10001);
+				await expect(testDatabaseConnection()).resolves.toBe(true);
+				expect(execute).toHaveBeenCalledTimes(2);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('resetConnectionTestCache() invalidiert den Cache sofort', async () => {
+			const execute = vi.fn().mockResolvedValue(undefined);
+			mockDrizzle.mockImplementation(() => createMockDb(execute));
+			envState.DATABASE_POSTGRES_URL = 'postgres://user:pass@localhost:5432/db';
+
+			const { testDatabaseConnection, resetConnectionTestCache } = await import('./index');
+
+			await expect(testDatabaseConnection()).resolves.toBe(true);
+			expect(execute).toHaveBeenCalledTimes(1);
+
+			resetConnectionTestCache();
+
+			await expect(testDatabaseConnection()).resolves.toBe(true);
+			expect(execute).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/src/lib/server/db/sightingFilesRepository.test.ts
+++ b/src/lib/server/db/sightingFilesRepository.test.ts
@@ -11,7 +11,11 @@ import {
 	sumFileSizesForReference
 } from './sightingFilesRepository';
 
-vi.mock('$lib/server/db', () => {
+// Gleicher Specifier wie im Code unter Test (`import { db } from '.'` in
+// sightingFilesRepository.ts) — sonst könnten Mock und echter Import bei
+// unterschiedlicher Alias-Auflösung auseinanderlaufen und der Mock griffe
+// nicht (PR #688 Review-Hinweis).
+vi.mock('.', () => {
 	const db: Record<string, any> = {
 		insert: vi.fn(),
 		update: vi.fn(),

--- a/src/lib/server/db/sightingFilesRepository.test.ts
+++ b/src/lib/server/db/sightingFilesRepository.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit Tests für sightingFilesRepository.ts
+ */
+import type { UploadedFileInfo } from '$lib/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sightingFiles } from './schema';
+import {
+	deleteFileByPath,
+	saveUploadedFile,
+	setSightingIdForReferenceId,
+	sumFileSizesForReference
+} from './sightingFilesRepository';
+
+vi.mock('$lib/server/db', () => {
+	const db: Record<string, any> = {
+		insert: vi.fn(),
+		update: vi.fn(),
+		select: vi.fn(),
+		delete: vi.fn()
+	};
+	return { db };
+});
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn(() => ({
+		info: vi.fn(),
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn()
+	}))
+}));
+
+import { db } from '.';
+
+describe('sightingFilesRepository', () => {
+	const mockUploadedFile: UploadedFileInfo = {
+		uid: 'file-1',
+		originalName: 'test.jpg',
+		fileName: 'test-123.jpg',
+		filePath: 'uploads/test-123.jpg',
+		url: '/uploads/test-123.jpg',
+		size: 1024000,
+		mimeType: 'image/jpeg',
+		uploadedAt: new Date('2024-01-15T10:00:00.000Z').toISOString(),
+		exifData: { latitude: 54.1, longitude: 12.3 }
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('saveUploadedFile', () => {
+		it('sollte eine Datei mit vollständigen Metadaten speichern', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			await saveUploadedFile(mockUploadedFile, 'ref-123', 42);
+
+			expect(mockDb.insert).toHaveBeenCalledWith(sightingFiles);
+			expect(valuesMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					uid: 'file-1',
+					sightingId: 42,
+					referenceId: 'ref-123',
+					originalName: 'test.jpg',
+					fileName: 'test-123.jpg',
+					filePath: 'uploads/test-123.jpg',
+					mimeType: 'image/jpeg',
+					size: 1024000,
+					url: '/uploads/test-123.jpg',
+					uploadedAt: new Date('2024-01-15T10:00:00.000Z'),
+					exifData: { latitude: 54.1, longitude: 12.3 }
+				})
+			);
+		});
+
+		it('sollte sightingId auf null setzen, wenn keine übergeben wird', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			await saveUploadedFile(mockUploadedFile, 'ref-123');
+
+			expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ sightingId: null }));
+		});
+
+		it('sollte fileName auf originalName zurückfallen lassen, wenn fileName fehlt', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const fileWithoutFileName = { ...mockUploadedFile, fileName: undefined as any };
+
+			await saveUploadedFile(fileWithoutFileName, 'ref-123');
+
+			expect(valuesMock).toHaveBeenCalledWith(
+				expect.objectContaining({ fileName: mockUploadedFile.originalName })
+			);
+		});
+
+		it('sollte url auf null setzen, wenn keine URL vorhanden ist', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const fileWithoutUrl = { ...mockUploadedFile, url: '' };
+
+			await saveUploadedFile(fileWithoutUrl, 'ref-123');
+
+			expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ url: null }));
+		});
+
+		it('sollte exifData auf null setzen, wenn keine EXIF-Daten vorhanden sind', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const fileWithoutExif = { ...mockUploadedFile, exifData: null };
+
+			await saveUploadedFile(fileWithoutExif, 'ref-123');
+
+			expect(valuesMock).toHaveBeenCalledWith(expect.objectContaining({ exifData: null }));
+		});
+
+		it('sollte uploadedAt auf den aktuellen Zeitpunkt defaulten, wenn keiner übergeben wird', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			const before = Date.now();
+			const fileWithoutUploadedAt = { ...mockUploadedFile, uploadedAt: undefined as any };
+
+			await saveUploadedFile(fileWithoutUploadedAt, 'ref-123');
+			const after = Date.now();
+
+			const insertedRecord = valuesMock.mock.calls[0]?.[0];
+			expect(insertedRecord.uploadedAt).toBeInstanceOf(Date);
+			const uploadedAtMs = (insertedRecord.uploadedAt as Date).getTime();
+			expect(uploadedAtMs).toBeGreaterThanOrEqual(before);
+			expect(uploadedAtMs).toBeLessThanOrEqual(after);
+		});
+
+		it('sollte einen übergebenen uploadedAt-String korrekt in ein Date konvertieren', async () => {
+			const mockDb = db as any;
+			const valuesMock = vi.fn().mockResolvedValue(undefined);
+			mockDb.insert.mockReturnValue({ values: valuesMock });
+
+			await saveUploadedFile(mockUploadedFile, 'ref-123');
+
+			const insertedRecord = valuesMock.mock.calls[0]?.[0];
+			expect(insertedRecord.uploadedAt).toEqual(new Date('2024-01-15T10:00:00.000Z'));
+		});
+	});
+
+	describe('deleteFileByPath', () => {
+		it('sollte eine Datei anhand des Pfads löschen', async () => {
+			const mockDb = db as any;
+			const returningMock = vi.fn().mockResolvedValue([{ uid: 'file-1' }]);
+			const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+			mockDb.delete.mockReturnValue({ where: whereMock });
+
+			await deleteFileByPath('uploads/test-123.jpg');
+
+			expect(mockDb.delete).toHaveBeenCalledWith(sightingFiles);
+			expect(whereMock).toHaveBeenCalled();
+			expect(returningMock).toHaveBeenCalledWith({ uid: sightingFiles.uid });
+		});
+
+		it('sollte auch dann nicht werfen, wenn keine Datei gefunden wurde', async () => {
+			const mockDb = db as any;
+			const returningMock = vi.fn().mockResolvedValue([]);
+			const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+			mockDb.delete.mockReturnValue({ where: whereMock });
+
+			await expect(deleteFileByPath('unbekannt/pfad.jpg')).resolves.toBeUndefined();
+		});
+	});
+
+	describe('sumFileSizesForReference', () => {
+		it('sollte die Summe der Dateigrößen für eine referenceId zurückgeben', async () => {
+			const mockDb = db as any;
+			const whereMock = vi.fn().mockResolvedValue([{ total: '2048000' }]);
+			const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.select.mockReturnValue({ from: fromMock });
+
+			const result = await sumFileSizesForReference('ref-123');
+
+			expect(result).toBe(2048000);
+			expect(mockDb.select).toHaveBeenCalled();
+		});
+
+		it('sollte 0 zurückgeben, wenn keine Dateien vorhanden sind (total ist null)', async () => {
+			const mockDb = db as any;
+			const whereMock = vi.fn().mockResolvedValue([{ total: null }]);
+			const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.select.mockReturnValue({ from: fromMock });
+
+			const result = await sumFileSizesForReference('ref-ohne-dateien');
+
+			expect(result).toBe(0);
+			expect(result).not.toBeNaN();
+		});
+
+		it('sollte 0 zurückgeben, wenn keine Zeile zurückkommt (row ist undefined)', async () => {
+			const mockDb = db as any;
+			const whereMock = vi.fn().mockResolvedValue([]);
+			const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.select.mockReturnValue({ from: fromMock });
+
+			const result = await sumFileSizesForReference('ref-leer');
+
+			expect(result).toBe(0);
+			expect(result).not.toBeNaN();
+		});
+	});
+
+	describe('setSightingIdForReferenceId', () => {
+		it('sollte standardmäßig die globale db-Instanz verwenden', async () => {
+			const mockDb = db as any;
+			const returningMock = vi.fn().mockResolvedValue([{ uid: 'file-1' }]);
+			const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+			const setMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			await setSightingIdForReferenceId('ref-123', 99);
+
+			expect(mockDb.update).toHaveBeenCalledWith(sightingFiles);
+			expect(setMock).toHaveBeenCalledWith({ sightingId: 99 });
+		});
+
+		it('sollte einen übergebenen Executor (z.B. Transaktion) statt der globalen db-Instanz verwenden', async () => {
+			const mockDb = db as any;
+			const returningMock = vi.fn().mockResolvedValue([{ uid: 'file-1' }]);
+			const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+			const setMock = vi.fn().mockReturnValue({ where: whereMock });
+			const txExecutor = { update: vi.fn().mockReturnValue({ set: setMock }) };
+
+			await setSightingIdForReferenceId('ref-123', 99, txExecutor as any);
+
+			expect(txExecutor.update).toHaveBeenCalledWith(sightingFiles);
+			expect(mockDb.update).not.toHaveBeenCalled();
+		});
+
+		it('sollte die Anzahl der aktualisierten Dateien nicht gegen einen Fehler abfangen (Fehler propagiert)', async () => {
+			const mockDb = db as any;
+			const dbError = new Error('Update failed');
+			const whereMock = vi.fn().mockReturnValue({ returning: vi.fn().mockRejectedValue(dbError) });
+			const setMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.update.mockReturnValue({ set: setMock });
+
+			await expect(setSightingIdForReferenceId('ref-123', 99)).rejects.toThrow('Update failed');
+		});
+	});
+});

--- a/src/lib/server/media/scanLocalUploads.test.ts
+++ b/src/lib/server/media/scanLocalUploads.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit Tests für scanLocalUploads.ts
+ *
+ * Ein Bug hier führt entweder dazu, dass verknüpfte Dateien fälschlich als
+ * „orphan" markiert werden (Datenverlust bei automatischem Cleanup) oder dass
+ * der Bestand nicht bereinigt wird (`.claude/rules/upload.md`). Die eigentliche
+ * Filterlogik (`selectOrphanedFiles`) ist bereits in `orphanCleanup.test.ts`
+ * abgedeckt — hier geht es ausschließlich um die Zusammenführung der drei
+ * Datenquellen und die korrekte Weitergabe an diese Filterlogik.
+ */
+import { db } from '$lib/server/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DiskEntry } from './orphanCleanup';
+import { scanLocalUploads } from './scanLocalUploads';
+
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: vi.fn()
+	}
+}));
+
+vi.mock('$lib/server/storage/uploadPath', () => ({
+	resolveUploadBasePath: vi.fn(() => '/srv/uploads')
+}));
+
+const { scanUploadDirMock, selectOrphanedFilesMock } = vi.hoisted(() => ({
+	scanUploadDirMock: vi.fn(),
+	selectOrphanedFilesMock: vi.fn()
+}));
+
+vi.mock('./orphanCleanup', () => ({
+	scanUploadDir: scanUploadDirMock,
+	selectOrphanedFiles: selectOrphanedFilesMock
+}));
+
+describe('scanLocalUploads', () => {
+	const mockDb = vi.mocked(db);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function mockSelectSequence(rows: unknown[][]) {
+		let call = 0;
+		mockDb.select.mockImplementation(
+			() =>
+				({
+					from: vi.fn().mockResolvedValue(rows[call++])
+				}) as never
+		);
+	}
+
+	it('führt Disk-Scan, Datei-Pfade und Referenz-IDs zusammen und reicht sie an selectOrphanedFiles weiter', async () => {
+		const entries: DiskEntry[] = [
+			{ relativePath: 'abc123/foto.jpg', modifiedAt: new Date('2026-01-01') }
+		];
+		scanUploadDirMock.mockResolvedValue(entries);
+		mockSelectSequence([
+			[{ filePath: 'abc123/foto.jpg' }, { filePath: 'def456/video.mp4' }],
+			[{ referenceId: 'abc123' }, { referenceId: 'def456' }]
+		]);
+		const orphaned: DiskEntry[] = [];
+		selectOrphanedFilesMock.mockReturnValue(orphaned);
+
+		const cutoff = new Date('2026-07-30T00:00:00Z');
+		const result = await scanLocalUploads(cutoff);
+
+		expect(scanUploadDirMock).toHaveBeenCalledWith('/srv/uploads');
+		expect(selectOrphanedFilesMock).toHaveBeenCalledWith(
+			entries,
+			{
+				paths: ['abc123/foto.jpg', 'def456/video.mp4'],
+				referenceIds: ['abc123', 'def456']
+			},
+			cutoff
+		);
+		expect(result).toBe(orphaned);
+	});
+
+	it('filtert null- und leere referenceId-Werte aus den Sichtungen heraus', async () => {
+		scanUploadDirMock.mockResolvedValue([]);
+		mockSelectSequence([
+			[],
+			[
+				{ referenceId: 'real-ref-1' },
+				{ referenceId: null },
+				{ referenceId: '' },
+				{ referenceId: undefined },
+				{ referenceId: 'real-ref-2' }
+			]
+		]);
+		selectOrphanedFilesMock.mockReturnValue([]);
+
+		await scanLocalUploads(new Date());
+
+		expect(selectOrphanedFilesMock).toHaveBeenCalledWith(
+			[],
+			expect.objectContaining({ referenceIds: ['real-ref-1', 'real-ref-2'] }),
+			expect.any(Date)
+		);
+	});
+
+	it('gibt eine leere Liste weiter, wenn weder Dateien noch Sichtungen bekannt sind', async () => {
+		scanUploadDirMock.mockResolvedValue([]);
+		mockSelectSequence([[], []]);
+		selectOrphanedFilesMock.mockReturnValue([]);
+
+		const result = await scanLocalUploads(new Date());
+
+		expect(selectOrphanedFilesMock).toHaveBeenCalledWith(
+			[],
+			{ paths: [], referenceIds: [] },
+			expect.any(Date)
+		);
+		expect(result).toEqual([]);
+	});
+
+	it('reicht den cutoff unverändert an selectOrphanedFiles durch', async () => {
+		scanUploadDirMock.mockResolvedValue([]);
+		mockSelectSequence([[], []]);
+		selectOrphanedFilesMock.mockReturnValue([]);
+
+		const cutoff = new Date('2025-12-24T12:00:00Z');
+		await scanLocalUploads(cutoff);
+
+		const passedCutoff = selectOrphanedFilesMock.mock.calls[0]?.[2];
+		expect(passedCutoff).toBe(cutoff);
+	});
+
+	it('holt Disk-Scan, Datei-Pfade und Referenz-IDs parallel (Promise.all), nicht nacheinander', async () => {
+		const callOrder: string[] = [];
+
+		scanUploadDirMock.mockImplementation(async () => {
+			callOrder.push('scanUploadDir:start');
+			await new Promise((resolve) => setTimeout(resolve, 10));
+			callOrder.push('scanUploadDir:end');
+			return [];
+		});
+
+		let selectCall = 0;
+		mockDb.select.mockImplementation(() => {
+			const label = selectCall++ === 0 ? 'files' : 'sightings';
+			return {
+				from: vi.fn().mockImplementation(async () => {
+					callOrder.push(`${label}:start`);
+					await new Promise((resolve) => setTimeout(resolve, 5));
+					callOrder.push(`${label}:end`);
+					return [];
+				})
+			} as never;
+		});
+		selectOrphanedFilesMock.mockReturnValue([]);
+
+		await scanLocalUploads(new Date());
+
+		// Alle drei müssen gestartet sein, bevor irgendeines zu Ende ist —
+		// sonst liefe der Disk-Scan sequentiell vor den DB-Abfragen statt
+		// parallel mit ihnen (Promise.all).
+		const firstEndIndex = callOrder.findIndex((entry) => entry.endsWith(':end'));
+		const startsBeforeFirstEnd = callOrder.slice(0, firstEndIndex);
+		expect(startsBeforeFirstEnd).toEqual(
+			expect.arrayContaining(['scanUploadDir:start', 'files:start', 'sightings:start'])
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Analyse der Server-Test-Coverage (`npm run test:coverage`) hatte vier Dateien mit auffällig niedriger Abdeckung identifiziert, obwohl sie Business-kritische Pfade abdecken:

- `src/lib/server/db/configRepository.ts` — App-Config (E-Mail-Templates, Security-Limits, Feature-Flags), 60s-Cache, `set()`/`upsert()`-Verträge (~8% → 100%)
- `src/lib/server/db/sightingFilesRepository.ts` — Metadaten-Normalisierung beim Upload, Größensummierung fürs Upload-Limit (NaN-Falle bei fehlenden Dateien), Transaktions-Executor für die nachträgliche Sichtungs-Verknüpfung (~31% → 100%)
- `src/lib/server/db/index.ts` — `closeDb()` (Graceful-Shutdown bei SIGTERM/SIGINT im Docker-Container, Idempotenz, Race-Schutz), `testDatabaseConnection()`-Caching, `_initError`-Zustand (~45% → ~83%; verbleibender Rest ist der `db`-Proxy-Handler selbst)
- `src/lib/server/media/scanLocalUploads.ts` — Zusammenführung von Disk-Scan und DB-Zustand (Datei-Pfade, Referenz-IDs) für den Orphan-Cleanup, `referenceId`-Filterung, `Promise.all`-Parallelität (0% → funktional vollständig)

Kein Produktionscode geändert — reine Testabdeckung nachgerüstet, jeweils nach dem bestehenden Mock-Pattern (`vi.mock('$lib/server/db', ...)`) aus `sightingRepository.test.ts`.

## Test plan

- [x] `npm run test:unit` — alle 218 Testdateien / 3125 Tests grün, keine Regressionen
- [x] `npm run lint` — sauber (2 vorbestehende Warnungen in unrelated Datei)
- [x] `npm run type-check` — sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)