### PR TITLE
fix(ui): Positions-Dropzone rechnet nur noch mit ihren eigenen Dateien

### DIFF
--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -81,6 +81,25 @@
 	let isDragOver = $state(false);
 	let fileInput: HTMLInputElement;
 
+	/**
+	 * Verschachtelungstiefe des Zeigers über der Fläche.
+	 *
+	 * `dragleave` feuert nicht nur beim Verlassen der Fläche, sondern auch, wenn
+	 * der Zeiger von ihr auf eines ihrer Kinder wechselt — und ihre Kinder sind
+	 * die Textzeilen im unteren Teil. Mit einem bloßen `isDragOver = false`
+	 * schaltete die Rückmeldung dort bei jeder Bewegung an und aus: Wer eine Datei
+	 * von unten heranzog, sah ein Flackern und traf den unteren Bereich praktisch
+	 * nicht.
+	 *
+	 * Jedes `dragenter` eines Nachfahren bubbelt hierher und zählt hoch, jedes
+	 * `dragleave` zählt herunter. Erst bei 0 hat der Zeiger die Fläche wirklich
+	 * verlassen. Kein `$state`: Der Wert steuert nur die Entscheidung unten,
+	 * gerendert wird `isDragOver`.
+	 */
+	let dragDepth = 0;
+
+	const dropPrompt = $derived(`${multiple ? 'Dateien' : 'Datei'} hier ablegen!`);
+
 	// Bleibender Fehlerbereich statt nur Toast: Ein Toast verschwindet nach
 	// Sekunden, und ein Validierungsfehler ohne Verknüpfung zum Bedienelement
 	// verletzt WCAG 2.1 SC 3.3.1. Der Toast bleibt zusätzlich — er meldet den
@@ -110,6 +129,7 @@
 
 	function handleDrop(event: DragEvent) {
 		event.preventDefault();
+		dragDepth = 0;
 		isDragOver = false;
 
 		if (event.dataTransfer?.files) {
@@ -117,14 +137,26 @@
 		}
 	}
 
+	function handleDragEnter(event: DragEvent) {
+		event.preventDefault();
+		dragDepth += 1;
+		isDragOver = true;
+	}
+
 	function handleDragOver(event: DragEvent) {
+		// `preventDefault` ist Pflicht — ohne es lehnt der Browser die Ablage ab.
+		// Setzt zusätzlich `isDragOver`: Geht der Zähler durch ein verpasstes
+		// `dragenter` einmal daneben, holt das die Rückmeldung wieder ein.
 		event.preventDefault();
 		isDragOver = true;
 	}
 
 	function handleDragLeave(event: DragEvent) {
 		event.preventDefault();
-		isDragOver = false;
+		dragDepth = Math.max(0, dragDepth - 1);
+		if (dragDepth === 0) {
+			isDragOver = false;
+		}
 	}
 
 	function processFiles(newFiles: File[]) {
@@ -289,14 +321,18 @@
 	<!-- Dropzone -->
 	<!-- Mit `actionLabel` ist diese Fläche nur noch Drop-Ziel; Rolle, Fokus und
 	     Handler wandern auf den Button darin (siehe Prop-Dokumentation). -->
+	<!-- Ohne `scale-[1.02]`: Der Transform verschob beim Ansprechen beide Kanten
+	     der Fläche — und damit das Ziel unter dem Zeiger, der es gerade erst
+	     getroffen hatte. Rahmen und Tint melden die Bereitschaft genauso. -->
 	<div
 		class="rounded-lg border-2 border-dashed transition-all duration-200
 			{compact ? 'p-4' : 'p-6'}
 			{actionLabel ? '' : 'cursor-pointer'}
 			{isDragOver
-			? 'border-primary bg-primary/10 scale-[1.02]'
+			? 'border-primary bg-primary/10'
 			: 'border-base-300 hover:border-primary hover:bg-primary/5'}"
 		ondrop={handleDrop}
+		ondragenter={handleDragEnter}
 		ondragover={handleDragOver}
 		ondragleave={handleDragLeave}
 		{...zoneTriggerAttributes}
@@ -330,13 +366,8 @@
 							? 'text-primary'
 							: 'text-base-content/70'}"
 					/>
