### PR TITLE
test(test): name the missing export when a contract-test mock is incomplete

### DIFF
--- a/src/tests/contract/export.contract.test.ts
+++ b/src/tests/contract/export.contract.test.ts
@@ -24,24 +24,30 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {
-		id: 'id',
-		sightingDate: 'sightingDate',
-		verified: 'verified',
-		entryChannel: 'entryChannel',
-		mediaUpload: 'mediaUpload'
-	}
-}));
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		sightings: {
+			id: 'id',
+			sightingDate: 'sightingDate',
+			verified: 'verified',
+			entryChannel: 'entryChannel',
+			mediaUpload: 'mediaUpload'
+		}
+	});
+});
 
-vi.mock('drizzle-orm', () => ({
-	and: vi.fn((...args) => args),
-	between: vi.fn((a, b, c) => ({ a, b, c })),
-	gte: vi.fn((a, b) => ({ a, b })),
-	lt: vi.fn((a, b) => ({ a, b })),
-	eq: vi.fn((a, b) => ({ a, b })),
-	isNotNull: vi.fn((a) => ({ a }))
-}));
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		and: vi.fn((...args) => args),
+		between: vi.fn((a, b, c) => ({ a, b, c })),
+		gte: vi.fn((a, b) => ({ a, b })),
+		lt: vi.fn((a, b) => ({ a, b })),
+		eq: vi.fn((a, b) => ({ a, b })),
+		isNotNull: vi.fn((a) => ({ a }))
+	});
+});
 
 vi.mock('$lib/server/auth/auth', () => ({
 	requireUserRole: vi.fn()

--- a/src/tests/contract/files.contract.test.ts
+++ b/src/tests/contract/files.contract.test.ts
@@ -26,12 +26,23 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightingFiles: {
-		id: 'id',
-		sightingId: 'sightingId',
-		filePath: 'filePath'
-	}
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		sightingFiles: {
+			id: 'id',
+			sightingId: 'sightingId',
+			filePath: 'filePath'
+		}
+	});
+});
+
+// Die Route schreibt einen Audit-Eintrag. Ohne diese Attrappe liefe der echte
+// `auditService` gegen die db-Attrappe, scheiterte still in seinem eigenen
+// catch und zöge `auditLogs` aus der Schema-Attrappe — dort fehlte es
+// unbemerkt, bis `strictModuleMock` es meldete.
+vi.mock('$lib/server/audit/auditService', () => ({
+	logAuditEvent: vi.fn().mockResolvedValue(undefined)
 }));
 
 vi.mock('$lib/server/db/sightingFilesRepository', () => ({
@@ -44,9 +55,12 @@ vi.mock('$lib/server/storage/factory', () => ({
 	})
 }));
 
-vi.mock('drizzle-orm', () => ({
-	eq: vi.fn((a, b) => ({ a, b }))
-}));
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		eq: vi.fn((a, b) => ({ a, b }))
+	});
+});
 
 vi.mock('$lib/logger.server', () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })

--- a/src/tests/contract/helpers/strictModuleMock.test.ts
+++ b/src/tests/contract/helpers/strictModuleMock.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	strictModuleMock,
+	drainMissingMockExports,
+	assertNoMissingMockExports
+} from './strictModuleMock';
+
+describe('strictModuleMock', () => {
+	// Jeder absichtlich provozierte Fehlgriff wird im Test selbst wieder
+	// abgeräumt — sonst lässt ihn der globale `afterEach` aus
+	// `vitest-setup-server.ts` zu Recht scheitern. `beforeEach` steht zusätzlich
+	// da, damit ein neuer Test nicht vom Vorgänger erbt.
+	beforeEach(() => {
+		drainMissingMockExports();
+	});
+
+	it('wirft bei einem fehlenden Export mit erklärender Meldung', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] });
+
+		expect(() => (mock as Record<string, unknown>).isNotNull).toThrowError(
+			/drizzle-orm-Attrappe in strictModuleMock\.test\.ts exportiert `isNotNull` nicht/
+		);
+
+		drainMissingMockExports();
+	});
+
+	it('nennt in der Meldung den mittelbaren Aufruf und die Abhilfe', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] });
+
+		let message = '';
+		try {
+			void (mock as Record<string, unknown>).isNotNull;
+		} catch (e) {
+			message = (e as Error).message;
+		}
+
+		expect(message).toContain('ggf. mittelbar');
+		expect(message).toContain('Ergänze den Helper in der Attrappe');
+
+		drainMissingMockExports();
+	});
+
+	it('reicht definierte Exporte unverändert durch', () => {
+		const and = () => ['ok'];
+		const mock = strictModuleMock('drizzle-orm', { and, zero: 0, nullish: null });
+
+		expect(mock.and).toBe(and);
+		expect(mock.zero).toBe(0);
+		expect(mock.nullish).toBeNull();
+		expect(Object.keys(mock)).toEqual(['and', 'zero', 'nullish']);
+	});
+
+	// Vitest/ESM tastet den Modul-Namespace auf diese Symbole ab — insbesondere
+	// `then` beim Auflösen von `await import(...)`. Würde der Trap dafür werfen,
+	// bräche schon der Import und keine Attrappe wäre mehr benutzbar.
+	it('lässt die ESM- und Promise-Sonden durch, ohne zu werfen', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] }) as Record<
+			string | symbol,
+			unknown
+		>;
+
+		for (const probe of ['then', 'catch', 'finally', 'default', '__esModule', 'toJSON']) {
+			expect(() => mock[probe]).not.toThrow();
+			expect(mock[probe]).toBeUndefined();
+		}
+	});
+
+	it('wirft nie bei Symbol-Keys', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] }) as Record<symbol, unknown>;
+
+		expect(() => mock[Symbol.toStringTag]).not.toThrow();
+		expect(() => mock[Symbol.iterator]).not.toThrow();
+		expect(() => mock[Symbol.asyncIterator]).not.toThrow();
+	});
+
+	// Der eigentliche Zweck: Routen fangen den Fehler in ihrem catch-Block und
+	// antworten mit 500 — die Meldung wäre sonst verloren (siehe PR #701).
+	it('merkt sich den fehlenden Export, damit ein verschluckter Wurf sichtbar bleibt', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] });
+
+		try {
+			void (mock as Record<string, unknown>).isNotNull;
+		} catch {
+			// wie in der Route: verschluckt
+		}
+
+		expect(() => assertNoMissingMockExports()).toThrowError(/`isNotNull` nicht/);
+	});
+
+	it('meldet nichts, wenn kein Export gefehlt hat', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] });
+		void mock.and;
+
+		expect(() => assertNoMissingMockExports()).not.toThrow();
+	});
+
+	it('leert den Speicher beim Prüfen, damit der Folgetest sauber startet', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] });
+		try {
+			void (mock as Record<string, unknown>).isNotNull;
+		} catch {
+			/* verschluckt */
+		}
+
+		expect(() => assertNoMissingMockExports()).toThrow();
+		expect(() => assertNoMissingMockExports()).not.toThrow();
+	});
+
+	it('meldet jeden fehlenden Export nur einmal pro Prüfung', () => {
+		const mock = strictModuleMock('drizzle-orm', { and: () => [] }) as Record<string, unknown>;
+		for (let i = 0; i < 3; i++) {
+			try {
+				void mock.isNotNull;
+			} catch {
+				/* verschluckt */
+			}
+		}
+
+		expect(drainMissingMockExports()).toHaveLength(1);
+	});
+});

--- a/src/tests/contract/helpers/strictModuleMock.test.ts
+++ b/src/tests/contract/helpers/strictModuleMock.test.ts
@@ -35,7 +35,28 @@ describe('strictModuleMock', () => {
 		}
 
 		expect(message).toContain('ggf. mittelbar');
-		expect(message).toContain('Ergänze den Helper in der Attrappe');
+		expect(message).toContain('Ergänze den Export in der Attrappe');
+
+		drainMissingMockExports();
+	});
+
+	// Die Attrappe deckt zwei Modularten ab: `drizzle-orm` exportiert Funktionen,
+	// `$lib/server/db/schema` Tabellen. Eine Tabelle wie `auditLogs` wird nicht
+	// „aufgerufen" — die Meldung muss für beides stimmen.
+	it('formuliert die Meldung neutral, also auch für Tabellen statt Funktionen', () => {
+		const mock = strictModuleMock('$lib/server/db/schema', { sightings: { id: 'id' } });
+
+		let message = '';
+		try {
+			void (mock as Record<string, unknown>).auditLogs;
+		} catch (e) {
+			message = (e as Error).message;
+		}
+
+		expect(message).toContain('$lib/server/db/schema-Attrappe');
+		expect(message).toContain('`auditLogs` nicht');
+		expect(message).not.toContain('ruft');
+		expect(message).not.toContain('Helper');
 
 		drainMissingMockExports();
 	});

