### PR TITLE
feat(ui): Bestimmungshilfe als eigenständige Seite unter /bestimmungshilfe

### DIFF
--- a/e2e/bestimmungshilfe.spec.ts
+++ b/e2e/bestimmungshilfe.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Die Bestimmungshilfe existierte lange nur hinter einem zugeklappten Toggle im
+ * Sichtungsformular — nicht verlinkbar, nicht auffindbar, nicht indexierbar.
+ * Diese Route macht sie zur eigenständigen Seite. Was hier geprüft wird, ist
+ * genau das, was den Unterschied ausmacht: Inhalt ohne Klick, eine saubere
+ * Überschriften-Hierarchie und Wege hin und zurück.
+ */
+test.describe('Bestimmungshilfe', () => {
+	test('zeigt den Inhalt ohne einen einzigen Klick', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		await expect(page.getByText('Wal oder Robbe?')).toBeVisible();
+		await expect(page.getByText('Im Zweifel nicht raten')).toBeVisible();
+		await expect(page.getByText('Schweinswal').first()).toBeVisible();
+	});
+
+	test('hat genau eine h1', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		const h1 = page.locator('h1');
+		await expect(h1).toHaveCount(1);
+		await expect(h1).toBeVisible();
+	});
+
+	/**
+	 * Der Toggle ist das Bedienelement der eingebetteten Variante. Steht er auf
+	 * der Seite, ist die Variante nicht durchgereicht worden — und der Nutzer
+	 * landet auf einer Seite mit einem einzigen Button.
+	 */
+	test('bietet keinen Aufklapp-Toggle an', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		await expect(page.getByRole('button', { name: 'Hilfe bei der Tiererkennung' })).toHaveCount(0);
+	});
+
+	test('trägt die allgemeingültigen Hinweise aus der Formularhilfe', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		await expect(page.getByRole('heading', { name: /Totfunde/ })).toBeVisible();
+		await expect(page.getByText('Bitte nicht berühren')).toBeVisible();
+		await expect(
+			page.getByRole('heading', { name: 'Wofür die Daten gebraucht werden' })
+		).toBeVisible();
+		await expect(page.getByText('HELCOM')).toBeVisible();
+		await expect(page.getByText('ASCOBANS')).toBeVisible();
+	});
+
+	/**
+	 * Die Bedienhilfe für das Formular („Schritt 1" … „Schritt 4") gehört ans
+	 * Formular, nicht auf eine Artbestimmungsseite.
+	 */
+	test('übernimmt die Formular-Bedienhilfe nicht', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		await expect(page.getByText('Schritt 1: Position & Zeitpunkt')).toHaveCount(0);
+		await expect(page.getByText('Schritt 4: Kontaktdaten')).toHaveCount(0);
+	});
+
+	test('setzt Seitentitel und Description für die Suche', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		await expect(page).toHaveTitle(/Bestimmungshilfe/);
+
+		/* Ohne `.first()`/`.last()`: Seit `app.html` keine eigenen SEO-Tags mehr
+		   setzt, gibt es jeden genau einmal. Dass das so bleibt, prüft
+		   `e2e/seo-meta.spec.ts` für alle öffentlichen Routen — hier steht nur,
+		   was diese Seite inhaltlich beiträgt. */
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+			'content',
+			/Schweinswal oder Robbe/
+		);
+		await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+			'content',
+			/Bestimmungshilfe/
+		);
+	});
+
+	test('führt zurück zum Meldeformular', async ({ page }) => {
+		await page.goto('/bestimmungshilfe');
+
+		const cta = page.getByRole('link', { name: /Sichtung melden/i }).first();
+		await expect(cta).toBeVisible();
+		await cta.click();
+		await expect(page).toHaveURL(/\/$/);
+	});
+
+	test.describe('Verlinkung', () => {
+		test('ist über die Navigation erreichbar', async ({ page }) => {
+			await page.goto('/');
+
+			// Unterhalb lg liegt das Menü hinter dem Burger; auf Desktop-Viewport
+			// steht es direkt in der Navbar.
+			const navLink = page.locator('header').getByRole('link', { name: 'Bestimmungshilfe' });
+			await expect(navLink.first()).toBeVisible();
+			await navLink.first().click();
+			await expect(page).toHaveURL(/\/bestimmungshilfe$/);
+		});
+
+		test('ist über den Footer erreichbar', async ({ page }) => {
+			await page.goto('/');
+
+			const footerLink = page.locator('footer').getByRole('link', { name: 'Bestimmungshilfe' });
+			await expect(footerLink).toBeVisible();
+			await footerLink.click();
+			await expect(page).toHaveURL(/\/bestimmungshilfe$/);
+		});
+	});
+
+	/**
+	 * Regressionsschutz für die Variante: Im Formular muss die Hilfe weiterhin
+	 * zugeklappt starten. Sonst schiebt sich ein 500-Zeilen-Panel zwischen das
+	 * Tierart-Feld und alles darunter.
+	 */
+	test('bleibt im Formular zugeklappt', async ({ page }) => {
+		await page.goto('/');
+
+		await expect(page.getByText('Wal oder Robbe?')).toHaveCount(0);
+	});
+});

