### PR TITLE
fix(security): 404 nicht mehr als Serverfehler loggen, Absender benennen

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -351,23 +351,36 @@ Kritische Admin-Aktionen werden in der `audit_logs` PostgreSQL-Tabelle gespeiche
 
 **Events in der DB:**
 
-| Action               | Wann                                                    | Details                       |
-| -------------------- | ------------------------------------------------------- | ----------------------------- |
-| `sighting.approve`   | Admin genehmigt Sichtung                                | `{ previousStatus }`          |
-| `sighting.reject`    | Admin lehnt Sichtung ab                                 | `{ previousStatus }`          |
-| `sighting.edit`      | Admin bearbeitet Sichtung                               | `{ changedFields: string[] }` |
-| `sighting.delete`    | Admin löscht Sichtung                                   | —                             |
-| `file.delete`        | Admin löscht Datei                                      | —                             |
-| `config.update`      | Einstellung geändert                                    | `{ key, category }`           |
-| `auth.login_success` | Erfolgreicher Admin-Login                               | —                             |
-| `auth.login_failure` | Fehlgeschlagener Login                                  | status: 'failure'             |
-| `auth.logout`        | Benutzer meldet sich ab (Session wird widerrufen)       | —                             |
-| `auth.session_revoked` | Sessions eines Benutzers gezielt widerrufen           | `{ sub }`                     |
-| `export.download`    | Admin startet Daten-Export über `/api/sightings/export` | `{ format }`                  |
+| Action                 | Wann                                                    | Details                       |
+| ---------------------- | ------------------------------------------------------- | ----------------------------- |
+| `sighting.approve`     | Admin genehmigt Sichtung                                | `{ previousStatus }`          |
+| `sighting.reject`      | Admin lehnt Sichtung ab                                 | `{ previousStatus }`          |
+| `sighting.edit`        | Admin bearbeitet Sichtung                               | `{ changedFields: string[] }` |
+| `sighting.delete`      | Admin löscht Sichtung                                   | —                             |
+| `file.delete`          | Admin löscht Datei                                      | —                             |
+| `config.update`        | Einstellung geändert                                    | `{ key, category }`           |
+| `auth.login_success`   | Erfolgreicher Admin-Login                               | —                             |
+| `auth.login_failure`   | Fehlgeschlagener Login                                  | status: 'failure'             |
+| `auth.logout`          | Benutzer meldet sich ab (Session wird widerrufen)       | —                             |
+| `auth.session_revoked` | Sessions eines Benutzers gezielt widerrufen             | `{ sub }`                     |
+| `export.download`      | Admin startet Daten-Export über `/api/sightings/export` | `{ format }`                  |
 
 **Pino stdout (nicht in DB):**
 
 - `security.rate_limit_hit` — Rate Limit überschritten (`rateLimit.ts`)
 - `security.auth_error` — Authentifizierungs-/Autorisierungsfehler, z. B. ungültiges Auth-Cookie (`hooks.server.ts`), fehlende Berechtigung (`requireUserRole`) oder Auth0-Callback-Fehler
