### PR TITLE
refactor(ui): Betreiber nach vorn, Superlative raus

### DIFF
--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -57,13 +57,18 @@ test.describe('About Page', () => {
 
 	   Der Test prüft beides: dass er eine eigene Überschrift trägt, und dass er
 	   vor den übrigen Abschnitten steht. Die Reihenfolge über die Position im
-	   DOM, nicht über Pixel — das ist unabhängig vom Layout. */
+	   DOM, nicht über Pixel — das ist unabhängig vom Layout.
+
+	   `level: 2` und `main h2` sind kein Zierrat: Ohne Ebene würde der Locator
+	   auch eine h3 „… Meeresmuseum" treffen, und ohne `main` zählten Überschriften
+	   aus Navbar und Footer in den Index mit. Beides trifft heute nicht zu — aber
+	   der Test würde dann das Falsche prüfen, ohne rot zu werden. */
 	test('der Betreiber steht mit eigener Überschrift an erster Stelle', async ({ page }) => {
-		const betreiber = page.getByRole('heading', { name: /Meeresmuseum/ });
+		const betreiber = page.getByRole('heading', { name: /Meeresmuseum/, level: 2 });
 		await expect(betreiber).toBeVisible();
 
 		const reihenfolge = await page.evaluate(() =>
-			[...document.querySelectorAll('h2')].map((h) => h.textContent?.trim() ?? '')
+			[...document.querySelectorAll('main h2')].map((h) => h.textContent?.trim() ?? '')
 		);
 
 		expect(

--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -50,6 +50,55 @@ test.describe('About Page', () => {
 		).toHaveCount(0);
 	});
 
+	/* Der Betreiber-Abschnitt war der einzige der Seite **ohne** Überschrift — und
+	   stand zugleich an vierter Stelle, hinter Mission und Plattform. „Wer
+	   betreibt das?" ist aber die Frage, die eine Über-uns-Seite zuerst
+	   beantworten muss.
+
+	   Der Test prüft beides: dass er eine eigene Überschrift trägt, und dass er
+	   vor den übrigen Abschnitten steht. Die Reihenfolge über die Position im
+	   DOM, nicht über Pixel — das ist unabhängig vom Layout. */
+	test('der Betreiber steht mit eigener Überschrift an erster Stelle', async ({ page }) => {
+		const betreiber = page.getByRole('heading', { name: /Meeresmuseum/ });
+		await expect(betreiber).toBeVisible();
+
+		const reihenfolge = await page.evaluate(() =>
+			[...document.querySelectorAll('h2')].map((h) => h.textContent?.trim() ?? '')
+		);
+
+		expect(
+			reihenfolge.findIndex((t) => /Meeresmuseum/.test(t)),
+			`Der Betreiber-Abschnitt muss die erste h2 sein. Gefunden: ${reihenfolge.join(' | ')}`
+		).toBe(0);
+	});
+
+	/* Überschriften-Ebenen dürfen keine Stufe überspringen (WCAG 1.3.1). Auf
+	   dieser Seite ist das keine Formalie: Beim Kürzen fallen ganze Abschnitte
+	   weg, und eine `h4`, deren umgebende `h3` mit verschwindet, hängt danach
+	   ohne Zwischenebene unter einer `h2`. Genau das ist der Fehler, den man beim
+	   Löschen nicht sieht. */
+	test('die Überschriften-Ebenen überspringen keine Stufe', async ({ page }) => {
+		const ebenen = await page.evaluate(() =>
+			[...document.querySelectorAll('main h1, main h2, main h3, main h4, main h5, main h6')].map(
+				(h) => ({ level: Number(h.tagName[1]), text: h.textContent?.trim().slice(0, 40) ?? '' })
+			)
+		);
+
+		expect(
+			ebenen.length,
+			'Die Seite rendert keine Überschriften — Selektor prüfen.'
+		).toBeGreaterThan(0);
+		expect(ebenen[0].level, 'Die erste Überschrift muss die h1 sein.').toBe(1);
+
+		const spruenge = ebenen
+			.slice(1)
+			.map((h, i) => ({ von: ebenen[i], zu: h }))
+			.filter(({ von, zu }) => zu.level > von.level + 1)
+			.map(({ von, zu }) => `h${von.level} „${von.text}" → h${zu.level} „${zu.text}"`);
+
+		expect(spruenge, 'Übersprungene Überschriften-Ebene (WCAG 1.3.1)').toEqual([]);
+	});
+
 	/* `/docs` ist die OpenAPI-Dokumentation („Testen Sie alle Endpunkte direkt im
 	   Browser") und damit für die Zielgruppe dieser Schaltflächen das falsche
 	   Ziel. Der Test verbietet es ausdrücklich, statt nur die richtigen Ziele

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -36,8 +36,11 @@
 <div class="mx-auto max-w-5xl p-6">
 	<!-- Hero Section -->
 	<div class="mb-16 text-center">
+		<!-- Wortmarke aus: direkt darunter steht „Über Ostsee-Tiere". Mit Text las
+		     das Logo den Namen ein zweites Mal — einmal als Grafik, einmal als
+		     Überschrift. -->
 		<div class="mb-8 flex flex-1 justify-center">
-			<OstseeTiereLogo size="lg" showText={true} />
+			<OstseeTiereLogo size="lg" showText={false} />
 		</div>
 
 		<!-- Größen aus der Rollen-Tabelle in design-system.md, nicht frei gewählt:
@@ -91,7 +94,7 @@
 					rel="noopener noreferrer"
 					class="btn btn-outline btn-sm"
 				>
-					<Icon icon="lucide:globe" width="16" class="mr-1" />
+					<Icon icon="lucide:globe" width="16" class="mr-1" aria-hidden="true" />
 					Meeresmuseum.de
 				</a>
 				<a
@@ -100,7 +103,7 @@
 					rel="noopener noreferrer"
 					class="btn btn-outline btn-sm"
 				>
-					<Icon icon="lucide:file-text" width="16" class="mr-1" />
+					<Icon icon="lucide:file-text" width="16" class="mr-1" aria-hidden="true" />
 					Mehr über Sichtungen
 				</a>
 			</div>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -58,6 +58,55 @@
 		</div>
 	</div>
 
+	<!-- Betreiber — steht bewusst direkt unter dem Hero (2026-08-02).
+	     Vorher an vierter Stelle hinter Mission und Plattform, und als einziger
+	     Abschnitt der Seite ganz ohne Überschrift. „Wer betreibt das?" ist aber
+	     die Frage, die eine Über-uns-Seite zuerst beantworten muss.
+
+	     Die h2 trägt `text-primary-content`, weil sie auf der Vollton-Fläche
+	     `bg-primary` sitzt — genau der Fall, für den die *-content-Regel aus
+	     design-system.md gedacht ist, kein Tint.
+
+	     „einem der führenden Zentren für Meeresforschung" ist als unbelegter
+	     Superlativ entfallen. „Seit über 70 Jahren" war richtig, aber vage und
+	     altert mit jedem Jahr — 1951 ist eine Jahreszahl, die stehen bleibt. -->
+	<div class="mb-16">
+		<div class="bg-primary text-primary-content rounded-lg p-8 text-center">
+			<h2 class="text-primary-content text-title mb-4 font-bold">
+				Betrieben vom Deutschen Meeresmuseum
+			</h2>
+			<img
+				src="/logo_dmm_negativ.svg"
+				alt="Deutsches Meeresmuseum Logo"
+				class="mx-auto mb-4 w-64 p-4"
+			/>
+			<p class="text-primary-content mx-auto mb-4 max-w-2xl leading-relaxed">
+				Das Meeresmuseum in Stralsund erforscht die Ostsee und ihre Lebensräume seit 1951. Die
+				Sichtungen, die hier gemeldet werden, fließen in diese Arbeit ein.
+			</p>
+			<div class="flex justify-center gap-4">
+				<a
+					href="https://www.deutsches-meeresmuseum.de"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn btn-outline btn-sm"
+				>
+					<Icon icon="lucide:globe" width="16" class="mr-1" />
+					Meeresmuseum.de
+				</a>
+				<a
+					href="https://www.deutsches-meeresmuseum.de/wissenschaft/sichtungen"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="btn btn-outline btn-sm"
+				>
+					<Icon icon="lucide:file-text" width="16" class="mr-1" />
+					Mehr über Sichtungen
+				</a>
+			</div>
+		</div>
+	</div>
+
 	<!-- Mission Section -->
 	<div class="mb-20">
 		<div class="grid items-center gap-12 md:grid-cols-2">
@@ -124,7 +173,7 @@
 				Unsere Plattform
 			</h2>
 			<p class="text-base-content/70 mx-auto max-w-2xl text-lg">
-				Modernste Technologie für einfache Bedienung und maximale wissenschaftliche Relevanz
+				Einfach zu bedienen und auf wissenschaftlich brauchbare Daten ausgelegt
 			</p>
 		</div>
 
@@ -193,42 +242,6 @@
 						<div class="badge badge-accent badge-outline">Open Data</div>
 					</div>
 				</div>
-			</div>
-		</div>
-	</div>
-
-	<!-- Partnership Section -->
-	<div class="mb-16">
-		<div class="bg-primary text-primary-content rounded-lg p-8 text-center">
-			<img
-				src="/logo_dmm_negativ.svg"
-				alt="Deutsches Meeresmuseum Logo"
-				class="mx-auto mb-4 w-64 p-4"
-			/>
-			<p class="text-primary-content mx-auto mb-4 max-w-2xl leading-relaxed">
-				Diese Plattform wird vom Deutschen Meeresmuseum in Stralsund betrieben, einem der führenden
-				Zentren für Meeresforschung und -bildung in Deutschland. Seit über 70 Jahren widmen wir uns
-				der Erforschung und dem Schutz der marinen Lebensräume.
-			</p>
-			<div class="flex justify-center gap-4">
-				<a
-					href="https://www.deutsches-meeresmuseum.de"
-					target="_blank"
-					rel="noopener noreferrer"
-					class="btn btn-outline btn-sm"
-				>
-					<Icon icon="lucide:globe" width="16" class="mr-1" />
-					Meeresmuseum.de
-				</a>
-				<a
-					href="https://www.deutsches-meeresmuseum.de/wissenschaft/sichtungen"
-					target="_blank"
-					rel="noopener noreferrer"
-					class="btn btn-outline btn-sm"
-				>
-					<Icon icon="lucide:file-text" width="16" class="mr-1" />
-					Mehr über Sichtungen
-				</a>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
> **Baut auf #700 auf** (`base` ist dessen Branch). Nach dessen Merge stelle ich die Basis auf `main` um.

Letzter Schritt des About-Umbaus: Struktur und Formulierungen.

## Der Betreiber stand an vierter Stelle — ohne Überschrift

Er war der **einzige Abschnitt der Seite ganz ohne `<h2>`** und stand hinter Mission und Plattform. „Wer betreibt das?" ist aber die Frage, die eine Über-uns-Seite zuerst beantworten muss. Jetzt direkt unter dem Hero, mit eigener Überschrift.

Die `h2` trägt `text-primary-content` — sie sitzt auf der Vollton-Fläche `bg-primary`, also genau dem Fall, für den die `*-content`-Regel aus `design-system.md` gedacht ist (kein Tint).

## Superlative und vage Angaben

| vorher | nachher |
| --- | --- |
| „einem der führenden Zentren für Meeresforschung und -bildung in Deutschland" | entfallen — unbelegt |
| „Seit über 70 Jahren widmen wir uns …" | „… erforscht die Ostsee und ihre Lebensräume **seit 1951**" |
| „Modernste Technologie für einfache Bedienung und maximale wissenschaftliche Relevanz" | „Einfach zu bedienen und auf wissenschaftlich brauchbare Daten ausgelegt" |

„Seit über 70 Jahren" war nicht falsch, aber vage — und es altert mit jedem Jahr. 1951 ist eine Jahreszahl, die stehen bleibt.

## Hero-Dopplung

Das Logo zeigt seine Wortmarke nicht mehr (`showText={false}`). Direkt darunter steht „Über Ostsee-Tiere" — der Name wurde zweimal hintereinander gelesen, einmal als Grafik und einmal als Überschrift.

## Zwei neue Tests

- **Der Betreiber ist die erste `h2`.** Geprüft über die DOM-Position, nicht über Pixel — das ist unabhängig vom Layout. War vor der Änderung rot.
- **Die Überschriften-Ebenen überspringen keine Stufe** (WCAG 1.3.1). Auf dieser Seite keine Formalie: Beim Kürzen fallen ganze Abschnitte weg, und eine `h4`, deren umgebende `h3` mitverschwindet, hängt danach ohne Zwischenebene unter einer `h2`. Genau der Fehler, den man beim Löschen nicht sieht. Der Test ist schon grün — er hält den in #700 erreichten Zustand fest.

## Endstand der Seite

```
H1  Über Ostsee-Tiere
H2  Betrieben vom Deutschen Meeresmuseum
H2  Unsere Mission          → H3 Citizen Science
H2  Unsere Plattform        → H3 Einfaches Melden / Interaktive Karte / Offene Daten
H2  Datenschutz & Sicherheit
H2  Technik
H2  Werden Sie Teil der Bewegung
```

| gemessen @500px | Ausgangslage | jetzt |
| --- | ---: | ---: |
| Höhe | 8.397px (11 Bildschirme) | **5.501px (7,3)** |
| Wörter | 737 | **422** |
| Karten | 8 | **5** |
| Badges | 14 | **4** |

## Verifikation

- `playwright test about-page + design-tokens` — 78 passed
- `npm run test:quick` — 219 Dateien, 3155 Tests passed
- Ergebnis im Browser bei 500px nachgemessen

> **Hinweis zum lokalen Testlauf:** Die Ports 4000/4001 waren zeitweise von parallelen Worktree-Sessions belegt, wodurch Playwright per `reuseExistingServer` fremden Code getestet hat. Die Läufe oben liefen gegen einen verifiziert eigenen Dev-Server (`lsof -a -p <pid> -d cwd` gegengeprüft). Für die Ursache gibt es eine eigene Aufgabe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)