### PR TITLE
feat(ui): Schweinswal-Icon ersetzt den Fisch an der Tierart

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -343,6 +343,31 @@ Das Formular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, mit 
 - UI-Icons ausschließlich über `src/lib/components/Icon.svelte` (unplugin-icons / lucide): `<Icon icon="lucide:map-pin" width="20" />`. Neue Icons dort einmalig importieren, nicht in Einzelkomponenten.
 - Wetter-Icons sind CSS-basiert (`src/css/weather-icons*.css`): `<i class="wi wi-day-sunny"></i>`.
 
+### Projekteigene Icons: `custom:` — eine begründete Ausnahme
+
+Es gibt genau ein Icon außerhalb von Lucide: `custom:porpoise`
+(`src/lib/components/icons/Porpoise.svelte`), registriert in `Icon.svelte` wie jedes
+andere. Die Aufrufstelle merkt keinen Unterschied — `<Icon icon="custom:porpoise" />`.
+
+**Warum die Ausnahme nötig war:** Das Tierart-Feld trug `lucide:fish`. Das Meeresmuseum
+hat das beanstandet — gemeldet werden Wale, Schweinswale und Robben, keine Fische. Ein
+Robben- oder Wal-Icon führt aber **kein** gängiger Satz: geprüft wurden Lucide, Tabler,
+Phosphor, Iconoir, MDI und Icon-Park; die dortigen `seal`-Treffer sind durchweg
+Wachssiegel. Ein zweiter Icon-Satz hätte das Motiv also nicht gelöst, aber den Stil
+gebrochen.
+
+**Es hält sich an die Lucide-Konventionen** — 24er-Raster, `fill="none"`,
+`stroke="currentColor"`, `stroke-width: 2`, runde Enden — und steht deshalb neben den
+übrigen Feld-Icons, ohne aufzufallen. Das Auge ist wie bei Lucide ein Pfad der Länge null
+(`h.01`), der über `stroke-linecap: round` als Punkt rendert; es trägt bei 16–20 px
+spürbar zur Erkennbarkeit bei. Eine gefüllte Silhouette wäre lesbarer gewesen, hätte aber
+als einziges Vollton-Icon zwischen lauter Outline-Icons gestanden.
+
+**Für neue Fälle gilt weiterhin Lucide.** Ein `custom:`-Icon ist erst dann richtig, wenn
+belegt ist, dass kein Satz das Motiv führt — nicht, wenn das vorhandene nur nicht gefällt.
+`iconRegistry.test.ts` prüft `lucide:` und `custom:` gleichermaßen, ein Tippfehler im
+Namen fällt also weiterhin im Test auf und nicht erst beim Nutzer.
+
 ---
 
 ## Keine toten Utility-Klassen

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -37,7 +37,6 @@
 	import FileText from '~icons/lucide/file-text';
 	import FileType from '~icons/lucide/file-type';
 	import Filter from '~icons/lucide/filter';
-	import Fish from '~icons/lucide/fish';
 	import Gauge from '~icons/lucide/gauge';
 	import Gem from '~icons/lucide/gem';
 	import Github from '~icons/lucide/github';
@@ -104,6 +103,7 @@
 	import Wind from '~icons/lucide/wind';
 	import X from '~icons/lucide/x';
 	import Zap from '~icons/lucide/zap';
+	import Porpoise from './icons/Porpoise.svelte';
 
 	// Icon map for dynamic icon lookup
 
@@ -183,7 +183,6 @@
 		'lucide:clock': Clock,
 		'lucide:cloud-rain': CloudRain,
 		'lucide:hash': Hash,
-		'lucide:fish': Fish,
 		'lucide:globe': Globe,
 		'lucide:message-circle': MessageCircle,
 		'lucide:mouse-pointer': MousePointer,
@@ -210,7 +209,10 @@
 		'lucide:hard-drive': HardDrive,
 		'lucide:bar-chart': BarChart,
 		'lucide:braces': Braces,
-		'lucide:file-code': FileCode
+		'lucide:file-code': FileCode,
+		// Projekteigenes Icon — es gibt in keinem gängigen Satz (Lucide, Tabler,
+		// Phosphor, Iconoir, MDI) ein Robben- oder Schweinswal-Icon.
+		'custom:porpoise': Porpoise
 	};
 
 	interface Props {

--- a/src/lib/components/Icon.svelte.test.ts
+++ b/src/lib/components/Icon.svelte.test.ts
@@ -60,4 +60,16 @@ describe('Icon', () => {
 		expect(consoleErrorSpy).not.toHaveBeenCalled();
 		expect(container.querySelector('svg path')).not.toBeNull();
 	});
+
+	// `aria-hidden` an einer dekorativen Aufrufstelle wirkt nur, wenn es bis auf
+	// das <svg> durchgereicht wird. Bei den unplugin-icons-Komponenten erledigt
+	// das die Bibliothek; `Porpoise.svelte` ist handgeschrieben und verlässt sich
+	// auf ein `{...rest}` am Element — fällt das weg, verschwindet das Attribut
+	// still, und der Screenreader sagt wieder eine unbeschriftete Grafik an.
+	it('reicht aria-hidden bis auf das <svg> durch — auch beim projekteigenen Icon', async () => {
+		const { container } = render(Icon, { icon: 'custom:porpoise', 'aria-hidden': 'true' });
+		await tick();
+
+		expect(container.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+	});
 });