--- a/src/tests/contract/helpers/strictModuleMock.ts
+++ b/src/tests/contract/helpers/strictModuleMock.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Modul-Attrappen, die einen fehlenden Export laut melden.
+ *
+ * Die Contract-Tests ersetzen `drizzle-orm` und `$lib/server/db/schema`
+ * **vollständig**. Ein Helper, den der getestete Code aufruft, hier aber fehlt,
+ * ist damit zur Laufzeit nicht vorhanden. Das passiert auch **mittelbar**: Seit
+ * `/sichtungen/showreports.json` sein Freigabe-Prädikat über `approvedOnly()`
+ * aus `$lib/server/db/approvalFilter` bezieht, hängt der Endpunkt an
+ * `isNotNull`, ohne es selbst zu importieren (PR #701).
+ *
+ * Vitest wirft in diesem Fall bereits von sich aus eine brauchbare Meldung
+ * (`[vitest] No "isNotNull" export is defined on the "drizzle-orm" mock`).
+ * Nur sieht sie niemand: Der Zugriff passiert im `try`-Block der Route, deren
+ * `catch` daraus eine 500 macht und den Fehler in einen gemockten Logger
+ * schreibt. Der Test meldet dann bloß „expected 500 to be 200".
+ *
+ * Ein Proxy allein löst das also nicht. Deshalb tut dieser hier beides:
+ *
+ * 1. **werfen** — damit der Code nicht mit einem fehlenden Helper weiterläuft;
+ * 2. **den Fehlgriff vermerken** — damit er den `catch`-Block der Route
+ *    überlebt. `vitest-setup-server.ts` prüft den Vermerk nach jedem Test und
+ *    lässt ihn scheitern, auch wenn der Wurf unterwegs verschluckt wurde.
+ */
+
+import { expect } from 'vitest';
+import { basename } from 'node:path';
+
+/**
+ * Symbole, die Vitest und der ESM-Interop auf jedem Modul-Namespace abfragen —
+ * `then` allein rund acht Mal beim Auflösen von `await import(...)`. Für sie
+ * darf der Trap nicht werfen, sonst bricht schon der Import.
+ *
+ * Von `Object.prototype` geerbte Namen (`toString`, `valueOf`, `constructor`, …)
+ * stehen bewusst nicht in der Liste: Sie erfüllen `prop in target` und laufen
+ * ohnehin durch.
+ */
+const MODULE_PROBES = new Set(['then', 'catch', 'finally', 'default', '__esModule', 'toJSON']);
+
+/** Ein Zugriff auf einen Export, den die Attrappe nicht kennt. */
+interface MissingMockExport {
+	moduleName: string;
+	exportName: string;
+	testFile: string;
+}
+
+/**
+ * Fehlgriffe des laufenden Tests. Modul-Zustand, weil die Attrappe im
+ * `vi.mock`-Factory entsteht und dort keine Hooks registriert werden können.
+ */
+const missing: MissingMockExport[] = [];
+
+/** Testdatei, in der der Fehlgriff passiert — zur Laufzeit des Traps gesetzt. */
+function currentTestFile(): string {
+	const testPath = expect.getState()?.testPath;
+	return testPath ? basename(testPath) : 'dieser Testdatei';
+}
+
+function describeMiss({ moduleName, exportName, testFile }: MissingMockExport): string {
+	return (
+		`${moduleName}-Attrappe in ${testFile} exportiert \`${exportName}\` nicht — ` +
+		`der getestete Code ruft es (ggf. mittelbar) auf. ` +
+		`Ergänze den Helper in der Attrappe.`
+	);
+}
+
+/**
+ * Umhüllt das Attrappen-Objekt eines vollständig ersetzten Moduls.
+ *
+ * Der Zugriff auf einen nicht definierten String-Export wirft mit einer
+ * Meldung, die Modul, Export und Testdatei nennt. Symbol-Keys und die
+ * ESM-Sonden aus {@link MODULE_PROBES} laufen unverändert durch.
+ *
+ * @example
+ * vi.mock('drizzle-orm', async () => {
+ *   const { strictModuleMock } = await import('./helpers/strictModuleMock');
+ *   return strictModuleMock('drizzle-orm', { and: vi.fn((...a) => a) });
+ * });
+ */
+export function strictModuleMock<T extends object>(moduleName: string, exports: T): T {
+	return new Proxy(exports, {
+		get(target, prop, receiver) {
+			if (typeof prop === 'string' && !Reflect.has(target, prop) && !MODULE_PROBES.has(prop)) {
+				const miss: MissingMockExport = {
+					moduleName,
+					exportName: prop,
+					testFile: currentTestFile()
+				};
+				// Erst vermerken, dann werfen: Fängt die Route den Fehler ab, holt
+				// ihn `assertNoMissingMockExports()` nach dem Test wieder hervor.
+				if (!missing.some((m) => m.moduleName === moduleName && m.exportName === prop)) {
+					missing.push(miss);
+				}
+				throw new Error(describeMiss(miss));
+			}
+			return Reflect.get(target, prop, receiver);
+		}
+	});
+}
+
+/** Liefert die vermerkten Fehlgriffe und leert den Speicher. */
+export function drainMissingMockExports(): MissingMockExport[] {
+	return missing.splice(0, missing.length);
+}
+
+/**
+ * Lässt den Test scheitern, wenn ein Export gefehlt hat — auch dann, wenn der
+ * Wurf unterwegs verschluckt wurde. Wird global in `vitest-setup-server.ts`
+ * nach jedem Test aufgerufen.
+ */
+export function assertNoMissingMockExports(): void {
+	const misses = drainMissingMockExports();
+	if (misses.length === 0) return;
+
+	throw new Error(
+		'Fehlender Export in einer Modul-Attrappe. Der Wurf wurde vom getesteten Code ' +
+			'verschluckt (Routen fangen Fehler ab und antworten mit 500) — er ist die ' +
+			'Ursache des Statuscode-Mismatch oben:\n' +
+			misses.map((m) => `  • ${describeMiss(m)}`).join('\n')
+	);
+}

--- a/src/tests/contract/helpers/strictModuleMock.ts
+++ b/src/tests/contract/helpers/strictModuleMock.ts
@@ -2,8 +2,10 @@
  * @fileoverview Modul-Attrappen, die einen fehlenden Export laut melden.
  *
  * Die Contract-Tests ersetzen `drizzle-orm` und `$lib/server/db/schema`
- * **vollständig**. Ein Helper, den der getestete Code aufruft, hier aber fehlt,
- * ist damit zur Laufzeit nicht vorhanden. Das passiert auch **mittelbar**: Seit
+ * **vollständig**. Ein Export, den der getestete Code verwendet, hier aber
+ * fehlt — eine Funktion wie `isNotNull` ebenso wie eine Tabelle wie
+ * `auditLogs` —, ist damit zur Laufzeit nicht da. Das passiert auch
+ * **mittelbar**: Seit
  * `/sichtungen/showreports.json` sein Freigabe-Prädikat über `approvedOnly()`
  * aus `$lib/server/db/approvalFilter` bezieht, hängt der Endpunkt an
  * `isNotNull`, ohne es selbst zu importieren (PR #701).
@@ -16,7 +18,7 @@
  *
  * Ein Proxy allein löst das also nicht. Deshalb tut dieser hier beides:
  *
- * 1. **werfen** — damit der Code nicht mit einem fehlenden Helper weiterläuft;
+ * 1. **werfen** — damit der Code nicht mit einem fehlenden Export weiterläuft;
  * 2. **den Fehlgriff vermerken** — damit er den `catch`-Block der Route
  *    überlebt. `vitest-setup-server.ts` prüft den Vermerk nach jedem Test und
  *    lässt ihn scheitern, auch wenn der Wurf unterwegs verschluckt wurde.
@@ -55,11 +57,16 @@ function currentTestFile(): string {
 	return testPath ? basename(testPath) : 'dieser Testdatei';
 }
 
+/**
+ * Bewusst neutral formuliert: Die Attrappe deckt zwei Modularten ab. Bei
+ * `drizzle-orm` fehlt eine Funktion, bei `$lib/server/db/schema` eine Tabelle
+ * wie `auditLogs` — die wird verwendet, nicht „aufgerufen".
+ */
 function describeMiss({ moduleName, exportName, testFile }: MissingMockExport): string {
 	return (
 		`${moduleName}-Attrappe in ${testFile} exportiert \`${exportName}\` nicht — ` +
-		`der getestete Code ruft es (ggf. mittelbar) auf. ` +
-		`Ergänze den Helper in der Attrappe.`
+		`der getestete Code verwendet es (ggf. mittelbar). ` +
+		`Ergänze den Export in der Attrappe.`
 	);
 }
 

--- a/src/tests/contract/legacy.contract.test.ts
+++ b/src/tests/contract/legacy.contract.test.ts
@@ -88,43 +88,46 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {
-		id: 'id',
-		sightingDate: 'sightingDate',
-		latitude: 'latitude',
-		longitude: 'longitude',
-		totalCount: 'totalCount',
-		juvenileCount: 'juvenileCount',
-		firstName: 'firstName',
-		lastName: 'lastName',
-		nameConsent: 'nameConsent',
-		waterway: 'waterway',
-		shipName: 'shipName',
-		shipNameConsent: 'shipNameConsent',
-		approvedAt: 'approvedAt',
-		species: 'species',
-		isDead: 'isDead',
-		email: 'email'
-	}
-}));
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		sightings: {
+			id: 'id',
+			sightingDate: 'sightingDate',
+			latitude: 'latitude',
+			longitude: 'longitude',
+			totalCount: 'totalCount',
+			juvenileCount: 'juvenileCount',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			nameConsent: 'nameConsent',
+			waterway: 'waterway',
+			shipName: 'shipName',
+			shipNameConsent: 'shipNameConsent',
+			approvedAt: 'approvedAt',
+			species: 'species',
+			isDead: 'isDead',
+			email: 'email'
+		}
+	});
+});
 
 // Attrappe für `drizzle-orm`: Die Contract-Tests prüfen ausschließlich die
 // Response gegen static/openapi.yml, nicht die erzeugte SQL — deshalb genügen
 // Platzhalter.
 //
