### PR TITLE
feat(admin): show dead-animal finds in the notification email

### DIFF
--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -151,6 +151,97 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	});
 
 	/**
+	 * Totfund: `isDead`, `deadCondition` und `deadSize` lagen bis 2026-08-04 im
+	 * Kontext, ohne dass eine ausgelieferte Vorlage sie je gerendert hätte — die
+	 * Mail zu einem Totfund unterschied sich in nichts von der zu einer lebenden
+	 * Sichtung. Ein Totfund ist der Fall, der eine Rückmeldung braucht (Bergung,
+	 * Beprobung).
+	 *
+	 * Der Betreff bleibt unverändert „Neue Sichtung: <REF>" — erkennbar ist der
+	 * Totfund also erst beim Öffnen der Mail, nicht schon in der Übersicht des
+	 * Posteingangs. Ein Betreff-Präfix wäre eine eigene Entscheidung (Mailfilter
+	 * beim DMM) und gehört nicht in diese Vorlage.
+	 */
+	describe('Totfund', () => {
+		function renderDeadFind(dead: {
+			isDead: boolean;
+			deadCondition?: string;
+			deadSize?: number | null;
+			deadPhoneContact?: boolean;
+		}) {
+			return render({
+				referenceId: 'REF-42',
+				adminUrl: 'https://example.com/admin/1',
+				currentDate: '04.08.2026',
+				currentTime: '12:00',
+				spamCheck: { score: 0, isHighRisk: false, indicators: [] },
+				sighting: {
+					species: 'Schweinswal',
+					sightingDate: '04.08.2026',
+					coordinatesFormatted: null,
+					balticSea: balticSeaEmailContext({}),
+					...dead
+				},
+				...emailColorContext()
+			});
+		}
+
+		it('weist einen Totfund aus und nennt Zustand und Körperlänge', () => {
+			const html = renderDeadFind({
+				isDead: true,
+				deadCondition: 'Mittlere Verwesung',
+				deadSize: 150
+			});
+
+			expect(html).toContain('Totfund');
+			expect(html).toContain('Mittlere Verwesung');
+			expect(html).toContain('150 cm');
+		});
+
+		it('lässt den Block bei einer lebenden Sichtung weg', () => {
+			const html = renderDeadFind({ isDead: false });
+
+			expect(html).not.toContain('Totfund');
+		});
+
+		// Zustand und Größe sind optional (`deadSize` ist in der Datenbank
+		// nullable). Ohne beides muss der Totfund trotzdem als solcher dastehen.
+		it('weist den Totfund auch ohne Zustand und Körperlänge aus', () => {
+			const html = renderDeadFind({ isDead: true, deadSize: null });
+
+			expect(html).toContain('Totfund');
+			expect(html).not.toContain('Zustand:');
+			// Nicht auf 'cm' prüfen: zwei Zeichen gegen das ganze Dokument wären
+			// bei jedem künftigen „cm" im Text falsch-rot.
+			expect(html).not.toContain('Körperlänge');
+		});
+
+		/**
+		 * `deadPhoneContact` beantwortet die Frage, ob das Meeresmuseum schon
+		 * telefonisch von dem Fund weiß. **Beide** Antworten sind eine Handlung:
+		 * „ja" heißt, dass die Bergung womöglich schon läuft und ein zweiter
+		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass sich niemand
+		 * gemeldet hat. Ein Block, der nur den Ja-Fall zeigt, ließe den
+		 * Empfänger im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint
+		 * wurde — deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 */
+		it('nennt eine bereits erfolgte telefonische Meldung', () => {
+			const html = renderDeadFind({ isDead: true, deadPhoneContact: true });
+
+			expect(html).toContain('Meeresmuseum');
+			expect(html).toContain('bereits telefonisch');
+		});
+
+		it('weist eine fehlende telefonische Meldung ebenfalls aus', () => {
+			const html = renderDeadFind({ isDead: true, deadPhoneContact: false });
+
+			expect(html).toContain('Meeresmuseum');
+			expect(html).not.toContain('bereits telefonisch');
+			expect(html).toContain('keine telefonische Meldung');
+		});
+	});
+
+	/**
 	 * Ein `<!-- … -->` mit `{{#if …}}` darin wird von Handlebars **ausgewertet**,
 	 * nicht zitiert — genau daran ist diese Vorlage beim Umbau einmal
 	 * unbalanciert geworden (Parse-Fehler erst zur Laufzeit). Erklärende Notizen
@@ -185,7 +276,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0');
+		expect(hash).toBe('32d2355c29f5800ece131f19746243cdb5962b0d884f6d50042bc0e3c80ea47e');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -217,13 +217,31 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 		});
 
 		/**
+		 * Gegenstück zu `sightingFormatter.test.ts` („unterdrückt deadCondition
+		 * beim UNKNOWN-Wert 0"): Dort endet der Enum-Wert 0 als `undefined`, hier
+		 * zählt, dass die Vorlage daraus keine Zeile macht. Ein leerer String
+		 * wäre der Fall, den `{{#if}}` allein nicht abfängt.
+		 */
+		it('lässt die Zustandszeile bei unbekanntem Zustand weg', () => {
+			const html = renderDeadFind({ isDead: true, deadCondition: '' });
+
+			expect(html).toContain('Totfund');
+			expect(html).not.toContain('Zustand:');
+		});
+
+		/**
 		 * `deadPhoneContact` beantwortet die Frage, ob das Meeresmuseum schon
 		 * telefonisch von dem Fund weiß. **Beide** Antworten sind eine Handlung:
 		 * „ja" heißt, dass die Bergung womöglich schon läuft und ein zweiter
-		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass sich niemand
-		 * gemeldet hat. Ein Block, der nur den Ja-Fall zeigt, ließe den
-		 * Empfänger im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint
-		 * wurde — deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass ein Rückruf nötig
+		 * sein kann. Ein Block, der nur den Ja-Fall zeigt, ließe den Empfänger
+		 * im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint wurde —
+		 * deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 *
+		 * Der Nein-Text bleibt bei „nicht als … gemeldet". Die Quelle ist ein
+		 * Kontrollkästchen mit Vorgabe „aus" (`totfund_telefon`, Standard 0);
+		 * ein „nicht informiert" behauptete über die Welt, was die Meldung nur
+		 * über sich selbst sagt.
 		 */
 		it('nennt eine bereits erfolgte telefonische Meldung', () => {
 			const html = renderDeadFind({ isDead: true, deadPhoneContact: true });
@@ -237,7 +255,9 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 
 			expect(html).toContain('Meeresmuseum');
 			expect(html).not.toContain('bereits telefonisch');
-			expect(html).toContain('keine telefonische Meldung');
+			expect(html).toContain('nicht als telefonisch informiert gemeldet');
+			// Der Empfänger soll wissen, was zu tun ist, nicht nur was fehlt.
+			expect(html).toContain('Rückruf');
 		});
 	});
 
