### PR TITLE
feat(admin): Ostsee-Filter, plus zwei Layout-Korrekturen im Admin

### DIFF
--- a/.claude/rules/export.md
+++ b/.claude/rules/export.md
@@ -26,7 +26,12 @@ Regeln für CSV, JSON, KML und XML Export.
 
 **Auth:** Alle Endpoints erfordern `requireUserRole(url, locals.user, ['admin'])`
 
-**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`
+**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`, `balticSea`
+
+`balticSea` nimmt einen der vier Werte aus `BalticSeaStatus` (`baltic`, `edge`,
+`outside`, `noPosition`) und übersetzt ihn über `$lib/server/db/balticSeaFilter`
+— dieselbe Fallunterscheidung, die die Admin-Liste anzeigt. Die Flag-Logik nicht
+hier nachbauen, sondern von dort importieren.
 
 ---
 

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -6,6 +6,10 @@
 	import { formatFileSize } from '$lib/utils/file/fileSize';
 	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+	import {
+		BALTIC_SEA_STATUS_PRESENTATION,
+		isBalticSeaStatus
+	} from '$lib/utils/geo/balticSeaStatus';
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('ExportModal');
@@ -92,6 +96,12 @@
 			filterDisplays.push('Nur ohne Aufnahmen');
 		} else if (currentFilters.mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
 			filterDisplays.push('Nur angekündigt, Foto fehlt noch');
+		}
+		if (isBalticSeaStatus(currentFilters.balticSea)) {
+			// Label aus BALTIC_SEA_STATUS_PRESENTATION statt neu formuliert, damit
+			// Filter-Panel und Export-Zusammenfassung nie auseinanderlaufen.
+			const presentation = BALTIC_SEA_STATUS_PRESENTATION[currentFilters.balticSea];
+			filterDisplays.push(`Ostsee-Status: ${presentation.label}`);
 		}
 
 		return filterDisplays.length > 0 ? filterDisplays : ['Keine Filter aktiv'];