+- `unhandled_error` — 5xx aus `handleError`, `level: 50`, mit `stack` und `causes`
+- `client_error` — 4xx aus `handleError`, `level: 40`, ohne Stack
+
+Die Trennung der beiden letzten ist der Punkt: SvelteKit ruft `handleError` auch für jede
+nicht gematchte Route auf (`respond.js`, Zweig `state.depth === 0`). Vorher ging damit
+jeder Bot-Scan als `level: 50` samt Stacktrace ins Log und war von einem echten Ausfall
+nicht zu unterscheiden. Beide Einträge tragen jetzt `method`, `clientIp`, `userAgent` und
+`referer` — ohne die war am 2026-08-03 nicht zu klären, wer wiederholt `/api/login`
+anfragte (ein Pfad, den kein Codepfad dieser Anwendung erzeugt). Diese Werte sind
+Client-Eingaben und laufen deshalb durch `redactSecrets` und eine Längenbegrenzung. Der
+Referer wird zusätzlich auf Herkunft und Pfad reduziert: `redactSecrets` redigiert nur
+Schlüssel, die nach einem Geheimnis aussehen — ein Same-Origin-Referer aus einer
+gefilterten Admin-Liste hätte den Suchbegriff (ggf. einen Personennamen) mitgeloggt.
 
 **Auswertung:** Drizzle Studio oder `docker compose logs app | grep '"event":"security.'`

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,8 @@ import { maintenanceMode } from '$lib/server/middleware/maintenanceMode';
 import { createSecurityHeadersHandler } from '$lib/server/middleware/securityHeaders';
 import { warnIfBodySizeLimitTooLow } from '$lib/server/startup/bodySizeLimit';
 import { formatStartupBanner, getBuildInfo } from '$lib/server/startup/versionInfo';
-import { buildErrorLogFields } from '$lib/server/utils/errorChain';
+import { buildErrorLogEntry } from '$lib/server/utils/errorChain';
+import { getClientIp } from '$lib/server/utils/getClientIp';
 import { ServerConfigService } from '$lib/services/configService';
 import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
