### PR TITLE
feat(ui): Datenschutzhinweis als Dialog und kompakter Schritt-1-Kopf

### DIFF
--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -38,7 +38,24 @@
 		 *
 		 * Ohne die Prop bleibt alles wie bisher (Schritt 3, Admin-Maske).
 		 */
-		actionLabel = undefined
+		actionLabel = undefined,
+		/**
+		 * Dichte Variante für Aufrufer, die bereits eine eigene Überschrift über
+		 * der Fläche haben.
+		 *
+		 * Auf Schritt 1 des Sichtungsformulars standen drei Beschriftungen
+		 * derselben Handlung übereinander — die Karten-Überschrift „Foto mit GPS
+		 * hochladen", der Dropzone-Titel „Foto hochladen" und der Button „Foto
+		 * auswählen" — und die Fläche kostete 212 px, bevor die Karte überhaupt
+		 * begann. `compact` streicht die mittlere Beschriftung samt dekorativem
+		 * Icon und nimmt den Innenabstand von `p-6` auf `p-4` zurück.
+		 *
+		 * Der Titel entfällt NUR zusammen mit einem `actionLabel`: Ohne Button ist
+		 * er über `zoneTriggerAttributes` der zugängliche Name der Fläche, und ein
+		 * Bedienelement ohne Beschriftung bliebe zurück (WCAG 4.1.2). Festgehalten
+		 * in `UnifiedDropzone.svelte.test.ts` → „compact".
+		 */
+		compact = false
 	} = $props<{
 		config: ValidationPreset;
 		files?: File[];
@@ -55,7 +72,11 @@
 		loadingText?: string;
 		showPreview?: boolean;
 		actionLabel?: string;
+		compact?: boolean;
 	}>();
+
+	// Der Titel darf nur weichen, wenn der Button den Namen trägt — siehe Prop.
+	const showZoneTitle = $derived(!(compact && actionLabel));
 
 	let isDragOver = $state(false);
 	let fileInput: HTMLInputElement;
@@ -269,7 +290,8 @@
 	<!-- Mit `actionLabel` ist diese Fläche nur noch Drop-Ziel; Rolle, Fokus und
 	     Handler wandern auf den Button darin (siehe Prop-Dokumentation). -->
 	<div
-		class="rounded-lg border-2 border-dashed p-6 transition-all duration-200
+		class="rounded-lg border-2 border-dashed transition-all duration-200
+			{compact ? 'p-4' : 'p-6'}
 			{actionLabel ? '' : 'cursor-pointer'}
 			{isDragOver
 			? 'border-primary bg-primary/10 scale-[1.02]'
@@ -301,17 +323,30 @@
 			</div>
 		{:else}
 			<div class="flex flex-col items-center">
-				<Icon
-					icon="lucide:upload"
-					class="mb-2 h-8 w-8 transition-colors {isDragOver
-						? 'text-primary'
-						: 'text-base-content/70'}"
-				/>
-				<p class="text-sm font-medium {isDragOver ? 'text-primary' : ''}">
-					{isDragOver ? `${multiple ? 'Dateien' : 'Datei'} hier ablegen!` : title}
-				</p>
+				{#if showZoneTitle}
+					<Icon
+						icon="lucide:upload"
+						class="mb-2 h-8 w-8 transition-colors {isDragOver
+							? 'text-primary'
+							: 'text-base-content/70'}"
+					/>
+				{/if}
+				<!-- In der dichten Variante bleibt die Zeile für die Ablage-Rückmeldung
+				     trotzdem erreichbar: Der Rahmenwechsel allein sagt nicht, dass jetzt
+				     losgelassen werden darf. -->
+				{#if showZoneTitle || isDragOver}
+					<p class="text-sm font-medium {isDragOver ? 'text-primary' : ''}">
+						{isDragOver ? `${multiple ? 'Dateien' : 'Datei'} hier ablegen!` : title}
+					</p>
+				{/if}
 				{#if actionLabel}
-					<button type="button" class="btn btn-primary mt-3 min-h-11" onclick={openFileDialog}>
+					<!-- Ohne Titelzeile darüber steht der Button oben in der Fläche; ein
+					     `mt-3` wäre dann Abstand zu nichts. -->
+					<button
+						type="button"
+						class="btn btn-primary min-h-11 {showZoneTitle ? 'mt-3' : ''}"
+						onclick={openFileDialog}
+					>
 						<Icon aria-hidden="true" icon="lucide:camera" width="18" />
 						{actionLabel}
 					</button>

--- a/src/lib/components/form/UnifiedDropzone.svelte.test.ts
+++ b/src/lib/components/form/UnifiedDropzone.svelte.test.ts
@@ -426,4 +426,89 @@ describe('UnifiedDropzone', () => {
 			expect(rawColorClasses).toEqual([]);
 		});
 	});