-				{/if}
-				<!-- In der dichten Variante bleibt die Zeile für die Ablage-Rückmeldung
-				     trotzdem erreichbar: Der Rahmenwechsel allein sagt nicht, dass jetzt
-				     losgelassen werden darf. -->
-				{#if showZoneTitle || isDragOver}
 					<p class="text-sm font-medium {isDragOver ? 'text-primary' : ''}">
-						{isDragOver ? `${multiple ? 'Dateien' : 'Datei'} hier ablegen!` : title}
+						{isDragOver ? dropPrompt : title}
 					</p>
 				{/if}
 				{#if actionLabel}
@@ -353,9 +384,22 @@
 				{/if}
 				<!-- Ein Steuerelement überall, nur der Hinweis ist responsiv: Ziehen gibt
 				     es auf einem Telefon nicht, der Satz beschriebe dort eine unmögliche
-				     Handlung. -->
-				<p class="text-base-content/70 text-support mt-1 {actionLabel ? 'hidden md:inline' : ''}">
-					{emptyText}
+				     Handlung.
+
+				     In der dichten Variante trägt diese Zeile zusätzlich die
+				     Ablage-Rückmeldung — der Rahmenwechsel allein sagt nicht, dass jetzt
+				     losgelassen werden darf. Sie ERSETZT den Hinweis, statt eine Zeile
+				     zu ergänzen: Eine zusätzliche Zeile ließ die Fläche unter dem Zeiger
+				     wachsen, und wer von unten heranzog, verlor sein Ziel wieder. Dass
+				     der Satz unterhalb `md` fehlt, ist derselbe Grund wie oben — dort
+				     wird nicht gezogen. -->
+				<p
+					class="text-support mt-1 {actionLabel ? 'hidden md:inline' : ''} {!showZoneTitle &&
+					isDragOver
+						? 'text-primary font-medium'
+						: 'text-base-content/70'}"
+				>
+					{!showZoneTitle && isDragOver ? dropPrompt : emptyText}
 				</p>
 				<p class="text-base-content/70 text-support mt-1">
 					{subtitle}{additionalText ? ` - ${additionalText}` : ''}

--- a/src/lib/components/form/UnifiedDropzone.svelte.test.ts
+++ b/src/lib/components/form/UnifiedDropzone.svelte.test.ts
@@ -368,6 +368,75 @@ describe('UnifiedDropzone', () => {
 				expect(onFilesAdded).toHaveBeenCalledWith([file]);
 			});
 		});