@@ -99,26 +100,34 @@ export const handle: Handle = sequence(
  * (Verbindungsabbruch, `too many connections`, Timeout) steht ausschließlich in
  * `error.cause`. Ohne dieses Feld ist ein Ausfall aus dem Log nicht rekonstruierbar.
  *
- * Alle drei Fehler-Felder kommen aus `buildErrorLogFields` — sie hier von Hand aus
- * `error.message`/`error.stack` zusammenzusetzen hiesse, die Redigierung an genau den
- * Feldern vorbeizuführen, die Drizzles Parameterblock tragen. Die Logik steht in
+ * Der gesamte Eintrag — Stufe, Meldung und Felder — kommt aus `buildErrorLogEntry`.
+ * Ihn hier von Hand zusammenzusetzen hiesse, die Redigierung an genau den Feldern
+ * vorbeizuführen, die Drizzles Parameterblock tragen. Die Logik steht in
  * `errorChain.ts`, damit sie testbar ist; `hooks.server.ts` liegt ausserhalb von
  * `src/lib/**` und wird von den Server-Tests nicht erfasst.
+ *
+ * Die Client-Antwort ist bewusst für jeden Status dieselbe generische Meldung: Was der
+ * Nutzer sieht, ist die Fehlerseite; die Unterscheidung 404/500 gehört ins Log, nicht
+ * in eine zweite Textvariante.
  */
 export const handleError: HandleServerError = ({ error, event, status, message }) => {
 	const errorId = randomUUID();
 
-	logger.error(
-		{
-			event: 'unhandled_error',
-			errorId,
-			status,
-			message,
-			pathname: event.url.pathname,
-			...buildErrorLogFields(error)
-		},
-		'Unerwarteter Serverfehler'
-	);
+	const entry = buildErrorLogEntry({
+		error,
+		errorId,
+		status,
+		message,
+		pathname: event.url.pathname,
+		method: event.request.method,
+		// getClientAddress() wirft, wenn ADDRESS_HEADER gesetzt, der Header aber nicht da ist —
+		// im Error-Hook wäre das ein Fehler beim Loggen eines Fehlers. getClientIp fängt das ab.
+		clientIp: getClientIp(event.getClientAddress, event.request),
+		userAgent: event.request.headers.get('user-agent'),
+		referer: event.request.headers.get('referer')
+	});
+
+	logger[entry.level](entry.fields, entry.msg);
 
 	return {
 		message: 'Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.',

--- a/src/lib/server/utils/errorChain.test.ts
+++ b/src/lib/server/utils/errorChain.test.ts
@@ -3,10 +3,13 @@ import {
 	MAX_AGGREGATE_ERRORS,
 	MAX_CAUSE_DEPTH,
 	MAX_MESSAGE_LENGTH,
+	MAX_REQUEST_HEADER_LENGTH,
+	buildErrorLogEntry,
 	buildErrorLogFields,
 	describeErrorCauses,
 	redactSecrets,
 	serializeErrorChain,
+	type ErrorLogEntryInput,
 	type SerializedError
 } from '$lib/server/utils/errorChain';
 
@@ -335,5 +338,171 @@ describe('buildErrorLogFields', () => {
 
 		expect(fields.stack).toBeUndefined();
 		expect(fields.causes).toBeUndefined();
+	});
+});
+
+/**
+ * Grundfall: ein 500er. Von hier weichen die 4xx-Tests jeweils in genau einem Feld ab.
+ */
+function input(overrides: Partial<ErrorLogEntryInput> = {}): ErrorLogEntryInput {
+	return {
+		error: new Error('boom'),
+		errorId: 'test-id',
+		status: 500,
+		message: 'Internal Error',
+		pathname: '/admin',
+		method: 'GET',
+		clientIp: '203.0.113.7',
+		userAgent: 'Mozilla/5.0',
+		referer: 'https://ostsee-tiere.de/admin',
+		...overrides
+	};
+}
+
+describe('buildErrorLogEntry', () => {
+	/* Der Anlass: SvelteKit ruft handleError auch für nicht gematchte Routen auf
+	   (respond.js, state.depth === 0). Jeder Bot-Scan auf /api/login landete deshalb
+	   als level 50 samt Stacktrace im Log und war von einem echten Ausfall nicht zu
+	   unterscheiden. */
+	it('stuft einen 404 zur Warnung herab und lässt den Stack weg', () => {
+		const entry = buildErrorLogEntry(
+			input({ status: 404, message: 'Not Found', pathname: '/api/login' })
+		);
+
+		expect(entry.level).toBe('warn');
+		expect(entry.fields.event).toBe('client_error');
+		expect(entry.msg).toBe('Nicht gefunden');
+		expect(entry.fields.stack).toBeUndefined();
+		expect(entry.fields.causes).toBeUndefined();
+	});
+
+	it('behält für 5xx Fehlerstufe, Stack und Ursachenkette', () => {
+		const entry = buildErrorLogEntry(
+			input({
+				error: new Error('Failed query: select 1', { cause: new Error('CONNECTION_ENDED') })
+			})
+		);
+
+		expect(entry.level).toBe('error');
+		expect(entry.fields.event).toBe('unhandled_error');
+		expect(entry.msg).toBe('Unerwarteter Serverfehler');
+		expect(entry.fields.stack).toBeDefined();
+		expect(entry.fields.causes).toEqual([{ name: 'Error', message: 'CONNECTION_ENDED' }]);
+	});
+
+	it('unterscheidet andere 4xx vom 404', () => {
+		const entry = buildErrorLogEntry(input({ status: 403, message: 'Forbidden' }));
+
+		expect(entry.level).toBe('warn');
+		expect(entry.msg).toBe('Anfrage nicht beantwortet');
+	});
+
+	/* Ohne diese Felder war am 2026-08-03 nicht zu klären, wer /api/login anfragt. */
+	it('nimmt Methode, Client-IP, User-Agent und Referer ins Log', () => {
+		const entry = buildErrorLogEntry(input({ status: 404 }));
+
+		expect(entry.fields).toMatchObject({
+			method: 'GET',
+			clientIp: '203.0.113.7',
+			userAgent: 'Mozilla/5.0',
+			referer: 'https://ostsee-tiere.de/admin'
+		});
+	});
+
+	it('übernimmt die bisherigen Felder unverändert', () => {
+		const entry = buildErrorLogEntry(input({ status: 404, message: 'Not Found' }));
+
+		expect(entry.fields).toMatchObject({
+			errorId: 'test-id',
+			status: 404,
+			message: 'Not Found',
+			pathname: '/admin'
+		});
+	});
+
+	/* `clientIp: null` im Log wäre eine Aussage über den Absender, die nicht getroffen
+	   wurde — getClientIp liefert in Dev ohne X-Forwarded-For legitim null. */
+	it('lässt nicht ermittelbare Felder weg, statt null zu loggen', () => {
+		const entry = buildErrorLogEntry(input({ clientIp: null, userAgent: null, referer: null }));
+
+		expect(entry.fields).not.toHaveProperty('clientIp');
+		expect(entry.fields).not.toHaveProperty('userAgent');
+		expect(entry.fields).not.toHaveProperty('referer');
+	});
+
+	it('behandelt leere Header wie fehlende', () => {
+		const entry = buildErrorLogEntry(input({ userAgent: '   ', referer: '' }));
+
+		expect(entry.fields).not.toHaveProperty('userAgent');
+		expect(entry.fields).not.toHaveProperty('referer');
+	});
+
+	/* User-Agent und Referer sind vom Client frei wählbar und unbegrenzt lang. */
+	it('kürzt überlange Header', () => {
+		const entry = buildErrorLogEntry(
+			input({ userAgent: 'x'.repeat(MAX_REQUEST_HEADER_LENGTH + 50) })
+		);
+
+		expect(String(entry.fields.userAgent).length).toBeLessThanOrEqual(
+			MAX_REQUEST_HEADER_LENGTH + 12
+		);
+		expect(entry.fields.userAgent).toContain('[gekürzt]');
+	});
+
+	it('redigiert Zugangsdaten im Referer', () => {
+		const entry = buildErrorLogEntry(
+			input({ referer: 'https://admin:geheim@ostsee-tiere.de/x?token=abc123' })
+		);
+
+		expect(entry.fields.referer).not.toContain('geheim');
+		expect(entry.fields.referer).not.toContain('abc123');
+	});
+});
+
+/*
+ * Nachtrag aus dem Review: `redactSecrets` greift bei Query-Parametern nur, wenn der
+ * Schlüssel nach einem Geheimnis aussieht — `?code=`, `?state=`, `?email=`, `?search=`
+ * blieben stehen. `Referrer-Policy: strict-origin-when-cross-origin` schneidet den Query
+ * nur bei fremder Herkunft ab; ein Same-Origin-Referer aus einer gefilterten Admin-Liste
+ * hätte den Suchbegriff — womöglich einen Personennamen — ins Log getragen.
+ */
+describe('buildErrorLogEntry — Referer ohne Query', () => {
+	function refererOf(referer: string): unknown {
+		return buildErrorLogEntry(input({ referer })).fields.referer;
+	}
+
+	it('reduziert den Referer auf Herkunft und Pfad', () => {
+		expect(refererOf('https://ostsee-tiere.de/admin?suche=Mustermann&seite=2')).toBe(
+			'https://ostsee-tiere.de/admin'
+		);
+	});
+
+	it('entfernt auch Fragment und Zugangsdaten', () => {
+		expect(refererOf('https://admin:geheim@ostsee-tiere.de/admin#tabelle')).toBe(
+			'https://ostsee-tiere.de/admin'
+		);
+	});
+
+	it('behält einen nicht zerlegbaren Referer als Hinweis, statt ihn zu verwerfen', () => {
+		expect(refererOf('kein-url-wert')).toBe('kein-url-wert');
+	});
+});
+
+/*
+ * Ebenfalls aus dem Review: Im Fallback-Zweig von getClientIp ist die IP das erste
+ * Segment eines client-gesetzten X-Forwarded-For — also dieselbe Art Eingabe wie die
+ * beiden Header und ohne Grund von deren Begrenzung ausgenommen.
+ */
+describe('buildErrorLogEntry — Client-IP', () => {
+	it('kürzt eine überlange Client-IP', () => {
+		const entry = buildErrorLogEntry(input({ clientIp: 'x'.repeat(MAX_REQUEST_HEADER_LENGTH + 50) }));
+
+		expect(entry.fields.clientIp).toContain('[gekürzt]');
+	});
+
+	it('lässt eine echte Adresse unverändert', () => {
+		expect(buildErrorLogEntry(input({ clientIp: '2001:db8::1' })).fields.clientIp).toBe(
+			'2001:db8::1'
+		);
 	});
 });

--- a/src/lib/server/utils/errorChain.test.ts
+++ b/src/lib/server/utils/errorChain.test.ts
@@ -506,3 +506,31 @@ describe('buildErrorLogEntry — Client-IP', () => {
 		);
 	});
 });
