### PR TITLE
feat(build): show version/commit on startup, health check, admin footer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,12 +65,21 @@ RUN npm prune --omit=dev
 # ============================================
 FROM node:24-alpine AS runtime
 
+# Build-Args aus .github/workflows/docker-publish.yml (dort schon gesetzt, hier
+# bisher ungenutzt — ohne ARG-Deklaration verwirft Docker sie stillschweigend).
+ARG VERSION=dev
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
 # OCI Image Labels (placed in final stage for proper metadata)
 LABEL org.opencontainers.image.title="Ostsee-Tiere"
 LABEL org.opencontainers.image.description="Marine animal sighting reporting platform for the Baltic Sea"
 LABEL org.opencontainers.image.source="https://github.com/jansinger/ostsee-tiere"
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.vendor="Ostsee-Tiere Project"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
 
 # Install runtime dependencies
 RUN apk add --no-cache \
@@ -126,7 +135,10 @@ ENV NODE_ENV=production \
     HOST=0.0.0.0 \
     BODY_SIZE_LIMIT=125829120 \
     STORAGE_PROVIDER=local \
-    UPLOAD_PATH=/app/uploads
+    UPLOAD_PATH=/app/uploads \
+    APP_VERSION=${VERSION} \
+    APP_GIT_SHA=${VCS_REF} \
+    APP_BUILD_DATE=${BUILD_DATE}
 
 # Use dumb-init to handle signals properly
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -136,7 +136,6 @@ ENV NODE_ENV=production \
     BODY_SIZE_LIMIT=125829120 \
     STORAGE_PROVIDER=local \
     UPLOAD_PATH=/app/uploads \
-    APP_VERSION=${VERSION} \
     APP_GIT_SHA=${VCS_REF} \
     APP_BUILD_DATE=${BUILD_DATE}
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"build": "svelte-kit sync && vite build",
 		"build:docker": "USE_NODE_ADAPTER=true svelte-kit sync && vite build",
 		"preview": "vite preview",
-		"docker:build": "docker build -t ostsee-tiere:latest .",
+		"docker:build": "docker build --build-arg VERSION=$(node -p \"require('./package.json').version\") --build-arg VCS_REF=$(git rev-parse --short HEAD) --build-arg BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) -t ostsee-tiere:latest .",
 		"docker:run": "mkdir -p ./uploads && if [ ! -f .env.docker ]; then echo '# .env.docker not found. Creating empty file. Add environment variables as needed.' > .env.docker; fi && docker run -p 3000:3000 -v ./uploads:/app/uploads --env-file .env.docker ostsee-tiere:latest",
 		"docker:compose": "docker compose -f docker-compose.production.yml up -d",
 		"docker:stop": "docker compose -f docker-compose.production.yml down",

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -51,11 +51,14 @@ echo "║                                           ║"
 echo "╚═══════════════════════════════════════════╝"
 echo ""
 
-# APP_VERSION/APP_GIT_SHA/APP_BUILD_DATE kommen aus den Docker-Build-Args
-# VERSION/VCS_REF/BUILD_DATE (siehe Dockerfile). Ein Image, das ohne diese
-# Build-Args gebaut wurde (z.B. lokal per `docker build .`), zeigt die
-# ARG-Defaults "dev"/"unknown" statt falsche Angaben vorzutäuschen.
-log_info "Version: ${APP_VERSION:-dev}"
+# Version aus package.json lesen — dieselbe Quelle, die die App selbst über
+# getBuildInfo() (versionInfo.ts) für /health und den strukturierten Startup-Log
+# verwendet. APP_VERSION (ARG-Default "dev", siehe Dockerfile) wird hier bewusst
+# NICHT gelesen: es würde bei einem Build ohne --build-arg VERSION="dev" zeigen,
+# während App-Log und /health im selben Container die echte package.json-Version
+# melden — zwei widersprüchliche Angaben für dieselbe laufende Instanz.
+APP_VERSION=$(node -p "require('/app/package.json').version" 2>/dev/null || echo "unknown")
+log_info "Version: ${APP_VERSION}"
 log_info "Commit:  ${APP_GIT_SHA:-unknown}"
 log_info "Built:   ${APP_BUILD_DATE:-unknown}"
 echo ""

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -51,6 +51,15 @@ echo "║                                           ║"
 echo "╚═══════════════════════════════════════════╝"
 echo ""
 
