### PR TITLE
fix(admin): Bearbeiten einer Sichtung lässt den Bestand unversehrt

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -435,6 +435,17 @@ All timestamp columns hold **true UTC instants**. Drizzle pins both directions
 explicitly (`toISOString()` on write, `+0000` on read), so storage does not
 depend on `TZ` either.
 
+The read half of that sentence needed help to be true. Drizzle only appends
+`+0000` when the driver hands it a **string**, and `postgres.js` parses
+`timestamp without time zone` itself — as local time of the process. Measured
+with a standalone client under `TZ=Europe/Berlin`: a column holding
+`2026-08-02 12:30:00` comes back as a `Date` at `10:30Z`. Since 2026-08-02 the
+driver is told to pass OID 1114 through as text
+(`src/lib/server/db/postgresTypes.ts`, covered by `timestampParsing.test.ts`),
+so the mapping no longer depends on the process timezone. The running
+application was never affected — its process runs in UTC — but the guarantee now
+rests on code rather than on this variable.
+
 This was not always true. The columns are `timestamp without time zone`, and the
 data inherited from the PHP predecessor held German wall-clock time — that system
 ran on a server in Europe/Berlin. A one-off migration converted it before launch:

--- a/e2e/admin-edit-preserves-record.spec.ts
+++ b/e2e/admin-edit-preserves-record.spec.ts
@@ -74,6 +74,8 @@ const POSITION = { latitude: '54.123456', longitude: '13.654321' };
  */
 const SIGHTING_DATE_UTC = '2024-06-01T08:30:00.000Z';
 
