### PR TITLE
fix(ui): globale h1-Regel aus dem Karten-CSS entfernen

### DIFF
--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -562,6 +562,112 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			const elements = await scanRoute({ page, context, request, baseURL }, route);
 			expect(findOffenders(TAILWIND_PALETTE, elements), TAILWIND_PALETTE.hint).toEqual([]);
 		});
+
+		/* Überschrift trägt eine Größen-Utility und rendert trotzdem anders.
+
+		   **Warum das ein eigener Test ist und nicht Teil des Klassen-Scans oben.**
+		   Die drei Regeln darüber lesen Klassennamen und entscheiden daraus. Der
+		   Fehler hier ist genau der, den man an der Klassenliste *nicht* sieht:
+		   `class="… text-6xl …"` steht korrekt im Markup, und der Scan meldet zu
+		   Recht nichts — die Utility greift nur nicht. Nachweisbar ist das erst am
+		   berechneten Wert.
+
+		   **Warum bei 375px.** Der gefundene Fall saß in einem
+		   `@media (max-width: 768px)`. Unterhalb `md` greift außerdem keine
+		   `md:`/`lg:`-Variante, die Basis-Utility ist dort also allein zuständig —
+		   der Vergleich unten braucht deshalb keine Breakpoint-Auflösung.
+
+		   **Was der Test wirklich prüft:** dass keine ungelayerte Element-Regel die
+		   Utilities schlägt. Tailwind legt sie in `@layer utilities`, und eine
+		   ungelayerte Regel gewinnt gegen jede gelayerte — unabhängig von der
+		   Spezifität (dieselbe Mechanik wie beim Fokus-Override, `daisyui.md`). Ein
+		   `h1 { font-size: … !important }` in einer beliebigen importierten CSS-Datei
+		   schlägt damit jede Größenangabe im Markup, auf jeder Seite.
+
+		   Gefunden wurde so `mapStyles.css`, das über `app.css` global importiert
+		   wird und dessen Mobil-Block jede `h1` der Anwendung auf 20px zwang — auf
+		   `/about` war der Seitentitel damit kleiner als jede Zwischenüberschrift.
+		   Ein Test über die CSS-Quelle hätte das nicht gesehen: dort steht eine
+		   plausible Regel in einer plausiblen Datei. */
+		test(`${route.path}: Größen-Utilities an Überschriften greifen`, async ({
+			page,
+			context,
+			request,
+			baseURL
+		}) => {
+			await page.setViewportSize({ width: 375, height: 812 });
+			await openRoute({ page, context, request, baseURL }, route);
+
+			/* Vor dem Messen auf die Hydration warten — sonst misst der Test die
+			   Einbettungs-Darstellung und nicht die, die ein Besucher sieht.
+
+			   `+layout.svelte` rendert `<div class:iframe-mode={!isNotIFrame}>`, und
+			   `isNotIFrame` ist eine Modulkonstante mit `browser && window === window.top`
+			   (`src/lib/utils/client/isNotIFrame.ts`). Beim Server-Rendering steht sie
+			   auf `false`, das Markup trägt also zunächst `.iframe-mode` — und der Block
+			   dazu in `app.css` setzt `h1` auf `--text-title` und `h2` auf
+			   `--text-section`, ungelayert und damit vor jeder Utility. Erst die
+			   Hydration nimmt die Klasse weg.
+
+			   Ohne dieses Warten meldet der Test jede Überschrift der Anwendung als
+			   Verstoß und sieht dabei aus wie ein Produktfehler. Genau das ist beim
+			   ersten Lauf passiert. */
+			await page.waitForFunction(() => !document.querySelector('.iframe-mode'));
+
+			const mismatches = await page.evaluate(() => {
+				const root = getComputedStyle(document.documentElement);
+				const remBase = parseFloat(root.fontSize) || 16;
+
+				const toPx = (value: string): number | null => {
+					const match = /^([\d.]+)(rem|px)$/.exec(value.trim());
+					if (!match) return null;
+					return Number(match[1]) * (match[2] === 'rem' ? remBase : 1);
+				};
+
+				const found: string[] = [];
+
+				for (const el of document.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+					/* Nur unpräfigierte Klassen: `md:text-3xl` greift bei 375px nicht.
+					   Ob eine `text-*`-Klasse eine Größe ist, entscheidet nicht eine
+					   gepflegte Liste, sondern das Theme selbst — `--text-6xl` existiert,
+					   `--text-primary` (Farbe) und `--text-center` (Ausrichtung) nicht.
+					   Damit deckt der Test auch die eigenen Rollen-Utilities ab
+					   (`text-display`, `text-title`, …) ohne Zweitpflege. */
+					const sizeUtilities = (el.getAttribute('class') ?? '')
+						.split(/\s+/)
+						.filter((name) => /^text-[a-z0-9]+$/.test(name))
+						.filter((name) => root.getPropertyValue(`--${name}`).trim() !== '');
+
+					/* Keine Größenangabe (z. B. nur `card-title`) — nichts zu prüfen.
+					   Mehrere widersprechen sich; das ist ein eigener Fehler und gehört
+					   nicht in diese Regel. */
+					if (sizeUtilities.length !== 1) continue;
+
+					const utility = sizeUtilities[0];
+					const declared = toPx(root.getPropertyValue(`--${utility}`));
+					const computed = toPx(getComputedStyle(el).fontSize);
+					if (declared === null || computed === null) continue;
+
+					if (Math.abs(declared - computed) > 0.5) {
+						const label = (el.textContent ?? '').trim().replace(/\s+/g, ' ').slice(0, 40);
+						found.push(
+							`<${el.tagName.toLowerCase()} class="${utility}"> „${label}" — ` +
+								`erwartet ${declared}px, gerendert ${computed}px`
+						);
+					}
+				}
+
+				return found;
+			});
+
+			expect(
+				mismatches,
+				'Eine Überschrift rendert nicht in der Größe, die ihre Utility angibt. ' +
+					'Ursache ist fast immer eine ungelayerte Element-Regel (oft mit !important) in einer ' +
+					'global importierten CSS-Datei — sie schlägt jede Utility aus @layer utilities. ' +
+					'Die Regel gehört auf ihren Kontext gescopt, nicht die Utility an der Aufrufstelle erhöht.'
+			).toEqual([]);
+		});
 	}
 });
 

