### PR TITLE
refactor(api): JS-seitige Freigabeprüfung über einen gemeinsamen Helper

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -239,6 +239,14 @@ kennt die Spalte nicht — dort ist ein Join auf `sichtungen` nötig. Der Epoch-
 (`EARLIEST_PLAUSIBLE_SIGHTING_DATE`) gilt zusätzlich, nicht statt dessen.
 Abgesichert durch `src/lib/server/db/statisticsApprovalScope.test.ts`.
 
+Wird der Status nicht in SQL, sondern über einer **bereits geladenen Zeile** ausgewertet,
+gilt `isSightingApproved(sighting)` aus demselben Modul — nicht ein neues `!!row.approvedAt`.
+Die beiden Medien-Endpunkte (`/uploads/[...path]`, `/api/media/[...path]`) entscheiden damit,
+ob eine Datei ohne Anmeldung ausgeliefert wird, `PATCH /api/sightings/[id]/verify` hält damit
+den Vorzustand im Audit-Log fest. `approvalFilter.test.ts` prüft beides: dass beide
+Schreibweisen dieselbe Grundmenge meinen, und dass die drei Routen keine der bekannten
+Inline-Schreibweisen zurückbekommen.
+
 ---
 
 ## PostGIS Patterns

--- a/src/lib/server/db/approvalFilter.test.ts
+++ b/src/lib/server/db/approvalFilter.test.ts
@@ -1,0 +1,158 @@
+/**
+ * @fileoverview Die Freigabe-Invariante in ihrer JavaScript-Schreibweise
+ *
+ * `approvedOnly()` beantwortet „ist diese Sichtung freigegeben?" in SQL. Drei
+ * Endpunkte beantworten dieselbe Frage aber **nach** dem Laden in JavaScript,
+ * weil sie die Zeile ohnehin schon geladen haben:
+ *
+ * - `GET /uploads/[...path]`
+ * - `GET /api/media/[...path]`
+ * - `PATCH /api/sightings/[id]/verify` (Vorzustand im Audit-Log)
+ *
+ * Jeder trug dafür seine eigene Inline-Prüfung (`!!…approvedAt`). Damit stand
+ * dieselbe Regel in zwei Sprachen an vier Stellen — und die beiden
+ * Medien-Endpunkte sind diejenigen, die Dateien **ohne Anmeldung** ausliefern.
+ * Eine versehentlich gelockerte Prüfung gäbe dort nicht freigegebene Fotos
+ * öffentlich frei.
+ *
+ * Diese Tests fixieren zwei Dinge:
+ * 1. `isSightingApproved()` liefert für **jeden** möglichen Wert von
+ *    `approvedAt` dasselbe wie das abgelöste `!!approvedAt` — der Umbau ist
+ *    damit belegt verhaltensgleich, nicht bloß behauptet.
+ * 2. Alle drei Endpunkte beziehen die Regel aus dem gemeinsamen Helper und
+ *    tragen keine der bekannten Inline-Schreibweisen mehr.
+ */
+
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { approvedOnly, isSightingApproved } from './approvalFilter';
+
+const dialect = new PgDialect();
+
+/**
+ * Jeder Wert, den `approvedAt` annehmen kann.
+ *
+ * Der Typ ist `Date | null` (Drizzle `timestamp(..., { mode: 'date' })`);
+ * `undefined` kommt hinzu, sobald eine Projektion die Spalte nicht auswählt.
+ * `new Date(0)` und das ungültige Datum stehen hier, weil sie die naheliegende
+ * Falle sind: Wer einen Zeitstempel als Zahl denkt, erwartet bei der Epoche
+ * `false` — ein `Date`-Objekt ist aber immer truthy, und genau das tat die
+ * abgelöste Inline-Prüfung auch.
+ */
+const moeglicheWerte: Array<{ label: string; value: Date | null | undefined }> = [
+	{ label: 'Freigabezeitpunkt', value: new Date('2026-01-01T00:00:00Z') },
+	{ label: 'Unix-Epoche (0 ms)', value: new Date(0) },
+	{ label: 'ungültiges Datum', value: new Date('kein Datum') },
+	{ label: 'null (nicht freigegeben)', value: null },
+	{ label: 'undefined (Spalte nicht selektiert)', value: undefined }
+];
+
+describe('isSightingApproved — Freigabeprüfung in JavaScript', () => {
+	describe('Verhaltensgleichheit mit der abgelösten Inline-Prüfung', () => {
+		for (const { label, value } of moeglicheWerte) {
+			it(`liefert für ${label} dasselbe wie !!approvedAt`, () => {
+				expect(isSightingApproved({ approvedAt: value })).toBe(!!value);
+			});
+		}
+	});
+
+	describe('Grundmenge', () => {
+		it('wertet dieselbe Regel aus wie approvedOnly() in SQL', () => {
+			// Der SQL-Zweig prüft `freigegeben_am IS NOT NULL`. Wenn der
+			// JS-Zweig etwas anderes prüfte, lieferten Karte und Medienabruf
+			// unterschiedliche Grundmengen.
+			expect(dialect.sqlToQuery(approvedOnly()).sql.toLowerCase()).toContain(
+				'"freigegeben_am" is not null'
+			);
+			expect(isSightingApproved({ approvedAt: new Date() })).toBe(true);
+			expect(isSightingApproved({ approvedAt: null })).toBe(false);
+		});
+
+		it('verweigert die Freigabe bei einem Wert außerhalb des Typs', () => {
+			// Das Argument für die Truthy-Prüfung statt `!= null` (siehe JSDoc am
+			// Helper) trägt nur außerhalb des deklarierten Typs — innerhalb sind
+			// beide Schreibweisen identisch, wie die Tabelle oben zeigt. Käme über
+			// einen ungetypten Pfad ein Leerstring oder eine 0 an, gewährte
+			// `!= null` den Zugriff. Hier wird die verweigernde Richtung gepinnt.
+			const typfremd = ['', 0] as unknown as Date[];
+			for (const wert of typfremd) {
+				expect(isSightingApproved({ approvedAt: wert }), String(wert)).toBe(false);
+			}
+		});
+	});
+});
+
+/**
+ * Die Endpunkte, die den Freigabestatus in JavaScript auswerten.
+ *
+ * Gelesen wird der Quelltext, nicht das Modul: Die Routen ziehen beim Import
+ * Datenbank-, Storage- und Rate-Limit-Module nach, die hier alle gemockt werden
+ * müssten — der Test prüft aber nur, welche Schreibweise der Regel im Quelltext
+ * steht. Was die Routen zur Laufzeit tun, decken ihre eigenen Tests ab
+ * (`uploads.test.ts`, `uploadsCache.test.ts`, `mediaCacheControl.test.ts`,
+ * `verify.test.ts`, `verify.contract.test.ts`).
+ */
+const jsAuswertendeRouten = [
+	{
+		name: 'GET /uploads/[...path]',
+		path: '../../../routes/uploads/[...path]/+server.ts'
+	},
+	{
+		name: 'GET /api/media/[...path]',
+		path: '../../../routes/api/media/[...path]/+server.ts'
+	},
+	{
+		name: 'PATCH /api/sightings/[id]/verify',
+		path: '../../../routes/api/sightings/[id]/verify/+server.ts'
+	}
+];
+
+/**
+ * Bekannte Schreibweisen einer eigenen Freigabeprüfung.
+ *
+ * Bewusst eine Aufzählung konkreter Muster und **kein** Beweis: Ein
+ * `if (row.approvedAt)` ohne weitere Operatoren ließe sich von einer legitimen
+ * Verwendung des Werts (z. B. `approvedAt ?? null` in der GET-Antwort desselben
+ * Endpunkts) nicht unterscheiden, ohne den Quelltext zu parsen. Der Guard fängt
+ * die Formen, die beim Zurückbauen tatsächlich entstehen — mehr behauptet er
+ * nicht.
+ */
+const eigeneFreigabepruefungen = [
+	{ form: '!!row.approvedAt', muster: /!![^;\n]*approvedAt/ },
+	{ form: 'Boolean(row.approvedAt)', muster: /Boolean\([^)]*approvedAt/ },
+	{ form: 'row.approvedAt !== null / != null', muster: /approvedAt\s*[!=]==?\s*null/ }
+];
+
+/** Liest die Route und meldet einen verschobenen Pfad als solchen. */
+function leseRoutenQuelle(name: string, path: string): string {
+	const absolut = fileURLToPath(new URL(path, import.meta.url));
+	try {
+		return readFileSync(absolut, 'utf-8');
+	} catch {
+		throw new Error(
+			`Quelltext von ${name} nicht lesbar (${absolut}). Wurde die Route verschoben? ` +
+				'Dann den Pfad in jsAuswertendeRouten mitziehen — nicht den Eintrag entfernen.'
+		);
+	}
+}
+
+describe('Endpunkte mit JavaScript-seitiger Freigabeprüfung', () => {
+	for (const { name, path } of jsAuswertendeRouten) {
+		describe(name, () => {
+			const source = leseRoutenQuelle(name, path);
+
+			it('bezieht die Regel aus approvalFilter', () => {
+				expect(source).toContain('isSightingApproved');
+				expect(source).toMatch(/from '\$lib\/server\/db\/approvalFilter'/);
+			});
+
+			for (const { form, muster } of eigeneFreigabepruefungen) {
+				it(`prüft den Freigabestatus nicht per ${form}`, () => {
+					expect(source).not.toMatch(muster);
+				});
+			}
+		});
+	}
+});