+
+	/**
+	 * `compact` ist die Variante für eine Dropzone, die bereits eine Überschrift
+	 * über sich hat — im Sichtungsformular die Hero-Karte „Foto mit GPS
+	 * hochladen" auf Schritt 1. Dort standen drei Beschriftungen derselben
+	 * Handlung übereinander (Karten-Überschrift, Dropzone-Titel, Button), und die
+	 * Fläche kostete 212 px, bevor die Karte überhaupt begann.
+	 *
+	 * Weggelassen werden darf der Titel deshalb nur, wenn ein `actionLabel` den
+	 * zugänglichen Namen trägt. Ohne Button IST der Titel der Name der Fläche
+	 * (`zoneTriggerAttributes`) — ihn dort zu entfernen ließe ein Bedienelement
+	 * ohne Beschriftung zurück.
+	 */
+	describe('compact', () => {
+		it('lässt Titelzeile und dekoratives Icon weg, wenn ein Button die Beschriftung trägt', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				actionLabel: 'Foto auswählen',
+				compact: true
+			});
+
+			await expect.element(page.getByRole('button', { name: 'Foto auswählen' })).toBeVisible();
+			expect(document.body.textContent).not.toContain('Foto hochladen');
+		});
+
+		it('behält die Titelzeile ohne actionLabel — sie ist dann der Name der Fläche', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				compact: true
+			});
+
+			await expect
+				.element(page.getByRole('button', { name: /Foto hochladen per Drag & Drop oder Klick/i }))
+				.toBeVisible();
+			expect(document.body.textContent).toContain('Foto hochladen');
+		});
+
+		it('zeigt die Titelzeile in der Standardvariante weiterhin an', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				actionLabel: 'Foto auswählen'
+			});
+
+			await expect.element(page.getByText('Foto hochladen')).toBeVisible();
+		});
+
+		it('meldet die Ablage-Bereitschaft trotz fehlender Titelzeile', async () => {
+			// Der Rahmenwechsel allein sagt nicht, dass jetzt losgelassen werden darf.
+			// Die Zeile ist im Ruhezustand weg, beim Ziehen aber wieder da.
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				actionLabel: 'Foto auswählen',
+				multiple: false,
+				compact: true
+			});
+
+			await expect.element(page.getByRole('button', { name: 'Foto auswählen' })).toBeVisible();
+
+			const zone = document.querySelector<HTMLElement>('.border-dashed');
+			if (!zone) throw new Error('Dropzone-Fläche nicht im DOM');
+			zone.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true }));
+
+			await expect.element(page.getByText('Datei hier ablegen!')).toBeVisible();
+		});
+
+		it('nimmt der Fläche Innenabstand', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				actionLabel: 'Foto auswählen',
+				compact: true
+			});
+
+			await expect.element(page.getByRole('button', { name: 'Foto auswählen' })).toBeVisible();
+
+			const zone = document.querySelector<HTMLElement>('.border-dashed');
+			if (!zone) throw new Error('Dropzone-Fläche nicht im DOM');
+			expect(zone.className).toContain('p-4');
+			expect(zone.className).not.toContain('p-6');
+		});
+	});
 });

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -377,8 +377,12 @@
 <Form {...formProps} bind:context={formContext}>
 	{#if isNotIFrame}
 		<!-- Form Title -->
-		<div class="mb-4 text-center md:mb-8">
-			<h1 class="text-base-content mb-2 text-2xl font-bold md:text-3xl lg:text-4xl">
+		<!-- Enger unterhalb `md`: Auf 375 px kostete der Kopf 376 px, bevor das
+		     Formular begann — die Schriftgrößen bleiben, gekürzt werden die
+		     Abstände. Kleinere Schrift wäre hier das falsche Mittel: Das Formular
+		     wird an Deck und bei Sonnenlicht ausgefüllt (design-system.md). -->
+		<div class="mb-3 text-center md:mb-8">
+			<h1 class="text-base-content mb-1 text-2xl font-bold md:mb-2 md:text-3xl lg:text-4xl">
 				Sichtung von Meeressäugetieren melden
 			</h1>
 			<p class="text-base-content/70 px-2 text-sm md:text-lg">

--- a/src/lib/report/components/form/UploadNotice.svelte
+++ b/src/lib/report/components/form/UploadNotice.svelte
@@ -5,12 +5,81 @@
 	 * Veröffentlichung entscheidet der Melder gesondert.
 	 *
 	 * Wortlaut und Begründung: $lib/form/consent/uploadNotice
+	 *
+	 * Der Hinweis stand bis zum 2026-08-02 als Dauer-Alert unter beiden
+	 * Dropzones. Auf Schritt 1 kostete das rund 150 px zwischen Foto-Auslöser
+	 * und Hero-Karte — die Karte begann auf einem 812-px-Gerät erst unterhalb
+	 * des Falzes. Er liegt deshalb jetzt eine Ebene tiefer, in einem Dialog
+	 * hinter einer beschrifteten Zeile.
+	 *
+	 * Das ist die mehrstufige Darstellung, die die Transparenz-Leitlinien zu
+	 * Art. 12/13 DSGVO ausdrücklich vorsehen — sie trägt aber nur, solange der
+	 * Auslöser unmittelbar an der Dropzone steht, als Datenschutzhinweis
+	 * beschriftet ist und der Wortlaut im Dialog **unverkürzt** erscheint. Eine
+	 * „kurze Zusammenfassung" an der Dropzone wäre keine Verbesserung, sondern
+	 * eine zweite, abweichende Aussage. Festgehalten in `UploadNotice.svelte.test.ts`.
 	 */
 	import Icon from '$lib/components/Icon.svelte';
 	import { UPLOAD_NOTICE } from '$lib/form/consent/uploadNotice';
+
+	// Die Komponente steht zweimal im Formular (Schritt 1 und Schritt 3). Eine
+	// feste ID wäre im DOM doppelt und machte `aria-labelledby` unbrauchbar.
+	const titleId = $props.id();
+
+	let dialogElement = $state<HTMLDialogElement | null>(null);
 </script>
 
-<div class="alert alert-info mb-4">
-	<Icon icon="lucide:info" width="20" aria-hidden="true" />
-	<span class="text-sm">{UPLOAD_NOTICE}</span>
-</div>
+<!-- `btn-ghost`, nicht `link`: Die 44px-Trefferfläche kommt aus dem zentralen
+     Touch-Target-Block in `app.css`, und der greift auf `.btn`. Ein Textlink
+     müsste sie an der Aufrufstelle nachbauen. -->
+<button
+	type="button"
+	class="btn btn-ghost btn-sm text-base-content/70 gap-2 px-2 font-normal"
+	onclick={() => dialogElement?.showModal()}
+	data-testid="upload-notice-trigger"
+>
+	<Icon icon="lucide:info" width="16" class="shrink-0" aria-hidden="true" />
+	<!-- Kurz genug für eine Zeile: In der iframe-Einbettung (schmalere Spalte)
+	     brach „Datenschutzhinweis zum Upload" um. Worum es geht, sagt der
+	     Dialogtitel. -->
+	<span>Datenschutzhinweis</span>
+</button>
+
+<dialog
+	bind:this={dialogElement}
+	class="modal"
+	aria-labelledby={titleId}
+	data-testid="upload-notice-dialog"
+>
+	<div class="modal-box">
+		<h3 id={titleId} class="flex items-center gap-2 text-lg font-bold">
+			<Icon icon="lucide:info" width="20" class="text-info-strong shrink-0" aria-hidden="true" />
+			Was mit Ihrer Aufnahme passiert
+		</h3>
+		<p class="mt-3 text-sm">{UPLOAD_NOTICE}</p>
+		<div class="modal-action">
+			<button
+				type="button"
+				class="btn btn-outline"
+				onclick={() => dialogElement?.close()}
+				data-testid="upload-notice-close"
+			>
+				Verstanden
+			</button>
+		</div>
+	</div>
+	<!-- DaisyUI zeigt für Schließen-Elemente `<form method="dialog">`. Das geht
+	     hier NICHT: Beide Aufrufstellen liegen im `<form>` aus `Form.svelte`, und
+	     ein verschachteltes Formular ist in HTML unzulässig. Svelte meldet das im
+	     SSR als `node_invalid_placement_ssr`, und der Parser verwirft das innere
+	     Element — das `</form>` beendet dabei das Sichtungsformular vorzeitig, vor
+	     der Hydration verlieren Bedienelemente darunter ihre Zugehörigkeit.
+	     `close()` tut dasselbe ohne Formular; Escape schließt weiterhin nativ.
+	     Gleiche Lösung wie in `fields/SpeciesIdentificationHelp.svelte`. -->
+	<button
+		type="button"
+		class="modal-backdrop"
+		onclick={() => dialogElement?.close()}
+		aria-label="Hinweis schließen"
+	></button>
+</dialog>

--- a/src/lib/report/components/form/UploadNotice.svelte.test.ts
+++ b/src/lib/report/components/form/UploadNotice.svelte.test.ts
@@ -1,0 +1,98 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { UPLOAD_NOTICE } from '$lib/form/consent/uploadNotice';
+import UploadNotice from './UploadNotice.svelte';
+
+/**
+ * Der Hinweis stand als Dauer-Alert an beiden Dropzones und kostete auf Schritt 1
+ * rund 150 px zwischen Foto-Auslöser und Karte. Er wandert deshalb in einen
+ * Dialog — das ist die von den Transparenz-Leitlinien vorgesehene mehrstufige
+ * Darstellung (Layered Notice), aber nur, solange zwei Dinge gelten:
+ *
+ *  1. Der Auslöser steht sichtbar an der Dropzone und ist als Datenschutzhinweis
+ *     beschriftet — ein nacktes (i) ohne Text ist keine Information.
+ *  2. Der Wortlaut bleibt vollständig und unverkürzt; gekürzt würde aus der
+ *     Zusammenfassung eine zweite, abweichende Aussage.
+ */
+function trigger(): HTMLButtonElement {
+	const element = document.querySelector<HTMLButtonElement>(
+		'[data-testid="upload-notice-trigger"]'
+	);
+	if (!element) throw new Error('Auslöser für den Upload-Hinweis nicht im DOM');
+	return element;
+}
+
+function dialog(): HTMLDialogElement {
+	const element = document.querySelector<HTMLDialogElement>('[data-testid="upload-notice-dialog"]');
+	if (!element) throw new Error('Dialog für den Upload-Hinweis nicht im DOM');
+	return element;
+}
+
+describe('UploadNotice', () => {
+	it('zeigt den Hinweis nicht dauerhaft ausgeklappt', () => {
+		// Der Platzgewinn IST das Feature: Ein offener Dialog wäre derselbe
+		// Dauer-Block wie vorher.
+		render(UploadNotice);
+
+		expect(dialog().open).toBe(false);
+	});
+
+	it('beschriftet den Auslöser als Datenschutzhinweis', () => {
+		render(UploadNotice);
+
+		expect(trigger().textContent).toMatch(/datenschutz/i);
+	});
+
+	it('öffnet den Dialog per Klick', async () => {
+		render(UploadNotice);
+
+		trigger().click();
+
+		expect(dialog().open).toBe(true);
+	});
+
+	it('zeigt im Dialog den vollständigen Wortlaut', () => {
+		// Vollständig, nicht zusammengefasst: Übertragung beim Ablegen, Zweck,
+		// Löschfrist und die getrennte Entscheidung über die Veröffentlichung
+		// stehen als eine Aussage in `UPLOAD_NOTICE`.
+		render(UploadNotice);
+
+		expect(dialog().textContent).toContain(UPLOAD_NOTICE);
+	});
+
+	it('bringt kein eigenes <form> mit', () => {
+		// Beide Aufrufstellen liegen im `<form>` aus `Form.svelte`. DaisyUIs
+		// `<form method="dialog">` wäre dort ein verschachteltes Formular: Svelte
+		// meldet `node_invalid_placement_ssr`, und der Parser verwirft das innere
+		// Element — das `</form>` beendet dabei das Sichtungsformular vorzeitig.
+		render(UploadNotice);
+
+		expect(document.querySelectorAll('form')).toHaveLength(0);
+	});
+
+	it('benennt zwei gleichzeitige Instanzen getrennt', () => {
+		// Die Komponente steht im Formular zweimal (Schritt 1 und Schritt 3). Mit
+		// einer festen ID zeigten beide `aria-labelledby` auf dasselbe Element.
+		render(UploadNotice);
+		render(UploadNotice);
+
+		const labels = Array.from(
+			document.querySelectorAll<HTMLDialogElement>('[data-testid="upload-notice-dialog"]')
+		).map((element) => element.getAttribute('aria-labelledby'));
+
+		expect(labels).toHaveLength(2);
+		expect(labels[0]).toBeTruthy();
+		expect(new Set(labels).size).toBe(2);
+	});
+
+	it('lässt sich wieder schließen', () => {
+		render(UploadNotice);
+		trigger().click();
+
+		const close = dialog().querySelector<HTMLButtonElement>('[data-testid="upload-notice-close"]');
+		if (!close) throw new Error('Schließen-Schaltfläche nicht im Dialog');
+		close.click();
+
+		expect(dialog().open).toBe(false);
+	});
+});

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -123,7 +123,13 @@
 		 * `UnifiedDropzone` durchgereicht (dort dokumentiert). Ohne Angabe bleibt
 		 * die gestrichelte Fläche selbst der Auslöser.
 		 */
-		actionLabel = undefined
+		actionLabel = undefined,
+		/**
+		 * Dichte Dropzone-Fläche — wird unverändert an `UnifiedDropzone`
+		 * durchgereicht (dort dokumentiert). Nur sinnvoll zusammen mit
+		 * `actionLabel` und einer eigenen Überschrift über der Fläche.
+		 */
+		compact = false
 	} = $props<{
 		referenceId: string;
 		maxFiles?: number;
@@ -135,6 +141,7 @@
 		onExifDateTimeApplied?: (applied: boolean) => void;
 		showPositionMap?: boolean;
 		actionLabel?: string;
+		compact?: boolean;
 	}>();
 
 	// Lokaler State für Dropzone-Dateien (temporär während des Drag & Drop)