+/** Derselbe Zeitpunkt, wie ihn `to_char` aus der Spalte liest. */
+const SIGHTING_DATE_STORED = '2024-06-01 08:30:00';
 
 function connect() {
 	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
@@ -143,6 +145,7 @@ interface StoredSighting {
 	strasse: string | null;
 	plz: string | null;
 	ort: string | null;
+	sichtungsdatum: string;
 	sonstige_auffaelligkeiten: string | null;
 	kommentar_intern: string | null;
 	vonwo: number;
@@ -165,6 +168,7 @@ async function readSighting(id: number): Promise<StoredSighting> {
 				gps_laenge::text AS lon,
 				ST_AsText(location) AS punkt,
 				vorname, name, email, strasse, plz, ort,
+				to_char(sichtungsdatum, 'YYYY-MM-DD HH24:MI:SS') AS sichtungsdatum,
 				sonstige_auffaelligkeiten, kommentar_intern, vonwo, entfernung
 			FROM sichtungen WHERE id = ${id}
 		`;
@@ -251,6 +255,12 @@ test.describe('Admin-Bearbeitung erhält den Bestand', () => {
 		expect(stored.lon).toBe(POSITION.longitude);
 		expect(stored.punkt).toBe(`POINT(${POSITION.longitude} ${POSITION.latitude})`);
 
+		/* Der Zeitpunkt geht als deutsche Wanduhrzeit durch das Formular und muss
+		   als derselbe UTC-Zeitpunkt zurückkommen — bei einer Bearbeitung, die ihn
+		   gar nicht anfasst, erst recht. Die Zusicherung deckt beide Richtungen ab:
+		   Lesen (`postgresTypes.ts`), Anzeige in Europe/Berlin und das Zurückrechnen
+		   in `berlinWallClockToUtc`. */
+		expect(stored.sichtungsdatum).toBe(SIGHTING_DATE_STORED);
 
 		// Gegenprobe: Die eine beabsichtigte Änderung ist auch angekommen.
 		expect(stored.sonstige_auffaelligkeiten).toBe('E2E: Nachtrag zur Beobachtung');

--- a/e2e/admin-edit-preserves-record.spec.ts
+++ b/e2e/admin-edit-preserves-record.spec.ts
@@ -93,14 +93,18 @@ function connect() {
  * gecastet — so steht die erwartete Genauigkeit im Test als Literal und nicht
  * als Fließkommazahl, die schon beim Schreiben wackeln könnte.
  *
- * `vonwo`, `entfernung` und `referenz_id` sind gesetzt, weil das Formular sonst
- * gar nicht erst absendet — `sightingSchema` verlangt alle drei.
+ * `referenz_id` ist gesetzt, weil `sightingSchema` sie verlangt; im Bestand
+ * trägt sie jede Zeile. `vonwo` und `entfernung` sind überschreibbar — der
+ * dritte Testfall braucht dort genau die Werte, an denen das Speichern bis
+ * 2026-08-02 scheiterte.
  */
 async function createSighting(options: {
 	latitude: string | null;
 	longitude: string | null;
 	waterway: string | null;
 	referenceId: string;
+	sightingFrom?: number;
+	distance?: number;
 }): Promise<number> {
 	const sql = connect();
 	try {
@@ -113,7 +117,9 @@ async function createSighting(options: {
 				datenschutz_einverstaendnis, kommentar_intern
 			) VALUES (
 				${SIGHTING_DATE_UTC}, NOW(), 1, 2,
-				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${options.referenceId},
+				${options.sightingFrom ?? SightingFromEnum.LAND},
+				${options.distance ?? DistanceEnum.FROM_10_TO_50M},
+				${options.referenceId},
 				${options.latitude}, ${options.longitude}, ${options.waterway},
 				${REPORTER.firstName}, ${REPORTER.lastName}, ${REPORTER.email},
 				${REPORTER.street}, ${REPORTER.zipCode}, ${REPORTER.city},
@@ -138,6 +144,9 @@ interface StoredSighting {
 	plz: string | null;
 	ort: string | null;
 	sonstige_auffaelligkeiten: string | null;
+	kommentar_intern: string | null;
+	vonwo: number;
+	entfernung: number;
 }
 
 /**
@@ -156,7 +165,7 @@ async function readSighting(id: number): Promise<StoredSighting> {
 				gps_laenge::text AS lon,
 				ST_AsText(location) AS punkt,
 				vorname, name, email, strasse, plz, ort,
-				sonstige_auffaelligkeiten
+				sonstige_auffaelligkeiten, kommentar_intern, vonwo, entfernung
 			FROM sichtungen WHERE id = ${id}
 		`;
 		return row;
@@ -271,4 +280,49 @@ test.describe('Admin-Bearbeitung erhält den Bestand', () => {
 		expect(stored.sonstige_auffaelligkeiten).toBe('E2E: Bearbeitung ohne Position');
 	});
 
+	/**
+	 * Der Bestandsfall, an dem das Speichern schlicht scheiterte: `entfernung = 0`
+	 * (282 Zeilen) und `vonwo = 0` ohne Freitext (1.120 Zeilen) sind keine
+	 * gültigen Eingaben am Meldeformular. Das Formular sendete deshalb gar nicht
+	 * erst — der Admin sah eine Fehlerliste zu Feldern, die er nie ausgefüllt hat.
+	 *
+	 * Dieser Fall bearbeitet den **internen Kommentar**, weil der bis 2026-08-02
+	 * nirgends ankam: `mapFormToSighting` bildete das Feld nicht ab. Die Zeile
+	 * verliert damit den Aufräum-Marker; auffindbar bleibt sie über die
+	 * `e2e-`-Referenz-ID.
+	 */
+	test('lässt eine Bestandssichtung mit unvollständigen Angaben speichern', async ({ page }) => {
+		const id = await createSighting({
+			...POSITION,
+			waterway: null,
+			referenceId: 'e2e-bestand',
+			sightingFrom: SightingFromEnum.OTHER,
+			distance: 0
+		});
+		createdIds.push(id);
+
+		await page.goto(`/admin/${id}/edit`);
+		const internalComment = page.locator('[data-testid="field-internalComment"]');
+		await expect(internalComment).toBeVisible();
+		await internalComment.fill('E2E: intern geprüft');
+
+		const [response] = await Promise.all([
+			page.waitForResponse(
+				(res) => res.url().includes(`/api/sightings/${id}`) && res.request().method() === 'PUT'
+			),
+			page.getByRole('button', { name: 'Speichern' }).click()
+		]);
+		expect(response.status()).toBe(200);
+
+		const stored = await readSighting(id);
+
+		// Der interne Kommentar kommt jetzt an …
+		expect(stored.kommentar_intern).toBe('E2E: intern geprüft');
+		// … und die unvollständigen Angaben stehen unverändert da, statt vom
+		// Formular durch erfundene Kategorien ersetzt zu werden.
+		expect(stored.vonwo).toBe(SightingFromEnum.OTHER);
+		expect(stored.entfernung).toBe(0);
+		expect(stored.strasse).toBe(REPORTER.street);
+		expect(stored.lat).toBe(POSITION.latitude);
+	});
 });

--- a/e2e/admin-edit-preserves-record.spec.ts
+++ b/e2e/admin-edit-preserves-record.spec.ts
@@ -1,0 +1,274 @@
+import { expect, test } from '@playwright/test';
+import { config as loadEnv } from 'dotenv';
+import postgres from 'postgres';
+import { DistanceEnum } from '../src/lib/report/formOptions/distance';
+import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * admin-edit-preserves-record.spec.ts — was eine Admin-Bearbeitung am Bestand
+ * **nicht** anfassen darf.
+ *
+ * Das Bearbeitungsformular zeigt weder Adresse noch Kontaktdaten an. Beide
+ * überstehen eine Bearbeitung trotzdem, aber nur über eine unsichtbare Kette:
+ * Der Loader holt die vollständige Zeile, `buildAdminEditInitialValues` legt sie
+ * in den Formularzustand, `handleSubmit` schickt ihn komplett an
+ * `PUT /api/sightings/[id]`, und `mapFormToSighting` schreibt jedes Feld zurück.
+ * Reißt irgendein Glied — ein Loader, der weniger Spalten liefert, ein Formular,
+ * das nur noch geänderte Felder sendet —, verschwindet die Adresse von 6.689
+ * Meldungen still. Die Unit-Tests sichern die Glieder einzeln; hier läuft die
+ * Kette einmal echt durch.
+ *
+ * **Warum die Koordinaten mitgeprüft werden:** Genau an dieser Kette hing bis
+ * 2026-08-02 ein Datenverlust, den kein Test bemerkte. Das Formular baute seine
+ * Startwerte mit `Number(sighting.latitude)?.toFixed(4)` und kürzte damit bei
+ * jeder Speicherung `numeric(8,6)` auf vier Nachkommastellen — auch dann, wenn
+ * niemand die Position angefasst hatte.
+ *
+ * Der Fall „ohne Position" ist der Gegenpart dazu und war **kein** Datenverlust:
+ * Der Startwert `'0.0000'` erreichte die Datenbank nie, weil Yup ihn vorher zur
+ * Zahl `0` castet und die im Null-Zweig landet. Der Test hält die Kombination
+ * fest, nicht einen behobenen Fehler — er war schon vor dem Fix grün.
+ *
+ * **Eigene Datensätze statt Bestandsdaten.** Die lokale Datenbank ist laut
+ * `docs/WORKTREES.md` über alle Worktrees geteilt; ein Test, der eine echte
+ * Meldung speichert, änderte echte Daten. Jeder Testfall legt deshalb seine
+ * eigene Zeile an und räumt sie wieder weg. Sie trägt denselben Marker wie
+ * `scripts/seed-e2e.ts` (`kommentar_intern = 'e2e-seed'`), damit ein Abbruch
+ * mitten im Lauf nichts hinterlässt, was `npm run db:seed:e2e -- --purge` nicht
+ * findet.
+ */
+
+/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
+   e2e/helpers/adminSession.ts. */
+loadEnv();
+
+const SEED_MARKER = 'e2e-seed';
+
+/** Melderdaten, die keine der beiden Bearbeitungen anfassen darf. */
+const REPORTER = {
+	firstName: 'Erika',
+	lastName: 'Mustermann',
+	email: 'erika.e2e@example.invalid',
+	street: 'Hafenstraße 12',
+	zipCode: '18439',
+	city: 'Stralsund'
+};
+
+/**
+ * Sechs Nachkommastellen — die volle Auflösung der Spalte. Vier davon zu
+ * behalten wäre der alte Fehler, deshalb steht hier bewusst kein runder Wert.
+ */
+const POSITION = { latitude: '54.123456', longitude: '13.654321' };
+
+/**
+ * Zeitpunkt der Sichtung, als ISO-UTC **mit `Z`** — im Formular erscheint er als
+ * 10:30 MESZ.
+ *
+ * Die Schreibweise ist nicht Geschmackssache: `postgres.js` serialisiert einen
+ * String-Parameter über `new Date(x).toISOString()`. Ohne `Z` legt Node den Wert
+ * als **Ortszeit** aus, und die Testzeile läge auf einem Rechner in Europe/Berlin
+ * zwei Stunden neben der Absicht — der Test misst dann seine eigene Zeitzone
+ * statt der Anwendung. Genau so ist der erste Anlauf dieses Tests gescheitert.
+ * Drizzle schreibt aus demselben Grund `toISOString()`.
+ */
+const SIGHTING_DATE_UTC = '2024-06-01T08:30:00.000Z';
+
+
+function connect() {
+	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
+	if (!databaseUrl) {
+		throw new Error(
+			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
+				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
+		);
+	}
+	return postgres(databaseUrl, { max: 1 });
+}
+
+/**
+ * Legt eine Sichtung an und liefert ihre ID.
+ *
+ * `gps_breite`/`gps_laenge` kommen als Text herein und werden von Postgres
+ * gecastet — so steht die erwartete Genauigkeit im Test als Literal und nicht
+ * als Fließkommazahl, die schon beim Schreiben wackeln könnte.
+ *
+ * `vonwo`, `entfernung` und `referenz_id` sind gesetzt, weil das Formular sonst
+ * gar nicht erst absendet — `sightingSchema` verlangt alle drei.
+ */
+async function createSighting(options: {
+	latitude: string | null;
+	longitude: string | null;
+	waterway: string | null;
+	referenceId: string;
+}): Promise<number> {
+	const sql = connect();
+	try {
+		const [row] = await sql<{ id: number }[]>`
+			INSERT INTO sichtungen (
+				sichtungsdatum, created, tierart, anzahl_gesamt,
+				vonwo, entfernung, referenz_id,
+				gps_breite, gps_laenge, fahrwasser,
+				vorname, name, email, strasse, plz, ort,
+				datenschutz_einverstaendnis, kommentar_intern
+			) VALUES (
+				${SIGHTING_DATE_UTC}, NOW(), 1, 2,
+				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${options.referenceId},
+				${options.latitude}, ${options.longitude}, ${options.waterway},
+				${REPORTER.firstName}, ${REPORTER.lastName}, ${REPORTER.email},
+				${REPORTER.street}, ${REPORTER.zipCode}, ${REPORTER.city},
+				1, ${SEED_MARKER}
+			)
+			RETURNING id
+		`;
+		return Number(row.id);
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+interface StoredSighting {
+	lat: string | null;
+	lon: string | null;
+	punkt: string | null;
+	vorname: string | null;
+	name: string | null;
+	email: string | null;
+	strasse: string | null;
+	plz: string | null;
+	ort: string | null;
+	sonstige_auffaelligkeiten: string | null;
+}
+
+/**
+ * Liest die gespeicherte Zeile.
+ *
+ * Koordinaten und Zeitstempel kommen als Text heraus: So vergleicht der Test den
+ * gespeicherten Wert und nicht das Rundungs- oder Zeitzonenverhalten eines
+ * Treibers — und misst damit nicht dieselbe Annahme, die er prüfen soll.
+ */
+async function readSighting(id: number): Promise<StoredSighting> {
+	const sql = connect();
+	try {
+		const [row] = await sql<StoredSighting[]>`
+			SELECT
+				gps_breite::text AS lat,
+				gps_laenge::text AS lon,
+				ST_AsText(location) AS punkt,
+				vorname, name, email, strasse, plz, ort,
+				sonstige_auffaelligkeiten
+			FROM sichtungen WHERE id = ${id}
+		`;
+		return row;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+async function deleteSighting(id: number): Promise<void> {
+	const sql = connect();
+	try {
+		await sql`DELETE FROM sichtungen WHERE id = ${id}`;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+/**
+ * Ändert ein einzelnes sichtbares Feld und speichert.
+ *
+ * Bewusst „Weitere Beobachtungen" und **nicht** der interne Kommentar: Der trägt
+ * den Aufräum-Marker. Bearbeitet wird überhaupt etwas, weil der Nachweis sonst
+ * wertlos wäre — die Frage ist ja gerade, was eine *echte* Bearbeitung mit den
+ * übrigen Feldern macht.
+ */
+async function editAndSave(
+	page: import('@playwright/test').Page,
+	id: number,
+	text: string
+): Promise<void> {
+	await page.goto(`/admin/${id}/edit`);
+
+	const observations = page.locator('[data-testid="field-otherObservations"]');
+	await expect(observations).toBeVisible();
+	await observations.fill(text);
+
+	const [response] = await Promise.all([
+		page.waitForResponse(
+			(res) => res.url().includes(`/api/sightings/${id}`) && res.request().method() === 'PUT'
+		),
+		page.getByRole('button', { name: 'Speichern' }).click()
+	]);
+
+	expect(response.status()).toBe(200);
+	await expect(page).toHaveURL(new RegExp(`/admin/${id}$`));
+}
+
+test.describe('Admin-Bearbeitung erhält den Bestand', () => {
+	const createdIds: number[] = [];
+
+	test.beforeEach(async ({ context, baseURL }) => {
+		await seedAdminSession(context, baseURL!);
+	});
+
+	test.afterEach(async () => {
+		while (createdIds.length > 0) {
+			await deleteSighting(createdIds.pop()!);
+		}
+	});
+
+	test('Adresse, Kontaktdaten und Koordinaten überstehen eine Bearbeitung', async ({ page }) => {
+		const id = await createSighting({
+			...POSITION,
+			waterway: null,
+			referenceId: 'e2e-mit-position'
+		});
+		createdIds.push(id);
+
+		await editAndSave(page, id, 'E2E: Nachtrag zur Beobachtung');
+
+		const stored = await readSighting(id);
+
+		// Der Grund für diesen Test: die Melderdaten, die das Formular nie zeigt.
+		expect(stored.vorname).toBe(REPORTER.firstName);
+		expect(stored.name).toBe(REPORTER.lastName);
+		expect(stored.email).toBe(REPORTER.email);
+		expect(stored.strasse).toBe(REPORTER.street);
+		expect(stored.plz).toBe(REPORTER.zipCode);
+		expect(stored.ort).toBe(REPORTER.city);
+
+		// Volle Auflösung — in der Spalte und im daraus gebauten PostGIS-Punkt.
+		expect(stored.lat).toBe(POSITION.latitude);
+		expect(stored.lon).toBe(POSITION.longitude);
+		expect(stored.punkt).toBe(`POINT(${POSITION.longitude} ${POSITION.latitude})`);
+
+
+		// Gegenprobe: Die eine beabsichtigte Änderung ist auch angekommen.
+		expect(stored.sonstige_auffaelligkeiten).toBe('E2E: Nachtrag zur Beobachtung');
+	});
+
+	test('Sichtung ohne Position bekommt keine erfundenen Koordinaten', async ({ page }) => {
+		const id = await createSighting({
+			latitude: null,
+			longitude: null,
+			waterway: 'Strelasund',
+			referenceId: 'e2e-ohne-position'
+		});
+		createdIds.push(id);
+
+		await editAndSave(page, id, 'E2E: Bearbeitung ohne Position');
+
+		const stored = await readSighting(id);
+
+		// 462 Bestandszeilen haben keine Position. Eine Bearbeitung darf ihnen
+		// keine andichten — heute verhindern das zwei Schichten unabhängig
+		// voneinander (Yup-Cast und Null-Zweig in `mapFormToSighting`), und genau
+		// deshalb steht hier eine Zusicherung: Fällt eine davon, fällt es auf.
+		expect(stored.lat).toBeNull();
+		expect(stored.lon).toBeNull();
+		expect(stored.punkt).toBeNull();
+		expect(stored.strasse).toBe(REPORTER.street);
+		expect(stored.sonstige_auffaelligkeiten).toBe('E2E: Bearbeitung ohne Position');
+	});
+
+});

--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect, type Page } from '@playwright/test';
+import { config as loadEnv } from 'dotenv';
+import postgres from 'postgres';
 import { FormPage } from './pages/FormPage';
 import {
 	fillStep1,
@@ -7,6 +9,36 @@ import {
 	expectCurrentStep,
 	waitForNextEnabled
 } from './helpers/form-helpers';
+
+/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
+   e2e/helpers/adminSession.ts. */
+loadEnv();
+
+/**
+ * Entfernt eine vom Test angelegte Sichtung wieder.
+ *
+ * Der Submit-Test unten schreibt eine **echte** Meldung, und zwar in dieselbe
+ * Datenbank, die lokal über alle Worktrees geteilt wird. Ohne dieses Aufräumen
+ * sammeln sich dort „Max Mustermann"-Zeilen an, die in jeder Auswertung über
+ * Melderzahlen mitzählen — am 2026-08-02 stand eine davon zwischen den echten
+ * Meldungen und ist niemandem aufgefallen.
+ *
+ * Den Test stattdessen zu mocken wäre der falsche Weg: Er ist der einzige, der
+ * den echten Schreibpfad bis in die Spalte prüft. Die übrigen Fälle in dieser
+ * Datei fangen den Endpunkt bewusst ab.
+ */
+async function deleteSighting(id: number): Promise<void> {
+	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
+	if (!databaseUrl) return;
+
+	const sql = postgres(databaseUrl, { max: 1 });
+	try {
+		await sql`DELETE FROM sichtungen WHERE id = ${id}`;
+	} finally {
+		// Sonst hält der offene Pool den Playwright-Prozess am Leben.
+		await sql.end({ timeout: 5 });
+	}
+}
 
 // ── Navigation Tests ────────────────────────────────────────────────────────
 
@@ -175,6 +207,14 @@ test.describe('Sichtung melden — Formular absenden', () => {
 		await expect(submitButton).toBeEnabled({ timeout: 3000 });
 	});
 
+	const createdSightingIds: number[] = [];
+
+	test.afterEach(async () => {
+		while (createdSightingIds.length > 0) {
+			await deleteSighting(createdSightingIds.pop()!);
+		}
+	});
+
 	/* Braucht eine echte Datenbank — der Test schreibt eine Sichtung.
 	   Läuft seit dem 2026-07-30 auch in CI: Der `e2e`-Job fährt einen
 	   Postgres-Service und setzt DATABASE_POSTGRES_URL auf Job-Ebene (ci.yml).
@@ -202,7 +242,19 @@ test.describe('Sichtung melden — Formular absenden', () => {
 		await formPage.skipStep();
 		await fillStep4(formPage);
 
-		await formPage.clickSubmit();
+		const [response] = await Promise.all([
+			page.waitForResponse(
+				(res) => res.url().includes('/api/sightings') && res.request().method() === 'POST'
+			),
+			formPage.clickSubmit()
+		]);
+
+		// Die angelegte Zeile sofort merken — auch ein danach fehlschlagender Test
+		// darf sie nicht in der Datenbank stehen lassen.
+		const created = (await response.json().catch(() => null)) as { id?: number } | null;
+		if (typeof created?.id === 'number') {
+			createdSightingIds.push(created.id);
+		}
 
 		await expect(page.getByRole('heading', { name: /Vielen Dank/i })).toBeVisible({
 			timeout: 10000

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -14,8 +14,10 @@
 	import Media from '$lib/report/components/sections/Media.svelte';
 	import SightingDetails from '$lib/report/components/sections/SightingDetails.svelte';
 	import type { FrontendSighting } from '$lib/types';
-	import { formatLocalDateTime, splitDateTime } from '$lib/utils/format/dateTime';
+	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import { untrack } from 'svelte';
+
+	import { buildAdminEditInitialValues } from './adminEditInitialValues';
 
 	let {
 		sighting = {} as FrontendSighting,
@@ -57,21 +59,11 @@
 	}
 
 	// Initialisiere das Formular mit den vorhandenen Daten (one-time, untracked)
-	const initProps = untrack(() => {
-		const { date, time } = splitDateTime(sighting.sightingDate);
-		return {
-			initialValues: {
-				...sighting,
-				sightingDate: date,
-				sightingTime: time,
-				longitude: Number(sighting.longitude)?.toFixed(4) || 0,
-				latitude: Number(sighting.latitude)?.toFixed(4) || 0,
-				hasPosition: Boolean(sighting.longitude && sighting.latitude)
-			},
-			validationSchema: adminSightingSchema,
-			onSubmit: submitForm
-		};
-	});
+	const initProps = untrack(() => ({
+		initialValues: buildAdminEditInitialValues(sighting),
+		validationSchema: adminSightingSchema,
+		onSubmit: submitForm
+	}));
 	let isValid = $derived(formContext.isValid);
 	let isSubmitting = $derived(formContext.isSubmitting);
 	let errors = $derived(formContext.errors);

--- a/src/lib/components/admin/adminEditInitialValues.test.ts
+++ b/src/lib/components/admin/adminEditInitialValues.test.ts
@@ -1,0 +1,89 @@
+import type { FrontendSighting } from '$lib/types/FrontendSighting';
+import { describe, expect, it } from 'vitest';
+import { buildAdminEditInitialValues } from './adminEditInitialValues';
+
+/**
+ * Erzeugt eine Sichtung in der Form, in der sie aus `GET /api/sightings/[id]`
+ * kommt: die vollständige Datenbankzeile, Zeitstempel als ISO-String.
+ */
+function createSighting(overrides: Record<string, unknown> = {}): FrontendSighting {
+	return {
+		id: 4711,
+		referenceId: 'ref-4711',
+		species: 1,
+		totalCount: 2,
+		sightingDate: '2024-06-01T08:30:00.000Z',
+		latitude: '54.123456',
+		longitude: '13.654321',
+		firstName: 'Erika',
+		lastName: 'Mustermann',
+		email: 'erika@example.com',
+		phone: '+49 381 123456',
+		fax: null,
+		street: 'Hafenstraße 12',
+		zipCode: '18439',
+		city: 'Stralsund',
+		notes: 'Altbestand',
+		...overrides
+	} as unknown as FrontendSighting;
+}
+
+describe('buildAdminEditInitialValues', () => {
+	describe('Bestandsdaten', () => {
+		it('reicht die Kontakt- und Adressdaten unverändert durch', () => {
+			const values = buildAdminEditInitialValues(createSighting());
+
+			expect(values.firstName).toBe('Erika');
+			expect(values.lastName).toBe('Mustermann');
+			expect(values.email).toBe('erika@example.com');
+			expect(values.phone).toBe('+49 381 123456');
+			expect(values.street).toBe('Hafenstraße 12');
+			expect(values.zipCode).toBe('18439');
+			expect(values.city).toBe('Stralsund');
+			expect(values.notes).toBe('Altbestand');
+		});
+
+		it('erhält Felder, die das Formular gar nicht anzeigt', () => {
+			const values = buildAdminEditInitialValues(createSighting({ fax: '+49 381 999' }));
+
+			expect(values.fax).toBe('+49 381 999');
+			expect(values.referenceId).toBe('ref-4711');
+		});
+	});
+
+	describe('Koordinaten', () => {
+		it('übernimmt die volle Genauigkeit der gespeicherten Koordinaten', () => {
+			const values = buildAdminEditInitialValues(createSighting());
+
+			expect(values.latitude).toBe('54.123456');
+			expect(values.longitude).toBe('13.654321');
+			expect(values.hasPosition).toBe(true);
+		});
+
+		it('erfindet für eine Sichtung ohne Position keine Koordinaten', () => {
+			const values = buildAdminEditInitialValues(
+				createSighting({ latitude: null, longitude: null })
+			);
+
+			expect(values.latitude).toBeNull();
+			expect(values.longitude).toBeNull();
+			expect(values.hasPosition).toBe(false);
+		});
+
+		it('meldet keine Position, wenn nur ein Wert vorliegt', () => {
+			const values = buildAdminEditInitialValues(createSighting({ longitude: null }));
+
+			expect(values.hasPosition).toBe(false);
+		});
+	});
+
+	describe('Datum und Uhrzeit', () => {
+		it('zerlegt den Zeitstempel in deutsche Wanduhrzeit', () => {
+			const values = buildAdminEditInitialValues(createSighting());
+
+			// 08:30 UTC am 1. Juni ist 10:30 MESZ
+			expect(values.sightingDate).toBe('2024-06-01');
+			expect(values.sightingTime).toBe('10:30');
+		});
+	});
+});

--- a/src/lib/components/admin/adminEditInitialValues.ts
+++ b/src/lib/components/admin/adminEditInitialValues.ts
@@ -1,0 +1,48 @@
+import { hasCoordinates } from '$lib/report/components/form/coordinateValue';
+import type { FrontendSighting } from '$lib/types/FrontendSighting';
+import { splitDateTime } from '$lib/utils/format/dateTime';
+
+/**
+ * Baut die Startwerte des Admin-Bearbeitungsformulars aus einer gespeicherten
+ * Sichtung.
+ *
+ * **Der Rückgabewert ist der vollständige Datensatz, nicht nur das Sichtbare.**
+ * Das Formular zeigt weder Kontaktdaten noch Adresse an — beide überstehen eine
+ * Bearbeitung nur, weil sie hier unverändert in den Formularzustand wandern und
+ * von dort unverändert wieder an `PUT /api/sightings/[id]` gehen. Wer diese
+ * Funktion umbaut, entscheidet damit über den Bestand der Melderdaten:
+ * `mapFormToSighting` schreibt jedes Feld zurück, das im Body steht.
+ *
+ * Umgeformt werden nur die drei Felder, deren Form im Formular eine andere ist
+ * als in der Datenbank:
+ *
+ * - `sightingDate`/`sightingTime` — ein UTC-Zeitstempel wird zu Datum und
+ *   Uhrzeit in deutscher Wanduhrzeit; `berlinWallClockToUtc` rechnet das beim
+ *   Speichern zurück.
+ * - `hasPosition` — steuert, ob das Formular die Koordinatenfelder oder die
+ *   Gewässerbeschreibung zeigt.
+ *
+ * **Die Koordinaten werden bewusst nicht gerundet.** Bis 2026-08-02 stand hier
+ * `Number(sighting.latitude)?.toFixed(4)`. Die Spalten sind `numeric(8,6)` —
+ * jede Speicherung kürzte den Bestand damit von sechs auf vier
+ * Nachkommastellen (19.421 von 19.880 Zeilen, bis zu ~6 m Versatz), und zwar
+ * auch dann, wenn der Admin die Position gar nicht angefasst hat. Eine
+ * Anzeige-Rundung gehört ins Eingabefeld, nicht in den gespeicherten Wert.
+ *
+ * `Number(null)` ist `0`, eine Sichtung **ohne** Position startete deshalb mit
+ * `'0.0000'`. In die Datenbank kam diese Null nie: `handleSubmit` reicht das von
+ * Yup gecastete Objekt weiter, dort ist der String längst die Zahl `0`, und die
+ * fällt in `mapFormToSighting` in den Null-Zweig. Der Startwert bleibt trotzdem
+ * falsch — er behauptet eine Position, wo keine ist, und die nächste Änderung an
+ * einer der beiden Stellen macht daraus einen Punkt bei 0°/0°.
+ */
+export function buildAdminEditInitialValues(sighting: FrontendSighting): Record<string, unknown> {
+	const { date, time } = splitDateTime(sighting.sightingDate);
+
+	return {
+		...sighting,
+		sightingDate: date,
+		sightingTime: time,
+		hasPosition: hasCoordinates(sighting.latitude, sighting.longitude)
+	};
+}

--- a/src/lib/form/validation/adminSightingSchemaLegacy.test.ts
+++ b/src/lib/form/validation/adminSightingSchemaLegacy.test.ts
@@ -1,0 +1,105 @@
+import { DistanceEnum } from '$lib/report/formOptions/distance';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+import { describe, expect, it } from 'vitest';
+import * as yup from 'yup';
+import { adminSightingSchema, sightingSchema } from './sightingSchema';
+
+/**
+ * Bestandssichtungen müssen im Admin bearbeitbar bleiben.
+ *
+ * `adminSightingSchema` existiert genau dafür: Das öffentliche Formular darf
+ * strenger sein als der Altbestand, sonst kann ein Admin eine 13 Jahre alte
+ * Meldung nicht mehr korrigieren — auch dann nicht, wenn er an einem ganz
+ * anderen Feld etwas richtigstellt. Bisher deckte es nur die Anzahlen ab.
+ *
+ * Die Werte hier sind keine Konstruktion: `entfernung = 0` tragen 282 Zeilen,
+ * `vonwo = 0` ohne Freitext weitere 1.120 (Messung 2026-08-02, 19.881 Zeilen).
+ */
+
+/** Feldwerte, wie sie `buildAdminEditInitialValues` aus einer Bestandszeile baut. */
+function legacyFormValues(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		species: 1,
+		totalCount: 2,
+		juvenileCount: 0,
+		sightingDate: '2024-06-01',
+		sightingTime: '10:30',
+		hasPosition: true,
+		latitude: 54.123456,
+		longitude: 13.654321,
+		sightingFrom: SightingFromEnum.LAND,
+		distance: DistanceEnum.FROM_10_TO_50M,
+		firstName: 'Erika',
+		lastName: 'Mustermann',
+		email: 'erika@example.invalid',
+		privacyConsent: true,
+		referenceId: 'ref-4711',
+		...overrides
+	};
+}
+
+/** Sammelt die Fehler eines Validierungslaufs feldweise. */
+async function collectErrors(values: Record<string, unknown>): Promise<Record<string, string>> {
+	try {
+		await adminSightingSchema.validate(values, { abortEarly: false });
+		return {};
+	} catch (error) {
+		if (!(error instanceof yup.ValidationError)) throw error;
+		return Object.fromEntries(
+			error.inner.map((inner) => [inner.path ?? '?', inner.message] as const)
+		);
+	}
+}
+
+describe('adminSightingSchema — Bestandssichtungen', () => {
+	it('akzeptiert einen vollständigen Datensatz (Absicherung der Testbasis)', async () => {
+		expect(await collectErrors(legacyFormValues())).toEqual({});
+	});
+
+	it('akzeptiert `entfernung = 0` — der Sentinel für "nicht angegeben"', async () => {
+		// 282 Bestandszeilen. `DistanceEnum` geht von 1 bis 5; die 0 liegt bewusst
+		// außerhalb und wird als "Unbekannt" angezeigt (siehe mapFormToSighting).
+		expect(await collectErrors(legacyFormValues({ distance: 0 }))).toEqual({});
+	});
+
+	/**
+	 * Nicht `vonwo` selbst ist der Blocker, sondern der Freitext dahinter:
+	 * `sightingFromText` ist Pflicht, sobald "Sonstiges" gewählt ist. 1.120
+	 * Bestandszeilen tragen `vonwo = 0` **ohne** Text — beim Melden mag die
+	 * Nachfrage richtig sein, beim Bearbeiten verlangt sie vom Admin, eine
+	 * Angabe zu erfinden, die der Melder nie gemacht hat.
+	 */
+	it('akzeptiert `vonwo = 0` ohne Freitext', async () => {
+		expect(
+			await collectErrors(
+				legacyFormValues({ sightingFrom: SightingFromEnum.OTHER, sightingFromText: undefined })
+			)
+		).toEqual({});
+	});
+
+	it('erbt Beschriftung und Metadaten des Freitextfelds vom Basis-Schema', () => {
+		// Die Feld-Pipeline liest beides aus `describe()` — `FieldRenderer` nimmt
+		// genau diesen Typ entgegen. Eine Kopie statt einer Ableitung liefe beim
+		// nächsten Textwechsel auseinander; dieselbe Begründung wie bei den
+		// Anzahlen.
+		const base = sightingSchema.describe().fields.sightingFromText as yup.SchemaDescription;
+		const admin = adminSightingSchema.describe().fields.sightingFromText as yup.SchemaDescription;
+
+		expect(admin.label).toBe(base.label);
+		expect(admin.meta).toEqual(base.meta);
+	});
+
+	it('akzeptiert `vonwo = 5` — das serverseitig gesetzte "Keine Angabe"', async () => {
+		// Nicht auswählbar, aber `mapFormToSighting` schreibt es. Eine so
+		// gespeicherte Sichtung muss wieder bearbeitbar sein.
+		expect(
+			await collectErrors(legacyFormValues({ sightingFrom: SightingFromEnum.UNKNOWN }))
+		).toEqual({});
+	});
+
+	it('bleibt streng, wo es um echte Angaben geht', async () => {
+		const errors = await collectErrors(legacyFormValues({ distance: 99, sightingFrom: 42 }));
+
+		expect(Object.keys(errors).sort()).toEqual(['distance', 'sightingFrom']);
+	});
+});

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -22,7 +22,11 @@ import {
 	isValidAnimalCondition
 } from '$lib/report/formOptions/animalCondition';
 import { getBoatDriveOptions, isValidBoatDrive } from '$lib/report/formOptions/boatDrive';
-import { getDistanceOptions, isValidDistance } from '$lib/report/formOptions/distance';
+import {
+	DISTANCE_UNSPECIFIED,
+	getDistanceOptions,
+	isValidDistance
+} from '$lib/report/formOptions/distance';
 import { getDistributionOptions, isValidDistribution } from '$lib/report/formOptions/distribution';
 import { getEntryChannelOptions, isValidEntryChannel } from '$lib/report/formOptions/entryChannel';
 import { getSeaStateOptions, isValidSeaState } from '$lib/report/formOptions/seaState';
@@ -1291,28 +1295,41 @@ export const sightingSchema = yup
 	.concat(sightingSchemaBase);
 
 /**
- * Schema der Admin-Maske: dasselbe Formular, aber ohne die Eingabegrenzen für
- * die Anzahlen.
+ * Schema der Admin-Maske: dasselbe Formular, aber ohne die Eingabegrenzen, die
+ * nur für **neue** Meldungen gelten.
  *
- * Die Grenzen in `sightingSchema` sind **Eingaberegeln für neue Meldungen** —
- * mindestens ein Tier, höchstens 15, Jungtiere nicht mehr als Tiere insgesamt.
- * Auf den Bestand angewendet sperren sie die Korrektur genau der Datensätze,
- * die eine Korrektur am ehesten brauchen (Stand 2026-07-31, 19.880 Zeilen):
+ * Die Grenzen in `sightingSchema` sind Eingaberegeln am Meldeformular —
+ * mindestens ein Tier, höchstens 15, Jungtiere nicht mehr als Tiere insgesamt,
+ * eine Entfernungskategorie, ein Freitext zu „Sonstiges". Auf den Bestand
+ * angewendet sperren sie die Korrektur genau der Datensätze, die eine Korrektur
+ * am ehesten brauchen (Messung 2026-08-02, 19.881 Zeilen):
  *
- * | Bedingung                    | Zeilen | Herkunft                          |
- * | ---------------------------- | -----: | --------------------------------- |
- * | `anzahl_gesamt = 0`          |      5 | Legacy-Konvention „0 = Totfund"   |
- * | `anzahl_jung > anzahl_gesamt`|      8 | Altbestand                        |
- * | `anzahl_gesamt > 15`         |     22 | Altbestand, Kappung kam später    |
+ * | Bedingung                             | Zeilen | Herkunft                        |
+ * | ------------------------------------- | -----: | ------------------------------- |
+ * | `anzahl_gesamt = 0`                   |      5 | Legacy-Konvention „0 = Totfund" |
+ * | `anzahl_jung > anzahl_gesamt`         |      8 | Altbestand                      |
+ * | `anzahl_gesamt > 15`                  |     22 | Altbestand, Kappung kam später  |
+ * | `entfernung = 0`                      |    282 | Sentinel „nicht angegeben"      |
+ * | `vonwo = 0` ohne `vonwo_text`         |  1.120 | Altbestand ohne Nachfrage       |
  *
  * Ohne diese Lockerung könnte ein Admin eine solche Zeile nicht mehr speichern
  * — auch dann nicht, wenn er an einem ganz anderen Feld etwas richtigstellt.
+ * Beim Melden bleibt jede dieser Regeln unverändert in Kraft.
  *
  * Abgeleitet statt neu geschrieben: `.min()`/`.max()` und ein `.test()` mit
  * gleichem Namen ersetzen in Yup den vorhandenen Eintrag. Label und `meta`
  * bleiben damit erhalten — die Feld-Pipeline (`FieldRenderer`) liest sie aus
  * `describe()`, eine Kopie würde beim nächsten Textwechsel auseinanderlaufen.
+ *
+ * Nur `sightingFromText` geht diesen Weg nicht: Seine Pflicht steckt in einem
+ * `when()`, und Yup kennt keinen Weg, eine gesetzte Bedingung wieder zu
+ * entfernen — sie wird bei jedem Lauf **nach** allem angewandt, was hier
+ * überschrieben würde. Das Feld wird deshalb neu aufgebaut, holt Beschriftung
+ * und `meta` aber ausdrücklich aus dem Basis-Schema, damit die Texte weiterhin
+ * an genau einer Stelle stehen (abgesichert in `adminSightingSchemaLegacy.test.ts`).
  */
+const sightingFromTextBase = sightingSchema.fields.sightingFromText as yup.StringSchema;
+
 export const adminSightingSchema = sightingSchema.shape({
 	totalCount: (sightingSchema.fields.totalCount as yup.NumberSchema)
 		.min(0, 'Die Anzahl darf nicht negativ sein')
@@ -1329,5 +1346,23 @@ export const adminSightingSchema = sightingSchema.shape({
 			exclusive: true,
 			message: '',
 			test: () => true
-		})
+		}),
+
+	// Lässt den Sentinel `0` ("nicht angegeben") zu, ohne die Kategorien
+	// aufzuweichen: Ein erfundener Wert wie 99 fällt weiterhin durch.
+	distance: (sightingSchema.fields.distance as yup.NumberSchema).test({
+		name: 'is-valid-distance',
+		exclusive: true,
+		message: 'Bitte wählen Sie eine gültige Entfernungskategorie.',
+		test: (value) =>
+			value === undefined || value === DISTANCE_UNSPECIFIED || isValidDistance(String(value))
+	}),
+
+	// Der Freitext bleibt begrenzt, aber nicht mehr Pflicht — siehe oben.
+	sightingFromText: yup
+		.string()
+		.max(255, 'Die Angabe darf nicht länger als 255 Zeichen sein.')
+		.label(sightingFromTextBase.spec.label ?? 'Sonstiger Ort')
+		.meta(sightingFromTextBase.spec.meta ?? {})
+		.notRequired()
 });

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -340,13 +340,19 @@
 		<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 			<div>
 				<label class="label" for="latitude">Breite (N)</label>
+				<!-- step deckt die volle Spaltengenauigkeit ab: `gps_breite` ist
+				     numeric(8,6). Mit dem früheren step="0.0001" wies die
+				     Constraint-Validierung des Browsers jede Bestandskoordinate mit
+				     mehr als vier Nachkommastellen ab — und zwar lautlos: Das
+				     Formular sendet dann nicht, ohne dass die App einen Fehler
+				     anzeigt, weil das submit-Ereignis gar nicht erst entsteht. -->
 				<input
 					id="latitude"
 					class="input w-full"
 					type="number"
 					min="-90"
 					max="90"
-					step="0.0001"
+					step="0.000001"
 					placeholder="Dezimalgrad"
 					bind:value={ddLatitude}
 					onchange={onDecimalChange}
@@ -360,7 +366,7 @@
 					type="number"
 					min="-180"
 					max="180"
-					step="0.0001"
+					step="0.000001"
 					placeholder="Dezimalgrad"
 					bind:value={ddLongitude}
 					onchange={onDecimalChange}

--- a/src/lib/report/formOptions/distance.ts
+++ b/src/lib/report/formOptions/distance.ts
@@ -11,6 +11,21 @@ export enum DistanceEnum {
 }
 
 /**
+ * Sentinel für eine fehlende Entfernungsangabe.
+ *
+ * `DistanceEnum` geht von 1 bis 5 — die `0` der Spalte `entfernung` ist damit
+ * keine Kategorie, sondern liegt bewusst außerhalb und wird von
+ * `getDistanceLabel` als "Unbekannt" aufgelöst. Anders als bei `tierart`,
+ * `verteilung` oder `verhalten` behauptet diese Null also nichts Falsches und
+ * braucht keinen eigenen Enum-Wert.
+ *
+ * Steht hier und nicht bei den Schreibpfaden, weil zwei Stellen sie brauchen:
+ * `mapFormToSighting` schreibt sie, und `adminSightingSchema` muss sie beim
+ * Bearbeiten von Bestandsdaten wieder annehmen (282 Zeilen).
+ */
+export const DISTANCE_UNSPECIFIED = 0;
+
+/**
  * Deutsche Bezeichnungen für die Entfernungen
  */
 export const distanceLabels: Record<DistanceEnum, string> = {

--- a/src/lib/server/db/index.ts
+++ b/src/lib/server/db/index.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/private';
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
+import { TIMESTAMP_AS_TEXT } from './postgresTypes';
 import * as schema from './schema';
 
 // Error message constant for consistency
@@ -47,7 +48,12 @@ function initializeDb(): void {
 		const client = postgres(databaseUrl, {
 			max: 10,
 			idle_timeout: 20,
-			connect_timeout: 10
+			connect_timeout: 10,
+			// Zeitstempel ohne Zeitzone als Text übernehmen, damit Drizzle sie als
+			// UTC auslegt statt als Ortszeit des Prozesses — Begründung und
+			// Messwerte in `postgresTypes.ts`, abgesichert durch
+			// `timestampParsing.test.ts`.
+			types: { timestampAsText: TIMESTAMP_AS_TEXT }
 		});
 		_client = client;
 		_realDb = drizzle(client, { schema });

--- a/src/lib/server/db/mapFormToSighting.test.ts
+++ b/src/lib/server/db/mapFormToSighting.test.ts
@@ -115,6 +115,21 @@ describe('mapFormToSighting', () => {
 	});
 
 	/**
+	 * Setzt Rohwerte an einem Formularobjekt, wie sie zur Laufzeit tatsächlich
+	 * ankommen.
+	 *
+	 * `SightingFormData` ist aus dem Yup-Schema abgeleitet und kennt für die
+	 * Koordinaten nur `number`. Über die Legacy-REST-Grenze und aus dem
+	 * DOM-Eingabefeld kommen aber Zeichenketten — genau die Fälle, um die es in
+	 * den Tests unten geht. Der Umweg über `Record<string, unknown>` hält das
+	 * ohne `any` fest.
+	 */
+	const withRawValues = (
+		formData: SightingFormData,
+		raw: Record<string, unknown>
+	): SightingFormData => Object.assign(formData, raw);
+
+	/**
 	 * Hilfsfunktion: Erstellt vollständige Testdaten
 	 */
 	const createCompleteFormData = (): SightingFormData => ({
@@ -340,9 +355,10 @@ describe('mapFormToSighting', () => {
 		 * vorher über Yup und kam nie hier an.
 		 */
 		it('sollte eine Koordinaten-Null als Zeichenkette nicht als Position werten', () => {
-			const formData = createMinimalFormData();
-			formData.latitude = '0.0000' as any;
-			formData.longitude = '0.0000' as any;
+			const formData = withRawValues(createMinimalFormData(), {
+				latitude: '0.0000',
+				longitude: '0.0000'
+			});
 
 			const result = mapFormToSighting(formData);
 
@@ -353,9 +369,10 @@ describe('mapFormToSighting', () => {
 		});
 
 		it('sollte die volle Nachkommastellen-Genauigkeit übernehmen', () => {
-			const formData = createMinimalFormData();
-			formData.latitude = '54.123456' as any;
-			formData.longitude = '13.654321' as any;
+			const formData = withRawValues(createMinimalFormData(), {
+				latitude: '54.123456',
+				longitude: '13.654321'
+			});
 
 			const result = mapFormToSighting(formData);
 

--- a/src/lib/server/db/mapFormToSighting.test.ts
+++ b/src/lib/server/db/mapFormToSighting.test.ts
@@ -364,6 +364,19 @@ describe('mapFormToSighting', () => {
 		});
 	});
 
+	describe('Freitext-Felder', () => {
+		it('sollte den internen Kommentar übernehmen', () => {
+			// Das Admin-Formular bietet das Feld an (`Administrative.svelte`), der
+			// Mapper bildete es aber nicht ab — getippter Text war nach dem
+			// Speichern spurlos weg. Clients können es nicht setzen: Der öffentliche
+			// POST überschreibt es mit `undefined` (`api/sightings/+server.ts`).
+			const formData = createMinimalFormData();
+			formData.internalComment = 'Rückfrage an den Melder offen';
+
+			expect(mapFormToSighting(formData).internalComment).toBe('Rückfrage an den Melder offen');
+		});
+	});
+
 	describe('Datum/Zeit-Verarbeitung', () => {
 		it('sollte Datum und Zeit korrekt kombinieren', () => {
 			const formData = createMinimalFormData();

--- a/src/lib/server/db/mapFormToSighting.test.ts
+++ b/src/lib/server/db/mapFormToSighting.test.ts
@@ -326,6 +326,42 @@ describe('mapFormToSighting', () => {
 			expect(result.longitude).toBeNull();
 			expect(checkBalticSeaFile).not.toHaveBeenCalled();
 		});
+
+		/**
+		 * Eine Null als **Zeichenkette** ist keine Position.
+		 *
+		 * Die Prüfung lief bis 2026-08-02 über die Truthiness des Rohwerts. Für
+		 * eine Zahl stimmt das — `0` ist falsy —, für den String `'0.0000'` nicht:
+		 * er ist truthy und hätte einen PostGIS-Punkt bei 0°/0° erzeugt.
+		 *
+		 * Erreichbar ist dieser Eingang über die Legacy-REST-Grenze:
+		 * `mapLegacyToCurrentSchema` reicht `gps_breite` weiter, wie es ankommt,
+		 * und die Spezifikation sieht dort Strings vor. Der Formularpfad castet
+		 * vorher über Yup und kam nie hier an.
+		 */
+		it('sollte eine Koordinaten-Null als Zeichenkette nicht als Position werten', () => {
+			const formData = createMinimalFormData();
+			formData.latitude = '0.0000' as any;
+			formData.longitude = '0.0000' as any;
+
+			const result = mapFormToSighting(formData);
+
+			expect(result.location).toBeNull();
+			expect(result.latitude).toBeNull();
+			expect(result.longitude).toBeNull();
+			expect(checkBalticSeaFile).not.toHaveBeenCalled();
+		});
+
+		it('sollte die volle Nachkommastellen-Genauigkeit übernehmen', () => {
+			const formData = createMinimalFormData();
+			formData.latitude = '54.123456' as any;
+			formData.longitude = '13.654321' as any;
+
+			const result = mapFormToSighting(formData);
+
+			expect(result.latitude).toBe('54.123456');
+			expect(result.longitude).toBe('13.654321');
+		});
 	});
 
 	describe('Datum/Zeit-Verarbeitung', () => {

--- a/src/lib/server/db/mapFormToSighting.ts
+++ b/src/lib/server/db/mapFormToSighting.ts
@@ -4,6 +4,7 @@ import {
 	SHIP_NAME_CONSENT_VERSION
 } from '$lib/form/consent/consentVersions';
 import { MEDIA_CONSENT_VERSION } from '$lib/form/consent/mediaConsentVersion';
+import { toCoordinate } from '$lib/report/components/form/coordinateValue';
 import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
 import { DistributionEnum } from '$lib/report/formOptions/distribution';
@@ -179,21 +180,25 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 	let inBaltic = false,
 		inChartArea = false;
 
-	if (
-		formData.latitude &&
-		formData.longitude &&
-		!isNaN(formData.latitude) &&
-		!isNaN(formData.longitude)
-	) {
+	// Erst in eine Zahl umwandeln, dann prüfen. Die Regel bleibt dieselbe wie
+	// zuvor — eine Null ist keine Position —, sie hängt nur nicht mehr an der
+	// Truthiness des Rohwerts: `0` ist falsy, die Zeichenkette `'0.0000'` nicht.
+	//
+	// Über das Formular kam dieser Unterschied nie an, weil `handleSubmit` das
+	// von Yup gecastete Objekt weiterreicht und dort jede Koordinate eine Zahl
+	// ist. Die Legacy-REST-Grenze castet nicht: `mapLegacyToCurrentSchema` gibt
+	// die Werte des Clients weiter, wie sie ankommen. Ein `"0.0000"` von dort
+	// hätte einen PostGIS-Punkt bei 0°/0° erzeugt.
+	const latitude = toCoordinate(formData.latitude) || null;
+	const longitude = toCoordinate(formData.longitude) || null;
+
+	if (latitude !== null && longitude !== null) {
 		// PostGIS erwartet SRID 4326 für WGS84 (GPS-Koordinaten)
 		// ST_MakePoint(longitude, latitude) - Achtung: X=Longitude, Y=Latitude!
-		location = sql`ST_SetSRID(ST_MakePoint(${formData.longitude}, ${formData.latitude}), 4326)`;
+		location = sql`ST_SetSRID(ST_MakePoint(${longitude}, ${latitude}), 4326)`;
 
 		// Geografische Validierung: Prüfe ob Koordinaten in der Ostsee liegen
-		({ inBaltic, inChartArea } = checkBalticSeaFile(
-			Number(formData.longitude),
-			Number(formData.latitude)
-		));
+		({ inBaltic, inChartArea } = checkBalticSeaFile(longitude, latitude));
 	}
 
 	/**
@@ -216,9 +221,11 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 		created: new Date(), // Erstellungszeitpunkt
 
 		// === GEOGRAFISCHE DATEN ===
-		// Koordinaten als Strings für Datenbankkompatibilität
-		latitude: formData.latitude ? String(formData.latitude) : null,
-		longitude: formData.longitude ? String(formData.longitude) : null,
+		// Koordinaten als Strings für Datenbankkompatibilität. Die Zahl geht dabei
+		// ungekürzt in den String — die Spalten sind `numeric(8,6)`, eine
+		// Anzeige-Rundung gehört ins Eingabefeld und nicht in den Bestand.
+		latitude: latitude !== null ? String(latitude) : null,
+		longitude: longitude !== null ? String(longitude) : null,
 		// PostGIS-Geometrie für räumliche Abfragen
 		location,
 		// Gewässer und Seezeichen

--- a/src/lib/server/db/mapFormToSighting.ts
+++ b/src/lib/server/db/mapFormToSighting.ts
@@ -7,6 +7,7 @@ import { MEDIA_CONSENT_VERSION } from '$lib/form/consent/mediaConsentVersion';
 import { toCoordinate } from '$lib/report/components/form/coordinateValue';
 import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
+import { DISTANCE_UNSPECIFIED } from '$lib/report/formOptions/distance';
 import { DistributionEnum } from '$lib/report/formOptions/distribution';
 import { EntryChannelEnum } from '$lib/report/formOptions/entryChannel';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
@@ -15,17 +16,6 @@ import type { NewSighting } from '$lib/types/sighting';
 import { sql } from 'drizzle-orm';
 import { berlinWallClockToUtc } from '$lib/server/datetime/berlinWallClockToUtc';
 import { checkBalticSeaFile } from '$lib/server/geo/checkBalticSeaFile';
-
-/**
- * Sentinel für eine fehlende Entfernungsangabe.
- *
- * `DistanceEnum` geht von 1 bis 5 — die `0` der Spalte `entfernung` ist damit
- * keine Kategorie, sondern liegt bewusst außerhalb und wird von
- * `getDistanceLabel` als "Unbekannt" aufgelöst. Anders als bei `tierart`,
- * `verteilung` oder `verhalten` behauptet diese Null also nichts Falsches und
- * braucht keinen eigenen Enum-Wert.
- */
-const DISTANCE_UNSPECIFIED = 0;
 
 /**
  * Prüft, ob für ein numerisches Auswahlfeld eine verwertbare Angabe vorliegt.
@@ -351,6 +341,15 @@ export function mapFormToSighting(formData: SightingFormValues): NewSighting {
 		// === FREITEXT-FELDER ===
 		// Admin-Notizen (nur im Admin-Bereich sichtbar)
 		notes: formData.notes,
+		// Interner Kommentar. Das Admin-Formular bietet ihn an
+		// (`Administrative.svelte`), hier fehlte er — getippter Text war nach dem
+		// Speichern spurlos weg, ohne Fehlermeldung.
+		//
+		// Über den öffentlichen Weg kann niemand hier hineinschreiben:
+		// `POST /api/sightings` überschreibt das Feld mit `undefined`, und der
+		// Legacy-Eingang kennt es nicht. Ein `undefined` erreicht die Spalte nie —
+		// Drizzle lässt es beim Insert wie beim Update aus.
+		internalComment: formData.internalComment,
 		// Weitere Beobachtungen durch Melder*in
 		otherObservations: formData.otherObservations,
 

--- a/src/lib/server/db/postgresTypes.ts
+++ b/src/lib/server/db/postgresTypes.ts
@@ -1,0 +1,53 @@
+/**
+ * Treiber-Typen für `postgres.js`, damit Zeitstempel nicht an der Zeitzone des
+ * Prozesses hängen.
+ *
+ * **Worum es geht.** Die Spalten der Sichtungstabelle sind `timestamp without
+ * time zone` und halten laut Konvention echte UTC-Zeitpunkte
+ * (`docs/ENVIRONMENT.md`, Abschnitt `TZ`). Drizzle pinnt beide Richtungen —
+ * `toISOString()` beim Schreiben, angehängtes `+0000` beim Lesen. Der Lesweg
+ * greift aber nur, wenn der Treiber einen **String** übergibt:
+ *
+ * ```js
+ * // drizzle-orm/pg-core/columns/timestamp.js
+ * mapFromDriverValue(value) {
+ *   if (typeof value === 'string') return new Date(value + '+0000');
+ *   return value;   // ← postgres.js landet hier
+ * }
+ * ```
+ *
+ * `postgres.js` parst den Wert nämlich selbst, und zwar als **Ortszeit** des
+ * Prozesses. Nachgemessen mit einem eigenständigen Client unter
+ * `TZ=Europe/Berlin`: Die Spalte enthält `2026-08-02 12:30:00`, zurück kommt ein
+ * `Date` auf `10:30Z`. Die Zusicherung „unabhängig von `TZ`" hängt damit allein
+ * am gepinnten `TZ=UTC` — und nicht am Code, wie die Dokumentation nahelegt.
+ *
+ * **Was nicht gilt:** Ein Fehlverhalten der laufenden Anwendung. Gemessen am
+ * 2026-08-02 liest sie Sommer- wie Winterzeitpunkte korrekt, auch ohne diesen
+ * Override, weil ihr Prozess in UTC läuft. Dieser Override ist deshalb eine
+ * zweite Sicherung, kein reparierter Fehler: Er nimmt der Zusicherung die
+ * Abhängigkeit von einer Umgebungsvariablen.
+ *
+ * **Bewusst nur 1114.** `timestamptz` (1184) trägt den Offset auf der Leitung
+ * und wird von `postgres.js` korrekt geparst; die Session-Spalten hängen daran.
+ * `date` (1082) bleibt ebenfalls unberührt — dort gibt es keine Uhrzeit, die
+ * verrutschen könnte.
+ */
+
+/** Postgres-OID von `timestamp without time zone`. */
+export const TIMESTAMP_OID = 1114;
+
+/**
+ * Reicht `timestamp`-Werte unverändert als Text durch.
+ *
+ * `to`/`serialize` sind Pflichtfelder der `types`-Option von `postgres.js`,
+ * kommen hier aber nie zum Zug: Sie greifen nur, wenn ein Wert ausdrücklich über
+ * `sql.typed.…` geschrieben wird. Geschrieben wird weiterhin über Drizzle, das
+ * `toISOString()` als gewöhnlichen Parameter schickt.
+ */
+export const TIMESTAMP_AS_TEXT = {
+	to: TIMESTAMP_OID,
+	from: [TIMESTAMP_OID],
+	serialize: (value: unknown): unknown => value,
+	parse: (value: string): string => value
+};

--- a/src/lib/server/db/timestampParsing.test.ts
+++ b/src/lib/server/db/timestampParsing.test.ts
@@ -1,0 +1,65 @@
+import { TEST_TIME_ZONES, withTimeZone } from '$lib/server/datetime/withTimeZone.testutil';
+import { describe, expect, it } from 'vitest';
+import { TIMESTAMP_AS_TEXT, TIMESTAMP_OID } from './postgresTypes';
+import { sightings } from './schema';
+
+/**
+ * Die Zeitstempel-Spalten halten echte UTC-Zeitpunkte — unabhängig davon, in
+ * welcher Zeitzone der Prozess läuft.
+ *
+ * Diese Zusicherung stand bis 2026-08-02 nur in `docs/ENVIRONMENT.md` („Drizzle
+ * pins both directions explicitly"). Für den Schreibweg stimmte sie
+ * (`toISOString()` trägt ein `Z`, das Postgres beim Einfügen in eine Spalte ohne
+ * Zeitzone verwirft), für den Lesweg nicht: Drizzle hängt sein `+0000` nur an,
+ * wenn der Treiber einen **String** liefert — `postgres.js` liefert für
+ * `timestamp without time zone` aber ein bereits geparstes `Date`, ausgelegt in
+ * der Zeitzone des Prozesses. Gehalten hat die Zusicherung damit allein das
+ * gepinnte `TZ=UTC`.
+ *
+ * **Kein beobachteter Fehler, sondern eine entfernte Abhängigkeit.** Die
+ * laufende Anwendung liest auch ohne diesen Override korrekt, weil ihr Prozess
+ * in UTC läuft (nachgemessen für Sommer- und Winterzeitpunkte). Der Test hält
+ * fest, dass das Ergebnis nicht mehr davon abhängt.
+ *
+ * Geprüft wird hier die Naht selbst — Parser-Override und Drizzle-Mapping —,
+ * weil sie ohne Datenbank vollständig bestimmt ist. Den Weg durch echte
+ * Postgres-Verbindung, Formular und zurück deckt
+ * `e2e/admin-edit-preserves-record.spec.ts` ab.
+ */
+
+/** Was Postgres für `timestamp without time zone` auf der Leitung schickt. */
+const WIRE_VALUE = '2024-06-01 08:30:00';
+const EXPECTED_INSTANT = '2024-06-01T08:30:00.000Z';
+
+describe('Zeitstempel-Parsing', () => {
+	it('deckt genau die Spalten ohne Zeitzone ab', () => {
+		// 1114 = timestamp without time zone. Die Session-Spalten sind
+		// `timestamptz` (1184) und werden von postgres.js korrekt mit Offset
+		// geparst — sie bleiben deshalb bewusst außen vor.
+		expect(TIMESTAMP_OID).toBe(1114);
+		expect(TIMESTAMP_AS_TEXT.from).toEqual([TIMESTAMP_OID]);
+	});
+
+	it('reicht den Rohwert unverändert an Drizzle weiter', () => {
+		expect(TIMESTAMP_AS_TEXT.parse(WIRE_VALUE)).toBe(WIRE_VALUE);
+	});
+
+	for (const timeZone of TEST_TIME_ZONES) {
+		it(`liest denselben UTC-Zeitpunkt unter ${timeZone}`, () => {
+			const instant = withTimeZone(timeZone, () => {
+				const raw = TIMESTAMP_AS_TEXT.parse(WIRE_VALUE);
+				return sightings.sightingDate.mapFromDriverValue(raw) as Date;
+			});
+
+			expect(instant.toISOString()).toBe(EXPECTED_INSTANT);
+		});
+	}
+
+	it('belegt, dass die Voreinstellung des Treibers das nicht leistet', () => {
+		// Gegenprobe zur Begründung oben: Ohne den Override parst postgres.js den
+		// Wert selbst, und Drizzle reicht ein fertiges Date unverändert durch.
+		const driverDefault = withTimeZone('Europe/Berlin', () => new Date(WIRE_VALUE));
+
+		expect(driverDefault.toISOString()).not.toBe(EXPECTED_INSTANT);
+	});
+});

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -16,6 +16,7 @@ import {
 import type { ExifData } from '$lib/types';
 import { createId } from '@paralleldrive/cuid2';
 import { error, isHttpError, json } from '@sveltejs/kit';
+import { ValidationError } from 'yup';
 import { eq } from 'drizzle-orm';
 import type { RequestHandler } from './$types';
 
@@ -198,6 +199,34 @@ export const PUT: RequestHandler = async ({ params, request, locals, url, getCli
 		return json(updatedSighting);
 	} catch (err) {
 		if (isHttpError(err)) throw err;
+
+		// Eine abgelehnte Eingabe ist kein Serverfehler. Als 500 las der Admin
+		// „Interner Serverfehler" und hatte keinen Anhaltspunkt, welches Feld ihn
+		// blockiert — die Meldung log genau dann, wenn sie hätte helfen können.
+		if (err instanceof ValidationError) {
+			// Gleiche Hülle wie `POST /api/sightings` (`success`/`code`/`message`/
+			// `errors`) — dieselbe Ressource soll denselben Fehler nicht in zwei
+			// Formen melden. `message` trägt hier den ersten konkreten Fehler statt
+			// eines Sammelbegriffs: Das Bearbeitungsformular zeigt genau dieses Feld
+			// an, und ein Admin korrigiert eine bestehende Zeile, keine Eingabe von
+			// Grund auf.
+			const errors: Record<string, string> = {};
+			for (const inner of err.inner) {
+				if (inner.path) errors[inner.path] = inner.message;
+			}
+			logger.info({ id, errors }, 'Sichtung abgelehnt: Validierung fehlgeschlagen');
+
+			return json(
+				{
+					success: false,
+					code: 'VALIDATION_ERROR',
+					message: err.errors[0] ?? 'Die Angaben sind unvollständig oder ungültig.',
+					errors
+				},
+				{ status: 400 }
+			);
+		}
+
 		logger.error({ err }, 'Fehler beim Aktualisieren der Sichtung:');
 		throw error(500, 'Interner Serverfehler');
 	}

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -1,4 +1,4 @@
-import { sightingSchema } from '$lib/form/validation/sightingSchema';
+import { adminSightingSchema } from '$lib/form/validation/sightingSchema';
 import { createLogger } from '$lib/logger.server';
 import type { SightingFormData } from '$lib/report/types';
 import { logAuditEvent } from '$lib/server/audit/auditService';
@@ -94,8 +94,15 @@ export const PUT: RequestHandler = async ({ params, request, locals, url, getCli
 
 		logger.debug({ formData, uploadedFiles }, 'Sichtung speichern');
 
-		// Validierung der Formulardaten
-		await sightingSchema.validate(formData, { abortEarly: false });
+		// Validierung der Formulardaten gegen das Admin-Schema. Dieser Endpunkt ist
+		// die Rückseite des Bearbeitungsformulars und damit der einzige, der
+		// **bestehende** Zeilen entgegennimmt — die Eingabegrenzen des
+		// Meldeformulars (Anzahlen, Entfernungskategorie, Freitext zu „Sonstiges")
+		// sperren dort 1.158 Bestandssichtungen aus. Mit `sightingSchema` blieb die
+		// Lockerung im Browser wirkungslos: Der Server warf die Meldung als 500
+		// zurück, und der Admin las „Interner Serverfehler". Neue Meldungen laufen
+		// unverändert über `POST /api/sightings` und das strenge Schema.
+		await adminSightingSchema.validate(formData, { abortEarly: false });
 
 		// Load current state for changedFields diff
 		const currentRecords = await db

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -214,6 +214,13 @@ export const PUT: RequestHandler = async ({ params, request, locals, url, getCli
 			for (const inner of err.inner) {
 				if (inner.path) errors[inner.path] = inner.message;
 			}
+			// Nicht jeder Fehler trägt ein Feld: Ein schemaweiter `.test()` schlägt
+			// ohne `path` fehl, und je nach Aufrufweg bleibt `inner` leer. Ohne
+			// Auffangwert bekäme das Formular eine leere Karte und hätte nichts
+			// anzuzeigen — derselbe Schlüssel wie im POST-Zweig.
+			if (Object.keys(errors).length === 0) {
+				errors.allgemein = err.message;
+			}
 			logger.info({ id, errors }, 'Sichtung abgelehnt: Validierung fehlgeschlagen');
 
 			return json(

--- a/src/routes/api/sightings/[id]/filePathValidation.test.ts
+++ b/src/routes/api/sightings/[id]/filePathValidation.test.ts
@@ -41,6 +41,10 @@ vi.mock('drizzle-orm', () => ({
 vi.mock('$lib/form/validation/sightingSchema', () => ({
 	sightingSchema: {
 		validate: vi.fn().mockResolvedValue(undefined)
+	},
+	// PUT validiert gegen das Admin-Schema (siehe +server.ts).
+	adminSightingSchema: {
+		validate: vi.fn().mockResolvedValue(undefined)
 	}
 }));
 

--- a/src/routes/api/sightings/[id]/server.test.ts
+++ b/src/routes/api/sightings/[id]/server.test.ts
@@ -302,4 +302,30 @@ describe('PUT /api/sightings/[id] - abgelehnte Eingaben', () => {
 		// Kein Update, wenn die Eingabe nicht durchkommt.
 		expect(updateSighting).not.toHaveBeenCalled();
 	});
+
+	/**
+	 * Nicht jeder Yup-Fehler trägt ein Feld: Ein schemaweiter `.test()` schlägt
+	 * ohne `path` fehl, und je nach Aufrufweg bleibt `inner` leer. Ohne Auffangwert
+	 * käme eine leere Fehlerkarte zurück — das Formular hätte dann nichts
+	 * anzuzeigen und der Admin keinen Anhaltspunkt. `POST /api/sightings` löst das
+	 * seit jeher über denselben Schlüssel.
+	 */
+	it('nennt einen Sammelschlüssel, wenn kein Feld benannt ist', async () => {
+		const validationError = new ValidationError('Die Angaben passen nicht zusammen.');
+		validationError.inner = [];
+		vi.mocked(adminSightingSchema.validate).mockRejectedValueOnce(validationError);
+
+		const response = await PUT({
+			params: { id: '42' },
+			request: createPutRequest({ species: 1 }) as unknown as Request,
+			locals: { user: { email: 'admin@example.com', roles: ['admin'] } } as unknown as App.Locals,
+			url: new URL('http://localhost/api/sightings/42'),
+			getClientAddress: mockGetClientAddress
+		} as Parameters<typeof PUT>[0]);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toMatchObject({
+			errors: { allgemein: 'Die Angaben passen nicht zusammen.' }
+		});
+	});
 });

--- a/src/routes/api/sightings/[id]/server.test.ts
+++ b/src/routes/api/sightings/[id]/server.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ValidationError } from 'yup';
 
 // Mock all external dependencies
 vi.mock('$lib/server/auth/auth', () => ({
@@ -51,6 +52,7 @@ vi.mock('$lib/logger', () => ({
 }));
 
 import { db } from '$lib/server/db';
+import { adminSightingSchema } from '$lib/form/validation/sightingSchema';
 import { updateSighting } from '$lib/server/db/sightingRepository';
 import { logAuditEvent } from '$lib/server/audit/auditService';
 import { PUT } from './+server';
@@ -254,5 +256,50 @@ describe('PUT /api/sightings/[id] - changedFields Audit-Diff', () => {
 		const changedFields: string[] = auditCall?.details?.changedFields as string[];
 
 		expect(changedFields.length).toBe(0);
+	});
+});
+
+describe('PUT /api/sightings/[id] - abgelehnte Eingaben', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	/**
+	 * Eine abgelehnte Eingabe ist kein Serverfehler.
+	 *
+	 * Vorher lief die Yup-`ValidationError` in den 500er-Zweig, und der Admin las
+	 * „Interner Serverfehler" — ausgerechnet in dem Fall, in dem die Meldung ihm
+	 * hätte sagen können, welches Feld ihn blockiert.
+	 */
+	it('antwortet mit 400 und nennt die betroffenen Felder', async () => {
+		const validationError = new ValidationError('Bitte geben Sie eine Entfernung an.');
+		validationError.inner = [
+			Object.assign(new ValidationError('Bitte geben Sie eine Entfernung an.'), {
+				path: 'distance'
+			}),
+			Object.assign(new ValidationError('Tierart fehlt'), { path: 'species' })
+		];
+		vi.mocked(adminSightingSchema.validate).mockRejectedValueOnce(validationError);
+
+		const mockRequest = createPutRequest({ species: 1 });
+		const response = await PUT({
+			params: { id: '42' },
+			request: mockRequest as unknown as Request,
+			locals: { user: { email: 'admin@example.com', roles: ['admin'] } } as unknown as App.Locals,
+			url: new URL('http://localhost/api/sightings/42'),
+			getClientAddress: mockGetClientAddress
+		} as Parameters<typeof PUT>[0]);
+
+		expect(response.status).toBe(400);
+		// Dieselbe Hülle wie bei POST /api/sightings — eine Ressource, ein Format.
+		await expect(response.json()).resolves.toEqual({
+			success: false,
+			code: 'VALIDATION_ERROR',
+			message: 'Bitte geben Sie eine Entfernung an.',
+			errors: { distance: 'Bitte geben Sie eine Entfernung an.', species: 'Tierart fehlt' }
+		});
+
+		// Kein Update, wenn die Eingabe nicht durchkommt.
+		expect(updateSighting).not.toHaveBeenCalled();
 	});
 });

--- a/src/routes/api/sightings/[id]/server.test.ts
+++ b/src/routes/api/sightings/[id]/server.test.ts
@@ -25,6 +25,10 @@ vi.mock('$lib/server/audit/auditService', () => ({
 vi.mock('$lib/form/validation/sightingSchema', () => ({
 	sightingSchema: {
 		validate: vi.fn().mockResolvedValue(undefined)
+	},
+	// PUT validiert gegen das Admin-Schema (siehe +server.ts).
+	adminSightingSchema: {
+		validate: vi.fn().mockResolvedValue(undefined)
 	}
 }));
 

--- a/src/routes/api/sightings/[id]/sighting.test.ts
+++ b/src/routes/api/sightings/[id]/sighting.test.ts
@@ -27,7 +27,10 @@ vi.mock('$lib/logger', () => ({
 }));
 
 vi.mock('$lib/form/validation/sightingSchema', () => ({
-	sightingSchema: { validate: vi.fn().mockResolvedValue(true) }
+	// PUT validiert gegen das Admin-Schema (Bestandssichtungen), POST gegen das
+	// strenge — beide mocken, sonst hängt der Test am Import.
+	sightingSchema: { validate: vi.fn().mockResolvedValue(true) },
+	adminSightingSchema: { validate: vi.fn().mockResolvedValue(true) }
 }));
 
 vi.mock('$lib/server/db', () => ({

--- a/src/tests/contract/sightings-id.contract.test.ts
+++ b/src/tests/contract/sightings-id.contract.test.ts
@@ -86,7 +86,9 @@ vi.mock('$lib/server/db/sightingRepository', () => ({
 }));
 
 vi.mock('$lib/form/validation/sightingSchema', () => ({
-	sightingSchema: { validate: vi.fn().mockResolvedValue(undefined) }
+	sightingSchema: { validate: vi.fn().mockResolvedValue(undefined) },
+	// PUT validiert gegen das Admin-Schema (siehe +server.ts).
+	adminSightingSchema: { validate: vi.fn().mockResolvedValue(undefined) }
 }));
 
 vi.mock('$lib/server/auth/auth', () => ({

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2928,28 +2928,42 @@ components:
 
     ValidationErrorResponse:
       type: object
+      description: |
+        Abgelehnte Eingabe. Beide Endpunkte, die darauf verweisen
+        (`POST /api/sightings` und `PUT /api/sightings/{id}`), liefern genau
+        diese Hülle.
+
+        Der Feldschlüssel entspricht dem Namen im `SightingFormData`-Schema und
+        trägt **eine** Meldung, nicht mehrere: Yup läuft mit `abortEarly: false`
+        und behält je Feld die zuletzt gefundene.
       required:
         - success
-        - error
-        - validationErrors
+        - code
+        - message
+        - errors
       properties:
         success:
           type: boolean
           example: false
-        error:
+        code:
           type: string
-          description: Allgemeine Fehlermeldung
-          example: "Validierungsfehler"
-        validationErrors:
+          description: Maschinenlesbare Fehlerkennung
+          example: "VALIDATION_ERROR"
+        message:
+          type: string
+          description: |
+            Menschenlesbare Meldung. `POST` nennt hier den Sammelbegriff,
+            `PUT` den ersten konkreten Feldfehler — das Bearbeitungsformular
+            zeigt genau diesen Text an.
+          example: "Bitte wählen Sie eine gültige Entfernungskategorie."
+        errors:
           type: object
           description: Feldspezifische Validierungsfehler
           additionalProperties:
-            type: array
-            items:
-              type: string
+            type: string
           example:
-            email: ["E-Mail ist erforderlich", "Ungültiges E-Mail-Format"]
-            latitude: ["Breitengrad muss zwischen -90 und 90 liegen"]
+            distance: "Bitte wählen Sie eine gültige Entfernungskategorie."
+            email: "Bitte geben Sie eine gültige E-Mail-Adresse ein."
 
     LegacySightingRequest:
       type: object


### PR DESCRIPTION
Ausgangsfrage: Was passiert mit der Adresse einer meldenden Person, wenn ein Admin die Sichtung bearbeitet und speichert? Die Adresse überlebt — sie wandert unsichtbar durch den Formularzustand. Beim Nachprüfen dieser Kette kamen vier Fehler heraus, die alle am selben Weg hängen.

## Was drin ist

**1. Koordinaten wurden bei jedem Speichern gekürzt** (`0d4feefb`)
Das Formular baute seine Startwerte mit `Number(sighting.latitude)?.toFixed(4)`. Die Spalten sind `numeric(8,6)` — jede Speicherung schnitt zwei Nachkommastellen ab, auch wenn niemand die Position angefasst hatte. Betroffen wären **19.421 von 19.881** Zeilen gewesen, bis zu ~6 m Versatz, PostGIS-Punkt inklusive.

Beim Entfernen der Rundung kam ein zweiter Fehler zum Vorschein: `step="0.0001"` an den Dezimalgrad-Feldern. Die Constraint-Validierung des Browsers wies jede Bestandskoordinate ab — **lautlos**, denn ohne `submit`-Ereignis läuft weder Yup noch die Fehlerliste.

**2. 1.158 Bestandssichtungen ließen sich gar nicht speichern** (`eec5da6b`)
`entfernung = 0` (282 Zeilen) und `vonwo = 0` ohne Freitext (1.120 Zeilen) sind gültige Altdaten, aber keine gültigen Eingaben am Meldeformular. Der Admin bekam eine Fehlerliste zu Feldern, die er nie ausgefüllt hat. `adminSightingSchema` deckt beides ab; beim Melden ändert sich nichts.

Die zweite Hälfte saß auf dem Server: `PUT /api/sightings/[id]` validierte gegen das strenge Schema. Die Lockerung im Browser war damit wirkungslos — auch die der Anzahlen, die es schon länger gibt.

Dazu: Der interne Kommentar wurde vom Formular angeboten, aber nirgends gespeichert.

**3. Zeitstempel-Lesweg hing an der Prozess-Zeitzone** (`62229075`)
Kein beobachteter Fehler — die Anwendung läuft in UTC und liest korrekt. Aber die Zusicherung aus `docs/ENVIRONMENT.md` hing allein am gepinnten `TZ`, nicht am Code: Drizzles `+0000` greift nur bei Strings, und `postgres.js` parst `timestamp without time zone` selbst als Ortszeit. Der Treiber gibt OID 1114 jetzt als Text weiter.

**4. Zwei Randnotizen** (`53736475`, `b09b4ce4`)
Der E2E-Submit-Test räumt seine echte Meldung wieder weg (drei Karteileichen standen im Bestand). Abgelehnte Bearbeitungen antworten 400 statt 500 und nennen das blockierende Feld; die OpenAPI-Spec beschreibt die Hülle jetzt so, wie sie tatsächlich kommt.

## Tests

`e2e/admin-edit-preserves-record.spec.ts` fährt die Kette einmal echt durch — Loader, Formular, PUT, Datenbank — und prüft, was eine Bearbeitung **nicht** anfassen darf: Adresse, Kontaktdaten, Koordinaten in voller Auflösung, Zeitpunkt. Bis dahin sicherte kein Test, dass die Melderdaten eine Bearbeitung überstehen; sie hingen an einem Spread in einer Svelte-Komponente.

Dazu Unit-Tests für die Startwert-Logik, das Admin-Schema mit Bestandswerten, die Koordinaten-Behandlung im Mapper und die Zeitstempel-Naht unter vier Zeitzonen. Jeder Fix ist RED→GREEN nachgewiesen, jeder Commit isoliert geprüft.

## Bekannte Grenzen

- Schon gekürzte Koordinaten sind nicht rekonstruierbar und von normalen Karteneinträgen nicht unterscheidbar (`OLMap` rundet die Geste ohnehin auf vier Stellen). Kein Reparaturlauf.
- `legacy-inbox/app.test.js` ist im Gesamtlauf sporadisch rot — isoliert grün, auf sauberem Baum genauso. Nicht von diesem PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)