### PR TITLE
fix(ui): navigation ordnen und die Karte nicht mehr abschneiden

### DIFF
--- a/e2e/app-shell-height.spec.ts
+++ b/e2e/app-shell-height.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mockMapSightingsSuccess } from './fixtures/mockApi';
+import { seedAdminSession } from './helpers/adminSession';
+import { MapPage } from './pages/MapPage';
+
+/**
+ * app-shell-height.spec.ts — die Karte muss unter *jedem* Header passen.
+ *
+ * **Der Bug:** `/map` setzte die Höhe des Karten-Containers als
+ * `calc(100dvh - 4rem)` — also unter der Annahme, der Header sei genau 64px
+ * hoch. Er ist es nie: einzeilig misst er 66px, und als Admin brach das
+ * Menü zwischen 1024px und 1440px in eine zweite Zeile um (99px). Der
+ * Container ragte damit 35px unter den Fensterrand, der „Karte/Liste"-
+ * Umschalter und das Museums-Logo lagen außerhalb des sichtbaren Bereichs.
+ * Der `MaintenanceBanner` steht zusätzlich zwischen Header und `<main>` und
+ * kam in der Rechnung überhaupt nicht vor.
+ *
+ * **Warum hier keine Zahl steht:** Der Test misst den Header und leitet die
+ * Erwartung daraus ab. Eine Assertion gegen „66px" würde beim nächsten
+ * Padding-Wechsel rot, ohne dass etwas kaputt wäre — und, schlimmer, sie
+ * würde grün bleiben, wenn Header und Container gemeinsam falsch liegen.
+ * Geprüft wird die *Beziehung*: bündig unter dem Header, bündig am
+ * Fensterrand.
+ *
+ * Die Admin-Variante ist der eigentliche Regressionsfall — sie ist die
+ * einzige mit genug Menüpunkten, um einen Umbruch überhaupt auszulösen.
+ * Zugang über `seedAdminSession` (dort steht, warum nicht über Auth0).
+ */
+
+/* 1px Toleranz: Sub-Pixel-Rundung von `getBoundingClientRect` gegen die
+   ganzzahlige `innerHeight`. Größer darf sie nicht sein — der Bug lag bei
+   2px im günstigsten und 35px im ungünstigsten Fall. */
+const TOLERANZ = 1;
+
+async function messeKartenGeometrie(page: Page) {
+	return page.evaluate(() => {
+		const header = document.querySelector('header');
+		const container = document.querySelector('#map')?.parentElement;
+		if (!header || !container) throw new Error('Header oder Karten-Container nicht gefunden');
+		return {
+			headerUnterkante: header.getBoundingClientRect().bottom,
+			containerOberkante: container.getBoundingClientRect().top,
+			containerUnterkante: container.getBoundingClientRect().bottom,
+			fensterhoehe: window.innerHeight
+		};
+	});
+}
+
+test.describe('App-Shell — Kartenhöhe folgt dem Header', () => {
+	test('anonym: Karte schließt bündig an den Header an und endet am Fensterrand', async ({
+		page
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await mockMapSightingsSuccess(page);
+		const mapPage = new MapPage(page);
+		await mapPage.goto();
+		await mapPage.waitForLoad();
+
+		const g = await messeKartenGeometrie(page);
+
+		expect(Math.abs(g.containerOberkante - g.headerUnterkante)).toBeLessThanOrEqual(TOLERANZ);
+		expect(g.containerUnterkante).toBeLessThanOrEqual(g.fensterhoehe + TOLERANZ);
+	});
+
+	test('als Admin bei 1280px: Karte ragt nicht unter den Fensterrand', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await mockMapSightingsSuccess(page);
+			const mapPage = new MapPage(page);
+			await mapPage.goto();
+			await mapPage.waitForLoad();
+
+			const g = await messeKartenGeometrie(page);
+
+			expect(Math.abs(g.containerOberkante - g.headerUnterkante)).toBeLessThanOrEqual(TOLERANZ);
+			expect(g.containerUnterkante).toBeLessThanOrEqual(g.fensterhoehe + TOLERANZ);
+		} finally {
+			await context.close();
+		}
+	});
+});

--- a/e2e/app-shell-height.spec.ts
+++ b/e2e/app-shell-height.spec.ts
@@ -3,6 +3,12 @@ import { mockMapSightingsSuccess } from './fixtures/mockApi';
 import { seedAdminSession } from './helpers/adminSession';
 import { MapPage } from './pages/MapPage';
 
+/* Ein Datumsfilter in der Zukunft liefert eine leere Trefferliste — die
+   einzige kurze Seite im Admin-Bereich. Nur an ihr bindet eine zu groß
+   geratene Mindesthöhe überhaupt; auf den langen Seiten (Statistiken,
+   Einstellungen, Sichtungsliste) bliebe sie unsichtbar. */
+const KURZE_ADMIN_SEITE = '/admin?fromDate=2099-01-01&toDate=2099-01-02';
+
 /**
  * app-shell-height.spec.ts — die Karte muss unter *jedem* Header passen.
  *
@@ -60,6 +66,55 @@ test.describe('App-Shell — Kartenhöhe folgt dem Header', () => {
 
 		expect(Math.abs(g.containerOberkante - g.headerUnterkante)).toBeLessThanOrEqual(TOLERANZ);
 		expect(g.containerUnterkante).toBeLessThanOrEqual(g.fensterhoehe + TOLERANZ);
+	});
+
+	/**
+	 * Derselbe Fehler eine Ebene tiefer: Das Admin-Layout setzte `min-h-screen`
+	 * auf seine eigene Box. In der neuen Shell sitzt die aber bereits in einer
+	 * auf Viewport-Höhe gestreckten Flex-Spalte — 100vh INNERHALB von
+	 * „Viewport minus Header" ergibt genau die Header-Höhe an überflüssigem
+	 * Scrollweg (gemessen: `main` 900px statt der verfügbaren 834px).
+	 *
+	 * Auch hier keine Zahl in der Assertion: Geprüft wird, dass der Inhalt am
+	 * Fensterrand endet, statt darüber hinauszuragen.
+	 */
+	test('eine kurze Admin-Seite erzeugt keinen überflüssigen Scrollweg', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto(KURZE_ADMIN_SEITE);
+			await expect(page.getByRole('navigation', { name: 'Verwaltung' })).toBeVisible();
+			/* Der Header hängt an `isNotIFrame` und erscheint erst nach der
+			   Hydration — ohne dieses Warten misst der Test gegen ein noch
+			   nicht vorhandenes Element. */
+			await expect(page.locator('header')).toBeVisible();
+
+			const g = await page.evaluate(() => {
+				const main = document.querySelector('main');
+				const header = document.querySelector('header');
+				if (!main || !header) throw new Error('main oder header nicht gefunden');
+				return {
+					mainUnterkante: main.getBoundingClientRect().bottom,
+					mainHoehe: main.getBoundingClientRect().height,
+					verfuegbar: window.innerHeight - header.getBoundingClientRect().height,
+					fensterhoehe: window.innerHeight
+				};
+			});
+
+			expect(
+				g.mainUnterkante,
+				`main ist ${Math.round(g.mainHoehe)}px hoch, verfügbar sind ${Math.round(g.verfuegbar)}px`
+			).toBeLessThanOrEqual(g.fensterhoehe + TOLERANZ);
+		} finally {
+			await context.close();
+		}
 	});
 
 	test('als Admin bei 1280px: Karte ragt nicht unter den Fensterrand', async ({

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -223,7 +223,11 @@ test.describe('Styleguide — Bedienung', () => {
 		await page.getByRole('button', { name: /Feldmodus/ }).click();
 		await expect.poll(() => densityAttribute(page)).toBe('field');
 
-		await page.getByRole('link', { name: 'Meldung' }).click();
+		/* Auf den Header eingegrenzt: Seit der Footer-Neuordnung (2026-08-03)
+		   führt auch die Gruppe „Navigation" im Footer einen Link „Meldung",
+		   ein ungebundener Rollen-Selektor ist damit mehrdeutig. Gemeint ist
+		   hier die TopBar — ein Klick im Footer würde erst dorthin scrollen. */
+		await page.locator('header').getByRole('link', { name: 'Meldung' }).click();
 		await expect(page).toHaveURL(/\/$/);
 
 		await expect

--- a/e2e/footer-layout.spec.ts
+++ b/e2e/footer-layout.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * footer-layout.spec.ts — der Footer bricht auf schmalen Geräten wirklich um.
+ *
+ * **Der Bug:** `footer-center` ist in DaisyUI 5 auf *jedem* Breakpoint
+ * `grid-auto-flow: column dense` — es gibt keine responsive Umschaltung. Die
+ * drei Blöcke standen deshalb auch auf 390px nebeneinander, jeder rund 130px
+ * breit, und die sechs Navigationslinks wurden darin zu einer sechszeiligen
+ * Spalte gequetscht. Auf 1280px war es umgekehrt: dieselben sechs Links
+ * zweizeilig im linken Drittel, während rechts Platz frei blieb.
+ *
+ * Ein früherer Anlauf (2026-07-30) hatte nur das `md:grid-flow-col` der
+ * inneren `<nav>` entfernt. Das behob den horizontalen Überlauf, ließ die
+ * äußere Spaltenanordnung aber unangetastet — sie kommt aus `footer-center`
+ * selbst. Der Test greift deshalb die Anordnung der Blöcke ab, nicht die der
+ * Links.
+ */
+
+const GRUPPEN = ['Navigation', 'Rechtliches', 'Projekt'] as const;
+
+/** Oberkanten der Footer-Gruppen — gleiche Zahl = gleiche Zeile. */
+async function gruppenZeilen(page: Page): Promise<number> {
+	return page.evaluate(() => {
+		const gruppen = document.querySelectorAll('footer nav');
+		if (gruppen.length === 0) throw new Error('Keine Footer-Gruppen gefunden');
+		return new Set(Array.from(gruppen).map((g) => Math.round(g.getBoundingClientRect().top))).size;
+	});
+}
+
+test.describe('Footer — Anordnung', () => {
+	test('auf 390px stehen die Gruppen untereinander', async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto('/');
+
+		const footer = page.locator('footer');
+		await expect(footer).toBeAttached();
+
+		expect(await gruppenZeilen(page), 'Gruppen stehen nebeneinander statt untereinander').toBe(
+			GRUPPEN.length
+		);
+	});
+
+	test('ab 1024px stehen die Gruppen nebeneinander', async ({ page }) => {
+		await page.setViewportSize({ width: 1024, height: 900 });
+		await page.goto('/');
+		await expect(page.locator('footer nav').first()).toBeAttached();
+
+		expect(await gruppenZeilen(page), 'Gruppen stapeln sich, obwohl Platz da ist').toBe(1);
+	});
+
+	/* Der Auslöser des Vorgänger-Bugs: zwischen 768px und ~890px passte die
+	   Linkzeile nicht mehr, das Dokument wurde breiter als der Viewport und die
+	   ganze Seite ließ sich seitlich schieben — der Schritt-Stepper darüber
+	   wurde mit angeschnitten. */
+	test('das Dokument wird auf keiner Breite breiter als das Fenster', async ({ page }) => {
+		for (const breite of [360, 390, 640, 768, 890, 1024, 1280]) {
+			await page.setViewportSize({ width: breite, height: 900 });
+			await page.goto('/');
+			const ueberlauf = await page.evaluate(
+				() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+			);
+			expect(ueberlauf, `horizontaler Überlauf bei ${breite}px`).toBeLessThanOrEqual(0);
+		}
+	});
+
+	test('die Pflichtangaben stehen in einer eigenen, benannten Gruppe', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/');
+
+		for (const name of GRUPPEN) {
+			await expect(page.getByRole('navigation', { name })).toBeVisible();
+		}
+
+		/* § 5 DDG und Art. 13 DSGVO: auffindbar, nicht als Platz 5 und 6 einer
+		   Linkwurst. Verlinkt sind bewusst die Seiten des Betreibers — eine
+		   zweite, separat zu pflegende Fassung derselben Rechtstexte würde nur
+		   auseinanderlaufen. */
+		const rechtliches = page.getByRole('navigation', { name: 'Rechtliches' });
+		await expect(rechtliches.getByRole('link', { name: 'Impressum' })).toHaveAttribute(
+			'href',
+			/deutsches-meeresmuseum\.de\/impressum$/
+		);
+		await expect(rechtliches.getByRole('link', { name: 'Datenschutz' })).toHaveAttribute(
+			'href',
+			/deutsches-meeresmuseum\.de\/datenschutz$/
+		);
+	});
+});

--- a/e2e/footer-layout.spec.ts
+++ b/e2e/footer-layout.spec.ts
@@ -64,6 +64,29 @@ test.describe('Footer — Anordnung', () => {
 		}
 	});
 
+	/**
+	 * GitHub und „Deutsches Meeresmuseum" waren `btn btn-ghost btn-xs` und
+	 * bekamen ihre 44px über den Touch-Target-Block in `app.css` — der greift
+	 * auf `.btn`, nicht auf `.link`. Beim Umbau auf einheitliche Textlinks wäre
+	 * das still verlorengegangen; die übrigen Footer-Links hatten die Größe
+	 * ohnehin nie.
+	 */
+	test('Footer-Links erfüllen das 44px-Ziel', async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		await page.goto('/');
+
+		const links = page.locator('footer nav a');
+		await expect(links.first()).toBeAttached();
+
+		for (const link of await links.all()) {
+			const kasten = await link.boundingBox();
+			expect(
+				kasten?.height ?? 0,
+				`„${await link.innerText()}" ist nur ${Math.round(kasten?.height ?? 0)}px hoch`
+			).toBeGreaterThanOrEqual(44);
+		}
+	});
+
 	test('die Pflichtangaben stehen in einer eigenen, benannten Gruppe', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 900 });
 		await page.goto('/');