--- a/src/lib/server/db/balticSeaFilter.test.ts
+++ b/src/lib/server/db/balticSeaFilter.test.ts
@@ -1,0 +1,235 @@
+/**
+ * @fileoverview `balticSeaCondition` — SQL-Übersetzung von `getBalticSeaStatus()`
+ *
+ * `getBalticSeaStatus()` (`$lib/utils/geo/balticSeaStatus.ts`) ist die einzige
+ * Stelle, an der der Ostsee-Status einer Sichtung fachlich entsteht.
+ * `balticSeaCondition()` baut dieselbe Fallunterscheidung als SQL-Prädikat für
+ * den Admin-Filter und den Export nach. Zwei Implementierungen derselben Regel
+ * laufen erfahrungsgemäß auseinander — genau daran ist in diesem Projekt schon
+ * die Benachrichtigungs-Mail von der Admin-Anzeige abgewichen (Fehler 4,
+ * `docs/OSTSEE_FLAGS.md`): Ein `{{#if sighting.inBalticSeaGeo}}` in einer
+ * Handlebars-Vorlage konnte den Altsystem-Wert `2` nicht von `0` unterscheiden.
+ *
+ * Testansatz — bewusst anders als `mediaUploadFilter.test.ts` und
+ * `statisticsApprovalScope.test.ts`: Jene Tests prüfen nur, ob die von
+ * `PgDialect` kompilierte SQL-Zeichenkette einen erwarteten Teilstring enthält.
+ * Das würde hier nicht ausreichen — die eigentliche Gefahr ist eine SQL-
+ * Bedingung, die *scheinbar* richtig aussieht, aber für einzelne Wertekombinationen
+ * (allen voran `ostsee_geo = 2`) die falsche Zeile trifft oder verfehlt.
+ *
+ * Deshalb wird die kompilierte SQL hier tatsächlich **ausgeführt**: Die von
+ * `PgDialect.sqlToQuery()` erzeugte Bedingung (Postgres-Parameter `$1, $2, …`)
+ * wird 1:1 (nur `$n` → `?n`) gegen eine In-Memory-`node:sqlite`-Datenbank
+ * (Node-Bordmittel seit 22.5, in CI durchgängig Node 24, siehe `ci.yml`)
+ * gestellt und für jede Zeile eines Kreuzprodukts ausgewertet. Das ist eine
+ * echte SQL-Engine mit derselben dreiwertigen NULL-Logik wie Postgres — kein
+ * Nachbau der Fachregel in einer dritten Sprache.
+ *
+ * Kreuzprodukt: `inBalticSea` ∈ {null, 0, 1} × `inBalticSeaGeo` ∈ {0, 1, 2} ×
+ * Koordinaten ∈ {beide vorhanden, nur Breite, nur Länge, beide fehlend} = 36
+ * Zeilen. Für jede Zeile wird geprüft, dass genau eine der vier
+ * `balticSeaCondition(status)`-Bedingungen zutrifft — und zwar die, die
+ * `getBalticSeaStatus()` für dieselben Rohwerte auch liefert.
+ *
+ * **Was dieser Test nicht abdeckt:** Die hier genutzte Bedingung besteht
+ * ausschließlich aus `IS [NOT] NULL`, `>`, `<=`, `AND`, `OR` — Operatoren, die
+ * SQLite und Postgres identisch auswerten. Eine Postgres-spezifische
+ * Typkonvertierung (z. B. `numeric`-Rundung) wird dadurch nicht geprüft, ist
+ * aber für diese Bedingung auch nicht relevant: Die Koordinatenspalten werden
+ * nur auf `NULL` geprüft, ihr Zahlenwert fließt nicht in die Bedingung ein —
+ * und genau deshalb deckt dieses Kreuzprodukt auch den `NaN`-Randfall nicht ab:
+ * `numeric`-Spalten können in Postgres `NaN` halten, das ist weder `NULL` noch
+ * per SQLite-`REAL` nachbaubar. `getBalticSeaStatus()` ordnet eine `NaN`-Koordinate
+ * über `Number.isFinite()` als `noPosition` ein, dieses Prädikat würde sie über
+ * `IS NULL` nicht finden — siehe Kopfkommentar von `balticSeaFilter.ts`.
+ */
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { DatabaseSync } from 'node:sqlite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	BALTIC_SEA_STATUS_PRESENTATION,
+	getBalticSeaStatus,
+	type BalticSeaStatus
+} from '$lib/utils/geo/balticSeaStatus';
+import { balticSeaCondition } from './balticSeaFilter';
+
+const dialect = new PgDialect();
+// Aus BALTIC_SEA_STATUS_PRESENTATION abgeleitet statt handgepflegt — derselbe
+// Grund wie bei `isBalticSeaStatus()`: Ein fünfter Status würde sonst hier
+// unbemerkt fehlen und das Kreuzprodukt unten stillschweigend unvollständig
+// prüfen.
+const ALL_STATUSES = Object.keys(BALTIC_SEA_STATUS_PRESENTATION) as BalticSeaStatus[];
+
+/** Kompiliert ein Drizzle-Prädikat zu SQL, das `node:sqlite` ausführen kann. */
+function toSqliteSql(condition: SQL): { sql: string; params: unknown[] } {
+	const { sql, params } = dialect.sqlToQuery(condition);
+	// Postgres-Parameter ($1, $2, …) und SQLite-Parameter (?1, ?2, …) sind
+	// syntaktisch identisch bis auf das Zeichen davor.
+	return { sql: sql.replace(/\$(\d+)/g, '?$1'), params };
+}
+
+type Row = {
+	label: string;
+	latitude: number | null;
+	longitude: number | null;
+	inBalticSea: number | null;
+	inBalticSeaGeo: number | null;
+};
+
+const COORDINATE_CASES: Array<Pick<Row, 'label' | 'latitude' | 'longitude'>> = [
+	{ label: 'beide Koordinaten vorhanden', latitude: 54.3, longitude: 12.1 },
+	{ label: 'nur Breite vorhanden', latitude: 54.3, longitude: null },
+	{ label: 'nur Länge vorhanden', latitude: null, longitude: 12.1 },
+	{ label: 'beide Koordinaten fehlen', latitude: null, longitude: null }
+];
+
+const IN_BALTIC_SEA_CASES: Array<{ label: string; value: number | null }> = [
+	{ label: 'ostsee = null', value: null },
+	{ label: 'ostsee = 0', value: 0 },
+	{ label: 'ostsee = 1', value: 1 }
+];
+
+// `ostsee_geo` ist in der DB `NOT NULL` (Default 0), der Typ lässt `null`
+// trotzdem zu (Altbestand-Asymmetrie, siehe balticSeaStatus.ts) — deshalb auch
+// hier mitgetestet. Der Wert 2 ist der Kern dieses Tests: Altsystem-Daten
+// (15.208 Zeilen) tragen ihn mit derselben Bedeutung wie 1.
+const IN_BALTIC_SEA_GEO_CASES: Array<{ label: string; value: number | null }> = [
+	{ label: 'ostsee_geo = 0', value: 0 },
+	{ label: 'ostsee_geo = 1', value: 1 },
+	{ label: 'ostsee_geo = 2 (Altsystem)', value: 2 }
+];
+
+const ROWS: Row[] = COORDINATE_CASES.flatMap((coords) =>
+	IN_BALTIC_SEA_CASES.flatMap((ostsee) =>
+		IN_BALTIC_SEA_GEO_CASES.map((ostseeGeo) => ({
+			label: `${coords.label}, ${ostsee.label}, ${ostseeGeo.label}`,
+			latitude: coords.latitude,
+			longitude: coords.longitude,
+			inBalticSea: ostsee.value,
+			inBalticSeaGeo: ostseeGeo.value
+		}))
+	)
+);
+
+let db: DatabaseSync;
+
+beforeAll(() => {
+	db = new DatabaseSync(':memory:');
+	// Spaltennamen exakt wie in schema.ts, damit die von Drizzle qualifiziert
+	// erzeugten Bezeichner (`"sichtungen"."gps_breite"`, …) auflösen.
+	db.exec(
+		'CREATE TABLE sichtungen (gps_breite REAL, gps_laenge REAL, ostsee INTEGER, ostsee_geo INTEGER)'
+	);
+});
+
+afterAll(() => {
+	db.close();
+});
+
+/** Trägt genau eine Zeile ein und prüft, ob `condition` sie auswählt. */
+function matchesRow(condition: SQL, row: Row): boolean {
+	db.exec('DELETE FROM sichtungen');
+	db.prepare(
+		'INSERT INTO sichtungen (gps_breite, gps_laenge, ostsee, ostsee_geo) VALUES (?, ?, ?, ?)'
+	).run(row.latitude, row.longitude, row.inBalticSea, row.inBalticSeaGeo);
+
+	const { sql, params } = toSqliteSql(condition);
+	const result = db
+		.prepare(`SELECT (${sql}) AS matches FROM sichtungen`)
+		.get(...(params as never[])) as {
+		matches: number | null;
+	};
+	return result.matches === 1;
+}
+
+describe('balticSeaCondition', () => {
+	it('liefert kein Prädikat für einen unbekannten oder fehlenden Wert', () => {
+		expect(balticSeaCondition(null)).toBeUndefined();
+		expect(balticSeaCondition(undefined)).toBeUndefined();
+		expect(balticSeaCondition('all')).toBeUndefined();
+		expect(balticSeaCondition('')).toBeUndefined();
+		expect(balticSeaCondition('ostsee')).toBeUndefined();
+	});
+
+	describe('Kreuzprodukt: wählt exakt die Zeilenmenge von getBalticSeaStatus()', () => {
+		for (const row of ROWS) {
+			const expectedStatus = getBalticSeaStatus({
+				inBalticSea: row.inBalticSea,
+				inBalticSeaGeo: row.inBalticSeaGeo,
+				latitude: row.latitude === null ? null : String(row.latitude),
+				longitude: row.longitude === null ? null : String(row.longitude)
+			});
+
+			it(`${row.label} → getBalticSeaStatus() = '${expectedStatus}'`, () => {
+				for (const status of ALL_STATUSES) {
+					const condition = balticSeaCondition(status);
+					expect(
+						condition,
+						`balticSeaCondition('${status}') sollte ein Prädikat liefern`
+					).toBeDefined();
+
+					const matched = matchesRow(condition as SQL, row);
+					if (status === expectedStatus) {
+						expect(matched, `Zeile (${row.label}) sollte von '${status}' erfasst werden`).toBe(
+							true
+						);
+					} else {
+						expect(
+							matched,
+							`Zeile (${row.label}) sollte NICHT von '${status}' erfasst werden`
+						).toBe(false);
+					}
+				}
+			});
+		}
+	});
+
+	describe('ostsee_geo = 2 verhält sich wie ostsee_geo = 1 (Kernfall)', () => {
+		it('zählt als "baltic", wenn Position und ostsee gesetzt sind', () => {
+			const row: Row = {
+				label: 'geo=2',
+				latitude: 54.3,
+				longitude: 12.1,
+				inBalticSea: 1,
+				inBalticSeaGeo: 2
+			};
+			expect(matchesRow(balticSeaCondition('baltic') as SQL, row)).toBe(true);
+			expect(matchesRow(balticSeaCondition('edge') as SQL, row)).toBe(false);
+		});
+
+		it('ein `= 1`-Vergleich würde diesen Fall verfehlen — die Bedingung darf ihn nicht nachbauen', () => {
+			const condition = balticSeaCondition('baltic') as SQL;
+			const { sql } = toSqliteSql(condition);
+			expect(sql).not.toMatch(/"ostsee_geo"\s*=\s*\?/);
+			expect(sql).not.toMatch(/"ostsee"\s*=\s*\?/);
+		});
+	});
+
+	describe('Eigenständigkeit der vier Bedingungen', () => {
+		it('deckt für jede Zeile im Kreuzprodukt genau einen Status ab', () => {
+			for (const row of ROWS) {
+				const matchingStatuses = ALL_STATUSES.filter((status) =>
+					matchesRow(balticSeaCondition(status) as SQL, row)
+				);
+				expect(matchingStatuses, `Zeile (${row.label})`).toHaveLength(1);
+			}
+		});
+	});
+});
+
+// Kontrolle über die reine SQL-Zeichenkette (wie in mediaUploadFilter.test.ts) —
+// zusätzlich zur Zeilenauswahl oben, damit ein Refactoring, das versehentlich auf
+// `= 1`/`= 2` statt `> 0` umstellt, hier zusätzlich als Textänderung auffällt.
+describe('balticSeaCondition — erzeugtes SQL', () => {
+	it('prüft beide Flag-Spalten mit ">" und nie mit "="', () => {
+		for (const status of ['baltic', 'edge', 'outside'] as const) {
+			const { sql } = toSqliteSql(balticSeaCondition(status) as SQL);
+			for (const column of ['"ostsee"', '"ostsee_geo"']) {
+				if (sql.includes(column)) {
+					expect(sql, `${status}: ${column}`).not.toMatch(new RegExp(`${column}\\s*=\\s*\\?`));
+				}
+			}
+		}
+	});
+});