+# APP_VERSION/APP_GIT_SHA/APP_BUILD_DATE kommen aus den Docker-Build-Args
+# VERSION/VCS_REF/BUILD_DATE (siehe Dockerfile). Ein Image, das ohne diese
+# Build-Args gebaut wurde (z.B. lokal per `docker build .`), zeigt die
+# ARG-Defaults "dev"/"unknown" statt falsche Angaben vorzutäuschen.
+log_info "Version: ${APP_VERSION:-dev}"
+log_info "Commit:  ${APP_GIT_SHA:-unknown}"
+log_info "Built:   ${APP_BUILD_DATE:-unknown}"
+echo ""
+
 # ============================================
 # Environment Validation
 # ============================================

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,6 +7,7 @@ import { databaseCheck } from '$lib/server/middleware/databaseCheck';
 import { maintenanceMode } from '$lib/server/middleware/maintenanceMode';
 import { createSecurityHeadersHandler } from '$lib/server/middleware/securityHeaders';
 import { warnIfBodySizeLimitTooLow } from '$lib/server/startup/bodySizeLimit';
+import { formatStartupBanner, getBuildInfo } from '$lib/server/startup/versionInfo';
 import { buildErrorLogFields } from '$lib/server/utils/errorChain';
 import { ServerConfigService } from '$lib/services/configService';
 import type { Handle, HandleServerError } from '@sveltejs/kit';
@@ -18,6 +19,13 @@ const NODE_ENV = env.NODE_ENV ?? 'development';
 const ENCRYPTION_KEY = env.ENCRYPTION_KEY ?? '';
 
 const logger = createLogger('hooks:server');
+
+// gitSha/buildDate kommen aus den Docker-Build-Args VCS_REF/BUILD_DATE (siehe Dockerfile)
+// und existieren nur im Container-Image. Ein lokaler `npm run dev` hat sie nicht —
+// formatStartupBanner zeigt das dann bewusst als "unknown", statt eine falsche
+// Versionsangabe vorzutäuschen.
+const buildInfo = getBuildInfo();
+logger.info({ ...buildInfo, nodeEnv: NODE_ENV }, formatStartupBanner(buildInfo, NODE_ENV));
 
 // Guard: Der Server startet in Produktion nicht mit einem fehlenden oder unbrauchbaren
 // ENCRYPTION_KEY. Die Prüflogik steht in secretGuard.ts, damit sie testbar ist —

