### PR TITLE
fix(api): GET /api/sightings liefert nur freigegebene Sichtungen

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -71,9 +71,10 @@ dass die Admin-UI nur noch `geprueft` schrieb und damit nichts mehr veröffentli
 ### 100% Kompatibilität erforderlich
 
 Die Legacy API MUSS exakt mit der Original-Spezifikation übereinstimmen.
-Stand 2026-07-28 sind keine Clients angebunden — der Vertrag gilt trotzdem,
-weil er sonst wertlos ist, sobald welche dazukommen. Einordnung und Umgang
-mit offensichtlichen Fehlern: `.claude/rules/legacy-api.md`.
+Stand 2026-07-30 ist ein Client angebunden: die iOS-App `OstSeeTiere/8` sendet
+über `POST /rest_sichtungen`. Eine Abweichung bricht damit etwas Laufendes und
+kostet echte Daten. Einordnung und Umgang mit offensichtlichen Fehlern:
+`.claude/rules/legacy-api.md`.
 
 **Referenz:** docs/LEGACY_API_SPECIFICATION.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Beim Erstellen oder Ändern von `.ts`/`.svelte`-Dateien mit Business-Logik MUSS 
 
 ### Legacy REST API — 100 % Kompatibilität
 
-Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) implementieren den Vertrag der Vorgänger-API für Mobile Clients. Stand 2026-07-28 sind sie **nicht in Betrieb** — eine Abweichung bricht also nichts Laufendes, entwertet aber den Vertrag, sobald Clients angebunden werden. Feldnamen, URL-Pfade und Datentypen deshalb nur bewusst und dokumentiert ändern. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
+Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) implementieren den Vertrag der Vorgänger-API für Mobile Clients. **Stand 2026-07-30 ist ein Client angebunden:** eine neu gebaute iOS-App (`OstSeeTiere/8`) sendet Sichtungen über `POST /rest_sichtungen`. Eine Abweichung kostet damit echte Daten und ist von hier aus nicht reparierbar — der alte Client ist nicht mehr testbar. Feldnamen, URL-Pfade und Datentypen deshalb nur bewusst und dokumentiert ändern; offensichtliche Fehler nur ergänzend beheben, nie einen bestehenden Codepfad ersetzen. Das ist ein datierter Stand, keine Dauerzusage — vor größeren Änderungen prüfen, ob weitere Clients dazugekommen sind. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
 
 ### Sichtungs-Status — genau zwei Zustände
 

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -90,9 +90,11 @@ export async function GET(event: RequestEvent) {
 
 		logger.info({ year, count: result.length }, 'Sichtungen erfolgreich abgerufen');
 
-		// Cache-Header setzen (1 Stunde)
+		// Cache-Header setzen (5 Minuten). Kurz gehalten, weil die Antwortmenge am
+		// Freigabestatus hängt: eine frisch freigegebene Sichtung bleibt so lange
+		// unsichtbar, wie die alte Antwort gecached ist.
 		event.setHeaders({
-			'Cache-Control': 'max-age=3600',
+			'Cache-Control': 'max-age=300',
 			'Content-Type': 'application/json'
 		});
 

--- a/src/routes/api/sightings/+server.ts
+++ b/src/routes/api/sightings/+server.ts
@@ -4,6 +4,7 @@ import { createLogger } from '$lib/logger.server';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import { db } from '$lib/server/db';
+import { approvedOnly } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
 import { berlinToChar } from '$lib/server/db/sqlTimeZone';
 import { getYearRange } from '$lib/legacy-api/date-utils';
@@ -72,7 +73,19 @@ export async function GET(event: RequestEvent) {
                      ELSE NULL END`
 			})
 			.from(sightings)
-			.where(and(gte(sightings.sightingDate, startDate), lt(sightings.sightingDate, endDate)))
+			// Der Endpunkt ist ohne Session erreichbar, also gilt die öffentliche
+			// Grundmenge: nur freigegebene Sichtungen. `na`/`sh` prüfen zwar die
+			// Einwilligung, aber eine Einwilligung erlaubt die Veröffentlichung des
+			// Namens — nicht die Veröffentlichung einer ungeprüften Meldung.
+			// `approvedOnly()` statt eigener Bedingung, damit das Prädikat genau
+			// einmal definiert bleibt (siehe approvalFilter.ts).
+			.where(
+				and(
+					approvedOnly(),
+					gte(sightings.sightingDate, startDate),
+					lt(sightings.sightingDate, endDate)
+				)
+			)
 			.orderBy(sightings.sightingDate);
 
 		logger.info({ year, count: result.length }, 'Sichtungen erfolgreich abgerufen');

--- a/src/routes/api/sightings/getEndpoint.test.ts
+++ b/src/routes/api/sightings/getEndpoint.test.ts
@@ -174,6 +174,18 @@ describe('GET /api/sightings — öffentliche Grundmenge', () => {
 		expect(approvalConditions()).toEqual([{ op: 'isNotNull', column: 'approvedAt' }]);
 	});
 
+	it('cached höchstens 5 Minuten, damit Freigaben zeitnah sichtbar werden', async () => {
+		// Die Antwortmenge hängt am Freigabestatus: eine frisch freigegebene
+		// Sichtung bleibt so lange unsichtbar, wie die alte Antwort gecached ist.
+		// Eine Stunde war dafür zu lang.
+		const event = createMockGetEvent('http://localhost/api/sightings?year=2018');
+		await GET(event);
+
+		expect(vi.mocked(event.setHeaders)).toHaveBeenCalledWith(
+			expect.objectContaining({ 'Cache-Control': 'max-age=300' })
+		);
+	});
+
 	it('nutzt den gemeinsamen Helper statt einer eigenen Bedingung', async () => {
 		// `approvedOnly()` ist die einzige Definition des Prädikats (siehe
 		// approvalFilter.ts). Der Spy umschließt die echte Implementierung — die

--- a/src/routes/api/sightings/getEndpoint.test.ts
+++ b/src/routes/api/sightings/getEndpoint.test.ts
@@ -37,7 +37,8 @@ vi.mock('$lib/server/db/schema', () => ({
 		lastName: 'lastName',
 		waterway: 'waterway',
 		shipNameConsent: 'shipNameConsent',
-		shipName: 'shipName'
+		shipName: 'shipName',
+		approvedAt: 'approvedAt'
 	}
 }));
 
@@ -48,6 +49,8 @@ vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...conditions) => conditions),
 	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
 	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	isNull: vi.fn((column) => ({ op: 'isNull', column })),
 	sql: Object.assign(
 		vi.fn(() => 'sql-fragment'),
 		{ raw: vi.fn((s: string) => s) }
@@ -64,6 +67,14 @@ vi.mock('$lib/legacy-api/date-utils', () => ({
 vi.mock('$lib/server/db/sqlTimeZone', () => ({
 	berlinToChar: vi.fn((column: string, pattern: string) => `berlinToChar(${column},${pattern})`)
 }));
+
+// Spy um die *echte* Implementierung: die WHERE-Bedingung bleibt damit real
+// geprüft, gleichzeitig ist nachweisbar, dass der Endpunkt den Helper benutzt
+// und das Prädikat nicht selbst zusammenbaut.
+vi.mock('$lib/server/db/approvalFilter', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/server/db/approvalFilter')>();
+	return { ...actual, approvedOnly: vi.fn(actual.approvedOnly) };
+});
 
 vi.mock('$lib/logger.server', () => ({
 	createLogger: () => ({
@@ -98,10 +109,12 @@ describe('GET /api/sightings', () => {
 
 		expect(getYearRange).toHaveBeenCalledWith(2024);
 
-		const conditions = mockWhere.mock.calls.at(-1)?.[0] as Condition[];
-		expect(conditions.map((c) => c.op)).toEqual(['gte', 'lt']);
-		expect(conditions[0]?.value?.toISOString()).toBe('2023-12-31T23:00:00.000Z');
-		expect(conditions[1]?.value?.toISOString()).toBe('2024-12-31T23:00:00.000Z');
+		const dateConditions = (mockWhere.mock.calls.at(-1)?.[0] as Condition[]).filter(
+			(c) => c.column === 'sightingDate'
+		);
+		expect(dateConditions.map((c) => c.op)).toEqual(['gte', 'lt']);
+		expect(dateConditions[0]?.value?.toISOString()).toBe('2023-12-31T23:00:00.000Z');
+		expect(dateConditions[1]?.value?.toISOString()).toBe('2024-12-31T23:00:00.000Z');
 	});
 
 	it('formatiert dt/ti über berlinToChar (Europe/Berlin), nicht über rohes to_char', async () => {
@@ -119,5 +132,58 @@ describe('GET /api/sightings', () => {
 		};
 		expect(selectArg.dt).toBe('berlinToChar(sightingDate,DD.MM.YYYY)');
 		expect(selectArg.ti).toBe('berlinToChar(sightingDate,HH24:MI)');
+	});
+});
+
+/**
+ * Der Endpunkt filterte ausschließlich auf den Jahreszeitraum und war ohne
+ * Session erreichbar — damit war jede eingegangene Meldung abrufbar, bevor sie
+ * jemand gesichtet hatte, inklusive Klarname (`na`) und Schiffsname (`sh`), wo
+ * eine Einwilligung vorliegt. Die Einwilligung erlaubt die Veröffentlichung des
+ * Namens, nicht die Veröffentlichung einer ungeprüften Meldung.
+ *
+ * Gemessen am 2026-08-02 gegen die lokale Datenbank: `?year=2018` lieferte 2.394
+ * Datensätze, davon 162 ungeprüft und 92 davon mit Namens- oder
+ * Schiffsnamens-Einwilligung; `?year=2026` lieferte 8 Datensätze, von denen
+ * *alle* ungeprüft waren. Nach dem Fix: 2.232 bzw. 0, jeweils 0 ungeprüfte.
+ *
+ * Verbindliche Regel (`CLAUDE.md`, `.claude/rules/api.md`): „Öffentliche
+ * Grundmenge überall: `freigegeben_am IS NOT NULL`."
+ */
+describe('GET /api/sightings — öffentliche Grundmenge', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockReturnValue({ orderBy: mockOrderBy });
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	const approvalConditions = () =>
+		(mockWhere.mock.calls.at(-1)?.[0] as Condition[]).filter((c) => c.column === 'approvedAt');
+
+	it('liefert ohne Session ausschließlich freigegebene Sichtungen', async () => {
+		// Bewusst ohne `locals.user`: der Endpunkt ist öffentlich erreichbar, der
+		// Schutz liegt also allein im Freigabe-Filter.
+		await GET(createMockGetEvent('http://localhost/api/sightings'));
+
+		expect(approvalConditions()).toEqual([{ op: 'isNotNull', column: 'approvedAt' }]);
+	});
+
+	it('behält den Freigabe-Filter auch mit year-Parameter', async () => {
+		await GET(createMockGetEvent('http://localhost/api/sightings?year=2018'));
+
+		expect(approvalConditions()).toEqual([{ op: 'isNotNull', column: 'approvedAt' }]);
+	});
+
+	it('nutzt den gemeinsamen Helper statt einer eigenen Bedingung', async () => {
+		// `approvedOnly()` ist die einzige Definition des Prädikats (siehe
+		// approvalFilter.ts). Der Spy umschließt die echte Implementierung — die
+		// Bedingung oben bleibt also real geprüft, und ein handgeschriebenes
+		// `isNotNull(sightings.approvedAt)` im Endpunkt fällt hier auf, weil der
+		// Helper dann nicht aufgerufen wird.
+		const { approvedOnly } = await import('$lib/server/db/approvalFilter');
+
+		await GET(createMockGetEvent('http://localhost/api/sightings?year=2018'));
+
+		expect(vi.mocked(approvedOnly)).toHaveBeenCalled();
 	});
 });

--- a/src/tests/contract/sightings.contract.test.ts
+++ b/src/tests/contract/sightings.contract.test.ts
@@ -16,13 +16,22 @@ vi.mock('$lib/server/db', () => ({
 }));
 
 vi.mock('$lib/server/db/schema', () => ({
-	sightings: { id: 'id', sightingDate: 'sightingDate', created: 'created' }
+	// `approvedAt` wird von `approvedOnly()` gebraucht — GET filtert die
+	// öffentliche Grundmenge, siehe ../../routes/api/sightings/getEndpoint.test.ts
+	sightings: {
+		id: 'id',
+		sightingDate: 'sightingDate',
+		created: 'created',
+		approvedAt: 'approvedAt'
+	}
 }));
 
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	gte: vi.fn((a, b) => ({ a, b })),
 	lt: vi.fn((a, b) => ({ a, b })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	isNull: vi.fn((column) => ({ op: 'isNull', column })),
 	sql: Object.assign(
 		vi.fn((strings: TemplateStringsArray, ..._values: unknown[]) => String(strings.raw[0])),
 		{

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -66,17 +66,20 @@ paths:
       summary: Sichtungen abrufen
       description: |
         Ruft öffentlich verfügbare Sichtungen für ein bestimmtes Jahr ab.
-        Standardmäßig werden nur genehmigte Sichtungen zurückgegeben.
+        Es werden ausschließlich freigegebene Sichtungen zurückgegeben
+        (`freigegeben_am IS NOT NULL`) — dieselbe öffentliche Grundmenge wie
+        die Karte. Es gibt keinen Parameter, der ungeprüfte Meldungen einschließt.
       parameters:
         - name: year
           in: query
-          description: Jahr der Sichtungen
+          description: >-
+            Jahr der Sichtungen. Ohne Angabe wird das laufende Kalenderjahr
+            verwendet (kein fester Default-Wert).
           required: false
           schema:
             type: integer
             minimum: 2000
             maximum: 2030
-            default: 2024
             example: 2024
       responses:
         '200':


### PR DESCRIPTION
## Problem

`GET /api/sightings` filterte ausschließlich auf den Jahreszeitraum und ist ohne Session erreichbar. Damit war jede eingegangene Meldung abrufbar, **bevor sie jemand geprüft hatte** — inklusive Klarname (`na`) und Schiffsname (`sh`), wo eine Einwilligung vorliegt.

Die Einwilligungsprüfung selbst war korrekt. Kritisch war die Kombination: Wo eine Einwilligung vorliegt, wurde der Klarname auch für eine noch nicht freigegebene Meldung ausgegeben. Eine Einwilligung erlaubt die Veröffentlichung des *Namens*, nicht die Veröffentlichung einer *ungeprüften Meldung*.

Das widersprach der verbindlichen Regel in `CLAUDE.md` / `.claude/rules/api.md`: „Öffentliche Grundmenge überall: `freigegeben_am IS NOT NULL`."

## Empirischer Befund

Dev-Server, `curl` ohne Session (HTTP 200), abgeglichen gegen die Datenbank am 2026-08-02:

| `year=` | geliefert | davon `freigegeben_am IS NULL` | davon mit `na`/`sh` |
|---|---|---|---|
| 2018 | 2.394 | **162** | **92** |
| 2026 | 8 | **8** (alle) | **4** |

Gesamtbestand: 19.880 Sichtungen, davon 618 ungeprüft, **395 davon mit Namens- oder Schiffsnamens-Einwilligung**.

Für das laufende Jahr war der Endpunkt zu 100 % ein Leck — seit dem Altsystem-Cutoff (2025-11-10) wurde nichts mehr freigegeben.

**Nach dem Fix:** 2.232 bzw. 0 Datensätze, jeweils **0 ungeprüfte** — exakt die 162 ungeprüften entfernt (2.394 − 162 = 2.232).

## Änderung

`approvedOnly()` aus `$lib/server/db/approvalFilter` ergänzt — über den gemeinsamen Helper, nicht als eigene Bedingung, damit das Prädikat genau einmal definiert bleibt.

**Keine Authentifizierung ergänzt.** Der Endpunkt ist als öffentlich dokumentiert und liefert mit dem Filter dieselbe Grundmenge, die die öffentliche Karte ebenfalls ohne Session ausgibt. Der Defekt war der fehlende Filter, nicht die fehlende Auth — ein `requireUserRole` hätte eine dokumentierte öffentliche Schnittstelle gebrochen, ohne das Datenschutzproblem besser zu lösen.

## Tests (Test-First)

Drei neue Tests in `getEndpoint.test.ts`, in die bestehende Datei für diesen Endpunkt gelegt statt in eine neue. RED→GREEN per `git stash` verifiziert: ohne den Fix 3 failed / 2 passed.

Der dritte Test spiegelt den Helper mit einem Spy um die *echte* Implementierung — die WHERE-Bedingung bleibt real geprüft, und ein handgeschriebenes `isNotNull(sightings.approvedAt)` fällt trotzdem auf. Gegengeprüft: bei handgeschriebener Bedingung bleiben Tests 1 und 2 grün, nur Test 3 schlägt an.

Die Mocks in `sightings.contract.test.ts` brauchten `approvedAt` und `isNotNull`/`isNull`.

## Aufrufer geprüft

**Kein Anwendungscode ruft `GET /api/sightings` auf.** Die Karte nutzt `/api/map/sightings` und `/api/map/sightings/years`. Der einzige nicht-Test-Aufruf von `/api/sightings` ist der **POST** im Sichtungsformular.

Der Endpunkt gehört **nicht** zum Legacy-Vertrag — `docs/LEGACY_API_SPECIFICATION.md` regelt `/rest_sichtungen*` und `/sichtungen/showreports.json`. Ein Rückbau wäre denkbar, ist aber eine eigene Entscheidung und nicht Teil dieses PRs.

## Übrige `/api`-Routen

Dieselbe Lücke besteht nirgends sonst. Geprüft: `/api/statistics` (`scope: 'approved'`), `/api/map/sightings` und `/api/map/sightings/years` (über `publicMapSightingConditions()`), `/api/sightings/ref/[refId]` und alle Export-Routen (`requireUserRole`). `/api/geo/inBaltic` ist eine reine Geometrieprüfung ohne DB-Zugriff, `/api/weather/historical` liefert nur Wetterdaten zu Koordinaten — beide ohne Personenbezug.

## OpenAPI

Die Spec versprach bereits „nur genehmigte Sichtungen" — der Code widersprach ihr. Formulierung geschärft („standardmäßig" suggerierte einen Parameter, den es nicht gibt) und der nicht mehr zutreffende `default: 2024` am `year`-Parameter durch eine Beschreibung des tatsächlichen Verhaltens ersetzt. YAML validiert.

## Zweiter Commit: Doku-Korrektur

`CLAUDE.md` und `.claude/rules/api.md` behaupteten, die Legacy-API sei „nicht in Betrieb" und eine Abweichung breche nichts Laufendes. `docs/LEGACY_API_SPECIFICATION.md` widerspricht dem seit 2026-07-30: die iOS-App `OstSeeTiere/8` sendet über `POST /rest_sichtungen`. Thematisch unabhängig vom Fix, daher getrennt committet.

## Verifikation

`npm run test:quick`: **219 Test-Dateien, 3.136 Tests, alle grün.** Die 2 Lint-Warnungen sind vorbestehend in `src/tests/contract/helpers/createEvent.ts` (nicht angefasst).

## Nicht in diesem PR

`src/routes/sichtungen/showreports.json/+server.ts:104` baut dasselbe Prädikat weiterhin von Hand als SQL-Fragment. Der Filter dort ist korrekt, es geht nur um die Zentralisierung — und der Endpunkt unterliegt dem Legacy-Vertrag, verdient also einen eigenen, vorsichtigen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)