@@ -944,6 +951,7 @@
 		<UnifiedDropzone
 			{config}
 			{actionLabel}
+			{compact}
 			bind:files={dropzoneFiles}
 			onFilesAdded={handleFilesAdded}
 			onFileRemoved={handleFileRemoved}

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -204,9 +204,9 @@
 </script>
 
 <SectionCard title="Positionsangabe" icon="lucide:map-pin" variant="inset">
-	<p class="text-base-content/70 mb-6 text-sm">
-		Wo haben Sie das Tier gesehen? Ein Foto mit GPS-Daten ist der schnellste Weg.
-	</p>
+	<!-- Nur noch die Frage: „Ein Foto mit GPS-Daten ist der schnellste Weg" stand
+	     zwei Zeilen später in der Hero-Karte fast wörtlich noch einmal. -->
+	<p class="text-base-content/70 mb-4 text-sm">Wo haben Sie das Tier gesehen?</p>
 
 	<!-- Hero: Foto mit GPS. Tint-Fläche trägt bewusst text-base-content,
 	     NICHT text-primary-content (weiß auf hellblau ≈ 1,3:1). -->
@@ -218,14 +218,20 @@
 			<Icon aria-hidden="true" icon="lucide:camera" width="20" class="text-primary" />
 			Foto mit GPS hochladen
 		</h4>