+
+/*
+ * Nachtrag aus dem PR-Review (#727): Der Fallback für nicht zerlegbare Referer liess
+ * Query und Fragment stehen. Ein Client darf senden, was er will — `/admin?suche=…`
+ * scheitert an `new URL()` und wäre samt Suchbegriff im Log gelandet, also genau der
+ * Fall, den refererField verhindern soll.
+ */
+describe('buildErrorLogEntry — Referer ohne Query, Fallback-Pfad', () => {
+	function refererOf(referer: string): unknown {
+		return buildErrorLogEntry(input({ referer })).fields.referer;
+	}
+
+	it('schneidet den Query auch bei einem relativen Referer ab', () => {
+		expect(refererOf('/admin?suche=Mustermann')).toBe('/admin');
+	});
+
+	it('schneidet Fragment und Query bei fremdem Schema ab', () => {
+		expect(refererOf('android-app://de.example/admin?suche=Mustermann#tabelle')).toBe(
+			'android-app://de.example/admin'
+		);
+	});
+
+	it('lässt das Feld weg, wenn nach dem Schnitt nichts übrig bleibt', () => {
+		expect(buildErrorLogEntry(input({ referer: '?suche=Mustermann' })).fields).not.toHaveProperty(
+			'referer'
+		);
+	});
+});

