### PR TITLE
fix(test): Gradient-Stops in der Paletten-Regel erfassen

### DIFF
--- a/e2e/helpers/bannedClasses.test.ts
+++ b/e2e/helpers/bannedClasses.test.ts
@@ -233,6 +233,61 @@ describe('TAILWIND_PALETTE', () => {
 			expect(TAILWIND_PALETTE.offends(className)).toBe(false);
 		}
 	);
+
+	/* Die dritte strukturelle Lücke derselben Regel — und wieder eine in der
+	   Grammatik, nicht in den Daten: Das Muster kannte die Präfixe `bg`, `text`
+	   und `border`. Ein Verlauf trägt seine Farben aber an `from-`, `via-` und
+	   `to-`, und `from-green-50` umgeht das Theme exakt so vollständig wie
+	   `bg-green-50` — es ist dieselbe Farbe an derselben Fläche, nur über eine
+	   andere Utility gesetzt.
+
+	   Der Fall ist nicht hypothetisch: `src/routes/about/+page.svelte` trug zwei
+	   solche Verläufe (`from-green-50 to-emerald-50` und
+	   `from-purple-50 to-indigo-50`), und `/about` steht seit jeher in der
+	   Scanliste von `design-tokens.spec.ts`. Die Route war also abgedeckt, der
+	   Scan lief grün, und die Fundstellen standen trotzdem im DOM. */
+	it.each([
+		'from-green-50',
+		'via-sky-200',
+		'to-emerald-50',
+		'from-purple-50',
+		'to-indigo-50',
+		'from-gray-900/80'
+	])('meldet den Gradient-Stop %s', (className) => {
+		expect(TAILWIND_PALETTE.offends(className)).toBe(true);
+	});
+
+	/* `white`/`black` gelten an Gradient-Stops aus demselben Grund wie oben. */
+	it.each(['from-white', 'to-black/40', 'via-black'])(
+		'meldet den Gradient-Stop %s',
+		(className) => {
+			expect(TAILWIND_PALETTE.offends(className)).toBe(true);
+		}
+	);
+
+	/* Die Gegenprobe trägt hier mehr Gewicht als sonst: Verläufe aus
+	   Theme-Tokens sind im Bestand die Regel, nicht die Ausnahme (Mission-Card
+	   und CTA auf /about, beide mit `from-primary/5 via-secondary/5
+	   to-accent/5`). Eine Regel, die diese mitnimmt, wäre unerfüllbar und würde
+	   beim ersten roten Lauf aufgeweicht statt befolgt. */
+	it.each([
+		'from-primary/5',
+		'via-secondary/5',
+		'to-accent/5',
+		'from-base-100',
+		'to-base-200',
+		'via-scrim/40'
+	])('lässt den Theme-Gradient-Stop %s durch', (className) => {
+		expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+	});
+
+	/* Verankerung: Die neuen Präfixe dürfen nicht als Teilwort greifen.
+	   `to-` steckt in `photo-`, `from-` in Wörtern wie `fromage` — beides keine
+	   Tailwind-Utilities, aber der Beleg dafür, dass das Muster am Wortanfang
+	   verankert bleibt und nicht irgendwo in der Klasse sucht. */
+	it.each(['photo-red-500', 'chromatic-white', 'shadow-raised'])('lässt %s durch', (className) => {
+		expect(TAILWIND_PALETTE.offends(className)).toBe(false);
+	});
 });
 
 describe('findOffenders', () => {

--- a/e2e/helpers/bannedClasses.ts
+++ b/e2e/helpers/bannedClasses.ts
@@ -220,8 +220,33 @@ const PALETTE_HUES = [
  * Die Verankerung trägt `white`/`black` als ganzes Wort: `bg-whitesmoke` (oder
  * eine eigene Utility mit diesem Präfix) ist kein Verstoß.
  */
+/**
+ * Präfixe, über die eine Farbe ins Layout kommt.
+ *
+ * `from`, `via` und `to` sind die Gradient-Stops und stehen seit 2026-08-02
+ * dabei. Sie fehlten, und zwar wieder aus dem Grund, den diese Datei zweimal
+ * beschreibt: Die Lücke saß in der **Grammatik** des Musters, nicht in der
+ * Aufzählung der Farben. `from-green-50` umgeht das Theme exakt so vollständig
+ * wie `bg-green-50` — dieselbe Farbe auf derselben Fläche, nur über eine andere
+ * Utility gesetzt.
+ *
+ * Anders als bei `white`/`black` war der Fall auch nicht theoretisch:
+ * `src/routes/about/+page.svelte` trug zwei solche Verläufe, und `/about` steht
+ * seit jeher in der Scanliste von `design-tokens.spec.ts`. Die Route war also
+ * abgedeckt, der Scan lief grün, und die Fundstellen standen trotzdem im DOM.
+ * Das ist die unangenehmste Sorte Lücke — sie erzeugt Deckung, die es nicht
+ * gibt.
+ *
+ * `outline`, `ring`, `divide`, `accent` und `caret` fehlen weiterhin bewusst
+ * **nicht** aus Bestandsgründen, sondern weil sie im Projekt keine Farbe
+ * tragen — wer die erste solche Aufrufstelle anlegt, ergänzt hier eine Zeile.
+ * Das Argument „gibt es im Bestand nicht" allein trägt nach den drei
+ * Vorfällen oben nicht mehr.
+ */
+const PALETTE_PREFIXES = ['bg', 'text', 'border', 'from', 'via', 'to'] as const;
+
 const TAILWIND_PALETTE_PATTERN = new RegExp(
-	String.raw`^(?:bg|text|border)-(?:(?:${PALETTE_HUES.join('|')})-\d{2,3}|white|black)${OPACITY_SUFFIX}$`
+	String.raw`^(?:${PALETTE_PREFIXES.join('|')})-(?:(?:${PALETTE_HUES.join('|')})-\d{2,3}|white|black)${OPACITY_SUFFIX}$`
 );
 
 /** Tailwind-Paletten-Farbe statt Theme-Token. */

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -321,9 +321,13 @@
 		</div>
 
 		<!-- GDPR Compliance Notice -->
-		<div
-			class="border-success/10 mt-8 rounded-lg border bg-gradient-to-r from-green-50 to-emerald-50 p-6"
-		>
+		<!-- Verlauf aus der Tailwind-Palette ersetzt (2026-08-02). `from-green-50
+		     to-emerald-50` umging das Theme genauso vollständig wie ein
+		     `bg-green-50` — der Klassen-Scan hat es nur nicht gemeldet, weil sein
+		     Muster die Gradient-Stops nicht kannte. Der Tint trägt hier dieselbe
+		     Aussage, kommt aber aus dem Theme; die Rahmen-Deckkraft ist auf /20
+		     gezogen wie an der Datenschutz-Karte weiter oben. -->
+		<div class="border-success/20 bg-success/5 mt-8 rounded-lg border p-6">
 			<div class="flex items-start gap-4">
 				<Icon icon="lucide:file-text" width="24" class="text-success-strong" />
 				<div class="flex-1">
@@ -519,9 +523,21 @@ SOFTWARE.</pre>
 		</div>
 
 		<!-- Contribution & Issues -->
-		<div
-			class="border-purple/10 mt-8 rounded-lg border bg-gradient-to-r from-purple-50 to-indigo-50 p-6"
-		>
+		<!-- Vorher: `border-purple/10 border bg-gradient-to-r from-purple-50
+		     to-indigo-50`. Zwei Fehler in einer Klassenliste.
+
+		     Der Verlauf kam aus der Tailwind-Palette und umging das Theme. Und
+		     `border-purple/10` existierte als Utility überhaupt nicht — Tailwind
+		     führt `purple` nur mit Farbstufe, der Name erzeugt also nichts. Die
+		     Box trug damit die Default-Rahmenfarbe statt des gedachten Tints, und
+		     zwar unbemerkt, weil eine tote Klasse im Markup aussieht wie eine
+		     wirksame.
+
+		     Ersatz ist `bg-base-200` ohne Rahmen — dieselbe Fläche wie die
+		     Danksagungs- und die Kontakt-Box weiter unten. Kein Statusfarbton:
+		     „Fehler gefunden oder Verbesserungsvorschlag?" ist eine Einladung,
+		     keine Warnung; die Bedeutung trägt das Icon. -->
+		<div class="bg-base-200 mt-8 rounded-lg p-6">
 			<div class="flex items-start gap-4">
 				<Icon icon="lucide:circle-alert" width="32" height="32" class="text-warning-strong mt-1" />
 				<div class="flex-1">


### PR DESCRIPTION
## Befund

Das Muster in `e2e/helpers/bannedClasses.ts` kannte die Präfixe `bg`, `text` und `border`. Ein Verlauf trägt seine Farben aber an `from-`, `via-` und `to-` — und `from-green-50` umgeht das Theme exakt so vollständig wie `bg-green-50`: dieselbe Farbe auf derselben Fläche, nur über eine andere Utility gesetzt.

Nach dem Deckkraft-Suffix und nach `white`/`black` ist das die **dritte Lücke derselben Bauart** in dieser Regel: sie saß in der Grammatik des Musters, nicht in der Aufzählung der Farben.

## Warum das schlimmer ist als die beiden Vorgänger

`white`/`black` waren beim Schließen ein Bestandsfund. Dieser Fall war eine **Deckung, die es nicht gab**: `src/routes/about/+page.svelte` trug zwei solche Verläufe, und `/about` steht seit jeher in der Scanliste von `design-tokens.spec.ts`. Die Route galt also als abgedeckt, der Scan lief grün, und die Fundstellen standen trotzdem im DOM.

Nach dem Schließen meldet der Scan sie sofort — und nur auf `/about`, die übrigen sechs Routen bleiben grün:

```
<div> from-green-50 to-emerald-50 — in class="border-success/10 … bg-gradient-to-r from-green-50 to-emerald-50 p-6"
<div> from-purple-50 to-indigo-50 — in class="border-purple/10 … bg-gradient-to-r from-purple-50 to-indigo-50 p-6"
```

## Beide Fundstellen mit behoben

| Box | vorher | nachher |
| --- | --- | --- |
| DSGVO-Konformität | `border-success/10` + `from-green-50 to-emerald-50` | `border-success/20 bg-success/5` |
| „Fehler gefunden?" | `border-purple/10` + `from-purple-50 to-indigo-50` | `bg-base-200` |

Bei der zweiten Box steckten **zwei** Fehler in einer Klassenliste: `border-purple/10` existierte als Utility überhaupt nicht — Tailwind führt `purple` nur mit Farbstufe. Die Box trug damit die Default-Rahmenfarbe statt des gedachten Tints, und zwar unbemerkt, weil eine tote Klasse im Markup aussieht wie eine wirksame. Ersatz ist `bg-base-200` ohne Rahmen, dieselbe Fläche wie die Danksagungs- und die Kontakt-Box weiter unten. Kein Statusfarbton: „Fehler gefunden oder Verbesserungsvorschlag?" ist eine Einladung, keine Warnung — die Bedeutung trägt das Icon.

## Zu den Gegenproben

Sie wiegen hier schwerer als bei den vorherigen Lücken: **Verläufe aus Theme-Tokens sind im Bestand die Regel, nicht die Ausnahme** — Mission-Card und CTA auf `/about` fahren beide `from-primary/5 via-secondary/5 to-accent/5`. Eine Regel, die die mitnimmt, wäre unerfüllbar und würde beim ersten roten Lauf aufgeweicht statt befolgt. Der Test hält deshalb sechs Theme-Stops und drei Teilwort-Fälle (`photo-red-500`, `chromatic-white`) ausdrücklich als „muss durchkommen" fest.

`outline`, `ring`, `divide`, `accent` und `caret` fehlen weiterhin — aber begründet: sie tragen im Projekt keine Farbe. Das Argument „gibt es im Bestand nicht" allein trägt nach drei Vorfällen nicht mehr, deshalb steht es so im Code.

## Verifikation

- `npx vitest run e2e/helpers/bannedClasses.test.ts` — 92 passed (vor dem Fix: 9 failed)
- `npx playwright test e2e/design-tokens.spec.ts e2e/about-page.spec.ts` — 68 passed
- `npm run test:unit` — 219 Dateien, 3151 Tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)