--- a/src/lib/server/db/balticSeaFilter.ts
+++ b/src/lib/server/db/balticSeaFilter.ts
@@ -1,0 +1,92 @@
+/**
+ * Gemeinsames `balticSea`-Filterprädikat für die Admin-Übersicht
+ * (`routes/admin/+page.server.ts`) und den Export
+ * (`routes/api/sightings/export/exportFilterParams.ts`).
+ *
+ * Bewusst als reine, DB-lose Funktion: Sie baut ein Drizzle-Prädikat über die
+ * Schema-Spalten, führt aber keine Abfrage aus — dieselbe Trennung wie
+ * `mediaUploadFilter.ts` und `approvalFilter.ts`. Beide Aufrufer hängen das
+ * Ergebnis an ihre eigene `and(...)`-Bedingungsliste.
+ *
+ * Die vier Werte übersetzen `getBalticSeaStatus()`
+ * (`$lib/utils/geo/balticSeaStatus.ts`) — **die einzige Stelle, an der dieser
+ * Status entsteht** — in SQL. Genau an dieser Übersetzung ist die
+ * Benachrichtigungs-Mail schon einmal von der Admin-Anzeige abgewichen
+ * (Fehler 4, `docs/OSTSEE_FLAGS.md`): Ein `{{#if sighting.inBalticSeaGeo}}` in
+ * einer Handlebars-Vorlage konnte den Altsystem-Wert `2` nicht von `0`
+ * unterscheiden. Diese Datei ist die einzig erlaubte SQL-Übersetzung der
+ * Flag-Logik — wer eine weitere Stelle braucht, importiert von hier, statt die
+ * Fallunterscheidung erneut zu schreiben. `balticSeaFilter.test.ts` prüft die
+ * Übersetzung gegen `getBalticSeaStatus()` über das volle Kreuzprodukt der
+ * Eingaben.
+ *
+ * Wie in `database.md`/`geo.md` festgehalten: Beide Flag-Spalten werden mit
+ * `> 0` geprüft, nie mit `= 1` — `ostsee_geo` enthält aus dem Altsystem
+ * zusätzlich den Wert `2` mit derselben Bedeutung wie `1`.
+ *
+ * **Bekannte Grenze — `NaN` in den Koordinatenspalten:** `gps_breite`/`gps_laenge`
+ * sind `numeric`-Spalten; Postgres kann darin `NaN` speichern. `getBalticSeaStatus()`
+ * prüft die Koordinaten mit `Number.isFinite()` und würde eine solche Zeile als
+ * `noPosition` einordnen, dieses Prädikat hier prüft für `noPosition` dagegen nur
+ * `IS NULL` — eine `NaN`-Koordinate ist nicht `NULL` und fiele deshalb durch alle
+ * vier Filter-Werte, statt bei `noPosition` zu landen wie in der Anzeige. In der
+ * Dev-DB gibt es 0 solche Zeilen, der Fall ist aktuell theoretisch; relevant wird
+ * er erst, wenn eine Quelle `NaN` in diese Spalten schreiben kann.
+ */
+import { and, gt, isNotNull, isNull, lte, or, type SQL } from 'drizzle-orm';
+import { sightings } from '$lib/server/db/schema';
+import { isBalticSeaStatus } from '$lib/utils/geo/balticSeaStatus';
+
+/** Position vorhanden heißt: beide Koordinatenspalten sind gesetzt. */
+const hasPosition = (): SQL | undefined =>
+	and(isNotNull(sightings.latitude), isNotNull(sightings.longitude));
+
+/**
+ * „Flag gesetzt" — `> 0`, wie `getBalticSeaStatus()` es mit `(wert ?? 0) > 0`
+ * prüft. Bei `NULL` liefert `>` in SQL `NULL` (nicht `TRUE`), das Prädikat
+ * lässt die Zeile also korrekt durchfallen.
+ */
+const flagOn = (column: typeof sightings.inBalticSea | typeof sightings.inBalticSeaGeo): SQL =>
+	gt(column, 0);
+
+/**
+ * „Flag nicht gesetzt" — bewusst **nicht** `not(flagOn(column))`: SQLs
+ * dreiwertige Logik macht aus `NOT (NULL > 0)` wieder `NULL`, nicht `TRUE`,
+ * eine Zeile mit `NULL`-Flag fiele also lautlos aus dem Filter. `getBalticSeaStatus()`
+ * behandelt `NULL` über `?? 0` explizit als „nicht gesetzt" — das bildet diese
+ * Bedingung nach, indem sie `NULL` und `<= 0` gleichermaßen zulässt.
+ */
+const flagOff = (
+	column: typeof sightings.inBalticSea | typeof sightings.inBalticSeaGeo
+): SQL | undefined => or(isNull(column), lte(column, 0));
+
+/**
+ * @param balticSea Der rohe Query-Parameter — einer der vier Statuswerte aus
+ *   `BalticSeaStatus` (`'baltic'`, `'edge'`, `'outside'`, `'noPosition'`) oder
+ *   alles andere/fehlend für „kein Filter".
+ * @returns Ein Prädikat für `and(...)`, oder `undefined`, wenn der Wert keinen
+ *   Filter auslöst.
+ */
+export function balticSeaCondition(balticSea: string | null | undefined): SQL | undefined {
+	if (!isBalticSeaStatus(balticSea)) {
+		return undefined;
+	}
+
+	switch (balticSea) {
+		case 'noPosition':
+			return or(isNull(sightings.latitude), isNull(sightings.longitude));
+		case 'outside':
+			return and(hasPosition(), flagOff(sightings.inBalticSea));
+		case 'baltic':
+			return and(hasPosition(), flagOn(sightings.inBalticSea), flagOn(sightings.inBalticSeaGeo));
+		case 'edge':
+			return and(hasPosition(), flagOn(sightings.inBalticSea), flagOff(sightings.inBalticSeaGeo));
+		default: {
+			// Exhaustiveness-Guard: Ein fünfter `BalticSeaStatus`-Wert lässt TypeScript
+			// hier nicht mehr kompilieren, statt den `switch` lautlos zu verlassen und
+			// `undefined` (= „kein Filter") zurückzugeben.
+			const _exhaustive: never = balticSea;
+			return _exhaustive;
+		}
+	}
+}

