### PR TITLE
feat(report): Ortsbeschreibung im Meldeformular als ein Freitextfeld

### DIFF
--- a/e2e/form-position.spec.ts
+++ b/e2e/form-position.spec.ts
@@ -39,9 +39,13 @@ test.describe('PositionAndTime — Single-Panel-Positionseingabe', () => {
 
 	test('Ortsbeschreibung ist ohne Moduswechsel erreichbar und Pflicht', async ({ page }) => {
 		await expect(page.locator('[data-testid="field-waterway"]')).toBeVisible({ timeout: 3000 });
-		await expect(page.locator('[data-testid="field-seaMark"]')).toBeVisible({ timeout: 3000 });
 
-		// Ohne Koordinaten ist das Fahrwasser Pflicht — sichtbar am Sternchen
+		// Seit A2.4 (Wunsch des Deutschen Meeresmuseums) ist die Ortsbeschreibung
+		// EIN Freitextfeld. `seaMark` bleibt im Schema und in der Admin-Maske,
+		// steht im Meldeformular aber nicht mehr.
+		await expect(page.locator('[data-testid="field-seaMark"]')).toHaveCount(0);
+
+		// Ohne Koordinaten ist die Ortsbeschreibung Pflicht — sichtbar am Sternchen
 		// und semantisch an aria-required. Kein nachgestelltes ` input`: das
 		// data-testid hängt bereits am Input (FieldRenderer.svelte:188).
 		await expect(page.locator('[data-testid="field-waterway"]')).toHaveAttribute(

--- a/e2e/pages/FormPage.ts
+++ b/e2e/pages/FormPage.ts
@@ -64,12 +64,13 @@ export class FormPage {
 	}
 
 	/**
-	 * Fahrwasser/Seegebiet — Pflichtfeld solange keine GPS-Position vorliegt
-	 * (`hasPosition !== true`). Es gibt keine Methodenwahl mehr: Das Feld steht
-	 * immer im Block „Ortsbeschreibung" (`LocationDescription.svelte`) und ist
-	 * ohne Koordinaten von Anfang an aufgeklappt. Mit Koordinaten und leeren
-	 * Beschreibungsfeldern startet der Block zugeklappt — dann vorher die
-	 * `<summary>` klicken, sonst greift `fill()` ins Leere.
+	 * Ortsbeschreibung („Wo ungefähr?", Feldname weiterhin `waterway`) —
+	 * Pflichtfeld solange keine GPS-Position vorliegt (`hasPosition !== true`).
+	 * Es gibt keine Methodenwahl mehr und seit A2.4 auch kein zweites Feld für
+	 * das Seezeichen: Das eine Feld steht immer im Block „Ortsbeschreibung"
+	 * (`LocationDescription.svelte`) und ist ohne Koordinaten von Anfang an
+	 * aufgeklappt. Mit Koordinaten und leerem Feld startet der Block zugeklappt —
+	 * dann vorher die `<summary>` klicken, sonst greift `fill()` ins Leere.
 	 */
 	async fillWaterway(value: string) {
 		await this.page.locator('[data-testid="field-waterway"]').fill(value);

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -275,33 +275,44 @@ export const sightingSchemaBase = yup.object().shape({
 		}),
 
 	/**
-	 * Fahrwasser oder Meeresgebiet, in dem die Sichtung erfolgte
+	 * Ortsbeschreibung in Freitext — Seegebiet, Fahrwasser oder Orientierungspunkte.
 	 * Alternative zur GPS-Position: erforderlich, wenn keine GPS-Position vorliegt
 	 * (hasPosition !== true), damit ein leeres Formular Schritt 1 nicht passieren kann.
+	 *
+	 * **Deckt seit A2.4 auch `seaMark` mit ab.** Das Meldeformular zeigt die
+	 * Ortsbeschreibung als EIN Freitextfeld (Wunsch des Deutschen Meeresmuseums:
+	 * „User beschreibt im Freitext"); `seaMark` ist dort nur aus `formStepsConfig`
+	 * und dem Markup genommen. Beschriftung, Hilfetext und Platzhalter müssen
+	 * deshalb beide Aspekte nennen — sonst verliert das Formular die
+	 * Orientierungspunkte. Abgesichert in `src/lib/report/formConfig.test.ts`.
 	 */
 	waterway: yup
 		.string()
-		.max(255, 'Der Name des Fahrwassers/Seegebiets ist zu lang (maximal 255 Zeichen)')
-		.label('Fahrwasser/Seegebiet')
+		.max(255, 'Die Ortsbeschreibung ist zu lang (maximal 255 Zeichen)')
+		.label('Wo ungefähr?')
 		.meta({
-			placeholder: 'z.B. Kieler Bucht, Fehmarnbelt, Greifswalder Bodden',
-			helpText: 'In welchem Gewässer oder Gebiet befanden Sie sich?',
+			placeholder: 'z. B. Kieler Bucht, Fehmarnbelt, vor Leuchtturm Dahmeshöved',
+			helpText: 'Seegebiet, Fahrwasser oder Orientierungspunkte in der Nähe',
 			valueText:
-				'Gewässerbezeichnungen helfen bei der regionalen Populationsverteilung - auch ungefähre Angaben sind wissenschaftlich wertvoll',
+				'Gewässerbezeichnungen und Orientierungspunkte helfen bei der regionalen Populationsverteilung - auch ungefähre Angaben sind wissenschaftlich wertvoll',
 			icon: Waves
 		})
 		.when('hasPosition', {
 			is: (value: unknown) => value !== true,
 			then: (schema) =>
-				schema.required(
-					'Bitte beschreiben Sie das Fahrwasser/Seegebiet oder wählen Sie eine GPS-Position'
-				),
+				schema.required('Bitte beschreiben Sie den Ort oder wählen Sie eine GPS-Position'),
 			otherwise: (schema) => schema.notRequired()
 		}),
 
 	/**
 	 * Seezeichen in der Nähe der Sichtung
 	 * Optionale Zusatzinformation zur genaueren Ortsbestimmung
+	 *
+	 * **Nur noch in der Admin-Maske** (`sections/Location.svelte`) und über die
+	 * Legacy-API (`seezeichen`) erreichbar — im Meldeformular ist der Aspekt in
+	 * `waterway` aufgegangen (A2.4). Feld und DB-Spalte bleiben, damit der
+	 * Altbestand angezeigt und korrigiert werden kann; `meta` deshalb NICHT
+	 * entfernen — `FormField` wirft ohne.
 	 */
 	seaMark: yup
 		.string()

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -316,11 +316,12 @@ export const sightingSchemaBase = yup.object().shape({
 	 */
 	seaMark: yup
 		.string()
-		.max(255, 'Der Name des Seezeichensist zu lang (maximal 255 Zeichen)')
-		.label('Seezeichen in der Nähe')
+		.max(255, 'Der Name des Seezeichens ist zu lang (maximal 255 Zeichen)')
+		.label('Seezeichen (nur Altbestand)')
 		.meta({
 			placeholder: 'z.B. Leuchtturm Dahmeshöved, Tonne 14, Ansteuerungstonne',
-			helpText: 'Gab es markante Orientierungspunkte in der Nähe?',
+			helpText:
+				'Wird im Meldeformular nicht mehr erfasst — neue Meldungen beschreiben den Ort im Feld darüber. Bleibt für Altmeldungen und die Legacy-Schnittstelle bearbeitbar.',
 			valueText:
 				'Seezeichen helfen Wissenschaftlern bei der Positionsverifizierung und schaffen Vertrauen in die Datenqualität',
 			icon: Anchor

--- a/src/lib/form/validation/sightingSchemaPosition.test.ts
+++ b/src/lib/form/validation/sightingSchemaPosition.test.ts
@@ -24,8 +24,7 @@ import { validateStep } from './stepValidation';
 const step1 = {
 	sightingDate: '2026-07-31',
 	sightingTime: '12:00',
-	waterway: '',
-	seaMark: ''
+	waterway: ''
 };
 
 describe('Position außerhalb der Ostsee blockiert Schritt 1 nicht', () => {

--- a/src/lib/report/components/form/position/LocationDescription.svelte
+++ b/src/lib/report/components/form/position/LocationDescription.svelte
@@ -10,20 +10,22 @@
 
 	const coordinatesPresent = $derived(hasCoordinates($form.latitude, $form.longitude));
 
-	// Fahrwasser ist laut Schema Pflicht, solange keine GPS-Position vorliegt
-	// (`waterway.when('hasPosition', { is: (v) => v !== true, ... })`).
+	// Die Ortsbeschreibung ist laut Schema Pflicht, solange keine GPS-Position
+	// vorliegt (`waterway.when('hasPosition', { is: (v) => v !== true, ... })`).
+	// Der Override ist nötig, weil `FieldRenderer` `required` aus der statischen
+	// Schema-Beschreibung ableitet, in der ein `when()` nicht sichtbar ist.
 	const waterwayRequired = $derived($form.hasPosition !== true);
 
 	// Startzustand, EINMALIG beim Mounten bestimmt — bewusst über `get(form)`
 	// statt `$form`, damit daraus keine reaktive Abhängigkeit wird.
 	//
-	// `descriptionCollapsed` hängt an `waterway`/`seaMark`. Würde der Auf-/
-	// Zuklapp-Zustand reaktiv daran gebunden, kippte er beim ersten `change` in
-	// genau dem Feld, in dem gerade getippt wird. Vorher lag darunter sogar ein
-	// `{#if}` mit zwei eigenen `FormField`-Instanzen: Svelte riss den Teilbaum ab,
-	// das fokussierte Feld verschwand und `document.activeElement` fiel auf
-	// `<body>` zurück. Die Felder stehen deshalb jetzt genau einmal im Markup, in
-	// einem Container, der nie ausgetauscht wird.
+	// `descriptionCollapsed` hängt an `waterway`. Würde der Auf-/Zuklapp-Zustand
+	// reaktiv daran gebunden, kippte er beim ersten `change` in genau dem Feld,
+	// in dem gerade getippt wird. Vorher lag darunter sogar ein `{#if}` mit
+	// eigenen `FormField`-Instanzen: Svelte riss den Teilbaum ab, das fokussierte
+	// Feld verschwand und `document.activeElement` fiel auf `<body>` zurück. Das
+	// Feld steht deshalb genau einmal im Markup, in einem Container, der nie
+	// ausgetauscht wird.
 	//
 	// Kein `bind:open`: `PositionPanel.focusDescription()` klappt Vorfahren-
 	// `<details>` imperativ auf, bevor es fokussiert. Ein gebundener Zustand
@@ -31,8 +33,7 @@
 	const initialValues = get(form);
 	const startsOpen = !descriptionCollapsed(
 		hasCoordinates(initialValues.latitude, initialValues.longitude),
-		initialValues.waterway,
-		initialValues.seaMark
+		initialValues.waterway
 	);
 </script>
 
@@ -50,11 +51,21 @@
 	</summary>
 	<div class="collapse-content">
 		<p class="text-base-content/70 text-support mb-3">
-			Nicht jede Sichtung lässt sich exakt verorten. Auch eine Beschreibung des Fahrwassers oder
-			ungefähre Positionsangaben sind für die Forschung wertvoll.
+			Nicht jede Sichtung lässt sich exakt verorten. Auch eine Beschreibung des Seegebiets, ein
+			markanter Punkt in der Nähe oder eine ungefähre Positionsangabe sind für die Forschung
+			wertvoll.
 		</p>
 
+		<!--
+			EIN Freitextfeld statt der früheren zwei (Wunsch des Deutschen
+			Meeresmuseums, A2.4): Seegebiet, Fahrwasser und Orientierungspunkte
+			werden gemeinsam beschrieben. `seaMark` bleibt im Schema und in der
+			Admin-Maske (`sections/Location.svelte`), damit der Altbestand
+			korrigierbar bleibt — hier gehört es nicht mehr hin.
+
+			`data-testid="field-waterway"` ist der Sprungpunkt von
+			`PositionPanel.focusDescription()` und von `scrollToFirstError`.
+		-->
 		<FormField name="waterway" required={waterwayRequired} />
-		<FormField name="seaMark" />
 	</div>
 </details>

--- a/src/lib/report/components/form/position/LocationDescription.svelte
+++ b/src/lib/report/components/form/position/LocationDescription.svelte
@@ -45,9 +45,16 @@
 	<!-- `<summary>` ist nativ fokussierbar — kein `tabindex` nötig. -->
 	<summary class="collapse-title flex min-h-11 items-center gap-2 py-3 text-sm font-medium">
 		<Icon aria-hidden="true" icon="lucide:waves" width="16" class="text-primary shrink-0" />
+		<!--
+			„den Ort", nicht „das Seegebiet": Das Feld darunter deckt seit A2.4 auch
+			Fahrwasser und Orientierungspunkte ab — eine engere Aufforderung legt
+			Melder unnötig auf eine Gewässerbezeichnung fest. Gleiche Wortwahl wie
+			in der Pflicht-Fehlermeldung des Schemas („Bitte beschreiben Sie den Ort
+			oder wählen Sie eine GPS-Position").
+		-->
 		{coordinatesPresent
 			? 'Ortsbeschreibung ergänzen (optional)'
-			: 'Kein GPS? Beschreiben Sie das Seegebiet'}
+			: 'Kein GPS? Beschreiben Sie den Ort'}
 	</summary>
 	<div class="collapse-content">
 		<p class="text-base-content/70 text-support mb-3">

--- a/src/lib/report/components/form/position/LocationDescription.svelte.test.ts
+++ b/src/lib/report/components/form/position/LocationDescription.svelte.test.ts
@@ -8,13 +8,17 @@ import type { FormContext, SightingFormData } from '$lib/types';
 import LocationDescription from './LocationDescription.svelte';
 
 /**
- * Der Block darf die Felder, in denen gerade getippt wird, nicht neu aufbauen.
+ * Der Block darf das Feld, in dem gerade getippt wird, nicht neu aufbauen.
  *
- * Vorher rendert die Komponente `waterway`/`seaMark` in zwei Zweigen eines
- * `{#if collapsed}` — und `collapsed` hängt an genau diesen Feldern. Der erste
- * Tastendruck, der `waterway` füllt, riss deshalb den gesamten Teilbaum ab: Das
- * gerade fokussierte Feld wurde ersetzt, `document.activeElement` fiel auf
- * `<body>` zurück und der nächste Tab begann wieder oben auf der Seite.
+ * Ursprünglich rendert die Komponente die Beschreibungsfelder in zwei Zweigen
+ * eines `{#if collapsed}` — und `collapsed` hängt an genau diesen Feldern. Der
+ * erste Tastendruck, der `waterway` füllt, riss deshalb den gesamten Teilbaum
+ * ab: Das gerade fokussierte Feld wurde ersetzt, `document.activeElement` fiel
+ * auf `<body>` zurück und der nächste Tab begann wieder oben auf der Seite.
+ *
+ * Seit dem Zusammenlegen der Ortsbeschreibung (A2.4) steht dort genau ein Feld;
+ * die Teardown-Gefahr bleibt dieselbe, weil `startsOpen` weiterhin aus dem
+ * Feldwert abgeleitet wird.
  */
 function renderWithForm(overrides: Partial<SightingFormData> = {}): void {
 	const context = {
@@ -54,11 +58,23 @@ const WITH_COORDINATES: Partial<SightingFormData> = {
 	latitude: 54.5,
 	longitude: 13.5,
 	hasPosition: true,
-	waterway: '',
-	seaMark: ''
+	waterway: ''
 };
 
 describe('LocationDescription', () => {
+	/**
+	 * Wunsch des Deutschen Meeresmuseums (A2.4): eine Ortsbeschreibung als **ein**
+	 * Freitextfeld. `seaMark` bleibt im Schema und in der Admin-Maske, hier darf es
+	 * aber nicht mehr auftauchen.
+	 */
+	it('zeigt genau ein Beschreibungsfeld — kein separates Seezeichen-Feld', async () => {
+		renderWithForm({ latitude: undefined, longitude: undefined, waterway: '' });
+
+		expect(document.querySelectorAll('[data-testid^="field-"]')).toHaveLength(1);
+		expect(document.querySelector('[data-testid="field-seaMark"]')).toBeNull();
+		expect(field('waterway')).toBeTruthy();
+	});
+
 	it('behält Fokus und Feld-Knoten, wenn waterway seinen ersten Wert bekommt', async () => {
 		renderWithForm(WITH_COORDINATES);
 
@@ -66,14 +82,14 @@ describe('LocationDescription', () => {
 		block().open = true;
 		await tick();
 
-		const seaMarkBefore = field('seaMark');
-		seaMarkBefore.focus();
-		expect(document.activeElement).toBe(seaMarkBefore);
+		const waterwayBefore = field('waterway');
+		waterwayBefore.focus();
+		expect(document.activeElement).toBe(waterwayBefore);
 
-		await fireChange(field('waterway'), 'Kieler Bucht');
+		await fireChange(waterwayBefore, 'Kieler Bucht');
 
-		expect(document.activeElement).toBe(seaMarkBefore);
-		expect(field('seaMark')).toBe(seaMarkBefore);
+		expect(document.activeElement).toBe(waterwayBefore);
+		expect(field('waterway')).toBe(waterwayBefore);
 	});
 
 	it('verliert den getippten Text nicht, wenn waterway wieder geleert wird', async () => {
@@ -92,12 +108,29 @@ describe('LocationDescription', () => {
 	});
 
 	it('ist ohne Koordinaten von Anfang an offen', async () => {
-		renderWithForm({ latitude: undefined, longitude: undefined, waterway: '', seaMark: '' });
+		renderWithForm({ latitude: undefined, longitude: undefined, waterway: '' });
 
 		expect(block().open).toBe(true);
 	});
 
-	it('startet mit Koordinaten und leeren Feldern zugeklappt, bleibt aber erreichbar', async () => {
+	/**
+	 * Die konditionale Pflicht (`waterway.when('hasPosition', …)`) ist aus
+	 * `describe()` nicht ableitbar — sie hängt am `required`-Override der
+	 * Komponente. Ohne ihn widersprächen Sternchen und Validierung einander.
+	 */
+	it('markiert die Ortsbeschreibung ohne GPS-Position als Pflichtfeld', async () => {
+		renderWithForm({ latitude: undefined, longitude: undefined, hasPosition: false, waterway: '' });
+
+		expect(field('waterway').getAttribute('aria-required')).toBe('true');
+	});
+
+	it('nimmt der Ortsbeschreibung die Pflicht, sobald Koordinaten vorliegen', async () => {
+		renderWithForm(WITH_COORDINATES);
+
+		expect(field('waterway').getAttribute('aria-required')).not.toBe('true');
+	});
+
+	it('startet mit Koordinaten und leerem Feld zugeklappt, bleibt aber erreichbar', async () => {
 		renderWithForm(WITH_COORDINATES);
 
 		expect(block().open).toBe(false);

--- a/src/lib/report/components/form/position/positionPanelState.test.ts
+++ b/src/lib/report/components/form/position/positionPanelState.test.ts
@@ -102,27 +102,35 @@ describe('shouldOpenMapOnCoordinateChange', () => {
 	});
 });
 
+/**
+ * Seit dem Zusammenlegen der Ortsbeschreibung (Wunsch des Deutschen
+ * Meeresmuseums, A2.4) steht im Meldeformular nur noch `waterway` im Block —
+ * `seaMark` ist aus dem Melde-Schritt genommen. Die Regel urteilt deshalb über
+ * genau ein Feld; ein zweiter Parameter hätte nichts mehr zu bewerten.
+ */
 describe('descriptionCollapsed', () => {
 	it('bleibt offen, solange keine Koordinaten vorliegen', () => {
-		expect(descriptionCollapsed(false, '', '')).toBe(false);
-		expect(descriptionCollapsed(false, 'Kieler Bucht', '')).toBe(false);
+		expect(descriptionCollapsed(false, '')).toBe(false);
+		expect(descriptionCollapsed(false, 'Kieler Bucht')).toBe(false);
 	});
 
-	it('klappt zu, wenn Koordinaten vorliegen und beide Felder leer sind', () => {
-		expect(descriptionCollapsed(true, '', '')).toBe(true);
-		expect(descriptionCollapsed(true, undefined, undefined)).toBe(true);
+	it('klappt zu, wenn Koordinaten vorliegen und das Feld leer ist', () => {
+		expect(descriptionCollapsed(true, '')).toBe(true);
+		expect(descriptionCollapsed(true, undefined)).toBe(true);
 	});
 
-	it('klappt zu, wenn die Felder nur Leerzeichen enthalten', () => {
-		expect(descriptionCollapsed(true, '   ', '\t')).toBe(true);
+	it('klappt zu, wenn das Feld nur Leerzeichen enthält', () => {
+		expect(descriptionCollapsed(true, '   ')).toBe(true);
 	});
 
-	it('bleibt offen, wenn das Fahrwasser bereits eingegeben wurde', () => {
-		expect(descriptionCollapsed(true, 'Kieler Bucht', '')).toBe(false);
+	it('bleibt offen, wenn die Ortsbeschreibung bereits eingegeben wurde', () => {
+		expect(descriptionCollapsed(true, 'Kieler Bucht')).toBe(false);
 	});
 
-	it('bleibt offen, wenn ein Seezeichen bereits eingegeben wurde', () => {
-		expect(descriptionCollapsed(true, '', 'Tonne 14')).toBe(false);
+	it('bleibt offen, wenn nur ein Orientierungspunkt eingetragen wurde', () => {
+		// Beide bisherigen Aspekte laufen jetzt durch dasselbe Feld — auch ein
+		// reiner Seezeichen-Text darf nicht hinter einer Disclosure verschwinden.
+		expect(descriptionCollapsed(true, 'vor Leuchtturm Dahmeshöved')).toBe(false);
 	});
 });
 

--- a/src/lib/report/components/form/position/positionPanelState.ts
+++ b/src/lib/report/components/form/position/positionPanelState.ts
@@ -94,15 +94,15 @@ function isFilledText(value: unknown): boolean {
 }
 
 /**
- * Die Ortsbeschreibung klappt nur zu, wenn Koordinaten vorliegen UND beide Felder
- * leer sind. Wer erst das Seegebiet beschreibt und danach ein Foto mit GPS
+ * Die Ortsbeschreibung klappt nur zu, wenn Koordinaten vorliegen UND das Feld
+ * leer ist. Wer erst das Seegebiet beschreibt und danach ein Foto mit GPS
  * hochlädt, darf seinen Text nicht verlieren.
+ *
+ * Ein Parameter, nicht zwei: Seit A2.4 steht im Meldeformular nur noch
+ * `waterway` im Block — Seegebiet, Fahrwasser und Orientierungspunkte laufen
+ * durch dasselbe Feld. `seaMark` gibt es dort nicht mehr zu bewerten.
  */
-export function descriptionCollapsed(
-	hasCoordinates: boolean,
-	waterway: unknown,
-	seaMark: unknown
-): boolean {
+export function descriptionCollapsed(hasCoordinates: boolean, waterway: unknown): boolean {
 	if (!hasCoordinates) return false;
-	return !isFilledText(waterway) && !isFilledText(seaMark);
+	return !isFilledText(waterway);
 }

--- a/src/lib/report/components/sections/Location.svelte
+++ b/src/lib/report/components/sections/Location.svelte
@@ -33,10 +33,24 @@
 				<VerifyLocation {longitude} {latitude} />
 			{/if}
 		</div>
-	{:else}
-		<!-- Waterway Input (shown when hasPosition = false) -->
-		<FormField name="waterway" />
-		<!-- Sea Mark (always optional) -->
-		<FormField name="seaMark" />
 	{/if}
+
+	<!--
+		Ortsbeschreibung und Seezeichen stehen UNABHÄNGIG von `hasPosition` — anders
+		als im Meldeformular, wo die Beschreibung die Alternative zur Position ist.
+		Hier wird ein vorhandener Datensatz korrigiert, nicht eine Meldung erfasst:
+		Koordinaten und Ortstext schließen einander nicht aus, sie stehen im
+		Altbestand regelmäßig nebeneinander.
+
+		Vorher lagen beide Felder im `{:else}`-Zweig, und `adminEditInitialValues`
+		leitet `hasPosition` aus den Koordinaten ab. Damit war ausgerechnet der
+		Altbestand unerreichbar, dessentwegen `seaMark` überhaupt im Schema bleibt:
+		902 der 1.033 Datensätze mit Seezeichen tragen zugleich Koordinaten, bei
+		`fahrwasser` sind es 1.191 (gemessen am 2026-08-02).
+
+		Das Meldeformular ist davon nicht betroffen — es nutzt
+		`position/LocationDescription.svelte` und zeigt seit A2.4 nur `waterway`.
+	-->
+	<FormField name="waterway" />
+	<FormField name="seaMark" />
 </SectionCard>

--- a/src/lib/report/components/sections/Location.svelte.test.ts
+++ b/src/lib/report/components/sections/Location.svelte.test.ts
@@ -18,14 +18,16 @@ import Location from './Location.svelte';
  * (`position/LocationDescription.svelte` vs. diese) — dieser Test hält fest,
  * dass das so bleibt.
  *
- * **Grenze, die dieser Test bewusst nicht überschreitet:** Die Komponente
- * rendert beide Ortsfelder nur im `{:else}`-Zweig von `{#if hasPosition}`, und
- * `adminEditInitialValues.ts:46` leitet `hasPosition` aus den Koordinaten ab.
- * Eine Sichtung MIT Koordinaten zeigt deshalb weder `waterway` noch `seaMark`
- * — im Bestand betrifft das 902 der 1.033 Datensätze mit Seezeichen (gemessen
- * am 2026-08-02). Das ist Verhalten von vor dieser Änderung und keine Folge des
- * Zusammenlegens; es hier festzuschreiben wäre falsch, es zu verschweigen auch.
- * Die Tests unten prüfen deshalb ausdrücklich den Fall ohne GPS-Position.
+ * **Beide Felder stehen unabhängig von der GPS-Position.** Vorher lagen sie im
+ * `{:else}`-Zweig von `{#if hasPosition}`, und `adminEditInitialValues.ts:46`
+ * leitet `hasPosition` aus den Koordinaten ab — eine Sichtung MIT Koordinaten
+ * zeigte deshalb weder `waterway` noch `seaMark`. Im Bestand betraf das 902 der
+ * 1.033 Datensätze mit Seezeichen und 1.191 mit Fahrwasser (gemessen am
+ * 2026-08-02): genau die Altmeldungen, die zu korrigieren der Grund ist, aus dem
+ * `seaMark` überhaupt im Schema bleibt. Die Kopplung an `hasPosition` war im
+ * Meldeformular sinnvoll (dort ist die Beschreibung die Alternative zur
+ * Position), in der Admin-Maske ist sie es nie gewesen: Dort wird ein
+ * vorhandener Datensatz korrigiert, nicht eine Meldung erfasst.
  */
 function renderAdminLocation(overrides: Partial<SightingFormData> = {}): void {
 	const context = {
@@ -58,5 +60,32 @@ describe('sections/Location — Admin-Maske', () => {
 		expect(seaMark?.value).toBe('Tonne 14');
 		expect(seaMark?.disabled).toBe(false);
 		expect(seaMark?.readOnly).toBe(false);
+	});
+
+	/**
+	 * Der praktisch wichtigere Fall: 902 der 1.033 Datensätze mit Seezeichen
+	 * tragen zugleich Koordinaten. Blieben die Felder an `hasPosition` gekoppelt,
+	 * wäre genau dieser Altbestand nicht erreichbar.
+	 */
+	it('zeigt beide Ortsfelder AUCH mit GPS-Position', () => {
+		renderAdminLocation({
+			hasPosition: true,
+			latitude: 54.5,
+			longitude: 13.5,
+			waterway: 'Greifswalder Bodden',
+			seaMark: 'Leuchtturm Warnemünde'
+		});
+
+		expect(field('waterway')?.value).toBe('Greifswalder Bodden');
+		expect(field('seaMark')?.value).toBe('Leuchtturm Warnemünde');
+	});
+
+	it('lässt beide Felder mit GPS-Position bearbeiten', () => {
+		renderAdminLocation({ hasPosition: true, latitude: 54.5, longitude: 13.5 });
+
+		for (const name of ['waterway', 'seaMark']) {
+			expect(field(name)?.disabled, name).toBe(false);
+			expect(field(name)?.readOnly, name).toBe(false);
+		}
 	});
 });

--- a/src/lib/report/components/sections/Location.svelte.test.ts
+++ b/src/lib/report/components/sections/Location.svelte.test.ts
@@ -1,0 +1,62 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import Location from './Location.svelte';
+
+/**
+ * Die **Admin-Maske** behält beide Ortsfelder — auch nachdem das Meldeformular
+ * sie zu einem zusammengelegt hat (A2.4). Sie ist der einzige Ort, an dem die
+ * `seezeichen`-Spalte des Altbestands noch bearbeitet werden kann; die
+ * Legacy-API nimmt `seezeichen` weiterhin entgegen.
+ *
+ * Der Test existiert wegen eines konkreten Präzedenzfalls: In PR #669 hat eine
+ * Feld-Entfernung im Meldeformular der Admin-Maske drei Felder mit weggenommen,
+ * weil beide dieselbe Komponente teilten. Hier sind es zwei getrennte
+ * (`position/LocationDescription.svelte` vs. diese) — dieser Test hält fest,
+ * dass das so bleibt.
+ *
+ * **Grenze, die dieser Test bewusst nicht überschreitet:** Die Komponente
+ * rendert beide Ortsfelder nur im `{:else}`-Zweig von `{#if hasPosition}`, und
+ * `adminEditInitialValues.ts:46` leitet `hasPosition` aus den Koordinaten ab.
+ * Eine Sichtung MIT Koordinaten zeigt deshalb weder `waterway` noch `seaMark`
+ * — im Bestand betrifft das 902 der 1.033 Datensätze mit Seezeichen (gemessen
+ * am 2026-08-02). Das ist Verhalten von vor dieser Änderung und keine Folge des
+ * Zusammenlegens; es hier festzuschreiben wäre falsch, es zu verschweigen auch.
+ * Die Tests unten prüfen deshalb ausdrücklich den Fall ohne GPS-Position.
+ */
+function renderAdminLocation(overrides: Partial<SightingFormData> = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(Location, { context: new Map([[formContextKey, context]]) });
+}
+
+function field(name: string): HTMLInputElement | null {
+	return document.querySelector<HTMLInputElement>(`[data-testid="field-${name}"]`);
+}
+
+describe('sections/Location — Admin-Maske', () => {
+	it('zeigt ohne GPS-Position weiterhin BEIDE Ortsfelder', () => {
+		renderAdminLocation({ hasPosition: false });
+
+		expect(field('waterway')).not.toBeNull();
+		expect(field('seaMark')).not.toBeNull();
+	});
+
+	it('lässt das Seezeichen bearbeiten — der Altbestand muss korrigierbar bleiben', () => {
+		renderAdminLocation({ hasPosition: false, seaMark: 'Tonne 14' });
+
+		const seaMark = field('seaMark');
+		expect(seaMark?.value).toBe('Tonne 14');
+		expect(seaMark?.disabled).toBe(false);
+		expect(seaMark?.readOnly).toBe(false);
+	});
+});

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type * as yup from 'yup';
+import { formStepsConfig, sightingSchemaFields } from './formConfig';
+
+/**
+ * Die Ortsbeschreibung im **Meldeformular** ist seit dem Wunsch des Deutschen
+ * Meeresmuseums (A2.4) genau ein Freitextfeld: `waterway`. `seaMark` ist nur aus
+ * dem Melde-Schritt genommen — Schema-Eintrag und DB-Spalte `seezeichen` bleiben,
+ * weil die Admin-Maske (`sections/Location.svelte`) den Altbestand weiter
+ * anzeigen und korrigieren können muss und die Legacy-API `seezeichen` weiterhin
+ * entgegennimmt.
+ *
+ * Die Tests hier halten beide Hälften zusammen: Was aus dem Schritt verschwindet,
+ * darf nicht aus dem Schema verschwinden.
+ */
+const step1Fields = formStepsConfig[0]?.fields ?? [];
+
+function describeField(name: string): yup.SchemaDescription {
+	const field = sightingSchemaFields[name] as yup.SchemaDescription | undefined;
+	if (!field) throw new Error(`Feld "${name}" fehlt im Schema`);
+	return field;
+}
+
+function meta(name: string): Record<string, unknown> {
+	return (describeField(name).meta ?? {}) as Record<string, unknown>;
+}
+
+describe('formStepsConfig — Ortsbeschreibung in Schritt 1', () => {
+	it('führt waterway als Feld des Melde-Schritts', () => {
+		expect(step1Fields).toContain('waterway');
+	});
+
+	// Über ALLE Schritte geprüft, nicht nur über Schritt 1: Ein Feld, das aus dem
+	// Melde-Schritt genommen und versehentlich anderswo einsortiert wird, wäre
+	// weiterhin im Formular — nur an der falschen Stelle.
+	it('führt seaMark in keinem Schritt mehr', () => {
+		expect(formStepsConfig.flatMap((step) => step.fields)).not.toContain('seaMark');
+	});
+});
+
+describe('sightingSchema — seaMark bleibt erhalten', () => {
+	it('kennt seaMark weiterhin, damit Admin-Maske und Legacy-API es schreiben können', () => {
+		expect(sightingSchemaFields.seaMark).toBeDefined();
+	});
+
+	it('hält seaMark bedienbar: Label und Feld-Meta bleiben gepflegt', () => {
+		// Ohne `meta` wirft `FormField` — die Admin-Maske könnte das Feld dann
+		// nicht mehr rendern, und der Altbestand wäre nicht korrigierbar.
+		expect(meta('seaMark')).not.toEqual({});
+	});
+});
+
+/**
+ * Der Wortlaut muss **beide** bisherigen Felder abdecken. Fiele er auf die alte
+ * Fahrwasser-Beschriftung zurück, verlöre das zusammengelegte Feld genau den
+ * Aspekt, für den `seaMark` da war — die Orientierungspunkte.
+ */
+describe('waterway — Beschriftung deckt beide bisherigen Felder ab', () => {
+	const waterwayMeta = meta('waterway');
+	const copy = [describeField('waterway').label, waterwayMeta.helpText, waterwayMeta.placeholder]
+		.join(' ')
+		.toLowerCase();
+
+	it('nennt das Seegebiet', () => {
+		expect(copy).toContain('seegebiet');
+	});
+
+	it('nennt das Fahrwasser', () => {
+		expect(copy).toContain('fahrwasser');
+	});
+
+	it('nennt Orientierungspunkte — den Aspekt des entfallenen Seezeichen-Feldes', () => {
+		expect(copy).toContain('orientierungspunkt');
+	});
+
+	it('bietet im Platzhalter ein Beispiel für einen Orientierungspunkt', () => {
+		expect(String(waterwayMeta.placeholder).toLowerCase()).toContain('leuchtturm');
+	});
+});

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -48,6 +48,18 @@ describe('sightingSchema — seaMark bleibt erhalten', () => {
 		// nicht mehr rendern, und der Altbestand wäre nicht korrigierbar.
 		expect(meta('seaMark')).not.toEqual({});
 	});
+
+	/**
+	 * `seaMark` steht nur noch in der Admin-Maske — dort direkt unter `waterway`,
+	 * dessen Hilfetext ebenfalls Orientierungspunkte nennt. Ohne einen Hinweis auf
+	 * den Altbestand beanspruchen beide Felder sichtbar dasselbe, und wer den
+	 * Datensatz korrigiert, weiß nicht, in welches der beiden er schreiben soll.
+	 */
+	it('weist seaMark als Altbestands-Feld aus', () => {
+		const copy = [describeField('seaMark').label, meta('seaMark').helpText].join(' ').toLowerCase();
+
+		expect(copy).toContain('altbestand');
+	});
 });
 
 /**

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -55,8 +55,11 @@ export const formStepsConfig: FormStep[] = [
 			'hasPosition',
 			'latitude',
 			'longitude',
+			// `seaMark` steht hier bewusst NICHT mehr: Die Ortsbeschreibung ist seit
+			// A2.4 ein einziges Freitextfeld (`waterway`). Schema-Eintrag und
+			// DB-Spalte `seezeichen` bleiben — die Admin-Maske und die Legacy-API
+			// schreiben es weiter.
 			'waterway',
-			'seaMark',
 			'sightingDate',
 			'sightingTime'
 		]


### PR DESCRIPTION
Das Meldeformular fragt die Ortsbeschreibung ab sofort in **einem** Freitextfeld ab („Wo ungefähr?") statt in zwei getrennten Feldern für Fahrwasser/Seegebiet und Seezeichen.

Wunsch des Deutschen Meeresmuseums (Analyse A2.4/A2.4a). Der frühere Einwand — „beim Totfund brauchen wir das Seezeichen für die Bergung" — trägt nicht: Das Museum führt Orientierungspunkte ausdrücklich als Inhalt des einen Freitextfelds.

## 1. Meldeformular: ein Feld statt zwei

| Datei | Änderung |
| --- | --- |
| `sightingSchema.ts` | `waterway` neu beschriftet (Label, Hilfetext, Platzhalter, beide Fehlermeldungen) |
| `formConfig.ts` | `seaMark` aus den Feldern von Schritt 1 genommen |
| `position/LocationDescription.svelte` | zweites `FormField` entfernt |
| `position/positionPanelState.ts` | `descriptionCollapsed(hasCoordinates, waterway)` — der zweite Feldparameter entfällt |

Neuer Wortlaut: Label „Wo ungefähr?", Hilfetext „Seegebiet, Fahrwasser oder Orientierungspunkte in der Nähe", Platzhalter „z. B. Kieler Bucht, Fehmarnbelt, vor Leuchtturm Dahmeshöved". Dazu passend „Bitte beschreiben Sie den Ort oder wählen Sie eine GPS-Position" (Pflicht ohne GPS) und „Die Ortsbeschreibung ist zu lang (maximal 255 Zeichen)".

**Der Wortlaut ist mit dem Museum noch nicht abgestimmt** — er ist so gewählt, dass er beide bisherigen Felder abdeckt, und gehört ins Anschreiben.

Geschrieben wird weiterhin `waterway`. `seaMark` ist **nur** aus dem Melde-Schritt und dem Markup genommen — Schema-Eintrag und DB-Spalte `seezeichen` bleiben. Unberührt: **Legacy-API** (`mapLegacyToCurrentSchema` nimmt `seezeichen` unverändert entgegen), **Kartensuche** (`/api/map/sightings` durchsucht beide Spalten), **Spam-Erkennung** und alle vier **Export-Formate**.

Die konditionale Pflicht sitzt weiterhin auf `waterway` und damit am zusammengelegten Feld, samt des `required`-Overrides an `FormField`, den `FieldRenderer` aus der statischen Schema-Beschreibung nicht ableiten kann. `data-testid="field-waterway"` (Sprungziel von `PositionPanel.focusDescription()` und `scrollToFirstError`) ist erhalten.

## 2. Admin-Maske: zwei Befunde aus dem Review, beide behoben

Die Admin-Maske nutzt mit `sections/Location.svelte` eine eigene Komponente — anders als bei `Behavior`/`Environment`, wo PR #669 dem Admin über eine geteilte Komponente Felder weggenommen hat. Sie behält beide Ortsfelder. Beim Review zeigten sich dort zwei Probleme:

**a) Die Ortsfelder hingen an `hasPosition`.** Sie standen nur im `{:else}`-Zweig von `{#if hasPosition}`, und `adminEditInitialValues.ts:46` leitet `hasPosition` aus den Koordinaten ab. Eine Sichtung **mit** Koordinaten war damit in **beiden** Feldern nicht bearbeitbar — ausgerechnet der Altbestand, um dessentwillen `seaMark` überhaupt im Schema bleibt:

| | Anzahl |
| --- | --- |
| Datensätze mit `seezeichen` | 1.033 |
| davon zugleich mit Koordinaten → war nicht editierbar | **902** |
| Datensätze mit `fahrwasser` + Koordinaten → ebenfalls nicht | **1.191** |

Das war Verhalten von vor dieser PR, machte die Zusage „der Altbestand bleibt korrigierbar" aber weitgehend gegenstandslos. Beide Felder stehen jetzt unabhängig von der Position. Im Meldeformular bleibt die Kopplung richtig — dort ist die Beschreibung die Alternative zur Position; in der Admin-Maske wird ein vorhandener Datensatz korrigiert, und Koordinaten und Ortstext stehen im Bestand regelmäßig nebeneinander.

**b) Beide Felder beanspruchten dieselbe Bedeutung.** `seaMark` steht jetzt direkt unter `waterway`, dessen Hilfetext ebenfalls Orientierungspunkte nennt. `seaMark` ist deshalb als Altbestands-Feld gekennzeichnet: Label „Seezeichen (nur Altbestand)", Hilfetext „Wird im Meldeformular nicht mehr erfasst — neue Meldungen beschreiben den Ort im Feld darüber. Bleibt für Altmeldungen und die Legacy-Schnittstelle bearbeitbar."

Bewusst im Schema und **nicht** als Label-Override im Markup: Der `required`-Override an `FormField` existiert nur, weil ein Yup-`when()` aus `describe()` nicht ableitbar ist — für ein Label gibt es diese Not nicht, und `.claude/rules/forms.md` verlangt die Beschriftung im Schema. Das melderseitige Label bleibt „Wo ungefähr?"; die Doppelung war ein reines Admin-Problem.

## Tests

Test-First: erst die Tests umgestellt (RED belegt), dann implementiert.

- `npm run test:quick` — 3.296 Tests, Lint, Typen und `svelte-check` grün
- `npm run test:unit:client` — 286 grün
- E2E grün: `form-position`, `form-position-photo`, `form-a11y`, `form-submit`, `form-autosave`, `form-field-mode`, `admin-edit-preserves-record`

Neue Regressionswächter, wegen des PR-#669-Präzedenzfalls:

- `sections/Location.svelte.test.ts` — der Admin zeigt und bearbeitet beide Felder, **mit und ohne** GPS-Position
- `report/formConfig.test.ts` — `seaMark` steht in keinem Schritt mehr, bleibt aber mitsamt `meta` im Schema (ohne `meta` wirft `FormField`) und ist als Altbestands-Feld gekennzeichnet; `waterway`s Beschriftung muss Seegebiet, Fahrwasser **und** Orientierungspunkte nennen, damit der Text nicht auf die alte Fahrwasser-Fassung zurückfallen kann

🤖 Generated with [Claude Code](https://claude.com/claude-code)