### PR TITLE
fix(ui): cut the stepper bar at the circles instead of under them

### DIFF
--- a/e2e/form-stepper-affordance.spec.ts
+++ b/e2e/form-stepper-affordance.spec.ts
@@ -33,6 +33,13 @@ const STEP_BUTTON = 'nav[aria-label="Formular-Schritte"]:visible .step-button';
 const NICHT_ERREICHT = '.steps .step:not(.step-primary)';
 
 /**
+ * Die Leiste selbst. Sie ist zugleich Bildausschnitt und Koordinaten-Ursprung
+ * der Pixelmessung weiter unten — beides muss dasselbe Element sein, sonst
+ * verschiebt die Zeilenhöhe des umgebenden `nav` die Messpunkte.
+ */
+const STEPPER_LEISTE = 'nav[aria-label="Formular-Schritte"] .steps';
+
+/**
  * Wartet, bis alle laufenden CSS-Transitions durch sind.
  *
  * Ohne das misst dieser Test sich selbst blind: Der Schrittwechsel färbt den
@@ -214,6 +221,122 @@ test.describe('Stepper — erkennbar als Navigation', () => {
 			kreis.ratio,
 			`Ziffer ${kreis.foreground} auf ${kreis.background} misst nur ${formatRatio(kreis.ratio)}:1`
 		).toBeGreaterThanOrEqual(4.5);
+	});
+
+	test('der Verbindungsbalken wird vor dem Ziffernkreis wirklich abgeschnitten', async ({
+		page
+	}) => {
+		await gotoStepTwo(page);
+
+		// Der Test darüber prüft, welche Farben Kreis und Balken DEKLARIEREN. Das
+		// war zu wenig: Die Farben unterschieden sich, sichtbar lag der Balken
+		// trotzdem quer durch die Ziffer. Grund ist DaisyUIs Geometrie — der
+		// Balken eines Schritts spannt von der Kreis*mitte* des vorherigen bis zur
+		// eigenen und verlässt sich darauf, dass die beiden Kreise (`z-index: 1`)
+		// die Enden verdecken. Sobald ein `<li>` einen eigenen Stacking-Context
+		// aufmacht — `opacity-70` am gesperrten Schritt tut genau das —, bleibt
+		// das `z-index: 1` darin gefangen, und der Balken des FOLGENDEN Schritts
+		// malt über den Kreis davor.
+		//
+		// Deshalb wird hier gemessen, was tatsächlich gemalt wurde, nicht was
+		// berechnet ist: Screenshot in ein Canvas, Pixel auslesen. Eine
+		// Geometrie-Rechnung im Test wäre keine Alternative — sie müsste DaisyUIs
+		// Zusammenspiel aus `width: 100%`, negativem `margin-inline-start` und
+		// `justify-self: center` nachbauen und damit genau das duplizieren, was
+		// sie prüfen soll.
+		const nav = page.locator(STEPPER_LEISTE);
+		// An den Seitenanfang, NICHT `scrollIntoViewIfNeeded`: Das schiebt die
+		// Leiste gerade eben in den Viewport — und damit unter die feststehende
+		// Navbar. Der Ausschnitt zeigte dann deren Fläche, und weil die überall
+		// dieselbe Farbe hat, waren Kreis- und Balkenprobe gleich: ein Befund, der
+		// nur die Verdeckung gemessen hätte.
+		await page.evaluate(() => window.scrollTo(0, 0));
+		// Aufnahme über den Locator, nicht über `page.screenshot({clip})`: Der
+		// Stepper steht am Seitenkopf und ist nach dem Schrittwechsel oft aus dem
+		// Bild gescrollt — ein Clip mit negativem `y` bricht ab.
+		const bild = (await nav.screenshot()).toString('base64');
+
+		const { verdeckt, befunde } = await page.evaluate(
+			async ({ bild, navSelektor, selektor }) => {
+				const img = new Image();
+				img.src = `data:image/png;base64,${bild}`;
+				await img.decode();
+				const canvas = document.createElement('canvas');
+				canvas.width = img.width;
+				canvas.height = img.height;
+				const ctx = canvas.getContext('2d')!;
+				ctx.drawImage(img, 0, 0);
+
+				// Ursprung ist die Ecke des Stepper-Ausschnitts; der Faktor fängt
+				// einen konfigurierten `deviceScaleFactor` ab.
+				const ursprung = document.querySelector(navSelektor)!.getBoundingClientRect();
+				const faktor = img.width / ursprung.width;
+				const pixel = (x: number, y: number): string => {
+					const d = ctx.getImageData(
+						Math.round((x - ursprung.left) * faktor),
+						Math.round((y - ursprung.top) * faktor),
+						1,
+						1
+					).data;
+					return `${d[0]},${d[1]},${d[2]}`;
+				};
+
+				// Nur Schritte, deren Kreis base-100 trägt und deren Nachfolger einen
+				// base-300-Balken hat. Bei zwei aufeinanderfolgenden `step-primary`
+				// sind Kreis und Balken bewusst dieselbe Farbe — dort wäre die
+				// Gleichheit kein Befund, sondern das gewünschte Bild.
+				const leiste = document.querySelector(navSelektor)!;
+				const messpunkte = [...document.querySelectorAll<HTMLElement>(selektor)]
+					.filter((li) => li.nextElementSibling?.classList.contains('step'))
+					.map((li) => {
+						const r = li.getBoundingClientRect();
+						const nachbar = (li.nextElementSibling as HTMLElement).getBoundingClientRect();
+						const mitteX = r.left + r.width / 2;
+						// Zeile 1 des `.step`-Grids ist 40px hoch und trägt Kreis (32px)
+						// und Balken (8px); beide sind darin zentriert.
+						const mitteY = r.top + 20;
+						return {
+							schritt: li.textContent?.trim().slice(0, 30) ?? '',
+							// 12px aus der Mitte: sicher innerhalb des 16px-Radius und
+							// neben der Ziffer, die nur ~8px breit ist.
+							kreisPunkt: [mitteX + 12, mitteY] as const,
+							// Mitte zwischen den beiden Kreisen — dort ist unstrittig Balken.
+							balkenPunkt: [(mitteX + nachbar.left + nachbar.width / 2) / 2, mitteY] as const
+						};
+					});
+
+				// Liegt an einem Messpunkt etwas anderes obenauf als die Leiste selbst
+				// — die feststehende Navbar etwa —, misst die Probe dessen Farbe.
+				// Beide Punkte wären dann gleich und der Test meldete einen Fehler,
+				// den es nicht gibt. Deshalb hier abfangen und benennen.
+				const verdeckt = messpunkte
+					.flatMap((p) => [p.kreisPunkt, p.balkenPunkt].map((q) => ({ schritt: p.schritt, q })))
+					.filter(({ q }) => !leiste.contains(document.elementFromPoint(q[0], q[1])))
+					.map(({ schritt, q }) => `${schritt} bei ${Math.round(q[0])}/${Math.round(q[1])}`);
+
+				const befunde = messpunkte.map((p) => ({
+					schritt: p.schritt,
+					imKreis: pixel(...p.kreisPunkt),
+					aufBalken: pixel(...p.balkenPunkt)
+				}));
+
+				return { verdeckt, befunde };
+			},
+			{ bild, navSelektor: STEPPER_LEISTE, selektor: NICHT_ERREICHT }
+		);
+
+		expect(
+			verdeckt,
+			`Messpunkte sind verdeckt, die Probe misst fremde Fläche: ${verdeckt.join(', ')}`
+		).toEqual([]);
+		expect(befunde.length, 'Es muss überhaupt etwas gemessen worden sein').toBeGreaterThan(0);
+
+		expect(
+			befunde.filter((b) => b.imKreis === b.aufBalken),
+			`Der Balken ist im Kreis dieser Schritte sichtbar: ${befunde
+				.map((b) => `${b.schritt} (${b.imKreis})`)
+				.join(', ')}`
+		).toEqual([]);
 	});
 
 	test('die Schaltflächen benennen die Aktion, nicht nur den Schritt', async ({ page }) => {

--- a/src/app.css
+++ b/src/app.css
@@ -523,6 +523,38 @@ label:has(> .toggle) {
 	grid-template-columns: minmax(0, 1fr);
 }
 
+/* ===== Der Verbindungsbalken endet an den Kreisen, statt sie zu unterlaufen =====
+
+   DaisyUIs Balken (`::before`) spannt von der Kreis*mitte* des vorherigen
+   Schritts bis zur eigenen — `width: 100%` plus `margin-inline-start: -100%`
+   ergibt zusammen mit `justify-self: center` genau diese Strecke. Beide Enden
+   liegen damit UNTER einem Kreis, und dass man sie nicht sieht, hängt allein
+   daran, dass der Kreis (`::after`, `z-index: 1`) darüber malt.
+
+   Diese Zusage hält nicht: `opacity-70` am gesperrten Schritt (`FormSteps.svelte`)
+   macht aus dem `<li>` einen eigenen Stacking-Context. Das `z-index: 1` seines
+   Kreises reicht dann nur noch bis zum `<li>`-Rand, während der Balken des
+   FOLGENDEN Schritts als späteres Geschwister darüber liegt — er malt quer
+   durch die Ziffer davor. Genau so war „die Zahlen werden von den Balken
+   überlagert" gemeint; die Korrektur in #691 (eigene Kreisfläche, siehe unten)
+   hat die Farben getrennt, den Balken aber weiterhin obenauf gelassen.
+
+   `calc(100% - 2rem)` nimmt dem Balken die beiden Kreisdurchmesser-Hälften an
+   seinen Enden. Da die Kreise 2rem breit sind und `justify-self: center` den
+   Balken mittig hält, stößt er danach exakt an ihre Ränder — bei JEDER
+   Spaltenbreite, denn beide Größen wachsen mit derselben Hälfte. Das Bild
+   bleibt dasselbe wie bisher beabsichtigt; es hängt nur nicht mehr an der
+   Malreihenfolge.
+
+   Abgesichert durch `e2e/form-stepper-affordance.spec.ts` → „der
+   Verbindungsbalken wird vor dem Ziffernkreis wirklich abgeschnitten". Der Test
+   liest Pixel aus einem Screenshot statt `getComputedStyle` — an berechneten
+   Werten war der Fehler nicht zu sehen, Kreis und Balken deklarierten längst
+   verschiedene Farben. */
+.steps .step::before {
+	width: calc(100% - 2rem);
+}
+
 /* ===== Der Kreis eines noch nicht erreichten Schritts ist nicht der Balken =====
 
    DaisyUI speist beide Pseudo-Elemente aus derselben Variablen: `--step-bg`
@@ -531,10 +563,11 @@ label:has(> .toggle) {
    beiden; für noch nicht erreichte ist beides `base-300`, und der Balken läuft
    damit farbgleich quer durch die Ziffer.
 
-   Gemeldet wurde das als „die Zahlen werden von den Balken überlagert" — der
-   Kreis liegt tatsächlich davor (DaisyUI gibt ihm `z-index: 1`), er ist nur
-   nicht von ihm zu unterscheiden. Eine z-index-Korrektur ginge deshalb ins
-   Leere; es fehlt der Farbunterschied.
+   Gemeldet wurde das als „die Zahlen werden von den Balken überlagert". Der
+   Farbunterschied fehlte tatsächlich — er war aber nur die halbe Ursache: Beim
+   gesperrten Schritt lag der Balken auch wirklich obenauf. Warum das so ist und
+   was daran hängt, steht im Block darüber; der Kreis hier bekommt seine eigene
+   Farbe, damit er sich vom Balken abhebt, wo die beiden aneinanderstoßen.
 
    Gefüllt statt umrandet wäre hier falsch herum: „ausgefüllt" ist im Stepper
    die Auszeichnung des Erledigten, die `step-primary` schon trägt. Der offene


### PR DESCRIPTION
## Was war kaputt

Gemeldet als „die Anzeige des Steppers ist immer noch kaputt": Der Verbindungsbalken läuft sichtbar quer durch die Ziffern 2 und 3.

Reproduziert bei 1024 px und 1280 px, Schritt 1 wie Schritt 2.

## Warum #691 es nicht behoben hat

#691 hat dem Ziffernkreis eine eigene Farbe gegeben (`base-100` statt `base-300`). Der fehlende Farbunterschied war real — aber nur die halbe Ursache:

1. DaisyUIs Balken (`::before`) spannt von der Kreis**mitte** des vorherigen Schritts bis zur eigenen (`width: 100%` + `margin-inline-start: -100%` + `justify-self: center`). Beide Enden liegen damit **unter** einem Kreis, und dass man sie nicht sieht, hängt allein daran, dass der Kreis (`::after`, `z-index: 1`) darüber malt.
2. `opacity-70` am gesperrten Schritt (`FormSteps.svelte`) macht aus dem `<li>` einen **eigenen Stacking-Context**. Das `z-index: 1` des Kreises reicht dann nur noch bis zum `<li>`-Rand, während der Balken des *folgenden* Schritts als späteres Geschwister darüber liegt.

Deshalb war Ziffer 1 sauber (ihr `<li>` trägt keine Opazität) und 2 und 3 nicht.

## Der Fix

```css
.steps .step::before {
	width: calc(100% - 2rem);
}
```

Nimmt dem Balken die beiden Kreisradien an seinen Enden. Mit `justify-self: center` stößt er danach **exakt** an die Kreisränder — bei jeder Spaltenbreite, denn Kreis-Halbmesser und Verkürzung wachsen mit derselben Hälfte. Das Bild ist dasselbe wie ohnehin beabsichtigt; es hängt nur nicht mehr an der Malreihenfolge und damit auch nicht am nächsten `transform`, `filter` oder `isolation`, das jemand auf `.step` legt.

Der Kommentarblock zu `::after` behauptete bisher, eine z-index-Korrektur ginge „ins Leere, es fehlt der Farbunterschied". Das stimmte nur zur Hälfte und ist mit korrigiert.

## Test

Der bestehende Regressionstest konnte das **strukturell nicht sehen**: Er vergleicht `getComputedStyle`, und Kreis und Balken deklarieren seit #691 verschiedene Farben. Der neue Fall in `e2e/form-stepper-affordance.spec.ts` liest stattdessen **Pixel aus einem Screenshot** (Canvas, `getImageData`).

Zwei Fallstricke sind darin mit abgesichert, weil sie beim Schreiben zugeschlagen haben:

- `scrollIntoViewIfNeeded` schiebt die Leiste gerade eben in den Viewport — und damit **unter die feststehende Navbar**. Beide Proben maßen dann deren einheitliche Fläche, waren gleich und sahen wie ein echter Befund aus. Jetzt: an den Seitenanfang scrollen, plus eine `elementFromPoint`-Prüfung, die eine Verdeckung als solche benennt.
- Eine Geometrie-Rechnung im Test wäre keine Alternative gewesen: Sie müsste DaisyUIs Zusammenspiel aus `width`, negativem `margin-inline-start` und `justify-self` nachbauen — also genau das duplizieren, was sie prüfen soll.

Belegt rot ohne den Fix:

```
Error: Der Balken ist im Kreis dieser Schritte sichtbar: Weitere Informationen (201,208,216)
```

## Verifikation

- `npm run test:quick` — 3287 Tests grün, Lint/Types/Svelte-Check sauber
- Einzeln: `form-stepper-affordance` 11/11, `form-a11y` 17/17, `form-field-mode` 15/15, `design-tokens` 77/77
- Visuell nachgesehen bei 1024 px und 1280 px, Schritt 1 und Schritt 2

**Hinweis für Reviewer:** Ein Lauf mit drei Specs gleichzeitig zeigte 4 Fehler auf `/map`, `/about` und `/admin`. Das ist Bestandsflakiness und **nicht** diese Änderung — derselbe Kombi-Lauf auf dem gestashten Baseline-Stand fiel ebenfalls um, nur mit zwei anderen Tests. Einzeln sind alle vier Specs grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