--- a/src/lib/server/utils/errorChain.ts
+++ b/src/lib/server/utils/errorChain.ts
@@ -300,10 +300,11 @@ export function buildErrorLogFields(
 }
 
 /**
- * Ab dieser Länge werden `userAgent` und `referer` gekürzt.
+ * Ab dieser Länge werden `clientIp`, `userAgent` und `referer` gekürzt.
  *
- * Beide Werte wählt der Client frei. Ein Bot mit 8-KB-User-Agent würde sonst pro
- * 404 dieselbe Menge ins Log schreiben — und 404er kommen in Serien.
+ * Alle drei wählt der Client frei — die IP im Fallback-Zweig von `getClientIp`, wo sie
+ * aus einem gesetzten `X-Forwarded-For` stammt. Ein Bot mit 8-KB-User-Agent würde sonst
+ * pro 404 dieselbe Menge ins Log schreiben, und 404er kommen in Serien.
  */
 export const MAX_REQUEST_HEADER_LENGTH = 300;
 
@@ -357,8 +358,12 @@ function requestHeaderField(value: string | null): string | undefined {
  * welcher Seite kam die Anfrage") steckt vollständig in Herkunft und Pfad.
  *
  * `URL.origin` lässt Zugangsdaten der Form `https://benutzer:passwort@host` mit wegfallen.
- * Ein nicht zerlegbarer Wert bleibt erhalten — dass ein Client Unsinn schickt, ist selbst
- * ein Hinweis, und ohne URL-Struktur gibt es auch keinen Query-Teil.
+ *
+ * Der Referer ist laut Spezifikation absolut — ein Client kann trotzdem senden, was er
+ * will. Was `new URL()` nicht zerlegt, behält deshalb seinen Wert als Hinweis (dass da
+ * Unsinn ankommt, ist selbst diagnostisch), verliert aber alles ab dem ersten `?` oder
+ * `#`: Ein relativer `/admin?suche=…` scheitert am Parser und trüge sonst genau den
+ * Suchbegriff ins Log, den diese Funktion fernhalten soll.
  */
 function refererField(value: string | null): string | undefined {
 	const trimmed = value?.trim();
@@ -370,10 +375,10 @@ function refererField(value: string | null): string | undefined {
 			return requestHeaderField(`${url.origin}${url.pathname}`);
 		}
 	} catch {
-		// Kein zerlegbarer Wert — unten unverändert (nur redigiert und gekürzt) übernommen.
+		// Kein zerlegbarer Wert — dann greift der Schnitt an `?`/`#` unten.
 	}
 
-	return requestHeaderField(trimmed);
+	return requestHeaderField(trimmed.split(/[?#]/).at(0) ?? '');
 }
 
 /**

--- a/src/lib/server/utils/errorChain.ts
+++ b/src/lib/server/utils/errorChain.ts
@@ -298,3 +298,137 @@ export function buildErrorLogFields(
 
 	return fields;
 }
+
+/**
+ * Ab dieser Länge werden `userAgent` und `referer` gekürzt.
+ *
+ * Beide Werte wählt der Client frei. Ein Bot mit 8-KB-User-Agent würde sonst pro
+ * 404 dieselbe Menge ins Log schreiben — und 404er kommen in Serien.
+ */
+export const MAX_REQUEST_HEADER_LENGTH = 300;
+
+/** Was `handleError` über die Anfrage weiß. `null`, wo es nichts zu wissen gibt. */
+export interface ErrorLogEntryInput {
+	error: unknown;
+	errorId: string;
+	status: number;
+	message: string;
+	pathname: string;
+	method: string;
+	/** Aus `getClientIp` — in Dev ohne `X-Forwarded-For` legitim `null`. */
+	clientIp: string | null;
+	userAgent: string | null;
+	referer: string | null;
+}
+
+/** Ein fertiger Log-Aufruf: `logger[level](fields, msg)`. */
+export interface ErrorLogEntry {
+	level: 'warn' | 'error';
+	msg: string;
+	fields: Record<string, unknown>;
+}
+
+/**
+ * Ab diesem Status ist der Fehler unserer — darunter der des Clients.
+ *
+ * SvelteKit ruft `handleError` nicht nur bei geworfenen Ausnahmen auf, sondern auch
+ * für jede nicht gematchte Route (`respond.js`, Zweig `state.depth === 0`). Praktisch
+ * kommen hier also 500er und 404er an.
+ */
+const SERVER_ERROR_STATUS = 500;
+
+function requestHeaderField(value: string | null): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+
+	const redacted = redactSecrets(trimmed);
+	return redacted.length <= MAX_REQUEST_HEADER_LENGTH
+		? redacted
+		: `${redacted.slice(0, MAX_REQUEST_HEADER_LENGTH)}… [gekürzt]`;
+}
+
+/**
+ * Der Referer, reduziert auf Herkunft und Pfad — ohne Query und Fragment.
+ *
+ * `redactSecrets` allein reicht hier nicht: Seine Regel für Schlüssel-Wert-Paare greift
+ * nur bei Schlüsseln, die nach einem Geheimnis aussehen. `?suche=`, `?code=`, `?email=`
+ * blieben stehen, und ein Same-Origin-Referer aus einer gefilterten Admin-Liste trägt
+ * genau solche Werte — womöglich einen Personennamen. Der diagnostische Zweck ("von
+ * welcher Seite kam die Anfrage") steckt vollständig in Herkunft und Pfad.
+ *
+ * `URL.origin` lässt Zugangsdaten der Form `https://benutzer:passwort@host` mit wegfallen.
+ * Ein nicht zerlegbarer Wert bleibt erhalten — dass ein Client Unsinn schickt, ist selbst
+ * ein Hinweis, und ohne URL-Struktur gibt es auch keinen Query-Teil.
+ */
+function refererField(value: string | null): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+
+	try {
+		const url = new URL(trimmed);
+		if (url.protocol === 'http:' || url.protocol === 'https:') {
+			return requestHeaderField(`${url.origin}${url.pathname}`);
+		}
+	} catch {
+		// Kein zerlegbarer Wert — unten unverändert (nur redigiert und gekürzt) übernommen.
+	}
+
+	return requestHeaderField(trimmed);
+}
+
+/**
+ * Baut den vollständigen Log-Eintrag für `handleError` — Stufe, Meldung und Felder.
+ *
+ * Zwei Dinge, die diese Funktion regelt und die vorher fehlten:
+ *
+ * **Die Stufe hängt am Status.** Bis 2026-08-03 ging jeder 404 als `level: 50` mit
+ * vollem Stacktrace ins Log. In Produktion sah damit jeder Bot-Scan auf `/api/login`
+ * aus wie ein Serverausfall; ein echter 500er ging in dem Rauschen unter. Ein 404 ist
+ * kein unerwarteter Fehler, sein Stack zeigt immer dieselbe SvelteKit-interne Stelle
+ * und kostet nur Platz — beides entfällt jetzt unterhalb von 500.
+ *
+ * **Methode, IP, User-Agent und Referer stehen im Eintrag.** Ohne sie war am selben Tag
+ * nicht zu klären, wer `/api/login` anfragt — kein Codepfad der Anwendung tut es, und
+ * der Log-Eintrag nannte nur den Pfad. Die beiden Header sind Client-Eingaben: `redactSecrets`
+ * und die Längenbegrenzung gelten deshalb auch für sie, nicht nur für Fehlermeldungen.
+ */
+export function buildErrorLogEntry(input: ErrorLogEntryInput): ErrorLogEntry {
+	const isServerError = input.status >= SERVER_ERROR_STATUS;
+	const { error, stack, causes } = buildErrorLogFields(input.error);
+
+	// Auch die IP läuft durch die Begrenzung: Im Fallback-Zweig von `getClientIp` ist sie
+	// das erste Segment eines client-gesetzten `X-Forwarded-For` und damit unbegrenzt lang.
+	const clientIp = requestHeaderField(input.clientIp);
+	const userAgent = requestHeaderField(input.userAgent);
+	const referer = refererField(input.referer);
+
+	const fields: Record<string, unknown> = {
+		event: isServerError ? 'unhandled_error' : 'client_error',
+		errorId: input.errorId,
+		status: input.status,
+		message: input.message,
+		pathname: input.pathname,
+		method: input.method,
+		error
+	};
+
+	if (clientIp) fields.clientIp = clientIp;
+	if (userAgent) fields.userAgent = userAgent;
+	if (referer) fields.referer = referer;
+
+	// Der Stack eines 404 zeigt immer dieselbe SvelteKit-interne Stelle, Ursachen hat er keine.
+	if (isServerError) {
+		if (stack) fields.stack = stack;
+		if (causes) fields.causes = causes;
+	}
+
+	return {
+		level: isServerError ? 'error' : 'warn',
+		msg: isServerError
+			? 'Unerwarteter Serverfehler'
+			: input.status === 404
+				? 'Nicht gefunden'
+				: 'Anfrage nicht beantwortet',
+		fields
+	};
+}


### PR DESCRIPTION
## Anlass

In Produktion tauchten wiederholt Einträge dieser Art auf:

```json
{"level":50,"context":"hooks:server","event":"unhandled_error","status":404,"pathname":"/api/login","stack":"Error: Not found: /api/login\n    at resolve (...)","msg":"Unerwarteter Serverfehler"}
```

Zwei Probleme darin:

1. **Der Pfad ist keiner von uns.** Der Login-Endpunkt heißt `/api/auth/login`. `/api/login` kommt in keinem Codepfad, in `static/openapi.yml`, in `docs/LEGACY_API_SPECIFICATION.md` oder in der Git-Historie vor. Die Stack-Zeile führt auf `respond.js:716` — ein Zweig, der nur unter `state.depth === 0` erreicht wird, also ausschließlich bei einer direkt am Server ankommenden Anfrage. Ein interner `fetch` oder ein toter Link der eigenen App scheidet damit aus; der Absender ist extern.
2. **Er war nicht zuordenbar.** Der Eintrag nannte nur den Pfad — keine Methode, keine IP, keinen User-Agent. Ob Bot-Scan, altes Bookmark oder ein fremder Client, war aus dem Log nicht zu klären.

Dazu kommt: SvelteKit ruft `handleError` auch für jede nicht gematchte Route auf. Jeder Scan erzeugte damit `level: 50` samt Stacktrace und sah aus wie ein Serverausfall — ein echter 500er ging in dem Rauschen unter.

## Änderung

Der komplette Log-Aufruf entsteht jetzt in `buildErrorLogEntry` (`errorChain.ts`); `hooks.server.ts` ruft nur noch `logger[entry.level](entry.fields, entry.msg)`.

|  | vorher | jetzt |
| --- | --- | --- |
| 404 | `level: 50`, `event: unhandled_error`, mit Stacktrace | `level: 40`, `event: client_error`, ohne Stack |
| 5xx | unverändert | `level: 50`, `event: unhandled_error`, mit `stack` + `causes` |
| Felder | `pathname` | zusätzlich `method`, `clientIp`, `userAgent`, `referer` |

Drei Details, die nicht offensichtlich sind:

- **`getClientAddress()` wird nicht direkt gerufen.** Es wirft, wenn `ADDRESS_HEADER` gesetzt ist, der Header aber fehlt — im Error-Hook wäre das ein Fehler beim Loggen eines Fehlers. Stattdessen das vorhandene `getClientIp`, das den Fall abfängt.
- **Die drei neuen Werte sind Client-Eingaben** und laufen deshalb durch `redactSecrets` und eine Längenbegrenzung von 300 Zeichen — auch die IP, die im Fallback-Zweig von `getClientIp` aus einem client-gesetzten `X-Forwarded-For` stammt.
- **Der Referer wird zusätzlich auf Herkunft und Pfad reduziert.** `redactSecrets` redigiert nur Schlüssel, die nach einem Geheimnis aussehen; `?suche=`, `?code=`, `?email=` blieben stehen. `Referrer-Policy: strict-origin-when-cross-origin` schneidet den Query nur bei fremder Herkunft ab — ein Same-Origin-Referer aus einer gefilterten Admin-Liste hätte den Suchbegriff, womöglich einen Personennamen, ins Log getragen.

Nicht ermittelbare Felder werden weggelassen statt als `null` geloggt: `getClientIp` liefert in Dev ohne `X-Forwarded-For` legitim `null`, und `clientIp: null` wäre eine Aussage über den Absender, die nicht getroffen wurde.

## Verifikation

Test-first, RED → GREEN: 14 neue Tests in `errorChain.test.ts`, zuerst rot. `npm run test:quick` grün — **3325 Tests, 229 Dateien**, Lint und Types sauber.

Zusätzlich am laufenden Dev-Server mit einem echten Request auf den fraglichen Pfad gegengeprüft:

```json
{"level":40,"context":"hooks:server","event":"client_error","status":404,"pathname":"/api/login","method":"GET","error":"Not found: /api/login","clientIp":"::1","userAgent":"curl-probe/1.0","referer":"https://ostsee-tiere.de/admin","msg":"Nicht gefunden"}
```

Der 5xx-Pfad ist nur durch Unit-Tests abgedeckt, nicht end-to-end.

## Folge

Sobald das in Prod läuft, zeigt der nächste `/api/login`-Treffer den User-Agent — und damit, ob es ein Scanner ist oder ein Client, der repariert werden muss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
