### PR TITLE
fix(media): Zurücksetzen löscht die hochgeladenen Dateien mit

### DIFF
--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -26,6 +26,7 @@
 	} from '$lib/storage/localStorage';
 	import type { FormContext, SightingFormData, UserContactData } from '$lib/types';
 	import type { SightingFormValues } from '$lib/types/Form';
+	import { discardFormUploads } from '$lib/report/discardFormUploads';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 	import { scrollToFirstError } from '$lib/utils/fieldNavigation';
 	import { createId } from '@paralleldrive/cuid2';
@@ -344,8 +345,23 @@
 		return formContext.handleSubmit(e);
 	}
 
+	/**
+	 * Verwirft das Formular — samt der bereits hochgeladenen Dateien.
+	 *
+	 * `discardFormUploads` steht **vor** dem Aufräumen des Client-Zustands, und
+	 * das ist keine Stilfrage: Danach ist `uploadedFiles` leer, und niemand weiß
+	 * mehr, was zu löschen war. Die Dateien lägen dauerhaft unter
+	 * `uploads/<referenceId>/` und als Zeile in `sichtungen_dateien`, ohne dass je
+	 * eine Sichtung entsteht, zu der sie gehören.
+	 *
+	 * Es wird bewusst nicht gewartet: Warum, und warum der Medien-Store dabei ganz
+	 * geleert wird, steht in `discardFormUploads.ts`.
+	 */
 	function onReset() {
 		logger.info('Resetting form:');
+
+		discardFormUploads($form.uploadedFiles, formContext.mediaStore);
+
 		// Lösche alle gespeicherten Daten
 		clearFormDataOnly();
 		clearStorage();

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -1,0 +1,106 @@
+import { render } from 'vitest-browser-svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * „Formular zurücksetzen" verwarf bis PR #717 nur den Browser-Zustand.
+ *
+ * `onReset()` räumte ausschließlich clientseitig auf (`clearFormDataOnly`,
+ * `clearStorage`, `updateInitialValues`) — die bereits hochgeladenen Dateien
+ * blieben auf der Platte und als Zeile in `sichtungen_dateien` liegen, ohne
+ * dass je eine Sichtung entstand, zu der sie gehören. Wer das Formular
+ * verwarf, hinterließ seine Fotos dauerhaft.
+ *
+ * Getestet wird deshalb an der Naht, an der die Absicht verloren ging: Ruft
+ * der Reset dieselbe serverseitige Löschung an wie „Alle löschen"
+ * (`DropzoneEnhanced.handleClear`), und tut er es, BEVOR er die Dateiliste
+ * verwirft — danach weiß niemand mehr, was zu löschen war.
+ */
+const { deleteMultipleFiles } = vi.hoisted(() => ({
+	deleteMultipleFiles: vi.fn<(files: unknown[]) => Promise<void>>(async () => undefined)
+}));
+
+vi.mock('$lib/utils/upload/fileProcessing', () => ({ deleteMultipleFiles }));
+
+import { initialFormState } from '$lib/report/formConfig';
+import { STORAGE_KEYS } from '$lib/storage/localStorage';
+import type { UploadedFileInfo } from '$lib/types';
+import ModernReportForm from './ModernReportForm.svelte';
+
+const UPLOAD: UploadedFileInfo = {
+	uid: 'uid-1',
+	filePath: 'ref-1/uid-1.jpg',
+	originalName: 'foto.jpg',
+	fileName: 'uid-1.jpg',
+	mimeType: 'image/jpeg',
+	size: 1024
+} as UploadedFileInfo;
+
+/**
+ * Schritt 4 (Index 3) trägt kein Medien- und kein Kartenelement — der Reset
+ * ist von dort aus genauso erreichbar, das Rendern bleibt aber leicht.
+ */
+function seedFormWithUpload(step = 3): void {
+	sessionStorage.setItem(STORAGE_KEYS.CURRENT_STEP, JSON.stringify(step));
+	sessionStorage.setItem(
+		STORAGE_KEYS.FORM_DATA,
+		JSON.stringify({ ...initialFormState, referenceId: 'ref-1', uploadedFiles: [UPLOAD] })
+	);
+}
+
+function resetButton(): HTMLButtonElement {
+	const button = Array.from(document.querySelectorAll('button')).find(
+		(candidate) => candidate.textContent?.trim() === 'Formular zurücksetzen'
+	);
+	if (!button) throw new Error('Schaltfläche „Formular zurücksetzen" nicht im DOM');
+	return button;
+}
+
+function persistedUploads(): UploadedFileInfo[] {
+	const stored = sessionStorage.getItem(STORAGE_KEYS.FORM_DATA);
+	return stored ? (JSON.parse(stored).uploadedFiles ?? []) : [];
+}
+
+describe('ModernReportForm — Zurücksetzen räumt die Uploads mit auf', () => {
+	beforeEach(() => {
+		deleteMultipleFiles.mockReset();
+		deleteMultipleFiles.mockResolvedValue(undefined);
+	});
+
+	it('löscht die hochgeladenen Dateien vom Server', async () => {
+		seedFormWithUpload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		render(ModernReportForm);
+
+		resetButton().click();
+
+		await vi.waitFor(() => expect(deleteMultipleFiles).toHaveBeenCalled());
+		expect(deleteMultipleFiles.mock.calls[0]?.[0]).toEqual([UPLOAD]);
+	});
+
+	it('verwirft den Formularzustand trotzdem, wenn die Löschung scheitert', async () => {
+		// `deleteMultipleFiles` nutzt intern `Promise.allSettled` und wirft nicht —
+		// hier trotzdem der harte Fall (Netz weg, 403): Der Reset ist eine Zusage an
+		// den Nutzer und darf nicht daran hängenbleiben, dass der Server nicht
+		// mitspielt. Die Datei ist dann verwaist und Sache des serverseitigen
+		// Aufräumens (`media:cleanup-orphans`).
+		deleteMultipleFiles.mockRejectedValueOnce(new Error('Verbindung zum Server unterbrochen'));
+		seedFormWithUpload();
+		vi.spyOn(window, 'confirm').mockReturnValue(true);
+		render(ModernReportForm);
+
+		resetButton().click();
+
+		await vi.waitFor(() => expect(persistedUploads()).toEqual([]));
+	});
+
+	it('löscht nichts, wenn die Rückfrage abgelehnt wird', async () => {
+		seedFormWithUpload();
+		vi.spyOn(window, 'confirm').mockReturnValue(false);
+		render(ModernReportForm);
+
+		resetButton().click();
+
+		await vi.waitFor(() => expect(persistedUploads()).toEqual([UPLOAD]));
+		expect(deleteMultipleFiles).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/report/discardFormUploads.test.ts
+++ b/src/lib/report/discardFormUploads.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { discardFormUploads } from './discardFormUploads';
+import type { UploadedFileInfo } from '$lib/types';
+import type { MediaStore } from '$lib/utils/media/MediaFile.svelte';
+
+function upload(uid: string): UploadedFileInfo {
+	return {
+		uid,
+		filePath: `ref-1/${uid}.jpg`,
+		originalName: `${uid}.jpg`,
+		fileName: `${uid}.jpg`,
+		mimeType: 'image/jpeg',
+		size: 1024
+	} as UploadedFileInfo;
+}
+
+/** Der echte Store trägt `MediaFile`-Instanzen; hier zählt nur die Länge. */
+function storeWith(count: number): MediaStore {
+	return { mediaFiles: Array.from({ length: count }, () => ({})) } as unknown as MediaStore;
+}
+
+describe('discardFormUploads', () => {
+	it('löscht genau die übergebenen Dateien vom Server', () => {
+		const deleteFiles = vi.fn<(files: UploadedFileInfo[]) => Promise<void>>(async () => undefined);
+		const files = [upload('uid-1'), upload('uid-2')];
+
+		discardFormUploads(files, storeWith(2), { deleteFiles });
+
+		expect(deleteFiles).toHaveBeenCalledTimes(1);
+		expect(deleteFiles.mock.calls[0]?.[0]).toEqual(files);
+	});
+
+	it('leert den Medien-Store vollständig', () => {
+		// Ganz und nicht gefiltert: Der Reset verwirft alle Schritte — anders als
+		// `handleClear` in DropzoneEnhanced, das sich auf die eigenen Dateien
+		// beschränkt (PR #716).
+		const mediaStore = storeWith(3);
+
+		discardFormUploads([upload('uid-1')], mediaStore, { deleteFiles: async () => undefined });
+
+		expect(mediaStore.mediaFiles).toEqual([]);
+	});
+
+	it('räumt den Store auch dann auf, wenn es nichts zu löschen gibt', () => {
+		const deleteFiles = vi.fn<(files: UploadedFileInfo[]) => Promise<void>>(async () => undefined);
+		const mediaStore = storeWith(1);
+
+		discardFormUploads([], mediaStore, { deleteFiles });
+
+		expect(deleteFiles).not.toHaveBeenCalled();
+		expect(mediaStore.mediaFiles).toEqual([]);
+	});
+
+	it('kommt mit fehlender Dateiliste zurecht', () => {
+		// `$form.uploadedFiles` ist im Schema optional — ein `undefined` darf den
+		// Reset nicht mit einem TypeError abbrechen.
+		const deleteFiles = vi.fn<(files: UploadedFileInfo[]) => Promise<void>>(async () => undefined);
+
+		expect(() => discardFormUploads(undefined, storeWith(0), { deleteFiles })).not.toThrow();
+		expect(deleteFiles).not.toHaveBeenCalled();
+	});
+
+	it('läuft weiter, wenn die Löschung fehlschlägt', async () => {
+		// Netz weg oder 403: Der Reset ist eine Zusage an den Nutzer und darf
+		// daran nicht hängenbleiben. Weder eine geworfene noch eine abgelehnte
+		// Promise darf nach außen dringen.
+		const rejected = vi.fn(async () => {
+			throw new Error('Verbindung zum Server unterbrochen');
+		});
+		const mediaStore = storeWith(1);
+
+		expect(() =>
+			discardFormUploads([upload('uid-1')], mediaStore, { deleteFiles: rejected })
+		).not.toThrow();
+		expect(mediaStore.mediaFiles).toEqual([]);
+
+		// Die Ablehnung muss abgefangen sein — eine unbehandelte Rejection ließe
+		// den Test-Runner (und im Browser die Konsole) auflaufen.
+		await Promise.resolve();
+	});
+
+	it('bricht nicht ab, wenn die Löschfunktion synchron wirft', () => {
+		const throwing = vi.fn(() => {
+			throw new Error('kaputt');
+		}) as unknown as (files: UploadedFileInfo[]) => Promise<void>;
+
+		expect(() =>
+			discardFormUploads([upload('uid-1')], storeWith(0), { deleteFiles: throwing })
+		).not.toThrow();
+	});
+});

--- a/src/lib/report/discardFormUploads.ts
+++ b/src/lib/report/discardFormUploads.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Aufräumen der Uploads eines verworfenen Formulars.
+ *
+ * „Formular zurücksetzen" verwarf bis PR #717 nur den Browser-Zustand. Die
+ * bereits hochgeladenen Dateien blieben unter `uploads/<referenceId>/` und als
+ * Zeile in `sichtungen_dateien` liegen — ohne dass je eine Sichtung entsteht,
+ * zu der sie gehören.
+ *
+ * Die Regel steht hier und nicht in `ModernReportForm.svelte`, weil sie zwei
+ * Zusicherungen trägt, die ein Komponententest nur schwer sichtbar macht: Was
+ * genau gelöscht wird, und dass der Reset weiterläuft, wenn die Löschung
+ * scheitert.
+ */
+import { createLogger } from '$lib/logger';
+import type { UploadedFileInfo } from '$lib/types';
+import type { MediaStore } from '$lib/utils/media/MediaFile.svelte';
+import { deleteMultipleFiles } from '$lib/utils/upload/fileProcessing';
+
+const logger = createLogger('report:discard-form-uploads');
+
+export interface DiscardFormUploadsOptions {
+	/** Nur für Tests — sonst die echte Löschung über `DELETE /api/files/delete`. */
+	deleteFiles?: (files: UploadedFileInfo[]) => Promise<void>;
+}
+
+/**
+ * Löscht die Uploads eines verworfenen Formulars und leert den Medien-Store.
+ *
+ * **Synchron, absichtlich.** Der Aufrufer darf nicht auf die Antwort des Servers
+ * warten: Das Zurücksetzen ist eine Zusage an den Nutzer und darf nicht daran
+ * hängenbleiben, dass gerade kein Netz da ist. `deleteMultipleFiles` räumt
+ * intern mit `Promise.allSettled` auf und wirft deshalb weder bei einem 403
+ * noch bei einem Abbruch — der `catch` hier ist die Absicherung gegen alles,
+ * was davor scheitern kann, und gegen einen Aufrufer, der diese Zusage nicht
+ * hält. Was der Server nicht löscht, ist danach eine Waise und Sache von
+ * `npm run media:cleanup-orphans` (Klasse A: `sichtung_id IS NULL`).
+ *
+ * **Der Store wird ganz geleert, nicht gefiltert.** Anders als `handleClear` in
+ * `DropzoneEnhanced` (PR #716), das sich auf `ownedMediaFiles` beschränkt, weil
+ * ein Klick in Schritt 1 nicht die Medien aus Schritt 3 mitnehmen darf: Der
+ * Reset verwirft ausdrücklich alle Schritte. Ohne das Leeren blieben die
+ * Vorschaubilder der gerade gelöschten Dateien stehen — `mediaStore` hängt an
+ * `Form.svelte` und überlebt `updateInitialValues`.
+ *
+ * @param uploadedFiles Die Dateien aus `$form.uploadedFiles` — **vor** dem
+ *   Verwerfen des Formularzustands einsammeln. Danach ist die Liste leer und
+ *   niemand weiß mehr, was zu löschen war.
+ * @param mediaStore Der Medien-Store des Formulars (aus dem Form-Context).
+ */
+export function discardFormUploads(
+	uploadedFiles: readonly UploadedFileInfo[] | undefined,
+	mediaStore: MediaStore,
+	{ deleteFiles = deleteMultipleFiles }: DiscardFormUploadsOptions = {}
+): void {
+	mediaStore.mediaFiles = [];
+
+	const files = uploadedFiles ?? [];
+	if (files.length === 0) {
+		return;
+	}
+
+	logger.info({ count: files.length }, 'Deleting uploads of the discarded form');
+
+	try {
+		void deleteFiles([...files]).catch((error: unknown) => {
+			logger.error({ error }, 'Uploads des verworfenen Formulars konnten nicht gelöscht werden');
+		});
+	} catch (error) {
+		logger.error({ error }, 'Uploads des verworfenen Formulars konnten nicht gelöscht werden');
+	}
+}


### PR DESCRIPTION
## Problem

„Formular zurücksetzen" verwarf nur den Browser-Zustand. `onReset()` in
`ModernReportForm.svelte` räumte ausschließlich clientseitig auf
(`clearFormDataOnly`, `clearStorage`, `updateInitialValues`) — die bereits
hochgeladenen Dateien blieben unter `uploads/<referenceId>/` und als Zeile in
`sichtungen_dateien` liegen, ohne dass je eine Sichtung entsteht, zu der sie
gehören. `DropzoneEnhanced.handleClear()` („Neu auswählen"/„Alle löschen") tut
das Richtige und ruft `deleteMultipleFiles` — nur der Reset-Pfad nicht.

## Änderung

Neu: `src/lib/report/discardFormUploads.ts`. `onReset()` ruft es **vor** dem
Verwerfen des Client-Zustands auf — danach ist `uploadedFiles` leer und niemand
weiß mehr, was zu löschen war. Die Funktion löscht die Dateien serverseitig und
leert den Medien-Store.

Eigenes Modul statt Inline-Code, weil die zwei Zusicherungen (was genau gelöscht
wird, und dass der Reset weiterläuft, wenn die Löschung scheitert) sich als
Unit-Test sauber festnageln lassen — im Komponententest wären sie kaum sichtbar.

## Die drei Fragen aus dem Auftrag

**1. Reihenfolge und Fehlerfall.** Die Löschung steht vor dem Aufräumen, wird
aber **nicht abgewartet**: Der Reset ist eine Zusage an den Nutzer und darf
nicht daran hängenbleiben, dass gerade kein Netz da ist. `deleteMultipleFiles`
nutzt intern `Promise.allSettled` und wirft weder bei 403 noch bei Abbruch; der
`catch` sichert gegen alles ab, was davor scheitern kann, und gegen einen
künftigen Aufrufer, der diese Zusage nicht hält. Der Fehlerfall ist zweifach
getestet — abgelehnte Promise und synchron geworfener Fehler.

**2. `mediaStore` wird ganz geleert, nicht gefiltert.** Anders als
`handleClear` (PR #716), das sich auf `ownedMediaFiles` beschränkt, weil ein
Klick in Schritt 1 nicht die Medien aus Schritt 3 mitnehmen darf: Der Reset
verwirft ausdrücklich alle Schritte, die Eingrenzung wäre hier falsch. Nötig ist
das Leeren, weil der Store an `Form.svelte` hängt und `updateInitialValues`
überlebt — ohne die Zeile blieben die Vorschaubilder gerade gelöschter Dateien
stehen.

**3. Weitere Wege, auf denen Uploads verwaisen — Ergebnis der Prüfung.** Ja, es
gibt sie, und der Client-Fix kann sie prinzipiell nicht abdecken: Tab schließen,
Browser-Absturz, Ablauf des `sessionStorage`, abgebrochener Upload. In all diesen
Fällen erfährt der Client nie, dass er aufräumen müsste.

Das ist bereits serverseitig gelöst und deckt genau diesen Fall ab:
`src/tools/cleanup-orphaned-uploads.ts` (`npm run media:cleanup-orphans`) räumt
zwei Waisen-Klassen — **A)** Zeilen in `sichtungen_dateien` mit
`sichtung_id IS NULL`, deren Upload älter als die Frist ist (Default 24 h,
`ORPHAN_RETENTION_HOURS`), also abgebrochene Formularläufe, und **B)** Dateien
unter `uploads/` ohne Zeile. Denselben Lauf gibt es über
`POST /api/admin/cleanup-orphans` im Admin-Bereich (`CleanupPanel.svelte`).

**Der richtigere Ort ist also nicht „entweder/oder", sondern beides**, mit
unterschiedlicher Rolle:

- Der **Server** ist die Rückfallebene für alles, was der Client nicht mitbekommt
  — und bleibt es. Er ist aber nicht sofort: Die Datei liegt bis zu 24 h plus die
  Zeit bis zum nächsten Lauf. Und **es gibt keinen Zeitplan** — weder ein
  GitHub-Workflow noch ein Cron ruft das Tool auf; es läuft nur, wenn jemand den
  Befehl bzw. den Knopf im Admin-Bereich betätigt. Ohne den Client-Fix wäre die
  Aufräumfrist einer bewusst verworfenen Meldung damit „irgendwann, wenn ein
  Admin daran denkt".
- Der **Client** deckt den einen Fall ab, in dem die Absicht ausdrücklich
  vorliegt: Der Nutzer sagt „verwirf das" und bekommt bestätigt. Dass seine Fotos
  danach noch einen Tag auf dem Server liegen, ist datenschutzrechtlich schlecht
  begründbar, wenn wir sie sofort löschen können.

Ein Ausbau des Server-Laufs (Zeitplan) wäre eine sinnvolle Ergänzung, ist aber
nicht Teil dieses PRs.

## Tests (Test-First)

Zuerst der fehlschlagende Browser-Test, der den Befund festhält, dann die
Implementierung. Belegt: Vor dem Fix ist `ModernReportForm.svelte.test.ts` rot
(„expected vi.fn() to be called at least once"), danach grün; nimmt man die
`discardFormUploads`-Zeile wieder heraus, ist er sofort wieder rot.

- `src/lib/report/components/ModernReportForm.svelte.test.ts` (3 Tests,
  `npm run test:unit:client`) — die Verdrahtung: Löscht der Klick auf
  „Formular zurücksetzen" genau die hochgeladenen Dateien, verwirft er den
  Zustand auch bei fehlgeschlagener Löschung, und löscht er nichts, wenn die
  Rückfrage abgelehnt wird. Gerendert wird auf Schritt 4 — dort ist der Reset
  genauso erreichbar, aber weder Karte noch Medien-Galerie müssen dafür laufen.
- `src/lib/report/discardFormUploads.test.ts` (6 Tests, läuft in `test:quick`)
  — die Regel selbst: genau diese Dateien, Store vollständig geleert, leere und
  fehlende Liste, abgelehnte Promise, synchron geworfener Fehler.

`npm run test:quick`: 227 Dateien, 3293 Tests grün (Lint zeigt nur die zwei
vorbestehenden Warnungen in `createEvent.ts`).

## Nicht enthalten

Manuell nachgestellt wurde am Dev-Server bereits im Auftrag; ein erneuter Lauf
gegen `uploads/` unterblieb bewusst — das Verzeichnis ist zwischen allen
Worktrees geteilt (`docs/WORKTREES.md`), und `media:cleanup-orphans` beiläufig
laufen zu lassen träfe fremde Dateien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