--- a/src/lib/server/db/approvalFilter.ts
+++ b/src/lib/server/db/approvalFilter.ts
@@ -11,9 +11,10 @@
  * Aufrufer, der den Freigabestatus ignoriert, fällt beim Review auf, weil er
  * diesen Import nicht hat.
  *
- * Dieselbe Regel wird an zwei Stellen nicht in SQL, sondern in JavaScript über
+ * Dieselbe Regel wird an drei Stellen nicht in SQL, sondern in JavaScript über
  * einer bereits geladenen Zeile ausgewertet (`/uploads/[...path]`,
- * `/api/media/[...path]`). Dafür steht `isSightingApproved()` weiter unten —
+ * `/api/media/[...path]`, `PATCH /api/sightings/[id]/verify`). Dafür steht
+ * `isSightingApproved()` weiter unten —
  * bewusst in **dieser** Datei und nicht in einer eigenen: Eine Regel, die je
  * nach Auswertungsort in zwei Dateien steht, ist genau der Zustand, den dieses
  * Modul beseitigen soll. Wer eine der beiden Formen ändert, sieht die andere.
@@ -71,8 +72,11 @@ export type SightingApprovalState = { approvedAt: Date | null | undefined };
  *
  * Genutzt von `/uploads/[...path]` und `/api/media/[...path]`: Beide haben die
  * Sichtung wegen des Joins ohnehin in der Hand und entscheiden anhand dieses
