### PR TITLE
fix(test): rateLimit-Speichertest von CPU-Hunger befreien

### DIFF
--- a/legacy-inbox/src/rateLimit.test.js
+++ b/legacy-inbox/src/rateLimit.test.js
@@ -50,9 +50,16 @@ describe('erstelleRateLimit', () => {
 			jetzt: () => zeit
 		});
 
-		for (let i = 0; i < 5000; i++) {
+		// 500 IPs, nicht mehr: pruefeIp() räumt bei jedem Aufruf die ganze Map auf,
+		// die Schleife ist also quadratisch (5000 IPs ≙ 584 ms auf einer unbelasteten
+		// Maschine, unter Volllast über dem 5-s-Timeout von Vitest). Die Aussage hängt
+		// nicht an der Größe — sie steckt in den beiden expect() unten: Die Map wächst
+		// mit jeder neuen IP und ist nach dem Stundenwechsel wieder leer.
+		for (let i = 0; i < 500; i++) {
 			limit.pruefeIp(`10.0.${Math.floor(i / 256)}.${i % 256}`);
 		}
+		expect(limit.anzahlBeobachteterIps()).toBe(500);
+
 		zeit = 3_600_001;
 		limit.pruefeIp('1.1.1.1');
 


### PR DESCRIPTION
## Problem

`legacy-inbox/src/rateLimit.test.js` → „lässt den Speicher nicht unbegrenzt wachsen" fiel unter hoher Maschinenlast sporadisch mit `Test timed out in 5000ms` (beobachtet bei loadavg ~150 während eines vollen `npm run test:unit`).

Das ist **nicht** der Teardown-Mechanismus aus #709, wo dort als Folgearbeit vermerkt. Dort war das Prozess**ende** langsam; hier ist es schlichter CPU-Hunger in einer synchronen Schleife.

## Ursache

`pruefeIp()` räumt bei **jedem** Aufruf die gesamte Map auf und filtert dabei jedes Zeitstempel-Array neu. Die Testschleife ist damit quadratisch — 5000 Aufrufe ≙ ~12,5 Mio. Iterationen samt Array-Allokationen.

Gemessen auf einer unbelasteten Maschine (10 Kerne, Node 24, arm64):

| Iterationen | Dauer |
|---|---|
| 5000 | **584,0 ms** |
| 1000 | 21,3 ms |
| 500 | **5,8 ms** |
| 200 | 0,7 ms |

584 ms Grundkosten heißt: Ein 8,5-facher Slowdown reicht für den 5-s-Default. Bei loadavg 150 ist das keine Überraschung, sondern zu erwarten.

## Änderung

- **Iterationszahl 5000 → 500.** Kein expliziter Timeout, denn das wäre Symptombehandlung: Die Räum-Eigenschaft ist von N vollständig unabhängig, die Größe trug zur Aussage also nichts bei. 500 sind weiterhin klar „viele" (50× die Prüfschwelle) und spannen zwei /24-Blöcke, die Adresserzeugung bleibt damit sinnvoll.
- **Die Intention wandert von der Schleifengröße in eine Zusicherung.** Der Test prüfte bisher nur die Größe *nach* dem Stundenwechsel — hätte `pruefeIp()` überhaupt nichts gespeichert, wäre er grün geblieben. Ein `expect(...).toBe(500)` vor dem Wechsel sichert jetzt zu, was der Testname behauptet: Die Map wächst mit jeder neuen IP **und** ist danach wieder leer.

Kein Produktionscode geändert.

## Verifikation

- **10× unbelastet grün** — `tests 13–14 ms` für alle fünf Fälle der Datei zusammen (vorher kostete allein dieser eine 584 ms).
- **10× unter erzwungener Last grün** — 120 CPU-Lastprozesse auf 10 Kernen, loadavg 141–365, `tests 19–189 ms`. Das sind ~26× Marge zum Timeout; die sichtbare Gesamtdauer von 1,8–5,2 s ist praktisch vollständig Vitest-Start und Setup, nicht der Test.
- **Mutationsprobe** — beide Bruchstellen werden gefangen:
  - Aufräum-Schleife deaktiviert → `expected 501 to be less than 10`
  - `proIp.set(ip, eigene)` entfernt → `expected +0 to be 500` ← genau die vorher offene Lücke
- Volle Server-Suite grün: **3287/3287** (226 Dateien).
- ESLint und Prettier sauber.

## Anmerkung zum Nicht-Gemachten

Das quadratische Verhalten steckt im Produktionscode, nicht im Test: `pruefeIp()` ist O(beobachtete IPs) pro Aufruf. Für den realen Betrieb der Legacy-Inbox ist das unkritisch (der Durchsatz liegt Größenordnungen darunter, und das Aufräumen ist genau der Zweck), und ein Umbau auf amortisiertes Räumen wäre eine Verhaltensänderung an einem Legacy-API-kritischen Dienst. Das gehört separat entschieden — hier ging es um den Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