-// FALLE: Diese Attrappe ersetzt das Modul vollständig. Ein Helper, den die
-// getesteten Routen aufrufen, hier aber fehlt, ist zur Laufzeit `undefined`;
-// der Aufruf wirft, die Route fängt das in ihrem catch-Block und antwortet mit
-// **500 statt 200**. Der Test meldet dann einen Statuscode-Mismatch und nennt
-// die Ursache nicht. Das gilt auch für **mittelbare** Aufrufe: Seit
+// Diese Attrappe ersetzt das Modul vollständig, ein hier fehlender Helper ist
+// zur Laufzeit also nicht da — auch bei **mittelbarem** Aufruf: Seit
 // `/sichtungen/showreports.json` sein Freigabe-Prädikat über `approvedOnly()`
 // aus `$lib/server/db/approvalFilter` bezieht, hängt der Endpunkt an
-// `isNotNull`, ohne es selbst zu importieren.
+// `isNotNull`, ohne es selbst zu importieren. `strictModuleMock` nennt den
+// fehlenden Namen; ohne es meldete der Test nur „expected 500 to be 200",
+// weil der catch-Block der Route den Wurf verschluckt (PR #701).
 //
 // Bewusst nur die tatsächlich aufgerufenen Helper (YAGNI, empirisch geprüft):
 // `gte`/`lt` etwa nutzt der Endpunkt für den `year`-Filter, den hier kein Test