- * Werts, ob eine Datei **ohne Anmeldung** ausgeliefert wird. Vorher trug jede
- * Route dafür ein eigenes `!!file.approvedAt`.
+ * Werts, ob eine Datei **ohne Anmeldung** ausgeliefert wird — das sind die
+ * Aufrufer, bei denen ein Fehlurteil weh tut. `PATCH /api/sightings/[id]/verify`
+ * hält damit zusätzlich den Vorzustand im Audit-Log fest; dort entscheidet der
+ * Wert über keinen Zugriff. Vorher trug jede der drei Routen ihre eigene
+ * Inline-Prüfung.
  *
  * Bewusst die Truthy-Prüfung und nicht `!= null`: Für den deklarierten Typ sind
  * beide identisch (ein `Date` ist immer truthy, auch `new Date(0)`), aber bei

--- a/src/lib/server/db/approvalFilter.ts
+++ b/src/lib/server/db/approvalFilter.ts
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Freigabestatus (`freigegeben_am`) als expliziter Abfragefilter
+ * @fileoverview Freigabestatus (`freigegeben_am`) als explizite Prüfung
  *
  * Die öffentliche Karte (`/sichtungen/showreports.json`) zeigt ausschließlich
  * freigegebene Sichtungen. Die öffentlichen Statistiken zählten dagegen lange
@@ -10,6 +10,13 @@
  * **einmal** definiert und von allen öffentlichen Abfragen importiert. Ein
  * Aufrufer, der den Freigabestatus ignoriert, fällt beim Review auf, weil er
  * diesen Import nicht hat.
+ *
+ * Dieselbe Regel wird an zwei Stellen nicht in SQL, sondern in JavaScript über
+ * einer bereits geladenen Zeile ausgewertet (`/uploads/[...path]`,
+ * `/api/media/[...path]`). Dafür steht `isSightingApproved()` weiter unten —
+ * bewusst in **dieser** Datei und nicht in einer eigenen: Eine Regel, die je
+ * nach Auswertungsort in zwei Dateien steht, ist genau der Zustand, den dieses
+ * Modul beseitigen soll. Wer eine der beiden Formen ändert, sieht die andere.
  *
  * Vorgabe des Deutschen Meeresmuseums (2026-07-27):
  * 1. Im öffentlichen Bereich zählen nur freigegebene Sichtungen.
