### PR TITLE
test(db): doppelte Legacy-Filter-Zusicherung auf eine Stelle reduzieren

### DIFF
--- a/src/lib/server/db/approvalFilter.ts
+++ b/src/lib/server/db/approvalFilter.ts
@@ -38,8 +38,8 @@ export type ResolvedSightingScope = Exclude<SightingScope, 'both'>;
  * Auch `/sichtungen/showreports.json` (Legacy-Karte) filtert hierüber, damit
  * Karte und Statistik dieselbe Menge zählen. Dieser Endpunkt ist an den
  * Legacy-Vertrag gebunden: Änderungen an diesem Prädikat ändern seine Response.
- * `statisticsApprovalScope.test.ts` pinnt es deshalb gegen den Ausdruck, der
- * dort ursprünglich wörtlich stand.
+ * `showreports.test.ts` pinnt es deshalb gegen den Ausdruck, der dort
+ * ursprünglich wörtlich stand.
  */
 export const approvedOnly = (): SQL => isNotNull(sightings.approvedAt);
 

--- a/src/lib/server/db/approvalFilter.ts
+++ b/src/lib/server/db/approvalFilter.ts
@@ -38,8 +38,8 @@ export type ResolvedSightingScope = Exclude<SightingScope, 'both'>;
  * Auch `/sichtungen/showreports.json` (Legacy-Karte) filtert hierüber, damit
  * Karte und Statistik dieselbe Menge zählen. Dieser Endpunkt ist an den
  * Legacy-Vertrag gebunden: Änderungen an diesem Prädikat ändern seine Response.
- * `showreports.test.ts` pinnt es deshalb gegen den Ausdruck, der dort
- * ursprünglich wörtlich stand.
+ * `src/routes/sichtungen/showreports.json/showreports.test.ts` pinnt es
+ * deshalb gegen den Ausdruck, der dort ursprünglich wörtlich stand.
  */
 export const approvedOnly = (): SQL => isNotNull(sightings.approvedAt);
 

