### PR TITLE
fix(test): legacy-inbox/app.test.js deterministisch machen

### DIFF
--- a/legacy-inbox/app.test.js
+++ b/legacy-inbox/app.test.js
@@ -6,27 +6,124 @@ import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const WURZEL = path.dirname(fileURLToPath(import.meta.url));
+const APP = path.join(WURZEL, 'app.js');
 
-function starte(umgebung) {
-	return new Promise((fertig) => {
-		const prozess = spawn(process.execPath, [path.join(WURZEL, 'app.js')], {
+/**
+ * Budget für einen Kindprozess. Überschreitet er es, meldet der Helfer selbst
+ * einen Fehler — mit der bis dahin gesammelten Ausgabe. Das ist der Unterschied
+ * zwischen „app.js hat sich nach 45 s nicht beendet, Ausgabe war: …" und dem
+ * nackten `Test timed out in 5000ms`, das wie eine Regression des eigenen Diffs
+ * aussieht, obwohl `legacy-inbox/` nichts aus `src/` importiert.
+ *
+ * Die Zahl ist gemessen, nicht geraten (2026-08-02, macOS 26/Node 24, unter
+ * vollem `npm run test:unit`): Das Prozessende trat spätestens nach 15,1 s ein.
+ * 45 s sind das Dreifache und damit Reserve, keine Erwartung — im Normalfall
+ * wartet hier niemand, siehe `fertigWenn` unten.
+ */
+const PROZESS_BUDGET_MS = 45_000;
+const TEST_TIMEOUT_MS = PROZESS_BUDGET_MS + 5_000;
+
+/**
+ * Startet einen Kindprozess und sammelt stdout und stderr.
+ *
+ * **Warum `fertigWenn` existiert.** Wer nur die Ausgabe prüft, darf nicht auf
+ * das Prozessende warten. Ein Prozess, der `node:http` geladen hat — jedes
+ * `app.js`, das bis zum Server kommt —, braucht auf dieser Plattform nach
+ * `process.exit()` noch 0,4 bis 15 s, bis das Betriebssystem ihn abräumt. Der
+ * JavaScript-Teil ist dabei längst fertig: gemessen steht die erwartete Ausgabe
+ * nach ~90 ms, der `exit`-Handler des Kindes läuft nach ~16 ms, und die
+ * restliche Zeit vergeht in der nativen Abbau-Phase (praktisch ohne CPU-Last,
+ * mit der Systemlast wachsend). Ursache ist das Laden von `node:http`/`node:tls`
+ * allein — ohne diesen Import beendet sich derselbe Prozess in ~35 ms.
+ *
+ * Genau daran hingen die sporadischen Timeouts: Nicht der Start war langsam,
+ * sondern das Sterben, und die Tests warteten darauf, obwohl ihr Beweis
+ * längst vorlag. Wer `fertigWenn` angibt, wartet deshalb auf das Signal in der
+ * Ausgabe und beendet den Prozess danach selbst (SIGTERM räumt sofort ab, ohne
+ * die Abbau-Phase). Nur wer den Exit-Code prüft, wartet auf `exit` — dafür
+ * gibt es kein früheres Signal, das Betriebssystem meldet den Status erst dann.
+ *
+ * @param {object} optionen
+ * @param {string[]} optionen.argumente Argumente für `node`.
+ * @param {Record<string, string>} optionen.umgebung Zusätzliche Umgebungsvariablen.
+ * @param {(ausgabe: string) => boolean} [optionen.fertigWenn] Abbruchsignal auf
+ *   der gesammelten Ausgabe. Ohne Angabe wird auf das Prozessende gewartet.
+ * @returns {Promise<{ ausgabe: string, code: number | null }>} `code` ist `null`,
+ *   wenn `fertigWenn` gegriffen hat — dann wurde der Prozess beendet, statt sich
+ *   selbst zu beenden.
+ */
+function fuehreAus({ argumente, umgebung, fertigWenn }) {
+	return new Promise((erfuelle, lehneAb) => {
+		const prozess = spawn(process.execPath, argumente, {
 			env: { ...process.env, ...umgebung }
 		});
 		let ausgabe = '';
-		prozess.stdout.on('data', (d) => {
-			ausgabe += d;
-			// Beide Zeilen abwarten, nicht nur die erste: console.log-Aufrufe
-			// werden vom Betriebssystem-Pipe nicht garantiert in einem
-			// gemeinsamen 'data'-Ereignis ausgeliefert — ein Kill direkt nach
-			// der ersten Zeile wäre ein rassebehafteter Fehlschlag.
-			if (ausgabe.includes('lauscht auf Port') && ausgabe.includes('Datenverzeichnis:')) {
-				prozess.kill();
-				fertig({ ausgabe, code: 0 });
-			}
+		let erledigt = false;
+
+		const wecker = setTimeout(() => {
+			if (erledigt) return;
+			erledigt = true;
+			prozess.kill('SIGKILL');
+			lehneAb(
+				new Error(
+					`app.js hat sich nach ${PROZESS_BUDGET_MS} ms nicht beendet. ` +
+						`Ausgabe bis dahin: ${ausgabe.trim() ? JSON.stringify(ausgabe.trim()) : '(keine)'}`
+				)
+			);
+		}, PROZESS_BUDGET_MS);
+		// Ein hängengebliebener Timer soll den Worker nicht offenhalten.
+		wecker.unref?.();
+
+		const beende = (wert) => {
+			if (erledigt) return;
+			erledigt = true;
+			clearTimeout(wecker);
+			erfuelle(wert);
+		};
+
+		/*
+		 * Ohne diesen Handler bliebe ein fehlgeschlagener spawn (unter Last etwa
+		 * EAGAIN) unbeantwortet: Node meldet dann 'error', und 'exit' folgt laut
+		 * Dokumentation nicht zwingend. Die Promise würde nie erfüllt, und der
+		 * Test liefe in den generischen Timeout statt in eine lesbare Meldung.
+		 */
+		prozess.on('error', (fehler) => {
+			if (erledigt) return;
+			erledigt = true;
+			clearTimeout(wecker);
+			lehneAb(new Error(`app.js liess sich nicht starten: ${fehler.message}`));
 		});
-		prozess.stderr.on('data', (d) => (ausgabe += d));
-		prozess.on('exit', (code) => fertig({ ausgabe, code }));
+
+		const pruefeSignal = () => {
+			if (!erledigt && fertigWenn?.(ausgabe)) {
+				prozess.kill();
+				beende({ ausgabe, code: null });
+			}
+		};
+		// setEncoding statt Buffer-Konkatenation: Sonst zerfällt ein Umlaut, der
+		// genau auf eine Chunk-Grenze fällt. Die geprüften Teilstrings sind
+		// umlautfrei, die Meldungen aus startPruefung.js („prüfen", „größerer")
+		// nicht — und die stehen im Diagnosetext des Budget-Fehlers.
+		prozess.stdout.setEncoding('utf8');
+		prozess.stderr.setEncoding('utf8');
+		prozess.stdout.on('data', (daten) => {
+			ausgabe += daten;
+			pruefeSignal();
+		});
+		prozess.stderr.on('data', (daten) => {
+			ausgabe += daten;
+			pruefeSignal();
+		});
+		// 'close' statt 'exit': Erst dann sind stdout und stderr sicher am Ende.
+		// Bei 'exit' dürfen sie laut Node-Doku noch offen sein — für die beiden
+		// Tests, die Ausgabe *und* Exit-Code zusichern, wäre das die falsche
+		// Kante. app.js startet keinen Enkelprozess, der die Pipes offenhielte.
+		prozess.on('close', (code) => beende({ ausgabe, code }));
 	});
+}
+
+function starte({ umgebung, fertigWenn }) {
+	return fuehreAus({ argumente: [APP], umgebung, fertigWenn });
 }
 
 /**
@@ -39,43 +136,48 @@ function starte(umgebung) {
  * lädt ESM aus CJS nur, wenn der Modulgraph kein Top-Level-`await` enthält.
  * Sonst gibt es ERR_REQUIRE_ASYNC_MODULE, bevor eigener Code läuft — und
  * `node app.js` allein hätte das nie gezeigt.
+ *
+ * Das `setTimeout` im Kind ist die Notbremse für den Fall, dass der Start
+ * weder die erwartete Zeile ausgibt noch abbricht: Dann endet der Prozess von
+ * selbst, und der Test scheitert an der Ausgabe statt am Budget.
  */
-function starteWiePassenger(umgebung) {
-	return new Promise((fertig) => {
-		const prozess = spawn(
-			process.execPath,
-			[
-				'--input-type=commonjs',
-				'-e',
-				`require(${JSON.stringify(path.join(WURZEL, 'app.js'))});` +
-					'setTimeout(() => process.exit(0), 2000);'
-			],
-			{ env: { ...process.env, ...umgebung } }
-		);
-		let ausgabe = '';
-		prozess.stdout.on('data', (d) => (ausgabe += d));
-		prozess.stderr.on('data', (d) => (ausgabe += d));
-		prozess.on('exit', (code) => fertig({ ausgabe, code }));
+function starteWiePassenger({ umgebung, fertigWenn }) {
+	return fuehreAus({
+		argumente: [
+			'--input-type=commonjs',
+			'-e',
+			`require(${JSON.stringify(APP)});setTimeout(() => process.exit(0), 2000);`
+		],
+		umgebung,
+		fertigWenn
 	});
 }
 
-describe('app.js', () => {
+describe('app.js', { timeout: TEST_TIMEOUT_MS }, () => {
 	it('lässt sich laden, wie Passenger es lädt', async () => {
 		const verzeichnis = await mkdtemp(path.join(tmpdir(), 'inbox-passenger-'));
 		const { ausgabe } = await starteWiePassenger({
-			LEGACY_INBOX_DATA_DIR: verzeichnis,
-			PORT: '0'
+			umgebung: { LEGACY_INBOX_DATA_DIR: verzeichnis, PORT: '0' },
+			fertigWenn: (bisher) => bisher.includes('lauscht auf Port')
 		});
 
 		expect(ausgabe).not.toContain('ERR_REQUIRE_ASYNC_MODULE');
 		expect(ausgabe).toContain('lauscht auf Port');
 
 		await rm(verzeichnis, { recursive: true, force: true });
-	}, 20_000);
+	});
 
 	it('startet und meldet Port und Datenverzeichnis', async () => {
 		const verzeichnis = await mkdtemp(path.join(tmpdir(), 'inbox-app-'));
-		const { ausgabe } = await starte({ LEGACY_INBOX_DATA_DIR: verzeichnis, PORT: '0' });
+		const { ausgabe } = await starte({
+			umgebung: { LEGACY_INBOX_DATA_DIR: verzeichnis, PORT: '0' },
+			// Auf den Pfad warten, nicht nur auf das Label davor: Zugesichert wird
+			// unten `verzeichnis`, und der steht erst in der zweiten Zeile. Ein
+			// Signal, das schon bei „Datenverzeichnis:" greift, könnte den Prozess
+			// beenden, bevor sein Beweis vollständig angekommen ist — die beiden
+			// console.log-Aufrufe landen nicht garantiert im selben 'data'-Ereignis.
+			fertigWenn: (bisher) => bisher.includes('lauscht auf Port') && bisher.includes(verzeichnis)
+		});
 
 		expect(ausgabe).toContain('lauscht auf Port');
 		expect(ausgabe).toContain(verzeichnis);
@@ -96,9 +198,9 @@ describe('app.js', () => {
 				await chmod(path.join(verzeichnis, unter), 0o500);
 			}
 
+			// Ohne `fertigWenn`: Der Exit-Code ist hier Teil der Zusicherung.
 			const { ausgabe, code } = await starte({
-				LEGACY_INBOX_DATA_DIR: verzeichnis,
-				PORT: '0'
+				umgebung: { LEGACY_INBOX_DATA_DIR: verzeichnis, PORT: '0' }
 			});
 
 			expect(code).not.toBe(0);
@@ -113,7 +215,8 @@ describe('app.js', () => {
 	);
 
 	it('bricht ohne LEGACY_INBOX_DATA_DIR mit klarer Meldung ab', async () => {
-		const { ausgabe, code } = await starte({ LEGACY_INBOX_DATA_DIR: '' });
+		// Ohne `fertigWenn`: Der Exit-Code ist hier Teil der Zusicherung.
+		const { ausgabe, code } = await starte({ umgebung: { LEGACY_INBOX_DATA_DIR: '' } });
 
 		expect(code).not.toBe(0);
 		expect(ausgabe).toContain('LEGACY_INBOX_DATA_DIR');

--- a/legacy-inbox/app.test.js
+++ b/legacy-inbox/app.test.js
@@ -91,7 +91,7 @@ function fuehreAus({ argumente, umgebung, fertigWenn }) {
 			if (erledigt) return;
 			erledigt = true;
 			clearTimeout(wecker);
-			lehneAb(new Error(`app.js liess sich nicht starten: ${fehler.message}`));
+			lehneAb(new Error(`app.js ließ sich nicht starten: ${fehler.message}`));
 		});
 
 		const pruefeSignal = () => {


### PR DESCRIPTION
## Problem

`legacy-inbox/app.test.js` fiel sporadisch mit `Test timed out in 5000ms` — rund 1 von 8 Läufen, unter paralleler Last 3 von 6. Ein roter Lauf las sich wie eine Regression des eigenen Diffs, obwohl `legacy-inbox/` nichts aus `src/` importiert.

## Ursache

Nicht der Start war langsam, sondern das **Sterben**.

Ein Prozess, der `node:http` geladen hat (über `src/server.js`), braucht auf dieser Plattform (macOS 26, Node 24, arm64) nach `process.exit()` noch **0,4–15 s**, bis das Betriebssystem ihn abräumt. Der JavaScript-Teil ist da längst fertig — der `exit`-Handler des Kindes läuft nach ~16 ms, die erwartete Ausgabe steht nach ~90 ms. Die restliche Zeit vergeht in der nativen Abbau-Phase: praktisch ohne CPU-Last (0,2 s CPU auf 9,5 s Wanduhr) und mit der Systemlast wachsend.

Bisect des Import-Graphen, alle Varianten verschränkt gemessen:

```
bare node    min  32  med  33  max   35 ms
net/dns/zlib min  31  med  34  max   39 ms
yup/rbush/turf/checkBalticSea      ~35–50 ms
node:tls     min 491  med 697  max  998 ms
node:http    min 483  med 666  max  796 ms   ← der Auslöser
```

Damit erklärt sich das Muster vollständig: Es fielen genau die Tests, die auf das **Prozessende** warteten — auch der Passenger-Test mit seinen 20 s —, und nie der eine, der sein Kind per SIGTERM abräumt. SIGTERM überspringt die Abbau-Phase (~85 ms).

Was die Tests tatsächlich abwarteten:

| Test | Beweis liegt vor nach | gewartet wurde (max, unter Last) |
|---|---|---|
| Passenger | 89 ms | **15 070 ms** |
| startet und meldet … (killt) | 76 ms | 126 ms |
| nicht beschreibbar | 77 ms | **9 014 ms** |
| ohne `LEGACY_INBOX_DATA_DIR` | 65 ms | **11 235 ms** |

## Änderung

- **Auf ein deterministisches Signal warten, nicht auf einen Zeitpunkt.** Wer nur die Ausgabe zusichert, wartet über `fertigWenn` auf genau den Teilstring, den er prüft, und beendet den Prozess danach selbst. Das betrifft jetzt auch den Passenger-Test, der bisher 2 s plus Teardown auf ein Prozessende wartete, das seine Zusicherung gar nicht berührt.
- **Auf `close` nur, wo der Exit-Code Teil der Zusicherung ist** (die beiden Abbruch-Tests). Dafür gibt es kein früheres Signal — den Status meldet das OS erst dann. Diese beiden bekommen ein explizites, an Messwerten belegtes Budget (45 s ≈ 3× des gemessenen Maximums) statt des unsichtbaren 5-s-Defaults.
- **`error`-Handler auf `spawn`** — fehlte. Nach `error` garantiert Node kein `exit`; ein fehlgeschlagener Spawn (unter Last etwa EAGAIN) hätte die Promise für immer offen gelassen.
- **Lesbarer Fehlschlag statt `Test timed out`:** Wird das Budget gerissen, meldet der Helfer die bis dahin gesammelte Ausgabe — `app.js hat sich nach 45000 ms nicht beendet. Ausgabe bis dahin: "LEGACY_INBOX_DATA_DIR ist nicht gesetzt. …"`. Damit ist sofort sichtbar, dass die App geantwortet hat und nur das Abräumen fehlt.

Kein Produktionscode geändert.

## Verifikation

- **24 aufeinanderfolgende Läufe grün**, davon 12 unter durchgehendem `npm run test:unit` (loadavg 43–61). Vorher-Baseline: 3 von 6 rot.
- Volle Suite 3× grün (3158/3158).
- Der Diagnosepfad wurde geprüft, indem das Budget vorübergehend auf 200 ms gesetzt wurde; die Timeout-Vererbung vom `describe` (inkl. `it.skipIf`) ebenso mit 300 ms.
- ESLint und Prettier sauber.

## Nicht enthalten, bewusst

`app.js` lädt `src/server.js` statisch, also auch auf den Fehlerpfaden. Ein dynamisches `import()` erst nach den Startprüfungen würde die beiden exit-prüfenden Tests von ~2–11 s auf ~35 ms bringen und die Abhängigkeit vom Teardown ganz beseitigen — es wäre der eigentliche Ursachenfix. Ich habe es gelassen: Produktionscode eines Legacy-API-kritischen Dienstes für eine Plattform-Eigenheit zu ändern, die auf Linux-CI womöglich gar nicht auftritt, gehört separat entschieden.

Getrennt beobachtet: `legacy-inbox/src/rateLimit.test.js` („lässt den Speicher nicht unbegrenzt wachsen") riss einmal bei künstlich erzeugtem loadavg ~150 die 5 s — 5000 synchrone Iterationen, also CPU-Hunger, anderer Mechanismus. Nicht Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)