--- a/src/lib/components/admin/AdminFooter.svelte
+++ b/src/lib/components/admin/AdminFooter.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+	// BuildInfo liegt unter $lib/types (nicht $lib/server/startup/versionInfo): Module
+	// unter $lib/server/** sind für Client-Code gesperrt, auch bei reinen Typ-Importen.
+	import type { BuildInfo } from '$lib/types/BuildInfo';
+
+	let { buildInfo }: { buildInfo: BuildInfo } = $props();
+</script>
+
+<footer class="border-base-300 text-base-content/70 mt-8 border-t p-4 text-center text-xs">
+	<p>
+		v{buildInfo.version} · commit {buildInfo.shortGitSha}
+		{#if buildInfo.buildDate}
+			· built {buildInfo.buildDate}
+		{/if}
+	</p>
+</footer>

--- a/src/lib/server/startup/versionInfo.test.ts
+++ b/src/lib/server/startup/versionInfo.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$env/dynamic/private', () => ({
+	env: { APP_GIT_SHA: 'abcdef1234567890', APP_BUILD_DATE: '2026-07-31T10:00:00Z' }
+}));
+
+describe('formatStartupBanner', () => {
+	it('enthält Version, Commit und Umgebung', async () => {
+		const { formatStartupBanner, resolveBuildInfo } = await import('./versionInfo');
+		const info = resolveBuildInfo('2.7.0', 'abc1234', '2026-07-31T10:00:00Z');
+
+		const banner = formatStartupBanner(info, 'production');
+
+		expect(banner).toContain('2.7.0');
+		expect(banner).toContain('abc1234');
+		expect(banner).toContain('2026-07-31T10:00:00Z');
+		expect(banner).toContain('production');
+	});
+
+	it('kürzt einen vollen 40-Zeichen-SHA auf 7 Stellen, wie git es üblicherweise anzeigt', async () => {
+		const { formatStartupBanner, resolveBuildInfo } = await import('./versionInfo');
+		const info = resolveBuildInfo('2.7.0', '1234567890abcdef1234567890abcdef12345678', null);
+
+		const banner = formatStartupBanner(info, 'production');
+
+		expect(banner).toContain('1234567');
+		expect(banner).not.toContain('1234567890abcdef');
+	});
+
+	it('markiert fehlende Werte als "unknown" statt sie zu verschweigen', async () => {
+		// Ein lokaler `docker run` ohne Build-Args (kein --build-arg beim Bauen) liefert
+		// leere Env-Variablen. Stillschweigend wegzulassen würde einen Docker-Start optisch
+		// nicht von einem `npm run dev`-Start unterscheidbar machen — genau das soll die
+		// Banner-Zeile verhindern.
+		const { formatStartupBanner, resolveBuildInfo } = await import('./versionInfo');
+		const info = resolveBuildInfo('2.7.0', null, null);
+
+		const banner = formatStartupBanner(info, 'development');
+
+		expect(banner).toContain('unknown');
+	});
+});
+
+describe('resolveBuildInfo', () => {
+	it('kürzt den SHA und behält Version/Build-Datum unverändert', async () => {
+		const { resolveBuildInfo } = await import('./versionInfo');
+		const info = resolveBuildInfo('2.7.0', '1234567890abcdef', '2026-07-31T10:00:00Z');
+
+		expect(info).toEqual({
+			version: '2.7.0',
+			gitSha: '1234567890abcdef',
+			shortGitSha: '1234567',
+			buildDate: '2026-07-31T10:00:00Z'
+		});
+	});
+
+	it('behandelt fehlenden/leeren SHA und Build-Datum als null bzw. "unknown"', async () => {
+		const { resolveBuildInfo } = await import('./versionInfo');
+
+		expect(resolveBuildInfo('2.7.0', undefined, undefined)).toEqual({
+			version: '2.7.0',
+			gitSha: null,
+			shortGitSha: 'unknown',
+			buildDate: null
+		});
+
+		// Ein leerer String ist der Zustand eines Build-Args, das zwar gesetzt aber
+		// nicht befüllt wurde (z.B. `--build-arg VCS_REF=`) — soll wie "fehlt" behandelt werden.
+		expect(resolveBuildInfo('2.7.0', '', '').gitSha).toBeNull();
+	});
+});
+
+describe('getBuildInfo', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('liest Version aus package.json und Commit/Build-Datum aus den Docker-Build-Args', async () => {
+		const { getBuildInfo } = await import('./versionInfo');
+
+		const info = getBuildInfo();
+
+		expect(info.version).toBe('2.7.0');
+		expect(info.gitSha).toBe('abcdef1234567890');
+		expect(info.shortGitSha).toBe('abcdef1');
+		expect(info.buildDate).toBe('2026-07-31T10:00:00Z');
+	});
+
+	it('cached das Ergebnis statt bei jedem Aufruf neu aufzulösen', async () => {
+		const { getBuildInfo } = await import('./versionInfo');
+
+		// Gleiche Objekt-Referenz über mehrere Aufrufe hinweg belegt, dass nicht jedes Mal
+		// neu berechnet wird — relevant, weil `/health` von Docker alle 30s abgefragt wird.
+		expect(getBuildInfo()).toBe(getBuildInfo());
+	});
+});