+
+		/**
+		 * `dragleave` feuert auch dann, wenn der Zeiger die Fläche gar nicht
+		 * verlässt, sondern nur auf eines ihrer Kinder wechselt — und die Kinder
+		 * sind hier die Textzeilen im unteren Teil der Fläche. Mit einem bloßen
+		 * `isDragOver = false` schaltete die Rückmeldung deshalb bei jeder Bewegung
+		 * über diesen Zeilen an und aus; wer eine Datei von unten heranzog, sah ein
+		 * Flackern und traf den unteren Bereich praktisch nicht.
+		 */
+		it('bleibt bereit, wenn der Zeiger von der Fläche auf eine ihrer Textzeilen wechselt', async () => {
+			render(UnifiedDropzone, { config: mockConfig, title: 'Foto hochladen', multiple: false });
+
+			const zone = document.querySelector<HTMLElement>('.border-dashed');
+			if (!zone) throw new Error('Dropzone-Fläche nicht im DOM');
+			zone.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true }));
+			await expect.element(page.getByText('Datei hier ablegen!')).toBeVisible();
+
+			// Zeiger wandert auf ein Kind: dessen `dragenter` bubbelt zur Fläche, und
+			// die Fläche bekommt zusätzlich ihr eigenes `dragleave`.
+			const line = zone.querySelector('p');
+			if (!line) throw new Error('Textzeile nicht im DOM');
+			line.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true }));
+			zone.dispatchEvent(new DragEvent('dragleave', { bubbles: true, relatedTarget: line }));
+
+			await expect.element(page.getByText('Datei hier ablegen!')).toBeVisible();
+		});
+
+		it('gibt die Fläche wieder frei, wenn der Zeiger sie wirklich verlässt', async () => {
+			render(UnifiedDropzone, { config: mockConfig, title: 'Foto hochladen', multiple: false });
+
+			const zone = document.querySelector<HTMLElement>('.border-dashed');
+			if (!zone) throw new Error('Dropzone-Fläche nicht im DOM');
+			zone.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true }));
+			await expect.element(page.getByText('Datei hier ablegen!')).toBeVisible();
+
+			zone.dispatchEvent(new DragEvent('dragleave', { bubbles: true, relatedTarget: null }));
+
+			await expect.element(page.getByText('Datei hier ablegen!')).not.toBeInTheDocument();
+		});
+
+		/**
+		 * Die Fläche darf unter dem Zeiger nicht wachsen. Sie tat es zweifach: In
+		 * der dichten Variante kam die Zeile „Datei hier ablegen!" beim Ziehen als
+		 * ZUSÄTZLICHE Zeile dazu, und `scale-[1.02]` verschob zusätzlich beide
+		 * Kanten. Wer von unten heranzog, verlor das Ziel dadurch wieder unter dem
+		 * Zeiger, sobald es einmal ansprang.
+		 */
+		it('meldet die Ablage-Bereitschaft, ohne die Fläche zu vergrößern', async () => {
+			render(UnifiedDropzone, {
+				config: mockConfig,
+				title: 'Foto hochladen',
+				actionLabel: 'Foto auswählen',
+				multiple: false,
+				compact: true
+			});
+			await expect.element(page.getByRole('button', { name: 'Foto auswählen' })).toBeVisible();
+
+			const zone = document.querySelector<HTMLElement>('.border-dashed');
+			if (!zone) throw new Error('Dropzone-Fläche nicht im DOM');
+			const heightBefore = zone.getBoundingClientRect().height;
+
+			zone.dispatchEvent(new DragEvent('dragenter', { bubbles: true, cancelable: true }));
+			await expect.element(page.getByText('Datei hier ablegen!')).toBeVisible();
+
+			expect(zone.getBoundingClientRect().height).toBe(heightBefore);
+			// Der Transform ist im Test-DOM nicht messbar (kein app.css, siehe
+			// „Vorschau-Buttons"), die Klasse ist aber der Mechanismus dahinter.
+			expect(zone.className).not.toMatch(/\bscale-/);
+		});
 	});
 
 	/**

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -325,13 +325,22 @@
 		if (newFiles.length === 0) return;
 
 		// Single-File-Modus: Bestehende Datei ersetzen
-		if (isSingleFileMode && mediaFiles.length > 0) {
+		//
+		// Gezählt wird über `ownedMediaFiles` und nicht über den ganzen Store —
+		// dieselbe Eingrenzung, mit der `positionMediaFile` und `handleClear` schon
+		// arbeiten. Vorher zählte hier der ganze `mediaStore` gegen `maxFiles`: Im
+		// Positions-Schritt (`maxFiles: 1`) belegte damit jedes Medium aus Schritt 3
+		// den einzigen Platz, der Ersetzen-Zweig löschte nichts (die fremde Datei
+		// gehört ihm nicht) und der Upload endete in „Nur 0 von 1 Dateien können
+		// hinzugefügt werden (Maximum: 1)". Im Medien-Schritt sind beide Mengen
+		// identisch, dort ändert sich nichts.
+		if (isSingleFileMode && ownedMediaFiles.length > 0) {
 			createToast('info', 'Nur eine Datei erlaubt. Bestehende Datei wird ersetzt.');
 			await handleClear();
 		}
 
 		// Datei-Limit prüfen und ggf. beschränken
-		const currentCount = mediaFiles?.length || 0;
+		const currentCount = ownedMediaFiles.length;
 		const allowedCount = Math.min(newFiles.length, maxFiles - currentCount);
 		const filesToProcess = newFiles.slice(0, allowedCount);
 
@@ -947,7 +956,14 @@
 			</div>
 		{/await}
 	{:else}
-		<!-- Unified Dropzone -->
+		<!-- Unified Dropzone
+
+		     `title` rechnet mit `ownedMediaFiles` wie das Datei-Limit oben: Über den
+		     ganzen Store gezählt hieß die Fläche im Positions-Schritt „Foto
+		     ersetzen", sobald irgendwo ein Medium aus Schritt 3 lag — auch wenn
+		     dieser Schritt gar kein Foto hat. Das trifft nicht nur die Beschriftung,
+		     sondern über `zoneTriggerAttributes` auch den zugänglichen Namen der
+		     Fläche (WCAG 4.1.2). -->
 		<UnifiedDropzone
 			{config}
 			{actionLabel}
@@ -958,7 +974,7 @@
 			onClear={handleClear}
 			multiple={!isSingleFileMode}
 			title={title ||
-				(mediaFiles && mediaFiles.length > 0
+				(ownedMediaFiles.length > 0
 					? isSingleFileMode
 						? 'Foto ersetzen'
 						: 'Weitere Dateien hinzufügen'

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
@@ -1,6 +1,26 @@
 import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
+
+/**
+ * Der Upload bleibt in der Schwebe, statt gegen einen Server zu laufen, den es
+ * hier nicht gibt: Eine abgelehnte Upload-Promise ließe `handleFilesAdded` die
+ * gerade angelegte Datei über `deleteFile` sofort wieder aus dem Store nehmen —
+ * ein Wettlauf mit jeder Zusicherung über den Store-Inhalt.
+ */
+vi.mock('$lib/utils/uploadUtils', () => ({
+	uploadFileDirect: () => ({ result: new Promise<never>(() => {}), abort: () => undefined }),
+	deleteFileDirect: async () => undefined
+}));
+
+vi.mock('$lib/utils/client/fileAnalysis', () => ({
+	analyzeClientFile: async (file: File) => ({
+		fileName: file.name,
+		size: file.size,
+		mimeType: file.type,
+		exifData: undefined
+	})
+}));
 import { createForm } from '$lib/form/createForm';
 import { key as formContextKey } from '$lib/report/formContext';
 import { initialFormState } from '$lib/report/formConfig';
