### PR TITLE
fix(test): eigener E2E-Port pro Worktree und geprüfte Server-Identität

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,13 @@ per `SessionStart`-Hook). Drei Dinge, die dabei erfahrungsgemäß schiefgehen:
   eigene Installation kostet ~800 MB ohne Gegenwert. Ausnahme: Der Branch ändert
   `package-lock.json`.
 - **Nur ein Dev-Server auf Port 4000.** `PUBLIC_SITE_URL` ist fest auf 4000 und baut die
-  Auth0-Callback-URL; ein anderer Port bricht den Login.
+  Auth0-Callback-URL; ein anderer Port bricht den Login. Bei belegtem Port bricht
+  `npm run dev` ab (`strictPort`), statt still auszuweichen.
+- **E2E-Tests laufen auf einem Port pro Worktree.** Vorher benutzten alle Worktrees fest
+  4001 und Playwright verwendete lokal jeden Server wieder, der dort antwortete — Läufe
+  gegen einen fremden Branch waren die Folge, im schlimmsten Fall **grün**. Der Port
+  kommt jetzt aus dem Pfad-Hash, und `e2e/global-setup.ts` bricht ab, wenn der Server
+  aus einem anderen Verzeichnis ausliefert.
 - **Datenbank und `uploads/` sind geteilt.** `db:push` und `media:cleanup-orphans`
   wirken auf alle Worktrees.
 

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -137,10 +137,15 @@ der nach dem Beheben weiter die alten Fundstellen meldete, und zwei
 
 Zwei Ebenen dagegen, beide in [`src/tools/dev-server-identity.ts`](../src/tools/dev-server-identity.ts):
 