-		<p class="text-base-content/70 mb-4 text-sm">
+		<p class="text-base-content/70 mb-3 text-sm">
 			Der schnellste Weg: Position, Datum und Uhrzeit werden automatisch übernommen.
 		</p>
 
 		{#if gpsPhotoConfig}
 			<!-- `showNoGpsWarning={false}`: Der Fall wird unten ausführlicher erklärt
 			     (Zustand C). Ohne das Abschalten stünden zwei Warn-Alerts mit
-			     derselben Aussage direkt übereinander. -->
+			     derselben Aussage direkt übereinander.
+
+			     `compact` + leerer `additionalText`: Die Überschrift dieser Karte
+			     und der Satz darüber sagen bereits, worum es geht und dass GPS
+			     ausgelesen wird. Der Dropzone-Titel „Foto hochladen" und der
+			     Default-Zusatz „GPS-Daten werden beim Upload verarbeitet" waren
+			     die dritte und vierte Formulierung derselben Aussage. -->
 			<DropzoneEnhanced
 				{referenceId}
 				maxFiles={1}
@@ -235,7 +241,8 @@
 				showPositionMap={false}
 				onExifDateTimeApplied={(applied) => (exifDateTimeApplied = applied)}
 				actionLabel="Foto auswählen"
-				additionalText="GPS-Daten werden automatisch ausgelesen"
+				compact={true}
+				additionalText=""
 			/>
 		{:else}
 			<div class="skeleton h-32 w-full"></div>
@@ -291,11 +298,12 @@
 			</div>
 		{/if}
 
-		<!-- BEWUSST unter der Dropzone: Die Hero-Karte begann auf einem 812-px-Gerät
-		     erst bei 659 px, und dazwischen standen ~150 px Datenschutz-Prosa
-		     zwischen „Der schnellste Weg …" und dem Auslöser. Der Hinweis bleibt
-		     vollständig, nur nicht mehr im Weg. -->
-		<div class="mt-4">
+		<!-- BEWUSST unter der Dropzone und bewusst als Auslöser statt als Alert:
+		     Die Hero-Karte begann auf einem 812-px-Gerät erst bei 659 px, und
+		     dazwischen standen ~150 px Datenschutz-Prosa. Der Wortlaut ist
+		     unverkürzt eine Ebene tiefer erreichbar (`UploadNotice.svelte`) und
+		     kostet hier nur noch eine Zeile. -->
+		<div class="mt-2">
 			<UploadNotice />
 		</div>
 	</div>

--- a/src/lib/report/components/steps/Step1LocationTime.svelte
+++ b/src/lib/report/components/steps/Step1LocationTime.svelte
@@ -3,10 +3,13 @@
 	import PositionAndTime from '$lib/report/components/sections/PositionAndTime.svelte';
 </script>
 
-<div class="space-y-8">
+<div class="space-y-6 md:space-y-8">
 	<!-- Step Header -->
 	<div class="space-y-2 px-2 text-center md:px-0">
-		<div class="flex justify-center">
+		<!-- Unterhalb `md` ausgeblendet: Das Symbol ist dekorativ (die Überschrift
+		     darunter sagt dasselbe) und kostete mit seinem Abstand 48 px in genau
+		     dem Bereich, in dem der Platz fehlt. Auf breiten Geräten bleibt es. -->
+		<div class="hidden justify-center md:flex">
 			<div
 				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>
@@ -15,8 +18,7 @@
 		</div>
 		<h2 class="text-base-content text-xl font-bold md:text-2xl">Position & Zeitpunkt</h2>
 		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
-			<strong>Wo und wann fand die Sichtung statt?</strong> Je genauer Ihre Angaben zu
-			<strong>Ort und Zeitpunkt</strong>, desto wertvoller sind sie für die Forschung.
+			<strong>Wo und wann fand die Sichtung statt?</strong> Je genauer, desto wertvoller für die Forschung.
 		</p>
 	</div>
 

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte
@@ -4,10 +4,11 @@
 	import Icon from '$lib/components/Icon.svelte';
 </script>
 
-<div class="space-y-8">
+<div class="space-y-6 md:space-y-8">
 	<!-- Step Header -->
 	<div class="space-y-2 px-2 text-center md:px-0">
-		<div class="flex justify-center">
+		<!-- Unterhalb `md` ausgeblendet: dekorativ, siehe Step1LocationTime.svelte. -->
+		<div class="hidden justify-center md:flex">
 			<div
 				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>

--- a/src/lib/report/components/steps/Step3Observations.svelte
+++ b/src/lib/report/components/steps/Step3Observations.svelte
@@ -40,10 +40,11 @@
 	}
 </script>
 
