### PR TITLE
fix(admin): interne Benachrichtigung als solche benennen

### DIFF
--- a/src/lib/server/services/configInitializer.ts
+++ b/src/lib/server/services/configInitializer.ts
@@ -56,7 +56,7 @@ const defaultConfigurations: ConfigItem[] = [
 	{
 		key: 'notification.email.template',
 		value: NOTIFICATION_EMAIL_DEFAULT_TEMPLATE,
-		description: 'HTML Template für E-Mail Benachrichtigungen (Handlebars Syntax)',
+		description: 'HTML Template für die interne Benachrichtigung (Handlebars Syntax)',
 		category: 'email'
 	},
 	{

--- a/src/lib/server/services/configInitializer.ts
+++ b/src/lib/server/services/configInitializer.ts
@@ -6,16 +6,23 @@ const logger = createLogger('configInitializer');
 
 const defaultConfigurations: ConfigItem[] = [
 	// Email Settings
+	//
+	// `notification.email.*` betrifft ausschließlich die interne Mail an das
+	// Museum. Die meldende Person wird nicht angeschrieben (#621). Die
+	// Beschreibungen sagen das jetzt ausdrücklich — sie erreichen allerdings nur
+	// Neuinstallationen, weil `initializeDefaultConfigurations()` über
+	// `insertManyIfAbsent` läuft und bestehende Zeilen unangetastet lässt. Die
+	// verlässliche Anzeigeebene ist deshalb `admin/settings/configLabels.ts`.
 	{
 		key: 'notification.email.enabled',
 		value: false,
-		description: 'E-Mail Benachrichtigungen für neue Sichtungen aktivieren',
+		description: 'Interne Benachrichtigung an das Museum bei neuer Sichtung aktivieren',
 		category: 'email'
 	},
 	{
 		key: 'notification.email.recipient',
 		value: '',
-		description: 'E-Mail Adresse für Benachrichtigungen über neue Sichtungen',
+		description: 'Interne Empfänger-Adresse für Benachrichtigungen über neue Sichtungen',
 		category: 'email'
 	},
 	// CC/BCC werden von emailService.getEmailConfig() über

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -677,8 +677,8 @@
 						<button
 							class="btn btn-ghost btn-sm"
 							onclick={() => sendTestEmail(sighting.id)}
-							title="Test-E-Mail senden"
-							aria-label="Test-E-Mail senden"
+							title="Interne Benachrichtigung testweise senden"
+							aria-label="Interne Benachrichtigung testweise senden"
 						>
 							<Icon icon="lucide:mail" class="h-4 w-4" />
 						</button>
@@ -956,8 +956,8 @@
 									<button
 										class="btn btn-ghost btn-xs"
 										onclick={() => sendTestEmail(sighting.id)}
-										title="Test-E-Mail senden"
-										aria-label="Test-E-Mail senden"
+										title="Interne Benachrichtigung testweise senden"
+										aria-label="Interne Benachrichtigung testweise senden"
 									>
 										<Icon icon="lucide:mail" class="h-4 w-4" />
 									</button>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -37,7 +37,8 @@
 	};
 
 	const categoryDescriptions: Record<string, string> = {
-		email: 'Konfigurieren Sie E-Mail-Benachrichtigungen und SMTP-Einstellungen',
+		email:
+			'Interne Benachrichtigung über neue Sichtungen und SMTP-Zugang. Meldende Personen erhalten derzeit keine E-Mail.',
 		display: 'Anpassung der Benutzeroberfläche und Kartenansichten',
 		security: 'Sicherheitseinstellungen und Upload-Beschränkungen',
 		data: 'Einstellungen für Datenverarbeitung und Validierung',

--- a/src/routes/admin/settings/configLabels.ts
+++ b/src/routes/admin/settings/configLabels.ts
@@ -21,14 +21,23 @@
 
 /** Anzeigename pro Konfigurationsschlüssel. */
 export const configLabels: Record<string, string> = {
-	// E-Mail-Benachrichtigungen
-	'notification.email.enabled': 'E-Mail-Benachrichtigungen aktiv',
-	'notification.email.recipient': 'Empfänger-Adresse',
+	// Interne Benachrichtigung über neue Sichtungen
+	//
+	// Der Zusatz „intern“ ist nicht schmückend: `notification.email.*` steuert
+	// ausschließlich die Mail an das Museum (`emailService.ts`, `to:
+	// config.recipient`). Die meldende Person bekommt bis heute überhaupt keine
+	// Mail — es gibt im ganzen Projekt nur zwei `sendMail`-Aufrufe, beide an
+	// interne Adressen. Unter dem alten Label „E-Mail-Benachrichtigungen aktiv“
+	// war das nicht zu erkennen; die naheliegende Lesart ist, dass hier der
+	// Melder-Versand hängt. Wenn #621 kommt, bekommt der einen eigenen
+	// Schlüssel — dieser hier ist dann nicht umzudeuten, sondern abzugrenzen.
+	'notification.email.enabled': 'Interne Benachrichtigung bei neuer Sichtung',
+	'notification.email.recipient': 'Empfänger-Adresse (Museum)',
 	'notification.email.cc': 'Empfänger in Kopie (CC)',
 	'notification.email.bcc': 'Empfänger in Blindkopie (BCC)',
 	'notification.email.sender': 'Absender-Adresse',
 	'notification.email.senderName': 'Absender-Name',
-	'notification.email.template': 'HTML-Vorlage der Benachrichtigung',
+	'notification.email.template': 'HTML-Vorlage der internen Benachrichtigung',
 
 	// SMTP-Zugang
 	'email.smtp.host': 'SMTP-Server',

--- a/src/routes/api/admin/test-email/+server.ts
+++ b/src/routes/api/admin/test-email/+server.ts
@@ -36,7 +36,11 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 				logger.info({ sightingId }, 'Test sighting email sent successfully');
 				return json({
 					success: true,
-					message: `Test-E-Mail für Sichtung ${sightingId} wurde erfolgreich gesendet`
+					// Empfänger benennen: Die Mail geht an die interne Adresse aus
+					// `notification.email.recipient`, nicht an die meldende Person.
+					// Ohne diesen Zusatz liest sich die Erfolgsmeldung so, als wäre der
+					// Melder angeschrieben worden (#621).
+					message: `Interne Benachrichtigung zu Sichtung ${sightingId} wurde an die konfigurierte Empfänger-Adresse gesendet`
 				});
 			} else {
 				return json(


### PR DESCRIPTION
## Worum es geht

Ausgangspunkt war die Frage, ob bei eingeschalteter „Sichter-Benachrichtigung" schon etwas passiert. Die Prüfung ergab: Die Einstellung wirkt — aber sie benachrichtigt das **Museum**, nicht die meldende Person.

`notification.email.*` steuert ausschließlich die interne Mail (`to: config.recipient` in `emailService.ts:351`). Es gibt im ganzen Projekt genau zwei `sendMail`-Aufrufe, beide an interne Adressen. Die Adresse des Melders wird erfasst, in der internen Mail als `mailto:` angezeigt — aber nie angeschrieben. Das ist #621, und das bleibt offen.

Das Label sagte davon nichts: „E-Mail-Benachrichtigungen aktiv" legt genau die falsche Lesart nahe. Dieser PR ändert **nur die Beschriftungen**, kein Verhalten.

## Was geändert wurde

| Stelle | vorher | nachher |
| --- | --- | --- |
| `notification.email.enabled` | E-Mail-Benachrichtigungen aktiv | **Interne Benachrichtigung bei neuer Sichtung** |
| `notification.email.recipient` | Empfänger-Adresse | Empfänger-Adresse **(Museum)** |
| `notification.email.template` | HTML-Vorlage der Benachrichtigung | HTML-Vorlage der **internen** Benachrichtigung |
| Bereichsbeschreibung E-Mail | „Konfigurieren Sie E-Mail-Benachrichtigungen und SMTP-Einstellungen" | nennt ausdrücklich, dass Melder derzeit keine E-Mail erhalten |
| Admin-Liste, Mail-Button | Test-E-Mail senden | Interne Benachrichtigung testweise senden |
| Erfolgsmeldung des Buttons | „Test-E-Mail für Sichtung N …" | benennt den tatsächlich verwendeten Empfänger |

Der Button in der Admin-Liste ist derselbe in Desktop- und Mobil-Ansicht — beide Vorkommen sind angepasst.

## Für Reviewer

**Warum `configLabels.ts` und nicht die DB-`description`.** `initializeDefaultConfigurations()` läuft über `insertManyIfAbsent` und lässt bestehende Zeilen unangetastet. Eine geänderte `description` in `configInitializer.ts` erreicht damit **nur Neuinstallationen** — auf bestehenden Installationen bliebe der alte Text stehen. Die verlässliche Anzeigeebene ist `configLabels.ts`, weil sie aus dem Code kommt. Beide Stellen sind entsprechend kommentiert; die `description`-Anpassung ist mit drin, damit Neuinstallationen nicht wieder auseinanderlaufen.

**Der Test-Button ist kein reiner Testversand.** `/api/admin/test-email` mit `testType: 'sighting'` ruft `sendNewSightingNotification()` und verschickt die echte Vorlage mit echten Daten an die konfigurierte interne Adresse. Der alte Name „Test-E-Mail senden" ließ offen, wo die Mail landet — genau das ist jetzt beantwortet. Der separate „Test-E-Mail"-Button auf der Settings-Seite (`/api/config/test-email` → `sendTestEmail()`) ist ein echter SMTP-Test und bleibt unverändert.

**`notification.email.enabled` behält seine Bedeutung.** Es wird nicht umgedeutet, sondern abgegrenzt. Wenn #621 kommt, bekommt der Melder-Versand einen **eigenen** Schlüssel — der Kommentar in `configLabels.ts` hält das fest, damit der Schlüssel nicht später doppelt belegt wird.

## Tests

`npm run test:quick` grün: 219 Testdateien, 3133 Tests. Kein neuer Test — es sind Anzeigezeichenketten, die dokumentierte Ausnahme in `.claude/rules/testing.md`. `configLabels.test.ts` deckt weiterhin Vollständigkeit gegen `getAvailableConfigurationKeys()` und Nicht-Leere jedes Labels ab.

Nicht visuell im Browser verifiziert: Die Settings-Seite hängt hinter dem Auth0-Admin-Login, und die Änderung ist ein String-Tausch in einem `Record<string, string>`, den `svelte-check` und `type-check` abdecken.

## Anschluss

#621 bleibt offen. Die zu klärenden Punkte sind dort als [Kommentar](https://github.com/jansinger/ostsee-tiere/issues/621#issuecomment-5151163215) festgehalten — Grundsatzentscheidung des DMM, mögliche Kopplung mit E-Mail-Verifikation und Auth0-Registrierung (drei Varianten, nicht additiv nachrüstbar) sowie der Einwilligungstext.

Refs #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)