--- a/src/lib/components/Icon.svelte.test.ts
+++ b/src/lib/components/Icon.svelte.test.ts
@@ -52,4 +52,12 @@ describe('Icon', () => {
 
 		expect(consoleErrorSpy).not.toHaveBeenCalled();
 	});
+
+	it('kennt das projekteigene custom:porpoise — es ersetzt das fachlich falsche Fisch-Icon', async () => {
+		const { container } = render(Icon, { icon: 'custom:porpoise' });
+		await tick();
+
+		expect(consoleErrorSpy).not.toHaveBeenCalled();
+		expect(container.querySelector('svg path')).not.toBeNull();
+	});
 });

--- a/src/lib/components/iconRegistry.test.ts
+++ b/src/lib/components/iconRegistry.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from 'vitest';
 const SOURCE_ROOT = 'src';
 const ICON_COMPONENT = 'src/lib/components/Icon.svelte';
 
-/** Alle im `iconMap` registrierten Namen. */
+/** Alle im `iconMap` registrierten Namen (Lucide und projekteigene). */
 function registeredIcons(): Set<string> {
 	const source = readFileSync(ICON_COMPONENT, 'utf-8');
 	const mapStart = source.indexOf('const iconMap');
@@ -29,14 +29,14 @@ function registeredIcons(): Set<string> {
 	// dieser Test würde mit einem TypeError abbrechen, statt die Registry zu
 	// prüfen. Ein Test, der still nicht prüft, ist schlimmer als keiner.
 	const names = Array.from(
-		source.slice(mapStart).matchAll(/'(lucide:[a-z0-9-]+)'\s*:/g),
+		source.slice(mapStart).matchAll(/'((?:lucide|custom):[a-z0-9-]+)'\s*:/g),
 		(match) => match[1] as string
 	);
 
 	return new Set(names);
 }
 
-/** Jede `icon="lucide:…"`- bzw. `icon: 'lucide:…'`-Stelle im Quelltext. */
+/** Jede `icon="lucide:…"`/`"custom:…"`-Stelle im Quelltext. */
 function usedIcons(): Map<string, string[]> {
 	const usages = new Map<string, string[]>();
 
@@ -51,7 +51,7 @@ function usedIcons(): Map<string, string[]> {
 			if (path === ICON_COMPONENT) continue;
 
 			const source = readFileSync(path, 'utf-8');
-			for (const match of source.matchAll(/["'](lucide:[a-z0-9-]+)["']/g)) {
+			for (const match of source.matchAll(/["']((?:lucide|custom):[a-z0-9-]+)["']/g)) {
 				const name = match[1] as string;
 				usages.set(name, [...(usages.get(name) ?? []), path]);
 			}

--- a/src/lib/components/icons/Porpoise.svelte
+++ b/src/lib/components/icons/Porpoise.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	/**
+	 * Schweinswal im Lucide-Stil (24er-Raster, `stroke-width: 2`, runde Enden) —
+	 * die Kontur folgt dem springenden Tier aus dem Projektlogo.
+	 *
+	 * Ersetzt `lucide:fish` am Tierart-Feld: Gemeldet werden Wale, Schweinswale
+	 * und Robben, keine Fische. Ein passendes Icon führt kein gängiger Satz
+	 * (Lucide, Tabler, Phosphor, Iconoir, MDI, Icon-Park) — deren `seal`-Treffer
+	 * sind Wachssiegel. Begründung und Regel: `.claude/rules/design-system.md`.
+	 *
+	 * Das Auge ist ein Pfad der Länge null (`h.01`); mit `stroke-linecap: round`
+	 * rendert er als Punkt. Dasselbe Mittel nutzt Lucide für Augen und Punkte.
+	 */
+	interface Props {
+		width?: string | number;
+		height?: string | number;
+		class?: string;
+		[key: string]: unknown;
+	}
+
+	let { width = '20', height = '20', class: className = '', ...rest }: Props = $props();
+</script>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	viewBox="0 0 24 24"
+	{width}
+	{height}
+	fill="none"
+	stroke="currentColor"
+	stroke-width="2"
+	stroke-linecap="round"
+	stroke-linejoin="round"
+	class={className}
+	{...rest}
+>
+	<path
+		d="M9.01 4.61C9.73 4.63 10.49 5.26 11.67 5.36C12.85 5.46 14.87 5.11 16.09 5.23C17.32 5.36 18.2 5.72 19.02 6.11C19.84 6.5 20.35 6.8 21.01 7.57C21.67 8.34 22.77 9.99 23 10.72C23.23 11.45 23.15 11.66 22.38 11.96C21.61 12.26 19.23 12.21 18.4 12.53C17.57 12.85 17.81 13.57 17.42 13.9C17.04 14.23 16.48 14.53 16.09 14.52C15.7 14.51 15.71 13.85 15.08 13.86C14.45 13.87 12.93 14.53 12.33 14.57C11.73 14.61 11.66 14.34 11.49 14.12C11.32 13.91 11.45 13.41 11.31 13.28C11.17 13.15 11.09 13.24 10.65 13.33C10.21 13.42 9.35 13.43 8.66 13.81C7.97 14.19 6.68 14.96 6.49 15.59C6.3 16.22 7.39 16.98 7.51 17.58C7.63 18.18 7.36 18.87 7.2 19.17C7.05 19.47 7.07 19.58 6.58 19.39C6.09 19.2 5.06 18.14 4.28 18.02C3.5 17.9 2.44 18.66 1.89 18.68C1.34 18.7 1.1 18.5 1 18.15C0.9 17.8 0.81 17.13 1.27 16.56C1.73 15.99 3.1 15.72 3.74 14.74C4.38 13.76 4.44 11.92 5.12 10.67C5.8 9.42 7.48 8.04 7.82 7.26C8.16 6.48 7.23 6.31 7.15 5.98C7.08 5.65 7.06 5.5 7.37 5.27C7.68 5.04 8.29 4.6 9.01 4.61Z"
+	/>
+	<path d="M18.62 9.21h.01" />
+</svg>

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -95,7 +95,6 @@ const icons = {
 	CountIcon: 'lucide:hash',
 	Eye: 'lucide:eye',
 	FileText: 'lucide:file-text',
-	Fish: 'lucide:fish',
 	Globe: 'lucide:globe',
 	Hash: 'lucide:hash',
 	Mail: 'lucide:mail',
@@ -106,6 +105,7 @@ const icons = {
 	Navigation: 'lucide:navigation',
 	Navigation2: 'lucide:navigation-2',
 	Phone: 'lucide:phone',
+	Porpoise: 'custom:porpoise',
 	ShieldCheck: 'lucide:shield-check',
 	Ship: 'lucide:ship',
 	Skull: 'lucide:skull',
@@ -135,7 +135,6 @@ const {
 	CountIcon,
 	Eye,
 	FileText,
-	Fish,
 	Globe,
 	Hash,
 	Mail,
@@ -146,6 +145,7 @@ const {
 	Navigation,
 	Navigation2,
 	Phone,
+	Porpoise,
 	ShieldCheck,
 	Ship,
 	Skull,
@@ -379,7 +379,7 @@ export const sightingSchemaBase = yup.object().shape({
 			valueText: 'Artbestimmung hilft beim Populationsmonitoring',
 			type: 'select',
 			options: getSpeciesOptions(true),
-			icon: Fish
+			icon: Porpoise
 		}),
 
 	/**

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -37,7 +37,7 @@
 				class="text-base-content flex items-center justify-center gap-3 text-3xl font-bold lg:text-4xl"
 			>
 				Vielen Dank!
-				<Icon icon="lucide:fish" width="32" height="32" class="text-primary" />
+				<Icon icon="custom:porpoise" width="32" height="32" class="text-primary" />
 			</h1>
 
 			<p class="text-base-content/80 text-xl">Ihre Sichtung wurde erfolgreich gemeldet</p>

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -37,7 +37,13 @@
 				class="text-base-content flex items-center justify-center gap-3 text-3xl font-bold lg:text-4xl"
 			>
 				Vielen Dank!
-				<Icon icon="custom:porpoise" width="32" height="32" class="text-primary" />
+				<Icon
+					icon="custom:porpoise"
+					width="32"
+					height="32"
+					class="text-primary"
+					aria-hidden="true"
+				/>
 			</h1>
 
 			<p class="text-base-content/80 text-xl">Ihre Sichtung wurde erfolgreich gemeldet</p>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -687,7 +687,7 @@ SOFTWARE.</pre>
 						href="/"
 						class="btn btn-primary btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
 					>
-						<Icon icon="lucide:fish" width="20" height="20" class="mr-2" />
+						<Icon icon="custom:porpoise" width="20" height="20" class="mr-2" />
 						Sichtung melden
 					</a>
 					<a

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -687,7 +687,7 @@ SOFTWARE.</pre>
 						href="/"
 						class="btn btn-primary btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
 					>
-						<Icon icon="custom:porpoise" width="20" height="20" class="mr-2" />
+						<Icon icon="custom:porpoise" width="20" height="20" class="mr-2" aria-hidden="true" />
 						Sichtung melden
 					</a>
 					<a


### PR DESCRIPTION
## Warum

Das Tierart-Feld trug `lucide:fish`. Rückmeldung des Meeresmuseums:

> Bei Auswahl der Art anderes Emoji statt Fisch eventuell eine Robbe

Der Einwand ist fachlich: Gemeldet werden Wale, Schweinswale und Robben — keine Fische.

## Warum ein projekteigenes Icon statt eines anderen Satzes

Ein Robben- oder Wal-Icon führt **kein** gängiger Icon-Satz. Geprüft wurden Lucide, Tabler, Phosphor, Iconoir, MDI und Icon-Park (alle über `@iconify/json` im Projekt verfügbar) — die dortigen `seal`-Treffer sind durchweg **Wachssiegel**, kein Tier. Ein zweiter Icon-Satz hätte das Motiv also nicht gelöst, aber den Stil gebrochen.

Auch das naheliegende `lucide:fish-symbol` scheidet aus: Es ist nur die abstrahierte Fisch-Silhouette und trifft den Einwand nicht — der zielt nicht auf den Zeichenstil, sondern darauf, dass ein Fisch bei einer Meeressäuger-Meldung sachlich falsch ist.

Deshalb `custom:porpoise`, dessen Kontur dem springenden Tier aus dem Projektlogo folgt.

## Was geändert wurde

| Datei | Änderung |
| --- | --- |
| `src/lib/components/icons/Porpoise.svelte` | **neu** — das Icon |
| `src/lib/components/Icon.svelte` | als `custom:porpoise` registriert, totes `lucide:fish` entfernt |
| `src/lib/form/validation/sightingSchema.ts` | Feld-Icon des `species`-Felds |
| `src/lib/report/components/SubmissionSuccess.svelte` | Erfolgsseite (32 px) |
| `src/routes/about/+page.svelte` | „Sichtung melden"-Button (20 px) |
| `src/lib/components/iconRegistry.test.ts` | prüft jetzt `lucide:` **und** `custom:` |
| `src/lib/components/Icon.svelte.test.ts` | Laufzeit-Test für das neue Icon |
| `.claude/rules/design-system.md` | dokumentiert die Ausnahme von der „nur Lucide"-Regel |

## Für Reviewer

**Es bricht den Stil nicht.** Das Icon hält sich an die Lucide-Konventionen — 24er-Raster, `fill="none"`, `stroke="currentColor"`, `stroke-width: 2`, runde Enden — und steht damit unauffällig neben `hash` und `baby` im selben Formularschritt.

**Das Auge ist Absicht, kein Artefakt.** `<path d="M18.62 9.21h.01"/>` ist ein Pfad der Länge null, der über `stroke-linecap: round` als Punkt rendert. Dasselbe Mittel nutzt Lucide für Augen und Punkte. Bei 16–20 px trägt es spürbar zur Erkennbarkeit bei — eine Variante ohne Auge war im Browser-Vergleich deutlich schlechter lesbar.

**Der Registry-Test musste mit.** `iconRegistry.test.ts` matchte nur auf `lucide:`. Ohne die Erweiterung wäre ein Tippfehler in `custom:porpoise` still als „?" beim Nutzer gelandet — genau die Lücke, die der Test seit #693 schließen soll.

**`design-system.md` schreibt die Regel nicht weich.** Für neue Fälle gilt weiterhin Lucide; ein `custom:`-Icon ist erst dann richtig, wenn belegt ist, dass kein Satz das Motiv führt — nicht, wenn das vorhandene nur nicht gefällt.

**Auf der Karte war die Rückmeldung schon erfüllt** — `src/lib/map/styleUtils.ts` nutzt seit jeher 🦭 für Robbe und 🐋/🐬 für Wale als Marker-Symbol. Diese Änderung betrifft nur das Formular und die zwei dekorativen Stellen.

## Verifikation

- `npm run test:quick` grün: Lint 0 Fehler (2 vorbestehende Warnungen in `src/tests/contract/helpers/createEvent.ts`), `tsc --noEmit`, svelte-check 0 Errors bei 2068 Dateien, 3133 Unit-Tests
- Icon-Komponententest 4/4 (Browser-Projekt), Registry-Test 2/2
- Im laufenden Dev-Server geprüft: Tierart-Feld bei 16 px und „Sichtung melden"-Button (weiß auf `btn-primary`) bei 20 px
- Statischer Größenvergleich 16/20/24/32/112 auf hellem und dunklem Grund

**Nicht direkt aufgerufen:** die Erfolgsseite (32 px) — dafür müsste eine echte Sichtung abgesendet werden. Dieselbe Komponente, und 32 px ist unkritischer als die geprüften 16 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)