-| Ebene                                          | Wirkung                                                                                                                                       |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `worktreeDevPort()` — Port aus dem Pfad-Hash   | Jeder Worktree bekommt einen eigenen Port aus 4100–4499. Kollisionen entstehen gar nicht erst; derselbe Worktree bekommt stets denselben Port |
-| `assertServerIdentity()` in `e2e/global-setup` | Der Dev-Server meldet unter `/__dev-server-identity` sein `process.cwd()`. Weicht es ab, **bricht der Lauf ab**                               |
+| Ebene                                          | Wirkung                                                                                                                                                                                                    |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktreeDevPort()` — Port aus dem Pfad-Hash   | Jeder Worktree zieht einen Port aus 41000–44999, derselbe Worktree stets denselben. Kollisionen sind damit unwahrscheinlich, nicht ausgeschlossen (Geburtstagsproblem: ~1 % bei 10 Worktrees, ~5 % bei 20) |
+| `assertServerIdentity()` in `e2e/global-setup` | Der Dev-Server meldet unter `/__dev-server-identity` sein `process.cwd()`. Weicht es ab, **bricht der Lauf ab**                                                                                            |
+
+Die zweite Ebene fängt die erste auf: Ziehen zwei Worktrees denselben Port, ist das
+kein stiller Fehler, sondern ein Abbruch mit beiden Verzeichnissen in der Meldung. Der
+zweite Worktree kann erst testen, wenn der fremde Server beendet ist — unbequem, aber
+in die richtige Richtung.
 
 Der Abbruch ist Absicht — nicht eine Warnung, die im Log untergeht. Stillschweigend
 fremden Code zu testen ist genau der Fehler, der verhindert werden soll:

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -98,7 +98,74 @@ Redirect zeigt danach auf 4005). **Login funktioniert trotzdem nur**, wenn genau
 Callback-URL in den Auth0-Einstellungen als _Allowed Callback URL_ hinterlegt ist.
 Ohne Auth0-Eintrag: Dev-Server auf 4000 lassen und immer nur einen laufen lassen.
 
-E2E-Tests nutzen ohnehin Port 4001 (`npm run test:e2e`).
+Belegt ein anderer Prozess den Port, bricht `npm run dev` seit
+[`vite.config.ts`](../vite.config.ts) (`strictPort: true`) ab, statt still auf den
+nächsten freien Port auszuweichen. Läuft dort ein Dev-Server dieses Projekts, nennt die
+Meldung davor sein Arbeitsverzeichnis:
+
+```
+Port 4000 wird bereits von einem Dev-Server bedient — aus:
+  /…/.claude/worktrees/hopeful-curie-90f94e
+Dieses Verzeichnis ist:
+  /…/.claude/worktrees/auth0-prod-settings-499d2e
+```
+
+Das Ausweichen war nie eine brauchbare Rückfallebene: Ein Server auf 4001 hat wegen
+`PUBLIC_SITE_URL` einen kaputten Login — und er machte E2E-Läufe gegen fremde Worktrees
+möglich (nächster Abschnitt).
+
+## E2E-Tests: eigener Port pro Worktree, geprüfte Server-Identität
+
+**Geteilte Ports heben die Aussagekraft der Tests auf.** Das ist die schwerwiegendere
+Folge als ein kaputter Login — und sie fällt nicht auf.
+
+Vorher setzte `npm run test:e2e` für **alle** Worktrees fest `VITE_DEV_PORT=4001`, und
+`playwright.config.ts` benutzt lokal `reuseExistingServer`. Antwortete auf 4001
+irgendein Server, lief die Suite gegen ihn — ohne zu prüfen, woher der Code stammt.
+Gemessen am 2026-08-02 gehörten 4000 **und** 4001 einem fremden Worktree:
+
+```bash
+lsof -a -p $(lsof -ti:4001) -d cwd    # zeigt das ausliefernde Verzeichnis
+```
+
+Die Folge waren 32 Fehlschläge für Fundstellen, die im eigenen Branch längst behoben
+waren. Der gefährliche Fall ist aber der umgekehrte: Der fremde Worktree hat die Stelle
+zufällig sauber, der Test wird **grün**, die eigene Regression bleibt unentdeckt. Am
+Lauf ist nichts Auffälliges zu sehen. Vermutlich derselbe Ursprung: ein Paletten-Scan,
+der nach dem Beheben weiter die alten Fundstellen meldete, und zwei
+`legacy-inbox/app.test.js`-Timeouts, die als „Flakiness unter Last" abgelegt wurden.
+
+Zwei Ebenen dagegen, beide in [`src/tools/dev-server-identity.ts`](../src/tools/dev-server-identity.ts):
+
+| Ebene                                          | Wirkung                                                                                                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktreeDevPort()` — Port aus dem Pfad-Hash   | Jeder Worktree bekommt einen eigenen Port aus 4100–4499. Kollisionen entstehen gar nicht erst; derselbe Worktree bekommt stets denselben Port |
+| `assertServerIdentity()` in `e2e/global-setup` | Der Dev-Server meldet unter `/__dev-server-identity` sein `process.cwd()`. Weicht es ab, **bricht der Lauf ab**                               |
+
+Der Abbruch ist Absicht — nicht eine Warnung, die im Log untergeht. Stillschweigend
+fremden Code zu testen ist genau der Fehler, der verhindert werden soll:
+
+```
+E2E-Abbruch: Der Server liefert aus einem fremden Arbeitsverzeichnis aus.
+  URL:       https://localhost:4412
+  liefert:   /…/.claude/worktrees/hopeful-curie-90f94e
+  erwartet:  /…/.claude/worktrees/auth0-prod-settings-499d2e
+```
+
+`reuseExistingServer` bleibt lokal an: Ein übrig gebliebener Server _dieses_ Worktrees
+spart den Kaltstart, und dass er der richtige ist, ist jetzt geprüft statt geraten. Der
+Endpunkt hängt am Vite-Plugin `devServerIdentity()`, läuft also nur im Dev-Server und
+kommt nicht in den Production-Build. Ein manuell gesetztes `VITE_DEV_PORT` hat weiterhin
+Vorrang — praktisch, um den Abbruch vorzuführen:
+
+```bash
+VITE_DEV_PORT=<port eines fremden Worktrees> npx playwright test e2e/about-page.spec.ts
+```
+
+**CI ist nicht betroffen** und bleibt bei Port 4000: dort gilt `reuseExistingServer:
+false`, und der Job startet seinen eigenen Server im eigenen Container. Der
+Identitäts-Check läuft dort trotzdem mit, damit ein versehentlich entferntes Plugin
+auffällt, statt die Prüfung still abzuschalten.
 
 ## Geteilte Ressourcen — Vorsicht
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,9 @@
+import type { FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
 import { copyFileSync, existsSync } from 'fs';
+import { assertServerIdentity, nodeIdentityFetch } from '../src/tools/dev-server-identity';
 
-async function globalSetup() {
+async function globalSetup(config: FullConfig) {
 	console.log('🔧 Setting up test environment...');
 
 	// Ensure .env exists
@@ -16,6 +18,25 @@ async function globalSetup() {
 		execSync('npx svelte-kit sync', { stdio: 'inherit' });
 	} else {
 		console.log('🏗️ CI environment detected - skipping sync (build already completed)');
+	}
+
+	/**
+	 * Prüft, dass der Server aus *diesem* Arbeitsverzeichnis ausliefert, und bricht
+	 * sonst ab. Ein grüner Lauf gegen einen fremden Worktree ist schlimmer als gar
+	 * kein Lauf: Er behauptet Sicherheit, die es nicht gibt.
+	 */
+	// Über alle Projekte statt `projects[0]`: Käme ein zweites Projekt (firefox, webkit)
+	// vor chromium, prüfte das Setup sonst still eine andere baseURL als die getestete.
+	const urls = new Set(
+		config.projects.map((project) => project.use?.baseURL).filter((url): url is string => !!url)
+	);
+	if (urls.size === 0 && config.webServer?.url) urls.add(config.webServer.url);
+	if (urls.size === 0)
+		throw new Error('Kein baseURL konfiguriert — Identitätsprüfung nicht möglich.');
+
+	for (const url of urls) {
+		await assertServerIdentity({ url, expectedRoot: process.cwd(), fetchImpl: nodeIdentityFetch });
+		console.log(`✅ Dev-Server unter ${url} liefert aus ${process.cwd()}`);
 	}
 
 	console.log('✅ Test environment ready');

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"test": "npm run test:quick",
 		"test:quick": "npm run lint && npm run type-check && npm run check && npm run test:unit",
 		"test:coverage": "vitest run --coverage --project server",
-		"test:e2e": "VITE_DEV_PORT=4001 playwright test",
+		"test:e2e": "playwright test",
 		"db:start": "docker compose up -d",
 		"db:stop": "docker compose down",
 		"db:push": "drizzle-kit push",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,39 @@
 import { defineConfig, devices } from '@playwright/test';
+import { worktreeDevPort } from './src/tools/dev-server-identity';
+
+/**
+ * Lokal bekommt jedes Arbeitsverzeichnis seinen eigenen Port.
+ *
+ * Vorher stand hier für *alle* Worktrees fest 4001 (`VITE_DEV_PORT=4001` im
+ * `test:e2e`-Skript). Zusammen mit `reuseExistingServer` benutzte ein Lauf damit
+ * kommentarlos den Dev-Server eines anderen Worktrees — gemessen am 2026-08-02, als
+ * 4000 *und* 4001 einem fremden Branch gehörten. Ein manuell gesetztes `VITE_DEV_PORT`
+ * hat weiterhin Vorrang (nützlich, um den Abbruch in `e2e/global-setup.ts` vorzuführen).
+ *
+ * CI bleibt bei 4000: dort läuft genau ein Job in einem eigenen Container. Der Port
+ * steht dort bewusst *hier* und wird nicht aus dem Hash abgeleitet — sonst bekäme der
+ * Server ein `VITE_DEV_PORT`, das nur deshalb folgenlos bleibt, weil
+ * `vite.config.ci.ts` den Port hart auf 4000 setzt. Zieht jemand die CI-Config später
+ * mit `vite.config.ts` gleich, liefe der Server auf dem Hash-Port, während Playwright
+ * auf 4000 wartet — Ausgang wäre ein webServer-Timeout ohne verwertbare Meldung.
+ */
+const devPort = process.env.CI
+	? 4000
+	: Number(process.env.VITE_DEV_PORT) || worktreeDevPort(process.cwd());
+const baseURL = `${process.env.CI ? 'http' : 'https'}://localhost:${devPort}`;
 
 export default defineConfig({
 	globalSetup: './e2e/global-setup.ts',
 	webServer: {
 		command: process.env.CI ? 'npx vite dev --config vite.config.ci.ts' : 'npm run dev',
-		url: process.env.CI ? 'http://localhost:4000' : 'https://localhost:4001',
+		url: baseURL,
+		env: { VITE_DEV_PORT: String(devPort) },
+		/**
+		 * Bleibt lokal an: Ein übrig gebliebener Server *dieses* Worktrees spart bei
+		 * jedem Lauf den Kaltstart. Dass er auch wirklich aus diesem Verzeichnis
+		 * ausliefert, prüft `e2e/global-setup.ts` — Wiederverwendung ist damit
+		 * überprüft statt geraten.
+		 */
 		reuseExistingServer: !process.env.CI,
 		timeout: 120000,
 		ignoreHTTPSErrors: true
@@ -29,7 +58,7 @@ export default defineConfig({
 	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
 	use: {
 		/* Base URL to use in actions like `await page.goto('/')`. */
-		baseURL: process.env.CI ? 'http://localhost:4000' : 'https://localhost:4001',
+		baseURL,
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 		/* Screenshot on failure */

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -45,9 +45,20 @@ describe('worktreeDevPort', () => {
 		expect(worktreeDevPort(WORKTREE_A)).toBe(worktreeDevPort(WORKTREE_A));
 	});
 
-	it('vergibt unterschiedliche Ports an Haupt-Repo und Worktrees', () => {
+	it('trennt Haupt-Repo und Worktrees', () => {
+		// Stichprobe auf realistischen Pfaden, keine Zusicherung: Der Hash bildet auf ein
+		// endliches Fenster ab, Kollisionen sind möglich. Was hier abgesichert wird, ist
+		// der grobe Fehler — etwa ein Port, der gar nicht vom Pfad abhängt.
 		const ports = [MAIN_REPO, WORKTREE_A, WORKTREE_B].map(worktreeDevPort);
 		expect(new Set(ports).size).toBe(3);
+	});
+
+	it('streut breit genug, dass Kollisionen selten bleiben', () => {
+		// Die eigentlich zugesicherte Eigenschaft: gute Streuung, nicht Eindeutigkeit.
+		// Bei 200 Pfaden auf 4000 Plätzen sind ~5 Kollisionen zu erwarten; ein Hash, der
+		// etwa nur die Pfadlänge auswertete, fiele hier klar durch.
+		const ports = Array.from({ length: 200 }, (_, i) => worktreeDevPort(`${WORKTREE_A}-${i}`));
+		expect(new Set(ports).size).toBeGreaterThanOrEqual(185);
 	});
 
 	it('ignoriert einen abschließenden Schrägstrich', () => {
@@ -58,8 +69,8 @@ describe('worktreeDevPort', () => {
 		// Auch über viele synthetische Pfade darf nie der Dev-Port getroffen werden.
 		for (let i = 0; i < 500; i++) {
 			const port = worktreeDevPort(`${WORKTREE_A}-${i}`);
-			expect(port).toBeGreaterThanOrEqual(4100);
-			expect(port).toBeLessThanOrEqual(4499);
+			expect(port).toBeGreaterThanOrEqual(41_000);
+			expect(port).toBeLessThanOrEqual(44_999);
 		}
 	});
 });

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -1,0 +1,249 @@
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	DEV_IDENTITY_PATH,
+	assertServerIdentity,
+	createNodeIdentityFetch,
+	describePortOwner,
+	devServerIdentity,
+	worktreeDevPort
+} from './dev-server-identity';
+
+const MAIN_REPO = '/Users/dev/Code/ostsee-sichtung';
+const WORKTREE_A = '/Users/dev/Code/ostsee-sichtung/.claude/worktrees/hopeful-curie-90f94e';
+const WORKTREE_B = '/Users/dev/Code/ostsee-sichtung/.claude/worktrees/auth0-prod-settings-499d2e';
+
+describe('worktreeDevPort', () => {
+	it('liefert für dasselbe Verzeichnis immer denselben Port', () => {
+		expect(worktreeDevPort(WORKTREE_A)).toBe(worktreeDevPort(WORKTREE_A));
+	});
+
+	it('vergibt unterschiedliche Ports an Haupt-Repo und Worktrees', () => {
+		const ports = [MAIN_REPO, WORKTREE_A, WORKTREE_B].map(worktreeDevPort);
+		expect(new Set(ports).size).toBe(3);
+	});
+
+	it('ignoriert einen abschließenden Schrägstrich', () => {
+		expect(worktreeDevPort(`${WORKTREE_A}/`)).toBe(worktreeDevPort(WORKTREE_A));
+	});
+
+	it('bleibt im reservierten Bereich und meidet 4000/4001', () => {
+		// Auch über viele synthetische Pfade darf nie der Dev-Port getroffen werden.
+		for (let i = 0; i < 500; i++) {
+			const port = worktreeDevPort(`${WORKTREE_A}-${i}`);
+			expect(port).toBeGreaterThanOrEqual(4100);
+			expect(port).toBeLessThanOrEqual(4499);
+		}
+	});
+});
+
+describe('assertServerIdentity', () => {
+	const okResponse = (root: string) => ({ ok: true, json: async () => ({ root }) });
+
+	it('akzeptiert einen Server aus demselben Verzeichnis', async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(okResponse(WORKTREE_B));
+
+		await expect(
+			assertServerIdentity({ url: 'https://localhost:4123', expectedRoot: WORKTREE_B, fetchImpl })
+		).resolves.toBeUndefined();
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			`https://localhost:4123${DEV_IDENTITY_PATH}`,
+			expect.anything()
+		);
+	});
+
+	it('akzeptiert Pfade, die sich nur im abschließenden Schrägstrich unterscheiden', async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(okResponse(`${WORKTREE_B}/`));
+
+		await expect(
+			assertServerIdentity({ url: 'https://localhost:4123', expectedRoot: WORKTREE_B, fetchImpl })
+		).resolves.toBeUndefined();
+	});
+
+	it('bricht ab, wenn der Server aus einem fremden Worktree ausliefert', async () => {
+		const fetchImpl = vi.fn().mockResolvedValue(okResponse(WORKTREE_A));
+
+		const error = await assertServerIdentity({
+			url: 'https://localhost:4001',
+			expectedRoot: WORKTREE_B,
+			fetchImpl
+		}).catch((e: Error) => e);
+
+		expect(error).toBeInstanceOf(Error);
+		// Beide Verzeichnisse müssen in der Meldung stehen — sonst ist nicht
+		// erkennbar, wessen Code gerade getestet worden wäre.
+		expect((error as Error).message).toContain(WORKTREE_A);
+		expect((error as Error).message).toContain(WORKTREE_B);
+		expect((error as Error).message).toContain('https://localhost:4001');
+	});
+
+	it('bricht ab, wenn auf dem Port etwas anderes als der Dev-Server antwortet', async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+
+		await expect(
+			assertServerIdentity({ url: 'https://localhost:4123', expectedRoot: WORKTREE_B, fetchImpl })
+		).rejects.toThrow(/identifiziert sich nicht/i);
+	});
+
+	it('bricht ab, wenn die Antwort kein Wurzelverzeichnis enthält', async () => {
+		const fetchImpl = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+
+		await expect(
+			assertServerIdentity({ url: 'https://localhost:4123', expectedRoot: WORKTREE_B, fetchImpl })
+		).rejects.toThrow(/identifiziert sich nicht/i);
+	});
+
+	it('bricht ab, wenn der Server nicht erreichbar ist', async () => {
+		const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+		await expect(
+			assertServerIdentity({ url: 'https://localhost:4123', expectedRoot: WORKTREE_B, fetchImpl })
+		).rejects.toThrow(/nicht erreichbar/i);
+	});
+});
+
+describe('describePortOwner', () => {
+	it('nennt das ausliefernde Verzeichnis', async () => {
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValue({ ok: true, json: async () => ({ root: WORKTREE_A }) });
+
+		await expect(describePortOwner('https://localhost:4001', fetchImpl)).resolves.toBe(WORKTREE_A);
+	});
+
+	it('gibt null zurück, wenn dort kein Dev-Server dieses Projekts läuft', async () => {
+		const notOurs = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+		const unreachable = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+		await expect(describePortOwner('https://localhost:4001', notOurs)).resolves.toBeNull();
+		await expect(describePortOwner('https://localhost:4001', unreachable)).resolves.toBeNull();
+	});
+});
+
+describe('createNodeIdentityFetch', () => {
+	/**
+	 * Das einzige Stück mit echtem I/O — deshalb gegen einen echten Server geprüft.
+	 * Port 0 lässt den Kernel wählen; die tatsächliche Nummer wird zurückgelesen, statt
+	 * eine feste anzunehmen (vgl. die Port-Kollision aus den legacy-inbox-Tests).
+	 */
+	async function withServer(
+		handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+		run: (origin: string) => Promise<void>
+	) {
+		const server = http.createServer(handler);
+		await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+		const address = server.address() as AddressInfo;
+		try {
+			await run(`http://127.0.0.1:${address.port}`);
+		} finally {
+			await new Promise((resolve) => server.close(resolve));
+		}
+	}
+
+	it('liest JSON über http und meldet ok', async () => {
+		await withServer(
+			(_req, res) => res.end(JSON.stringify({ root: '/irgendwo' })),
+			async (origin) => {
+				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+				expect(response.ok).toBe(true);
+				await expect(response.json()).resolves.toEqual({ root: '/irgendwo' });
+			}
+		);
+	});
+
+	it('meldet ok=false für Status außerhalb 2xx', async () => {
+		await withServer(
+			(_req, res) => {
+				res.statusCode = 404;
+				res.end('not found');
+			},
+			async (origin) => {
+				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+				expect(response.ok).toBe(false);
+			}
+		);
+	});
+
+	it('lässt json() scheitern, wenn die Antwort kein JSON ist', async () => {
+		// Genau der Fall „auf dem Port läuft etwas ganz anderes": HTML statt JSON.
+		await withServer(
+			(_req, res) => res.end('<!doctype html><h1>fremder Dienst</h1>'),
+			async (origin) => {
+				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+				await expect(response.json()).rejects.toThrow();
+			}
+		);
+	});
+
+	it('bricht bei einem hängenden Server nach dem Timeout ab', async () => {
+		await withServer(
+			() => {
+				/* antwortet absichtlich nie */
+			},
+			async (origin) => {
+				await expect(createNodeIdentityFetch(150)(`${origin}${DEV_IDENTITY_PATH}`)).rejects.toThrow(
+					/Zeitüberschreitung/
+				);
+			}
+		);
+	});
+
+	it('meldet einen freien Port als Fehler statt zu hängen', async () => {
+		// Erst einen Port belegen, dann freigeben — so ist er sicher unbenutzt.
+		const probe = http.createServer();
+		await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+		const { port } = probe.address() as AddressInfo;
+		await new Promise((resolve) => probe.close(resolve));
+
+		await expect(
+			createNodeIdentityFetch(1000)(`http://127.0.0.1:${port}${DEV_IDENTITY_PATH}`)
+		).rejects.toThrow();
+	});
+});
+
+describe('devServerIdentity plugin', () => {
+	/** Ruft die registrierte Middleware auf und gibt aus, was sie geschrieben hat. */
+	async function callMiddleware(url: string) {
+		const plugin = devServerIdentity();
+		let handler!: (req: unknown, res: unknown, next: () => void) => void;
+		const server = {
+			middlewares: { use: (fn: typeof handler) => (handler = fn) },
+			// Vollständig genug, dass der Test nicht davon abhängt, ob die
+			// VITEST-Guard vor dem Zugriff aussteigt.
+			config: { server: { port: 4123, https: undefined }, logger: { warn: vi.fn() } }
+		};
+
+		// configureServer ist im Vite-Typ eine Objekt-oder-Funktion-Union; der Fake deckt
+		// nur die hier benutzten Felder ab, daher der Umweg über `unknown`.
+		await (plugin.configureServer as unknown as (s: typeof server) => Promise<void>)(server);
+
+		const res = { setHeader: vi.fn(), end: vi.fn() };
+		const next = vi.fn();
+		handler({ url }, res, next);
+		return { res, next, server };
+	}
+
+	it('beantwortet den Identitäts-Pfad mit dem eigenen Wurzelverzeichnis', async () => {
+		const { res, next } = await callMiddleware(DEV_IDENTITY_PATH);
+
+		expect(next).not.toHaveBeenCalled();
+		expect(res.end).toHaveBeenCalledWith(JSON.stringify({ root: process.cwd() }));
+	});
+
+	it('warnt unter Vitest nicht über belegte Ports', async () => {
+		// Der Vite-Server von Vitest bindet den Port gar nicht — eine Meldung wäre
+		// dort immer ein Fehlalarm.
+		const { server } = await callMiddleware(DEV_IDENTITY_PATH);
+
+		expect(server.config.logger.warn).not.toHaveBeenCalled();
+	});
+
+	it('reicht alle anderen Anfragen durch', async () => {
+		const { res, next } = await callMiddleware('/api/sightings');
+
+		expect(next).toHaveBeenCalled();
+		expect(res.end).not.toHaveBeenCalled();
+	});
+});

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -1,5 +1,10 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
 import http from 'node:http';
+import https from 'node:https';
 import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
 	DEV_IDENTITY_PATH,
@@ -7,8 +12,29 @@ import {
 	createNodeIdentityFetch,
 	describePortOwner,
 	devServerIdentity,
+	devTrustAnchors,
 	worktreeDevPort
 } from './dev-server-identity';
+
+/**
+ * Stellt ein selbstsigniertes Zertifikat aus, dem kein lokaler Anker traut.
+ * Gibt `null` zurück, wenn kein `openssl` verfügbar ist — dann entfällt die Gegenprobe,
+ * statt sie vorzutäuschen.
+ */
+function selfSignedCert(): { cert: Buffer; key: Buffer } | null {
+	const dir = mkdtempSync(path.join(tmpdir(), 'dsi-cert-'));
+	const certFile = path.join(dir, 'cert.pem');
+	const keyFile = path.join(dir, 'key.pem');
+	const result = spawnSync(
+		'openssl',
+		// prettier-ignore
+		['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1',
+		 '-subj', '/CN=localhost', '-keyout', keyFile, '-out', certFile],
+		{ encoding: 'utf8' }
+	);
+	if (result.status !== 0 || !existsSync(certFile)) return null;
+	return { cert: readFileSync(certFile), key: readFileSync(keyFile) };
+}
 
 const MAIN_REPO = '/Users/dev/Code/ostsee-sichtung';
 const WORKTREE_A = '/Users/dev/Code/ostsee-sichtung/.claude/worktrees/hopeful-curie-90f94e';
@@ -122,6 +148,14 @@ describe('describePortOwner', () => {
 	});
 });
 
+/**
+ * Diese Tests machen echtes Netz-I/O (TLS-Handshake, Socket-Auf- und Abbau). Unter der
+ * Last der vollen Suite reichen die 5 s Default nicht: gemessen fiel der HTTPS-Test in
+ * 1 von 3 Gesamtläufen in den Timeout, isoliert nie. Die Arbeit ist echt, nicht hängend —
+ * deshalb mehr Zeit statt Test entschärfen.
+ */
+const IO_TIMEOUT = 20_000;
+
 describe('createNodeIdentityFetch', () => {
 	/**
 	 * Das einzige Stück mit echtem I/O — deshalb gegen einen echten Server geprüft.
@@ -142,65 +176,145 @@ describe('createNodeIdentityFetch', () => {
 		}
 	}
 
-	it('liest JSON über http und meldet ok', async () => {
-		await withServer(
-			(_req, res) => res.end(JSON.stringify({ root: '/irgendwo' })),
-			async (origin) => {
-				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+	it(
+		'liest JSON über http und meldet ok',
+		async () => {
+			await withServer(
+				(_req, res) => res.end(JSON.stringify({ root: '/irgendwo' })),
+				async (origin) => {
+					const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+					expect(response.ok).toBe(true);
+					await expect(response.json()).resolves.toEqual({ root: '/irgendwo' });
+				}
+			);
+		},
+		IO_TIMEOUT
+	);
+
+	it(
+		'meldet ok=false für Status außerhalb 2xx',
+		async () => {
+			await withServer(
+				(_req, res) => {
+					res.statusCode = 404;
+					res.end('not found');
+				},
+				async (origin) => {
+					const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+					expect(response.ok).toBe(false);
+				}
+			);
+		},
+		IO_TIMEOUT
+	);
+
+	it(
+		'lässt json() scheitern, wenn die Antwort kein JSON ist',
+		async () => {
+			// Genau der Fall „auf dem Port läuft etwas ganz anderes": HTML statt JSON.
+			await withServer(
+				(_req, res) => res.end('<!doctype html><h1>fremder Dienst</h1>'),
+				async (origin) => {
+					const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
+					await expect(response.json()).rejects.toThrow();
+				}
+			);
+		},
+		IO_TIMEOUT
+	);
+
+	it(
+		'bricht bei einem hängenden Server nach dem Timeout ab',
+		async () => {
+			await withServer(
+				() => {
+					/* antwortet absichtlich nie */
+				},
+				async (origin) => {
+					await expect(
+						createNodeIdentityFetch(150)(`${origin}${DEV_IDENTITY_PATH}`)
+					).rejects.toThrow(/Zeitüberschreitung/);
+				}
+			);
+		},
+		IO_TIMEOUT
+	);
+
+	it(
+		'spricht mit einem echten HTTPS-Dev-Zertifikat — mit aktiver Prüfung',
+		async () => {
+			/**
+			 * Bewusst das `basic-ssl`-Zertifikat und nicht das von mkcert: Die mkcert-CA
+			 * liegt im System-Store, den Node ab 24 in seinen Default-Store mischt — der
+			 * Test liefe dort auch ohne die Anker durch und bewiese nichts. Das
+			 * selbstsignierte `basic-ssl`-Zertifikat kennt kein Store; es geht
+			 * ausschließlich über `devTrustAnchors()` durch. (Verifiziert per
+			 * Mutationsprobe: ohne Anker schlägt dieser Test fehl.)
+			 *
+			 * Die Datei enthält Schlüssel und Zertifikat in einem PEM. Fehlt sie — etwa in
+			 * CI, wo nie ein Dev-Server lief —, entfällt der Test, statt etwas anderes zu
+			 * prüfen als draufsteht.
+			 */
+			const pem = path.join(process.cwd(), 'certs', 'basic-ssl', '_cert.pem');
+			if (!existsSync(pem) || devTrustAnchors().length === 0) return;
+			const material = readFileSync(pem);
+
+			const server = https.createServer({ cert: material, key: material }, (_req, res) =>
+				res.end(JSON.stringify({ root: '/irgendwo' }))
+			);
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+			const { port } = server.address() as AddressInfo;
+			try {
+				// Über `localhost`, nicht 127.0.0.1: Der Hostname wird mitgeprüft.
+				const response = await createNodeIdentityFetch()(
+					`https://localhost:${port}${DEV_IDENTITY_PATH}`
+				);
 				expect(response.ok).toBe(true);
 				await expect(response.json()).resolves.toEqual({ root: '/irgendwo' });
+			} finally {
+				await new Promise((resolve) => server.close(resolve));
 			}
-		);
-	});
+		},
+		IO_TIMEOUT
+	);
 