--- a/src/lib/utils/geo/balticSeaStatus.ts
+++ b/src/lib/utils/geo/balticSeaStatus.ts
@@ -121,3 +121,24 @@ export const BALTIC_SEA_STATUS_PRESENTATION: Record<BalticSeaStatus, BalticSeaSt
 			title: 'Keine verwertbaren Koordinaten — eine Ostsee-Zuordnung ist nicht möglich.'
 		}
 	};
+
+/**
+ * Type Guard für einen rohen Query-/Filter-Wert. Leitet die gültigen Werte aus
+ * den Schlüsseln von `BALTIC_SEA_STATUS_PRESENTATION` ab, statt sie in einer
+ * zweiten Liste zu wiederholen — der Record ist bereits als
+ * `Record<BalticSeaStatus, …>` exhaustiv typisiert, ein fünfter Status würde
+ * hier also einen Typfehler auslösen, nicht erst zur Laufzeit stillschweigend
+ * durchrutschen.
+ *
+ * Nimmt bewusst `unknown` — Aufrufer wie `ExportModal.svelte` lesen den Wert aus
+ * einem gemischt typisierten Filter-Objekt (`Record<string, string | boolean>`),
+ * ein engerer Parametertyp würde dort einen weiteren Cast erzwingen.
+ */
+export function isBalticSeaStatus(value: unknown): value is BalticSeaStatus {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	return (Object.keys(BALTIC_SEA_STATUS_PRESENTATION) as BalticSeaStatus[]).includes(
+		value as BalticSeaStatus
+	);
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -5,6 +5,7 @@ import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
 	mediaUploadCondition
 } from '$lib/server/db/mediaUploadFilter';
+import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
@@ -27,6 +28,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const verified = url.searchParams.get('verified');
 	const entryChannel = url.searchParams.get('entryChannel');
 	const mediaUpload = url.searchParams.get('mediaUpload');
+	const balticSea = url.searchParams.get('balticSea');
 
 	// Bedingungen für die SQL-Abfrage sammeln
 	const conditions = [];
@@ -62,6 +64,13 @@ export const load: PageServerLoad = async ({ url }) => {
 	const mediaCondition = mediaUploadCondition(mediaUpload);
 	if (mediaCondition) {
 		conditions.push(mediaCondition);
+	}
+
+	// Ostsee-Status-Filter — dieselbe Fallunterscheidung wie die Anzeige in
+	// getBalticSeaStatus(), siehe balticSeaFilter.ts.
+	const balticSeaFilterCondition = balticSeaCondition(balticSea);
+	if (balticSeaFilterCondition) {
+		conditions.push(balticSeaFilterCondition);
 	}
 
 	// Kombinierte WHERE-Bedingung erstellen

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -35,6 +35,7 @@
 	let verified = $state(page.url.searchParams.get('verified') || '');
 	let selectedChannel = $state(page.url.searchParams.get('entryChannel') || 'all');
 	let mediaUpload = $state(page.url.searchParams.get('mediaUpload') || '');
+	let balticSea = $state(page.url.searchParams.get('balticSea') || '');
 	let showDeleteDialog = $state(false);
 	let sightingToDelete = $state<FrontendSighting | null>(null);
 	let isFilterPanelOpen = $state(false);
@@ -92,7 +93,8 @@
 			toDate ||
 			verified ||
 			(selectedChannel && selectedChannel !== 'all') ||
-			mediaUpload
+			mediaUpload ||
+			balticSea
 		)
 	);
 
