### PR TITLE
fix(admin): send notification and test mails to CC/BCC recipients

### DIFF
--- a/.claude/rules/email.md
+++ b/.claude/rules/email.md
@@ -20,7 +20,40 @@ Regeln für den Email-Versand via nodemailer.
 EmailService.sendNewSightingNotification(sightingId: number): Promise<boolean>
 EmailService.sendTestEmail(recipient?: string): Promise<boolean>
 EmailService.initialize(test = false): Promise<void>
+EmailService.resetTransporter(): void
 ```
+
+### Transporter-Lebenszyklus
+
+Der Transporter wird beim Modulstart einmal gebaut, danach aber **bei Bedarf neu
+aufgebaut**: Beide Versandwege gehen über `ensureTransporter()`, das einen
+fehlenden Transporter aufbaut, statt die Mail zu verwerfen. `initialize()`
+schließt vorher die alte Verbindung; schlägt das Schließen fehl, wird nur
+gewarnt — sonst verhinderte die alte Verbindung den Aufbau der neuen.
+
+Zwei Fehler, die das bis 2026-08-04 verursachte:
+
+- **Geänderte SMTP-Einstellungen erreichten den Transporter nie.** Die Test-Mail
+  prüfte die alte Verbindung und bescheinigte eine Konfiguration als
+  funktionierend, die so gar nicht gespeichert war. `PUT`/`DELETE /api/config`
+  ruft deshalb bei `email.smtp.*` jetzt `EmailService.resetTransporter()` —
+  **nicht** bei `notification.email.*`: eine geänderte Empfängerliste ist kein
+  Grund, eine funktionierende Verbindung wegzuwerfen.
+- **Ein beim Start fehlgeschlagenes `verify()` war endgültig.** War der
+  SMTP-Server beim Serverstart kurz nicht erreichbar, blieb der Transporter
+  `null` und die Sichtungs-Benachrichtigung gab dauerhaft `false` zurück, bis
+  jemand den Container neu startete. Eine ausbleibende Benachrichtigung zeigt
+  nirgends etwas an — der Ausfall wäre unbemerkt geblieben.
+
+`ensureTransporter()` lässt **nur einen Aufbau gleichzeitig** zu (`initialization`-
+Promise). Ohne diese Klammer schloss bei zwei zeitgleich eingehenden Meldungen
+der zweite Lauf die Verbindung, die der erste gerade aufgebaut hatte.
+
+**Der Transporter ist statisch und überlebt den einzelnen Test.** In Testdateien,
+die ihn aufbauen, gehört `EmailService.resetTransporter()` ins `beforeEach` und
+`close: vi.fn()` in den Transporter-Mock — sonst entscheidet die Reihenfolge der
+Tests über ihr Ergebnis. Abgesichert durch `emailService.test.ts`
+(„Transporter-Lebenszyklus").
 
 ---
 
@@ -36,7 +69,33 @@ SMTP_PASSWORD=secret
 PUBLIC_SITE_URL=https://ostsee-tiere.de
 ```
 
-DB-Config wird 5 Minuten gecached.
+DB-Config wird 5 Minuten gecached. **`PUT`/`DELETE /api/config` muss bei jedem
+Schlüssel unter `notification.email.*` oder `email.smtp.*` zusätzlich
+`EmailService.clearCaches()` aufrufen** — `ConfigRepository.clearCache()` räumt
+nur den Repository-Cache, nicht die eigene Kopie im `EmailService`. Ohne das
+lieferte eine direkt nach dem Speichern ausgelöste Test-Mail bis zu fünf Minuten
+lang die alte Empfängerliste, ohne Fehlermeldung.
+
+---
+
+## CC/BCC
+
+`notification.email.cc` und `.bcc` sind Arrays (Settings-UI: kommagetrennte
+Eingabe, gespeichert als Array — `ConfigRepository.getArray` gibt bei einem
+String stillschweigend den Default zurück).
+
+**Beide Versandwege setzen sie:** die Sichtungs-Benachrichtigung _und_
+`sendTestEmail()`, letztere auch bei explizit übergebenem Empfänger — der Knopf
+in `/admin/settings` schickt den konfigurierten Empfänger immer explizit mit,
+ein Override-Sonderfall würde CC/BCC also genau auf dem einzigen Auslöseweg
+weglassen. Eine leere Liste wird zu `undefined`, damit „nicht konfiguriert" und
+„leer" in Header und Log unterscheidbar bleiben.
+
+Bis 2026-08-04 setzte **kein** Versandweg CC/BCC: `sendTestEmail()` kannte sie
+nicht, und die Benachrichtigung schrieb `config.recipient ? undefined :
+config.cc` — der Empfänger ist an der Stelle garantiert gesetzt, der Ausdruck
+war konstant `undefined`. Abgesichert durch `emailService.test.ts`
+(„CC/BCC-Empfänger") und `config.test.ts` („E-Mail-Cache").
 
 ---
 