-<div class="space-y-8">
+<div class="space-y-6 md:space-y-8">
 	<!-- Step Header -->
 	<div class="space-y-4 px-2 text-center md:px-0">
-		<div class="flex justify-center">
+		<!-- Unterhalb `md` ausgeblendet: dekorativ, siehe Step1LocationTime.svelte. -->
+		<div class="hidden justify-center md:flex">
 			<div
 				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -26,10 +26,11 @@
 	}
 </script>
 
-<div class="space-y-8">
+<div class="space-y-6 md:space-y-8">
 	<!-- Step Header -->
 	<div class="space-y-2 px-2 text-center md:px-0">
-		<div class="flex justify-center">
+		<!-- Unterhalb `md` ausgeblendet: dekorativ, siehe Step1LocationTime.svelte. -->
+		<div class="hidden justify-center md:flex">
 			<div
 				class="bg-primary/20 flex h-10 w-10 items-center justify-center rounded-full md:h-12 md:w-12"
 			>


### PR DESCRIPTION
## Warum

Auf einem 375×812-Gerät begann die Karte im Sichtungsformular erst bei y = 1263 — der Foto-Weg oben drückte sie aus dem ersten Bildschirm. Wer ein Foto hochgeladen hatte, sah die Karte nicht.

## Was

**1. Upload-Hinweis → Dialog** ([UploadNotice.svelte](../blob/claude/foto-upload-hinweis-dialog-a9fde5/src/lib/report/components/form/UploadNotice.svelte))