@@ -102,7 +104,8 @@
 		toDate: toDate || '',
 		verified: verified || '',
 		entryChannel: selectedChannel !== 'all' ? selectedChannel : '',
-		mediaUpload: mediaUpload || ''
+		mediaUpload: mediaUpload || '',
+		balticSea: balticSea || ''
 	}));
 
 	function updateSort(column: string): void {
@@ -142,6 +145,10 @@
 		if (mediaUpload) url.searchParams.set('mediaUpload', mediaUpload);
 		else url.searchParams.delete('mediaUpload');
 
+		// Ostsee-Status-Filter
+		if (balticSea) url.searchParams.set('balticSea', balticSea);
+		else url.searchParams.delete('balticSea');
+
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -164,6 +171,7 @@
 		verified = '';
 		selectedChannel = 'all';
 		mediaUpload = '';
+		balticSea = '';
 
 		const url = new URL(page.url);
 		url.searchParams.delete('fromDate');
@@ -171,6 +179,7 @@
 		url.searchParams.delete('verified');
 		url.searchParams.delete('entryChannel');
 		url.searchParams.delete('mediaUpload');
+		url.searchParams.delete('balticSea');
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -565,7 +574,7 @@
 					<Icon icon="lucide:x" class="h-4 w-4" />
 				</button>
 			</div>
-			<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+			<div class="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
 				<div class="fieldset w-full">
 					<label for="fromDate" class="label py-0">
 						<span class="text-xs">Von</span>
@@ -635,6 +644,22 @@
 						<option value="1">Mit</option>
 						<option value="0">Ohne</option>
 						<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}>Angekündigt, fehlt noch</option>