--- a/src/lib/server/db/statisticsApprovalScope.test.ts
+++ b/src/lib/server/db/statisticsApprovalScope.test.ts
@@ -21,10 +21,9 @@
  */
 
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { sql, type SQL } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { approvedOnly, pendingOnly } from './approvalFilter';
-import { sightings } from './schema';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQL): string => dialect.sqlToQuery(condition).sql;
@@ -113,24 +112,12 @@ describe('Freigabestatus in Sichtungs-Statistiken', () => {
 	});
 
 	describe('Grundmenge der öffentlichen Karte', () => {
-		/**
-		 * Der Filter, wie er bis zur Zentralisierung wörtlich in
-		 * `/sichtungen/showreports.json` stand.
-		 *
-		 * Der Legacy-Endpunkt importiert inzwischen selbst `approvedOnly()` — die
-		 * Grundmenge liegt damit nur noch an einer Stelle. Der Vergleich bleibt
-		 * trotzdem stehen: Er hält fest, dass der Helper dasselbe Prädikat erzeugt
-		 * wie der Ausdruck, an den der Legacy-Vertrag gebunden ist, und schlägt an,
-		 * falls jemand `approvedOnly()` inhaltlich umbaut.
-		 */
-		const legacyKartenFilter = sql`${sightings.approvedAt} IS NOT NULL`;
-
-		it('ist identisch mit dem historischen Filter des Legacy-Kartenendpunkts', () => {
-			const normalisiert = (condition: SQL) => toSqlText(condition).toLowerCase().trim();
-
-			expect(normalisiert(approvedOnly())).toBe(normalisiert(legacyKartenFilter));
-		});
-
+		// Dass `approvedOnly()` dasselbe Prädikat erzeugt wie der Ausdruck, der bis
+		// zur Zentralisierung wörtlich im Legacy-Endpunkt stand, prüft
+		// `src/routes/sichtungen/showreports.json/showreports.test.ts`
+		// („erzeugt dieselbe SQL wie der frühere Inline-Filter"). Diese Zusicherung
+		// stand hier zweimal; sie gehört an den Legacy-Vertrag, der an das Prädikat
+		// gebunden ist, und prüft dort zusätzlich die leere Parameterliste.
 		it('bezieht sich auf die Spalte freigegeben_am', () => {
 			expect(toSqlText(approvedOnly())).toContain('freigegeben_am');
 			expect(toSqlText(pendingOnly())).toContain('freigegeben_am');


### PR DESCRIPTION
## Problem

Nach #701 deklarierten **zwei** Testdateien denselben historischen Inline-Ausdruck neu und verglichen ihn case-insensitiv mit `approvedOnly()`:

| Datei | Test |
| --- | --- |
| `statisticsApprovalScope.test.ts` | „ist identisch mit dem historischen Filter des Legacy-Kartenendpunkts" |
| `showreports.test.ts` | „erzeugt dieselbe SQL wie der frühere Inline-Filter" |

Ein inhaltlicher Umbau von `approvedOnly()` ließ beide fehlschlagen (doppeltes Rauschen), und die zwei mehrzeiligen Begründungstexte mussten synchron gepflegt werden — genau die Drift, gegen die die Zentralisierung des Prädikats antritt.

## Änderung

Die schwächere Fassung in `statisticsApprovalScope.test.ts` entfällt. Die verbleibende in `showreports.test.ts` ist eine **echte Obermenge**: Sie prüft zusätzlich die leere Parameterliste und sitzt neben dem Legacy-Vertrag, der an dieses Prädikat gebunden ist.

## Belegt, nicht angenommen

Vor dem Löschen habe ich `approvedOnly()` mutiert und **nur** `showreports.test.ts` laufen lassen:

| Mutation | Ergebnis |
| --- | --- |
| `isNull(sightings.approvedAt)` (Polarität) | ✗ rot — `"freigegeben_am" is null` vs. `is not null` |
| `isNotNull(sightings.verified)` (Spalte) | ✗ rot — `"geprueft" is not null` vs. `"freigegeben_am"` |

Strukturell: `historischerInlineFilter` referenziert `sightings.approvedAt` symbolisch und wird über den echten `PgDialect` kompiliert — Spalte **und** Polarität stehen damit auf beiden Seiten des Vergleichs. Die gelöschte Fassung tat exakt dasselbe, nur ohne die `params`-Prüfung.

Nach dem Umbau fallen beide Mutationen weiterhin auf (3 bzw. 4 rote Tests über beide Dateien) — die Statistik-Datei fängt Polaritätsfehler zusätzlich über den zählenden Mock (`countForWhere` → `APPROVED_COUNT` statt `PENDING_COUNT`).

## Folgeänderungen

- `approvalFilter.ts`: Der Doc-Kommentar nannte `statisticsApprovalScope.test.ts` als Pin und wäre falsch geworden — zeigt jetzt auf `showreports.test.ts`.
- **`.claude/rules/database.md` bleibt unverändert.** Der Verweis in Zeile 240 sichert den Satz darüber ab („Wer eine neue Statistikabfrage ergänzt, muss den Status explizit setzen"). Das trägt weiterhin `EXPECTED_FILTERED_QUERIES = 7` in derselben Datei; die Regel nennt den Legacy-Pin an keiner Stelle.
- `docs/archive/FAKTENCHECK_FORMULARTEXTE_2026-07-27.md` erwähnt den Pin zweimal, ist aber ein datierter Archiv-Schnappschuss und dort schon in der größeren Aussage überholt (beschreibt den Endpunkt noch mit Inline-Filter, den #701 abgelöst hat). Bewusst nicht angefasst.

## Restlücke (keine Regression)

Bei einem Rename der DB-Spalte in `schema.ts` wandern beide Vergleichsseiten mit — das fängt keiner der beiden Tests, sondern der CI-Job `migration-check`. Galt für die gelöschte Fassung gleichermaßen.

## Test-First

Test-only-Refactor ohne Verhaltensänderung. Kein neuer Test: Die entfernte Zusicherung ist redundant, und die Mutationsläufe oben sind der Beleg, dass die Abdeckung unverändert ist.

## Verifikation

- `npm run test:quick` — 219 Dateien, 3157 Tests grün
- `npm run type-check` — fehlerfrei
- ESLint auf den geänderten Dateien — sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)