@@ -49,3 +56,31 @@ export const pendingOnly = (): SQL => isNull(sightings.approvedAt);
 /** Liefert den Filter zum jeweiligen Status. */
 export const approvalFilter = (scope: ResolvedSightingScope): SQL =>
 	scope === 'approved' ? approvedOnly() : pendingOnly();
+
+/**
+ * Der Teil einer geladenen Sichtung, der über ihren Freigabestatus entscheidet.
+ *
+ * `undefined` steht mit im Typ, damit eine Projektion, die `approvedAt` gar
+ * nicht auswählt, nicht als freigegeben durchgeht.
+ */
+export type SightingApprovalState = { approvedAt: Date | null | undefined };
+
+/**
+ * `approvedOnly()` für eine bereits geladene Zeile — dieselbe Grundmenge,
+ * ausgewertet in JavaScript statt in SQL.
+ *
+ * Genutzt von `/uploads/[...path]` und `/api/media/[...path]`: Beide haben die
+ * Sichtung wegen des Joins ohnehin in der Hand und entscheiden anhand dieses
+ * Werts, ob eine Datei **ohne Anmeldung** ausgeliefert wird. Vorher trug jede
+ * Route dafür ein eigenes `!!file.approvedAt`.
+ *
+ * Bewusst die Truthy-Prüfung und nicht `!= null`: Für den deklarierten Typ sind
+ * beide identisch (ein `Date` ist immer truthy, auch `new Date(0)`), aber bei
+ * einem Wert außerhalb des Typs verweigert die Truthy-Prüfung den Zugriff,
+ * während `!= null` ihn gewährte. In einem Endpunkt, dessen Fehlurteil nicht
+ * freigegebene Fotos öffentlich macht, ist die verweigernde Richtung die
+ * richtige. Die Gleichheit mit der abgelösten Schreibweise ist über alle
+ * möglichen Werte in `approvalFilter.test.ts` festgehalten.
+ */
+export const isSightingApproved = (sighting: SightingApprovalState): boolean =>
+	!!sighting.approvedAt;

--- a/src/routes/api/media/[...path]/+server.ts
+++ b/src/routes/api/media/[...path]/+server.ts
@@ -2,6 +2,7 @@ import { createLogger } from '$lib/logger.server';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { isAdminUser } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
+import { isSightingApproved } from '$lib/server/db/approvalFilter';
 import { sightingFiles, sightings } from '$lib/server/db/schema';
 import { getStorageProvider } from '$lib/server/storage/factory';
 import { isRangeHeaderSyntaxValid, parseRangeHeader } from '$lib/server/media/rangeHeader';