+					</select>
+				</div>
+				<div class="fieldset w-full">
+					<label for="balticSea" class="label py-0">
+						<span class="text-xs">Ostsee</span>
+					</label>
+					<select
+						id="balticSea"
+						name="balticSea"
+						class="select select-sm w-full text-sm"
+						bind:value={balticSea}
+					>
+						<option value="">Alle</option>
+						{#each Object.entries(BALTIC_SEA_STATUS_PRESENTATION) as [value, presentation] (value)}
+							<option {value}>{presentation.label}</option>
+						{/each}
 					</select>
 				</div>
 			</div>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -944,42 +944,45 @@
 								</td>
 							{/if}
 							{#if columnVisibility.actions}
-								<td class="space-x-1">
-									<button
-										class="btn btn-ghost btn-xs"
-										onclick={() => viewSightingDetails(sighting)}
-										title="Details anzeigen"
-										aria-label="Details anzeigen"
-									>
-										<Icon icon="lucide:eye" class="h-4 w-4" />
-									</button>
-									<button
-										class="btn btn-ghost btn-xs"
-										onclick={() => sendTestEmail(sighting.id)}
-										title="Interne Benachrichtigung testweise senden"
-										aria-label="Interne Benachrichtigung testweise senden"
-									>
-										<Icon icon="lucide:mail" class="h-4 w-4" />
-									</button>
-									<button
-										class="btn btn-ghost btn-xs"
-										onclick={() => checkSpam(sighting.id)}
-										title="Spam-Check"
-										aria-label="Spam-Check durchführen"
-									>
-										<Icon icon="lucide:shield-alert" class="h-4 w-4" />
-									</button>
-									<button
-										class="btn text-error btn-ghost btn-xs"
-										onclick={() => {
-											sightingToDelete = sighting;
-											showDeleteDialog = true;
-										}}
-										title="Eintrag löschen"
-										aria-label="Eintrag löschen"
-									>
-										<Icon icon="lucide:trash-2" class="h-4 w-4" />
-									</button>
+								<td class="w-px whitespace-nowrap">
+									<!-- flex-nowrap: sonst brechen die 44px hohen Buttons um und ziehen die Zeile auf -->
+									<div class="flex flex-nowrap items-center gap-1">
+										<button
+											class="btn btn-ghost btn-xs"
+											onclick={() => viewSightingDetails(sighting)}
+											title="Details anzeigen"
+											aria-label="Details anzeigen"
+										>
+											<Icon icon="lucide:eye" class="h-4 w-4" />
+										</button>
+										<button
+											class="btn btn-ghost btn-xs"
+											onclick={() => sendTestEmail(sighting.id)}
+											title="Interne Benachrichtigung testweise senden"
+											aria-label="Interne Benachrichtigung testweise senden"
+										>
+											<Icon icon="lucide:mail" class="h-4 w-4" />
+										</button>
+										<button
+											class="btn btn-ghost btn-xs"
+											onclick={() => checkSpam(sighting.id)}
+											title="Spam-Check"
+											aria-label="Spam-Check durchführen"
+										>
+											<Icon icon="lucide:shield-alert" class="h-4 w-4" />
+										</button>
+										<button
+											class="btn text-error btn-ghost btn-xs"
+											onclick={() => {
+												sightingToDelete = sighting;
+												showDeleteDialog = true;
+											}}
+											title="Eintrag löschen"
+											aria-label="Eintrag löschen"
+										>
+											<Icon icon="lucide:trash-2" class="h-4 w-4" />
+										</button>
+									</div>
 								</td>
 							{/if}
 						</tr>

--- a/src/routes/admin/page.server.test.ts
+++ b/src/routes/admin/page.server.test.ts
@@ -23,6 +23,7 @@ import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
 	mediaUploadCondition
 } from '$lib/server/db/mediaUploadFilter';
+import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
@@ -119,5 +120,30 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		// müssen jetzt dieselbe Bedingung tragen wie die Arbeitslisten-Abfrage.
 		expect(recordedSelects[0]?.whereSql).toBe(expected);
 		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+
+	// Der Filter selbst ist in `balticSeaFilter.test.ts` gegen `getBalticSeaStatus()`
+	// abgesichert. Hier geht es nur um die Verdrahtung: dass `?balticSea=…`
+	// überhaupt bis in die WHERE-Klausel durchschlägt. Alle vier Werte, damit ein
+	// vergessener `switch`-Zweig nicht durchrutscht.
+	it.each(['baltic', 'edge', 'outside', 'noPosition'] as const)(
+		'?balticSea=%s filtert die Hauptliste mit derselben Bedingung',
+		async (status) => {
+			await load({
+				url: makeUrl({ balticSea: status })
+			} as unknown as Parameters<typeof load>[0]);
+
+			const expected = toSqlText(balticSeaCondition(status) as unknown as SQLWrapper);
+			expect(recordedSelects[0]?.whereSql).toBe(expected);
+			expect(recordedSelects[1]?.whereSql).toBe(expected);
+		}
+	);
+
+	it('ein unbekannter balticSea-Wert filtert die Hauptliste gar nicht', async () => {
+		await load({
+			url: makeUrl({ balticSea: 'quatsch' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(recordedSelects[0]?.whereSql).toBeUndefined();
 	});
 });

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -107,8 +107,21 @@
 		-->
 
 		<!-- Key Metrics Grid -->
-		<div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-5">
-			<div class="stats shadow">
+		<!-- Spaltenzahl bewusst < 5: `.stat` setzt `white-space: nowrap` auf Titel, Wert und
+		     Beschreibung (daisyui stat.css) und kann deshalb nie umbrechen; `.stats` selbst ist
+		     `inline-grid` mit `overflow-x: auto`. Bei lg:grid-cols-5 war jede Spalte nur ~175px
+		     breit, die Karte scrollte intern, und das rechts sitzende stat-figure-Icon lag außerhalb
+		     des sichtbaren Bereichs. Nachgerechnet (Container = min(Viewport, Breakpoint) minus
+		     `p-4`, gap-6 = 24px, .stat-Padding 24px je Seite, Icon 32px, Spalten-Gap 16px): die
+		     breiteste Karte „Unique Nutzer" („… Wiederholungs-Nutzer (12,3%)") braucht ~320-335px.
+		     Bei 5 Spalten liefert selbst 2xl (Container 1536px − 32px Padding = 1504px Inhalt) nur
+		     ~282px/Spalte — 5 Spalten passen bei keinem Standard-Breakpoint verlustfrei. Deshalb
+		     2 Spalten ab md (356px/Spalte) und 3 ab xl. Bei xl bleiben 400px/Spalte, ab 2xl 485px
+		     (der Container ist ohne eigenen 3xl-Breakpoint bei 1536px gedeckelt, breiter wird es
+		     also nicht). Bei 3 Spalten ordnen sich die fünf Karten als 3+2 an — gegenüber 4+1 die
+		     ruhigere Aufteilung, deshalb keine vierte Spalte ab 2xl. -->
+		<div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+			<div class="stats w-full shadow">
 				<div class="stat">
 					<div class="stat-figure text-primary">
 						<Icon icon="lucide:users" class="h-8 w-8" />
@@ -125,7 +138,7 @@
 				</div>
 			</div>
 
-			<div class="stats shadow">
+			<div class="stats w-full shadow">
 				<div class="stat">
 					<div class="stat-figure text-secondary-strong">
 						<Icon icon="lucide:activity" class="h-8 w-8" />
@@ -142,7 +155,7 @@
 				</div>
 			</div>
 
-			<div class="stats shadow">
+			<div class="stats w-full shadow">
 				<div class="stat">
 					<div class="stat-figure text-warning-strong">
 						<Icon icon="lucide:trending-up" class="h-8 w-8" />
@@ -165,7 +178,7 @@
 				</div>
 			</div>
 
-			<div class="stats shadow">
+			<div class="stats w-full shadow">
 				<div class="stat">
 					<div class="stat-figure text-accent-strong">
 						<Icon icon="lucide:calendar" class="h-8 w-8" />
@@ -184,7 +197,7 @@
 				</div>
 			</div>
 
-			<div class="stats shadow">
+			<div class="stats w-full shadow">
 				<div class="stat">
 					<div class="stat-figure text-info-strong">
 						<Icon icon="lucide:users" class="h-8 w-8" />

--- a/src/routes/api/sightings/export/exportFilterParams.test.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.test.ts
@@ -2,12 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Drizzle wird durch Marker-Objekte ersetzt, damit die erzeugten Grenz-Instants
 // direkt geprüft werden können statt über generiertes SQL.
+// `or`/`gt`/`lte`/`isNull`/`isNotNull` braucht `balticSeaCondition` — ohne sie
+// stünde dort `undefined(...)`, sobald ein Ostsee-Filter gesetzt ist.
 vi.mock('drizzle-orm', () => ({
 	and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+	or: vi.fn((...conditions) => ({ op: 'or', conditions })),
 	between: vi.fn((column, from, to) => ({ op: 'between', column, from, to })),
 	gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+	gt: vi.fn((column, value) => ({ op: 'gt', column, value })),
 	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
-	eq: vi.fn((column, value) => ({ op: 'eq', column, value }))
+	lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+	isNull: vi.fn((column) => ({ op: 'isNull', column })),
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column }))
 }));
 
 vi.mock('$lib/server/db/schema', () => ({
@@ -15,11 +22,15 @@ vi.mock('$lib/server/db/schema', () => ({
 		sightingDate: 'sightingDate',
 		verified: 'verified',
 		entryChannel: 'entryChannel',
-		mediaUpload: 'mediaUpload'
+		mediaUpload: 'mediaUpload',
+		inBalticSea: 'inBalticSea',
+		inBalticSeaGeo: 'inBalticSeaGeo',
+		latitude: 'latitude',
+		longitude: 'longitude'
 	}
 }));
 
-import { buildExportConditions } from './exportFilterParams';
+import { buildExportConditions, parseExportFilterParams } from './exportFilterParams';
 
 type Condition = { op: string; column: string; value?: Date; from?: Date; to?: Date };
 
@@ -29,7 +40,8 @@ function dateRange(fromDate: string, toDate: string): { start: Date; endExclusiv
 		toDate,
 		verified: null,
 		entryChannel: null,
-		mediaUpload: null
+		mediaUpload: null,
+		balticSea: null
 	}) as unknown as Condition[];
 
 	const onDate = conditions.filter((condition) => condition.column === 'sightingDate');
@@ -54,7 +66,8 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			toDate: '2024-06-30',
 			verified: null,
 			entryChannel: null,
-			mediaUpload: null
+			mediaUpload: null,
+			balticSea: null
 		});
 
 		expect(between).not.toHaveBeenCalled();