Der Transparenzhinweis stand als Dauer-Alert an beiden Dropzonen und war auf 375 px **226 px** hoch. Jetzt: eine 44-px-Zeile „ⓘ Datenschutzhinweis" plus Dialog mit dem unverkürzten Wortlaut.

Das ist die mehrstufige Darstellung, die die Transparenz-Leitlinien zu Art. 12/13 DSGVO vorsehen. Sie trägt nur, solange drei Dinge gelten — Auslöser unmittelbar an der Dropzone, als Datenschutzhinweis beschriftet, Wortlaut im Dialog unverkürzt. Genau das nagelt `UploadNotice.svelte.test.ts` fest, damit später niemand „der Kürze halber" eine zweite, abweichende Kurzfassung an die Dropzone schreibt.

Kein `<form method="dialog">`, obwohl DaisyUI das so zeigt: Beide Aufrufstellen liegen im `<form>` aus `Form.svelte`. Ein verschachteltes Formular meldet Svelte im SSR als `node_invalid_placement_ssr`; der Parser verwirft das innere Element und beendet dabei das Sichtungsformular vorzeitig — vor der Hydration verlieren Bedienelemente darunter ihre Formularzugehörigkeit. `dialogElement.close()` tut dasselbe ohne Formular, Escape schließt weiterhin nativ. Das ist die Lösung, die `SpeciesIdentificationHelp.svelte` im selben Formular schon verwendet.