@@ -126,7 +127,7 @@ export const GET: RequestHandler = async ({ params, url, request, locals, getCli
 			throw error(404, 'File not found');
 		}
 
-		const isApproved = !!file.approvedAt; // File is approved if approvedAt is not null
+		const isApproved = isSightingApproved(file);
 
 		// Check permissions
 		if (!isApproved) {

--- a/src/routes/api/sightings/[id]/verify/+server.ts
+++ b/src/routes/api/sightings/[id]/verify/+server.ts
@@ -3,6 +3,7 @@ import { logAuditEvent } from '$lib/server/audit/auditService';
 import { requireUserRole } from '$lib/server/auth/auth';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { db } from '$lib/server/db';
+import { isSightingApproved } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
 import type { RequestHandler } from '@sveltejs/kit';
 import { error, isHttpError, json } from '@sveltejs/kit';
@@ -55,7 +56,8 @@ export const PATCH: RequestHandler = async ({ params, request, locals, url, getC
 			.where(eq(sightings.id, Number(id)))
 			.limit(1);
 
-		if (existingSighting.length === 0) {
+		const existing = existingSighting[0];
+		if (!existing) {
 			logger.warn({ id }, 'Sichtung zum Prüfen nicht gefunden');
 			throw error(404, 'Sichtung nicht gefunden');
 		}
@@ -83,15 +85,15 @@ export const PATCH: RequestHandler = async ({ params, request, locals, url, getC
 			details: {
 				verified,
 				approved,
-				previousVerified: existingSighting[0]?.verified,
-				previouslyApproved: !!existingSighting[0]?.approvedAt
+				previousVerified: existing.verified,
+				previouslyApproved: isSightingApproved(existing)
 			}
 		});
 
 		logger.info(
 			{
 				id,
-				previousStatus: existingSighting[0]?.verified,
+				previousStatus: existing.verified,
 				newStatus: verified,
 				approvedAt,
 				verifiedBy: locals.user?.email

--- a/src/routes/uploads/[...path]/+server.ts
+++ b/src/routes/uploads/[...path]/+server.ts
@@ -5,6 +5,7 @@ import { createReadStream } from 'fs';
 import { getStorageProvider, isCloudStorage } from '$lib/server/storage/factory';
 import { isAdminUser } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
+import { isSightingApproved } from '$lib/server/db/approvalFilter';
 import { sightingFiles, sightings } from '$lib/server/db/schema';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import {
@@ -46,7 +47,7 @@ async function assertFileAccessAllowed(
 		throw error(404, 'Datei nicht gefunden');
 	}
 
-	const isApproved = !!file.approvedAt;
+	const isApproved = isSightingApproved(file);
 	if (!isApproved) {
 		const user = locals.user;
 		if (!isAdminUser(user)) {

--- a/src/tests/contract/verify.contract.test.ts
+++ b/src/tests/contract/verify.contract.test.ts
@@ -232,6 +232,32 @@ describe('Contract: PATCH /api/sightings/{id}/verify', () => {
 		);
 	});
 
+	it('protokolliert eine noch nicht freigegebene Sichtung als previouslyApproved=false', async () => {
+		// Gegenstück zum Test darüber: Der Vorzustand muss auch dann korrekt im
+		// Audit-Log stehen, wenn `freigegeben_am` NULL ist. Dieser Zweig war vor
+		// der Zentralisierung der Freigabeprüfung nicht abgedeckt.
+		const { logAuditEvent } = vi.mocked(await import('$lib/server/audit/auditService'));
+		mockSelectLimit.mockResolvedValueOnce([{ id: 1, verified: 0, approvedAt: null }]);
+		const event = createEvent('/api/sightings/1/verify', {
+			method: 'PATCH',
+			params: { id: '1' },
+			locals: { user: mockAdminUser },
+			body: { verified: 1 }
+		});
+
+		await verifyPATCH(event);
+
+		expect(logAuditEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: 'sighting.verify',
+				details: expect.objectContaining({
+					previousVerified: 0,
+					previouslyApproved: false
+				})
+			})
+		);
+	});
+
 	it('throws 400 for invalid verified value', async () => {
 		const event = createEvent('/api/sightings/1/verify', {
 			method: 'PATCH',


### PR DESCRIPTION
## Warum

Die öffentliche Grundmenge ist projektweit `freigegeben_am IS NOT NULL`. In SQL kommt das Prädikat seit #701 überall aus `approvedOnly()` in `src/lib/server/db/approvalFilter.ts`. Drei Endpunkte beantworten dieselbe Frage aber **nach** dem Laden in JavaScript, weil sie die Zeile wegen des Joins ohnehin in der Hand haben — jeder mit seiner eigenen Inline-Prüfung:

| Endpunkt | vorher | wofür |
| --- | --- | --- |
| `GET /uploads/[...path]` | `!!file.approvedAt` | liefert Medien **ohne Anmeldung** aus |
| `GET /api/media/[...path]` | `!!file.approvedAt` | liefert Medien **ohne Anmeldung** aus |
| `PATCH /api/sightings/[id]/verify` | `!!existingSighting[0]?.approvedAt` | Vorzustand im Audit-Log |

Damit stand dieselbe Regel in zwei Sprachen an vier Stellen. Die beiden Medien-Endpunkte sind dabei die heiklen: Eine versehentlich gelockerte Prüfung gäbe nicht freigegebene Fotos öffentlich frei.

## Wo der Helper liegt — und warum dort

`isSightingApproved()` steht **in `approvalFilter.ts`**, direkt neben `approvedOnly()`, nicht in einer eigenen Datei. Eine Regel, die je nach Auswertungsort (SQL oder JS) in zwei Dateien steht, ist genau der Zustand, den dieses Modul beseitigen soll. So sieht jeder, der eine der beiden Formen anfasst, die andere.

## Kein Verhaltenswechsel

Die Implementierung behält bewusst die Truthy-Prüfung und wird **nicht** `!= null`:

- Innerhalb des deklarierten Typs (`Date | null`) sind beide identisch — ein `Date` ist immer truthy, auch `new Date(0)` und ein ungültiges Datum.
- Außerhalb des Typs (Leerstring, `0` über einen ungetypten Pfad) verweigert die Truthy-Prüfung den Zugriff, während `!= null` ihn gewährte.

Bei einem Endpunkt, dessen Fehlurteil nicht freigegebene Fotos veröffentlicht, ist die verweigernde Richtung die richtige. Die Gleichheit mit der abgelösten Schreibweise ist über **alle** möglichen Werte von `approvedAt` gepinnt (`Date`, `new Date(0)`, ungültiges Datum, `null`, `undefined`) — belegt, nicht angenommen.

An den Aufrufern bleibt die lokale Variable `isApproved`; der Diff beschränkt sich auf die rechte Seite der Zuweisung, sodass alle nachgelagerten Verzweigungen, Cache-Control-Entscheidungen und Log-Feldnamen unverändert bleiben.

### Eine Ausnahme, die Erwähnung verdient

`verify/+server.ts` bekommt zusätzlich das Muster der beiden Medien-Routen: `const existing = existingSighting[0]; if (!existing) → 404`. Nur so bekommt der Helper eine Zeile statt eines Optional-Chaining-Ausdrucks. Die drei folgenden `existingSighting[0]?.…` werden dadurch zu `existing.…` — gleiche Werte, gleiche Audit- und Log-Felder. Der neue Guard ist eine Obermenge des alten `length === 0` (er fängt zusätzlich ein `undefined`-Element ab, das Drizzle nicht liefert).

`GET` in derselben Datei bleibt unberührt: `approvedAt: sighting[0]?.approvedAt ?? null` gibt den Zeitstempel zurück, das ist keine Freigabeprüfung.

## Test-First

Neu: `src/lib/server/db/approvalFilter.test.ts`. Zuerst geschrieben, **12/12 rot**, dann grün; beim Nachziehen von `verify` erneut 2 rot → grün.

1. **Verhaltensgleichheit** über die Wertetabelle: `isSightingApproved({approvedAt}) === !!approvedAt` für jeden möglichen Wert.
2. **Übereinstimmung mit SQL**: `approvedOnly()` kompiliert durch den echten `PgDialect` zu `"freigegeben_am" is not null`; der JS-Zweig meint dieselbe Grundmenge.
3. **Verweigernde Richtung** für typfremde Werte — das Argument aus dem JSDoc wird belegt statt behauptet.
4. **Quelltext-Guard je Route** gegen die bekannten Rückbau-Schreibweisen: `!!x.approvedAt` (auch mit Index und Optional Chaining), `Boolean(x.approvedAt)`, `x.approvedAt !== null` / `!= null`. Bewusst eine Aufzählung konkreter Muster und kein Beweis: Ein blankes `if (row.approvedAt)` ließe sich ohne Parser nicht von legitimer Verwendung des Werts unterscheiden — der Test behauptet nicht mehr, als er hält. Verifiziert, dass er alle fünf Rückbau-Formen fängt und bei keiner der legitimen Verwendungen (`approvedAt: sightings.approvedAt`, `approvedAt ?? null`, …) anschlägt.

Ergänzt: `verify.contract.test.ts` hatte nur `previouslyApproved: true`. Der `null`-Zweig ist jetzt ebenfalls gepinnt. Ehrlichkeitshalber — dieser Test war von Anfang an grün; er treibt die Änderung nicht, er sichert den vorher ungedeckten Zweig gegen den Umbau ab.

Bestehende Abdeckung beider Medien-Routen vorher gelesen und unverändert grün: `uploads.test.ts`, `uploadsCache.test.ts`, `mediaCacheControl.test.ts`, `mediaRange*`, `mediaByteBudget`.

## Verifikation

`npm run test:quick`: lint, type-check, svelte-check grün; **3176 / 3178** Unit-Tests grün. Die zwei Fehlschläge sind ausschließlich `legacy-inbox/app.test.js` (Spawn-Timeout, bekannt flaky, hängt nicht an `src/`) — isoliert nachgelaufen: 4/4 grün.

Keine API-Vertragsänderung, daher keine Anpassung an `static/openapi.yml`. `.claude/rules/database.md` nennt jetzt die JS-Variante der Regel.

## Nicht Teil dieses PRs

Das bekannte Thema, dass die Medien-Endpunkte freigegebene Dateien ohne Anmeldung und ohne EXIF-Stripping ausliefern, bleibt unverändert bestehen. Hier ging es ausschließlich um die Vereinheitlichung der Freigabeprüfung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