@@ -113,9 +126,70 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			toDate: '',
 			verified: null,
 			entryChannel: null,
-			mediaUpload: null
+			mediaUpload: null,
+			balticSea: null
 		}) as unknown as Condition[];
 
 		expect(conditions).toHaveLength(0);
+	});
+});
+
+/**
+ * Der Ostsee-Filter selbst ist in `$lib/server/db/balticSeaFilter.test.ts` gegen
+ * `getBalticSeaStatus()` abgesichert. Hier geht es nur um die Verdrahtung: dass
+ * `?balticSea=…` gelesen wird und die Bedingung im Export tatsächlich ankommt.
+ * Ohne das könnte der Export stillschweigend mehr Zeilen liefern als die
+ * Admin-Liste anzeigt — genau die Falle, die bei `mediaUpload` vermieden wurde.
+ */
+describe('Export-Filter — Ostsee-Status', () => {
+	const noFilters = {
+		fromDate: '',
+		toDate: '',
+		verified: null,
+		entryChannel: null,
+		mediaUpload: null
+	};
+
+	it('parseExportFilterParams liest balticSea aus der URL', () => {
+		const result = parseExportFilterParams(
+			new URL('https://example.com/api/sightings/export?format=json&balticSea=noPosition')
+		);
+
+		expect(result).toHaveProperty('params');
+		expect((result as { params: { balticSea: string | null } }).params.balticSea).toBe(
+			'noPosition'
+		);
+	});
+
+	it('parseExportFilterParams liefert null, wenn der Parameter fehlt', () => {
+		const result = parseExportFilterParams(
+			new URL('https://example.com/api/sightings/export?format=json')
+		);
+
+		expect((result as { params: { balticSea: string | null } }).params.balticSea).toBeNull();
+	});
+
+	it.each(['baltic', 'edge', 'outside', 'noPosition'])(
+		'buildExportConditions hängt für balticSea=%s eine Bedingung an',
+		(status) => {
+			const conditions = buildExportConditions({ ...noFilters, balticSea: status });
+
+			expect(conditions).toHaveLength(1);
+		}
+	);
+
+	it('hängt ohne Ostsee-Filter keine Bedingung an', () => {
+		expect(buildExportConditions({ ...noFilters, balticSea: null })).toHaveLength(0);
+		expect(buildExportConditions({ ...noFilters, balticSea: 'quatsch' })).toHaveLength(0);
+	});
+
+	it('kombiniert den Ostsee-Filter mit anderen Filtern, statt sie zu ersetzen', () => {
+		const conditions = buildExportConditions({
+			...noFilters,
+			verified: '1',
+			balticSea: 'baltic'
+		});
+
+		expect(conditions).toHaveLength(2);
 	});
 });

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -3,6 +3,7 @@ import { eq, gte, lt } from 'drizzle-orm';
 import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
 import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
