### PR TITLE
fix(a11y): dekoratives Textarea-Icon vor Screenreadern verstecken

### DIFF
--- a/src/lib/report/components/form/fields/BaseTextarea.svelte
+++ b/src/lib/report/components/form/fields/BaseTextarea.svelte
@@ -54,7 +54,7 @@
 <div class="relative">
 	<!-- Icon (if available) -->
 	{#if icon !== undefined}
-		<div class="pointer-events-none absolute top-3 left-3 z-10">
+		<div aria-hidden="true" class="pointer-events-none absolute top-3 left-3 z-10">
 			<Icon {icon} width="16" class="text-base-content/60" />
 		</div>
 	{/if}

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -350,6 +350,31 @@ describe('FieldRenderer', () => {
 			expect(helpElement).not.toBeNull();
 			expect(helpElement?.textContent).toContain('Ihre E-Mail-Adresse für Rückfragen');
 		});
+
+		// Das Feld-Icon aus meta.icon ist rein dekorativ — die Bedeutung trägt das Label.
+		// Ohne aria-hidden meldet der Screenreader es als unbeschriftete Grafik.
+		it.each([
+			['text', 'text'],
+			['select', 'select'],
+			['textarea', 'textarea']
+		])('blendet das dekorative Feld-Icon aus (%s)', async (_name, fieldType) => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: makeFieldConfig({
+					label: 'Bemerkungen',
+					meta: {
+						type: fieldType,
+						icon: 'lucide:file-text',
+						options: [{ value: 1, label: 'Eins' }]
+					}
+				}),
+				name: 'notes',
+				value: ''
+			});
+
+			const svg = screen.container.querySelector('svg');
+			expect(svg).not.toBeNull();
+			expect(svg?.closest('[aria-hidden="true"]')).not.toBeNull();
+		});
 	});
 
 	describe('Hilfetext', () => {


### PR DESCRIPTION
## Was

`BaseTextarea.svelte` war der einzige Feldtyp, dessen Icon-Wrapper kein `aria-hidden="true"` trug:

| Komponente | vorher |
| --- | --- |
| `BaseInput.svelte:76` | ✅ am Wrapper-`<div>` |
| `BaseSelect.svelte:62` | ✅ am Wrapper-`<div>` |
| `BaseCheckbox.svelte:57`, `BaseRadio.svelte:55` | ✅ direkt am `<Icon>` |
| `BaseTextarea.svelte:57` | ❌ fehlt |

## Warum

Das Icon stammt aus `meta.icon` im Yup-Schema und ist rein dekorativ — die Bedeutung trägt das Label. Ohne das Attribut sagt der Screenreader es als unbeschriftete Grafik an.

Projektregel: `.claude/rules/design-system.md` — „Dekorative Icons bekommen `aria-hidden=\"true\"`; informationstragende Icons brauchen ein `aria-label` am fokussierbaren Element."

## Betroffene Felder

Im Schema gegengeprüft: genau **zwei** Felder haben `type: 'textarea'`, beide mit `icon: FileText`:

- `notes` („Bemerkungen", `sightingSchema.ts:1183`) — öffentliches Formular, Schritt 3
- `internalComment` („Interne Kommentare", `sightingSchema.ts:1260`) — Admin

`behaviorText` und `otherObservations` sind laut Schema **keine** Textareas und damit nicht betroffen. (Das Test-Fixture mockt `otherObservations` als Textarea — das entspricht nicht dem echten Schema, wurde hier aber nicht angefasst.)

## Test zuerst

Neuer parametrisierter Test in `FieldRenderer.svelte.test.ts` über `text` / `select` / `textarea`: das gerenderte `<svg>` muss in einem `aria-hidden="true"`-Container liegen.

Vor dem Fix: `text` und `select` grün, `textarea` rot — der Test reproduziert die Lücke also genau und deckt zugleich die beiden bereits korrekten Typen als Regressionsschutz ab.

## Verifikation

- `FieldRenderer.svelte.test.ts` — 37/37 grün (Chromium, `vitest-browser-svelte`)
- `npm run check` — 2068 Dateien, 0 Fehler
- `npm run lint` — 0 Fehler (die 2 `any`-Warnungen in `src/tests/contract/helpers/createEvent.ts` sind Altbestand, unverändert)

Keine visuelle Prüfung: Das Attribut ändert nichts am Rendering; der Unit-Test im echten Browser ist hier der aussagekräftigere Beleg.

## Herkunft

Gefunden beim Review von #695 (Schweinswal-Icon), dort bewusst nicht mitbehoben, weil unabhängig vom Icon-Thema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)