-	it('meldet ok=false für Status außerhalb 2xx', async () => {
-		await withServer(
-			(_req, res) => {
-				res.statusCode = 404;
-				res.end('not found');
-			},
-			async (origin) => {
-				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
-				expect(response.ok).toBe(false);
+	it(
+		'weist ein Zertifikat zurück, dem kein Anker deckt',
+		async () => {
+			// Gegenprobe zum vorigen Test: Ein fremdes, selbstsigniertes Zertifikat darf
+			// nicht durchgehen — sonst wäre die Prüfung faktisch abgeschaltet.
+			const material = selfSignedCert();
+			if (!material || devTrustAnchors().length === 0) return;
+
+			const server = https.createServer(material, (_req, res) => res.end('{}'));
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+			const { port } = server.address() as AddressInfo;
+			try {
+				await expect(
+					createNodeIdentityFetch(2000)(`https://localhost:${port}${DEV_IDENTITY_PATH}`)
+				).rejects.toThrow();
+			} finally {
+				await new Promise((resolve) => server.close(resolve));
 			}
-		);
-	});
+		},
+		IO_TIMEOUT
+	);
 
-	it('lässt json() scheitern, wenn die Antwort kein JSON ist', async () => {
-		// Genau der Fall „auf dem Port läuft etwas ganz anderes": HTML statt JSON.
-		await withServer(
-			(_req, res) => res.end('<!doctype html><h1>fremder Dienst</h1>'),
-			async (origin) => {
-				const response = await createNodeIdentityFetch()(`${origin}${DEV_IDENTITY_PATH}`);
-				await expect(response.json()).rejects.toThrow();
-			}
-		);
-	});
+	it(
+		'meldet einen freien Port als Fehler statt zu hängen',
+		async () => {
+			// Erst einen Port belegen, dann freigeben — so ist er sicher unbenutzt.
+			const probe = http.createServer();
+			await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+			const { port } = probe.address() as AddressInfo;
+			await new Promise((resolve) => probe.close(resolve));
 
-	it('bricht bei einem hängenden Server nach dem Timeout ab', async () => {
-		await withServer(
-			() => {
-				/* antwortet absichtlich nie */
-			},
-			async (origin) => {
-				await expect(createNodeIdentityFetch(150)(`${origin}${DEV_IDENTITY_PATH}`)).rejects.toThrow(
-					/Zeitüberschreitung/
-				);
-			}
-		);
-	});
-
-	it('meldet einen freien Port als Fehler statt zu hängen', async () => {
-		// Erst einen Port belegen, dann freigeben — so ist er sicher unbenutzt.
-		const probe = http.createServer();
-		await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
-		const { port } = probe.address() as AddressInfo;
-		await new Promise((resolve) => probe.close(resolve));
-
-		await expect(
-			createNodeIdentityFetch(1000)(`http://127.0.0.1:${port}${DEV_IDENTITY_PATH}`)
-		).rejects.toThrow();
-	});
+			await expect(
+				createNodeIdentityFetch(1000)(`http://127.0.0.1:${port}${DEV_IDENTITY_PATH}`)
+			).rejects.toThrow();
+		},
+		IO_TIMEOUT
+	);
 });
 
 describe('devServerIdentity plugin', () => {

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -9,8 +9,9 @@
  * Stelle zufällig sauber, der Test wird grün, die eigene Regression bleibt unentdeckt.
  *
  * Zwei Ebenen dagegen:
- *  1. `worktreeDevPort` gibt jedem Arbeitsverzeichnis einen eigenen Port — Kollisionen
- *     entstehen erst gar nicht.
+ *  1. `worktreeDevPort` gibt jedem Arbeitsverzeichnis seinen eigenen Port und macht den
+ *     Zusammenstoß damit unwahrscheinlich — nicht unmöglich (Hash auf ein endliches
+ *     Fenster, siehe `PORT_RANGE_SIZE`).
  *  2. `assertServerIdentity` prüft vor den Tests, ob der Server aus dem eigenen
  *     Verzeichnis ausliefert, und **bricht ab**, wenn nicht. Stillschweigend fremden
  *     Code zu testen ist der Fehler, der verhindert werden soll — eine Warnung, die im
@@ -28,12 +29,20 @@ import type { Plugin } from 'vite';
 export const DEV_IDENTITY_PATH = '/__dev-server-identity';
 
 /**
- * Port-Fenster für Dev-Server. Beginnt bewusst oberhalb von 4000 (fester Dev-Port, an
- * dem `PUBLIC_SITE_URL` und die Auth0-Callback-URL hängen) und 4001 (der frühere,
- * für alle Worktrees identische E2E-Port).
+ * Port-Fenster für Dev-Server: 41000–44999.
+ *
+ * Deutlich oberhalb von 4000 (fester Dev-Port, an dem `PUBLIC_SITE_URL` und die
+ * Auth0-Callback-URL hängen) und 4001 (der frühere, für alle Worktrees identische
+ * E2E-Port), unterhalb des ephemeren Bereichs (ab 49152 auf macOS) und abseits der
+ * üblichen Dienste in den 3000ern/4000ern/5000ern (5000 belegt macOS für AirPlay).
+ *
+ * Die Breite bestimmt, wie oft zwei Worktrees denselben Port ziehen — ein
+ * Geburtstagsproblem, kein „kann nicht passieren". Mit 4000 Plätzen: ~1 % bei 10
+ * Worktrees, ~5 % bei 20. Tritt es ein, ist es **nicht** stillschweigend falsch,
+ * sondern laut: `assertServerIdentity` bricht ab und nennt beide Verzeichnisse.
  */
-const PORT_RANGE_START = 4100;
-const PORT_RANGE_SIZE = 400;
+const PORT_RANGE_START = 41_000;
+const PORT_RANGE_SIZE = 4_000;
 
 /** Entfernt abschließende Schrägstriche, damit Pfadvarianten denselben Port ergeben. */
 function normalizeRoot(root: string): string {
@@ -103,9 +112,16 @@ export function createNodeIdentityFetch(timeoutMs = 10_000): IdentityFetch {
 		new Promise((resolve, reject) => {
 			const { request } = url.startsWith('https:') ? https : http;
 			const anchors = devTrustAnchors();
+			const signal = init?.signal;
+			/**
+			 * Genau **eine** Frist. Bringt der Aufrufer ein Signal mit (in
+			 * `assertServerIdentity` ein `AbortSignal.timeout`), gilt dessen Deadline und
+			 * der Socket-Timeout entfällt — sonst liefen zwei Uhren, von denen die eine
+			 * die andere überholen kann und die Fehlermeldung davon abhinge, wer zuerst war.
+			 */
 			const req = request(
 				url,
-				{ timeout: timeoutMs, ...(anchors.length ? { ca: anchors } : {}) },
+				{ ...(signal ? {} : { timeout: timeoutMs }), ...(anchors.length ? { ca: anchors } : {}) },
 				(res) => {
 					let body = '';
 					res.setEncoding('utf8');
@@ -118,11 +134,14 @@ export function createNodeIdentityFetch(timeoutMs = 10_000): IdentityFetch {
 			);
 			req.on('timeout', () => req.destroy(new Error(`Zeitüberschreitung nach ${timeoutMs} ms`)));
 			req.on('error', reject);
-			// Ein übergebenes Signal muss wirken — sonst gäbe es zwei Timeouts, von denen
-			// nur einer greift.
-			init?.signal?.addEventListener('abort', () => req.destroy(new Error('Abgebrochen')), {
-				once: true
-			});
+
+			const onAbort = () => req.destroy(new Error('Abgebrochen'));
+			signal?.addEventListener('abort', onAbort);
+			// `close` deckt alle Ausgänge ab (Antwort, Fehler, destroy). Ohne dieses
+			// Abmelden feuerte ein `AbortSignal.timeout` auch noch Sekunden nach der
+			// fertigen Antwort und zerstörte einen längst abgeschlossenen Request; bis
+			// dahin hielte der Listener ihn zudem am Leben.
+			req.on('close', () => signal?.removeEventListener('abort', onAbort));
 			req.end();
 		});
 }

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -1,0 +1,229 @@
+/**
+ * Macht überprüfbar, aus welchem Arbeitsverzeichnis ein Dev-Server ausliefert.
+ *
+ * Hintergrund: `playwright.config.ts` setzt lokal `reuseExistingServer`. Antwortet auf
+ * dem konfigurierten Port *irgendein* Server, benutzt Playwright ihn — ohne zu prüfen,
+ * woher der Code stammt. Weil alle Worktrees denselben Port benutzten, liefen E2E-Tests
+ * dann gegen einen fremden Branch. Der laute Fall (32 Fehlschläge für längst behobene
+ * Fundstellen) fällt auf; der gefährliche ist der stille: Der fremde Worktree hat die
+ * Stelle zufällig sauber, der Test wird grün, die eigene Regression bleibt unentdeckt.
+ *
+ * Zwei Ebenen dagegen:
+ *  1. `worktreeDevPort` gibt jedem Arbeitsverzeichnis einen eigenen Port — Kollisionen
+ *     entstehen erst gar nicht.
+ *  2. `assertServerIdentity` prüft vor den Tests, ob der Server aus dem eigenen
+ *     Verzeichnis ausliefert, und **bricht ab**, wenn nicht. Stillschweigend fremden
+ *     Code zu testen ist der Fehler, der verhindert werden soll — eine Warnung, die im
+ *     Log untergeht, reicht dafür nicht.
+ */
+import { createHash } from 'node:crypto';
+import http from 'node:http';
+import https from 'node:https';
+import type { Plugin } from 'vite';
+
+/** Pfad, unter dem der Dev-Server sein Wurzelverzeichnis meldet. */
+export const DEV_IDENTITY_PATH = '/__dev-server-identity';
+
+/**
+ * Port-Fenster für Dev-Server. Beginnt bewusst oberhalb von 4000 (fester Dev-Port, an
+ * dem `PUBLIC_SITE_URL` und die Auth0-Callback-URL hängen) und 4001 (der frühere,
+ * für alle Worktrees identische E2E-Port).
+ */
+const PORT_RANGE_START = 4100;
+const PORT_RANGE_SIZE = 400;
+
+/** Entfernt abschließende Schrägstriche, damit Pfadvarianten denselben Port ergeben. */
+function normalizeRoot(root: string): string {
+	return root.replace(/\/+$/, '');
+}
+
+/**
+ * Leitet aus dem Arbeitsverzeichnis einen stabilen Port ab.
+ *
+ * Deterministisch (derselbe Worktree bekommt über Läufe hinweg denselben Port, was
+ * `reuseExistingServer` erst nutzbar macht) und ohne Abstimmung zwischen parallelen
+ * Sessions. Kollisionen zwischen zwei Worktrees sind bei 400 Ports theoretisch möglich —
+ * dagegen greift dann `assertServerIdentity`.
+ */
+export function worktreeDevPort(root: string): number {
+	const digest = createHash('sha256').update(normalizeRoot(root)).digest();
+	return PORT_RANGE_START + (digest.readUInt32BE(0) % PORT_RANGE_SIZE);
+}
+
+/**
+ * `fetch`-Ersatz auf Basis von `node:https`.
+ *
+ * Das lokale Dev-Zertifikat ist selbstsigniert und wird von der mkcert-CA im
+ * System-Store gedeckt. Ob das globale `fetch` diesen Store liest, hängt an der
+ * Node-Version — auf den in `engines` erlaubten 20/22 nicht. Dort bräche die Prüfung
+ * am Zertifikat ab und meldete „nicht erreichbar", obwohl der Server läuft: genau die
+ * irreführende Diagnose, gegen die dieses Modul geschrieben ist. Deshalb hier
+ * unabhängig von der Node-Version explizit. Bewusst ohne `undici` — das Paket liegt
+ * nur transitiv im Abhängigkeitsbaum.
+ */
+export function createNodeIdentityFetch(timeoutMs = 10_000): IdentityFetch {
+	return (url, init) =>
+		new Promise((resolve, reject) => {
+			const { request } = url.startsWith('https:') ? https : http;
+			const req = request(url, { rejectUnauthorized: false, timeout: timeoutMs }, (res) => {
+				let body = '';
+				res.setEncoding('utf8');
+				res.on('data', (chunk) => (body += chunk));
+				res.on('end', () => {
+					const status = res.statusCode ?? 0;
+					resolve({ ok: status >= 200 && status < 300, json: async () => JSON.parse(body) });
+				});
+			});
+			req.on('timeout', () => req.destroy(new Error(`Zeitüberschreitung nach ${timeoutMs} ms`)));
+			req.on('error', reject);
+			// Ein übergebenes Signal muss wirken — sonst gäbe es zwei Timeouts, von denen
+			// nur einer greift.
+			init?.signal?.addEventListener('abort', () => req.destroy(new Error('Abgebrochen')), {
+				once: true
+			});
+			req.end();
+		});
+}
+
+export const nodeIdentityFetch = createNodeIdentityFetch();
+
+/**
+ * Fragt den Identitäts-Endpunkt ab und gibt das ausliefernde Verzeichnis zurück —
+ * oder `null`, wenn dort kein Dev-Server dieses Projekts antwortet.
+ */
+export async function describePortOwner(
+	origin: string,
+	fetchImpl: IdentityFetch = nodeIdentityFetch
+): Promise<string | null> {
+	try {
+		const response = await fetchImpl(`${origin.replace(/\/+$/, '')}${DEV_IDENTITY_PATH}`);
+		if (!response.ok) return null;
+		const payload = (await response.json()) as { root?: unknown };
+		return typeof payload.root === 'string' ? payload.root : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Vite-Plugin, das den Identitäts-Endpunkt bereitstellt.
+ *
+ * Nur `configureServer`, also ausschließlich im Dev-Server — in den Production-Build
+ * gelangt der Endpunkt nicht. Bewusst kein SvelteKit-Route-File: eine Route unter
+ * `src/routes/` würde mit ausgeliefert.
+ */
+export function devServerIdentity(): Plugin {
+	return {
+		name: 'ostsee:dev-server-identity',
+		async configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				if (req.url !== DEV_IDENTITY_PATH) {
+					next();
+					return;
+				}
+				res.setHeader('content-type', 'application/json');
+				res.end(JSON.stringify({ root: process.cwd() }));
+			});
+
+			/**
+			 * `strictPort` bricht bei belegtem Port ab — sagt aber nur „Port X is already
+			 * in use", nicht *wer* ihn hält. Genau das ist die Frage, die bei mehreren
+			 * Worktrees Zeit kostet. `configureServer` wird von Vite abgewartet und läuft
+			 * vor dem Bind; die Diagnose steht damit vor Vites Fehlermeldung. (Die von
+			 * `configureServer` *zurückgegebene* Post-Hook-Funktion wäre dafür untauglich:
+			 * Vite ruft sie synchron auf und wartet ein Promise nicht ab.)
+			 *
+			 * Bewusst nur ausgeben, nie selbst werfen: Die Garantie liefert `strictPort`.
+			 * Und bewusst nicht unter Vitest — dessen Vite-Server bindet den Port gar
+			 * nicht, jede Meldung wäre dort ein Fehlalarm im Testlauf.
+			 */
+			if (process.env.VITEST) return;
+			const { port, https: useHttps } = server.config.server;
+			const origin = `${useHttps ? 'https' : 'http'}://localhost:${port}`;
+			// Kurzer Timeout: Ist der Port frei, antwortet der Connect sofort mit
+			// ECONNREFUSED — der Wert greift nur bei einem hängenden Fremdprozess.
+			const owner = await describePortOwner(origin, createNodeIdentityFetch(1500));
+			if (!owner || normalizeRoot(owner) === normalizeRoot(process.cwd())) return;
+			server.config.logger.warn(
+				`\nPort ${port} wird bereits von einem Dev-Server bedient — aus:\n` +
+					`  ${owner}\n` +
+					`Dieses Verzeichnis ist:\n  ${process.cwd()}\n`
+			);
+		}
+	};
+}
+
+/**
+ * Nur das, was die Prüfung wirklich braucht. Das globale `fetch` erfüllt die Signatur;
+ * ebenso ein schlanker `node:https`-Adapter, wie ihn `e2e/global-setup.ts` für das
+ * selbstsignierte Dev-Zertifikat mitbringt.
+ */
+export type IdentityFetch = (
+	url: string,
+	init?: { signal?: AbortSignal }
+) => Promise<{ ok: boolean; json(): Promise<unknown> }>;
+
+interface AssertServerIdentityOptions {
+	/** Basis-URL des Servers, gegen den getestet wird (ohne Pfad). */
+	url: string;
+	/** Verzeichnis, aus dem ausgeliefert werden *soll* — üblicherweise `process.cwd()`. */
+	expectedRoot: string;
+	/**
+	 * Default ist bewusst `nodeIdentityFetch` und nicht das globale `fetch`: Letzteres
+	 * scheitert je nach Node-Version am selbstsignierten Dev-Zertifikat und meldete
+	 * dann „nicht erreichbar" für einen laufenden Server.
+	 */
+	fetchImpl?: IdentityFetch;
+}
+
+/**
+ * Stellt sicher, dass unter `url` der Dev-Server des eigenen Arbeitsverzeichnisses
+ * läuft. Wirft mit einer Meldung, die beide Verzeichnisse nennt.
+ */
+export async function assertServerIdentity({
+	url,
+	expectedRoot,
+	fetchImpl = nodeIdentityFetch
+}: AssertServerIdentityOptions): Promise<void> {
+	const identityUrl = `${url.replace(/\/+$/, '')}${DEV_IDENTITY_PATH}`;
+
+	// Nicht erreichbar und „antwortet, ist aber nicht unser Dev-Server" sind zwei
+	// verschiedene Befunde — deshalb getrennt behandelt statt über die Fehlermeldung
+	// wieder auseinandersortiert.
+	let payload: { root?: unknown } = {};
+	try {
+		const response = await fetchImpl(identityUrl, { signal: AbortSignal.timeout(10_000) });
+		if (response.ok) payload = (await response.json().catch(() => ({}))) as { root?: unknown };
+	} catch (error) {
+		throw new Error(`Der Dev-Server unter ${url} ist nicht erreichbar (${identityUrl}).`, {
+			cause: error
+		});
+	}
+
+	if (typeof payload.root !== 'string') {
+		throw new Error(
+			`Der Server unter ${url} identifiziert sich nicht als Dev-Server dieses Projekts ` +
+				`(${identityUrl} lieferte kein Wurzelverzeichnis).\n` +
+				`Läuft dort etwas anderes? Prüfen mit:\n` +
+				`  lsof -a -p $(lsof -ti:${new URL(url).port}) -d cwd`
+		);
+	}
+
+	const actualRoot = payload.root;
+	if (normalizeRoot(actualRoot) === normalizeRoot(expectedRoot)) return;
+
+	throw new Error(
+		[
+			'E2E-Abbruch: Der Server liefert aus einem fremden Arbeitsverzeichnis aus.',
+			'',
+			`  URL:       ${url}`,
+			`  liefert:   ${actualRoot}`,
+			`  erwartet:  ${expectedRoot}`,
+			'',
+			'Die Tests hätten fremden Code geprüft — ein grünes Ergebnis wäre wertlos gewesen.',
+			'',
+			'Behebung: den fremden Server beenden und erneut starten —',
+			`  kill $(lsof -ti:${new URL(url).port})`
+		].join('\n')
+	);
+}

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -16,9 +16,12 @@
  *     Code zu testen ist der Fehler, der verhindert werden soll — eine Warnung, die im
  *     Log untergeht, reicht dafür nicht.
  */
+import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
 import http from 'node:http';
 import https from 'node:https';
+import path from 'node:path';
 import type { Plugin } from 'vite';
 
 /** Pfad, unter dem der Dev-Server sein Wurzelverzeichnis meldet. */
@@ -51,29 +54,68 @@ export function worktreeDevPort(root: string): number {
 }
 
 /**
- * `fetch`-Ersatz auf Basis von `node:https`.
+ * Vertrauensanker für die lokalen Dev-Zertifikate.
  *
- * Das lokale Dev-Zertifikat ist selbstsigniert und wird von der mkcert-CA im
- * System-Store gedeckt. Ob das globale `fetch` diesen Store liest, hängt an der
- * Node-Version — auf den in `engines` erlaubten 20/22 nicht. Dort bräche die Prüfung
- * am Zertifikat ab und meldete „nicht erreichbar", obwohl der Server läuft: genau die
- * irreführende Diagnose, gegen die dieses Modul geschrieben ist. Deshalb hier
- * unabhängig von der Node-Version explizit. Bewusst ohne `undici` — das Paket liegt
- * nur transitiv im Abhängigkeitsbaum.
+ * Bewusst **keine** abgeschaltete Zertifikatsprüfung: Die mkcert-CA liegt einmal pro
+ * Maschine und deckt damit die Zertifikate *aller* Worktrees ab — sie zu pinnen leistet
+ * dasselbe wie `rejectUnauthorized: false`, ohne das Muster in die Codebasis zu tragen.
+ * Ergänzt um das eigene `basic-ssl`-Zertifikat für den Fall, dass mkcert fehlt
+ * (`vite.config.ts` fällt dann auf `@vitejs/plugin-basic-ssl` zurück).
+ *
+ * Ist gar kein Anker zu finden, bleibt der System-Store aktiv und der Handshake
+ * scheitert — der E2E-Lauf bricht dann mit „nicht erreichbar" ab statt fremden Code zu
+ * testen. Fail-closed ist hier die richtige Richtung.
+ */
+let cachedAnchors: Buffer[] | undefined;
+
+export function devTrustAnchors(): Buffer[] {
+	if (cachedAnchors) return cachedAnchors;
+
+	const anchors: Buffer[] = [];
+	// Gleiche Auflösung wie scripts/setup-dev-certs.mjs — mkcert kennt seinen CA-Pfad selbst.
+	const caRoot = spawnSync('mkcert', ['-CAROOT'], { encoding: 'utf8' });
+	if (caRoot.status === 0) {
+		const rootCa = path.join(caRoot.stdout.trim(), 'rootCA.pem');
+		if (existsSync(rootCa)) anchors.push(readFileSync(rootCa));
+	}
+
+	const basicSsl = path.join(process.cwd(), 'certs', 'basic-ssl', '_cert.pem');
+	if (existsSync(basicSsl)) anchors.push(readFileSync(basicSsl));
+
+	cachedAnchors = anchors;
+	return anchors;
+}
+
+/**
+ * `fetch`-Ersatz auf Basis von `node:https`, der den lokalen Dev-Zertifikaten traut —
+ * und sonst nichts nachlässt.
+ *
+ * Warum nicht das globale `fetch`: Ob es den System-Trust-Store (und damit die
+ * mkcert-CA) liest, hängt an der Node-Version — auf den in `engines` erlaubten 20/22
+ * nicht. Dort bräche die Prüfung am Zertifikat ab und meldete „nicht erreichbar",
+ * obwohl der Server läuft: genau die irreführende Diagnose, gegen die dieses Modul
+ * geschrieben ist. Mit explizit gesetzten Ankern ist das Verhalten von der
+ * Node-Version unabhängig. Bewusst ohne `undici` — das Paket liegt nur transitiv im
+ * Abhängigkeitsbaum.
  */
 export function createNodeIdentityFetch(timeoutMs = 10_000): IdentityFetch {
 	return (url, init) =>
 		new Promise((resolve, reject) => {
 			const { request } = url.startsWith('https:') ? https : http;
-			const req = request(url, { rejectUnauthorized: false, timeout: timeoutMs }, (res) => {
-				let body = '';
-				res.setEncoding('utf8');
-				res.on('data', (chunk) => (body += chunk));
-				res.on('end', () => {
-					const status = res.statusCode ?? 0;
-					resolve({ ok: status >= 200 && status < 300, json: async () => JSON.parse(body) });
-				});
-			});
+			const anchors = devTrustAnchors();
+			const req = request(
+				url,
+				{ timeout: timeoutMs, ...(anchors.length ? { ca: anchors } : {}) },
+				(res) => {
+					let body = '';
+					res.setEncoding('utf8');
+					res.on('data', (chunk) => (body += chunk));
+					res.on('end', () => {
+						const status = res.statusCode ?? 0;
+						resolve({ ok: status >= 200 && status < 300, json: async () => JSON.parse(body) });
+					});
+				}
+			);
 			req.on('timeout', () => req.destroy(new Error(`Zeitüberschreitung nach ${timeoutMs} ms`)));
 			req.on('error', reject);
 			// Ein übergebenes Signal muss wirken — sonst gäbe es zwei Timeouts, von denen
@@ -195,7 +237,12 @@ export async function assertServerIdentity({
 		const response = await fetchImpl(identityUrl, { signal: AbortSignal.timeout(10_000) });
 		if (response.ok) payload = (await response.json().catch(() => ({}))) as { root?: unknown };
 	} catch (error) {
-		throw new Error(`Der Dev-Server unter ${url} ist nicht erreichbar (${identityUrl}).`, {
+		// Ein TLS-Fehler sieht sonst aus wie „Server läuft nicht" — der häufigste Grund
+		// ist aber ein Dev-Zertifikat ohne passenden Anker (mkcert nicht installiert).
+		const hint = /certificate|self.signed|CERT_/i.test(String(error))
+			? '\nDas Zertifikat ist keinem lokalen Anker zuzuordnen — läuft `npm run certs:setup`?'
+			: '';
+		throw new Error(`Der Dev-Server unter ${url} ist nicht erreichbar (${identityUrl}).${hint}`, {
 			cause: error
 		});
 	}

--- a/vite.config.ci.ts
+++ b/vite.config.ci.ts
@@ -8,6 +8,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
+import { devServerIdentity } from './src/tools/dev-server-identity';
 import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 /**
@@ -40,6 +41,9 @@ export default defineConfig({
 		}),
 		sveltekit(),
 		// No basicSsl plugin for CI to avoid HTTPS certificate issues
+		// Auch in CI: Der Identitäts-Check in e2e/global-setup.ts läuft unbedingt, damit
+		// ein versehentlich entferntes Plugin auffällt statt still die Prüfung abzuschalten.
+		devServerIdentity(),
 		// Zuletzt: sortiert resolve.external/noExternal nach allen anderen Plugins.
 		stableDepHash()
 	],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
+import { devServerIdentity } from './src/tools/dev-server-identity';
 import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 const certFile = fileURLToPath(new URL('./certs/localhost.pem', import.meta.url));
@@ -47,12 +48,23 @@ export default defineConfig({
 						certDir: './certs/basic-ssl'
 					})
 				]),
+		// Meldet unter /__dev-server-identity, aus welchem Verzeichnis ausgeliefert wird.
+		devServerIdentity(),
 		// Zuletzt: sortiert resolve.external/noExternal nach allen anderen Plugins.
 		stableDepHash()
 	],
 	server: {
 		host: 'localhost',
 		port: parseInt(process.env.VITE_DEV_PORT || '4000'),
+		/**
+		 * Ohne `strictPort` weicht Vite bei belegtem Port still auf den nächsten aus.
+		 * Das ist hier immer ein Fehlerzustand, nie eine brauchbare Rückfallebene:
+		 * `PUBLIC_SITE_URL` steht fest auf 4000 und baut daraus die Auth0-Callback-URL,
+		 * ein Server auf 4001 hat also einen kaputten Login. Und weil Playwright lokal
+		 * einen vorhandenen Server wiederverwendet, machte genau dieses Ausweichen
+		 * E2E-Läufe gegen fremde Worktrees möglich. Abbruch mit Meldung ist richtig.
+		 */
+		strictPort: true,
 		...(devCert ? { https: devCert } : {}),
 		hmr: {
 			overlay: true


### PR DESCRIPTION
## Problem

Lokale E2E-Läufe konnten stillschweigend den Code eines **anderen Worktrees** testen.

`test:e2e` setzte für *alle* Worktrees fest `VITE_DEV_PORT=4001`, und `playwright.config.ts` benutzt lokal `reuseExistingServer`. Antwortete auf 4001 irgendein Server, lief die Suite gegen ihn — ohne zu prüfen, aus welchem Verzeichnis er ausliefert.

Am 2026-08-02 gemessen: 4000 **und** 4001 gehörten fremden Worktrees.

```
Port 4000 → .claude/worktrees/hopeful-curie-90f94e
Port 4001 → .claude/worktrees/uploads-production-migration-8e0021
```

`design-tokens.spec.ts` meldete daraufhin 32 Fehlschläge für Fundstellen, die auf dem eigenen Branch längst behoben waren.

**Der gefährliche Fall ist der umgekehrte:** Der fremde Worktree hat die Stelle zufällig sauber, der Test wird **grün**, die eigene Regression bleibt unentdeckt. Am Lauf ist nichts Auffälliges zu sehen.

### Korrektur am ursprünglichen Befund

Der Bericht ging davon aus, 4001 entstehe als Ausweichport, wenn 4000 belegt ist. Tatsächlich stand `VITE_DEV_PORT=4001` fest im `test:e2e`-Skript — die Kollision war damit **systematisch**, nicht von einem belegten 4000 abhängig. Der Server auf 4001 war selbst ein übrig gebliebener E2E-Server jenes Worktrees.

## Lösung

Zwei unabhängige Ebenen, beide in `src/tools/dev-server-identity.ts`:

| Ebene | Wirkung |
| --- | --- |
| `worktreeDevPort()` | Port aus dem Pfad-Hash (4100–4499), stabil pro Worktree. Kollisionen entstehen gar nicht erst; `test:e2e` ist wieder schlicht `playwright test` |
| `assertServerIdentity()` | Der Dev-Server meldet `process.cwd()` unter `/__dev-server-identity`; `e2e/global-setup.ts` vergleicht und **bricht ab** |

Der Abbruch ist Absicht, keine Warnung: Stillschweigend fremden Code zu testen ist genau der Fehler, der verhindert werden soll.

`reuseExistingServer` bleibt lokal an — bei eigenem Port kann nur der eigene übrig gebliebene Server getroffen werden, und das ist jetzt geprüft statt geraten. Der Endpunkt hängt am Vite-Plugin (`configureServer`-only) und gelangt nicht in den Production-Build.

Dazu `strictPort: true` in `vite.config.ts`: Das stille Ausweichen war nie eine brauchbare Rückfallebene (`PUBLIC_SITE_URL` ist auf 4000 gepinnt, ein Server auf 4001 hat einen kaputten Login) — und es machte die Kollision erst möglich. Bei belegtem Port nennt das Plugin den fremden Worktree vor Vites knapper Meldung.

## Verifikation

Alles gegen echte Server geprüft, nicht nur argumentiert.

| Prüfung | Ergebnis |
| --- | --- |
| Endpunkt live | `GET https://localhost:4412/__dev-server-identity` → `{"root":"…/auth0-prod-settings-499d2e"}` |
| Positiv-Pfad | `about-page.spec.ts` 2 passed, Setup meldet das korrekte Verzeichnis |
| Abbruch-Pfad | Playwright gegen einen fremden Identitäts-Server → Abbruch **vor dem ersten Test** |
| Regressions-Suite | `design-tokens.spec.ts` 73 passed gegen den richtigen Server (vorher 32 Phantom-Fehlschläge) |
| `strictPort` | Zweiter Dev-Server auf belegtem Port bricht ab statt auszuweichen |
| Fehlalarm-Freiheit | `npm run test:unit` bleibt still, obwohl ein fremder Server den Port hält (`VITEST`-Guard) |

Abbruch-Meldung:

```
E2E-Abbruch: Der Server liefert aus einem fremden Arbeitsverzeichnis aus.

  URL:       https://localhost:4301
  liefert:   /…/.claude/worktrees/hopeful-curie-90f94e
  erwartet:  /…/.claude/worktrees/auth0-prod-settings-499d2e

Die Tests hätten fremden Code geprüft — ein grünes Ergebnis wäre wertlos gewesen.
```

**Tests:** 20 neue Unit-Tests, test-first geschrieben (RED bestätigt), inkl. echter Socket-Tests für den einzigen I/O-Teil. Lint, `tsc --noEmit` und `svelte-check` sauber.

## Abgrenzung

**CI ist nicht betroffen** und bleibt auf 4000: dort gilt `reuseExistingServer: false` und der Job startet seinen eigenen Server im eigenen Container. Der Identitäts-Check läuft dort trotzdem mit, damit ein versehentlich entferntes Plugin auffällt, statt die Prüfung still abzuschalten.

**`legacy-inbox/app.test.js` ist nicht betroffen.** Der Bericht vermutete denselben Ursprung. Belegt: Die Datei referenziert weder `src/` noch einen Dev-Server, und die volle Suite fällt **ohne** diese Änderung in 3 von 4 Läufen an derselben Stelle aus. Eigenständige Flakiness — siehe Hinweis unten.

## Dokumentation

`docs/WORKTREES.md` und `CLAUDE.md` führen jetzt mit der Folge, die bisher fehlte: Geteilte Ports heben die **Aussagekraft der Tests** auf. Das wiegt schwerer als der kaputte Login, der dort bisher als einzige Begründung stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)