@@ -193,6 +213,55 @@ describe('DropzoneEnhanced — Eingrenzung auf den Positions-Schritt', () => {
 
 		await expect.poll(() => mediaStore.mediaFiles.map((file) => file.uid)).toEqual(['media-uid']);
 		expect(get(form).uploadedFiles.map((file) => file.uid)).toEqual(['media-uid']);
+	});
+});
+
+/**
+ * Das Datei-Limit gehört zur selben Eingrenzung wie `ownedMediaFiles`.
+ *
+ * `mediaStore` gehört dem ganzen Formular. `positionMediaFile` und `handleClear`
+ * rechnen deshalb nur mit den Dateien DIESES Schritts — `handleFilesAdded` zählte
+ * dagegen den ganzen Store gegen `maxFiles`. Im Positions-Schritt (`maxFiles: 1`)
+ * belegte damit jedes Medium aus Schritt 3 den einzigen Platz: Der Ersetzen-Zweig
+ * löschte nichts (die fremde Datei gehört ihm nicht), und der Upload endete in
+ * „Nur 0 von 1 Dateien können hinzugefügt werden (Maximum: 1)". Sichtbar wurde
+ * das nach „Neu auswählen" — das Positions-Foto war weg, der Platz blieb belegt.
+ */
+describe('DropzoneEnhanced — Datei-Limit im Positions-Schritt', () => {
+	it('nimmt ein Foto an, obwohl ein Medium aus Schritt 3 im Store liegt', async () => {
+		const { mediaStore } = renderDropzone(
+			[uploadedFile('media-uid')],
+			{ maxFiles: 1, enableGPSExtraction: true },
+			[restoredMediaFile('media-uid', false)]
+		);
+
+		const input = await vi.waitUntil(() =>
+			document.querySelector<HTMLInputElement>('input[data-testid="dropzone-input"]')
+		);
+		const transfer = new DataTransfer();
+		transfer.items.add(new File(['x'], 'position.jpg', { type: 'image/jpeg' }));
+		input.files = transfer.files;
+		input.dispatchEvent(new Event('change', { bubbles: true }));
+
+		await expect
+			.poll(() => mediaStore.mediaFiles.filter((file) => file.isFromPositionStep).length)
+			.toBe(1);
+	});
+
+	/**
+	 * Dieselbe Eingrenzung gilt für die Beschriftung der Fläche: Sie ist über
+	 * `zoneTriggerAttributes` auch ihr zugänglicher Name (WCAG 4.1.2). Mit einem
+	 * fremden Medium im Store hieß sie „Foto ersetzen", obwohl dieser Schritt kein
+	 * Foto hat, das er ersetzen könnte — und der Klick öffnet dann auch nichts
+	 * anderes als sonst.
+	 */
+	it('nennt die Fläche nicht „Foto ersetzen", wenn nur eine fremde Datei im Store liegt', async () => {
+		renderDropzone([uploadedFile('media-uid')], { maxFiles: 1, enableGPSExtraction: true }, [
+			restoredMediaFile('media-uid', false)
+		]);
+
+		await vi.waitUntil(() => document.querySelector('input[data-testid="dropzone-input"]'));
+		expect(document.body.textContent).not.toContain('Foto ersetzen');
 	});
 });
 