--- a/e2e/navbar-structure.spec.ts
+++ b/e2e/navbar-structure.spec.ts
@@ -1,0 +1,213 @@
+import { expect, test, type Page } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+import { formatRatio, measureContrast } from './helpers/contrast';
+
+/**
+ * navbar-structure.spec.ts — die TopBar bleibt einzeilig, auch als Admin.
+ *
+ * **Der Bug:** DaisyUI gibt `.navbar-end` fest `width: 50%`, und `.menu` ist
+ * `flex-flow: column wrap` — `menu-horizontal` dreht nur die Richtung, das
+ * `wrap` bleibt. Die sieben Admin-Links mussten damit in die halbe
+ * Containerbreite, während die Logo-Seite die andere Hälfte fast leer ließ.
+ * Zwischen 1024px und 1440px brach das Menü in eine zweite Zeile um; der
+ * Header wuchs von 66px auf 99px und schob den Seiteninhalt nach unten.
+ *
+ * Zwei Ursachen, zwei Zusicherungen:
+ *  1. Die 50%-Fessel ist weg (`w-auto`) — der Test misst die Zeilenzahl.
+ *  2. Die oberste Ebene trägt nur noch die Produkt-Navigation; Admin-Ziele
+ *     liegen in einer Gruppe. Der Test zählt die Einträge, damit ein achter
+ *     Link nicht unbemerkt wieder in die Zeile gedrückt wird.
+ *
+ * Zugang über `seedAdminSession` (dort steht, warum nicht über Auth0).
+ */
+
+/* Unterhalb von lg (1024px) übernimmt der Burger — darüber sind das die
+   Breiten, bei denen der Umbruch auftrat, plus eine schmale Reserve. */
+const DESKTOP_BREITEN = [1024, 1280, 1440] as const;
+
+async function menueZeilen(page: Page): Promise<number> {
+	return page.evaluate(() => {
+		const menu = document.querySelector('header ul.menu-horizontal');
+		if (!menu) throw new Error('Desktop-Menü nicht gefunden');
+		const oberkanten = Array.from(menu.children).map((li) =>
+			Math.round(li.getBoundingClientRect().top)
+		);
+		return new Set(oberkanten).size;
+	});
+}
+
+test.describe('TopBar — Struktur und Umbruchfreiheit', () => {
+	test('als Admin bleibt das Menü auf allen Desktop-Breiten einzeilig', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			for (const breite of DESKTOP_BREITEN) {
+				await page.setViewportSize({ width: breite, height: 900 });
+				await page.goto('/');
+				await expect(page.locator('header ul.menu-horizontal')).toBeVisible();
+
+				expect(await menueZeilen(page), `Menü bricht bei ${breite}px um`).toBe(1);
+			}
+		} finally {
+			await context.close();
+		}
+	});
+
+	test('die oberste Menüebene trägt die Produkt-Navigation plus eine Admin-Gruppe', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/');
+			const menu = page.locator('header ul.menu-horizontal');
+
+			/* Vier statt sieben: Meldung, Karte, Bestimmungshilfe + „Verwaltung".
+			   API-Docs sind kein Ziel für Museumsbesuchende und stehen als
+			   „Dokumentation" weiterhin im Footer. */
+			await expect(menu.locator('> li')).toHaveCount(4);
+			await expect(menu.getByRole('link', { name: 'Meldung' })).toBeVisible();
+			await expect(menu.getByRole('link', { name: 'Karte' })).toBeVisible();
+			await expect(menu.getByRole('link', { name: 'Bestimmungshilfe' })).toBeVisible();
+			await expect(menu.getByRole('link', { name: 'API-Docs' })).toHaveCount(0);
+
+			/* Die drei Admin-Ziele sind erreichbar — aber erst nach dem Aufklappen,
+			   damit sie die oberste Ebene nicht mehr belasten. */
+			/* `getByRole('group', { name })` greift hier nicht: `<details>` bildet auf
+			   `group` ab, bekommt aus dem `<summary>` aber keinen Accessible Name —
+			   „Verwaltung" ist Textinhalt, nicht Name. Geprüft wird deshalb die
+			   einzige Gruppe im Menü samt ihrer Beschriftung. */
+			const gruppe = menu.getByRole('group');
+			await expect(gruppe).toBeVisible();
+			await expect(gruppe).toContainText('Verwaltung');
+			await expect(gruppe.getByRole('link', { name: 'Sichtungen' })).toBeHidden();
+
+			await gruppe.locator('summary').click();
+			await expect(gruppe.getByRole('link', { name: 'Sichtungen' })).toBeVisible();
+			await expect(gruppe.getByRole('link', { name: 'Statistiken' })).toBeVisible();
+			await expect(gruppe.getByRole('link', { name: 'Einstellungen' })).toBeVisible();
+		} finally {
+			await context.close();
+		}
+	});
+
+	/**
+	 * Die Gruppe in der TopBar ist der Einstieg von außen. Innerhalb der
+	 * Verwaltung wäre sie der falsche Weg: Wer zwischen den drei Seiten
+	 * wechselt, bräuchte pro Wechsel zwei Klicks (aufklappen, wählen). Die
+	 * Unternavigation macht daraus einen.
+	 */
+	test('der Admin-Bereich trägt eine eigene Unternavigation mit aktiver Seite', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/admin/statistics');
+			const unternav = page.getByRole('navigation', { name: 'Verwaltung' });
+
+			await expect(unternav.getByRole('link', { name: 'Sichtungen' })).toBeVisible();
+			await expect(unternav.getByRole('link', { name: 'Statistiken' })).toBeVisible();
+			await expect(unternav.getByRole('link', { name: 'Einstellungen' })).toBeVisible();
+
+			/* aria-current statt einer reinen Farbklasse: Screenreader müssen die
+			   aktive Seite ebenso erkennen wie das Auge. */
+			await expect(unternav.getByRole('link', { name: 'Statistiken' })).toHaveAttribute(
+				'aria-current',
+				'page'
+			);
+			await expect(unternav.getByRole('link', { name: 'Sichtungen' })).not.toHaveAttribute(
+				'aria-current',
+				'page'
+			);
+
+			await unternav.getByRole('link', { name: 'Einstellungen' }).click();
+			await expect(page).toHaveURL(/\/admin\/settings$/);
+			await expect(unternav.getByRole('link', { name: 'Einstellungen' })).toHaveAttribute(
+				'aria-current',
+				'page'
+			);
+		} finally {
+			await context.close();
+		}
+	});
+
+	/**
+	 * DaisyUI färbt inaktive Reiter mit
+	 * `color-mix(in oklab, var(--color-base-content) 50%, transparent)` — fest
+	 * verdrahtet, ohne Theme-Variable. Auf `base-100` sind das gemessene
+	 * 3,54:1 und damit unter WCAG 1.4.3; es ist exakt die `/50`-Zeile aus der
+	 * Deckkraft-Tabelle in `design-system.md`, die dort als unzulässig steht.
+	 * `app.css` hebt die Stufe deshalb auf `/70` an (7,04:1).
+	 *
+	 * Die Messung muss im Browser laufen: `oklch()` und `color-mix(in oklab, …)`
+	 * sind erst nach dem Gamut-Mapping nach sRGB als Kontrastwert lesbar.
+	 */
+	test('inaktive Reiter der Unternavigation erfüllen WCAG AA', async ({ browser, baseURL }) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/admin/statistics');
+			await expect(page.getByRole('navigation', { name: 'Verwaltung' })).toBeVisible();
+
+			const [inaktiv, aktiv] = await measureContrast(page, [
+				{
+					name: 'inaktiver Reiter',
+					selector: 'nav[aria-label="Verwaltung"] a:not([aria-current])',
+					backdrop: 'var(--color-base-100)'
+				},
+				{
+					name: 'aktiver Reiter',
+					selector: 'nav[aria-label="Verwaltung"] a[aria-current]',
+					backdrop: 'var(--color-base-100)'
+				}
+			]);
+
+			expect(
+				inaktiv.ratio,
+				`inaktiver Reiter: ${formatRatio(inaktiv.ratio)}:1 (${inaktiv.foreground} auf ${inaktiv.background})`
+			).toBeGreaterThanOrEqual(4.5);
+
+			/* Der Override darf nicht über sein Ziel hinausschießen: ohne
+			   `:not(.tab-active)` schlägt er auch DaisyUIs Aktiv-Regel, beide
+			   Reiter messen dann denselben Wert und der Farbunterschied ist weg. */
+			expect(
+				aktiv.ratio,
+				`aktiver Reiter (${formatRatio(aktiv.ratio)}:1) muss kräftiger sein als der inaktive (${formatRatio(inaktiv.ratio)}:1)`
+			).toBeGreaterThan(inaktiv.ratio);
+		} finally {
+			await context.close();
+		}
+	});
+
+	test('ohne Admin-Rechte gibt es keine Verwaltungsgruppe', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/');
+
+		const menu = page.locator('header ul.menu-horizontal');
+		await expect(menu.locator('> li')).toHaveCount(3);
+		await expect(menu.getByRole('group')).toHaveCount(0);
+		expect(await menueZeilen(page)).toBe(1);
+	});
+});