--- a/src/lib/map/mapStyles.css
+++ b/src/lib/map/mapStyles.css
@@ -392,10 +392,36 @@
    Responsive Anpassungen
    =========================== */
 @media (max-width: 768px) {
-	h1 {
-		font-size: 1.25rem !important;
-		padding: 0.5rem !important;
-	}
+	/* Die `h1`-Regel ist hier ersatzlos entfallen (2026-08-02). Sie lautete
+	   `h1 { font-size: 1.25rem !important; padding: 0.5rem !important }` und war
+	   auf zwei Ebenen falsch.
+
+	   **Sie galt nicht nur für die Karte.** Diese Datei wird über `app.css`
+	   global importiert (dort Zeile 31), der Selektor war aber ein nacktes
+	   Element ohne Karten-Kontext. Er traf damit jede `h1` der Anwendung —
+	   `/about`, `/docs`, `/styleguide`, `/maintenance`, die Fehlerseite, das
+	   Sichtungsformular und vier Admin-Seiten. Auf `/about` rendert der
+	   Seitentitel dadurch mit 20px, während die Zwischenüberschriften darunter
+	   30–48px groß waren: die wichtigste Überschrift der Seite war die
+	   kleinste.
+
+	   Das `!important` hat das nicht abgemildert, sondern erst ermöglicht.
+	   Tailwind legt seine Utilities in `@layer utilities`; diese Datei ist
+	   ungelayert und gewinnt die Kaskade ohnehin (dieselbe Mechanik wie beim
+	   Fokus-Override, siehe `.claude/rules/daisyui.md`). Das `!important` schlug
+	   zusätzlich noch jede Angabe am Element selbst.
+
+	   **Für die Karte war sie ebenfalls falsch.** Die einzige `h1` im
+	   Kartenkontext ist der Glass-Badge in `SightingsMapView.svelte` (Zeile 673),
+	   und sein `titleClass` (Zeile 44) bringt `text-sm` sowie `px-3 py-1.5`
+	   bereits mit. Die Regel hat diese Angaben überschrieben und den Badge auf
+	   20px samt 0.5rem Innenabstand aufgezogen — sie hat die Karte also nicht
+	   geschützt, sondern deren eigene Gestaltung ausgehebelt.
+
+	   Kein Ersatz nötig: Der Badge ist danach so groß, wie seine Klassen sagen.
+	   Abgesichert durch `e2e/design-tokens.spec.ts` → „Größen-Utilities an
+	   Überschriften greifen"; ein Test über die CSS-Quelle hätte den Fall nicht
+	   gesehen, weil hier eine plausible Regel in einer plausiblen Datei stand. */
 
 	/* QW8: .w-90-Regel entfernt — die Panels heißen inzwischen w-100 (siehe
 	   FilterPanel.svelte/LegendPanel.svelte), diese Regel griff nie mehr. */

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -40,7 +40,12 @@
 			<OstseeTiereLogo size="lg" showText={true} />
 		</div>
 
-		<h1 class="text-primary mb-8 text-6xl font-bold tracking-tight">Über Ostsee-Tiere</h1>
+		<!-- Größen aus der Rollen-Tabelle in design-system.md, nicht frei gewählt:
+		     Seitentitel ist `display`, Abschnittstitel `title`, Titel in Karten
+		     `section`. Vorher standen hier text-6xl/5xl/4xl/3xl/2xl/xl — dass das
+		     nie auffiel, lag an der globalen h1-Regel aus mapStyles.css, die den
+		     Titel auf Mobil auf 20px zwang und die Staffelung damit verdeckte. -->
+		<h1 class="text-primary text-display mb-8 font-bold tracking-tight">Über Ostsee-Tiere</h1>
 		<div class="mx-auto max-w-4xl">
 			<p class="text-base-content/80 mb-6 text-2xl leading-relaxed">
 				Die Ostsee-Tiere Plattform ermöglicht es <strong class="text-primary"
@@ -57,7 +62,7 @@
 	<div class="mb-20">
 		<div class="grid items-center gap-12 md:grid-cols-2">
 			<div>
-				<h2 class="text-primary mb-6 flex items-center gap-3 text-4xl font-bold">
+				<h2 class="text-primary text-title mb-6 flex items-center gap-3 font-bold">
 					<Icon icon="lucide:zap" width="36" class="text-primary" />
 					Unsere Mission
 				</h2>
@@ -83,7 +88,7 @@
 					<div class="mb-6 flex justify-center">
 						<Icon icon="lucide:activity" width="60" class="text-primary opacity-80" />
 					</div>
-					<h3 class="text-primary mb-4 text-2xl font-bold">Citizen Science</h3>
+					<h3 class="text-primary text-section mb-4 font-bold">Citizen Science</h3>
 					<p class="text-base-content/70 text-lg leading-relaxed">
 						Bürgerwissenschaft macht <strong>jeden zum Forscher</strong> und trägt zu wichtigen wissenschaftlichen
 						Erkenntnissen bei.
@@ -107,7 +112,7 @@
 	<!-- Features Section -->
 	<div class="mb-20">
 		<div class="mb-12 text-center">
-			<h2 class="text-primary mb-4 flex items-center justify-center gap-3 text-4xl font-bold">
+			<h2 class="text-primary text-title mb-4 flex items-center justify-center gap-3 font-bold">
 				<Icon icon="lucide:zap" width="36" class="text-primary" />
 				Unsere Plattform
 			</h2>
@@ -124,7 +129,7 @@
 					>
 						<Icon icon="lucide:pen-line" width="48" class="text-primary" />
 					</div>
-					<h3 class="card-title text-primary mb-4 justify-center text-xl">Einfaches Melden</h3>
+					<h3 class="card-title text-primary text-section mb-4 justify-center">Einfaches Melden</h3>
 					<p class="text-base-content/80 text-base leading-relaxed">
 						<strong>Intuitive Formulare</strong> führen Sie Schritt für Schritt durch die Erfassung
 						Ihrer Sichtung mit <em>GPS-genauer Lokalisierung</em>.
@@ -142,7 +147,7 @@
 					>
 						<Icon icon="lucide:map" width="48" class="text-secondary-strong" />
 					</div>
-					<h3 class="card-title text-secondary-strong mb-4 justify-center text-xl">
+					<h3 class="card-title text-secondary-strong text-section mb-4 justify-center">
 						Interaktive Karte
 					</h3>
 					<!-- „alle Sichtungen" traf nicht zu: die Karte zeigt ausschließlich
@@ -164,7 +169,7 @@
 					>
 						<Icon icon="lucide:chart-pie" width="48" class="text-accent-strong" />
 					</div>
-					<h3 class="card-title text-accent-strong mb-4 justify-center text-xl">Offene Daten</h3>
+					<h3 class="card-title text-accent-strong text-section mb-4 justify-center">Offene Daten</h3>
 					<!-- Vorher: „Alle Daten sind für Forschungszwecke verfügbar und können in
 					     verschiedenen Formaten exportiert werden." Der Export in mehrere
 					     Formate ist eine Funktion des Admin-Bereichs, nicht der Öffentlichkeit
@@ -221,7 +226,7 @@
 
 	<!-- Data Protection & Security Section -->
 	<div class="mb-16">
-		<h2 class="mb-8 flex items-center justify-center gap-3 text-center text-3xl font-bold">
+		<h2 class="text-title mb-8 flex items-center justify-center gap-3 text-center font-bold">
 			<Icon icon="lucide:shield-check" width="30" class="text-success-strong" />
 			Datenschutz & Sicherheit
 		</h2>
@@ -382,7 +387,7 @@
 	<!-- Technology Section -->
 	<div class="bg-base-200 mb-16 rounded-lg p-8">
 		<div class="mb-6 flex flex-col items-center justify-center gap-2">
-			<h2 class="flex items-center gap-3 text-center text-3xl font-bold">
+			<h2 class="text-title flex items-center gap-3 text-center font-bold">
 				<Icon icon="lucide:zap" width="30" class="text-warning-strong" />
 				Technologie
 			</h2>
@@ -414,7 +419,7 @@
 
 	<!-- Open Source & Licensing Section -->
 	<div class="mb-16">
-		<h2 class="mb-8 flex items-center justify-center gap-3 text-center text-3xl font-bold">
+		<h2 class="text-title mb-8 flex items-center justify-center gap-3 text-center font-bold">
 			<Icon icon="lucide:scale" width="32" height="32" class="text-primary" />
 			Open Source & Lizenzen
 		</h2>
@@ -629,7 +634,7 @@ SOFTWARE.</pre>
 							<OstseeTiereLogo size="lg" showText={false} />
 						</div>
 					</div>
-					<h2 class="text-primary mb-6 text-5xl font-bold tracking-tight">
+					<h2 class="text-primary text-title mb-6 font-bold tracking-tight">
 						Werden Sie Teil der Bewegung
 					</h2>
 					<p class="text-base-content/80 mb-8 text-xl leading-relaxed">


### PR DESCRIPTION
## Befund

`src/lib/map/mapStyles.css` enthielt im Mobil-Block ein nacktes

```css
@media (max-width: 768px) {
	h1 { font-size: 1.25rem !important; padding: 0.5rem !important; }
}
```

Die Datei wird über `app.css:31` **global** importiert, der Selektor hatte aber keinen Karten-Kontext. Er traf damit jede `h1` der Anwendung — `/about`, `/docs`, `/styleguide`, `/maintenance`, die Fehlerseite, das Sichtungsformular und vier Admin-Seiten.

Auf `/about` rendert der Seitentitel dadurch unter 768px mit **20px**, während die Zwischenüberschriften darunter 30–48px groß waren: die wichtigste Überschrift der Seite war die kleinste.

Das `!important` hat das nicht abgemildert, sondern erst ermöglicht. Tailwind legt seine Utilities in `@layer utilities`; diese Datei ist ungelayert und gewinnt die Kaskade ohnehin — dieselbe Mechanik wie beim Fokus-Override in `.claude/rules/daisyui.md`.

## Warum ersatzlos statt gescopt

Die einzige `h1` im Kartenkontext ist der Glass-Badge in `SightingsMapView.svelte:673`; sein `titleClass` (Zeile 44) bringt `text-sm` und `px-3 py-1.5` bereits mit. Die Regel hat diese Angaben überschrieben und den Badge auf 20px samt 8px Innenabstand aufgezogen — sie hat die Karte also nicht geschützt, sondern deren eigene Gestaltung ausgehebelt.

Im Browser bei 500px nachgemessen:

| | vorher | nachher | laut Klassen |
| --- | --- | --- | --- |
| Karten-Badge | 20px / 8px | **14px / 6px 12px** | `text-sm` / `px-3 py-1.5` |
| `/about` h1 | 20px | **32px** | `text-display` |

## Überschriften auf /about

Ziehen mit auf die Rollen-Tabelle aus `design-system.md` (`display` 32 / `title` 24 / `section` 18) — vorher `text-6xl`, `-5xl`, `-4xl`, `-3xl`, `-2xl`, `-xl`. Ohne das hätte der Fix den Titel dort auf Mobil auf 60px gesetzt. Dass die Staffelung nie auffiel, lag an genau der entfernten `h1`-Regel.

## Neuer Wächter

`design-tokens.spec.ts` → **„Größen-Utilities an Überschriften greifen"**: jede Überschrift muss in der Größe rendern, die ihre Utility angibt.

- **Gemessen bei 375px**, wo keine `md:`/`lg:`-Variante dazwischenfunkt — die Basis-Utility ist dort allein zuständig, der Test braucht keine Breakpoint-Auflösung.
- Ob eine `text-*`-Klasse eine Größe ist, entscheidet das Theme selbst (`--text-6xl` existiert, `--text-primary` nicht) — keine zweite Liste zu pflegen, die eigenen Rollen-Utilities sind automatisch mit abgedeckt.
- Der bestehende Klassen-Scan konnte den Fall strukturell nicht sehen: `class="… text-6xl …"` steht korrekt im Markup und greift nur nicht. Nachweisbar ist das erst am berechneten Wert.
- **Der Test wartet vor dem Messen auf die Hydration.** Bis dahin trägt das Layout `.iframe-mode`, dessen ungelayerter Block `h1`/`h2` ebenfalls festsetzt — ohne das Warten meldet der Test jede Überschrift der Anwendung als Verstoß und sieht dabei aus wie ein Produktfehler.

Der Test war vor dem Fix auf 6 von 7 Routen rot.

## Verifikation

- `npx playwright test e2e/design-tokens.spec.ts e2e/about-page.spec.ts` — 75 passed
- `npm run test:quick` — 219 Dateien, 3133 Tests passed
- Karten-Badge und `/about` im Browser bei 500px nachgemessen (Werte oben)

🤖 Generated with [Claude Code](https://claude.com/claude-code)