-// setzt. Wer einen solchen Test ergänzt, muss sie nachtragen.
+// setzt. Wer einen solchen Test ergänzt, muss sie nachtragen — die Attrappe
+// sagt jetzt selbst, welchen.
 //
 // Die Rückgabetypen sind absichtlich uneinheitlich, weil es die Originale auch
 // sind: `and`/`between` sind Kombinatoren (Array/Objekt), `sql` und `isNotNull`
@@ -133,17 +136,20 @@ vi.mock('$lib/server/db/schema', () => ({
 // Suffix "is not null". Die Form ist hier ohnehin inert: Die Bedingungen wandern
 // über `and(...)` in `.where()`, und der `db`-Mock unten wertet dieses Argument
 // nicht aus.
-vi.mock('drizzle-orm', () => ({
-	and: vi.fn((...args) => args),
-	between: vi.fn((a, b, c) => ({ a, b, c })),
-	isNotNull: vi.fn((column) => `${String(column)} is not null`),
-	sql: Object.assign(
-		vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
-		{
-			raw: vi.fn((s: string) => s)
-		}
-	)
-}));
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		and: vi.fn((...args) => args),
+		between: vi.fn((a, b, c) => ({ a, b, c })),
+		isNotNull: vi.fn((column) => `${String(column)} is not null`),
+		sql: Object.assign(
+			vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
+			{
+				raw: vi.fn((s: string) => s)
+			}
+		)
+	});
+});
 
 vi.mock('$lib/logger.server', () => ({
 	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })

--- a/src/tests/contract/map-sightings.contract.test.ts
+++ b/src/tests/contract/map-sightings.contract.test.ts
@@ -21,43 +21,49 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {
-		id: 'id',
-		sightingDate: 'sightingDate',
-		verified: 'verified',
-		approvedAt: 'approvedAt',
-		firstName: 'firstName',
-		lastName: 'lastName',
-		nameConsent: 'nameConsent',
-		shipName: 'shipName',
-		shipNameConsent: 'shipNameConsent',
-		waterway: 'waterway',
-		seaMark: 'seaMark',
-		longitude: 'longitude',
-		latitude: 'latitude',
-		species: 'species',
-		totalCount: 'totalCount',
-		juvenileCount: 'juvenileCount',
-		isDead: 'isDead'
-	}
-}));
-
-vi.mock('drizzle-orm', () => ({
-	and: vi.fn((...args) => args),
-	between: vi.fn((a, b, c) => ({ a, b, c })),
-	gte: vi.fn((a, b) => ({ a, b })),
-	lte: vi.fn((a, b) => ({ a, b })),
-	lt: vi.fn((a, b) => ({ a, b })),
-	eq: vi.fn((a, b) => ({ a, b })),
-	isNotNull: vi.fn((a) => ({ isNotNull: a })),
-	sql: Object.assign(
-		vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
-		{
-			raw: vi.fn((s: string) => s)
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		sightings: {
+			id: 'id',
+			sightingDate: 'sightingDate',
+			verified: 'verified',
+			approvedAt: 'approvedAt',
+			firstName: 'firstName',
+			lastName: 'lastName',
+			nameConsent: 'nameConsent',
+			shipName: 'shipName',
+			shipNameConsent: 'shipNameConsent',
+			waterway: 'waterway',
+			seaMark: 'seaMark',
+			longitude: 'longitude',
+			latitude: 'latitude',
+			species: 'species',
+			totalCount: 'totalCount',
+			juvenileCount: 'juvenileCount',
+			isDead: 'isDead'
 		}
-	)
-}));
+	});
+});
+
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		and: vi.fn((...args) => args),
+		between: vi.fn((a, b, c) => ({ a, b, c })),
+		gte: vi.fn((a, b) => ({ a, b })),
+		lte: vi.fn((a, b) => ({ a, b })),
+		lt: vi.fn((a, b) => ({ a, b })),
+		eq: vi.fn((a, b) => ({ a, b })),
+		isNotNull: vi.fn((a) => ({ isNotNull: a })),
+		sql: Object.assign(
+			vi.fn((strings: TemplateStringsArray) => String(strings.raw[0])),
+			{
+				raw: vi.fn((s: string) => s)
+			}
+		)
+	});
+});
 
 vi.mock('$lib/map/mapUtils', () => ({
 	sightingsToGeoJSON: vi.fn().mockReturnValue({

--- a/src/tests/contract/sightings-id.contract.test.ts
+++ b/src/tests/contract/sightings-id.contract.test.ts
@@ -69,15 +69,29 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => mockSchema);
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', mockSchema);
+});
+
+// PUT und DELETE schreiben einen Audit-Eintrag. Ohne diese Attrappe liefe der
+// echte `auditService` gegen die db-Attrappe, scheiterte still in seinem
+// eigenen catch und zöge `auditLogs` aus der Schema-Attrappe — dort fehlte es
+// unbemerkt, bis `strictModuleMock` es meldete.
+vi.mock('$lib/server/audit/auditService', () => ({
+	logAuditEvent: vi.fn().mockResolvedValue(undefined)
+}));
 
 vi.mock('$lib/server/storage/factory', () => ({
 	getStorageProvider: vi.fn(() => ({ delete: vi.fn().mockResolvedValue(undefined) }))
 }));
 
-vi.mock('drizzle-orm', () => ({
-	eq: vi.fn((a, b) => ({ a, b }))
-}));
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		eq: vi.fn((a, b) => ({ a, b }))
+	});
+});
 
 vi.mock('$lib/server/db/sightingRepository', () => ({
 	loadSightingFiles: vi.fn().mockResolvedValue([]),

--- a/src/tests/contract/sightings.contract.test.ts
+++ b/src/tests/contract/sightings.contract.test.ts
@@ -15,30 +15,36 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	// `approvedAt` wird von `approvedOnly()` gebraucht — GET filtert die
-	// öffentliche Grundmenge, siehe ../../routes/api/sightings/getEndpoint.test.ts
-	sightings: {
-		id: 'id',
-		sightingDate: 'sightingDate',
-		created: 'created',
-		approvedAt: 'approvedAt'
-	}
-}));
-
-vi.mock('drizzle-orm', () => ({
-	and: vi.fn((...args) => args),
-	gte: vi.fn((a, b) => ({ a, b })),
-	lt: vi.fn((a, b) => ({ a, b })),
-	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
-	isNull: vi.fn((column) => ({ op: 'isNull', column })),
-	sql: Object.assign(
-		vi.fn((strings: TemplateStringsArray, ..._values: unknown[]) => String(strings.raw[0])),
-		{
-			raw: vi.fn((s: string) => s)
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		// `approvedAt` wird von `approvedOnly()` gebraucht — GET filtert die
+		// öffentliche Grundmenge, siehe ../../routes/api/sightings/getEndpoint.test.ts
+		sightings: {
+			id: 'id',
+			sightingDate: 'sightingDate',
+			created: 'created',
+			approvedAt: 'approvedAt'
 		}
-	)
-}));
+	});
+});
+
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		and: vi.fn((...args) => args),
+		gte: vi.fn((a, b) => ({ a, b })),
+		lt: vi.fn((a, b) => ({ a, b })),
+		isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+		isNull: vi.fn((column) => ({ op: 'isNull', column })),
+		sql: Object.assign(
+			vi.fn((strings: TemplateStringsArray, ..._values: unknown[]) => String(strings.raw[0])),
+			{
+				raw: vi.fn((s: string) => s)
+			}
+		)
+	});
+});
 
 vi.mock('$lib/server/db/sightingRepository', () => ({
 	saveSighting: vi.fn().mockResolvedValue({ id: 123 })

--- a/src/tests/contract/verify.contract.test.ts
+++ b/src/tests/contract/verify.contract.test.ts
@@ -33,17 +33,23 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
-vi.mock('$lib/server/db/schema', () => ({
-	sightings: {
-		id: 'id',
-		approvedAt: 'approvedAt',
-		verified: 'verified'
-	}
-}));
+vi.mock('$lib/server/db/schema', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('$lib/server/db/schema', {
+		sightings: {
+			id: 'id',
+			approvedAt: 'approvedAt',
+			verified: 'verified'
+		}
+	});
+});
 
-vi.mock('drizzle-orm', () => ({
-	eq: vi.fn((a, b) => ({ a, b }))
-}));
+vi.mock('drizzle-orm', async () => {
+	const { strictModuleMock } = await import('./helpers/strictModuleMock');
+	return strictModuleMock('drizzle-orm', {
+		eq: vi.fn((a, b) => ({ a, b }))
+	});
+});
 
 vi.mock('$lib/server/auth/auth', () => ({
 	requireUserRole: vi.fn()

--- a/vitest-setup-server.ts
+++ b/vitest-setup-server.ts
@@ -1,8 +1,28 @@
-import { vi } from 'vitest';
+import { afterEach, expect, vi } from 'vitest';
 import './src/tests/contract/helpers/specSetup';
+import { assertNoMissingMockExports } from './src/tests/contract/helpers/strictModuleMock';
 
 // Set NODE_ENV to test to prevent automatic service initialization
 process.env.NODE_ENV = 'test';
+
+/** Verzeichnis der Contract-Tests — dort und nur dort steht `strictModuleMock`. */
+const CONTRACT_TESTS = '/src/tests/contract/';
+
+// Holt einen fehlenden Export aus einer `strictModuleMock`-Attrappe wieder
+// hervor. Nötig, weil der Wurf im try-Block einer Route passiert: Deren catch
+// macht daraus eine 500 und der Test meldet sonst nur „expected 500 to be 200"
+// (so geschehen in PR #701).
+//
+// Dieses Setup gilt für alle Server-Tests, die Prüfung ist aber bewusst auf die
+// Contract-Tests eingegrenzt: So ist belegt, dass der Hook die übrigen rund 200
+// Testdateien nicht berühren kann. Wer `strictModuleMock` außerhalb dieses
+// Verzeichnisses einsetzt, muss den Pfad hier erweitern — sonst bleibt der
+// verschluckte Wurf wieder unsichtbar.
+afterEach(() => {
+	if (expect.getState().testPath?.includes(CONTRACT_TESTS)) {
+		assertNoMissingMockExports();
+	}
+});
 
 // Global mock for EmailService to prevent any real email sending during tests
 vi.mock('$lib/server/services/emailService', () => ({


### PR DESCRIPTION
## Ausgangslage

Die Contract-Tests ersetzen `drizzle-orm` und `$lib/server/db/schema` **vollständig**. Ein Helper, den der getestete Code aufruft, die Attrappe aber nicht exportiert, ist damit zur Laufzeit nicht da — auch bei **mittelbaren** Aufrufen. Genau das passierte in #701: `/sichtungen/showreports.json` bezog sein Freigabe-Prädikat über `approvedOnly()` und hing damit an `isNotNull`, ohne es selbst zu importieren.

## Eine Korrektur an der Annahme

Vitest 4 wickelt Modul-Attrappen **bereits** in einen werfenden Proxy. Nachgemessen: Der Zugriff wirft `[vitest] No "isNotNull" export is defined on the "drizzle-orm" mock`.

Ein Proxy allein hätte die Suche also nicht verkürzt. Der ursprüngliche Fehlerfall — durch Löschen von `isNotNull` reproduziert — meldete weiterhin nur `AssertionError: expected 500 to be 200`. Die Ursache ist nicht die fehlende Meldung, sondern **wo** der Zugriff passiert: im `try`-Block der Route, deren `catch` jeden Fehler in eine 500 verwandelt und in einen gemockten Logger schreibt. Die Meldung existierte und wurde verschluckt.

## Umsetzung

`src/tests/contract/helpers/strictModuleMock.ts` tut deshalb zweierlei:

1. **werfen** bei einem unbekannten String-Export — damit der Code nicht ohne den Helper weiterläuft;
2. **den Fehlgriff vermerken** — damit er den `catch` überlebt. `vitest-setup-server.ts` prüft den Vermerk nach jedem Test und lässt ihn scheitern.

Symbol-Keys und die ESM-/Promise-Sonden laufen durch. `then` allein wird pro `await import()` achtmal gelesen — gemessen, nicht angenommen; ein werfendes `then` bricht schon den Import.

Mit gelöschtem `isNotNull` meldet der Lauf jetzt zusätzlich zum Assertion-Fehler:

```
Fehlender Export in einer Modul-Attrappe. Der Wurf wurde vom getesteten Code
verschluckt (Routen fangen Fehler ab und antworten mit 500) — er ist die
Ursache des Statuscode-Mismatch oben:
  • drizzle-orm-Attrappe in legacy.contract.test.ts exportiert `isNotNull` nicht
    — der getestete Code ruft es (ggf. mittelbar) auf. Ergänze den Helper in der Attrappe.
```

Der Dateiname kommt aus `expect.getState().testPath` zur Trap-Laufzeit, es gibt also kein Literal, das bei einer Umbenennung veraltet.

## Gemeinsamer Helper statt lokaler Lösung

Sieben Contract-Tests ersetzen `drizzle-orm` vollständig, sieben `$lib/server/db/schema` — der Helper liegt deshalb in `helpers/` und alle sieben Dateien nutzen ihn. Die `vi.mock`-Factories sind `async` mit dynamischem `import()`; ein Top-Level-Import liefe in den Hoisting-Fallstrick der Dateien, die ihre Route auf Modulebene importieren.

Die Prüfung ist auf `/src/tests/contract/` eingegrenzt, damit belegbar ist, dass sie die übrigen rund 200 Server-Testdateien nicht berühren kann.

## Ein echter Befund beim ersten Lauf

Drei Tests in `files.contract.test.ts` und `sightings-id.contract.test.ts` wurden rot: Beide bespielen Routen, die `logAuditEvent` aufrufen, mockten `auditService` aber nie — anders als `export` und `verify`. Der echte Audit-Service lief gegen die db-Attrappe, scheiterte still in seinem eigenen `catch` und zog `auditLogs` aus einer Schema-Attrappe, die es nie hatte. Die Tests waren grün, weil der Audit-Schreibvorgang best-effort ist. Beide mocken ihn jetzt, passend zur Konvention der anderen beiden Dateien.

## Prüfung

- `npm run test:quick` — 220 Dateien / 3167 Tests grün (Lint, Type-Check, Svelte-Check inklusive)
- Contract-Suite: 18 Dateien / 204 Tests grün
- `strictModuleMock.test.ts`: 9 Tests, test-first geschrieben (RED belegt)
- Negativfall verifiziert: mit gelöschtem `isNotNull` erscheint die erklärende Meldung — auch mit der Pfad-Eingrenzung

Ein Lauf zeigte vier Timeouts in `legacy-inbox/app.test.js` — der bekannte Flake, der nicht an `src/` hängt; der Wiederholungslauf war vollständig grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)