--- a/e2e/navbar-structure.spec.ts
+++ b/e2e/navbar-structure.spec.ts
@@ -54,6 +54,16 @@ test.describe('TopBar — Struktur und Umbruchfreiheit', () => {
 				await expect(page.locator('header ul.menu-horizontal')).toBeVisible();
 
 				expect(await menueZeilen(page), `Menü bricht bei ${breite}px um`).toBe(1);
+
+				/* `flex-nowrap` verhindert den Umbruch — der Ersatz-Fehlerfall wäre
+				   ein Dokument breiter als das Fenster, also die seitlich
+				   verschiebbare Seite, gegen die `footer-layout.spec.ts` schützt.
+				   Dieser Test ist der einzige mit Admin-Menü und muss sie deshalb
+				   hier mitprüfen. */
+				const ueberlauf = await page.evaluate(
+					() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+				);
+				expect(ueberlauf, `horizontaler Überlauf bei ${breite}px`).toBeLessThanOrEqual(0);
 			}
 		} finally {
 			await context.close();
@@ -144,6 +154,37 @@ test.describe('TopBar — Struktur und Umbruchfreiheit', () => {
 				'aria-current',
 				'page'
 			);
+		} finally {
+			await context.close();
+		}
+	});
+
+	/**
+	 * DaisyUI setzt `.tab { height: calc(var(--size-field) * 10) }` — eine feste
+	 * `height` von 40px, die Inhalt nicht aufziehen kann. Der zentrale
+	 * Touch-Target-Block in `app.css` zielte auf `.btn` und die Control-Labels
+	 * und ließ `.tab` aus; der Reiter unterschritt damit die 44px aus
+	 * `design-system.md`, im Feldmodus um 16px.
+	 */
+	test('die Reiter der Unternavigation erfüllen das 44px-Ziel', async ({ browser, baseURL }) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/admin/statistics');
+			const reiter = page.getByRole('navigation', { name: 'Verwaltung' }).getByRole('link');
+			await expect(reiter.first()).toBeVisible();
+
+			for (const einzeln of await reiter.all()) {
+				const kasten = await einzeln.boundingBox();
+				expect(
+					kasten?.height ?? 0,
+					`Reiter „${await einzeln.innerText()}" ist nur ${Math.round(kasten?.height ?? 0)}px hoch`
+				).toBeGreaterThanOrEqual(44);
+			}
 		} finally {
 			await context.close();
 		}

--- a/src/app.css
+++ b/src/app.css
@@ -260,6 +260,25 @@ h6 {
 	border-left-width: 4px;
 }
 
+/* Reiter: inaktive Beschriftung von /50 auf /70.
+   DaisyUI setzt dafür fest
+   `color-mix(in oklab, var(--color-base-content) 50%, transparent)` — ohne
+   Theme-Variable, also nur per Override erreichbar. Auf base-100 sind das im
+   Browser gemessene 3,54:1 und damit unter WCAG 1.4.3; es ist genau die
+   /50-Zeile aus der Deckkraft-Tabelle in design-system.md, die dort als
+   unzulässig steht. /70 misst 7,04:1 und hält den Reiter trotzdem sichtbar
+   schwächer als den aktiven (16,50:1).
+   Ungelayert, gewinnt damit gegen DaisyUIs @layer utilities — sonst käme die
+   Regel gegen `.tab:is(.tabs > .tab)` (0,2,0) nicht an.
+
+   `:not(.tab-active)` ist nicht kosmetisch: Ohne die Einschränkung schlägt der
+   Override auch DaisyUIs Aktiv-Regel, und der aktive Reiter verliert seinen
+   Farbunterschied — er bliebe nur noch am Unterstrich erkennbar.
+   Abgesichert in e2e/navbar-structure.spec.ts. */
+.tabs > .tab:not(.tab-active) {
+	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
+}
+
 /* Enhanced form focus - WCAG AA konform.
    Ungelayert, gewinnt damit gegen DaisyUIs @layer utilities. */
 .input:focus,

--- a/src/app.css
+++ b/src/app.css
@@ -213,9 +213,16 @@ body {
 }
 
 /* Im eingebetteten Zustand trägt die Elternseite die Marke — die App darf
-   keine zweite Navigation und keine zweite Wortmarke zeigen. */
+   keine zweite Navigation und keine zweite Wortmarke zeigen.
+
+   Das Element, nicht die Klasse: `.footer` sitzt seit der Footer-Neuordnung
+   (2026-08-03) am inneren Raster-`div`, nicht mehr am `<footer>`. Ein Selektor
+   auf die Klasse ließe Fläche, Abstand und die Copyright-Zeile stehen. Heute
+   deckt `{#if isNotIFrame}` den Fall ohnehin ab — diese Regel ist das
+   Sicherheitsnetz für die serverseitige Variante über `data-embed`, die der
+   Kommentar oben offenhält, und muss deshalb selbst tragfähig bleiben. */
 .iframe-mode .navbar,