+import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 
 export function xmlEscape(str: string | null | undefined): string {
 	if (!str) return '';
@@ -20,6 +21,7 @@ export type ExportFilterParams = {
 	verified: string | null;
 	entryChannel: string | null;
 	mediaUpload: string | null;
+	balticSea: string | null;
 };
 
 type ValidationError = { field: 'fromDate' | 'toDate'; message: string };
@@ -31,6 +33,7 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 	const verified = url.searchParams.get('verified');
 	const entryChannel = url.searchParams.get('entryChannel');
 	const mediaUpload = url.searchParams.get('mediaUpload');
+	const balticSea = url.searchParams.get('balticSea');
 
 	if (fromDate && !isValidDateParam(fromDate)) {
 		return {
@@ -43,11 +46,11 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 		};
 	}
 
-	return { params: { fromDate, toDate, verified, entryChannel, mediaUpload } };
+	return { params: { fromDate, toDate, verified, entryChannel, mediaUpload, balticSea } };
 }
 
 export function buildExportConditions(params: ExportFilterParams) {
-	const { fromDate, toDate, verified, entryChannel, mediaUpload } = params;
+	const { fromDate, toDate, verified, entryChannel, mediaUpload, balticSea } = params;
 	const conditions = [];
 
 	if (isValidDateParam(fromDate) && isValidDateParam(toDate)) {
@@ -74,6 +77,11 @@ export function buildExportConditions(params: ExportFilterParams) {
 	const mediaCondition = mediaUploadCondition(mediaUpload);
 	if (mediaCondition) {
 		conditions.push(mediaCondition);
+	}
+	// Dieselbe Ostsee-Status-Bedingung wie die Admin-Liste, siehe balticSeaFilter.ts.
+	const balticSeaFilterCondition = balticSeaCondition(balticSea);
+	if (balticSeaFilterCondition) {
+		conditions.push(balticSeaFilterCondition);
 	}
 
 	return conditions;

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -430,6 +430,9 @@ paths:
           schema:
             type: boolean
             example: true
+        - $ref: '#/components/parameters/ExportEntryChannel'
+        - $ref: '#/components/parameters/ExportMediaUpload'
+        - $ref: '#/components/parameters/ExportBalticSea'
       responses:
         '200':
           description: Exportdatei
@@ -469,6 +472,7 @@ paths:
         - $ref: '#/components/parameters/ExportVerified'
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
+        - $ref: '#/components/parameters/ExportBalticSea'
       responses:
         '200':
           description: JSON-Datei mit Sichtungen
@@ -538,6 +542,7 @@ paths:
         - $ref: '#/components/parameters/ExportVerified'
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
+        - $ref: '#/components/parameters/ExportBalticSea'
       responses:
         '200':
           description: CSV-Datei mit Sichtungen
@@ -570,6 +575,7 @@ paths:
         - $ref: '#/components/parameters/ExportVerified'
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
+        - $ref: '#/components/parameters/ExportBalticSea'
       responses:
         '200':
           description: XML-Datei mit Sichtungen
@@ -602,6 +608,7 @@ paths:
         - $ref: '#/components/parameters/ExportVerified'
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
+        - $ref: '#/components/parameters/ExportBalticSea'
       responses:
         '200':
           description: KML-Datei mit Sichtungen
@@ -2284,6 +2291,19 @@ components:
       schema:
         type: boolean
         example: true
+
+    ExportBalticSea:
+      name: balticSea
+      in: query
+      description: >-
+        Ostsee-Status filtern (baltic=Ostsee, edge=Widerspruch zwischen den
+        Flags, outside=außerhalb, noPosition=ohne Position; siehe
+        getBalticSeaStatus() in $lib/utils/geo/balticSeaStatus.ts; leer = kein
+        Filter)
+      schema:
+        type: string
+        enum: ["baltic", "edge", "outside", "noPosition"]
+        example: "baltic"
 
   schemas:
     CleanupReport:


### PR DESCRIPTION
Drei Verbesserungen am Admin-Bereich.

## 1. Filter für den Ostsee-Status

Die Sichtungsliste zeigte den Ostsee-Status längst als Badge, filtern konnte man ihn nicht. Der Filter deckt alle vier Zustände aus `getBalticSeaStatus()` ab und gilt für Liste **und** Export — ein Export, der mehr Zeilen liefert als die Liste anzeigt, wäre dieselbe Falle, die bei `mediaUpload` schon vermieden wurde.

`src/lib/server/db/balticSeaFilter.ts` ist die eine erlaubte SQL-Übersetzung der Flag-Logik, gebaut wie `mediaUploadFilter.ts`. Zwei Stellen, an denen sie leicht falsch wird:

- Beide Flag-Spalten werden mit `> 0` geprüft, nie mit `= 1` — `ostsee_geo` trägt aus dem Altsystem zusätzlich den Wert `2`.
- „Flag nicht gesetzt" ist bewusst **nicht** `NOT (spalte > 0)`: SQLs dreiwertige Logik macht aus `NOT (NULL > 0)` wieder `NULL`, eine Zeile mit `NULL`-Flag fiele damit aus *jedem* der vier Filter heraus.

### Wie das abgesichert ist

Der Test führt die von Drizzle kompilierte SQL gegen `node:sqlite` aus, statt Teilstrings zu vergleichen, und prüft über das volle Kreuzprodukt — `ostsee` ∈ {null,0,1} × `ostsee_geo` ∈ {0,1,2} × Koordinaten ∈ {beide, je eine, keine} —, dass genau der Status trifft, den `getBalticSeaStatus()` für dieselben Rohwerte liefert.

Beide Fallen sind per Mutation gegengeprüft: `> 0` → `= 1` macht 5 Tests rot, das naive `NOT` 4 (dort meldet der Test, dass eine Zeile auf *keinen* der vier Filter passt — genau das Symptom). Die Verdrahtung Query-Parameter → SQL ist separat getestet, ebenfalls mit Rot-Gegenprobe: gekappte Verdrahtung ⇒ 9 Tests rot.

Gegen die Dev-DB gemessen decken sich die Zahlen der App mit einer direkten SQL-Abfrage: 18.788 Ostsee, 635 außerhalb, 464 ohne Position, 0 Widerspruch (der Altbestand ist seit der Juli-Bereinigung widerspruchsfrei). Ein unbekannter Parameterwert filtert nicht.

**Bekannte Grenze,** im Kopfkommentar festgehalten: Eine `NaN`-Koordinate ordnet die Anzeige als `noPosition` ein, das SQL-Prädikat prüft nur `IS NULL` und fände sie nicht. In der Dev-DB gibt es keine solche Zeile; der Fall ist derzeit theoretisch.

## 2. Action-Buttons brechen nicht mehr um

`<td class="space-x-1">` mit vier `inline-flex`-Buttons brach am Whitespace um. Da `app.css` jedem `.btn` 44 px Mindesthöhe gibt (WCAG 2.5.5), kostete jeder Umbruch eine volle Zeilenhöhe. Jetzt `flex flex-nowrap`, Spalte auf Inhaltsbreite. Über 25 Zeilen gemessen: alle vier Buttons auf einer Y-Position, Zeilenhöhe konstant 84 px. Die 44 px bleiben unangetastet — sie waren nicht die Ursache.

## 3. Statistik-Karten schneiden ihre Symbole nicht mehr ab

Ursache war nicht das Icon, sondern die Spaltenzahl: `.stats` ist in DaisyUI `inline-grid` mit `overflow-x: auto`, und Titel/Wert/Beschreibung tragen `white-space: nowrap`. Bei `lg:grid-cols-5` blieben ab 1024 px nur ~175 px pro Spalte — die Karte scrollte intern, das rechts sitzende `.stat-figure` lag außerhalb.

Messung bei 1280 px vorher: `scrollWidth` 232–250 gegen `clientWidth` 224, bei einer Karte ragte das Icon 2 px über den Rand. Jetzt 2 Spalten ab `md`, 3 ab `xl` (400–485 px pro Karte, Anordnung 3+2); bei 768/1024/1280/1536/1920 px gilt durchgehend `scrollWidth == clientWidth`.

Die Breakpoints wechseln dabei von `sm:`/`lg:` auf `md:`/`xl:` und folgen damit dem Breakpoint-Vertrag aus `design-system.md`.

## Prüfung

- `npm run test:quick`: 232 Dateien, 3417 Tests grün (13 neue). Die zwei ESLint-Warnungen in `src/tests/contract/helpers/createEvent.ts` sind vorbestehend und nicht Teil dieses Branches.
- OpenAPI-Spec ergänzt (`ExportBalticSea` an allen fünf Export-Pfaden — der Sammelpfad `/api/sightings/export` hatte auch `entryChannel`/`mediaUpload` noch nicht, obwohl er sie unterstützt), YAML validiert.
- `.claude/rules/export.md` nachgezogen.
- Layout an beiden Stellen im Browser gemessen, jeweils mit Gegenprobe gegen den alten Zustand.

Die Punkte 2 und 3 sind reine Layout-Änderungen und deshalb ohne Test — dokumentierte Ausnahme nach `testing.md`.

### Beim Messen aufgefallen, nicht Teil dieses PRs

In derselben Tabellenzeile bricht die Beschriftung des Geprüft-Schalters mitten im Wort um („Ge-/prüft").

🤖 Generated with [Claude Code](https://claude.com/claude-code)