**2. `compact`-Variante für `UnifiedDropzone`**

Auf Schritt 1 standen drei Beschriftungen derselben Handlung übereinander: Karten-Überschrift „Foto mit GPS hochladen", Dropzone-Titel „Foto hochladen", Button „Foto auswählen". `compact` streicht die mittlere samt dekorativem Icon und nimmt `p-6` auf `p-4` zurück — **212 px → 104 px**.

Der Titel entfällt **nur** zusammen mit einem `actionLabel`: ohne Button ist er über `zoneTriggerAttributes` der zugängliche Name der Fläche (WCAG 4.1.2). Die Zeile „Datei hier ablegen!" kommt beim Ziehen zurück — der Rahmenwechsel allein sagt nicht, dass losgelassen werden darf. Beides ist getestet.

**3. Seitenkopf enger unterhalb `md`**

Dekoratives Schritt-Symbol ausgeblendet (48 px), Schritt-Beschreibung auf zwei Zeilen, Abstände gekürzt — **376 px → 292 px**.

Schriftgrößen bleiben unverändert: Sie skalieren bereits responsiv nach unten, und das Formular wird laut `design-system.md` an Deck bei Sonnenlicht ausgefüllt. Der Platz saß in Abständen und Doppelungen. Symbol und Abstand sind in **allen vier Schritten** gleich behandelt, sonst wären die Schritt-Köpfe beim Weiterblättern unterschiedlich hoch.