-.iframe-mode .footer {
+.iframe-mode footer {
 	display: none;
 }
 
@@ -271,11 +278,26 @@ h6 {
    Ungelayert, gewinnt damit gegen DaisyUIs @layer utilities — sonst käme die
    Regel gegen `.tab:is(.tabs > .tab)` (0,2,0) nicht an.
 
-   `:not(.tab-active)` ist nicht kosmetisch: Ohne die Einschränkung schlägt der
-   Override auch DaisyUIs Aktiv-Regel, und der aktive Reiter verliert seinen
-   Farbunterschied — er bliebe nur noch am Unterstrich erkennbar.
+   Die Ausschlussliste ist nicht kosmetisch, sie spiegelt DaisyUIs eigene:
+   - `.tab-active` und die vier ARIA-/Checked-Varianten sind dort gleichwertig
+     „aktiv". Ohne sie schlägt der Override auch die Aktiv-Regel, und der
+     aktive Reiter verliert seinen Farbunterschied — er bliebe nur noch am
+     Unterstrich erkennbar.
+   - `:hover` nimmt DaisyUI ausdrücklich von der Abdunklung aus und setzt
+     daneben `color: var(--color-base-content)`. Der ungelayerte Override
+     gewinnt gegen beides; `tabs-border` animiert nur `--tab-border-color`,
+     das für inaktive Reiter konstant base-300 ist. Übrig bliebe gar keine
+     Hover-Rückmeldung.
    Abgesichert in e2e/navbar-structure.spec.ts. */
-.tabs > .tab:not(.tab-active) {
+.tabs
+	> .tab:not(
+		.tab-active,
+		:hover,
+		[aria-current='page'],
+		[aria-selected='true'],
+		:checked,
+		label:has(:checked)
+	) {
 	color: color-mix(in oklab, var(--color-base-content) 70%, transparent);
 }
 
@@ -317,6 +339,14 @@ summary.btn {
 
 .btn-circle:not(.target-exempt) {
 	min-width: var(--target-min);
+}
+
+/* Reiter: DaisyUI setzt `height: calc(var(--size-field) * 10)` — eine feste
+   Höhe von 40px, die Inhalt nicht aufziehen kann; `min-height` klemmt sie
+   korrekt hoch. Ohne diese Regel unterschreitet jeder `tabs`-Eintrag die
+   44px, im Feldmodus um 16px. Abgesichert in e2e/navbar-structure.spec.ts. */
+.tabs > .tab:not(.target-exempt) {
+	min-height: var(--target-min);
 }
 
 /* Checkbox, Radio und Toggle über --size statt über min-height.

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -21,13 +21,19 @@
 			äußere Spaltenanordnung aber unberührt — die kommt aus `footer-center`
 			selbst. Abgesichert in `e2e/footer-layout.spec.ts`.
 		-->
+		<!--
+			`aria-labelledby` statt `aria-label`: Der Gruppenname steht ohnehin als
+			sichtbare Überschrift da, und zwei Quellen für denselben String laufen
+			auseinander. Der Accessible Name bleibt identisch — die E2E-Tests
+			greifen die Gruppen weiterhin über ihn ab.
+		-->
 		<div class="footer sm:footer-horizontal container mx-auto p-6 sm:p-8">
-			<nav aria-label="Navigation">
-				<h2 class="footer-title">Navigation</h2>
-				<a href="/" class="link link-hover py-1.5">Meldung</a>
-				<a href="/map" class="link link-hover py-1.5">Sichtungskarte</a>
-				<a href="/bestimmungshilfe" class="link link-hover py-1.5">Bestimmungshilfe</a>
-				<a href="/about" class="link link-hover py-1.5">Über uns</a>
+			<nav aria-labelledby="footer-navigation">
+				<h2 id="footer-navigation" class="footer-title">Navigation</h2>
+				<a href="/" class="link link-hover py-3">Meldung</a>
+				<a href="/map" class="link link-hover py-3">Sichtungskarte</a>
+				<a href="/bestimmungshilfe" class="link link-hover py-3">Bestimmungshilfe</a>
+				<a href="/about" class="link link-hover py-3">Über uns</a>
 			</nav>
 
 			<!--
@@ -46,30 +52,30 @@
 				Seit 2026-08-03 stehen sie in einer eigenen Gruppe statt auf Platz 5 und
 				6 einer Linkzeile — auffindbar ist Teil der Pflicht.
 			-->
-			<nav aria-label="Rechtliches">
-				<h2 class="footer-title">Rechtliches</h2>
+			<nav aria-labelledby="footer-rechtliches">
+				<h2 id="footer-rechtliches" class="footer-title">Rechtliches</h2>
 				<a
 					href="https://www.deutsches-meeresmuseum.de/impressum"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="link link-hover py-1.5">Impressum</a
+					class="link link-hover py-3">Impressum</a
 				>
 				<a
 					href="https://www.deutsches-meeresmuseum.de/datenschutz"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="link link-hover py-1.5">Datenschutz</a
+					class="link link-hover py-3">Datenschutz</a
 				>
 			</nav>
 
-			<nav aria-label="Projekt">
-				<h2 class="footer-title">Projekt</h2>
-				<a href="/docs" class="link link-hover py-1.5">Dokumentation</a>
+			<nav aria-labelledby="footer-projekt">
+				<h2 id="footer-projekt" class="footer-title">Projekt</h2>
+				<a href="/docs" class="link link-hover py-3">Dokumentation</a>
 				<a
 					href="https://github.com/jansinger/ostsee-tiere"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="link link-hover inline-flex items-center gap-2 py-1.5"
+					class="link link-hover inline-flex items-center gap-2 py-3"
 				>
 					<Icon icon="lucide:github" width="16" height="16" aria-hidden="true" />
 					GitHub
@@ -78,7 +84,7 @@
 					href="https://deutsches-meeresmuseum.de"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="link link-hover py-1.5">Deutsches Meeresmuseum</a
+					class="link link-hover py-3">Deutsches Meeresmuseum</a
 				>
 			</nav>
 		</div>

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -1,88 +1,97 @@
-<script>
-	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
+<script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
+	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 </script>
 
 <!-- Footer with navigation (versteckt in iFrame) -->
 {#if isNotIFrame}
-	<footer class="footer footer-center bg-base-200 text-base-content mt-8 rounded-t-lg p-4 sm:p-6">
-		<!-- Navigation Links — umbrechende Flexbox, kein Grid -->
+	<footer class="bg-base-200 text-base-content mt-8 rounded-t-lg">
 		<!--
-			Bewusst KEIN `md:grid md:grid-flow-col`: Das zwang die fünf Links ab 768px
-			in eine einzige Grid-Zeile, die nicht umbrechen kann. Zwischen 768 und
-			~890px passte sie nicht mehr — das Dokument wurde dadurch breiter als der
-			Viewport (gemessen 891px bei 768px Breite), die ganze Seite ließ sich
-			seitlich schieben und der Schritt-Stepper darüber wurde mit angeschnitten.
-			`flex flex-wrap` trägt jede Breite und braucht keine Ausnahme.
+			`footer sm:footer-horizontal` statt `footer-center`.
+
+			`footer-center` ist in DaisyUI 5 auf JEDEM Breakpoint
+			`grid-auto-flow: column dense` — es gibt dazu keine responsive Variante.
+			Die drei Blöcke standen deshalb auch auf 390px nebeneinander, jeder rund
+			130px breit, und die Linkliste wurde darin zu einer sechszeiligen Spalte
+			gequetscht. Umgekehrt drängten sich auf 1280px dieselben Links zweizeilig
+			ins linke Drittel, während rechts Platz frei blieb.
+
+			Ein früherer Anlauf (2026-07-30) hatte nur das `md:grid-flow-col` der
+			inneren `<nav>` entfernt. Das behob den horizontalen Überlauf, ließ die
+			äußere Spaltenanordnung aber unberührt — die kommt aus `footer-center`
+			selbst. Abgesichert in `e2e/footer-layout.spec.ts`.
 		-->
-		<nav class="flex flex-wrap justify-center gap-2 sm:gap-4">
-			<a href="/about" class="link link-hover text-sm sm:text-base">Über uns</a>
-			<a href="/docs" class="link link-hover text-sm sm:text-base">Dokumentation</a>
-			<a href="/map" class="link link-hover text-sm sm:text-base">Sichtungskarte</a>
-			<a href="/bestimmungshilfe" class="link link-hover text-sm sm:text-base">Bestimmungshilfe</a>
+		<div class="footer sm:footer-horizontal container mx-auto p-6 sm:p-8">
+			<nav aria-label="Navigation">
+				<h2 class="footer-title">Navigation</h2>
+				<a href="/" class="link link-hover py-1.5">Meldung</a>
+				<a href="/map" class="link link-hover py-1.5">Sichtungskarte</a>
+				<a href="/bestimmungshilfe" class="link link-hover py-1.5">Bestimmungshilfe</a>
+				<a href="/about" class="link link-hover py-1.5">Über uns</a>
+			</nav>
+
 			<!--
-				Anbieterkennzeichnung nach § 5 DDG und Datenschutzhinweis nach Art. 13 DSGVO.
-				Beides fehlte bis 2026-07-30 vollständig: es gab weder eine Route noch einen
-				Link, und unter eigener Domain deckt die iframe-Einbettung auf
+				Anbieterkennzeichnung nach § 5 DDG und Datenschutzhinweis nach Art. 13
+				DSGVO. Beides fehlte bis 2026-07-30 vollständig: es gab weder eine Route
+				noch einen Link, und unter eigener Domain deckt die iframe-Einbettung auf
 				meeresmuseum.de die Pflicht nicht ab.
 
-				Verlinkt werden bewusst die Seiten des Betreibers (Deutsches Meeresmuseum)
-				statt einer eigenen Kopie — eine zweite, separat zu pflegende Fassung
-				derselben Rechtstexte würde nur auseinanderlaufen. „Ständig verfügbar" ist
-				gegeben, weil dieser Footer auf jeder Seite steht; im iframe-Modus ist er
-				ausgeblendet, dort trägt die einbettende Seite ihre eigene Kennzeichnung.
-			-->
-			<a
-				href="https://www.deutsches-meeresmuseum.de/impressum"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="link link-hover text-sm sm:text-base">Impressum</a
-			>
-			<a
-				href="https://www.deutsches-meeresmuseum.de/datenschutz"
-				target="_blank"
-				rel="noopener noreferrer"
-				class="link link-hover text-sm sm:text-base">Datenschutz</a
-			>
-		</nav>
+				Verlinkt werden bewusst die Seiten des Betreibers (Deutsches
+				Meeresmuseum) statt einer eigenen Kopie — eine zweite, separat zu
+				pflegende Fassung derselben Rechtstexte würde nur auseinanderlaufen.
+				„Ständig verfügbar" ist gegeben, weil dieser Footer auf jeder Seite
+				steht; im iframe-Modus ist er ausgeblendet, dort trägt die einbettende
+				Seite ihre eigene Kennzeichnung.
 
-		<!-- External Links - Stack on Mobile, Inline on Desktop -->
-		<nav>
-			<div class="flex flex-col gap-2 sm:flex-row sm:gap-4">
+				Seit 2026-08-03 stehen sie in einer eigenen Gruppe statt auf Platz 5 und
+				6 einer Linkzeile — auffindbar ist Teil der Pflicht.
+			-->
+			<nav aria-label="Rechtliches">
+				<h2 class="footer-title">Rechtliches</h2>
+				<a
+					href="https://www.deutsches-meeresmuseum.de/impressum"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="link link-hover py-1.5">Impressum</a
+				>
+				<a
+					href="https://www.deutsches-meeresmuseum.de/datenschutz"
+					target="_blank"
+					rel="noopener noreferrer"
+					class="link link-hover py-1.5">Datenschutz</a
+				>
+			</nav>
+
+			<nav aria-label="Projekt">
+				<h2 class="footer-title">Projekt</h2>
+				<a href="/docs" class="link link-hover py-1.5">Dokumentation</a>
 				<a
 					href="https://github.com/jansinger/ostsee-tiere"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="btn btn-ghost btn-xs sm:btn-sm text-xs sm:text-sm"
-					aria-label="GitHub Repository"
+					class="link link-hover inline-flex items-center gap-2 py-1.5"
 				>
-					<Icon icon="lucide:github" width="16" height="16" class="h-3 w-3 sm:h-5 sm:w-5" />
-					<span class="xs:inline hidden">GitHub</span>
-					<span class="xs:hidden">Code</span>
+					<Icon icon="lucide:github" width="16" height="16" aria-hidden="true" />
+					GitHub
 				</a>
 				<a
 					href="https://deutsches-meeresmuseum.de"
 					target="_blank"
 					rel="noopener noreferrer"
-					class="btn btn-ghost btn-xs sm:btn-sm text-xs sm:text-sm"
+					class="link link-hover py-1.5">Deutsches Meeresmuseum</a
 				>
-					<span class="hidden sm:inline">Deutsches Meeresmuseum</span>
-					<span class="sm:hidden">Meeresmuseum</span>
-				</a>
-			</div>
-		</nav>
+			</nav>
+		</div>
 
-		<!-- Copyright - Mobile Optimized -->
-		<aside class="text-center">
-			<p class="text-xs opacity-70 sm:text-sm">
-				© 2025–2026
-				<span class="hidden sm:inline">Deutsches Meeresmuseum, Stralsund, Deutschland</span>
-				<span class="sm:hidden">Deutsches Meeresmuseum</span>
-			</p>
-			<p class="mt-1 text-xs opacity-70">
-				<span class="hidden sm:inline">Meldeplattform für Meerestiere in der Ostsee</span>
-				<span class="sm:hidden">Ostsee Sichtungen</span>
-			</p>
-		</aside>
+		<!-- Copyright als eigene Zeile über die volle Breite, nicht als dritte
+		     Spalte: es ist keine Navigation und konkurrierte dort mit den Links. -->
+		<div class="border-base-300 border-t">
+			<div class="container mx-auto px-6 py-4 sm:px-8">
+				<p class="text-base-content/70 text-support">
+					© 2025–2026 Deutsches Meeresmuseum, Stralsund, Deutschland · Meldeplattform für
+					Meerestiere in der Ostsee
+				</p>
+			</div>
+		</div>
 	</footer>
 {/if}

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -3,6 +3,7 @@
 	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
+	import { ADMIN_BEREICHE, istAdminPfad } from '$lib/config/adminNav';
 	import type { PublicUser } from '$lib/types/User';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 	import OstseeTiereLogo from './OstseeTiereLogo.svelte';
@@ -13,9 +14,9 @@
 
 	const currentPath = $derived(page.url.pathname);
 
-	/* Detailseiten (/admin/123) gehören zur Sichtungsverwaltung, nicht zu
-	   Statistiken oder Einstellungen — deshalb kein reines `startsWith`. */
-	const istAdminBereich = $derived(currentPath === '/admin' || currentPath.startsWith('/admin/'));
+	/* Die Gruppe fasst den ganzen Verwaltungs-Teilbaum zusammen — welcher der
+	   drei Bereiche darin aktiv ist, zeigt erst die Unternavigation. */
+	const istAdminBereich = $derived(istAdminPfad(currentPath));
 
 	let mobileMenuElement = $state<HTMLDetailsElement | null>(null);
 	let adminMenuElement = $state<HTMLDetailsElement | null>(null);
@@ -50,22 +51,13 @@
 {/snippet}
 
 {#snippet adminItems()}
-	<li>
-		<a href="/admin" class={currentPath === '/admin' ? 'active font-medium' : ''}> Sichtungen </a>
-	</li>
-	<li>
-		<a
-			href="/admin/statistics"
-			class={currentPath === '/admin/statistics' ? 'active font-medium' : ''}
-		>
-			Statistiken
-		</a>
-	</li>
-	<li>
-		<a href="/admin/settings" class={currentPath === '/admin/settings' ? 'active font-medium' : ''}>
-			Einstellungen
-		</a>
-	</li>
+	{#each ADMIN_BEREICHE as bereich (bereich.href)}
+		<li>
+			<a href={bereich.href} class={currentPath === bereich.href ? 'active font-medium' : ''}>
+				{bereich.label}
+			</a>
+		</li>
+	{/each}
 {/snippet}
 
 {#if isNotIFrame}
@@ -112,7 +104,13 @@
 										<summary class={istAdminBereich ? 'active font-medium' : ''}>
 											Verwaltung
 										</summary>
-										<ul class="rounded-box bg-base-100 z-50 w-52 p-2 shadow">
+										<!-- Kein eigenes `z-*`: Der Header trägt bereits einen
+										     z-index und bildet damit einen Stacking-Context —
+										     alles darin liegt über dem Seiteninhalt. Freie
+										     `z-*`-Utilities verbietet design-system.md, und ein
+										     Token wäre hier eine Zahl ohne Wirkung. Schatten aus
+										     dem Token, nicht aus DaisyUIs `shadow`. -->
+										<ul class="rounded-box bg-base-100 shadow-floating w-52 p-2">
 											{@render adminItems()}
 										</ul>
 									</details>
@@ -121,7 +119,7 @@
 						</ul>
 
 						<!-- User Menu - Desktop -->
-						<UserMenu user={user || null} position="right" />
+						<UserMenu {user} />
 					</div>
 
 					<!-- Mobile menu -->
@@ -147,7 +145,7 @@
 
 							<!-- User Menu - Mobile -->
 							<div class="divider my-2"></div>
-							<UserMenuMobile user={user || null} />
+							<UserMenuMobile {user} />
 						</ul>
 					</details>
 				</div>

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -13,7 +13,12 @@
 
 	const currentPath = $derived(page.url.pathname);
 
+	/* Detailseiten (/admin/123) gehören zur Sichtungsverwaltung, nicht zu
+	   Statistiken oder Einstellungen — deshalb kein reines `startsWith`. */
+	const istAdminBereich = $derived(currentPath === '/admin' || currentPath.startsWith('/admin/'));
+
 	let mobileMenuElement = $state<HTMLDetailsElement | null>(null);
+	let adminMenuElement = $state<HTMLDetailsElement | null>(null);
 
 	// Close mobile menu when navigating (SvelteKit client-side navigation keeps component mounted)
 	$effect(() => {
@@ -21,14 +26,16 @@
 		if (mobileMenuElement?.open) {
 			mobileMenuElement.open = false;
 		}
+		if (adminMenuElement?.open) {
+			adminMenuElement.open = false;
+		}
 	});
 </script>
 
-{#snippet menuitems()}
+{#snippet publicItems()}
 	<li>
 		<a href="/" class={currentPath === '/' ? 'active font-medium' : ''}> Meldung </a>
 	</li>
-
 	<li>
 		<a href="/map" class={currentPath === '/map' ? 'active font-medium' : ''}> Karte </a>
 	</li>
@@ -40,29 +47,24 @@
 			Bestimmungshilfe
 		</a>
 	</li>
-	{#if isAdmin}
-		<li>
-			<a href="/admin" class={currentPath === '/admin' ? 'active font-medium' : ''}> Verwalten </a>
-		</li>
-		<li>
-			<a
-				href="/admin/statistics"
-				class={currentPath === '/admin/statistics' ? 'active font-medium' : ''}
-			>
-				Statistiken
-			</a>
-		</li>
-		<li>
-			<a
-				href="/admin/settings"
-				class={currentPath === '/admin/settings' ? 'active font-medium' : ''}
-			>
-				Einstellungen
-			</a>
-		</li>
-	{/if}
+{/snippet}
+
+{#snippet adminItems()}
 	<li>
-		<a href="/docs" class={currentPath.includes('/docs') ? 'active font-medium' : ''}> API-Docs </a>
+		<a href="/admin" class={currentPath === '/admin' ? 'active font-medium' : ''}> Sichtungen </a>
+	</li>
+	<li>
+		<a
+			href="/admin/statistics"
+			class={currentPath === '/admin/statistics' ? 'active font-medium' : ''}
+		>
+			Statistiken
+		</a>
+	</li>
+	<li>
+		<a href="/admin/settings" class={currentPath === '/admin/settings' ? 'active font-medium' : ''}>
+			Einstellungen
+		</a>
 	</li>
 {/snippet}
 
@@ -70,15 +72,23 @@
 	<!-- Fixed Navbar -->
 	<header class="bg-base-200/95 sticky top-0 z-50 shadow-md backdrop-blur-lg">
 		<div class="container mx-auto">
-			<div class="navbar">
-				<div class="navbar-start">
+			<!--
+				`justify-between` + `w-auto` an beiden Seiten ersetzt DaisyUIs feste
+				50/50-Teilung. Die kostete die Menüseite die Hälfte der Containerbreite,
+				während die Logoseite ihre Hälfte fast leer ließ — und weil `.menu`
+				`flex-flow: column wrap` ist (`menu-horizontal` dreht nur die Richtung),
+				brach das Menü darin still in eine zweite Zeile um, statt breiter zu
+				werden. Abgesichert in `e2e/navbar-structure.spec.ts`.
+			-->
+			<div class="navbar justify-between">
+				<div class="navbar-start w-auto">
 					<OstseeTiereLogo size="sm" showText={true} className="ml-2" />
-					<span class="divider divider-horizontal mx-2"></span>
 					{#if isAdmin}
+						<span class="divider divider-horizontal mx-2"></span>
 						<span class="text-base-content/70 text-lg font-semibold">Admin</span>
 					{/if}
 				</div>
-				<div class="navbar-end gap-2">
+				<div class="navbar-end w-auto gap-2">
 					<!--
 						Sichtbar nur ohne Verbindung — im Normalfall rendert die Komponente
 						nichts und kostet keinen Platz.
@@ -87,12 +97,31 @@
 
 					<!-- Desktop menu -->
 					<div class="hidden lg:flex lg:items-center lg:gap-4">
-						<ul class="menu menu-horizontal px-1">
-							{@render menuitems()}
+						<ul class="menu menu-horizontal flex-nowrap px-1">
+							{@render publicItems()}
+
+							<!--
+								Die drei Verwaltungsziele liegen in einer Gruppe statt einzeln auf
+								der obersten Ebene. Sie richten sich an eine andere Zielgruppe als
+								Meldung/Karte/Bestimmungshilfe, und sieben gleichrangige Links
+								waren genau die Last, die den Umbruch auslöste.
+							-->
+							{#if isAdmin}
+								<li>
+									<details bind:this={adminMenuElement}>
+										<summary class={istAdminBereich ? 'active font-medium' : ''}>
+											Verwaltung
+										</summary>
+										<ul class="rounded-box bg-base-100 z-50 w-52 p-2 shadow">
+											{@render adminItems()}
+										</ul>
+									</details>
+								</li>
+							{/if}
 						</ul>
 
 						<!-- User Menu - Desktop -->
-						<UserMenu user={user || null} position="right" {isAdmin} />
+						<UserMenu user={user || null} position="right" />
 					</div>
 
 					<!-- Mobile menu -->
@@ -103,11 +132,22 @@
 						<ul
 							class="dropdown-content menu menu-sm rounded-box bg-base-100 absolute right-0 z-50 mt-3 w-52 p-2 shadow"
 						>
-							{@render menuitems()}
+							{@render publicItems()}
+
+							<!--
+								Im Burger-Menü stehen die Verwaltungsziele flach unter einer
+								Überschrift statt in einem zweiten Aufklapper: Platz ist hier
+								nicht knapp, und ein `details` im `details` kostet einen Tipp
+								mehr ohne Gegenwert.
+							-->
+							{#if isAdmin}
+								<li class="menu-title">Verwaltung</li>
+								{@render adminItems()}
+							{/if}
 
 							<!-- User Menu - Mobile -->
 							<div class="divider my-2"></div>
-							<UserMenuMobile user={user || null} {isAdmin} />
+							<UserMenuMobile user={user || null} />
 						</ul>
 					</details>
 				</div>

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -2,14 +2,16 @@
 	import type { PublicUser } from '$lib/types/User';
 	import Icon from '$lib/components/Icon.svelte';
 
+	/* `isAdmin` ist hier bewusst weggefallen: Das Menü führte einen Eintrag
+	   „Admin-Bereich" auf /admin, den die TopBar seit 2026-08-03 als Gruppe
+	   „Verwaltung → Sichtungen" trägt. Zwei Wege zum selben Ziel, einer davon
+	   hinter dem Profilbild versteckt — das Profilmenü ist für das Konto da. */
 	let {
 		user,
-		position = 'right',
-		isAdmin = false
+		position = 'right'
 	}: {
 		user: PublicUser | null;
 		position?: 'left' | 'right';
-		isAdmin?: boolean;
 	} = $props();
 
 	let detailsElement = $state<HTMLDetailsElement | null>(null);
@@ -99,17 +101,6 @@
 
 			<!-- Menu Items -->
 			<div class="py-2">
-				{#if isAdmin}
-					<a
-						href="/admin"
-						class="hover:bg-base-200 flex items-center gap-2 rounded px-4 py-2"
-						onclick={closeMenu}
-					>
-						<Icon icon="lucide:settings" width="16" class="h-4 w-4" />
-						Admin-Bereich
-					</a>
-				{/if}
-
 				<a
 					href="/api/auth/logout"
 					class="text-error hover:bg-error/10 flex items-center gap-2 rounded px-4 py-2"

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -5,14 +5,12 @@
 	/* `isAdmin` ist hier bewusst weggefallen: Das Menü führte einen Eintrag
 	   „Admin-Bereich" auf /admin, den die TopBar seit 2026-08-03 als Gruppe
 	   „Verwaltung → Sichtungen" trägt. Zwei Wege zum selben Ziel, einer davon
-	   hinter dem Profilbild versteckt — das Profilmenü ist für das Konto da. */
-	let {
-		user,
-		position = 'right'
-	}: {
-		user: PublicUser | null;
-		position?: 'left' | 'right';
-	} = $props();
+	   hinter dem Profilbild versteckt — das Profilmenü ist für das Konto da.
+
+	   `position` ebenso: Der Default war 'right', die einzige Aufrufstelle
+	   setzte genau das noch einmal explizit. Eine Wahlmöglichkeit, die nie
+	   jemand gewählt hat. */
+	let { user }: { user: PublicUser | null } = $props();
 
 	let detailsElement = $state<HTMLDetailsElement | null>(null);
 
@@ -47,10 +45,7 @@
 </script>
 
 {#if user}
-	<details
-		bind:this={detailsElement}
-		class="dropdown {position === 'right' ? 'dropdown-end' : 'dropdown-start'}"
-	>
+	<details bind:this={detailsElement} class="dropdown dropdown-end">
 		<!-- User Picture Button -->
 		<summary class="btn btn-ghost btn-circle" aria-label="Benutzer-Menü">
 			{#if user.picture}

--- a/src/lib/components/UserMenuMobile.svelte
+++ b/src/lib/components/UserMenuMobile.svelte
@@ -2,13 +2,10 @@
 	import type { PublicUser } from '$lib/types/User';
 	import Icon from '$lib/components/Icon.svelte';
 
-	let {
-		user,
-		isAdmin = false
-	}: {
-		user: PublicUser | null;
-		isAdmin?: boolean;
-	} = $props();
+	/* `isAdmin` ist hier bewusst weggefallen — Begründung in `UserMenu.svelte`:
+	   Der Eintrag „Admin-Bereich" dupliziert „Verwaltung → Sichtungen" aus dem
+	   Burger-Menü, das direkt darüber steht. */
+	let { user }: { user: PublicUser | null } = $props();
 </script>
 
 {#if user}
@@ -40,15 +37,6 @@
 	</div>
 
 	<!-- User Menu Items for Mobile -->
-	{#if isAdmin}
-		<li>
-			<a href="/admin" class="flex items-center gap-2">
-				<Icon icon="lucide:settings" width="16" class="h-4 w-4" />
-				Admin-Bereich
-			</a>
-		</li>
-	{/if}
-
 	<li>
 		<a href="/api/auth/logout" class="text-error hover:bg-error/10 flex items-center gap-2">
 			<Icon icon="lucide:log-out" width="16" class="h-4 w-4" />

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -746,8 +746,15 @@
 		</div>
 	{/if}
 
-	<!-- Vollbild-Karte -->
-	<div class="relative h-full w-full">
+	<!-- Vollbild-Karte — `absolute inset-0` statt `h-full w-full`:
+	     Der Container ist seit 2026-08-03 ein Flex-Item (`flex-1`) statt einer
+	     ausgerechneten Höhe. Seine *benutzte* Höhe stimmt damit zwar, seine
+	     berechnete `height` bleibt aber `auto` — und `height: 100%` löst gegen
+	     `auto` zu 0 auf. Die Kette brach still: OpenLayers meldete nur
+	     „No map visible because the map container's width or height are 0",
+	     die Seite blieb leer. `inset-0` hängt sich an den Rand des
+	     positionierten Containers und braucht keine Höhenkette. -->
+	<div class="absolute inset-0">
 		<!--
 			K3: tabindex="0" macht das OL-Target fokussierbar — damit greifen die
 			OpenLayers-Default-Interactions KeyboardPan (Pfeiltasten) und

--- a/src/lib/config/adminNav.test.ts
+++ b/src/lib/config/adminNav.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { ADMIN_BEREICHE, aktiverAdminBereich, istAdminPfad } from './adminNav';
+
+describe('istAdminPfad', () => {
+	it('erkennt den Bereich und seine Unterseiten', () => {
+		expect(istAdminPfad('/admin')).toBe(true);
+		expect(istAdminPfad('/admin/settings')).toBe(true);
+		expect(istAdminPfad('/admin/1234')).toBe(true);
+		expect(istAdminPfad('/admin/ref/AB-12')).toBe(true);
+	});
+
+	it('lässt sich von einem Pfad mit gleichem Präfix nicht täuschen', () => {
+		/* Der Grund für den Schrägstrich in der Implementierung: `/administration`
+		   beginnt mit `/admin`, gehört aber nicht dazu. */
+		expect(istAdminPfad('/administration')).toBe(false);
+		expect(istAdminPfad('/admin-handbuch')).toBe(false);
+	});
+
+	it('erkennt Pfade außerhalb der Verwaltung nicht als Verwaltung', () => {
+		expect(istAdminPfad('/')).toBe(false);
+		expect(istAdminPfad('/map')).toBe(false);
+		expect(istAdminPfad('/docs')).toBe(false);
+	});
+});
+
+describe('aktiverAdminBereich', () => {
+	it('ordnet die drei Bereiche ihrem eigenen Pfad zu', () => {
+		for (const bereich of ADMIN_BEREICHE) {
+			expect(aktiverAdminBereich(bereich.href)).toBe(bereich.href);
+		}
+	});
+
+	it('rechnet Detail- und Referenzseiten der Sichtungsverwaltung zu', () => {
+		/* Ohne diese Zuordnung verlöre die Unternavigation beim Öffnen einer
+		   Sichtung ohne erkennbaren Grund ihre Markierung. */
+		expect(aktiverAdminBereich('/admin/1234')).toBe('/admin');
+		expect(aktiverAdminBereich('/admin/1234/edit')).toBe('/admin');
+		expect(aktiverAdminBereich('/admin/ref/AB-12')).toBe('/admin');
+	});
+
+	it('markiert auf Unterseiten der Statistiken und Einstellungen den richtigen Bereich', () => {
+		expect(aktiverAdminBereich('/admin/statistics')).toBe('/admin/statistics');
+		expect(aktiverAdminBereich('/admin/settings')).toBe('/admin/settings');
+	});
+
+	it('markiert auf /admin/docs keinen Bereich', () => {
+		expect(aktiverAdminBereich('/admin/docs')).toBeNull();
+	});
+
+	it('markiert außerhalb der Verwaltung keinen Bereich', () => {
+		expect(aktiverAdminBereich('/')).toBeNull();
+		expect(aktiverAdminBereich('/map')).toBeNull();
+		expect(aktiverAdminBereich('/administration')).toBeNull();
+	});
+});

--- a/src/lib/config/adminNav.ts
+++ b/src/lib/config/adminNav.ts
@@ -1,0 +1,56 @@
+/**
+ * Die drei Bereiche der Verwaltung — an genau einer Stelle.
+ *
+ * Sie erscheinen zweimal: als Gruppe „Verwaltung" in der TopBar
+ * (`PublicNavbar.svelte`, der Einstieg von außen) und als Unternavigation
+ * innerhalb des Bereichs (`routes/admin/+layout.svelte`, zum Wechseln mit
+ * einem Klick). Beide Listen von Hand zu pflegen hieße, dass eine neue
+ * Sektion an einer der beiden Stellen fehlt — und zwar unbemerkt, weil beide
+ * Ansichten für sich vollständig aussehen.
+ */
+export interface AdminBereich {
+	href: string;
+	label: string;
+}
+
+export const ADMIN_BEREICHE: readonly AdminBereich[] = [
+	{ href: '/admin', label: 'Sichtungen' },
+	{ href: '/admin/statistics', label: 'Statistiken' },
+	{ href: '/admin/settings', label: 'Einstellungen' }
+] as const;
+
+/**
+ * Welcher Bereich zu einem Pfad gehört.
+ *
+ * „Sichtungen" per Ausschluss statt über `pfad === '/admin'`: Detail-,
+ * Bearbeiten- und Referenzseiten (`/admin/123`, `/admin/ref/…`) sind Teil
+ * derselben Aufgabe. Ohne den Ausschluss verlöre die Markierung beim Öffnen
+ * einer Sichtung ohne erkennbaren Grund ihren aktiven Eintrag.
+ *
+ * Die Kehrseite ist bewusst in Kauf genommen: Eine künftige Sektion unter
+ * `/admin/` fällt hier automatisch unter „Sichtungen", bis sie in
+ * `ADMIN_BEREICHE` steht. Deshalb liegt die Zuordnung hier neben der Liste
+ * und nicht in einer der beiden Komponenten — wer die Liste erweitert, sieht
+ * die Regel.
+ */
+export function aktiverAdminBereich(pfad: string): string | null {
+	if (!istAdminPfad(pfad)) return null;
+
+	const treffer = ADMIN_BEREICHE.find(
+		(bereich) => bereich.href !== '/admin' && pfad.startsWith(bereich.href)
+	);
+	if (treffer) return treffer.href;
+
+	/* /admin/docs ist keiner der drei Bereiche — dort ist kein Eintrag aktiv. */
+	return pfad.startsWith('/admin/docs') ? null : '/admin';
+}
+
+/**
+ * Gehört der Pfad zum Verwaltungsbereich?
+ *
+ * Der Schrägstrich in `'/admin/'` ist nicht kosmetisch: `startsWith('/admin')`
+ * allein würde auch `/administration` einschließen.
+ */
+export function istAdminPfad(pfad: string): boolean {
+	return pfad === '/admin' || pfad.startsWith('/admin/');
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,18 +18,38 @@
 		Zum Hauptinhalt springen
 	</a>
 
-	<PublicNavbar user={data.user} isAdmin={data.showAdminMenu} />
+	<!--
+		Kopfbereich und Inhalt bilden zusammen genau einen Viewport (`min-h-dvh`),
+		der Footer steht bewusst AUSSERHALB dieser Box.
 
-	<!-- Maintenance Mode Banner for Admins -->
-	{#if data.maintenanceConfig?.enabled && data.showAdminMenu && isNotIFrame}
-		<div class="container mx-auto px-4 py-2">
-			<MaintenanceBanner isAdmin={true} maintenanceMessage={data.maintenanceConfig.message} />
-		</div>
-	{/if}
+		Damit ergibt sich die Höhe des Inhalts aus dem, was der Header tatsächlich
+		einnimmt — Seiten müssen sie nicht mehr schätzen. `/map` rechnete vorher
+		`calc(100dvh - 4rem)` und lag damit immer daneben: der Header misst
+		einzeilig 66px, als Admin mit umbrechendem Menü 99px, und der
+		Wartungsbanner darunter kam in der Rechnung gar nicht vor. Die Karte ragte
+		entsprechend unter den Fensterrand, ihre unteren Bedienelemente lagen
+		außerhalb des Fensters (abgesichert in `e2e/app-shell-height.spec.ts`).
 
-	<main id="main-content">
-		{@render children()}
-	</main>
+		Der Footer bleibt draußen, damit die Karte weiterhin das ganze sichtbare
+		Fenster füllt und der Footer wie bisher erst beim Scrollen erscheint —
+		innerhalb der Box würde er auf `/map` dauerhaft ~130px Kartenfläche kosten.
+	-->
+	<div class="flex min-h-dvh flex-col">
+		<PublicNavbar user={data.user} isAdmin={data.showAdminMenu} />
+
+		<!-- Maintenance Mode Banner for Admins -->
+		{#if data.maintenanceConfig?.enabled && data.showAdminMenu && isNotIFrame}
+			<div class="container mx-auto shrink-0 px-4 py-2">
+				<MaintenanceBanner isAdmin={true} maintenanceMessage={data.maintenanceConfig.message} />
+			</div>
+		{/if}
+
+		<!-- flex-col + min-h-0: Seiten können ihren Inhalt mit `flex-1` auf die
+		     verbleibende Höhe strecken, ohne sie zu kennen. -->
+		<main id="main-content" class="flex min-h-0 flex-1 flex-col">
+			{@render children()}
+		</main>
+	</div>
 
 	<PublicFooter />
 

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -13,38 +13,50 @@
 	const aktiv = $derived(aktiverAdminBereich(page.url.pathname));
 </script>
 
-<!-- Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit -->
-<div class="w-full">
-	<div class="flex min-h-screen flex-col">
-		<!--
-			Unternavigation der Verwaltung. In der TopBar liegen dieselben drei Ziele
-			hinter einem Aufklapper — der ist der Einstieg von außen, taugt aber nicht
-			zum Wechseln innerhalb des Bereichs (zwei Klicks pro Wechsel).
+<!--
+	Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit.
 
-			`<nav>` mit `aria-current` statt `role="tablist"`/`role="tab"`: Das sind
-			Links auf eigene Seiten, keine Reiter über gemeinsamem Inhalt. Die
-			`tabs`-Klassen sind reine Optik und brauchen die Rollen nicht — DaisyUI
-			stylt über `.tabs > .tab`.
+	`flex-1 min-h-0` statt `min-h-screen`: Diese Box sitzt seit dem Umbau der
+	App-Shell in einer bereits auf Viewport-Höhe gestreckten Flex-Spalte. 100vh
+	INNERHALB von „Viewport minus Header" ergab genau die Header-Höhe an
+	überflüssigem Scrollweg — gemessen 900px statt der verfügbaren 834px, auf
+	jeder Admin-Seite, deren Inhalt kürzer als ein Fenster ist. Es war dieselbe
+	geratene Höhe wie das `calc(100dvh - 4rem)` auf `/map`, nur eine Ebene tiefer.
+	Mit `flex-1` fällt das Raten weg: Die Box bekommt, was da ist, und der
+	AdminFooter sitzt weiterhin unten. Abgesichert in `e2e/app-shell-height.spec.ts`.
 
-			Bewusst nicht `sticky top-16`: Das wäre wieder eine geratene Header-Höhe,
-			genau der Fehler, den `e2e/app-shell-height.spec.ts` seit 2026-08-03
-			absichert. Der Header misst 66px, nicht 64px.
-		-->
-		<nav aria-label="Verwaltung" class="border-base-300 bg-base-100 tabs tabs-border border-b px-4">
-			{#each ADMIN_BEREICHE as bereich (bereich.href)}
-				<a
-					href={bereich.href}
-					class="tab {bereich.href === aktiv ? 'tab-active font-medium' : ''}"
-					aria-current={bereich.href === aktiv ? 'page' : undefined}
-				>
-					{bereich.label}
-				</a>
-			{/each}
-		</nav>
+	Der frühere äußere `w-full`-Wrapper ist dabei entfallen — er hätte die
+	Flex-Kette zwischen `<main>` und dieser Box unterbrochen und trug sonst nichts.
+-->
+<div class="flex min-h-0 w-full flex-1 flex-col">
+	<!--
+		Unternavigation der Verwaltung. In der TopBar liegen dieselben drei Ziele
+		hinter einem Aufklapper — der ist der Einstieg von außen, taugt aber nicht
+		zum Wechseln innerhalb des Bereichs (zwei Klicks pro Wechsel).
 
-		<div class="w-full flex-1">
-			{@render children()}
-		</div>
-		<AdminFooter buildInfo={data.buildInfo} />
+		`<nav>` mit `aria-current` statt `role="tablist"`/`role="tab"`: Das sind
+		Links auf eigene Seiten, keine Reiter über gemeinsamem Inhalt. Die
+		`tabs`-Klassen sind reine Optik und brauchen die Rollen nicht — DaisyUI
+		stylt über `.tabs > .tab`.
+
+		Bewusst nicht `sticky top-16`: Das wäre wieder eine geratene Header-Höhe,
+		genau der Fehler, den `e2e/app-shell-height.spec.ts` seit 2026-08-03
+		absichert. Der Header misst 66px, nicht 64px.
+	-->
+	<nav aria-label="Verwaltung" class="border-base-300 bg-base-100 tabs tabs-border border-b px-4">
+		{#each ADMIN_BEREICHE as bereich (bereich.href)}
+			<a
+				href={bereich.href}
+				class="tab {bereich.href === aktiv ? 'tab-active font-medium' : ''}"
+				aria-current={bereich.href === aktiv ? 'page' : undefined}
+			>
+				{bereich.label}
+			</a>
+		{/each}
+	</nav>
+
+	<div class="w-full flex-1">
+		{@render children()}
 	</div>
+	<AdminFooter buildInfo={data.buildInfo} />
 </div>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,14 +1,60 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import AdminFooter from '$lib/components/admin/AdminFooter.svelte';
 	import type { LayoutData } from './$types';
 
 	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
+
+	const pfad = $derived(page.url.pathname);
+
+	/* „Sichtungen" deckt neben der Liste auch Detail-, Bearbeiten- und
+	   Referenz-Seiten ab — sie sind Teil derselben Aufgabe. Deshalb per
+	   Ausschluss bestimmt und nicht über `pfad === '/admin'`: sonst hätte
+	   /admin/123 gar keinen aktiven Eintrag, und der Reiter würde beim
+	   Öffnen einer Sichtung ohne erkennbaren Grund seine Markierung verlieren.
+	   /admin/docs bleibt bewusst außen vor — es ist keiner der drei Bereiche. */
+	const istStatistiken = $derived(pfad.startsWith('/admin/statistics'));
+	const istEinstellungen = $derived(pfad.startsWith('/admin/settings'));
+	const istSichtungen = $derived(
+		!istStatistiken && !istEinstellungen && !pfad.startsWith('/admin/docs')
+	);
+
+	const bereiche = $derived([
+		{ href: '/admin', label: 'Sichtungen', aktiv: istSichtungen },
+		{ href: '/admin/statistics', label: 'Statistiken', aktiv: istStatistiken },
+		{ href: '/admin/settings', label: 'Einstellungen', aktiv: istEinstellungen }
+	]);
 </script>
 
 <!-- Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit -->
 <div class="w-full">
 	<div class="flex min-h-screen flex-col">
-		<!-- Page content with top padding for fixed navbar -->
+		<!--
+			Unternavigation der Verwaltung. In der TopBar liegen dieselben drei Ziele
+			hinter einem Aufklapper — der ist der Einstieg von außen, taugt aber nicht
+			zum Wechseln innerhalb des Bereichs (zwei Klicks pro Wechsel).
+
+			`<nav>` mit `aria-current` statt `role="tablist"`/`role="tab"`: Das sind
+			Links auf eigene Seiten, keine Reiter über gemeinsamem Inhalt. Die
+			`tabs`-Klassen sind reine Optik und brauchen die Rollen nicht — DaisyUI
+			stylt über `.tabs > .tab`.
+
+			Bewusst nicht `sticky top-16`: Das wäre wieder eine geratene Header-Höhe,
+			genau der Fehler, den `e2e/app-shell-height.spec.ts` seit 2026-08-03
+			absichert. Der Header misst 66px, nicht 64px.
+		-->
+		<nav aria-label="Verwaltung" class="border-base-300 bg-base-100 tabs tabs-border border-b px-4">
+			{#each bereiche as bereich (bereich.href)}
+				<a
+					href={bereich.href}
+					class="tab {bereich.aktiv ? 'tab-active font-medium' : ''}"
+					aria-current={bereich.aktiv ? 'page' : undefined}
+				>
+					{bereich.label}
+				</a>
+			{/each}
+		</nav>
+
 		<div class="w-full flex-1">
 			{@render children()}
 		</div>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,29 +1,16 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { ADMIN_BEREICHE, aktiverAdminBereich } from '$lib/config/adminNav';
 	import AdminFooter from '$lib/components/admin/AdminFooter.svelte';
 	import type { LayoutData } from './$types';
 
 	let { children, data }: { children: import('svelte').Snippet; data: LayoutData } = $props();
 
-	const pfad = $derived(page.url.pathname);
-
-	/* „Sichtungen" deckt neben der Liste auch Detail-, Bearbeiten- und
-	   Referenz-Seiten ab — sie sind Teil derselben Aufgabe. Deshalb per
-	   Ausschluss bestimmt und nicht über `pfad === '/admin'`: sonst hätte
-	   /admin/123 gar keinen aktiven Eintrag, und der Reiter würde beim
-	   Öffnen einer Sichtung ohne erkennbaren Grund seine Markierung verlieren.
-	   /admin/docs bleibt bewusst außen vor — es ist keiner der drei Bereiche. */
-	const istStatistiken = $derived(pfad.startsWith('/admin/statistics'));
-	const istEinstellungen = $derived(pfad.startsWith('/admin/settings'));
-	const istSichtungen = $derived(
-		!istStatistiken && !istEinstellungen && !pfad.startsWith('/admin/docs')
-	);
-
-	const bereiche = $derived([
-		{ href: '/admin', label: 'Sichtungen', aktiv: istSichtungen },
-		{ href: '/admin/statistics', label: 'Statistiken', aktiv: istStatistiken },
-		{ href: '/admin/settings', label: 'Einstellungen', aktiv: istEinstellungen }
-	]);
+	/* Liste und Zuordnung liegen in `$lib/config/adminNav` — dieselbe Quelle,
+	   aus der die Gruppe „Verwaltung" in der TopBar entsteht. Zwei Listen von
+	   Hand zu pflegen hieße, dass eine neue Sektion an einer der beiden
+	   Stellen fehlt, ohne dass es auffällt. */
+	const aktiv = $derived(aktiverAdminBereich(page.url.pathname));
 </script>
 
 <!-- Kein eigenes <main>: Root-Layout stellt bereits <main id="main-content"> bereit -->
@@ -44,11 +31,11 @@
 			absichert. Der Header misst 66px, nicht 64px.
 		-->
 		<nav aria-label="Verwaltung" class="border-base-300 bg-base-100 tabs tabs-border border-b px-4">
-			{#each bereiche as bereich (bereich.href)}
+			{#each ADMIN_BEREICHE as bereich (bereich.href)}
 				<a
 					href={bereich.href}
-					class="tab {bereich.aktiv ? 'tab-active font-medium' : ''}"
-					aria-current={bereich.aktiv ? 'page' : undefined}
+					class="tab {bereich.href === aktiv ? 'tab-active font-medium' : ''}"
+					aria-current={bereich.href === aktiv ? 'page' : undefined}
 				>
 					{bereich.label}
 				</a>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -39,5 +39,5 @@
 	title="Sichtungskarte"
 	showTitle={true}
 	showLogo={true}
-	containerClass="relative h-[calc(100dvh-4rem)] w-screen overflow-hidden"
+	containerClass="relative min-h-0 w-full flex-1 overflow-hidden"
 />


### PR DESCRIPTION
## Ausgangslage

Die TopBar brach als Admin **immer** um, und die Karte darunter wurde abgeschnitten. Gemessen im Browser auf `/map`, 900px Fensterhöhe:

| Breite | Header (Admin) | Karten-Container |
| --- | --- | --- |
| 1024–1440 | 99px (2 Menüzeilen) | ragt **35px** unter den Fensterrand |
| ab 1536 | 66px (1 Zeile) | ragt 2px unter den Fensterrand |

Der „Karte/Liste"-Umschalter und das Museums-Logo lagen damit außerhalb des sichtbaren Bereichs. Dazu kamen zwei Anordnungsprobleme: sieben gleichrangige Links in der TopBar für zwei verschiedene Zielgruppen, und ein Footer, der auf 390px drei Spalten nebeneinander zeigte.

## Drei Ursachen

**1. Eine geratene Header-Höhe.** `/map` rechnete `calc(100dvh - 4rem)`. Der Header ist nie 64px — einzeilig 66px, umgebrochen 99px. Der `MaintenanceBanner` steht zusätzlich zwischen Header und `<main>` und kam in der Rechnung gar nicht vor.

**2. DaisyUIs 50/50-Teilung der Navbar.** `.navbar-end` hat fest `width: 50%`, und `.menu` ist `flex-flow: column wrap` — `menu-horizontal` dreht nur die Richtung, das `wrap` bleibt. Die sieben Links mussten in die halbe Containerbreite, während die Logoseite ihre Hälfte fast leer ließ, und brachen dort still um statt breiter zu werden.

**3. `footer-center` schaltet nicht.** Es ist auf *jedem* Breakpoint `grid-auto-flow: column dense`; eine responsive Variante gibt es nicht. Der Anlauf vom 30.07. hatte nur das `md:grid-flow-col` der inneren `<nav>` entfernt — das behob den horizontalen Überlauf, ließ die äußere Spaltenanordnung aber unberührt.

## Änderungen

**A — App-Shell** (`74159af1`): Header und Inhalt bilden eine `min-h-dvh`-Flex-Spalte, der Footer steht bewusst außerhalb (innerhalb würde er auf `/map` dauerhaft ~130px Kartenfläche kosten). Seiten strecken sich mit `flex-1`, statt die Header-Höhe zu schätzen.

Dabei ein Folgefehler mitbehoben: `height: 100%` löst gegen ein Flex-Item zu `0` auf, weil dessen berechnete `height` `auto` bleibt. Die Karte blieb leer, OpenLayers loggte nur „No map visible because the map container's width or height are 0". Der innere Wrapper ist jetzt `absolute inset-0`.

**B — TopBar** (`3137b449`): `justify-between` + `w-auto` ersetzt die 50/50-Teilung. Die drei Verwaltungsziele liegen in einer Gruppe „Verwaltung", die oberste Ebene trägt nur noch die Produkt-Navigation. Der Admin-Bereich bekommt eine eigene Unternavigation (`<nav>` + `aria-current`, keine tablist/tab-Rollen — das sind Links auf eigene Seiten). Der doppelte Eintrag „Admin-Bereich" im Profilmenü entfällt.

**C — Footer** (`1047f0ad`): `footer sm:footer-horizontal` statt `footer-center`. Drei benannte Gruppen, Copyright als eigene Zeile über die volle Breite.

**Review-Nachträge** (`b3ec434a`): 44px-Ziel für Reiter und Footer-Links, Hover-Rückmeldung der Reiter wiederhergestellt, `.iframe-mode`-Selektor auf das `<footer>`-Element, gemeinsames Navigations-Modul für die beiden Admin-Listen.

## Ergebnis

Header als Admin durchgehend 66px, Karte 834px, Unterkante bündig mit dem Fensterrand — bei 1024, 1100, 1280, 1440 und 1536px.

## Verhaltensänderung, die auffallen wird

**„API-Docs" ist aus der TopBar verschwunden** — für alle, nicht nur für Admins. Es ist kein Ziel für Museumsbesuchende und steht weiterhin im Footer unter „Projekt → Dokumentation".

## Nebenbefunde am Design-System

Zwei DaisyUI-Defaults verletzen Projektregeln und sind in `app.css` korrigiert:

- Inaktive Reiter tragen fest 50 % Deckkraft → **3,54:1** auf `base-100`, unter WCAG 1.4.3. Es ist genau die `/50`-Zeile, die `design-system.md` ausschließt. Jetzt `/70` (7,04:1), mit einer Ausschlussliste, die DaisyUIs eigene spiegelt, damit Hover und Aktiv-Zustand erhalten bleiben.
- `.tab` hat eine feste `height` von 40px, die der zentrale Touch-Target-Block nicht erfasste.

## Tests

Vier neue Specs, alle vor der Implementierung geschrieben und rot gesehen:

- `e2e/app-shell-height.spec.ts` — Karte bündig unter dem Header, bündig am Fensterrand
- `e2e/navbar-structure.spec.ts` — Einzeiligkeit bei 1024/1280/1440, kein horizontaler Überlauf, Menüstruktur, 44px-Ziel, Kontrast
- `e2e/footer-layout.spec.ts` — Umbruch, kein Überlauf auf sieben Breiten, Pflichtangaben, 44px-Ziel
- `src/lib/config/adminNav.test.ts` — Pfadzuordnung inkl. der `/administration`-Präfixfalle

Sie messen durchweg *Beziehungen* (Header-Unterkante zu Container-Oberkante, Zeilenzahl, Kontrastverhältnis) statt Pixelkonstanten — eine Assertion gegen „66px" wäre beim nächsten Padding-Wechsel rot, ohne dass etwas kaputt wäre.

Eine bestehende Assertion in `design-tokens.spec.ts` musste nachgezogen werden: der Footer trägt jetzt ebenfalls einen Link „Meldung", der ungebundene Rollen-Selektor war dadurch mehrdeutig.

`npm run test:quick` grün (3319 Unit-Tests, Lint 0 Fehler, `tsc` und `svelte-check` sauber), volle E2E-Suite 300 grün.

> `form-map-pan-zoom.spec.ts` fiel in einem Zwischenlauf einmal um und war in Wiederholungs- und Endlauf grün — der bekannt flaky Spec, keine Folge dieser Änderungen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
