### PR TITLE
fix(ui): tote min-h-10/min-h-11 Utilities entfernen

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -377,7 +377,7 @@ haben, genau wie bei einem Auth0-Redirect oder einer 403-Seite. Deshalb:
 
 | Wächter                   | Fehlerfall, den er abfängt                                   |
 | ------------------------- | ------------------------------------------------------------ |
-| Umleitung ≠ eigene Origin | Session-Zeile fehlt oder Cookie-Name passt nicht              |
+| Umleitung ≠ eigene Origin | Session-Zeile fehlt oder Cookie-Name passt nicht             |
 | Status 401/403            | Cookie gilt, aber `roles` reicht nicht für `requireUserRole` |
 | `renders`-Sonden          | Seite antwortet 200 und rendert trotzdem nichts              |
 
@@ -510,10 +510,9 @@ Vollständiger Scan über beide Verzeichnisse (nicht nur eine Teilmenge):
 Touch-Target-Block in `app.css` gegenstandslos. `.btn:not(.target-exempt)`
 steht dort ungelayert und gewinnt gegen Tailwinds `@layer utilities` — im
 Browser gemessen liefern `btn btn-xs`, `btn btn-sm` und sogar
-`btn btn-sm min-h-10` alle 44px. Umgekehrt heißt das: die zwei verbliebenen
-`min-h-11` und die vier `min-h-10` an den Paginierungs-Schaltflächen sind tote
-Utilities und können bei Gelegenheit weg — `min-h-10` ist dabei irreführend,
-weil es 40px verspricht und nichts bewirkt.
+`btn btn-sm min-h-10` alle 44px. Die vier toten `min-h-10` an den
+Paginierungs-Schaltflächen (`src/routes/admin/+page.svelte`) und die zwei
+toten `min-h-11` in `CleanupPanel.svelte` sind mit #630 entfernt.
 
 **Korrektur vom 2026-07-29: Die hier ursprünglich gelisteten „32 Statusfarben
 als Textfarbe" und „2 `opacity-50` auf Text" existieren nicht.** Beide Zahlen

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1006,7 +1006,7 @@
 
 		<div class="join">
 			<button
-				class="btn join-item btn-sm min-h-10"
+				class="btn join-item btn-sm"
 				onclick={() => changePage(1)}
 				disabled={data.pagination.page === 1}
 				title="Erste Seite"
@@ -1014,7 +1014,7 @@
 				«
 			</button>
 			<button
-				class="btn join-item btn-sm min-h-10"
+				class="btn join-item btn-sm"
 				onclick={() => changePage(data.pagination.page - 1)}
 				disabled={data.pagination.page === 1}
 				title="Vorherige Seite"
@@ -1022,12 +1022,12 @@
 				‹
 			</button>
 
-			<button class="btn btn-active join-item btn-sm min-h-10 min-w-32 text-xs sm:text-sm">
+			<button class="btn btn-active join-item btn-sm min-w-32 text-xs sm:text-sm">
 				{data.pagination.page} / {data.pagination.totalPages}
 			</button>
 
 			<button
-				class="btn join-item btn-sm min-h-10"
+				class="btn join-item btn-sm"
 				onclick={() => changePage(data.pagination.page + 1)}
 				disabled={data.pagination.page === data.pagination.totalPages}
 				title="Nächste Seite"
@@ -1035,7 +1035,7 @@
 				›
 			</button>
 			<button
-				class="btn join-item btn-sm min-h-10"
+				class="btn join-item btn-sm"
 				onclick={() => changePage(data.pagination.totalPages)}
 				disabled={data.pagination.page === data.pagination.totalPages}
 				title="Letzte Seite"

--- a/src/routes/admin/settings/CleanupPanel.svelte
+++ b/src/routes/admin/settings/CleanupPanel.svelte
@@ -58,15 +58,11 @@
 		</p>
 
 		<div class="mt-4 flex flex-wrap gap-2">
-			<button class="btn btn-primary min-h-11" disabled={busy} onclick={() => run(false)}>
+			<button class="btn btn-primary" disabled={busy} onclick={() => run(false)}>
 				Vorschau laden
 			</button>
 			{#if hasFindings}
-				<button
-					class="btn btn-outline btn-error btn-sm min-h-11"
-					disabled={busy}
-					onclick={confirmCleanup}
-				>
+				<button class="btn btn-outline btn-error btn-sm" disabled={busy} onclick={confirmCleanup}>
 					Endgültig löschen
 				</button>
 			{/if}


### PR DESCRIPTION
## Summary
- Entfernt 5× `min-h-10` an den Admin-Paginierungs-Schaltflächen (`src/routes/admin/+page.svelte`) und 2× `min-h-11` im `CleanupPanel.svelte` — beide sind seit dem ungelayerten Touch-Target-Block in `app.css` (`.btn:not(.target-exempt) { min-height: var(--target-min) }`) wirkungslos, `min-h-10` zusätzlich irreführend (verspricht 40px, bewirkt nichts).
- Aktualisiert `docs/DESIGN_SYSTEM.md`, damit die Doku nicht mehr "können bei Gelegenheit weg" sagt, sondern den erledigten Zustand widerspiegelt.

Closes #630.

## Test plan
- [x] `npm run test:quick` (Lint + Types + Check + Unit, 3133 Tests) — grün
- [x] `grep` bestätigt: keine `min-h-10`/`min-h-11`-Reste mehr in den beiden Dateien
- [x] Touch-Target bleibt unverändert bei 44px (kommt aus `app.css`, nicht aus den entfernten Utilities)

Reine CSS/Utility-Änderung ohne Logik → TDD-Ausnahme laut `.claude/rules/testing.md` greift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)