--- a/src/lib/server/startup/versionInfo.test.ts
+++ b/src/lib/server/startup/versionInfo.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { version as packageVersion } from '../../../../package.json';
 
 vi.mock('$env/dynamic/private', () => ({
 	env: { APP_GIT_SHA: 'abcdef1234567890', APP_BUILD_DATE: '2026-07-31T10:00:00Z' }
@@ -80,7 +81,7 @@ describe('getBuildInfo', () => {
 
 		const info = getBuildInfo();
 
-		expect(info.version).toBe('2.7.0');
+		expect(info.version).toBe(packageVersion);
 		expect(info.gitSha).toBe('abcdef1234567890');
 		expect(info.shortGitSha).toBe('abcdef1');
 		expect(info.buildDate).toBe('2026-07-31T10:00:00Z');

--- a/src/lib/server/startup/versionInfo.ts
+++ b/src/lib/server/startup/versionInfo.ts
@@ -1,0 +1,54 @@
+/**
+ * Baut Version-/Commit-/Build-Info für Startup-Log, `/health` und Admin-Footer.
+ *
+ * Docker-Images tragen kein `.git` — Version/Commit/Build-Zeit kommen deshalb als
+ * Build-Args (`VERSION`, `VCS_REF`, `BUILD_DATE`, siehe Dockerfile) über die Env-Variablen
+ * `APP_GIT_SHA`/`APP_BUILD_DATE` herein (`APP_VERSION` existiert zwar ebenfalls als
+ * Env-Var, wird hier aber bewusst nicht gelesen — die Version kommt aus `package.json`,
+ * siehe Kommentar bei `getBuildInfo()`). Lokale `npm run dev`-Starts und manuelle
+ * `docker run` ohne Build-Args liefern hier `null` — dann steht explizit "unknown" da,
+ * statt die Zeile stillschweigend zu verkürzen.
+ */
+import { env } from '$env/dynamic/private';
+import type { BuildInfo } from '$lib/types/BuildInfo';
+import { version as packageVersion } from '../../../../package.json';
+
+export type { BuildInfo };
+
+const SHORT_SHA_LENGTH = 7;
+
+export function resolveBuildInfo(
+	version: string,
+	gitSha: string | null | undefined,
+	buildDate: string | null | undefined
+): BuildInfo {
+	const sha = gitSha ? gitSha.trim() || null : null;
+	const build = buildDate ? buildDate.trim() || null : null;
+
+	return {
+		version,
+		gitSha: sha,
+		shortGitSha: sha ? sha.slice(0, SHORT_SHA_LENGTH) : 'unknown',
+		buildDate: build
+	};
+}
+
+export function formatStartupBanner(info: BuildInfo, nodeEnv: string): string {
+	return `Ostsee-Tiere v${info.version} | commit ${info.shortGitSha} | built ${info.buildDate ?? 'unknown'} | env ${nodeEnv}`;
+}
+
+// version kommt aus package.json statt aus env.APP_VERSION/env.npm_package_version: Der
+// Docker-Container startet mit `node build/index.js` (siehe docker-entrypoint.sh), nicht
+// über `npm run` — npm_package_version ist dort nie gesetzt. env.APP_VERSION wäre zwar
+// gesetzt, trägt aber je nach Build-Pfad ein anderes Format als package.json (CI-Tags
+// haben ein führendes "v", `npm run docker:build` nicht) — package.json ist die einzige
+// Quelle, die in jedem Kontext (lokal, Docker, CI) konsistent ist.
+//
+// Gecacht, weil version/gitSha/buildDate für die Prozesslaufzeit konstant sind — `/health`
+// wird von Docker alle 30s abgefragt und soll dafür nicht bei jedem Request neu auflösen.
+let cachedBuildInfo: BuildInfo | undefined;
+
+export function getBuildInfo(): BuildInfo {
+	cachedBuildInfo ??= resolveBuildInfo(packageVersion, env.APP_GIT_SHA, env.APP_BUILD_DATE);
+	return cachedBuildInfo;
+}

--- a/src/lib/types/BuildInfo.ts
+++ b/src/lib/types/BuildInfo.ts
@@ -1,0 +1,13 @@
+/**
+ * Version-/Commit-/Build-Info für Startup-Log, `/health` und Admin-Footer.
+ *
+ * Liegt unter `$lib/types` statt bei `$lib/server/startup/versionInfo.ts`, weil
+ * `AdminFooter.svelte` (Client-Code) den Typ braucht — Module unter `$lib/server/**`
+ * sind für Client-Imports gesperrt, auch bei reinen Typ-Importen.
+ */
+export interface BuildInfo {
+	version: string;
+	gitSha: string | null;
+	shortGitSha: string;
+	buildDate: string | null;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -95,3 +95,6 @@ export type {
 
 // Weather types
 export type { WeatherDataWithMetadata } from './weather.js';
+
+// Build/version info (startup log, /health, admin footer)
+export type { BuildInfo } from './BuildInfo.js';

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -1,4 +1,5 @@
 import { requireUserRole } from '$lib/server/auth/auth';
+import { getBuildInfo } from '$lib/server/startup/versionInfo';
 import type { PublicUser } from '$lib/types/User';
 import type { LayoutServerLoad } from './$types';
 
@@ -20,6 +21,7 @@ export const load = (async ({ locals, url }) => {
 	return {
 		user: adminUser,
 		// Server-computed admin status - no client-side role checking needed
-		isAdmin: true // We know user is admin since requireUserRole passed
+		isAdmin: true, // We know user is admin since requireUserRole passed
+		buildInfo: getBuildInfo()
 	};
 }) satisfies LayoutServerLoad;

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
-	let { children }: { children: import('svelte').Snippet } = $props();
+	import AdminFooter from '$lib/components/admin/AdminFooter.svelte';
+	import type { LayoutData } from './$types';
+
+	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
 </script>
 
 <!-- Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit -->
 <div class="w-full">
 	<div class="flex min-h-screen flex-col">
 		<!-- Page content with top padding for fixed navbar -->
-		<div class="w-full">
+		<div class="w-full flex-1">
 			{@render children()}
 		</div>
+		<AdminFooter buildInfo={data.buildInfo} />
 	</div>
 </div>

--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -11,6 +11,7 @@
 
 import { env } from '$env/dynamic/private';
 import { testDatabaseConnection } from '$lib/server/db';
+import { getBuildInfo } from '$lib/server/startup/versionInfo';
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 
@@ -22,13 +23,19 @@ const NO_CACHE_HEADERS = {
 export const GET: RequestHandler = async () => {
 	const startTime = Date.now();
 
+	// Herkunft von version/gitSha/buildDate ist in versionInfo.ts dokumentiert
+	// (getBuildInfo()). Gecacht — läuft hier auf jedem Docker-Healthcheck-Poll (alle 30s).
+	const buildInfo = getBuildInfo();
+
 	// Basis-Status
 	const health: Record<string, unknown> = {
 		status: 'healthy',
 		timestamp: new Date().toISOString(),
 		uptime: process.uptime(),
 		environment: env.NODE_ENV ?? process.env.NODE_ENV ?? 'unknown',
-		version: env.npm_package_version ?? process.env.npm_package_version ?? 'unknown'
+		version: buildInfo.version,
+		gitSha: buildInfo.shortGitSha,
+		buildDate: buildInfo.buildDate ?? 'unknown'
 	};
 
 	// Readiness: echte DB-Konnektivität prüfen. Docker/compose fragt nur `/health`

--- a/src/routes/health/health.test.ts
+++ b/src/routes/health/health.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const testDatabaseConnection = vi.fn();
 
 vi.mock('$env/dynamic/private', () => ({
-	env: { NODE_ENV: 'test', npm_package_version: '0.0.0' }
+	env: { NODE_ENV: 'test', APP_GIT_SHA: 'abcdef1234567890', APP_BUILD_DATE: '2026-07-31T10:00:00Z' }
 }));
 
 vi.mock('$lib/server/db', () => ({
@@ -35,6 +35,17 @@ describe('GET /health', () => {
 		expect(res.status).toBe(200);
 		expect(body.status).toBe('healthy');
 		expect(body.database).toBe('connected');
+	});
+
+	it('liefert Version, Commit (gekürzt auf 7 Stellen) und Build-Datum', async () => {
+		testDatabaseConnection.mockResolvedValue(true);
+
+		const res = await GET(event);
+		const body = await res.json();
+
+		expect(body.version).toBe('2.7.0');
+		expect(body.gitSha).toBe('abcdef1');
+		expect(body.buildDate).toBe('2026-07-31T10:00:00Z');
 	});
 
 	it('liefert 503 und status "unhealthy" wenn die DB nicht erreichbar ist', async () => {

--- a/src/routes/health/health.test.ts
+++ b/src/routes/health/health.test.ts
@@ -5,6 +5,7 @@
  * DB nicht erreichbar oder Fehler → 503 unhealthy.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { version as packageVersion } from '../../../package.json';
 
 const testDatabaseConnection = vi.fn();
 
@@ -43,7 +44,7 @@ describe('GET /health', () => {
 		const res = await GET(event);
 		const body = await res.json();
 
-		expect(body.version).toBe('2.7.0');
+		expect(body.version).toBe(packageVersion);
 		expect(body.gitSha).toBe('abcdef1');
 		expect(body.buildDate).toBe('2026-07-31T10:00:00Z');
 	});

--- a/src/tests/contract/health.contract.test.ts
+++ b/src/tests/contract/health.contract.test.ts
@@ -12,7 +12,7 @@ vi.mock('$lib/logger', () => ({
 }));
 
 vi.mock('$env/dynamic/private', () => ({
-	env: { NODE_ENV: 'test', npm_package_version: '0.0.0' }
+	env: { NODE_ENV: 'test', APP_GIT_SHA: 'abcdef1234567890', APP_BUILD_DATE: '2026-07-31T10:00:00Z' }
 }));
 
 // DB-Konnektivität mocken: gesund (true), damit der Contract-Test 200 erhält

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -3409,6 +3409,19 @@ components:
           type: string
           description: Anwendungsversion
           example: "2.2.3"
+        gitSha:
+          type: string
+          description: >-
+            Auf 7 Stellen gekürzter Git-Commit-Hash des laufenden Builds. Kommt aus
+            dem Docker-Build-Arg VCS_REF; "unknown" bei Builds ohne dieses Build-Arg
+            (z.B. lokales `npm run dev`).
+          example: "a1b2c3d"
+        buildDate:
+          type: string
+          description: >-
+            Zeitpunkt, zu dem das laufende Image gebaut wurde (Docker-Build-Arg
+            BUILD_DATE). "unknown" bei Builds ohne dieses Build-Arg.
+          example: "2026-07-31T10:00:00Z"
         responseTime:
           type: string
           description: Antwortzeit des letzten Checks


### PR DESCRIPTION
## Summary
- Wires the `VERSION`/`VCS_REF`/`BUILD_DATE` Docker build-args (already passed by `docker-publish.yml`, but silently discarded — the Dockerfile never declared them as `ARG`) through to the running container as `APP_GIT_SHA`/`APP_BUILD_DATE`, and prints them in the `docker-entrypoint.sh` startup banner.
- Adds a structured startup log line in `hooks.server.ts` (version/commit/build-date/env) — also fires for `npm run dev`, where it shows `unknown` for commit/build-date since there's no Docker build-arg.
- Extends `/health` with `gitSha`/`buildDate`, and fixes its `version` field, which was always `"unknown"` in Docker because the app starts via `node build/index.js`, not `npm run` (so `npm_package_version` was never set).
- Adds a small footer to every admin page showing version/commit/build-date.
- New shared `getBuildInfo()`/`resolveBuildInfo()` in `versionInfo.ts` (cached, single source of truth) and `BuildInfo` type in `$lib/types/BuildInfo.ts` (needed there since `$lib/server/**` types are blocked from client imports).
- `npm run docker:build` now passes real version/commit/build-date build-args too, so local builds aren't stuck on `dev`/`unknown`.
- `static/openapi.yml` updated for the new `/health` fields.

## Test plan
- [x] `npm run test:quick` — 215 files / 3061 tests pass
- [x] `npm run type-check`, `npm run check`, `npm run lint` — clean
- [x] `/review` skill run (anti-pattern checks + `/simplify`) — findings addressed
- [x] `node --input-type=commonjs -e "..."` — `static/openapi.yml` validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)