### PR DESCRIPTION
## Zwei gemeldete Fehler in der Dropzone auf Schritt 1

### 1. „Nur 0 von 1 Dateien können hinzugefügt werden (Maximum: 1)"

Der `mediaStore` gehört dem ganzen Formular. `positionMediaFile`, `ownedMediaFiles` und `handleClear` grenzen deshalb längst auf die Dateien des jeweiligen Schritts ein — `handleFilesAdded` und die Titelberechnung taten es nicht und zählten den ganzen Store gegen `maxFiles`.

Im Positions-Schritt (`maxFiles: 1`) belegte damit **jedes Medium aus Schritt 3 den einzigen Platz**:

- der Ersetzen-Zweig löschte nichts (die fremde Datei gehört ihm nicht),
- `currentCount` blieb 1 → `allowedCount = 0` → die gemeldete Meldung,
- die Fläche hieß „Foto ersetzen", obwohl dieser Schritt kein Foto hatte — über `zoneTriggerAttributes` auch ihr zugänglicher Name (WCAG 4.1.2).

Sichtbar wurde es nach „Neu auswählen": Das Positions-Foto war weg, der Platz blieb belegt. Am laufenden Dev-Server reproduziert und nach dem Fix nachgestellt — Upload und „Neu auswählen"-Zyklus funktionieren wieder, die Datei aus Schritt 3 bleibt dabei unangetastet.

### 2. Zitternde Dropzone, unterer Bereich reagiert nicht

Zwei Ursachen, beide in `UnifiedDropzone.svelte`:

- **`dragleave` feuert auch beim Wechsel auf ein Kindelement** — und die Kinder sind genau die Textzeilen im unteren Teil der Fläche. Der Zustand schaltete dort bei jeder Bewegung an und aus. Ein Zähler über `dragenter`/`dragleave` entscheidet jetzt, wann der Zeiger die Fläche wirklich verlassen hat; `dragover` bleibt als selbstheilender Rückfall.
- **Die Fläche wuchs unter dem Zeiger:** In der dichten Variante kam „Datei hier ablegen!" als *zusätzliche* Zeile dazu, dazu verschob `scale-[1.02]` beide Kanten. Wer von unten heranzog, verlor das Ziel wieder, sobald es ansprang. Die Rückmeldung ersetzt jetzt den Hinweistext statt eine Zeile zu ergänzen, und der Transform entfällt — Rahmen und Tint melden die Bereitschaft genauso.

Im Browser mit echtem CSS nachgemessen: Höhe konstant 165 px in Ruhe, beim Ziehen und über der untersten Textzeile; der aktive Zustand hält beim Wechsel auf die Zeile und geht erst beim echten Verlassen aus.

## Tests

Fünf neue Tests, vorher rot:

- `DropzoneEnhanced` — Upload wird angenommen, obwohl ein Medium aus Schritt 3 im Store liegt (reproduziert `0 statt 1`)
- `DropzoneEnhanced` — die Fläche heißt in diesem Zustand nicht „Foto ersetzen"
- `UnifiedDropzone` — bleibt bereit beim Wechsel auf eine Textzeile
- `UnifiedDropzone` — gibt frei, wenn der Zeiger wirklich verlässt
- `UnifiedDropzone` — meldet Bereitschaft ohne die Fläche zu vergrößern (Höhe + kein `scale-`)

`npm run test:unit` 3287 ✓ · Browser-Tests 283 ✓ · `npm run check` 0 Fehler · Lint ohne neue Warnungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)