### PR TITLE
fix(ui): unbekannte Icon-Namen scheitern laut in dev

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -225,6 +225,14 @@
 
 	// Get the icon component based on the icon name - Svelte 5 runes syntax
 	let IconComponent = $derived(iconMap[icon] || null);
+
+	$effect(() => {
+		if (!IconComponent && import.meta.env.DEV) {
+			console.error(
+				`[Icon] Unbekannter Icon-Name: "${icon}" — bitte in Icon.svelte importieren und in iconMap registrieren.`
+			);
+		}
+	});
 </script>
 
 {#if IconComponent}

--- a/src/lib/components/Icon.svelte.test.ts
+++ b/src/lib/components/Icon.svelte.test.ts
@@ -1,0 +1,55 @@
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import Icon from './Icon.svelte';
+
+/**
+ * Issue #629: Ein unbekannter Icon-Name rendert bisher still ein „?"
+ * (`Icon.svelte`, `{:else}`-Zweig) — vier produktiv ausgelieferte Fälle sind
+ * dadurch unbemerkt geblieben. `iconRegistry.test.ts` prüft das statisch per
+ * Grep über den Quelltext; dieser Test prüft den *Laufzeit*-Fallback selbst.
+ *
+ * Beschlossenes Verhalten: In `dev` (`import.meta.env.DEV`) soll ein
+ * unbekannter Name laut über `console.error` scheitern — in `prod` bleibt
+ * das „?"-Fallback unverändert still. Kein Verhaltensunterschied für Nutzer,
+ * nur zusätzliches Feedback für Entwickler.
+ */
+
+describe('Icon', () => {
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	it('meldet einen unbekannten Icon-Namen über console.error (im Dev-Modus)', async () => {
+		render(Icon, { icon: 'lucide:does-not-exist' });
+		await tick();
+
+		expect(consoleErrorSpy).toHaveBeenCalled();
+		const messages = consoleErrorSpy.mock.calls.map((call: unknown[]) => call.join(' '));
+		expect(messages.some((message: string) => message.includes('lucide:does-not-exist'))).toBe(
+			true
+		);
+	});
+
+	it('rendert weiterhin das „?"-Fallback für unbekannte Icons — Nutzerverhalten bleibt gleich', async () => {
+		const { container } = render(Icon, { icon: 'lucide:does-not-exist' });
+		await tick();
+
+		const fallback = container.querySelector('[title="Missing icon: lucide:does-not-exist"]');
+		expect(fallback).not.toBeNull();
+		expect(fallback?.textContent).toBe('?');
+	});
+
+	it('ruft console.error NICHT auf, wenn der Icon-Name bekannt ist', async () => {
+		render(Icon, { icon: 'lucide:map-pin' });
+		await tick();
+
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- `Icon.svelte` meldet einen unregistrierten Icon-Namen jetzt per `console.error` in `import.meta.env.DEV` — das „?"-Fallback für den Nutzer bleibt unverändert (dev *und* prod).
- Gewählte Option aus #629 (dev-seitiges Scheitern statt Ersatz-Icon oder Abschaffung der Registry): geringster Aufwand/Risiko, da `iconRegistry.test.ts` bereits eine statische CI-Absicherung liefert — dieser Fix schließt die Lücke beim *Laufzeit*-Verhalten.

Closes #629

## Test plan
- [x] Neuer Komponententest `src/lib/components/Icon.svelte.test.ts` (TDD: RED bestätigt, bevor die Komponente geändert wurde) — deckt console.error bei unbekanntem Namen, unverändertes „?"-Fallback, kein console.error bei bekanntem Namen ab
- [x] `npm run test:quick` (lint, type-check, svelte-check, alle Unit-Tests inkl. Browser-Tests) — grün, 3133/3133 Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)