### PR TITLE
fix(ui): Ziffernkreis im Stepper bekommt eine eigene Fläche

### DIFF
--- a/e2e/form-stepper-affordance.spec.ts
+++ b/e2e/form-stepper-affordance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
+import { formatRatio, measureContrast } from './helpers/contrast';
 import { FormPage } from './pages/FormPage';
 
 /**
@@ -23,6 +24,13 @@ import { FormPage } from './pages/FormPage';
  */
 
 const STEP_BUTTON = 'nav[aria-label="Formular-Schritte"]:visible .step-button';
+
+/**
+ * Ein Schritt, der noch nicht erreicht ist. `step-primary` trägt im Stepper
+ * genau die erreichten Schritte — die Negation ist damit dieselbe Menge, die
+ * auch das CSS in `app.css` adressiert, und kein zweites Regelwerk.
+ */
+const NICHT_ERREICHT = '.steps .step:not(.step-primary)';
 
 /**
  * Wartet, bis alle laufenden CSS-Transitions durch sind.
@@ -161,6 +169,51 @@ test.describe('Stepper — erkennbar als Navigation', () => {
 		await gesperrt.hover({ force: true });
 		await transitionsSettled(page);
 		expect(alphaOf(await style(gesperrt, 'background-color'))).toBe(0);
+	});
+
+	test('die Ziffer eines gesperrten Schritts liegt nicht auf dem Verbindungsbalken', async ({
+		page
+	}) => {
+		await gotoStepTwo(page);
+
+		// DaisyUI speist Kreis (`::after`) UND Verbindungsbalken (`::before`) aus
+		// derselben Variablen `--step-bg`. Für noch nicht erreichte Schritte ist
+		// das beidesmal `base-300` — der 8px-Balken läuft damit farbgleich durch
+		// den 32px-Kreis, und die Ziffer sitzt sichtbar auf dem Balken statt auf
+		// einer eigenen Fläche. Gemeldet als „Zahlen werden von den Balken
+		// überlagert"; der Kreis liegt tatsächlich davor (`z-index: 1`), er ist
+		// nur nicht von ihm zu unterscheiden.
+		//
+		// Gemessen wird über `measureContrast`, nicht mit einer eigenen Rechnung:
+		// Die Farben stehen in `oklch()` und lassen sich erst nach dem
+		// Gamut-Mapping des Browsers vergleichen, und der gesperrte Schritt trägt
+		// zusätzlich `opacity-70` — beides löst der Helfer bereits auf.
+		const [kreis, balken] = await measureContrast(page, [
+			{
+				name: 'Ziffernkreis eines nicht erreichten Schritts',
+				selector: NICHT_ERREICHT,
+				pseudo: '::after',
+				backdrop: 'var(--color-base-100)'
+			},
+			{
+				name: 'Verbindungsbalken davor',
+				selector: NICHT_ERREICHT,
+				pseudo: '::before',
+				backdrop: 'var(--color-base-100)'
+			}
+		]);
+
+		expect(
+			kreis.background,
+			`Kreis und Balken sind farbgleich (${kreis.background}) — die Ziffer steht damit auf dem Balken`
+		).not.toBe(balken.background);
+
+		// WCAG 1.4.3 für die Ziffer auf ihrer eigenen Fläche. Vor der Korrektur
+		// war die Bezugsfläche faktisch der Balken.
+		expect(
+			kreis.ratio,
+			`Ziffer ${kreis.foreground} auf ${kreis.background} misst nur ${formatRatio(kreis.ratio)}:1`
+		).toBeGreaterThanOrEqual(4.5);
 	});
 
 	test('die Schaltflächen benennen die Aktion, nicht nur den Schritt', async ({ page }) => {

--- a/e2e/helpers/contrast.ts
+++ b/e2e/helpers/contrast.ts
@@ -12,6 +12,12 @@ import type { Page } from '@playwright/test';
  *
  * Transparente Elementhintergründe (z. B. `btn-outline`) werden über `backdrop`
  * komponiert, damit auch Textfarben auf durchsichtigen Flächen korrekt messen.
+ *
+ * Ebenso die `opacity` des gemessenen Elements und — bei `pseudo` — die seines
+ * Pseudo-Elements. **Nicht** berücksichtigt wird die Deckkraft von Vorfahren:
+ * dafür müsste die Kette bis zum Backdrop bekannt sein, und `backdrop` sagt
+ * gerade, dass sie es nicht ist. Sitzt das Messziel in einem abgeblendeten
+ * Container, gehört dessen Deckkraft in die `backdrop`-Farbe eingerechnet.
  */
 export interface ContrastProbe {
 	/** Beschriftung für die Fehlermeldung. */
@@ -131,8 +137,14 @@ export async function measureContrast(
 			// Die Deckkraft steht am Element selbst, gemessen wird ggf. sein
 			// Pseudo-Element — `opacity` ist nicht vererbbar, die Gruppe wird aber
 			// samt Pseudo-Elementen als Ganzes abgeblendet.
-			const deckkraft = Number(getComputedStyle(element).opacity);
+			//
+			// Trägt das Pseudo-Element zusätzlich eine eigene Deckkraft, multiplizieren
+			// sich beide. Ohne `pseudo` liest `style.opacity` denselben Wert wie
+			// `hostDeckkraft` — dort darf deshalb NICHT multipliziert werden, sonst
+			// ginge die Deckkraft quadratisch ein.
+			const hostDeckkraft = Number(getComputedStyle(element).opacity);
 			const style = getComputedStyle(element, item.pseudo ?? null);
+			const deckkraft = item.pseudo ? hostDeckkraft * Number(style.opacity) : hostDeckkraft;
 			const fg = toRgb(style.color, backdrop, deckkraft);
 			const bg = toRgb(style.backgroundColor, backdrop, deckkraft);
 			temporary?.remove();

--- a/e2e/helpers/contrast.ts
+++ b/e2e/helpers/contrast.ts
@@ -20,6 +20,14 @@ export interface ContrastProbe {
 	className?: string;
 	/** Statt eines Probe-Elements ein echtes Element aus der Seite messen. */
 	selector?: string;
+	/**
+	 * Statt des Elements sein Pseudo-Element messen (`'::before'`, `'::after'`).
+	 *
+	 * Nötig für Komponenten, die ihre Flächen dort erzeugen — der Stepper zeichnet
+	 * Verbindungsbalken und Ziffernkreis als Pseudo-Elemente, ein Selektor kommt
+	 * dort grundsätzlich nicht hin.
+	 */
+	pseudo?: string;
 	/** CSS-Farbe der Fläche, auf der das Element liegt (z. B. `var(--color-base-200)`). */
 	backdrop: string;
 }
@@ -68,17 +76,27 @@ export async function measureContrast(
 			return value;
 		}
 
-		/** Serialisierte CSS-Farbe → sRGB-Bytes, ggf. über einen Backdrop komponiert. */
-		function toRgb(cssColor: string, backdrop?: string): [number, number, number] {
+		/**
+		 * Serialisierte CSS-Farbe → sRGB-Bytes, ggf. über einen Backdrop komponiert.
+		 *
+		 * `deckkraft` ist die `opacity` des gemessenen Elements. Sie wirkt auf die
+		 * fertig zusammengesetzte Gruppe und nicht auf die einzelnen Farben — Vorder-
+		 * und Hintergrund müssen deshalb beide damit auf den Backdrop gelegt werden,
+		 * sonst misst ein abgeblendetes Element zu gut.
+		 */
+		function toRgb(cssColor: string, backdrop?: string, deckkraft = 1): [number, number, number] {
 			ctx.clearRect(0, 0, 1, 1);
+			ctx.globalAlpha = 1;
 			ctx.fillStyle = '#000000';
 			if (backdrop) {
 				ctx.fillStyle = backdrop;
 				ctx.fillRect(0, 0, 1, 1);
 				ctx.fillStyle = '#000000';
 			}
+			ctx.globalAlpha = deckkraft;
 			ctx.fillStyle = cssColor;
 			ctx.fillRect(0, 0, 1, 1);
+			ctx.globalAlpha = 1;
 			const d = ctx.getImageData(0, 0, 1, 1).data;
 			return [d[0], d[1], d[2]];
 		}
@@ -110,9 +128,13 @@ export async function measureContrast(
 				element = temporary;
 			}
 
-			const style = getComputedStyle(element);
-			const fg = toRgb(style.color, backdrop);
-			const bg = toRgb(style.backgroundColor, backdrop);
+			// Die Deckkraft steht am Element selbst, gemessen wird ggf. sein
+			// Pseudo-Element — `opacity` ist nicht vererbbar, die Gruppe wird aber
+			// samt Pseudo-Elementen als Ganzes abgeblendet.
+			const deckkraft = Number(getComputedStyle(element).opacity);
+			const style = getComputedStyle(element, item.pseudo ?? null);
+			const fg = toRgb(style.color, backdrop, deckkraft);
+			const bg = toRgb(style.backgroundColor, backdrop, deckkraft);
 			temporary?.remove();
 
 			const l1 = luminance(fg);

--- a/src/app.css
+++ b/src/app.css
@@ -523,6 +523,46 @@ label:has(> .toggle) {
 	grid-template-columns: minmax(0, 1fr);
 }
 
+/* ===== Der Kreis eines noch nicht erreichten Schritts ist nicht der Balken =====
+
+   DaisyUI speist beide Pseudo-Elemente aus derselben Variablen: `--step-bg`
+   färbt den Verbindungsbalken (`::before`, 8px hoch) UND den Kreis mit der
+   Ziffer (`::after`, 32px). Für erreichte Schritte trennt `step-primary` die
+   beiden; für noch nicht erreichte ist beides `base-300`, und der Balken läuft
+   damit farbgleich quer durch die Ziffer.
+
+   Gemeldet wurde das als „die Zahlen werden von den Balken überlagert" — der
+   Kreis liegt tatsächlich davor (DaisyUI gibt ihm `z-index: 1`), er ist nur
+   nicht von ihm zu unterscheiden. Eine z-index-Korrektur ginge deshalb ins
+   Leere; es fehlt der Farbunterschied.
+
+   Gefüllt statt umrandet wäre hier falsch herum: „ausgefüllt" ist im Stepper
+   die Auszeichnung des Erledigten, die `step-primary` schon trägt. Der offene
+   Kreis in der Seitenfläche (`base-100` — der Stepper sitzt im
+   Formular-Container `div.bg-base-100`) unterbricht den Balken sichtbar und
+   gibt der Ziffer ihre eigene Fläche.
+
+   Die Ziffernfarbe bleibt bewusst DaisyUIs `--step-fg`: für nicht-primäre
+   Schritte ist das ohnehin `base-content` und darauf richtig (16,53:1, durch
+   das `opacity-70` des gesperrten Schritts effektiv 7,04:1). Sie hier zu
+   wiederholen wäre ein zweiter Ort für denselben Wert.
+
+   Der Ring selbst ist Dekoration und trägt keine Information — dieselbe
+   Begründung wie bei den Segmenten in `StepProgressCompact.svelte`: Die Ansage
+   liegt in der Ziffer, im Titel darunter und in `aria-current`/`aria-label`.
+   WCAG 1.4.11 greift damit nicht, und `base-300` auf `base-100` bleibt
+   zulässig — es ist derselbe Ton, den der Balken schon hat.
+
+   Abgesichert durch `e2e/form-stepper-affordance.spec.ts` → „die Ziffer eines
+   gesperrten Schritts liegt nicht auf dem Verbindungsbalken". Der Test misst
+   Kreis, Balken und Ziffer als fertig zusammengesetzte sRGB-Werte inklusive
+   der Deckkraft — aus den Variablen allein wäre der Unterschied nicht
+   ablesbar. */
+.steps .step:not(.step-primary)::after {
+	background-color: var(--color-base-100);
+	border-color: var(--color-base-300);
+}
+
 /* ===== Der Stepper muss aussehen wie Navigation =====
 
    Er WAR immer welche — besuchte Schritte lassen sich seit jeher anspringen


### PR DESCRIPTION
## Problem

Die Zahlen im Stepper wirkten von den Verbindungsbalken überlagert — im nicht anklickbaren Zustand.

Es ist **kein** z-index-Problem: DaisyUI setzt den Kreis bereits davor (`z-index: 1`). Beide Pseudo-Elemente zeichnen nur aus derselben Variablen — `--step-bg` färbt den Verbindungsbalken (`::before`, 8px) **und** den Kreis mit der Ziffer (`::after`, 32px). Für erreichte Schritte trennt `step-primary` die beiden; für noch nicht erreichte ist beides `base-300`, im Browser gemessen beidseitig `rgb(202, 208, 217)`. Eine z-index-Korrektur wäre ins Leere gelaufen.

## Lösung

Der Kreis eines nicht erreichten Schritts steht jetzt offen in der Seitenfläche (`base-100`-Füllung, `base-300`-Ring). Der Balken bricht damit sichtbar am Kreis ab, und die Ziffer bekommt ihre eigene Fläche.

Gefüllt wäre falsch herum: „ausgefüllt" ist im Stepper die Auszeichnung des Erledigten, die `step-primary` schon trägt.

## Design-System-Prüfung

| Regel | Status |
| --- | --- |
| Nur Theme-Tokens, keine Hex-/Tailwind-Palette, kein `white`/`black` | ✅ `--color-base-100` / `--color-base-300` |
| `*-content` nur auf Vollton-Flächen | ✅ nicht verwendet |
| Statusfarben als Vordergrund nur mit `-strong` | ✅ keine Statusfarbe beteiligt |
| Deckkraft-Untergrenze `/60` für Text | ✅ Ziffer über `opacity-70` bei 7,04:1 auf `base-100` |
| Keine toten Utilities, kein neuer Token | ✅ reine Override-Regel |

Die Ziffernfarbe bleibt bewusst bei DaisyUIs `--step-fg` — für nicht-primäre Schritte ohnehin `base-content` und auf der neuen Füllung richtig. Sie hier zu wiederholen wäre ein zweiter Ort für denselben Wert.

Der Ring selbst ist Dekoration und trägt keine Information (dieselbe Begründung wie bei den Segmenten in `StepProgressCompact.svelte`: die Ansage liegt in der Ziffer, im Titel darunter und in `aria-current`/`aria-label`). WCAG 1.4.11 greift damit nicht.

## Test zuerst

Neu in `e2e/form-stepper-affordance.spec.ts`: „die Ziffer eines gesperrten Schritts liegt nicht auf dem Verbindungsbalken". Vorher rot mit *„Kreis und Balken sind farbgleich (rgb(202, 208, 217))"*, danach grün.

`measureContrast` hat dafür `pseudo` und Deckkraft-Komposition bekommen, statt eine dritte Kopie der sRGB-Leuchtdichte-Rechnung anzulegen — die Messmechanik soll an einer Stelle liegen (so begründet in `daisyui.md`). Deckkraft wirkt auf die fertig zusammengesetzte Gruppe, Vorder- und Hintergrund werden deshalb jetzt beide damit auf den Backdrop gelegt; ein abgeblendetes Element maß vorher zu gut. Keine bestehende Probe sitzt auf einem abgeblendeten Element, alle bisherigen Messwerte bleiben also unverändert.

## Verifikation

- `npm run test:quick` — 3133 Tests grün (lint, type-check, svelte-check, unit)
- `form-a11y` + `design-tokens` + `form-stepper-affordance` — 93 grün
- Visuell auf Schritt 1 und Schritt 2 im Browser geprüft

🤖 Generated with [Claude Code](https://claude.com/claude-code)