## Wirkung

Playwright, 375 × 812, Schritt 1:

| | vorher | nachher |
|---|---|---|
| **Karte, eingebettet (Produktion)** | y = 1207 | **733** — im ersten Bildschirm |
| Karte, eigenständige Seite | y = 1263 | 833 |
| „Mein aktueller Standort", eingebettet | y = 1039 | 564 |
| Foto-Karte gesamt | 400 px | 288 px |
| Kopfbereich (h1 → Formular) | 376 px | 292 px |

Der Sprung in der Einbettung ist größer, weil `isNotIFrame` den Seitentitel dort ohnehin ausblendet — die Produktion profitiert fast nur von den Kürzungen darunter.

## Tests

- 12 neue Fälle (`UploadNotice.svelte.test.ts` 7, `UnifiedDropzone.svelte.test.ts` +5), RED→GREEN
- `npm run test:quick` grün (3287), Browser-Tests grün (279), Lint und svelte-check ohne Befund
- Verifiziert: SSR-HTML enthält kein `node_invalid_placement_ssr` und genau ein `<form>`; alle drei Schließwege des Dialogs (Button, Escape, Backdrop) geprüft

Punkt 3 ist eine reine Styling-/Copy-Änderung — die in `.claude/rules/testing.md` vorgesehene Test-Ausnahme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