--- a/src/lib/server/services/emailService.envFallback.test.ts
+++ b/src/lib/server/services/emailService.envFallback.test.ts
@@ -109,8 +109,11 @@ describe('EmailService — SMTP-Konfiguration aus der Umgebung', () => {
 		vi.clearAllMocks();
 		vi.mocked(nodemailer.createTransport).mockReturnValue({
 			sendMail: vi.fn(),
-			verify: vi.fn().mockResolvedValue(true)
+			verify: vi.fn().mockResolvedValue(true),
+			close: vi.fn()
 		} as unknown as ReturnType<typeof nodemailer.createTransport>);
+		// Der Transporter ist statisch und überlebt den einzelnen Test.
+		EmailService.resetTransporter();
 	});
 
 	it('nimmt die ENV-Werte, wenn die DB-Einträge leer sind', async () => {

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -102,7 +102,8 @@ import { DEFAULT_EMAIL_TEMPLATE, EmailService } from './emailService';
 function createMockTransporter(sendMailResult = { messageId: 'test-id-123' }) {
 	return {
 		verify: vi.fn().mockResolvedValue(true),
-		sendMail: vi.fn().mockResolvedValue(sendMailResult)
+		sendMail: vi.fn().mockResolvedValue(sendMailResult),
+		close: vi.fn()
 	};
 }
 
@@ -202,6 +203,11 @@ describe('EmailService', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		EmailService.clearCaches();
+		// Der Transporter ist statisch und überlebt sonst den einzelnen Test —
+		// ein in Test A aufgebauter Transporter ließ Test B versenden, obwohl der
+		// dort gar keinen aufgebaut hatte. Die Reihenfolge der Tests entschied
+		// damit über ihr Ergebnis.
+		EmailService.resetTransporter();
 
 		// Standard-Transporter-Mock
 		mockTransporter = createMockTransporter();
@@ -334,7 +340,14 @@ describe('EmailService', () => {
 			expect(result).toBe(false);
 		});
 
-		it('gibt false zurück wenn Transporter nicht initialisiert', async () => {
+		// Bis 2026-08-04 war das Gegenteil zugesichert („kein Transporter → false"),
+		// und genau daran starb der Versand: Ein beim Start fehlgeschlagenes
+		// verify() ließ den Transporter dauerhaft `null`, ohne dass je ein neuer
+		// Versuch stattfand. Ein fehlender Transporter ist ein Grund, ihn
+		// aufzubauen — kein Grund, die Benachrichtigung zu verwerfen. Dass ein
+		// **gescheiterter** Aufbau weiterhin `false` liefert, sichert der Test
+		// „gibt false zurück wenn der Neuaufbau ebenfalls scheitert" ab.
+		it('baut einen fehlenden Transporter auf statt die Mail zu verwerfen', async () => {
 			const mockSighting = createMockSighting();
 			vi.mocked(db.select).mockReturnValue({
 				from: vi.fn().mockReturnValue({
@@ -349,8 +362,8 @@ describe('EmailService', () => {
 
 			const result = await EmailService.sendNewSightingNotification(42);
 
-			// Kein Transporter → false
-			expect(result).toBe(false);
+			expect(result).toBe(true);
+			expect(nodemailer.createTransport).toHaveBeenCalledOnce();
 		});
 
 		it('sendet E-Mail und gibt true zurück wenn alles korrekt konfiguriert', async () => {
@@ -682,6 +695,257 @@ describe('EmailService', () => {
 			const result = await EmailService.sendTestEmail();
 
 			expect(result).toBe(false);
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// CC/BCC-Empfänger
+	//
+	// `notification.email.cc` und `.bcc` sind seit 2026-07-30 in den Einstellungen
+	// pflegbar, wurden aber von **keinem** Versandweg tatsächlich gesetzt:
+	//
+	// - `sendEmailNotification()` schrieb `config.recipient ? undefined : config.cc`.
+	//   Der Empfänger ist an dieser Stelle durch die Prüfung darüber garantiert
+	//   gesetzt — der Ausdruck war also konstant `undefined`. Der Kommentar
+	//   („nicht für Test-Mails") beschrieb einen Pfad, der hier gar nicht liegt.
+	// - `sendTestEmail()` kannte CC/BCC überhaupt nicht.
+	//
+	// Beides fiel nicht auf, weil eine Mail an den Hauptempfänger ankommt und
+	// niemand die stillen Mitleser vermisst.
+	// ---------------------------------------------------------------------------
+	describe('CC/BCC-Empfänger', () => {
+		async function sendNotificationWith(cc: string[], bcc: string[]) {
+			vi.mocked(db.select).mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([createMockSighting()])
+					})
+				})
+			} as any);
+
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com', cc, bcc });
+			await EmailService.initialize(false);
+			await EmailService.sendNewSightingNotification(42);
+
+			return mockTransporter.sendMail.mock.calls[0]?.[0] as {
+				cc?: string[];
+				bcc?: string[];
+			};
+		}
+
+		async function sendTestMailWith(cc: string[], bcc: string[], recipient?: string) {
+			setupConfigRepositoryMocks({
+				enabled: true,
+				smtpHost: 'smtp.example.com',
+				recipient: 'admin@ostsee-tiere.de',
+				cc,
+				bcc
+			});
+			await EmailService.initialize(false);
+			await EmailService.sendTestEmail(recipient);
+
+			return mockTransporter.sendMail.mock.calls[0]?.[0] as {
+				cc?: string[];
+				bcc?: string[];
+			};
+		}
+
+		it('setzt CC und BCC bei der Sichtungs-Benachrichtigung', async () => {
+			const mailOptions = await sendNotificationWith(['kopie@example.com'], ['blind@example.com']);
+
+			expect(mailOptions.cc).toEqual(['kopie@example.com']);
+			expect(mailOptions.bcc).toEqual(['blind@example.com']);
+		});
+
+		it('setzt CC und BCC bei der Test-E-Mail', async () => {
+			const mailOptions = await sendTestMailWith(
+				['kopie@example.com', 'zweite@example.com'],
+				['blind@example.com']
+			);
+
+			expect(mailOptions.cc).toEqual(['kopie@example.com', 'zweite@example.com']);
+			expect(mailOptions.bcc).toEqual(['blind@example.com']);
+		});
+
+		// Der Knopf in `/admin/settings` schickt den konfigurierten Empfänger
+		// **explizit** mit. Ein Override darf CC/BCC deshalb nicht abschalten,
+		// sonst wäre der einzige Weg, eine Test-Mail auszulösen, genau der Weg,
+		// der die Mitleser wieder verliert.
+		it('setzt CC und BCC auch bei explizit übergebenem Empfänger', async () => {
+			const mailOptions = await sendTestMailWith(
+				['kopie@example.com'],
+				['blind@example.com'],
+				'abweichend@example.com'
+			);
+
+			expect(mailOptions.cc).toEqual(['kopie@example.com']);
+			expect(mailOptions.bcc).toEqual(['blind@example.com']);
+		});
+
+		it('lässt CC und BCC weg wenn nichts konfiguriert ist', async () => {
+			const mailOptions = await sendNotificationWith([], []);
+
+			expect(mailOptions.cc).toBeUndefined();
+			expect(mailOptions.bcc).toBeUndefined();
+		});
+
+		it('lässt CC und BCC in der Test-E-Mail weg wenn nichts konfiguriert ist', async () => {
+			const mailOptions = await sendTestMailWith([], []);
+
+			expect(mailOptions.cc).toBeUndefined();
+			expect(mailOptions.bcc).toBeUndefined();
+		});
+
+		// `getArray` liefert den JSONB-Wert ungeprüft. Die Settings-Oberfläche
+		// filtert Leereinträge zwar heraus, `PUT /api/config` nimmt aber jedes
+		// Array entgegen — ein Leerstring würde als leere Adresse im Header landen.
+		it('verwirft leere Einträge in CC und BCC', async () => {
+			const mailOptions = await sendNotificationWith(['', '  ', 'kopie@example.com'], ['', '   ']);
+
+			expect(mailOptions.cc).toEqual(['kopie@example.com']);
+			expect(mailOptions.bcc).toBeUndefined();
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// HTML-Escaping in der Test-E-Mail
+	//
+	// Die Test-Mail nennt Empfänger und CC im Fließtext. Beide stammen aus
+	// Eingaben: CC aus den Einstellungen, der Empfänger aus dem Request-Body von
+	// `POST /api/config/test-email`, der ihn — anders als die Admin-Route — gar
+	// nicht validiert. Ohne Escaping landet der Wert roh im HTML-Body.
+	// ---------------------------------------------------------------------------
+	describe('HTML-Escaping in der Test-E-Mail', () => {
+		it('escapt Empfänger und CC im Mail-Text', async () => {
+			setupConfigRepositoryMocks({
+				enabled: true,
+				smtpHost: 'smtp.example.com',
+				cc: ['<img src=x onerror=alert(1)>@example.com']
+			});
+			await EmailService.initialize(false);
+
+			await EmailService.sendTestEmail('"><script>alert(1)</script>@example.com');
+
+			const { html } = mockTransporter.sendMail.mock.calls[0]?.[0] as { html: string };
+
+			expect(html).not.toContain('<script>');
+			expect(html).not.toContain('<img src=x');
+			expect(html).toContain('&lt;script&gt;');
+		});
+	});
+
+	// ---------------------------------------------------------------------------
+	// Transporter-Lebenszyklus
+	//
+	// Der Transporter ist ein Singleton, das beim Modulstart einmal gebaut wird.
+	// Zwei Folgen davon waren falsch:
+	//
+	// - Geänderte SMTP-Einstellungen erreichten ihn nie. Die Test-Mail prüfte
+	//   damit die alte Verbindung und bescheinigte eine Konfiguration als
+	//   funktionierend, die so gar nicht gespeichert war.
+	// - War der SMTP-Server beim Serverstart kurz nicht erreichbar, schlug
+	//   `verify()` fehl, der Transporter blieb `null` — und die
+	//   Sichtungs-Benachrichtigung gab von da an dauerhaft `false` zurück, bis
+	//   jemand den Container neu startete. Nur `sendTestEmail()` versuchte es
+	//   erneut.
+	// ---------------------------------------------------------------------------
+	describe('Transporter-Lebenszyklus', () => {
+		function mockSightingRow() {
+			vi.mocked(db.select).mockReturnValue({
+				from: vi.fn().mockReturnValue({
+					where: vi.fn().mockReturnValue({
+						limit: vi.fn().mockResolvedValue([createMockSighting()])
+					})
+				})
+			} as any);
+		}
+
+		it('schließt die alte Verbindung bei resetTransporter()', async () => {
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'alt.example.com' });
+			await EmailService.initialize(false);
+
+			EmailService.resetTransporter();
+
+			expect(mockTransporter.close).toHaveBeenCalledOnce();
+		});
+
+		it('baut den Transporter nach resetTransporter() mit dem neuen SMTP-Host neu auf', async () => {
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'alt.example.com' });
+			await EmailService.initialize(false);
+			expect(nodemailer.createTransport).toHaveBeenCalledTimes(1);
+
+			// Admin speichert einen neuen Host — die Route verwirft den Transporter.
+			EmailService.resetTransporter();
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'neu.example.com' });
+
+			const result = await EmailService.sendTestEmail('test@example.com');
+
+			expect(result).toBe(true);
+			expect(nodemailer.createTransport).toHaveBeenCalledTimes(2);
+			expect(nodemailer.createTransport).toHaveBeenLastCalledWith(
+				expect.objectContaining({ host: 'neu.example.com' })
+			);
+		});
+
+		it('baut den Transporter für die Sichtungs-Benachrichtigung bei Bedarf neu auf', async () => {
+			mockSightingRow();
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com' });
+			await EmailService.initialize(false);
+
+			EmailService.resetTransporter();
+
+			const result = await EmailService.sendNewSightingNotification(42);
+
+			expect(result).toBe(true);
+			expect(mockTransporter.sendMail).toHaveBeenCalledOnce();
+		});
+
+		// Der eigentliche Betriebsfall: SMTP beim Serverstart nicht erreichbar.
+		it('erholt sich von einem beim Start fehlgeschlagenen verify()', async () => {
+			mockSightingRow();
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com' });
+			mockTransporter.verify.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+			// Serverstart: verify() scheitert, der Transporter bleibt null.
+			await EmailService.initialize(false);
+			expect(nodemailer.createTransport).toHaveBeenCalledOnce();
+
+			// SMTP ist wieder erreichbar. Die nächste Sichtung baut die Verbindung
+			// selbst neu auf — früher blieb sie bis zum Container-Neustart tot.
+			const result = await EmailService.sendNewSightingNotification(42);
+
+			expect(result).toBe(true);
+			expect(nodemailer.createTransport).toHaveBeenCalledTimes(2);
+		});
+
+		// Zwei gleichzeitig eingehende Meldungen sehen beide `transporter === null`
+		// und liefen beide in `initialize()`. Der zweite Lauf schloss dabei über
+		// `resetTransporter()` die Verbindung, die der erste gerade aufgebaut
+		// hatte. Realistisch wird das nach einer SMTP-Störung, seit ein fehlender
+		// Transporter überhaupt neu aufgebaut wird.
+		it('baut bei gleichzeitigem Versand nur einen Transporter auf', async () => {
+			mockSightingRow();
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com' });
+
+			const results = await Promise.all([
+				EmailService.sendNewSightingNotification(42),
+				EmailService.sendNewSightingNotification(42),
+				EmailService.sendNewSightingNotification(42)
+			]);
+
+			expect(results).toEqual([true, true, true]);
+			expect(nodemailer.createTransport).toHaveBeenCalledOnce();
+			expect(mockTransporter.close).not.toHaveBeenCalled();
+		});
+
+		it('gibt false zurück wenn der Neuaufbau ebenfalls scheitert', async () => {
+			mockSightingRow();
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: '' });
+
+			const result = await EmailService.sendNewSightingNotification(42);
+
+			expect(result).toBe(false);
+			expect(mockTransporter.sendMail).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -72,6 +72,40 @@ async function configOrEnv(key: string, envValue: string): Promise<string> {
 	return (await ConfigRepository.getString(key, '')) || envValue;
 }
 
+/**
+ * Macht aus einer Empfängerliste den Wert, den nodemailer erwartet: die
+ * bereinigte Liste, oder `undefined` wenn nichts konfiguriert ist.
+ *
+ * Ein leeres Array als `cc`/`bcc` wäre für nodemailer zwar unschädlich, taucht
+ * aber im Mail-Header und in den Logs als gesetztes Feld auf — „nicht
+ * konfiguriert" und „konfiguriert, aber leer" sollen unterscheidbar bleiben.
+ *
+ * Leereinträge fliegen raus: `ConfigRepository.getArray()` reicht den
+ * JSONB-Wert ungeprüft durch. Die Settings-Oberfläche filtert sie zwar schon
+ * beim Eingeben, `PUT /api/config` nimmt aber jedes Array entgegen — ein
+ * Leerstring landete sonst als leere Adresse im Header.
+ */
+/**
+ * Escapt einen Wert für die Einbettung in den HTML-Body der Test-Mail.
+ *
+ * Empfänger und CC stammen aus Eingaben: CC aus den Einstellungen, der
+ * Empfänger aus dem Request-Body von `POST /api/config/test-email` — der ihn,
+ * anders als die Admin-Route, gar nicht gegen ein E-Mail-Muster prüft. Beides
+ * ist zwar Admin-beschränkt, roh interpoliertes HTML bleibt es trotzdem.
+ */
+function escape(value: string): string {
+	return Handlebars.escapeExpression(value);
+}
+
+function recipientsOrUndefined(recipients: string[] | undefined): string[] | undefined {
+	const cleaned = (recipients ?? [])
+		.filter((entry): entry is string => typeof entry === 'string')
+		.map((entry) => entry.trim())
+		.filter((entry) => entry.length > 0);
+
+	return cleaned.length > 0 ? cleaned : undefined;
+}
+
 export interface EmailConfig {
 	enabled: boolean;
 	recipient: string;
@@ -89,6 +123,8 @@ export interface EmailConfig {
 
 export class EmailService {
 	private static transporter: Transporter | null = null;
+	/** Läuft gerade ein Aufbau? Siehe `ensureTransporter()`. */
+	private static initialization: Promise<void> | null = null;
 	private static templateCache = new Map<string, HandlebarsTemplateDelegate>();
 	private static configCache: { config: EmailConfig; timestamp: number } | null = null;
 	private static readonly CONFIG_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
@@ -134,9 +170,17 @@ export class EmailService {
 			const smtpSecure = await ConfigRepository.getBoolean('email.smtp.secure', false);
 
 			if (!smtpHost) {
+				// Auch einen bestehenden Transporter verwerfen: Wird der Host in den
+				// Einstellungen geleert, wäre „kein Host konfiguriert" sonst ein
+				// Zustand, in dem trotzdem noch über die alte Verbindung versendet wird.
+				this.resetTransporter();
 				logger.warn('Email service not initialized: SMTP host not configured');
 				return;
 			}
+
+			// Vor dem Neuaufbau die alte Verbindung schließen, sonst bleibt bei jeder
+			// Konfigurationsänderung ein Socket-Pool zurück.
+			this.resetTransporter();
 
 			// Create transporter mit expliziten Timeouts, damit ein hängender SMTP-Server
 			// den Request/Prozess nicht blockiert (Single-Container-Docker-Betrieb).
@@ -160,6 +204,68 @@ export class EmailService {
 			logger.error({ error }, 'Failed to initialize email service');
 			this.transporter = null;
 		}
+	}
+
+	/**
+	 * Verwirft den Transporter samt offener SMTP-Verbindung.
+	 *
+	 * Aufzurufen, wenn sich `email.smtp.*` geändert hat. Der Transporter ist ein
+	 * Singleton, das beim Modulstart einmal gebaut wird — ohne diesen Aufruf
+	 * erreichten geänderte Verbindungsdaten ihn erst beim nächsten Neustart des
+	 * Containers. Die Test-Mail prüfte damit die *alte* Verbindung und
+	 * bescheinigte eine Konfiguration als funktionierend, die so gar nicht
+	 * gespeichert war.
+	 *
+	 * Kein Neuaufbau an dieser Stelle: Der nächste Versand erledigt das über
+	 * `ensureTransporter()`. So kostet eine Konfigurationsänderung keine
+	 * SMTP-Verbindung, wenn danach gar keine Mail ansteht.
+	 */
+	static resetTransporter(): void {
+		if (!this.transporter) {
+			return;
+		}
+
+		// Das Schließen der ALTEN Verbindung darf den Aufbau der neuen nicht
+		// verhindern — `resetTransporter()` läuft direkt vor `createTransport()`.
+		// Ein Fehler hier kostet höchstens einen Socket, ein Abbruch dagegen den
+		// gesamten Mailversand.
+		try {
+			this.transporter.close();
+		} catch (error) {
+			logger.warn({ error }, 'Failed to close previous SMTP transporter');
+		}
+
+		this.transporter = null;
+		logger.info('SMTP transporter discarded, will be rebuilt on next send');
+	}
+
+	/**
+	 * Liefert einen einsatzbereiten Transporter und baut ihn bei Bedarf auf.
+	 *
+	 * Der Neuaufbau ist nicht nur für Konfigurationsänderungen da: Schlug
+	 * `verify()` beim Serverstart fehl (SMTP-Server kurz nicht erreichbar),
+	 * blieb der Transporter `null` — und der Versand gab dauerhaft `false`
+	 * zurück, bis jemand den Container neu startete. Ein Zustand, den niemand
+	 * bemerkt, weil eine ausbleibende Benachrichtigung nichts anzeigt.
+	 */
+	private static async ensureTransporter(test = false): Promise<Transporter | null> {
+		if (this.transporter) {
+			return this.transporter;
+		}
+
+		// Nur ein Aufbau gleichzeitig. Ohne diese Klammer liefen zwei zeitgleich
+		// eingehende Meldungen beide in `initialize()`, und der zweite Lauf schloss
+		// über `resetTransporter()` die Verbindung, die der erste gerade aufgebaut
+		// hatte. Der Fall wurde erst dadurch realistisch, dass ein fehlender
+		// Transporter überhaupt neu aufgebaut wird — etwa nach einer SMTP-Störung,
+		// wenn mehrere Meldungen gleichzeitig anstehen.
+		this.initialization ??= this.initialize(test).finally(() => {
+			this.initialization = null;
+		});
+
+		await this.initialization;
+
+		return this.transporter;
 	}
 
 	/**
@@ -294,8 +400,15 @@ export class EmailService {
 		try {
 			const enabled = await ConfigRepository.getBoolean('notification.email.enabled', false);
 
-			if (!enabled || !this.transporter) {
-				logger.debug('Email notifications disabled or service not initialized');
+			if (!enabled) {
+				logger.debug('Email notifications disabled');
+				return false;
+			}
+
+			const transporter = await this.ensureTransporter();
+
+			if (!transporter) {
+				logger.warn('Email service not available, notification not sent');
 				return false;
 			}
 
@@ -349,15 +462,15 @@ export class EmailService {
 					address: config.sender
 				},
 				to: config.recipient,
-				cc: config.recipient ? undefined : config.cc, // Don't use cc/bcc for test emails
-				bcc: config.recipient ? undefined : config.bcc,
+				cc: recipientsOrUndefined(config.cc),
+				bcc: recipientsOrUndefined(config.bcc),
 				subject: `Neue Sichtung: ${referenceId}`,
 				html: htmlContent,
 				text: this.htmlToText(htmlContent)
 			};
 
 			// Send email
-			const info = await this.transporter.sendMail(mailOptions);
+			const info = await transporter.sendMail(mailOptions);
 
 			logger.info(
 				{
@@ -380,11 +493,12 @@ export class EmailService {
 	 */
 	static async sendTestEmail(recipient?: string): Promise<boolean> {
 		try {
-			if (!this.transporter) {
-				await this.initialize(true);
-			}
+			// `test = true`: Eine Test-Mail muss auch dann gehen, wenn die
+			// Benachrichtigungen selbst noch abgeschaltet sind — genau so prüft man
+			// die Konfiguration, bevor man sie scharf schaltet.
+			const transporter = await this.ensureTransporter(true);
 
-			if (!this.transporter) {
+			if (!transporter) {
 				throw new Error('Email service not available');
 			}
 
@@ -395,28 +509,43 @@ export class EmailService {
 				throw new Error('No recipient specified');
 			}
 
+			// CC/BCC gehören zur Konfiguration, die diese Mail prüfen soll — auch
+			// bei explizit übergebenem Empfänger. Der Knopf in `/admin/settings`
+			// schickt den konfigurierten Empfänger immer explizit mit; ein
+			// Override-Sonderfall würde CC/BCC genau auf dem einzigen Weg
+			// auslassen, auf dem eine Test-Mail überhaupt ausgelöst wird.
+			const cc = recipientsOrUndefined(config.cc);
+			const bcc = recipientsOrUndefined(config.bcc);
+
 			const mailOptions: SendMailOptions = {
 				from: {
 					name: config.senderName,
 					address: config.sender
 				},
 				to: testRecipient,
+				cc,
+				bcc,
 				subject: 'Test E-Mail - Ostsee-Tiere Konfiguration',
 				html: `
 					<h2>Test E-Mail</h2>
 					<p>Diese Test-E-Mail wurde erfolgreich von der Ostsee-Tiere Anwendung gesendet.</p>
 					<p><strong>Zeitpunkt:</strong> ${new Date().toLocaleString('de-DE', { timeZone: 'Europe/Berlin' })}</p>
 					<p><strong>Konfiguration:</strong> Funktioniert korrekt ✅</p>
+					<p><strong>Empfänger:</strong> ${escape(testRecipient)}${
+						cc ? `, Kopie an ${escape(cc.join(', '))}` : ''
+					}</p>
 				`,
 				text: 'Test E-Mail - Die Ostsee-Tiere E-Mail Konfiguration funktioniert korrekt.'
 			};
 
-			const info = await this.transporter.sendMail(mailOptions);
+			const info = await transporter.sendMail(mailOptions);
 
 			logger.info(
 				{
 					messageId: info.messageId,
-					recipient: testRecipient
+					recipient: testRecipient,
+					cc,
+					bcc
 				},
 				'Simple test email sent successfully'
 			);

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -73,6 +73,18 @@ async function configOrEnv(key: string, envValue: string): Promise<string> {
 }
 
 /**
+ * Escapt einen Wert für die Einbettung in den HTML-Body der Test-Mail.
+ *
+ * Empfänger und CC stammen aus Eingaben: CC aus den Einstellungen, der
+ * Empfänger aus dem Request-Body von `POST /api/config/test-email` — der ihn,
+ * anders als die Admin-Route, gar nicht gegen ein E-Mail-Muster prüft. Beides
+ * ist zwar Admin-beschränkt, roh interpoliertes HTML bleibt es trotzdem.
+ */
+function escape(value: string): string {
+	return Handlebars.escapeExpression(value);
+}
+
+/**
  * Macht aus einer Empfängerliste den Wert, den nodemailer erwartet: die
  * bereinigte Liste, oder `undefined` wenn nichts konfiguriert ist.
  *
@@ -85,18 +97,6 @@ async function configOrEnv(key: string, envValue: string): Promise<string> {
  * beim Eingeben, `PUT /api/config` nimmt aber jedes Array entgegen — ein
  * Leerstring landete sonst als leere Adresse im Header.
  */
-/**
- * Escapt einen Wert für die Einbettung in den HTML-Body der Test-Mail.
- *
- * Empfänger und CC stammen aus Eingaben: CC aus den Einstellungen, der
- * Empfänger aus dem Request-Body von `POST /api/config/test-email` — der ihn,
- * anders als die Admin-Route, gar nicht gegen ein E-Mail-Muster prüft. Beides
- * ist zwar Admin-beschränkt, roh interpoliertes HTML bleibt es trotzdem.
- */
-function escape(value: string): string {
-	return Handlebars.escapeExpression(value);
-}
-
 function recipientsOrUndefined(recipients: string[] | undefined): string[] | undefined {
 	const cleaned = (recipients ?? [])
 		.filter((entry): entry is string => typeof entry === 'string')

--- a/src/routes/api/config/+server.ts
+++ b/src/routes/api/config/+server.ts
@@ -8,6 +8,7 @@ import {
 	canUserAccessConfigKey
 } from '$lib/server/config/accessControl';
 import { requireUserRole } from '$lib/server/auth/auth';
+import { EmailService } from '$lib/server/services/emailService';
 import { warnIfBodySizeLimitTooLow } from '$lib/server/startup/bodySizeLimit';
 import { json, type RequestEvent } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
@@ -24,6 +25,32 @@ const BODY_SIZE_RELEVANT_CONFIG_KEYS = new Set([
 	'security.maxFileSize',
 	'security.maxVideoFileSize'
 ]);
+
+/**
+ * Verwirft die Kopie der Mail-Konfiguration im `EmailService`, wenn ein
+ * Schlüssel geändert wurde, den er liest.
+ *
+ * `ConfigRepository.clearCache()` reicht dafür nicht: Der `EmailService` hält
+ * seine eigene, fünf Minuten gültige Kopie (`getEmailConfig()`). Wer CC/BCC
+ * eintrug und direkt danach eine Test-Mail auslöste, bekam bis zu fünf Minuten
+ * lang die alte Empfängerliste — ohne Fehlermeldung, die Mail kam ja an, nur
+ * eben nicht bei den neuen Empfängern.
+ */
+function invalidateEmailCacheIfNeeded(key: string): void {
+	if (!key.startsWith('notification.email.') && !key.startsWith('email.smtp.')) {
+		return;
+	}
+
+	EmailService.clearCaches();
+
+	// Nur die SMTP-Schlüssel beschreiben die Verbindung selbst. Eine geänderte
+	// Empfängerliste ist kein Grund, eine funktionierende Verbindung wegzuwerfen
+	// — der Transporter wird sonst bei jedem Speichern in den Einstellungen neu
+	// aufgebaut.
+	if (key.startsWith('email.smtp.')) {
+		EmailService.resetTransporter();
+	}
+}
 
 const logger = createLogger('api:config');
 
@@ -119,6 +146,7 @@ export const PUT: RequestHandler = async ({
 
 		// Clear entire cache for configuration changes
 		ConfigRepository.clearCache();
+		invalidateEmailCacheIfNeeded(key);
 
 		const clientIp = getClientIp(getClientAddress, request);
 		await logAuditEvent({
@@ -170,6 +198,7 @@ export const DELETE: RequestHandler = async ({
 
 		// Clear entire cache for configuration changes
 		ConfigRepository.clearCache();
+		invalidateEmailCacheIfNeeded(key);
 
 		const clientIp = getClientIp(getClientAddress, request);
 		await logAuditEvent({

--- a/src/routes/api/config/config.test.ts
+++ b/src/routes/api/config/config.test.ts
@@ -35,7 +35,25 @@ vi.mock('$lib/server/config/accessControl', () => ({
 	canUserAccessConfigKey: vi.fn().mockReturnValue(true)
 }));
 
+vi.mock('$lib/server/services/emailService', () => ({
+	EmailService: { clearCaches: vi.fn(), resetTransporter: vi.fn() }
+}));
+
+import { EmailService } from '$lib/server/services/emailService';
 import { PUT, DELETE } from './+server';
+
+function putEvent(key: string, value: unknown, category: string) {
+	return {
+		request: new Request('http://localhost/api/config', {
+			method: 'PUT',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ key, value, category })
+		}),
+		locals: { user: { email: 'admin@test.com', sub: 'auth0|admin', roles: ['admin'] } },
+		url: new URL('http://localhost/api/config'),
+		getClientAddress: () => '127.0.0.1'
+	};
+}
 
 describe('PUT /api/config — Audit Logging', () => {
 	beforeEach(() => {
@@ -65,6 +83,55 @@ describe('PUT /api/config — Audit Logging', () => {
 				details: expect.objectContaining({ key: 'maintenance_mode', category: 'system' })
 			})
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// E-Mail-Cache
+//
+// `EmailService` hält seine eigene Kopie der Mail-Konfiguration fünf Minuten
+// lang. `ConfigRepository.clearCache()` erreicht die nicht. Wer also CC/BCC
+// speicherte und danach eine Test-Mail auslöste, bekam bis zu fünf Minuten lang
+// die alte Empfängerliste — die frisch eingetragene Adresse blieb aus, ohne
+// dass irgendwo ein Fehler erschien.
+// ---------------------------------------------------------------------------
+describe('PUT /api/config — E-Mail-Cache', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('verwirft den EmailService-Cache bei notification.email.*', async () => {
+		await PUT(putEvent('notification.email.cc', ['kopie@example.com'], 'email') as never);
+
+		expect(EmailService.clearCaches).toHaveBeenCalledOnce();
+	});
+
+	it('verwirft den EmailService-Cache bei email.smtp.*', async () => {
+		await PUT(putEvent('email.smtp.host', 'smtp.example.com', 'email') as never);
+
+		expect(EmailService.clearCaches).toHaveBeenCalledOnce();
+	});
+
+	it('rührt den EmailService-Cache bei fremden Schlüsseln nicht an', async () => {
+		await PUT(putEvent('display.maintenanceMode', true, 'display') as never);
+
+		expect(EmailService.clearCaches).not.toHaveBeenCalled();
+	});
+
+	// Der Transporter hält eine offene SMTP-Verbindung. Er muss neu aufgebaut
+	// werden, wenn sich die Verbindungsdaten ändern — aber auch nur dann: eine
+	// geänderte Empfängerliste ist kein Grund, eine funktionierende Verbindung
+	// wegzuwerfen.
+	it('verwirft den Transporter bei email.smtp.*', async () => {
+		await PUT(putEvent('email.smtp.host', 'smtp.example.com', 'email') as never);
+
+		expect(EmailService.resetTransporter).toHaveBeenCalledOnce();
+	});
+
+	it('verwirft den Transporter NICHT bei notification.email.*', async () => {
+		await PUT(putEvent('notification.email.cc', ['kopie@example.com'], 'email') as never);
+
+		expect(EmailService.resetTransporter).not.toHaveBeenCalled();
 	});
 });
 

--- a/vitest-setup-server.ts
+++ b/vitest-setup-server.ts
@@ -30,6 +30,7 @@ vi.mock('$lib/server/services/emailService', () => ({
 		sendNewSightingNotification: vi.fn().mockResolvedValue(true),
 		sendTestEmail: vi.fn().mockResolvedValue(true),
 		initialize: vi.fn().mockResolvedValue(undefined),
+		clearCaches: vi.fn(),
 		clearTemplateCache: vi.fn(),
 		// Static methods that might be called
 		getEmailConfig: vi.fn().mockResolvedValue({


### PR DESCRIPTION
## Befund

CC und BCC sind seit 2026-07-30 in den Einstellungen pflegbar — **kein Versandweg hat sie je gesetzt.**

- `sendEmailNotification()` schrieb `config.recipient ? undefined : config.cc`. Der Empfänger ist an der Stelle durch die Prüfung darüber garantiert gesetzt, der Ausdruck also konstant `undefined`. Der Kommentar („nicht für Test-Mails") beschrieb einen Pfad, der dort gar nicht liegt.
- `sendTestEmail()` kannte CC/BCC überhaupt nicht.

Beides fiel nicht auf, weil die Mail an den Hauptempfänger ankommt und niemand die stillen Mitleser vermisst.

Zwei weitere Ursachen für „der neue Empfänger kommt nicht an":

- **`EmailService` hält eine eigene, 5 Minuten gültige Kopie der Mail-Konfiguration**, die `ConfigRepository.clearCache()` nicht erreicht. Wer CC/BCC speicherte und sofort testete, bekam bis zu fünf Minuten lang die alte Empfängerliste — ohne Fehlermeldung.
- **Der SMTP-Transporter ist ein Startup-Singleton.** Geänderte Verbindungsdaten erreichten ihn nie; die Test-Mail prüfte die alte Verbindung und bescheinigte eine Konfiguration als funktionierend, die so gar nicht gespeichert war.

## Nebenbefund: stiller Dauerausfall

Der Transporter-Neuaufbau behebt einen zweiten Fehler. Schlug `verify()` beim Serverstart fehl (SMTP kurz nicht erreichbar), blieb der Transporter `null` — und `sendEmailNotification()` gab **dauerhaft** `false` zurück, bis jemand den Container neu startete. Nur die Test-Mail versuchte es erneut; die echten Benachrichtigungen blieben tot. Eine ausbleibende Benachrichtigung zeigt nirgends etwas an.

Ein fehlender Transporter ist jetzt ein Grund, ihn aufzubauen — kein Grund, die Mail zu verwerfen. Ein *gescheiterter* Aufbau liefert weiterhin `false`.

## Änderungen

- CC/BCC auf **beiden** Versandwegen. Leere Liste → `undefined`, damit „nicht konfiguriert" und „leer" in Header und Log unterscheidbar bleiben.
- Test-Mail setzt CC/BCC **auch bei explizit übergebenem Empfänger**: Der Knopf in `/admin/settings` schickt den konfigurierten Empfänger immer explizit mit, ein Override-Sonderfall hätte CC/BCC genau auf dem einzigen Auslöseweg weggelassen.
- `PUT`/`DELETE /api/config` verwirft den `EmailService`-Cache bei `notification.email.*` und `email.smtp.*`; den **Transporter** nur bei `email.smtp.*` — eine geänderte Empfängerliste ist kein Grund, eine funktionierende Verbindung wegzuwerfen.
- `ensureTransporter()` lässt nur einen Aufbau gleichzeitig zu. Ohne die Klammer bauten drei gleichzeitige Meldungen drei Transporter auf und schlossen einander die frisch aufgebaute Verbindung (im Test reproduziert).
- Empfänger und CC werden im Test-Mail-Body HTML-escapt — `POST /api/config/test-email` validiert den Empfänger nicht — und Leereinträge fliegen aus CC/BCC, weil `getArray()` den JSONB-Wert ungeprüft durchreicht.

## Zwei Dinge, die Review braucht

**Ein bestehender Test wurde umgeschrieben.** `„gibt false zurück wenn Transporter nicht initialisiert"` sicherte genau das Verhalten zu, das dieser PR beseitigt. Er heißt jetzt `„baut einen fehlenden Transporter auf statt die Mail zu verwerfen"`. Bewusste Vertragsänderung; der Gegenfall (Neuaufbau scheitert → `false`) hat einen eigenen Test.

**Die Tests waren reihenfolgeabhängig.** Der Transporter ist statisch und überlebte den einzelnen Test — ein in Test A aufgebauter ließ Test B versenden, obwohl der dort keinen aufgebaut hatte. `resetTransporter()` steht jetzt im `beforeEach`.

## Tests

Test-First, jeder Fix zuerst rot: 8 Tests für CC/BCC und Cache-Invalidierung, 6 für den Transporter-Lebenszyklus, 3 aus dem Selbst-Review (Escaping, Leereinträge, Nebenläufigkeit).

`npm run test:quick` grün — 232 Dateien, 3435 Tests, exit 0. Die 2 Lint-Warnungen sind vorbestehend (`src/tests/contract/helpers/createEvent.ts`).

**Nicht verifiziert:** der echte SMTP-Weg — das geht nur mit erreichbarem Server. Im Staging prüfbar: falschen Host eintragen, speichern, Test-Mail auslösen — sie muss jetzt sofort scheitern statt über die alte Verbindung zu gehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)