### PR TITLE
refactor(api): use shared approvedOnly() filter in showreports.json

### DIFF
--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -667,11 +667,12 @@ immer noch 7.383 (38 %).
 
 **Grund 2 — `.claude/rules/api.md` verbietet es.** Dort ist die öffentliche
 Grundmenge verbindlich auf `approvedAt IS NOT NULL` festgelegt, ausdrücklich für
-die Legacy-API **und** die moderne Karte (`/api/map/sightings`, via
-`approvedOnly()` aus `src/lib/server/db/approvalFilter.ts`), mit der Begründung,
-dass zwei verschiedene Filter für zwei öffentliche Flächen zwangsläufig
-auseinanderlaufen. Ein zusätzlicher Marker-Filter nur hier wäre genau dieser
-Fall.
+die Legacy-API **und** die moderne Karte, mit der Begründung, dass zwei
+verschiedene Filter für zwei öffentliche Flächen zwangsläufig auseinanderlaufen.
+Beide Flächen beziehen das Prädikat inzwischen aus derselben Quelle —
+`approvedOnly()` in `src/lib/server/db/approvalFilter.ts` —, dieser Endpunkt
+ebenso wie `/api/map/sightings`. Ein zusätzlicher Marker-Filter nur hier wäre
+genau der Divergenzfall, den das verhindern soll.
 
 **Was das für Clients heißt:** Die Ergebnismenge ist eine Obermenge dessen, was
 die Spec beschreibt. Ein Client bekommt zusätzliche Meldungen, keine fehlenden —

--- a/src/lib/server/db/approvalFilter.ts
+++ b/src/lib/server/db/approvalFilter.ts
@@ -35,8 +35,11 @@ export type ResolvedSightingScope = Exclude<SightingScope, 'both'>;
 /**
  * Nur freigegebene Sichtungen — die Grundmenge des öffentlichen Bereichs.
  *
- * Identisch mit dem Filter in `/sichtungen/showreports.json` (Legacy-Karte),
- * damit Karte und Statistik dieselbe Menge zählen.
+ * Auch `/sichtungen/showreports.json` (Legacy-Karte) filtert hierüber, damit
+ * Karte und Statistik dieselbe Menge zählen. Dieser Endpunkt ist an den
+ * Legacy-Vertrag gebunden: Änderungen an diesem Prädikat ändern seine Response.
+ * `statisticsApprovalScope.test.ts` pinnt es deshalb gegen den Ausdruck, der
+ * dort ursprünglich wörtlich stand.
  */
 export const approvedOnly = (): SQL => isNotNull(sightings.approvedAt);
 