@@ -276,7 +296,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('32d2355c29f5800ece131f19746243cdb5962b0d884f6d50042bc0e3c80ea47e');
+		expect(hash).toBe('aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -34,6 +34,11 @@
  * aktuellen Stands und schlägt bei jeder Änderung fehl.
  */
 export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
+	// Stand bis 2026-08-04: ohne Totfund-Abschnitt. `isDead`, `deadCondition`
+	// und `deadSize` lagen im Kontext, wurden aber von keiner ausgelieferten
+	// Vorlage gerendert — die Mail zu einem Totfund war von der zu einer
+	// lebenden Sichtung nicht zu unterscheiden.
+	'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
 	// Stand bis 2026-07-30: Foto-Hinweis wortidentisch, aber „rebuilter
 	// iOS-Client" statt der im Projekt sonst üblichen Formulierung „neu
 	// gebauter iOS-Client" (siehe .claude/rules/legacy-api.md).
@@ -154,6 +159,31 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 			{{/if}}
 		</table>
 	</div>
+
+	{{!--
+		Totfund. Der Zustand kommt als **Label** aus formatSightingForDisplay() —
+		der Rohwert ist ein Enum-Code und stünde hier als „Zustand: 3". Die Größe
+		ist eine Zahl in Zentimetern (Schema: „Körperlänge (cm)"), die Einheit
+		gehört deshalb in die Vorlage.
+
+		Die Zeile zum Meeresmuseum steht als einzige in **beiden** Fällen da: ein
+		„ja" warnt vor der Doppelmeldung, ein „nein" sagt, dass sich niemand
+		gemeldet hat. Ein weggelassener Nein-Fall wäre von einer fehlenden Angabe
+		nicht zu unterscheiden.
+	--}}
+	{{#if sighting.isDead}}
+	<div style="background: {{colors.errorSurface}}; border-left: 4px solid {{colors.errorStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 12px 0; color: {{colors.errorStrong}};">💀 Totfund</h3>
+		<p style="margin: 0;">Diese Meldung betrifft ein totes Tier.</p>
+		{{#if sighting.deadCondition}}
+		<p style="margin: 8px 0 0 0;"><strong>Zustand:</strong> {{sighting.deadCondition}}</p>
+		{{/if}}
+		{{#if sighting.deadSize}}
+		<p style="margin: 8px 0 0 0;"><strong>Körperlänge:</strong> {{sighting.deadSize}} cm</p>
+		{{/if}}
+		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}keine telefonische Meldung angegeben.{{/if}}</p>
+	</div>
+	{{/if}}
 
 	{{!--
 		Foto-Ankündigung: Der neu gebaute iOS-Client (OstSeeTiere/8, Stand

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -167,9 +167,17 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		gehört deshalb in die Vorlage.
 
 		Die Zeile zum Meeresmuseum steht als einzige in **beiden** Fällen da: ein
-		„ja" warnt vor der Doppelmeldung, ein „nein" sagt, dass sich niemand
-		gemeldet hat. Ein weggelassener Nein-Fall wäre von einer fehlenden Angabe
-		nicht zu unterscheiden.
+		„ja" warnt vor der Doppelmeldung, ein „nein" heißt, dass ein Rückruf
+		nötig sein kann. Ein weggelassener Nein-Fall wäre für den Empfänger von
+		einer fehlenden Angabe nicht zu unterscheiden.
+
+		Der Nein-Zweig sagt bewusst „nicht als telefonisch informiert gemeldet"
+		und nicht „nicht informiert": Die Quelle ist ein Kontrollkästchen mit
+		Vorgabe „aus" (Spalte totfund_telefon, Standard 0). Ein nicht gesetztes
+		Häkchen bedeutet, dass die Meldung dazu nichts aussagt — ein Anruf am
+		Telefon vorbei an diesem Formular ist damit nicht ausgeschlossen. Die
+		Vorlage darf deshalb den Zustand der Meldung wiedergeben, nicht den der
+		Welt.
 	--}}
 	{{#if sighting.isDead}}
 	<div style="background: {{colors.errorSurface}}; border-left: 4px solid {{colors.errorStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
@@ -181,7 +189,7 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		{{#if sighting.deadSize}}
 		<p style="margin: 8px 0 0 0;"><strong>Körperlänge:</strong> {{sighting.deadSize}} cm</p>
 		{{/if}}
-		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}keine telefonische Meldung angegeben.{{/if}}</p>
+		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}nicht als telefonisch informiert gemeldet — ein Rückruf beim Melder kann nötig sein.{{/if}}</p>
 	</div>
 	{{/if}}
 

--- a/src/lib/utils/format/sightingFormatter.test.ts
+++ b/src/lib/utils/format/sightingFormatter.test.ts
@@ -103,6 +103,21 @@ describe('sightingFormatter', () => {
 			expect(result.deadConditionRaw).toBe(AnimalConditionEnum.MEDIUM_DECOMPOSITION);
 		});
 
+		/**
+		 * `deadCondition` ist `notNull` mit Vorgabe 0 — „nicht ausgefüllt" kommt
+		 * aus der Datenbank also als `UNKNOWN` und nicht als `null` zurück.
+		 * Übersetzt ergäbe das die Zeile „Zustand: Unbekannt", die nichts
+		 * aussagt; unterdrückt bleibt der Abschnitt still. Das ist der Grund für
+		 * `if (deadCondition)` statt `if (deadCondition !== undefined)`.
+		 */
+		it('unterdrückt deadCondition beim UNKNOWN-Wert 0', () => {
+			const result = formatSightingForDisplay(
+				makeSighting({ isDead: true, deadCondition: AnimalConditionEnum.UNKNOWN })
+			);
+			expect(result.deadCondition).toBeUndefined();
+			expect(result.deadConditionRaw).toBeUndefined();
+		});
+
 		it('lässt deadCondition weg wenn nicht gesetzt', () => {
 			const sighting = makeSighting({});
 			delete (sighting as Record<string, unknown>).deadCondition;

--- a/src/lib/utils/format/sightingFormatter.test.ts
+++ b/src/lib/utils/format/sightingFormatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { AnimalConditionEnum } from '$lib/report/formOptions/animalCondition';
 import { SpeciesEnum } from '$lib/report/formOptions/species';
 import type { SightingFormValues } from '$lib/types/Form';
 import { formatSightingForDisplay, isUnknownOrMissingSpecies } from './sightingFormatter';
@@ -87,6 +88,27 @@ describe('sightingFormatter', () => {
 			const result = formatSightingForDisplay(sighting);
 			expect(result.distance).toBeUndefined();
 			expect(result.distanceRaw).toBeUndefined();
+		});
+
+		/**
+		 * Der Zustand eines Totfunds ist ein Enum-Code. Ungefiltert stünde in der
+		 * Benachrichtigungs-Mail „Zustand: 3" — die Vorlage kann ihn nicht
+		 * auflösen, hier ist die einzige Stelle, an der die Übersetzung passiert.
+		 */
+		it('übersetzt deadCondition-Enum wenn vorhanden', () => {
+			const result = formatSightingForDisplay(
+				makeSighting({ isDead: true, deadCondition: AnimalConditionEnum.MEDIUM_DECOMPOSITION })
+			);
+			expect(result.deadCondition).toBe('Mittlere Verwesung');
+			expect(result.deadConditionRaw).toBe(AnimalConditionEnum.MEDIUM_DECOMPOSITION);
+		});
+
+		it('lässt deadCondition weg wenn nicht gesetzt', () => {
+			const sighting = makeSighting({});
+			delete (sighting as Record<string, unknown>).deadCondition;
+			const result = formatSightingForDisplay(sighting);
+			expect(result.deadCondition).toBeUndefined();
+			expect(result.deadConditionRaw).toBeUndefined();
 		});
 
 		it('enthält restliche Felder unverändert', () => {

--- a/src/lib/utils/format/sightingFormatter.ts
+++ b/src/lib/utils/format/sightingFormatter.ts
@@ -2,6 +2,10 @@ import {
 	getAnimalBehaviorLabel,
 	type AnimalBehaviorEnum
 } from '$lib/report/formOptions/animalBehavior';
+import {
+	getAnimalConditionLabel,
+	type AnimalConditionEnum
+} from '$lib/report/formOptions/animalCondition';
 import { getDistanceLabel, type DistanceEnum } from '$lib/report/formOptions/distance';
 import { getSpeciesLabel, isValidSpecies, type SpeciesEnum } from '$lib/report/formOptions/species';
 import type { SightingFormValues } from '$lib/types/Form';
@@ -13,7 +17,7 @@ import { formatLocation } from './formatLocation';
  */
 export interface FormattedSightingData extends Omit<
 	SightingFormValues,
-	'species' | 'behavior' | 'distance'
+	'species' | 'behavior' | 'distance' | 'deadCondition'
 > {
 	species: string;
 	speciesRaw?: SpeciesEnum | number;
@@ -21,6 +25,8 @@ export interface FormattedSightingData extends Omit<
 	behaviorRaw?: AnimalBehaviorEnum | number;
 	distance?: string;
 	distanceRaw?: DistanceEnum | number;
+	deadCondition?: string;
+	deadConditionRaw?: AnimalConditionEnum | number;
 	sightingDate: string;
 	coordinatesFormatted: string | null;
 }
@@ -31,7 +37,7 @@ export interface FormattedSightingData extends Omit<
  */
 export function formatSightingForDisplay(sighting: SightingFormValues): FormattedSightingData {
 	// Destructure and omit the properties we'll replace
-	const { species, behavior, distance, ...restSighting } = sighting;
+	const { species, behavior, distance, deadCondition, ...restSighting } = sighting;
 
 	const formatted: FormattedSightingData = {
 		...restSighting,
@@ -59,6 +65,13 @@ export function formatSightingForDisplay(sighting: SightingFormValues): Formatte
 	if (distance) {
 		formatted.distance = getDistanceLabel(distance as DistanceEnum);
 		formatted.distanceRaw = distance as DistanceEnum;
+	}
+
+	// Zustand eines Totfunds. Wie oben nur bei gesetztem Wert: 0 ist
+	// `UNKNOWN` und liefert „Unbekannt" — eine Zeile, die nichts aussagt.
+	if (deadCondition) {
+		formatted.deadCondition = getAnimalConditionLabel(deadCondition as AnimalConditionEnum);
+		formatted.deadConditionRaw = deadCondition as AnimalConditionEnum;
 	}
 
 	return formatted;

--- a/src/tools/refresh-email-template.ts
+++ b/src/tools/refresh-email-template.ts
@@ -169,6 +169,15 @@ async function run(sql: postgres.Sql, connectionString: string): Promise<number>
 		console.error('    Bounding Box (z. B. Hamburger Hafen) weiterhin als Ostsee aus.');
 		console.error('    Details: docs/OSTSEE_FLAGS.md (Fehler 4)');
 		console.error('');
+		console.error('    Ebenfalls nachzutragen ist der Totfund-Abschnitt — ohne ihn ist eine');
+		console.error('    Totfund-Meldung in der Mail von einer lebenden Sichtung nicht zu');
+		console.error('    unterscheiden:');
+		console.error('      {{#if sighting.isDead}} … {{/if}}');
+		console.error('        ├ {{sighting.deadCondition}} — Zustand (fertiges Label)');
+		console.error('        ├ {{sighting.deadSize}} cm   — Körperlänge in Zentimetern');
+		console.error('        └ {{#if sighting.deadPhoneContact}} … {{else}} … {{/if}}');
+		console.error('            └ Meeresmuseum telefonisch informiert (beide Fälle nennen)');
+		console.error('');
 		console.error('    Bewusst verwerfen: erneut mit --force aufrufen.');
 		return 1;
 	}


### PR DESCRIPTION
## Problem

Der Handlebars-Kontext der Benachrichtigungs-Mail trägt `isDead`, `deadCondition`, `deadSize` und `deadPhoneContact` — **gerendert hat sie keine ausgelieferte Vorlage**. Die Mail zu einem Totfund war von der zu einer lebenden Sichtung nicht zu unterscheiden, obwohl genau dieser Fall eine Rückmeldung braucht (Bergung, Beprobung).

Die gelöschte `sightingNotificationTemplate.html` hatte einen solchen Block, wurde aber nie nach `build/` gebündelt und erreichte damit nie die Produktion — das ist eine alte Lücke, keine Regression aus #739.

## Änderung

**Totfund-Abschnitt** in `NOTIFICATION_EMAIL_DEFAULT_TEMPLATE`, zwischen Sichtungsdetails und Foto-Ankündigung:

```
💀 Totfund
Diese Meldung betrifft ein totes Tier.
Zustand: Mittlere Verwesung
Körperlänge: 150 cm
Meeresmuseum: laut Melder bereits telefonisch informiert — vor einem
              Rückruf bitte den Stand abgleichen, sonst entsteht eine
              Doppelmeldung.
```

Zwei Entscheidungen, die beim Bauen aufkamen:

- **`deadCondition` ist ein Enum-Code**, kein Text. `{{sighting.deadCondition}}` hätte „Zustand: 3" ergeben — derselbe Fehler steckte in der gelöschten `.html`. Die Übersetzung passiert jetzt in `formatSightingForDisplay()`, nach dem bestehenden Muster von `species`/`behavior`/`distance` (Label + `…Raw`, nur bei gesetztem Wert — `0` ist `UNKNOWN` und sagt nichts aus). `deadSize` bleibt eine Zahl, die Einheit steht in der Vorlage.
- **`deadPhoneContact` ist das einzige Feld mit `{{else}}`-Zweig.** Beide Antworten sind eine Handlung: „ja" warnt vor der Doppelmeldung, „nein" sagt, dass sich niemand gemeldet hat. Ein weggelassener Nein-Fall wäre für den Empfänger nicht von einer fehlenden Angabe zu unterscheiden.

Farben kommen aus den `{{colors.*}}`-Tokens (`errorSurface`/`errorStrong`, Überschrift auf Tint 5,4:1 → WCAG AA), erzwungen durch `emailTokens.test.ts`.

## Deploy — ohne diesen Schritt wirkt nichts

Der Wert in `app_config` gewinnt gegen die Konstante, und `refresh-email-template` läuft weder beim Container-Start noch als Migration. **Staging und Produktion verschicken die Mail weiterhin ohne den Block, bis dort einmal**

```bash
npm run config:refresh-email-template
```

**gelaufen ist** (vorher `:dry-run`). Der bisherige Stand `2444299392…` steht dafür in `PREVIOUS_SHIPPED_TEMPLATE_HASHES`; ein angepasster Kundentext wird nicht angefasst, sondern gemeldet — die Hand-Anleitung im `customised`-Zweig nennt den Totfund-Block jetzt mit. Laufende Instanzen halten die alte Vorlage bis zu 5 Minuten im Cache.

## Tests

Test-First, jeweils erst rot: Totfund ausgewiesen mit Zustand und Größe · weggelassen bei lebender Sichtung · ausgewiesen auch ohne Zustand und Größe · telefonische Meldung in beiden Richtungen (`notificationEmailDefault.test.ts`); Label-Übersetzung und Auslassung bei fehlendem Wert (`sightingFormatter.test.ts`).

`npm run test:quick` grün: 232 Dateien / 3436 Tests, Lint 0 Fehler, `tsc --noEmit` und `svelte-check` sauber.

## Bewusst nicht enthalten

- **Betreff** bleibt `Neue Sichtung: <REF>` — im Posteingang ist der Totfund weiter nicht erkennbar, erst beim Öffnen. Ein Präfix wäre eine eigene Entscheidung (Mailfilter beim DMM).
- **`deadSex`** fehlt im Mail-Kontext ganz (`loadSightingForEmail` überträgt es nicht). Nachzuziehen wären drei Stellen — als Vorlagen-Zeile allein stünde dort wieder ein Enum-Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)