--- a/e2e/bestimmungshilfe.spec.ts
+++ b/e2e/bestimmungshilfe.spec.ts
@@ -83,7 +83,17 @@ test.describe('Bestimmungshilfe', () => {
 		const cta = page.getByRole('link', { name: /Sichtung melden/i }).first();
 		await expect(cta).toBeVisible();
 		await cta.click();
-		await expect(page).toHaveURL(/\/$/);
+
+		/* `waitForURL` statt `toHaveURL`: Das Ziel ist das Mehrschritt-Formular,
+		   die schwerste Seite der Anwendung. Im vollen Suite-Lauf hat diese
+		   Navigation die Standard-Assertionsfrist einmal gerissen, isoliert nie —
+		   `waitForURL` wartet auf das Navigationsereignis statt auf ein Zeitfenster.
+
+		   Und die Überschrift zusätzlich zur URL: Ein Pfadwechsel allein belegt
+		   nicht, dass der Melder beim Formular angekommen ist. Genau das soll der
+		   Rückweg leisten. */
+		await page.waitForURL((url) => url.pathname === '/');
+		await expect(page.getByRole('heading', { name: /Sichtung.*melden/i }).first()).toBeVisible();
 	});
 
 	test.describe('Verlinkung', () => {

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -341,6 +341,7 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 		{ path: '/', auth: false, needsDb: false },
 		{ path: '/map', auth: false, needsDb: false },
 		{ path: '/about', auth: false, needsDb: false },
+		{ path: '/bestimmungshilfe', auth: false, needsDb: false },
 		/* Die `renders`-Sonden sind für die beiden datengetriebenen Seiten keine
 		   Zugabe, sondern der Kern ihrer Aussagekraft: Eine leere Tabelle liefert
 		   ein DOM ohne eine einzige verbotene Kombination und wäre damit

--- a/e2e/seo-meta.spec.ts
+++ b/e2e/seo-meta.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * `src/app.html` trug bis 2026-08-02 einen eigenen Satz SEO-Tags, und
+ * `%sveltekit.head%` steht darunter. Jede Seite mit eigenem `<svelte:head>`
+ * lieferte damit zwei `<title>`, zwei `description`, zwei `og:title` — welche
+ * davon eine Suchmaschine nimmt, ist nicht garantiert. Die seitenspezifische
+ * Fassung konnte still ignoriert werden.
+ *
+ * Der Scan unten ist der Wächter dagegen: Er prüft nicht, WAS in den Tags steht
+ * (das tun die Seiten-Specs), sondern dass es jeden genau einmal gibt.
+ */
+
+/** Öffentlich erreichbare Seiten. Admin bleibt außen vor — nicht indexierbar. */
+const PUBLIC_ROUTES = ['/', '/about', '/map', '/bestimmungshilfe', '/docs'] as const;
+
+/**
+ * Tags, die den Seiteninhalt beschreiben und deshalb pro Seite genau einmal
+ * vorkommen müssen. `og:site_name`, `og:image` und `twitter:image` stehen
+ * bewusst NICHT hier: die sind seitenunabhängig und gehören weiterhin global
+ * in `app.html`.
+ */
+const UNIQUE_TAGS = [
+	/* `head > title` und nicht `title`: Ein `<title>` in einem Inline-SVG ist ein
+	   legitimer Zugänglichkeitstitel und darf nicht mitgezählt werden. */
+	'head > title',
+	'meta[name="description"]',
+	'meta[name="keywords"]',
+	'meta[property="og:type"]',
+	'meta[property="og:title"]',
+	'meta[property="og:description"]',
+	'meta[name="twitter:card"]',
+	'meta[name="twitter:title"]',
+	'meta[name="twitter:description"]'
+] as const;
+
+/**
+ * `expect(...).toHaveCount()` statt eines einmaligen `.count()`: Nur die
+ * Assertion wiederholt sich, bis sie stimmt oder das Timeout greift.
+ *
+ * Das ist hier keine Stilfrage. `/map` trägt `export const ssr = false`
+ * (`src/routes/map/+page.ts`) — der Server liefert einen leeren `<head>` aus,
+ * Titel und Meta-Tags setzt erst die Hydration. Ein einmaliger `.count()`
+ * unmittelbar nach `goto()` zählt dort null und meldet einen Verlust, den es
+ * nicht gibt.
+ */
+async function expectExactlyOne(page: Page, selector: string, route: string): Promise<void> {
+	await expect(page.locator(selector), `${route}: ${selector} muss genau 1× vorkommen`).toHaveCount(
+		1
+	);
+}
+
+test.describe('SEO-Meta — jede Seite beschreibt sich genau einmal', () => {
+	for (const route of PUBLIC_ROUTES) {
+		/*
+		 * `toBe(1)` und nicht `toBeLessThanOrEqual(1)`: Die obere Grenze allein
+		 * fängt nur die Dopplung, gegen die dieser Wächter ursprünglich gebaut
+		 * wurde — nicht den Verlust. Genau da ist `/map` durchgerutscht: Die Route
+		 * hatte nie eigene og:-Tags und lebte von der globalen Vorgabe in
+		 * `app.html`; nach deren Entfernung stand sie ohne da, und ein „höchstens
+		 * eins"-Test war dabei grün. Die exakte Zahl deckt beide Richtungen ab.
+		 */
+		test(`${route} trägt jeden Beschreibungs-Tag genau einmal`, async ({ page }) => {
+			await page.goto(route);
+
+			for (const selector of UNIQUE_TAGS) {
+				await expectExactlyOne(page, selector, route);
+			}
+		});
+
+		test(`${route} hat eine aussagekräftige Beschreibung`, async ({ page }) => {
+			await page.goto(route);
+
+			await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', /.{40,}/);
+			await expect(page.locator('head > title')).not.toBeEmpty();
+		});
+	}
+
+	/**
+	 * Der Titel muss die Seite unterscheiden — sonst sieht eine Trefferliste
+	 * fünfmal gleich aus. Bis zum Umbau lieferte `app.html` allen Seiten
+	 * zusätzlich denselben Titel „Ostsee-Tiere - Marine Tiere melden".
+	 */
+	test('die Seitentitel unterscheiden sich voneinander', async ({ page }) => {
+		const titles: string[] = [];
+		for (const route of PUBLIC_ROUTES) {
+			await page.goto(route);
+			titles.push(await page.title());
+		}
+
+		expect(new Set(titles).size, `Titel: ${titles.join(' | ')}`).toBe(PUBLIC_ROUTES.length);
+	});
+});

--- a/src/app.html
+++ b/src/app.html
@@ -67,11 +67,19 @@
 		<link rel="preconnect" href="https://tiles.openseamap.org" crossorigin />
 
 		<!-- Open Graph / Twitter — nur was auf jeder Seite gleich ist.
-		     og:type, og:title, og:description und twitter:title/description
-		     setzt die jeweilige Route. -->
+		     og:type, og:title, og:description und twitter:card/title/description
+		     setzt die jeweilige Route.
+
+		     og: nutzt `property` (RDFa, so schreibt es das Open-Graph-Protokoll
+		     vor), twitter: nutzt `name` (so dokumentiert es Twitter/X). Das ist
+		     kein Flüchtigkeitsfehler in der Zeile darunter, sondern der
+		     Unterschied zwischen zwei Spezifikationen. Vor 2026-08-02 stand hier
+		     der ganze twitter:-Satz fälschlich auf `property` — beim Aufräumen
+		     der Tag-Dopplung ist `twitter:image` als einziges übrig geblieben und
+		     wich damit von den `name`-Tags der Routen ab. -->
 		<meta property="og:site_name" content="Ostsee-Tiere" />
 		<meta property="og:image" content="/ostsee-tiere-256.png" />
-		<meta property="twitter:image" content="/ostsee-tiere-256.png" />
+		<meta name="twitter:image" content="/ostsee-tiere-256.png" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" data-theme="meeresmuseum">

--- a/src/app.html
+++ b/src/app.html
@@ -25,15 +25,29 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
 		<link rel="manifest" href="%sveltekit.assets%/manifest.json" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>Ostsee-Tiere - Marine Tiere melden</title>
-		<meta
-			name="description"
-			content="Ostsee-Tiere - Melden Sie Ihre Wal- und Robbensichtung in der Ostsee. Helfen Sie der Meeresforschung mit Ihren Beobachtungen."
-		/>
-		<meta
-			name="keywords"
-			content="Ostsee-Tiere, Wal, Robbe, Sichtung, Ostsee, Meeresforschung, Schweinswal, Kegelrobbe, Baltic Sea, Marine Animals"
-		/>
+
+		<!--
+			HIER STEHEN NUR SEITENUNABHÄNGIGE TAGS.
+
+			Titel, Description, Keywords und die seitenbezogenen og:/twitter:-Tags
+			gehören in den Kopf-Block der jeweiligen Route; jede +page.svelte im
+			Projekt hat einen. Sie hier zusätzlich als "Vorgabe" zu setzen war
+			keine: Der SvelteKit-Kopf-Platzhalter steht weiter unten, und SvelteKit
+			dedupliziert Meta-Tags nicht. Jede Seite lieferte dadurch zwei Titel,
+			zwei Descriptions und zwei og:title mit verschiedenem Inhalt aus, und
+			welche davon eine Suchmaschine nimmt, ist nicht garantiert — die
+			seitenspezifische Fassung konnte still ignoriert werden.
+
+			ACHTUNG beim Ergänzen dieses Kommentars: Der Kopf-Platzhalter wird auch
+			INNERHALB eines HTML-Kommentars ersetzt (reine String-Ersetzung). Der
+			eingefügte Block enthält selbst einen Kommentar, dessen Ende diesen hier
+			vorzeitig schließt — alles danach wird zu echtem Markup, inklusive eines
+			zweiten Titel-Elements im Body. Deshalb steht hier weder der Platzhalter
+			noch Tag-Syntax in spitzen Klammern.
+
+			Abgesichert durch e2e/seo-meta.spec.ts. Wer hier einen
+			seitenbeschreibenden Tag ergänzt, macht den Test rot.
+		-->
 		<meta name="language" content="de" />
 		<meta name="robots" content="index, follow" />
 		<meta name="author" content="Deutsches Meeresmuseum" />
@@ -52,23 +66,11 @@
 		<link rel="preconnect" href="https://tile.openstreetmap.org" crossorigin />
 		<link rel="preconnect" href="https://tiles.openseamap.org" crossorigin />
 
-		<!-- Open Graph / Facebook -->
-		<meta property="og:type" content="website" />
-		<meta property="og:title" content="Ostsee-Tiere - Marine Tiere melden" />
+		<!-- Open Graph / Twitter — nur was auf jeder Seite gleich ist.
+		     og:type, og:title, og:description und twitter:title/description
+		     setzt die jeweilige Route. -->
 		<meta property="og:site_name" content="Ostsee-Tiere" />
-		<meta
-			property="og:description"
-			content="Ostsee-Tiere - Melden Sie Ihre Wal- und Robbensichtung in der Ostsee. Jede Beobachtung hilft der Meeresforschung."
-		/>
 		<meta property="og:image" content="/ostsee-tiere-256.png" />
-
-		<!-- Twitter -->
-		<meta property="twitter:card" content="summary" />
-		<meta property="twitter:title" content="Ostsee-Tiere - Marine Tiere melden" />
-		<meta
-			property="twitter:description"
-			content="Ostsee-Tiere - Melden Sie Ihre Wal- und Robbensichtung in der Ostsee."
-		/>
 		<meta property="twitter:image" content="/ostsee-tiere-256.png" />
 		%sveltekit.head%
 	</head>

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -19,6 +19,7 @@
 			<a href="/about" class="link link-hover text-sm sm:text-base">Über uns</a>
 			<a href="/docs" class="link link-hover text-sm sm:text-base">Dokumentation</a>
 			<a href="/map" class="link link-hover text-sm sm:text-base">Sichtungskarte</a>
+			<a href="/bestimmungshilfe" class="link link-hover text-sm sm:text-base">Bestimmungshilfe</a>
 			<!--
 				Anbieterkennzeichnung nach § 5 DDG und Datenschutzhinweis nach Art. 13 DSGVO.
 				Beides fehlte bis 2026-07-30 vollständig: es gab weder eine Route noch einen

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -32,6 +32,14 @@
 	<li>
 		<a href="/map" class={currentPath === '/map' ? 'active font-medium' : ''}> Karte </a>
 	</li>
+	<li>
+		<a
+			href="/bestimmungshilfe"
+			class={currentPath === '/bestimmungshilfe' ? 'active font-medium' : ''}
+		>
+			Bestimmungshilfe
+		</a>
+	</li>
 	{#if isAdmin}
 		<li>
 			<a href="/admin" class={currentPath === '/admin' ? 'active font-medium' : ''}> Verwalten </a>

--- a/src/lib/components/info/DataUsageNotice.svelte
+++ b/src/lib/components/info/DataUsageNotice.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { infoStyles, type InfoVariant } from '$lib/components/info/variant';
+
+	let { variant = 'inline' }: { variant?: InfoVariant } = $props();
+
+	const styles = $derived(infoStyles(variant));
+</script>
+
+<!--
+	Nennt zwei fremde Gremien namentlich (HELCOM, ASCOBANS). Genau deshalb geteilt
+	statt kopiert: eine zweite Fassung könnte still von der ersten abweichen und
+	eine Zusage machen, die die Plattform nicht hält.
+-->
+<div class="alert alert-info">
+	<Icon icon="lucide:info" width={styles.iconWidth} class="shrink-0" aria-hidden="true" />
+	<div>
+		<svelte:element this={styles.headingTag} class={styles.headingClass}>
+			Wofür die Daten gebraucht werden
+		</svelte:element>
+		<p class={styles.bodyClass}>
+			Ihre Meldung wird vom Deutschen Meeresmuseum wissenschaftlich ausgewertet und direkt an die
+			internationalen Gremien für den Schutz der Ostsee-Schweinswale weitergegeben: an
+			<strong>HELCOM</strong>, die Helsinki-Kommission zum Schutz der Ostsee, und an
+			<strong>ASCOBANS</strong>, das internationale Abkommen zum Schutz der Kleinwale. So trägt Ihre
+			Beobachtung zum Bild von Verbreitung und Vorkommen der Tiere bei.
+		</p>
+	</div>
+</div>

--- a/src/lib/components/info/DeadFindingNotice.svelte
+++ b/src/lib/components/info/DeadFindingNotice.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { infoStyles, type InfoVariant } from '$lib/components/info/variant';
+	import type { Snippet } from 'svelte';
+
+	let {
+		variant = 'inline',
+		children
+	}: {
+		variant?: InfoVariant;
+		/**
+		 * Anhang unter dem Text. Die Formularhilfe schiebt hier ihre
+		 * Totfund-Kennzahl aus `/api/statistics` hinein; die Bestimmungshilfe
+		 * lädt keine Statistiken und lässt es leer.
+		 */
+		children?: Snippet;
+	} = $props();
+
+	const styles = $derived(infoStyles(variant));
+</script>
+
+<!--
+	Fachliche Aussage (Behördenmeldung, „nicht berühren") — bewusst geteilt und
+	nicht kopiert: eine zweite Fassung würde bei der nächsten Textkorrektur
+	auseinanderlaufen. Dasselbe Argument, mit dem der Footer die Rechtstexte
+	verlinkt statt sie nachzubauen.
+-->
+<div class="alert alert-warning">
+	<Icon
+		icon="lucide:triangle-alert"
+		width={styles.iconWidth}
+		class="text-warning-strong shrink-0"
+		aria-hidden="true"
+	/>
+	<div>
+		<svelte:element this={styles.headingTag} class={styles.headingClass}>
+			Totfunde – Besonders wichtig!
+		</svelte:element>
+		<p class={styles.bodyClass}>
+			Tote Tiere liefern wichtige Erkenntnisse über Todesursachen und Gesundheit der Population.
+			<strong>Bitte nicht berühren!</strong> Melden Sie den Fund auch an die örtlichen Behörden (Wasserschutzpolizei,
+			Nationalparkamt).
+		</p>
+		{@render children?.()}
+	</div>
+</div>

--- a/src/lib/components/info/variant.ts
+++ b/src/lib/components/info/variant.ts
@@ -1,0 +1,42 @@
+/**
+ * Geteilte Darstellungsvariante der Hinweis-Komponenten unter `info/`.
+ *
+ * Denselben Namen trägt die Prop an `SpeciesIdentificationHelp` — die drei
+ * Komponenten erscheinen immer gemeinsam (eingebettet in der Formularhilfe oder
+ * nebeneinander auf `/bestimmungshilfe`) und müssen deshalb dieselbe Sprache
+ * sprechen.
+ *
+ * - `inline`: eingebettet in der zugeklappten Formularhilfe — h4, kompakte Schrift
+ * - `page`: eigenständige Seite — h2, Fließtextgröße (die h1 gehört der Route)
+ */
+export type InfoVariant = 'inline' | 'page';
+
+export type InfoStyles = {
+	headingTag: 'h2' | 'h4';
+	headingClass: string;
+	bodyClass: string;
+	iconWidth: string;
+};
+
+const INLINE: InfoStyles = {
+	headingTag: 'h4',
+	headingClass: 'font-semibold',
+	bodyClass: 'mt-1 text-xs',
+	iconWidth: '16'
+};
+
+const PAGE: InfoStyles = {
+	headingTag: 'h2',
+	headingClass: 'text-2xl font-bold',
+	bodyClass: 'mt-1 text-base',
+	iconWidth: '24'
+};
+
+/**
+ * Die Klassennamen stehen hier ausgeschrieben und werden nicht zusammengesetzt:
+ * Tailwind erzeugt eine Utility nur, wenn ihr Name als vollständiger String im
+ * gescannten Quelltext steht (siehe .claude/rules/daisyui.md).
+ */
+export function infoStyles(variant: InfoVariant): InfoStyles {
+	return variant === 'page' ? PAGE : INLINE;
+}

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -6,6 +6,8 @@
 	import SpeciesIdentificationHelp from './form/fields/SpeciesIdentificationHelp.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 	import StatusBlock from '$lib/components/StatusBlock.svelte';
+	import DataUsageNotice from '$lib/components/info/DataUsageNotice.svelte';
+	import DeadFindingNotice from '$lib/components/info/DeadFindingNotice.svelte';
 
 	// Keine Platzhalter-Zahlen: Statistiken werden erst angezeigt, wenn sie
 	// tatsächlich geladen wurden. Erfundene Fallback-Werte würden Bürgern sonst
@@ -249,48 +251,29 @@
 						</div>
 					</div>
 
-					<div class="alert alert-warning">
-						<div>
-							<h4 class="flex items-center gap-2 font-semibold">
-								<Icon icon="lucide:triangle-alert" width="16" class="text-warning-strong" />
-								Totfunde - Besonders wichtig!
-							</h4>
-							<p class="mt-1 text-xs">
-								Tote Tiere liefern wichtige Erkenntnisse über Todesursachen und Gesundheit der
-								Population.
-								<strong>Bitte nicht berühren!</strong> Melden Sie den Fund auch an die örtlichen Behörden
-								(Wasserschutzpolizei, Nationalparkamt).
-							</p>
-							<div class="bg-warning/10 mt-3 rounded-lg p-3">
-								<div class="text-center">
-									<div class="text-warning-strong mb-1 text-xl font-bold">
-										{#if loading}
-											<span class="loading loading-dots loading-sm"></span>
-										{:else}
-											{statistics?.deadAnimalsFound.toLocaleString('de-DE') ?? '–'}
-										{/if}
-									</div>
-									<div class="text-base-content text-xs">
-										freigegebene Totfunde bereits für die Wissenschaft dokumentiert
-									</div>
+					<!--
+						Text und Fachaussage liegen seit /bestimmungshilfe in geteilten
+						Komponenten; hier kommt nur die Kennzahl dazu, die es auf der
+						Bestimmungshilfe bewusst nicht gibt (die Seite lädt keine Statistiken).
+					-->
+					<DeadFindingNotice>
+						<div class="bg-warning/10 mt-3 rounded-lg p-3">
+							<div class="text-center">
+								<div class="text-warning-strong mb-1 text-xl font-bold">
+									{#if loading}
+										<span class="loading loading-dots loading-sm"></span>
+									{:else}
+										{statistics?.deadAnimalsFound.toLocaleString('de-DE') ?? '–'}
+									{/if}
+								</div>
+								<div class="text-base-content text-xs">
+									freigegebene Totfunde bereits für die Wissenschaft dokumentiert
 								</div>
 							</div>
 						</div>
-					</div>
+					</DeadFindingNotice>
 
-					<div class="alert alert-info">
-						<Icon icon="lucide:info" class="shrink-0" aria-hidden="true" />
-						<div>
-							<h4 class="font-semibold">Wofür die Daten gebraucht werden</h4>
-							<p class="mt-1 text-xs">
-								Ihre Meldung wird vom Deutschen Meeresmuseum wissenschaftlich ausgewertet und direkt
-								an die internationalen Gremien für den Schutz der Ostsee-Schweinswale weitergegeben:
-								an <strong>HELCOM</strong>, die Helsinki-Kommission zum Schutz der Ostsee, und an
-								<strong>ASCOBANS</strong>, das internationale Abkommen zum Schutz der Kleinwale. So
-								trägt Ihre Beobachtung zum Bild von Verbreitung und Vorkommen der Tiere bei.
-							</p>
-						</div>
-					</div>
+					<DataUsageNotice />
 				</div>
 			</div>
 		</details>

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
+	import type { InfoVariant } from '$lib/components/info/variant';
 	import { speciesGroups } from '$lib/report/formOptions/species';
 	import {
 		frequencyLabels,
@@ -12,17 +13,79 @@
 	import { sanitizeHtml } from '$lib/utils/sanitize';
 
 	let {
-		currentValue = undefined
+		currentValue = undefined,
+		variant = 'inline'
 	}: {
 		currentValue?: SightingFormData[keyof SightingFormData];
+		/**
+		 * `inline` ist die eingebettete Hilfe im Sichtungsformular: zugeklappt
+		 * hinter einem Toggle, Überschriften ab h4, kompakte Schrift.
+		 * `page` ist die eigenständige Route `/bestimmungshilfe`: sofort sichtbar,
+		 * Überschriften ab h2 (die h1 gehört der Route) und Schriftgrößen aus den
+		 * Typografie-Rollen statt 12px.
+		 *
+		 * Bewusst EINE Prop statt `defaultExpanded` + `headingLevel`: die beiden
+		 * kippen immer gemeinsam, zwei Props ließen die sinnlose Kombination
+		 * „aufgeklappt, aber h4" zu.
+		 *
+		 * Derselbe Typ wie an `DeadFindingNotice`/`DataUsageNotice` — die drei
+		 * erscheinen immer gemeinsam und dürfen nicht auseinanderlaufen.
+		 */
+		variant?: InfoVariant;
 	} = $props();
+
+	const isPage = $derived(variant === 'page');
+
+	/*
+	 * Alle variantenabhängigen Tags und Klassen an einer Stelle statt als
+	 * `{#if}`-Streuung im Markup. Die Klassennamen stehen ausgeschrieben, weil
+	 * Tailwind Utilities nur aus vollständigen Strings im Quelltext erzeugt —
+	 * zusammengesetzte Namen landen nicht im Build (siehe .claude/rules/daisyui.md).
+	 */
+	const INLINE_STYLE = {
+		sectionTag: 'h5',
+		subTag: 'h6',
+		groupHeading: 'text-primary mb-2 text-sm font-medium',
+		panelHeading: 'text-base-content mb-1 flex items-center gap-1 text-xs font-semibold',
+		subHeading: 'text-base-content mb-1 text-xs font-medium',
+		subHeadingWithIcon: 'text-base-content mb-1 flex items-center gap-1 text-xs font-medium',
+		body: 'text-base-content/80 text-xs',
+		list: 'text-base-content/80 ml-3 list-disc space-y-0.5 text-xs',
+		support: 'text-base-content/70 text-xs',
+		/* `/70`, nicht `/60`: Die Grunddaten (Größe, Gewicht, wissenschaftlicher
+		   Name) sind Sekundärtext, und der gehört laut design-system.md auf `/70`
+		   — `/60` ist die Untergrenze für Dekoratives, nicht der Normalwert. Beim
+		   Bündeln in diese Konstante war der richtige Moment, das zu ziehen. */
+		muted: 'text-base-content/70 text-xs',
+		summary: 'collapse-title py-3 text-sm font-medium',
+		iconWidth: '14'
+	} as const;
+
+	const PAGE_STYLE = {
+		sectionTag: 'h2',
+		subTag: 'h3',
+		groupHeading: 'text-primary mt-8 mb-3 text-2xl font-bold',
+		panelHeading: 'text-base-content mb-2 flex items-center gap-2 text-lg font-semibold',
+		subHeading: 'text-base-content mb-1 text-lg font-semibold',
+		subHeadingWithIcon: 'text-base-content mb-1 flex items-center gap-2 text-lg font-semibold',
+		body: 'text-base-content/80 text-base',
+		list: 'text-base-content/80 ml-4 list-disc space-y-1 text-base',
+		support: 'text-base-content/70 text-support',
+		muted: 'text-base-content/70 text-support',
+		summary: 'collapse-title py-3 text-lg font-medium',
+		iconWidth: '20'
+	} as const;
+
+	const styles = $derived(isPage ? PAGE_STYLE : INLINE_STYLE);
 
 	// Die Komponente wird mehrfach gerendert (Tierart-Feld und generisches
 	// Hilfe-Panel). Eine feste ID wäre im DOM doppelt und würde aria-controls
 	// unbrauchbar machen.
 	const helpContentId = $props.id();
 
+	// Auf der eigenen Seite gibt es nichts aufzuklappen — der Inhalt IST die Seite.
 	let isExpanded = $state(false);
+	const showContent = $derived(isPage || isExpanded);
 	let modalImageSrc = $state<string | null>(null);
 	let modalImageAlt = $state<string>('');
 	let modalImageCopyright = $state<string | null>(null);
@@ -97,45 +160,53 @@
 	}
 </script>
 
-<div class="mt-2">
-	<!-- Toggle Button -->
-	<button
-		type="button"
-		class="btn btn-ghost btn-sm flex w-full justify-start gap-2 text-left"
-		onclick={toggleExpanded}
-		aria-expanded={isExpanded}
-		aria-controls={helpContentId}
-	>
-		<Icon icon={isExpanded ? 'lucide:chevron-down' : 'lucide:chevron-right'} width="16" />
-		<Icon icon="lucide:circle-help" width="16" />
-		<span>Hilfe bei der Tiererkennung</span>
-	</button>
+<div class={isPage ? 'help-page' : 'help-inline mt-2'}>
+	<!-- Toggle Button — auf der eigenen Seite gibt es nichts aufzuklappen -->
+	{#if !isPage}
+		<button
+			type="button"
+			class="btn btn-ghost btn-sm flex w-full justify-start gap-2 text-left"
+			onclick={toggleExpanded}
+			aria-expanded={isExpanded}
+			aria-controls={helpContentId}
+		>
+			<Icon icon={isExpanded ? 'lucide:chevron-down' : 'lucide:chevron-right'} width="16" />
+			<Icon icon="lucide:circle-help" width="16" />
+			<span>Hilfe bei der Tiererkennung</span>
+		</button>
+	{/if}
 
-	<!-- Expandable Content -->
-	{#if isExpanded}
-		<div id={helpContentId} class="bg-base-100 border-base-300 mt-2 rounded-lg border p-4">
-			<div class="mb-4">
-				<h4 class="text-base-content mb-2 text-sm font-semibold">
-					Bestimmungshilfe für Meerestiere
-				</h4>
-				<p class="text-base-content/70 text-xs">
-					Klicken Sie auf eine Tierart, um die Erkennungsmerkmale zu sehen. Merkmale sind danach
-					gekennzeichnet, ob sie bei einer echten Sichtung überhaupt zu erkennen sind.
-				</p>
-			</div>
+	{#if showContent}
+		<div
+			id={helpContentId}
+			class={isPage ? '' : 'bg-base-100 border-base-300 mt-2 rounded-lg border p-4'}
+		>
+			<!-- Titel und Einführung stellt im Seitenmodus die Route: sonst stünde
+			     unter der h1 sofort eine zweite Überschrift mit demselben Inhalt. -->
+			{#if !isPage}
+				<div class="mb-4">
+					<h4 class="text-base-content mb-2 text-sm font-semibold">
+						Bestimmungshilfe für Meerestiere
+					</h4>
+					<p class="text-base-content/70 text-xs">
+						Klicken Sie auf eine Tierart, um die Erkennungsmerkmale zu sehen. Merkmale sind danach
+						gekennzeichnet, ob sie bei einer echten Sichtung überhaupt zu erkennen sind.
+					</p>
+				</div>
+			{/if}
 
 			<!-- Wichtigste Regel zuerst -->
 			<div class="bg-warning/10 border-warning/30 mb-4 rounded-lg border p-3">
-				<h5 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
+				<svelte:element this={styles.sectionTag} class={styles.panelHeading}>
 					<Icon
 						icon="lucide:triangle-alert"
-						width="14"
-						class="text-warning-strong"
+						width={styles.iconWidth}
+						class="text-warning-strong shrink-0"
 						aria-hidden="true"
 					/>
 					Im Zweifel nicht raten
-				</h5>
-				<p class="text-base-content/80 text-xs">
+				</svelte:element>
+				<p class={styles.body}>
 					Wählen Sie „Unbekannte Walart" oder „Unbekannte Robbenart" und machen Sie wenn möglich ein
 					Foto — auch ein unscharfes. Eine unsichere Meldung mit Bild ist für die Forschung
 					wertvoller als eine falsch bestimmte.
@@ -144,11 +215,13 @@
 
 			{#each groupedData as group (group.groupName)}
 				<div class="mb-4">
-					<h5 class="text-primary mb-2 text-sm font-medium">{group.groupName}</h5>
+					<svelte:element this={styles.sectionTag} class={styles.groupHeading}
+						>{group.groupName}</svelte:element
+					>
 					<div class="grid grid-cols-1 gap-2">
 						{#each group.species as species (species.enum)}
 							<details class="collapse-arrow border-base-300 bg-base-100 collapse border">
-								<summary class="collapse-title min-h-11 py-3 text-sm font-medium">
+								<summary class={styles.summary}>
 									<div class="flex flex-wrap items-center gap-2">
 										{#if species.images.length > 0 && species.images[0]}
 											<div class="avatar">
@@ -173,7 +246,7 @@
 								<div class="collapse-content px-4 pb-3">
 									<div class="space-y-3">
 										<!-- Häufigkeit einordnen -->
-										<p class="text-base-content/80 text-xs italic">
+										<p class="{styles.body} italic">
 											{species.frequency.text}
 										</p>
 
@@ -205,9 +278,9 @@
 																<Icon icon="lucide:zoom-in" width="24" class="text-on-scrim" />
 															</div>
 														</button>
-														<p class="text-base-content/70 mt-1 text-xs">{image.alt}</p>
+														<p class="{styles.support} mt-1">{image.alt}</p>
 														{#if image.copyright}
-															<p class="text-base-content/70 text-xs">
+															<p class={styles.support}>
 																<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 																{@html sanitizeHtml(image.copyright)}
 															</p>
@@ -219,18 +292,16 @@
 
 										<!-- So sieht es an der Oberfläche aus: das Wichtigste zuerst -->
 										<div class="bg-info/10 rounded-lg p-3">
-											<h6
-												class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold"
-											>
+											<svelte:element this={styles.subTag} class={styles.subHeadingWithIcon}>
 												<Icon
 													icon="lucide:eye"
-													width="14"
-													class="text-info-strong"
+													width={styles.iconWidth}
+													class="text-info-strong shrink-0"
 													aria-hidden="true"
 												/>
 												So sieht es an der Oberfläche aus
-											</h6>
-											<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">
+											</svelte:element>
+											<ul class={styles.list}>
 												{#each species.surfacing as item (item)}
 													<li>{item}</li>
 												{/each}
@@ -239,7 +310,9 @@
 
 										<!-- Erkennungsmerkmale, nach Beobachtbarkeit gruppiert -->
 										<div>
-											<h6 class="text-base-content mb-1 text-xs font-medium">Erkennungsmerkmale</h6>
+											<svelte:element this={styles.subTag} class={styles.subHeading}
+												>Erkennungsmerkmale</svelte:element
+											>
 											<div class="space-y-2">
 												{#each observabilityOrder as level (level)}
 													{@const features = featuresFor(species.distinguishing, level)}
@@ -248,7 +321,7 @@
 															<span class="badge badge-xs {observabilityBadge[level]} mb-1">
 																{observabilityLabels[level]}
 															</span>
-															<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">
+															<ul class={styles.list}>
 																{#each features as feature (feature.text)}
 																	<li>{feature.text}</li>
 																{/each}
@@ -262,13 +335,16 @@
 										<!-- Verwechslungsgefahr -->
 										{#if species.confusion.length > 0}
 											<div>
-												<h6
-													class="text-base-content mb-1 flex items-center gap-1 text-xs font-medium"
-												>
-													<Icon icon="lucide:git-compare-arrows" width="14" />
+												<svelte:element this={styles.subTag} class={styles.subHeadingWithIcon}>
+													<Icon
+														icon="lucide:git-compare-arrows"
+														width={styles.iconWidth}
+														class="shrink-0"
+														aria-hidden="true"
+													/>
 													Häufig verwechselt mit
-												</h6>
-												<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">
+												</svelte:element>
+												<ul class={styles.list}>
 													{#each species.confusion as item (item)}
 														<li>{item}</li>
 													{/each}
@@ -278,10 +354,10 @@
 
 										<!-- Typisches Verhalten -->
 										<div>
-											<h6 class="text-base-content mb-1 text-xs font-medium">
-												Typisches Verhalten
-											</h6>
-											<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">
+											<svelte:element this={styles.subTag} class={styles.subHeading}
+												>Typisches Verhalten</svelte:element
+											>
+											<ul class={styles.list}>
 												{#each species.behavior as behaviorItem (behaviorItem)}
 													<li>{behaviorItem}</li>
 												{/each}
@@ -290,16 +366,14 @@
 
 										<!-- Merkregel -->
 										{#if species.fieldTip}
-											<p
-												class="border-primary/40 text-base-content/80 border-l-2 pl-2 text-xs font-medium italic"
-											>
+											<p class="border-primary/40 {styles.body} border-l-2 pl-2 font-medium italic">
 												{species.fieldTip}
 											</p>
 										{/if}
 
 										<!-- Grunddaten: bewusst zuletzt, weil im Feld nicht schätzbar -->
 										<div class="border-base-300 border-t pt-2">
-											<div class="text-base-content/60 grid grid-cols-1 gap-1 text-xs">
+											<div class="{styles.muted} grid grid-cols-1 gap-1">
 												<div>
 													<span class="font-medium">Größe:</span>
 													<span class="ml-1">{species.size}</span>
@@ -324,14 +398,21 @@
 				</div>
 			{/each}
 
-			<!-- Übergreifende Unterscheidungshilfen -->
+			<!-- Übergreifende Unterscheidungshilfen.
+			     Sie stehen auf der Sektionsebene, nicht darunter: inhaltlich sind sie
+			     Geschwister der Artgruppen („Wale", „Robben"), keine Unterpunkte. -->
 			<div class="space-y-3">
 				<div class="bg-base-200 rounded-lg p-3">
-					<h6 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
-						<Icon icon="lucide:circle-help" width="14" />
+					<svelte:element this={styles.sectionTag} class={styles.panelHeading}>
+						<Icon
+							icon="lucide:circle-help"
+							width={styles.iconWidth}
+							class="shrink-0"
+							aria-hidden="true"
+						/>
 						Wal oder Robbe? Die häufigste Verwechslung
-					</h6>
-					<div class="text-base-content/80 space-y-1 text-xs">
+					</svelte:element>
+					<div class="{styles.body} space-y-1">
 						<p>
 							<strong>Robbe:</strong> Der runde Kopf steht senkrecht aus dem Wasser und bleibt liegen.
 							Augen, Schnauze und Barthaare sind erkennbar. Es gibt keine Rückenflosse.
@@ -344,11 +425,16 @@
 				</div>
 
 				<div class="bg-base-200 rounded-lg p-3">
-					<h6 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
-						<Icon icon="lucide:circle-help" width="14" />
+					<svelte:element this={styles.sectionTag} class={styles.panelHeading}>
+						<Icon
+							icon="lucide:circle-help"
+							width={styles.iconWidth}
+							class="shrink-0"
+							aria-hidden="true"
+						/>
 						Robben unterscheiden: erst das Kopfprofil, dann die Nasenlöcher
-					</h6>
-					<div class="text-base-content/80 space-y-1 text-xs">
+					</svelte:element>
+					<div class="{styles.body} space-y-1">
 						<p>
 							<strong>Kegelrobbe:</strong> langer Kopf, gerade Linie von der Schnauze zur Stirn; Nasenlöcher
 							parallel, laufen unten nicht zusammen.
@@ -361,7 +447,7 @@
 							<strong>Ringelrobbe:</strong> kleinste Art, helle Ringe im Fell — in deutschen Gewässern
 							aber praktisch nicht anzutreffen.
 						</p>
-						<p class="text-base-content/60">
+						<p class="text-base-content/70">
 							Das Kopfprofil ist auch auf 100–200 m mit dem Fernglas erkennbar. Die Nasenlöcher sind
 							das sicherste Merkmal, aber meist nur auf einem Foto zu beurteilen.
 						</p>
@@ -369,11 +455,16 @@
 				</div>
 
 				<div class="bg-base-200 rounded-lg p-3">
-					<h6 class="text-base-content mb-1 flex items-center gap-1 text-xs font-semibold">
-						<Icon icon="lucide:camera" width="14" />
+					<svelte:element this={styles.sectionTag} class={styles.panelHeading}>
+						<Icon
+							icon="lucide:camera"
+							width={styles.iconWidth}
+							class="shrink-0"
+							aria-hidden="true"
+						/>
 						Was der Forschung am meisten hilft
-					</h6>
-					<ul class="text-base-content/80 ml-3 list-disc space-y-0.5 text-xs">
+					</svelte:element>
+					<ul class={styles.list}>
 						<li>Ein Foto, auch unscharf — bei Großwalen möglichst die Fluke beim Abtauchen</li>
 						<li>Genaue Position und Uhrzeit</li>
 						<li>Größe im Vergleich zu Ihrem Boot statt einer Meterschätzung</li>
@@ -447,6 +538,16 @@
 		transition: all 0.2s ease-in-out;
 	}
 
+	/* WCAG 2.5.5: Das Ziel ist die ganze Zusammenfassungszeile, nicht der Text
+	   darin. Der zentrale Touch-Target-Block in `app.css` greift hier nicht — er
+	   zielt auf `.btn`, und ein `summary.collapse-title` ist keiner (dieselbe
+	   Begründung wie beim Skip-Link dort). Der Wert kommt aus dem Token statt aus
+	   einem `min-h-11` an der Aufrufstelle, damit der Feldmodus die 56px
+	   mitnimmt. */
+	.collapse-title {
+		min-height: var(--target-min);
+	}
+
 	.avatar .mask {
 		transition: transform 0.2s ease;
 	}
@@ -478,21 +579,34 @@
 		box-shadow: 0 4px 6px -1px oklch(0% 0 0 / 0.1);
 	}
 
-	/* Copyright-Links stammen aus {@html} und brauchen daher globale Selektoren */
-	:global(.text-base-content\/50 a),
-	:global(.text-base-content\/60 a) {
+	/* Copyright-Links stammen aus {@html} und brauchen daher globale Selektoren.
+	   `/70` ist die Deckkraft der Bildunterschriften, `/60` die des
+	   Modal-Copyrights. Ein dritter Zweig für `/50` stand hier ohne Fundstelle —
+	   entfernt, weil ein Selektor ohne Ziel nicht prüfbar ist und beim nächsten
+	   Leser den Eindruck erweckt, es gäbe irgendwo Text auf `/50` (was die
+	   Deckkraft-Untergrenze aus design-system.md verletzen würde). */
+	:global(.text-base-content\/60 a),
+	:global(.text-base-content\/70 a) {
 		color: inherit;
 		text-decoration: underline;
 		text-underline-offset: 2px;
 		transition: opacity 0.2s ease;
 	}
-	:global(.text-base-content\/50 a:hover),
-	:global(.text-base-content\/60 a:hover) {
+	:global(.text-base-content\/60 a:hover),
+	:global(.text-base-content\/70 a:hover) {
 		opacity: 0.8;
 	}
 
 	@media (max-width: 640px) {
-		.collapse-title {
+		/* Nur die eingebettete Variante. Ungelayerte Scoped-Styles schlagen
+		   Tailwind-Utilities (die in `@layer utilities` liegen) unabhängig von der
+		   Spezifität — ohne die Einschränkung auf `.help-inline` würde diese Regel
+		   das `text-lg` der Seitenvariante überschreiben und die zwölf Artnamen auf
+		   `/bestimmungshilfe` unterhalb 640px auf 14px drücken. Also genau im
+		   Feldfall, für den die Seitenvariante die Typografie-Rollen überhaupt
+		   bekommen hat. Inline ändert die Regel nichts (`text-sm` ist derselbe
+		   Wert) — sie bleibt nur als bewusster Deckel stehen. */
+		.help-inline .collapse-title {
 			font-size: 0.875rem;
 		}
 

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte.test.ts
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import SpeciesIdentificationHelp from './SpeciesIdentificationHelp.svelte';
+
+/**
+ * Die Hilfe hat zwei Aufrufkontexte: eingebettet im Formular (zugeklappt, unter
+ * einem Toggle, Überschriften ab h4) und als eigenständige Seite
+ * (`/bestimmungshilfe` — sofort sichtbar, Überschriften ab h2, weil die `h1` der
+ * Route gehört). Beides hängt an derselben Prop, damit die sinnlose Kombination
+ * „aufgeklappt, aber h4" gar nicht erst konstruierbar ist.
+ */
+describe('SpeciesIdentificationHelp', () => {
+	function root(): HTMLElement {
+		return document.body;
+	}
+
+	describe('variant="inline" (Default)', () => {
+		it('startet zugeklappt und zeigt den Inhalt erst nach Klick', async () => {
+			render(SpeciesIdentificationHelp);
+
+			expect(root().textContent).not.toContain('Im Zweifel nicht raten');
+
+			const toggle = root().querySelector('button[aria-expanded]') as HTMLButtonElement | null;
+			expect(toggle).not.toBeNull();
+			expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+
+			toggle?.click();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(root().textContent).toContain('Im Zweifel nicht raten');
+		});
+
+		it('beginnt die Hierarchie bei h4 und rendert keine h1/h2', async () => {
+			render(SpeciesIdentificationHelp);
+
+			(root().querySelector('button[aria-expanded]') as HTMLButtonElement | null)?.click();
+			await new Promise((resolve) => setTimeout(resolve, 0));
+
+			expect(root().querySelectorAll('h1, h2')).toHaveLength(0);
+			// h3 stammt ausschließlich aus dem Bild-Modal und ist ohne offenes Modal nicht da.
+			expect(root().querySelectorAll('h4').length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('variant="page"', () => {
+		it('zeigt den Inhalt ohne Klick und bietet keinen Toggle an', () => {
+			render(SpeciesIdentificationHelp, { variant: 'page' });
+
+			expect(root().textContent).toContain('Im Zweifel nicht raten');
+			expect(root().textContent).toContain('Wal oder Robbe?');
+			expect(root().querySelector('button[aria-expanded]')).toBeNull();
+		});
+
+		it('rendert keine eigene h1 — die gehört der Route', () => {
+			render(SpeciesIdentificationHelp, { variant: 'page' });
+
+			expect(root().querySelectorAll('h1')).toHaveLength(0);
+		});
+
+		it('beginnt die Hierarchie bei h2 und rendert keine h5/h6', () => {
+			render(SpeciesIdentificationHelp, { variant: 'page' });
+
+			expect(root().querySelectorAll('h2').length).toBeGreaterThan(0);
+			expect(root().querySelectorAll('h5, h6')).toHaveLength(0);
+		});
+
+		/**
+		 * `text-xs` ist 12px. Auf einer Seite, die per Suchmaschine gefunden und an
+		 * Deck gelesen wird, liegt das unter der Typografie-Untergrenze
+		 * (design-system.md: `support` = 13px).
+		 */
+		it('nutzt keine 12px-Schrift', () => {
+			render(SpeciesIdentificationHelp, { variant: 'page' });
+
+			const withXs = Array.from(root().querySelectorAll('[class*="text-xs"]'));
+			expect(withXs).toHaveLength(0);
+		});
+	});
+
+	/**
+	 * Die zwölf Arten bleiben in beiden Varianten zugeklappt: aufgeklappt wären es
+	 * zwölf Steckbriefe mit je ein bis zwei Fotos auf einer Seite.
+	 */
+	it('lässt die Arten-Akkordeons auch auf der Seite zugeklappt', () => {
+		render(SpeciesIdentificationHelp, { variant: 'page' });
+
+		const accordions = Array.from(root().querySelectorAll('details'));
+		expect(accordions.length).toBeGreaterThan(0);
+		expect(accordions.every((d) => !d.open)).toBe(true);
+	});
+});

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -697,12 +697,16 @@ SOFTWARE.</pre>
 						<Icon icon="lucide:map" width="20" height="20" class="mr-2" />
 						Karte erkunden
 					</a>
+					<!-- Zeigte bis 2026-08-02 auf /docs — die OpenAPI-Referenz. „Mehr
+					     erfahren" führte damit vom Werbeblock für Bürger direkt in die
+					     Entwicklerdokumentation. Die Bestimmungshilfe ist das, was an
+					     dieser Stelle tatsächlich gemeint war. -->
 					<a
-						href="/docs"
+						href="/bestimmungshilfe"
 						class="btn btn-accent btn-outline btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
 					>
 						<Icon icon="lucide:book-open" width="20" height="20" class="mr-2" />
-						Mehr erfahren
+						Tiere bestimmen
 					</a>
 				</div>
 			</div>

--- a/src/routes/bestimmungshilfe/+page.svelte
+++ b/src/routes/bestimmungshilfe/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import DataUsageNotice from '$lib/components/info/DataUsageNotice.svelte';
+	import DeadFindingNotice from '$lib/components/info/DeadFindingNotice.svelte';
+	import SpeciesIdentificationHelp from '$lib/report/components/form/fields/SpeciesIdentificationHelp.svelte';
+
+	const title = 'Bestimmungshilfe: Wale und Robben der Ostsee erkennen';
+	const description =
+		'Schweinswal oder Robbe? Kegelrobbe oder Seehund? Erkennungsmerkmale, Artfotos und Verwechslungsgefahren für alle Meeressäuger der Ostsee — sortiert danach, was bei einer echten Sichtung auf dem Wasser überhaupt zu sehen ist.';
+</script>
+
+<svelte:head>
+	<title>{title} - Ostsee-Tiere</title>
+	<meta name="description" content={description} />
+	<meta
+		name="keywords"
+		content="Bestimmungshilfe, Schweinswal erkennen, Kegelrobbe, Seehund, Robbe oder Wal, Ostsee, Meeressäuger, Artbestimmung, Sichtung melden"
+	/>
+
+	<!-- Open Graph -->
+	<meta property="og:title" content="{title} - Ostsee-Tiere" />
+	<meta property="og:description" content={description} />
+	<meta property="og:type" content="article" />
+
+	<!-- Twitter Card -->
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content="{title} - Ostsee-Tiere" />
+	<meta name="twitter:description" content={description} />
+</svelte:head>
+
+<div class="mx-auto max-w-5xl p-6">
+	<div class="mb-10">
+		<h1 class="text-primary mb-4 text-4xl font-bold tracking-tight">
+			Bestimmungshilfe für Meerestiere
+		</h1>
+		<p class="text-base-content/80 mb-4 text-xl leading-relaxed">
+			Welches Tier war das? Diese Seite hilft bei der Artbestimmung von Walen und Robben in der
+			Ostsee — mit Fotos, Erkennungsmerkmalen und den Verwechslungen, die am häufigsten vorkommen.
+		</p>
+		<p class="text-base-content/70 leading-relaxed">
+			Klicken Sie auf eine Tierart, um ihre Merkmale zu sehen. Die Merkmale sind danach
+			gekennzeichnet, ob sie bei einer echten Sichtung überhaupt zu erkennen sind — auf Entfernung,
+			erst aus der Nähe oder nur mit Hintergrundwissen.
+		</p>
+	</div>
+
+	<SpeciesIdentificationHelp variant="page" />
+
+	<div class="mt-10 space-y-6">
+		<DeadFindingNotice variant="page" />
+		<DataUsageNotice variant="page" />
+	</div>
+
+	<!-- Rückweg zum Formular: Wer hier landet, hat in aller Regel gerade etwas
+	     gesehen und will es melden. -->
+	<div class="border-base-300 mt-12 flex flex-wrap justify-center gap-4 border-t pt-10">
+		<a href="/" class="btn btn-primary btn-lg">
+			<Icon icon="custom:porpoise" width="20" height="20" aria-hidden="true" />
+			Sichtung melden
+		</a>
+		<a href="/map" class="btn btn-outline btn-lg">
+			<Icon icon="lucide:map" width="20" height="20" aria-hidden="true" />
+			Sichtungskarte ansehen
+		</a>
+	</div>
+</div>

--- a/src/routes/docs/+layout.svelte
+++ b/src/routes/docs/+layout.svelte
@@ -2,11 +2,12 @@
 	// Documentation layout
 </script>
 
-<svelte:head>
-	<title>Dokumentation - Ostsee-Tiere</title>
-	<meta name="description" content="API-Dokumentation für die Ostsee-Tiere Plattform" />
-</svelte:head>
-
+<!--
+	Kein `<svelte:head>`: Alle drei Seiten unter /docs (`+page`, `api/+page`,
+	`api/fallback/+page`) setzen Titel und Description selbst. Ein Layout-Head
+	käme zusätzlich statt stattdessen — SvelteKit dedupliziert Meta-Tags nicht.
+	Abgesichert durch `e2e/seo-meta.spec.ts`.
+-->
 <div class="container mx-auto p-4">
 	<slot />
 </div>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -4,7 +4,34 @@
 
 <svelte:head>
 	<title>Sichtungskarte - Ostsee-Tiere</title>
-	<meta name="description" content="Interaktive Karte der Meerestier-Sichtungen" />
+	<meta
+		name="description"
+		content="Interaktive Karte der freigegebenen Wal- und Robbensichtungen in der Ostsee — jahrweise filterbar, mit Verbreitung und Hotspots."
+	/>
+	<meta
+		name="keywords"
+		content="Sichtungskarte, Ostsee, Schweinswal, Robbe, Verbreitung, Karte, Meeressäuger, Citizen Science"
+	/>
+
+	<!--
+		og:/twitter:-Tags standen bis 2026-08-02 global in `app.html` und trugen
+		dort den Text der Startseite. Beim Entfernen der Dopplung (siehe Kommentar
+		in `app.html`) war diese Route die einzige öffentliche ohne eigenen Satz —
+		sie wäre sonst beim Teilen ohne Vorschaukarte geblieben.
+	-->
+	<meta property="og:title" content="Sichtungskarte - Ostsee-Tiere" />
+	<meta
+		property="og:description"
+		content="Freigegebene Wal- und Robbensichtungen in der Ostsee auf einer interaktiven Karte."
+	/>
+	<meta property="og:type" content="website" />
+
+	<meta name="twitter:card" content="summary" />
+	<meta name="twitter:title" content="Sichtungskarte - Ostsee-Tiere" />
+	<meta
+		name="twitter:description"
+		content="Freigegebene Wal- und Robbensichtungen in der Ostsee auf einer interaktiven Karte."
+	/>
 </svelte:head>
 
 <LazyMapWrapper


### PR DESCRIPTION
Die Artbestimmungs-Hilfe war bisher nur hinter einem zugeklappten Toggle im Sichtungsformular erreichbar — nicht verlinkbar, nicht auffindbar, nicht indexierbar. Dabei ist „Schweinswal oder Robbe?" der natürliche Sucheinstieg für neue Melder. Diese PR macht sie zur eigenständigen öffentlichen Seite und behebt dabei zwei Vorbefunde, die im Weg standen.

## Die Route

`/bestimmungshilfe` verwendet `SpeciesIdentificationHelp` wieder, statt sie zu kopieren. Die Komponente bekommt dafür eine `variant`-Prop:

| | `inline` (Default) | `page` |
|---|---|---|
| Toggle | ja, zugeklappt | entfällt, Inhalt direkt |
| Eigener Titel | h4 | entfällt — die h1 gehört der Route |
| Überschriften | h5 / h6 | h2 / h3 |
| Schrift | `text-xs` (12px) | Typografie-Rollen (16px Fließtext) |

Bewusst **eine** Prop statt `defaultExpanded` + `headingLevel`: beide kippen immer gemeinsam, zwei Props ließen die sinnlose Kombination „aufgeklappt, aber h4" zu. Die Variantenlogik liegt in zwei Konstanten am Kopf der Datei, nicht als `{#if}`-Streuung im Markup.

Die zwölf Arten-Akkordeons bleiben auch auf der Seite zugeklappt — aufgeklappt wären es zwölf Steckbriefe mit je ein bis zwei Fotos.

## Geteilte Hinweis-Blöcke

„Totfunde – Besonders wichtig!" und „Wofür die Daten gebraucht werden" (HELCOM, ASCOBANS) wandern aus `FormHelp` nach `lib/components/info/`. Beides sind fachliche Aussagen über Meldepflichten und fremde Gremien; eine zweite Fassung würde bei der nächsten Textkorrektur auseinanderlaufen. `FormHelp` reicht seine Statistik-Kachel als Snippet hinein, die Seite braucht damit keinen `fetch`.

Die Formular-Bedienhilfe („Schritt 1" bis „Schritt 4") bleibt am Formular.

## Zwei Fixes im angefassten Code

**Die Mobile-Media-Query hätte die Seiten-Typografie ausgehebelt.** `.collapse-title { font-size: 0.875rem }` unter 640px ist jetzt an die Inline-Variante gebunden. Ungelayerte Scoped-Styles schlagen Tailwind-Utilities unabhängig von der Spezifität — die Regel hätte die zwölf Artnamen auf 14px gedrückt, also genau im Feldfall, für den die Seitenvariante die Typografie-Rollen überhaupt bekommen hat. Auf CSSOM-Ebene nachgeprüft.

**`min-h-11` am Arten-`<summary>` ist nicht ersatzlos entfallen,** sondern durch `min-height: var(--target-min)` ersetzt. Der zentrale Touch-Target-Block in `app.css` zielt auf `.btn`, und ein `summary.collapse-title` ist keiner — ein ersatzloses Entfernen wäre eine WCAG-2.5.5-Regression gewesen. Über das Token greift jetzt auch der Feldmodus mit 56px.

## Zweiter Commit: doppelte Meta-Tags

`app.html` trug einen eigenen Satz SEO-Tags. Der SvelteKit-Kopf-Platzhalter steht darunter, und SvelteKit dedupliziert Meta-Tags nicht — **jede** Seite lieferte Titel, Description und `og:title` doppelt mit verschiedenem Inhalt aus. Welche Fassung eine Suchmaschine nimmt, ist nicht garantiert; die seitenspezifische konnte still ignoriert werden. Das hätte den SEO-Zweck der neuen Seite direkt untergraben.

Eine Vorgabe waren die Tags ohnehin nie: **jede einzelne `+page.svelte` im Projekt setzt bereits eigenen Titel.** `app.html` trägt jetzt nur noch Seitenunabhängiges.

Zwei Folgefunde: `docs/+layout.svelte` setzte Titel und Description zusätzlich zu allen drei Seiten darunter (entfernt), und `/map` war die einzige öffentliche Route ohne eigene `og:`-Tags — sie hätte ohne Vorschaukarte dagestanden und ist jetzt versorgt.

`e2e/seo-meta.spec.ts` prüft **genau einmal**, nicht „höchstens einmal". Die obere Schranke allein hat `/map` durchgelassen.

## Tests

Test-First: erst die fehlschlagenden Tests, dann die Implementierung.

- `SpeciesIdentificationHelp.svelte.test.ts` (7) — Varianten-Logik
- `e2e/bestimmungshilfe.spec.ts` (10) — Inhalt ohne Klick, genau eine h1, kein Toggle, beide Hinweise, Navbar-/Footer-Link, CTA; plus Regressionsfall, dass die Hilfe im Formular zugeklappt bleibt
- `e2e/seo-meta.spec.ts` (11) — Meta-Tag-Wächter über alle öffentlichen Routen
- `/bestimmungshilfe` in der Scanliste von `e2e/design-tokens.spec.ts`

Grün: `lint`, `type-check`, `svelte-check` (0 Fehler / 2074 Dateien), 3131 Server-Tests, 267 Client-Tests, E2E **272 passed / 2 failed**.

Beide E2E-Fehlschläge sind bestehende Flakiness, gegen den gestashten Stand gegengeprüft: `form-map-pan-zoom.spec.ts` scheitert an einer Sub-Pixel-Assertion (Baseline 3 von 4 Läufen rot, mit den Änderungen 1 von 3), `form-stepper.spec.ts` scheitert mit und ohne Änderungen jeweils nur im ersten Lauf nach kaltem Vite-Start.

## Hinweis für Reviewer

Beim Kommentieren in `app.html`: Der Kopf-Platzhalter wird auch **innerhalb eines HTML-Kommentars** ersetzt. Der eingefügte Block enthält einen eigenen Kommentar, dessen Ende den umgebenden schließt — alles danach wird zu echtem Markup. Der Kommentar dort nennt deshalb weder den Platzhalter noch Tag-Syntax in spitzen Klammern, und sagt auch warum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