--- a/src/lib/server/db/statisticsApprovalScope.test.ts
+++ b/src/lib/server/db/statisticsApprovalScope.test.ts
@@ -114,16 +114,18 @@ describe('Freigabestatus in Sichtungs-Statistiken', () => {
 
 	describe('Grundmenge der öffentlichen Karte', () => {
 		/**
-		 * Der Filter, wie er wörtlich in `/sichtungen/showreports.json` steht.
+		 * Der Filter, wie er bis zur Zentralisierung wörtlich in
+		 * `/sichtungen/showreports.json` stand.
 		 *
-		 * Der Legacy-Endpunkt bedient produktive Mobile Apps und wird deshalb
-		 * bewusst nicht auf den gemeinsamen Helper umgestellt. Stattdessen wird
-		 * hier festgehalten, dass beide Ausdrücke dasselbe Prädikat erzeugen —
-		 * wer eine der beiden Seiten ändert, bricht diesen Test.
+		 * Der Legacy-Endpunkt importiert inzwischen selbst `approvedOnly()` — die
+		 * Grundmenge liegt damit nur noch an einer Stelle. Der Vergleich bleibt
+		 * trotzdem stehen: Er hält fest, dass der Helper dasselbe Prädikat erzeugt
+		 * wie der Ausdruck, an den der Legacy-Vertrag gebunden ist, und schlägt an,
+		 * falls jemand `approvedOnly()` inhaltlich umbaut.
 		 */
 		const legacyKartenFilter = sql`${sightings.approvedAt} IS NOT NULL`;
 
-		it('ist identisch mit dem Filter des Legacy-Kartenendpunkts', () => {
+		it('ist identisch mit dem historischen Filter des Legacy-Kartenendpunkts', () => {
 			const normalisiert = (condition: SQL) => toSqlText(condition).toLowerCase().trim();
 
 			expect(normalisiert(approvedOnly())).toBe(normalisiert(legacyKartenFilter));

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -27,6 +27,7 @@ import { createLogger } from '$lib/logger.server';
 import { getSpeciesLabel } from '$lib/report/formOptions/species.js';
 import { isAdminUser } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
+import { approvedOnly } from '$lib/server/db/approvalFilter';
 import { consentGatedNameSearch, containsPattern } from '$lib/server/db/consentGatedSearch';
 import { sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
@@ -97,11 +98,17 @@ export async function GET(event: RequestEvent): Promise<Response> {
 		const whereConditions = [];
 
 		// Only show approved sightings (as per PDF: "freigegeben").
-		// Deliberately kept as inline SQL — this legacy endpoint must not change.
-		// The public statistics use `approvedOnly()` from `$lib/server/db/approvalFilter`;
-		// `statisticsApprovalScope.test.ts` pins both to the same predicate so map
-		// and numbers cannot drift apart again.
-		whereConditions.push(sql`${sightings.approvedAt} IS NOT NULL`);
+		// Bewusst der gemeinsame Helper und kein nachgebautes Inline-SQL: Das
+		// Prädikat ist in `$lib/server/db/approvalFilter` einmal definiert, damit
+		// Karte und öffentliche Statistik nicht erneut auseinanderlaufen.
+		//
+		// Der Wechsel ist rein syntaktisch und damit vertragsneutral: Der Helper
+		// kompiliert zu demselben qualifizierten Prädikat auf `freigegeben_am` wie
+		// das frühere Inline-SQL — nur mit klein geschriebenen SQL-Schlüsselwörtern,
+		// die PostgreSQL nicht unterscheidet — und trägt keine Parameter, die die
+		// Platzhalter-Nummerierung der übrigen Filter verschieben könnten.
+		// Festgehalten in `showreports.test.ts`, describe „Freigabefilter".
+		whereConditions.push(approvedOnly());
 
 		// Year filter - PDF specification behavior
 		if (year) {

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -11,8 +11,10 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { GET, POST, PUT, DELETE } from './+server';
 import type { RequestEvent } from '@sveltejs/kit';
-import type { SQL } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
+import { approvedOnly } from '$lib/server/db/approvalFilter';
+import { sightings } from '$lib/server/db/schema';
 
 // Die WHERE-Bedingung wird aus dem DB-Mock herausgereicht, damit die Tests die
 // tatsächlich erzeugte SQL prüfen können statt nur den HTTP-Status. Ohne das
@@ -541,13 +543,68 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			expect(response.status).toBe(200);
 			// Database limit is tested through integration - query structure is mocked
 		});
+	});
 
-		it('should only return approved sightings', async () => {
-			const event = createMockRequestEvent();
-			const response = await GET(event);
+	describe('Freigabefilter', () => {
+		// Das Prädikat ist in `$lib/server/db/approvalFilter` **einmal** definiert,
+		// damit Karte und öffentliche Statistik nicht erneut auseinanderlaufen
+		// (19.262 vs. 19.877, Stand 2026-07-27). Dieser Endpunkt hatte es lange
+		// von Hand nachgebaut — die Zentralisierung greift nur, wenn der Aufrufer
+		// den Import wirklich hat.
 
-			expect(response.status).toBe(200);
-			// Approved filter is tested through integration - query structure is mocked
+		/**
+		 * Der Filter, wie er bis zur Umstellung wörtlich im Endpunkt stand.
+		 *
+		 * `/sichtungen/showreports.json` unterliegt dem Legacy-Vertrag
+		 * (docs/LEGACY_API_SPECIFICATION.md) und bedient seit 2026-07-30 einen
+		 * produktiven iOS-Client. Der Wechsel auf den Helper darf deshalb nur die
+		 * Schreibweise ändern, nicht die Semantik — genau das hält der Vergleich
+		 * unten fest.
+		 */
+		const historischerInlineFilter = sql`${sightings.approvedAt} IS NOT NULL`;
+
+		it('nutzt das gemeinsame Prädikat aus approvedOnly()', async () => {
+			await GET(createMockRequestEvent());
+
+			const { text } = capturedWhereQuery();
+			// Die Groß-/Kleinschreibung ist hier **absichtlich** das
+			// Unterscheidungsmerkmal und `toContain` deshalb case-sensitiv zu
+			// lassen: Der Helper rendert `is not null`, ein von Hand nachgebautes
+			// `sql`-Literal nach altem Muster `IS NOT NULL`. Nur so schlägt dieser
+			// Test an, wenn jemand den Import wieder durch Inline-SQL ersetzt.
+			// Der Test darunter zeigt, dass beide Schreibweisen für PostgreSQL
+			// dasselbe bedeuten — das gilt für den Vertrag, nicht für diese Prüfung.
+			expect(text).toContain(dialect.sqlToQuery(approvedOnly()).sql);
+		});
+
+		it('erzeugt dieselbe SQL wie der frühere Inline-Filter', () => {
+			const helper = dialect.sqlToQuery(approvedOnly());
+			const inline = dialect.sqlToQuery(historischerInlineFilter);
+
+			// SQL-Schlüsselwörter sind case-insensitiv; alles andere muss
+			// zeichengleich sein, inklusive der Tabellenqualifizierung.
+			expect(helper.sql.toLowerCase()).toBe(inline.sql.toLowerCase());
+			// Keine Parameter auf beiden Seiten — sonst verschöbe sich die
+			// Nummerierung der übrigen Platzhalter in der zusammengesetzten Query.
+			expect(helper.params).toEqual([]);
+			expect(inline.params).toEqual([]);
+		});
+
+		it('bleibt neben den übrigen Filtern erhalten', async () => {
+			await GET(createMockRequestEvent({ year: '2012', bbox: '9,53,31,66', search: 'Schneider' }));
+
+			const { text } = capturedWhereQuery();
+			expect(text).toContain(dialect.sqlToQuery(approvedOnly()).sql);
+			expect(text).toContain('sichtungsdatum');
+		});
+
+		it('filtert auch für eingeloggte Admins auf freigegebene Sichtungen', async () => {
+			// Der Endpunkt liefert Admins zwar eine weitere Suche, aber keine
+			// ungeprüften Sichtungen — die Grundmenge ist für alle dieselbe.
+			await GET(createAdminRequestEvent({ search: 'Schneider' }));
+
+			const { text } = capturedWhereQuery();
+			expect(text).toContain(dialect.sqlToQuery(approvedOnly()).sql);
 		});
 	});
 });

--- a/src/tests/contract/legacy.contract.test.ts
+++ b/src/tests/contract/legacy.contract.test.ts
@@ -109,9 +109,26 @@ vi.mock('$lib/server/db/schema', () => ({
 	}
 }));
 
+// Attrappe für `drizzle-orm`: Die Contract-Tests prüfen ausschließlich die
+// Response gegen static/openapi.yml, nicht die erzeugte SQL — deshalb genügen
+// Platzhalter.
+//
+// FALLE: Diese Attrappe ersetzt das Modul vollständig. Ein Helper, den die
+// getesteten Routen aufrufen, hier aber fehlt, ist zur Laufzeit `undefined`;
+// der Aufruf wirft, die Route fängt das in ihrem catch-Block und antwortet mit
+// **500 statt 200**. Der Test meldet dann einen Statuscode-Mismatch und nennt
+// die Ursache nicht. Das gilt auch für **mittelbare** Aufrufe: Seit
+// `/sichtungen/showreports.json` sein Freigabe-Prädikat über `approvedOnly()`
+// aus `$lib/server/db/approvalFilter` bezieht, hängt der Endpunkt an
+// `isNotNull`, ohne es selbst zu importieren.
+//
+// Bewusst nur die tatsächlich aufgerufenen Helper (YAGNI, empirisch geprüft):
+// `gte`/`lt` etwa nutzt der Endpunkt für den `year`-Filter, den hier kein Test
+// setzt. Wer einen solchen Test ergänzt, muss sie nachtragen.
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn((a, b, c) => ({ a, b, c })),
+	isNotNull: vi.fn((column) => `${String(column)} is not null`),
 	sql: Object.assign(
 		vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
 		{

--- a/src/tests/contract/legacy.contract.test.ts
+++ b/src/tests/contract/legacy.contract.test.ts
@@ -125,6 +125,14 @@ vi.mock('$lib/server/db/schema', () => ({
 // Bewusst nur die tatsächlich aufgerufenen Helper (YAGNI, empirisch geprüft):
 // `gte`/`lt` etwa nutzt der Endpunkt für den `year`-Filter, den hier kein Test
 // setzt. Wer einen solchen Test ergänzt, muss sie nachtragen.
+//
+// Die Rückgabetypen sind absichtlich uneinheitlich, weil es die Originale auch
+// sind: `and`/`between` sind Kombinatoren (Array/Objekt), `sql` und `isNotNull`
+// bauen SQL-Fragmente und geben deshalb beide einen String zurück — im echten
+// drizzle ist `isNotNull(value)` nichts anderes als ein sql-Template mit dem
+// Suffix "is not null". Die Form ist hier ohnehin inert: Die Bedingungen wandern
+// über `and(...)` in `.where()`, und der `db`-Mock unten wertet dieses Argument
+// nicht aus.
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...args) => args),
 	between: vi.fn((a, b, c) => ({ a, b, c })),


### PR DESCRIPTION
## Warum

`/sichtungen/showreports.json` baute das Freigabe-Prädikat von Hand nach:

```ts
whereConditions.push(sql`${sightings.approvedAt} IS NOT NULL`);
```

Das widerspricht der Begründung im Datei-Doc von `src/lib/server/db/approvalFilter.ts`: „Damit beide Seiten nicht erneut auseinanderlaufen, wird das Prädikat hier **einmal** definiert und von allen öffentlichen Abfragen importiert. Ein Aufrufer, der den Freigabestatus ignoriert, fällt beim Review auf, weil er diesen Import nicht hat." Genau dieser Aufrufer hatte den Import nicht — die Kontrolle konnte hier also nicht greifen.

Gefunden beim Review des PR zu `GET /api/sightings`, wo derselbe fehlende Filter ein Datenschutzproblem war. **`showreports.json` hat korrekt gefiltert** — hier geht es ausschließlich um die Zentralisierung des Prädikats, nicht um einen Bug.

## Der Legacy-Vertrag bleibt gewahrt

`/sichtungen/showreports.json` unterliegt `docs/LEGACY_API_SPECIFICATION.md` und bedient seit 2026-07-30 einen produktiven iOS-Client (`OstSeeTiere/8`). Die Umstellung ist rein syntaktisch — beide Formen durch den echten `PgDialect` kompiliert:

```
inline: "sichtungen"."freigegeben_am" IS NOT NULL   params: []
helper: "sichtungen"."freigegeben_am" is not null   params: []
```

Gleiche Tabellenqualifizierung, gleiche Spalte, Unterschied nur in der Groß-/Kleinschreibung der SQL-Schlüsselwörter, die PostgreSQL nicht unterscheidet. `approvedOnly()` ist `isNotNull(sightings.approvedAt)`, und drizzles `isNotNull` ist wörtlich ``sql`${value} is not null` `` — dieselbe Konstruktion, die der Endpunkt ausgeschrieben hatte.

**Null Parameter auf beiden Seiten** ist dabei der Punkt, der leicht untergeht: Ein Prädikat mit Platzhalter würde die Nummerierung (`$1`, `$2`, …) der übrigen Filter in der zusammengesetzten Query verschieben. Tut es nicht — festgehalten als eigene Assertion.

Die Response ändert sich nicht.

## Test-First

Die vorhandene Abdeckung hatte an genau dieser Stelle eine Attrappe:

```ts
it('should only return approved sightings', async () => {
    expect(response.status).toBe(200);
    // Approved filter is tested through integration - query structure is mocked
});
```

Ersetzt durch ein `Freigabefilter`-Describe in `showreports.test.ts`, das die tatsächlich erzeugte WHERE-Klausel kompiliert und prüft: Prädikat allein, zusammen mit `year`+`bbox`+`search`, für eingeloggte Admins, sowie ein reiner SQL-Vergleich gegen den historischen Inline-Ausdruck inkl. leerer Parameterliste. RED ergab exakt die 3 erwarteten Fehlschläge, GREEN nach der Umstellung.

## Nebenbefund: stiller 500 in den Contract-Tests

`src/tests/contract/legacy.contract.test.ts` ersetzt `drizzle-orm` vollständig durch eine Attrappe, die nur `and`, `between` und `sql` exportierte. Der mittelbare Aufruf von `isNotNull` traf damit `undefined`, warf, und der `catch`-Block des Endpunkts machte daraus eine **500 statt 200** — die Contract-Tests wurden rot und nannten die Ursache nicht.

Behoben durch Ergänzung von `isNotNull` plus einem Kommentar, der die Falle allgemein benennt (sie gilt für jeden mittelbar aufgerufenen Helper). Bewusst **nur** der tatsächlich aufgerufene Helper — `gte`/`lt` für den `year`-Filter fehlen weiterhin, weil kein Contract-Test diesen Parameter setzt; der Kommentar sagt, dass sie beim Ergänzen eines solchen Tests nachzutragen sind.

## Doku und Kommentare, die die Änderung falsifiziert hat

- `statisticsApprovalScope.test.ts` behauptete, der Legacy-Endpunkt sei „bewusst nicht auf den gemeinsamen Helper umgestellt".
- `approvalFilter.ts` sagte „identisch mit dem Filter in `showreports.json`" — der Helper **ist** dieser Filter jetzt.
- `docs/LEGACY_API_SPECIFICATION.md` führte `approvedOnly()` nur als Weg der modernen Karte ein.

Die Äquivalenz-Assertion in `statisticsApprovalScope.test.ts` bleibt bewusst stehen, obwohl sie sich mit der neuen in `showreports.test.ts` überschneidet: Sie ist der aus `.claude/rules/database.md` referenzierte Pin gegen einen inhaltlichen Umbau von `approvedOnly()` selbst. Eine bestehende Zusicherung zu entfernen wäre Coverage-Verlust ohne Gegenwert.

## Verifikation

| Prüfung | Ergebnis |
| --- | --- |
| `npm run lint` | 0 Fehler (2 Bestands-Warnungen in einer nicht berührten Datei) |
| `npm run type-check` | grün |
| `npm run check` | 2068 Dateien, 0 Fehler |
| Server-Suite | 219 Dateien / 3154 Tests grün |
| Contract-Tests | 195 grün |

Kein Schema-Change, keine Migration, keine OpenAPI-Änderung (Response unverändert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)