### PR TITLE
chore(db): SQL to pull the notification template forward on hosts without a checkout

### DIFF
--- a/scripts/migrations/2026-08-04-notification-email-totfund.sql
+++ b/scripts/migrations/2026-08-04-notification-email-totfund.sql
@@ -1,0 +1,281 @@
+-- Zieht die geseedete Benachrichtigungs-Vorlage auf den Stand mit Totfund-Abschnitt.
+--
+-- Hintergrund: `app_config.notification.email.template` gewinnt gegen den
+-- Code-Default (`ConfigRepository.getString(…, NOTIFICATION_EMAIL_DEFAULT_TEMPLATE)`).
+-- Ohne diesen Lauf verschickt die Installation die Mail weiter ohne den Block —
+-- eine Totfund-Meldung ist dort von einer lebenden Sichtung nicht zu unterscheiden.
+--
+-- Das Gegenstück zu `npm run config:refresh-email-template`, für Hosts, auf denen
+-- kein Checkout liegt (das Runtime-Image enthält `src/tools/` nicht).
+--
+-- Aufruf auf dem DMM-Host: Die Datenbank veröffentlicht dort keinen Port, sie
+-- hängt nur im internen Docker-Netz `ostsee_internal`. Weder ein psql vom Host
+-- noch ein SSH-Tunnel erreichen sie — der Weg führt durch den Container:
+--
+--   scp scripts/migrations/2026-08-04-notification-email-totfund.sql dmm:/tmp/
+--   ssh dmm
+--   cd /opt/ostsee-tiere
+--   sudo -v   # Passwort vorab, damit die Eingabeumleitung unten nicht mit dem
+--             # Prompt konkurriert
+--   sudo docker compose exec -T db psql -U postgres -d ostsee \
+--     < /tmp/2026-08-04-notification-email-totfund.sql
+--
+-- `psql -U postgres` im Container braucht kein Passwort (lokale Socket-
+-- Verbindung, `trust` in der pg_hba des Images). Erwartete Ausgabe: `UPDATE 1`
+-- und die OK-Meldung; bei `UPDATE 0` entscheidet die Schluss-Abfrage, ob der
+-- Stand schon aktuell oder der Text angepasst ist.
+--
+-- Sicherheit: Die UPDATE-Bedingung prüft den SHA-256 des gespeicherten Werts gegen
+-- die Liste der jemals ausgelieferten Stände. Ein im Admin-Bereich angepasster
+-- Text trifft keinen Eintrag und bleibt unangetastet — der Lauf meldet dann
+-- `UPDATE 0` und die Schluss-Abfrage sagt es im Klartext.
+--
+-- Idempotent: Ein zweiter Lauf ändert nichts (der aktuelle Stand steht bewusst
+-- nicht in der Liste der erlaubten Ausgangswerte).
+
+BEGIN;
+
+-- 1. Ist-Zustand vor der Änderung
+SELECT
+	updated_by,
+	updated_at,
+	length(value #>> '{}') AS zeichen,
+	encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS hash_vorher
+FROM app_config
+WHERE key = 'notification.email.template';
+
+-- 2. Nachziehen — nur, wenn der gespeicherte Wert ein unveränderter Seed ist
+UPDATE app_config
+SET
+	value = to_jsonb($tpl$<!DOCTYPE html>
+<html lang="de">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Neue Sichtung - {{referenceId}}</title>
+	<style>
+		.alert-warning { background: {{colors.warningSurface}}; border-left: 4px solid {{colors.warningStrong}}; padding: 12px; margin: 16px 0; }
+		.alert-success { background: {{colors.successSurface}}; border-left: 4px solid {{colors.successStrong}}; padding: 12px; margin: 16px 0; }
+		.alert-info { background: {{colors.infoSurface}}; border-left: 4px solid {{colors.infoStrong}}; padding: 12px; margin: 16px 0; }
+		/* Die Fläche kommt inline aus {{sighting.balticSea.surface}} — ein
+		   Klassenname pro Status wäre eine zweite Zuordnung des Status. */
+		.badge { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 12px; font-weight: bold; }
+		.coordinates { font-family: monospace; background: {{colors.page}}; padding: 4px 8px; border-radius: 4px; }
+	</style>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 650px; margin: 0 auto; padding: 20px; line-height: 1.6; color: {{colors.text}};">
+	<!-- Header -->
+	<div style="background: {{colors.brand}}; color: {{colors.brandContent}}; padding: 24px; border-radius: 8px; text-align: center; margin-bottom: 24px;">
+		<h1 style="margin: 0; font-size: 24px;">🐋 Neue Sichtung eingegangen</h1>
+		<p style="margin: 8px 0 0 0; opacity: 0.9;">Referenz: <strong>{{referenceId}}</strong></p>
+		<p style="margin: 4px 0 0 0; font-size: 14px; opacity: 0.8;">{{currentDate}} um {{currentTime}}</p>
+	</div>
+
+	<!-- Spam Check Warning -->
+	{{#if spamCheck.isHighRisk}}
+	<div class="alert-warning">
+		<h4 style="margin: 0 0 8px 0; color: {{colors.warningStrong}};">⚠️ Spam-Verdacht (Score: {{spamCheck.score}})</h4>
+		<ul style="margin: 8px 0 0 20px; padding: 0;">
+			{{#each spamCheck.indicators}}
+			<li style="margin: 4px 0;">{{this}}</li>
+			{{/each}}
+		</ul>
+		<p style="margin: 8px 0 0 0; font-size: 14px;"><strong>Hinweis:</strong> Bitte prüfen Sie diese Sichtung besonders sorgfältig.</p>
+	</div>
+	{{/if}}
+
+	<!-- Geographic Validation -->
+	{{!--
+		Handlebars-Kommentar, kein HTML-Kommentar: in einem <!-- --> würde die
+		unten genannte Bedingung ausgewertet statt zitiert.
+
+		Der ganze Block hing früher an der Koordinaten-Bedingung — eine Meldung
+		ohne Koordinaten erwähnte die Position dann gar nicht, während die
+		Admin-Übersicht „ohne Position" anzeigte. Der Status steht deshalb immer
+		da; nur die Koordinatenzeile hängt an den Koordinaten.
+	--}}
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}}; display: flex; align-items: center;">
+			📍 Positionsangabe
+			<span class="badge" style="margin-left: 12px; background: {{sighting.balticSea.surface}}; color: {{colors.text}};">{{sighting.balticSea.label}}</span>
+		</h3>
+		{{#if sighting.coordinatesFormatted}}
+		<p><strong>Koordinaten:</strong> <span class="coordinates">{{sighting.coordinatesFormatted}}</span></p>
+		{{/if}}
+		{{#if sighting.waterway}}
+		<p><strong>Gewässer:</strong> {{sighting.waterway}}</p>
+		{{/if}}
+		{{#if sighting.seaMark}}
+		<p><strong>Seezeichen:</strong> {{sighting.seaMark}}</p>
+		{{/if}}
+		
+		{{#if sighting.balticSea.needsAttention}}
+		<div class="alert-info">
+			<p style="margin: 0; font-size: 14px;">
+				<strong>Achtung:</strong> {{sighting.balticSea.title}}
+			</p>
+		</div>
+		{{/if}}
+	</div>
+
+	<!-- Sighting Details -->
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}};">🔍 Sichtungsdetails</h3>
+		<table style="width: 100%; border-collapse: collapse;">
+			<tr>
+				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top; width: 120px;">Datum:</td>
+				<td style="padding: 8px 0;">{{sighting.sightingDate}}</td>
+			</tr>
+			{{#if sighting.species}}
+			<tr>
+				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top;">Tierart:</td>
+				<td style="padding: 8px 0;">{{sighting.species}}</td>
+			</tr>
+			{{/if}}
+			{{#if sighting.totalCount}}
+			<tr>
+				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top;">Anzahl:</td>
+				<td style="padding: 8px 0;">{{sighting.totalCount}}</td>
+			</tr>
+			{{/if}}
+			{{#if sighting.distance}}
+			<tr>
+				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top;">Entfernung:</td>
+				<td style="padding: 8px 0;">{{sighting.distance}}</td>
+			</tr>
+			{{/if}}
+			{{#if sighting.behavior}}
+			<tr>
+				<td style="padding: 8px 12px 8px 0; font-weight: bold; vertical-align: top;">Verhalten:</td>
+				<td style="padding: 8px 0;">{{sighting.behavior}}</td>
+			</tr>
+			{{/if}}
+		</table>
+	</div>
+
+	{{!--
+		Totfund. Der Zustand kommt als **Label** aus formatSightingForDisplay() —
+		der Rohwert ist ein Enum-Code und stünde hier als „Zustand: 3". Die Größe
+		ist eine Zahl in Zentimetern (Schema: „Körperlänge (cm)"), die Einheit
+		gehört deshalb in die Vorlage.
+
+		Die Zeile zum Meeresmuseum steht als einzige in **beiden** Fällen da: ein
+		„ja" warnt vor der Doppelmeldung, ein „nein" heißt, dass ein Rückruf
+		nötig sein kann. Ein weggelassener Nein-Fall wäre für den Empfänger von
+		einer fehlenden Angabe nicht zu unterscheiden.
+
+		Der Nein-Zweig sagt bewusst „nicht als telefonisch informiert gemeldet"
+		und nicht „nicht informiert": Die Quelle ist ein Kontrollkästchen mit
+		Vorgabe „aus" (Spalte totfund_telefon, Standard 0). Ein nicht gesetztes
+		Häkchen bedeutet, dass die Meldung dazu nichts aussagt — ein Anruf am
+		Telefon vorbei an diesem Formular ist damit nicht ausgeschlossen. Die
+		Vorlage darf deshalb den Zustand der Meldung wiedergeben, nicht den der
+		Welt.
+	--}}
+	{{#if sighting.isDead}}
+	<div style="background: {{colors.errorSurface}}; border-left: 4px solid {{colors.errorStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 12px 0; color: {{colors.errorStrong}};">💀 Totfund</h3>
+		<p style="margin: 0;">Diese Meldung betrifft ein totes Tier.</p>
+		{{#if sighting.deadCondition}}
+		<p style="margin: 8px 0 0 0;"><strong>Zustand:</strong> {{sighting.deadCondition}}</p>
+		{{/if}}
+		{{#if sighting.deadSize}}
+		<p style="margin: 8px 0 0 0;"><strong>Körperlänge:</strong> {{sighting.deadSize}} cm</p>
+		{{/if}}
+		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}nicht als telefonisch informiert gemeldet — ein Rückruf beim Melder kann nötig sein.{{/if}}</p>
+	</div>
+	{{/if}}
+
+	{{!--
+		Foto-Ankündigung: Der neu gebaute iOS-Client (OstSeeTiere/8, Stand
+		2026-07-30) setzt aufnahmeHochladen, kann aber selbst keine Datei
+		hochladen — der Melder wird gebeten, das Foto per E-Mail nachzureichen.
+		Ohne diesen Hinweis lässt sich die später eintreffende Foto-Mail keiner
+		Sichtung zuordnen. Siehe $lib/utils/media/photoAnnouncement.ts.
+	--}}
+	{{#if sighting.mediaUpload}}
+	<div class="alert-info">
+		<p style="margin: 0; font-size: 14px;">
+			<strong>📷 Foto angekündigt:</strong> Der Melder hat laut App ein Foto, kann es aber nicht direkt hochladen — es kommt separat per E-Mail nach. Beim Eintreffen bitte anhand der Referenz-ID <strong>{{referenceId}}</strong> zuordnen.
+		</p>
+	</div>
+	{{/if}}
+
+	<!-- Contact Information -->
+	{{#if sighting.email}}
+	<div style="background: {{colors.surface}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 16px 0; color: {{colors.brand}};">👤 Kontaktdaten</h3>
+		{{#if sighting.firstName}}
+		<p><strong>Name:</strong> {{sighting.firstName}} {{sighting.lastName}}</p>
+		{{/if}}
+		<p><strong>E-Mail:</strong> <a href="mailto:{{sighting.email}}" style="color: {{colors.brand}};">{{sighting.email}}</a></p>
+		{{#if sighting.phone}}
+		<p><strong>Telefon:</strong> <a href="tel:{{sighting.phone}}" style="color: {{colors.brand}};">{{sighting.phone}}</a></p>
+		{{/if}}
+	</div>
+	{{/if}}
+
+	<!-- Notes -->
+	{{#if sighting.notes}}
+	<div style="background: {{colors.warningSurface}}; border-left: 4px solid {{colors.warningStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 12px 0; color: {{colors.warningStrong}};">💬 Bemerkungen</h3>
+		<p style="margin: 0; white-space: pre-wrap;">{{sighting.notes}}</p>
+	</div>
+	{{/if}}
+
+	<!-- Additional Spam Indicators -->
+	{{#if spamCheck.indicators}}
+	{{#unless spamCheck.isHighRisk}}
+	{{#if spamCheck.score}}
+	<div style="background: {{colors.warningSurface}}; padding: 16px; border-radius: 6px; margin: 20px 0; font-size: 14px;">
+		<p style="margin: 0 0 8px 0;"><strong>Hinweise zur Qualitätsprüfung (Score: {{spamCheck.score}}):</strong></p>
+		<ul style="margin: 0; padding-left: 20px;">
+			{{#each spamCheck.indicators}}
+			<li style="margin: 2px 0;">{{this}}</li>
+			{{/each}}
+		</ul>
+	</div>
+	{{/if}}
+	{{/unless}}
+	{{/if}}
+	
+	<!-- Action Button -->
+	<div style="text-align: center; margin: 32px 0;">
+		<a href="{{adminUrl}}" style="display: inline-block; background: {{colors.brand}}; color: {{colors.brandContent}}; padding: 16px 32px; text-decoration: none; border-radius: 8px; font-weight: bold;">
+			🔍 Sichtung im Admin-Bereich prüfen
+		</a>
+	</div>
+
+	<!-- Footer -->
+	<div style="text-align: center; margin-top: 32px; padding-top: 24px; border-top: 1px solid {{colors.border}}; color: {{colors.textMuted}}; font-size: 14px;">
+		<p style="margin: 0;">Ostsee-Tiere · Sichtungsmeldungen für den Meeresschutz</p>
+		<p style="margin: 8px 0 0 0;">Diese E-Mail wurde automatisch generiert am {{currentDate}} um {{currentTime}}</p>
+	</div>
+</body>
+</html>$tpl$::text),
+	updated_by = 'refresh-email-template-sql',
+	updated_at = NOW()
+WHERE key = 'notification.email.template'
+	AND encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') = ANY (ARRAY[
+		'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
+		'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
+		'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
+		'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
+		'ba2a26024338b19b441c6b5aa2d6b8d66aea611fa474952952d859b0c40d46bc'
+	]);
+
+-- 3. Ergebnis im Klartext
+SELECT CASE
+	WHEN h = 'aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763'
+		THEN 'OK — Vorlage ist auf dem aktuellen Stand (Totfund-Abschnitt enthalten).'
+	ELSE 'ACHTUNG — kein bekannter Seed, es wurde nichts geaendert. Angepasster Text, Hash: ' || h
+END AS ergebnis
+FROM (
+	SELECT encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS h
+	FROM app_config
+	WHERE key = 'notification.email.template'
+) t;
+
+COMMIT;
+
+-- Laufende Instanzen halten die alte Vorlage bis zu 5 Minuten im Config-Cache.

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -151,6 +151,97 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	});
 
 	/**
+	 * Totfund: `isDead`, `deadCondition` und `deadSize` lagen bis 2026-08-04 im
+	 * Kontext, ohne dass eine ausgelieferte Vorlage sie je gerendert hätte — die
+	 * Mail zu einem Totfund unterschied sich in nichts von der zu einer lebenden
+	 * Sichtung. Ein Totfund ist der Fall, der eine Rückmeldung braucht (Bergung,
+	 * Beprobung).
+	 *
+	 * Der Betreff bleibt unverändert „Neue Sichtung: <REF>" — erkennbar ist der
+	 * Totfund also erst beim Öffnen der Mail, nicht schon in der Übersicht des
+	 * Posteingangs. Ein Betreff-Präfix wäre eine eigene Entscheidung (Mailfilter
+	 * beim DMM) und gehört nicht in diese Vorlage.
+	 */
+	describe('Totfund', () => {
+		function renderDeadFind(dead: {
+			isDead: boolean;
+			deadCondition?: string;
+			deadSize?: number | null;
+			deadPhoneContact?: boolean;
+		}) {
+			return render({
+				referenceId: 'REF-42',
+				adminUrl: 'https://example.com/admin/1',
+				currentDate: '04.08.2026',
+				currentTime: '12:00',
+				spamCheck: { score: 0, isHighRisk: false, indicators: [] },
+				sighting: {
+					species: 'Schweinswal',
+					sightingDate: '04.08.2026',
+					coordinatesFormatted: null,
+					balticSea: balticSeaEmailContext({}),
+					...dead
+				},
+				...emailColorContext()
+			});
+		}
+
+		it('weist einen Totfund aus und nennt Zustand und Körperlänge', () => {
+			const html = renderDeadFind({
+				isDead: true,
+				deadCondition: 'Mittlere Verwesung',
+				deadSize: 150
+			});
+
+			expect(html).toContain('Totfund');
+			expect(html).toContain('Mittlere Verwesung');
+			expect(html).toContain('150 cm');
+		});
+
+		it('lässt den Block bei einer lebenden Sichtung weg', () => {
+			const html = renderDeadFind({ isDead: false });
+
+			expect(html).not.toContain('Totfund');
+		});
+
+		// Zustand und Größe sind optional (`deadSize` ist in der Datenbank
+		// nullable). Ohne beides muss der Totfund trotzdem als solcher dastehen.
+		it('weist den Totfund auch ohne Zustand und Körperlänge aus', () => {
+			const html = renderDeadFind({ isDead: true, deadSize: null });
+
+			expect(html).toContain('Totfund');
+			expect(html).not.toContain('Zustand:');
+			// Nicht auf 'cm' prüfen: zwei Zeichen gegen das ganze Dokument wären
+			// bei jedem künftigen „cm" im Text falsch-rot.
+			expect(html).not.toContain('Körperlänge');
+		});
+
+		/**
+		 * `deadPhoneContact` beantwortet die Frage, ob das Meeresmuseum schon
+		 * telefonisch von dem Fund weiß. **Beide** Antworten sind eine Handlung:
+		 * „ja" heißt, dass die Bergung womöglich schon läuft und ein zweiter
+		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass sich niemand
+		 * gemeldet hat. Ein Block, der nur den Ja-Fall zeigt, ließe den
+		 * Empfänger im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint
+		 * wurde — deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 */
+		it('nennt eine bereits erfolgte telefonische Meldung', () => {
+			const html = renderDeadFind({ isDead: true, deadPhoneContact: true });
+
+			expect(html).toContain('Meeresmuseum');
+			expect(html).toContain('bereits telefonisch');
+		});
+
+		it('weist eine fehlende telefonische Meldung ebenfalls aus', () => {
+			const html = renderDeadFind({ isDead: true, deadPhoneContact: false });
+
+			expect(html).toContain('Meeresmuseum');
+			expect(html).not.toContain('bereits telefonisch');
+			expect(html).toContain('keine telefonische Meldung');
+		});
+	});
+
+	/**
 	 * Ein `<!-- … -->` mit `{{#if …}}` darin wird von Handlebars **ausgewertet**,
 	 * nicht zitiert — genau daran ist diese Vorlage beim Umbau einmal
 	 * unbalanciert geworden (Parse-Fehler erst zur Laufzeit). Erklärende Notizen
@@ -185,7 +276,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0');
+		expect(hash).toBe('32d2355c29f5800ece131f19746243cdb5962b0d884f6d50042bc0e3c80ea47e');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -217,13 +217,31 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 		});
 
 		/**
+		 * Gegenstück zu `sightingFormatter.test.ts` („unterdrückt deadCondition
+		 * beim UNKNOWN-Wert 0"): Dort endet der Enum-Wert 0 als `undefined`, hier
+		 * zählt, dass die Vorlage daraus keine Zeile macht. Ein leerer String
+		 * wäre der Fall, den `{{#if}}` allein nicht abfängt.
+		 */
+		it('lässt die Zustandszeile bei unbekanntem Zustand weg', () => {
+			const html = renderDeadFind({ isDead: true, deadCondition: '' });
+
+			expect(html).toContain('Totfund');
+			expect(html).not.toContain('Zustand:');
+		});
+
+		/**
 		 * `deadPhoneContact` beantwortet die Frage, ob das Meeresmuseum schon
 		 * telefonisch von dem Fund weiß. **Beide** Antworten sind eine Handlung:
 		 * „ja" heißt, dass die Bergung womöglich schon läuft und ein zweiter
-		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass sich niemand
-		 * gemeldet hat. Ein Block, der nur den Ja-Fall zeigt, ließe den
-		 * Empfänger im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint
-		 * wurde — deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 * Rückruf eine Doppelmeldung wäre; „nein" heißt, dass ein Rückruf nötig
+		 * sein kann. Ein Block, der nur den Ja-Fall zeigt, ließe den Empfänger
+		 * im Nein-Fall im Unklaren, ob die Angabe fehlt oder verneint wurde —
+		 * deshalb hier als einziges Feld mit `{{else}}`-Zweig.
+		 *
+		 * Der Nein-Text bleibt bei „nicht als … gemeldet". Die Quelle ist ein
+		 * Kontrollkästchen mit Vorgabe „aus" (`totfund_telefon`, Standard 0);
+		 * ein „nicht informiert" behauptete über die Welt, was die Meldung nur
+		 * über sich selbst sagt.
 		 */
 		it('nennt eine bereits erfolgte telefonische Meldung', () => {
 			const html = renderDeadFind({ isDead: true, deadPhoneContact: true });
@@ -237,7 +255,9 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 
 			expect(html).toContain('Meeresmuseum');
 			expect(html).not.toContain('bereits telefonisch');
-			expect(html).toContain('keine telefonische Meldung');
+			expect(html).toContain('nicht als telefonisch informiert gemeldet');
+			// Der Empfänger soll wissen, was zu tun ist, nicht nur was fehlt.
+			expect(html).toContain('Rückruf');
 		});
 	});
 
@@ -276,7 +296,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('32d2355c29f5800ece131f19746243cdb5962b0d884f6d50042bc0e3c80ea47e');
+		expect(hash).toBe('aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -34,6 +34,11 @@
  * aktuellen Stands und schlägt bei jeder Änderung fehl.
  */
 export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
+	// Stand bis 2026-08-04: ohne Totfund-Abschnitt. `isDead`, `deadCondition`
+	// und `deadSize` lagen im Kontext, wurden aber von keiner ausgelieferten
+	// Vorlage gerendert — die Mail zu einem Totfund war von der zu einer
+	// lebenden Sichtung nicht zu unterscheiden.
+	'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
 	// Stand bis 2026-07-30: Foto-Hinweis wortidentisch, aber „rebuilter
 	// iOS-Client" statt der im Projekt sonst üblichen Formulierung „neu
 	// gebauter iOS-Client" (siehe .claude/rules/legacy-api.md).
@@ -154,6 +159,31 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 			{{/if}}
 		</table>
 	</div>
+
+	{{!--
+		Totfund. Der Zustand kommt als **Label** aus formatSightingForDisplay() —
+		der Rohwert ist ein Enum-Code und stünde hier als „Zustand: 3". Die Größe
+		ist eine Zahl in Zentimetern (Schema: „Körperlänge (cm)"), die Einheit
+		gehört deshalb in die Vorlage.
+
+		Die Zeile zum Meeresmuseum steht als einzige in **beiden** Fällen da: ein
+		„ja" warnt vor der Doppelmeldung, ein „nein" sagt, dass sich niemand
+		gemeldet hat. Ein weggelassener Nein-Fall wäre von einer fehlenden Angabe
+		nicht zu unterscheiden.
+	--}}
+	{{#if sighting.isDead}}
+	<div style="background: {{colors.errorSurface}}; border-left: 4px solid {{colors.errorStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
+		<h3 style="margin: 0 0 12px 0; color: {{colors.errorStrong}};">💀 Totfund</h3>
+		<p style="margin: 0;">Diese Meldung betrifft ein totes Tier.</p>
+		{{#if sighting.deadCondition}}
+		<p style="margin: 8px 0 0 0;"><strong>Zustand:</strong> {{sighting.deadCondition}}</p>
+		{{/if}}
+		{{#if sighting.deadSize}}
+		<p style="margin: 8px 0 0 0;"><strong>Körperlänge:</strong> {{sighting.deadSize}} cm</p>
+		{{/if}}
+		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}keine telefonische Meldung angegeben.{{/if}}</p>
+	</div>
+	{{/if}}
 
 	{{!--
 		Foto-Ankündigung: Der neu gebaute iOS-Client (OstSeeTiere/8, Stand

--- a/src/lib/server/templates/notificationEmailDefault.ts
+++ b/src/lib/server/templates/notificationEmailDefault.ts
@@ -167,9 +167,17 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		gehört deshalb in die Vorlage.
 
 		Die Zeile zum Meeresmuseum steht als einzige in **beiden** Fällen da: ein
-		„ja" warnt vor der Doppelmeldung, ein „nein" sagt, dass sich niemand
-		gemeldet hat. Ein weggelassener Nein-Fall wäre von einer fehlenden Angabe
-		nicht zu unterscheiden.
+		„ja" warnt vor der Doppelmeldung, ein „nein" heißt, dass ein Rückruf
+		nötig sein kann. Ein weggelassener Nein-Fall wäre für den Empfänger von
+		einer fehlenden Angabe nicht zu unterscheiden.
+
+		Der Nein-Zweig sagt bewusst „nicht als telefonisch informiert gemeldet"
+		und nicht „nicht informiert": Die Quelle ist ein Kontrollkästchen mit
+		Vorgabe „aus" (Spalte totfund_telefon, Standard 0). Ein nicht gesetztes
+		Häkchen bedeutet, dass die Meldung dazu nichts aussagt — ein Anruf am
+		Telefon vorbei an diesem Formular ist damit nicht ausgeschlossen. Die
+		Vorlage darf deshalb den Zustand der Meldung wiedergeben, nicht den der
+		Welt.
 	--}}
 	{{#if sighting.isDead}}
 	<div style="background: {{colors.errorSurface}}; border-left: 4px solid {{colors.errorStrong}}; padding: 20px; border-radius: 8px; margin: 20px 0;">
@@ -181,7 +189,7 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		{{#if sighting.deadSize}}
 		<p style="margin: 8px 0 0 0;"><strong>Körperlänge:</strong> {{sighting.deadSize}} cm</p>
 		{{/if}}
-		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}keine telefonische Meldung angegeben.{{/if}}</p>
+		<p style="margin: 8px 0 0 0;"><strong>Meeresmuseum:</strong> {{#if sighting.deadPhoneContact}}laut Melder bereits telefonisch informiert — vor einem Rückruf bitte den Stand abgleichen, sonst entsteht eine Doppelmeldung.{{else}}nicht als telefonisch informiert gemeldet — ein Rückruf beim Melder kann nötig sein.{{/if}}</p>
 	</div>
 	{{/if}}
 

--- a/src/lib/utils/format/sightingFormatter.test.ts
+++ b/src/lib/utils/format/sightingFormatter.test.ts
@@ -103,6 +103,21 @@ describe('sightingFormatter', () => {
 			expect(result.deadConditionRaw).toBe(AnimalConditionEnum.MEDIUM_DECOMPOSITION);
 		});
 
+		/**
+		 * `deadCondition` ist `notNull` mit Vorgabe 0 — „nicht ausgefüllt" kommt
+		 * aus der Datenbank also als `UNKNOWN` und nicht als `null` zurück.
+		 * Übersetzt ergäbe das die Zeile „Zustand: Unbekannt", die nichts
+		 * aussagt; unterdrückt bleibt der Abschnitt still. Das ist der Grund für
+		 * `if (deadCondition)` statt `if (deadCondition !== undefined)`.
+		 */
+		it('unterdrückt deadCondition beim UNKNOWN-Wert 0', () => {
+			const result = formatSightingForDisplay(
+				makeSighting({ isDead: true, deadCondition: AnimalConditionEnum.UNKNOWN })
+			);
+			expect(result.deadCondition).toBeUndefined();
+			expect(result.deadConditionRaw).toBeUndefined();
+		});
+
 		it('lässt deadCondition weg wenn nicht gesetzt', () => {
 			const sighting = makeSighting({});
 			delete (sighting as Record<string, unknown>).deadCondition;

--- a/src/lib/utils/format/sightingFormatter.test.ts
+++ b/src/lib/utils/format/sightingFormatter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { AnimalConditionEnum } from '$lib/report/formOptions/animalCondition';
 import { SpeciesEnum } from '$lib/report/formOptions/species';
 import type { SightingFormValues } from '$lib/types/Form';
 import { formatSightingForDisplay, isUnknownOrMissingSpecies } from './sightingFormatter';
@@ -87,6 +88,27 @@ describe('sightingFormatter', () => {
 			const result = formatSightingForDisplay(sighting);
 			expect(result.distance).toBeUndefined();
 			expect(result.distanceRaw).toBeUndefined();
+		});
+
+		/**
+		 * Der Zustand eines Totfunds ist ein Enum-Code. Ungefiltert stünde in der
+		 * Benachrichtigungs-Mail „Zustand: 3" — die Vorlage kann ihn nicht
+		 * auflösen, hier ist die einzige Stelle, an der die Übersetzung passiert.
+		 */
+		it('übersetzt deadCondition-Enum wenn vorhanden', () => {
+			const result = formatSightingForDisplay(
+				makeSighting({ isDead: true, deadCondition: AnimalConditionEnum.MEDIUM_DECOMPOSITION })
+			);
+			expect(result.deadCondition).toBe('Mittlere Verwesung');
+			expect(result.deadConditionRaw).toBe(AnimalConditionEnum.MEDIUM_DECOMPOSITION);
+		});
+
+		it('lässt deadCondition weg wenn nicht gesetzt', () => {
+			const sighting = makeSighting({});
+			delete (sighting as Record<string, unknown>).deadCondition;
+			const result = formatSightingForDisplay(sighting);
+			expect(result.deadCondition).toBeUndefined();
+			expect(result.deadConditionRaw).toBeUndefined();
 		});
 
 		it('enthält restliche Felder unverändert', () => {

--- a/src/lib/utils/format/sightingFormatter.ts
+++ b/src/lib/utils/format/sightingFormatter.ts
@@ -2,6 +2,10 @@ import {
 	getAnimalBehaviorLabel,
 	type AnimalBehaviorEnum
 } from '$lib/report/formOptions/animalBehavior';
+import {
+	getAnimalConditionLabel,
+	type AnimalConditionEnum
+} from '$lib/report/formOptions/animalCondition';
 import { getDistanceLabel, type DistanceEnum } from '$lib/report/formOptions/distance';
 import { getSpeciesLabel, isValidSpecies, type SpeciesEnum } from '$lib/report/formOptions/species';
 import type { SightingFormValues } from '$lib/types/Form';
@@ -13,7 +17,7 @@ import { formatLocation } from './formatLocation';
  */
 export interface FormattedSightingData extends Omit<
 	SightingFormValues,
-	'species' | 'behavior' | 'distance'
+	'species' | 'behavior' | 'distance' | 'deadCondition'
 > {
 	species: string;
 	speciesRaw?: SpeciesEnum | number;
@@ -21,6 +25,8 @@ export interface FormattedSightingData extends Omit<
 	behaviorRaw?: AnimalBehaviorEnum | number;
 	distance?: string;
 	distanceRaw?: DistanceEnum | number;
+	deadCondition?: string;
+	deadConditionRaw?: AnimalConditionEnum | number;
 	sightingDate: string;
 	coordinatesFormatted: string | null;
 }
@@ -31,7 +37,7 @@ export interface FormattedSightingData extends Omit<
  */
 export function formatSightingForDisplay(sighting: SightingFormValues): FormattedSightingData {
 	// Destructure and omit the properties we'll replace
-	const { species, behavior, distance, ...restSighting } = sighting;
+	const { species, behavior, distance, deadCondition, ...restSighting } = sighting;
 
 	const formatted: FormattedSightingData = {
 		...restSighting,
@@ -59,6 +65,13 @@ export function formatSightingForDisplay(sighting: SightingFormValues): Formatte
 	if (distance) {
 		formatted.distance = getDistanceLabel(distance as DistanceEnum);
 		formatted.distanceRaw = distance as DistanceEnum;
+	}
+
+	// Zustand eines Totfunds. Wie oben nur bei gesetztem Wert: 0 ist
+	// `UNKNOWN` und liefert „Unbekannt" — eine Zeile, die nichts aussagt.
+	if (deadCondition) {
+		formatted.deadCondition = getAnimalConditionLabel(deadCondition as AnimalConditionEnum);
+		formatted.deadConditionRaw = deadCondition as AnimalConditionEnum;
 	}
 
 	return formatted;

--- a/src/tools/refresh-email-template.ts
+++ b/src/tools/refresh-email-template.ts
@@ -169,6 +169,15 @@ async function run(sql: postgres.Sql, connectionString: string): Promise<number>
 		console.error('    Bounding Box (z. B. Hamburger Hafen) weiterhin als Ostsee aus.');
 		console.error('    Details: docs/OSTSEE_FLAGS.md (Fehler 4)');
 		console.error('');
+		console.error('    Ebenfalls nachzutragen ist der Totfund-Abschnitt — ohne ihn ist eine');
+		console.error('    Totfund-Meldung in der Mail von einer lebenden Sichtung nicht zu');
+		console.error('    unterscheiden:');
+		console.error('      {{#if sighting.isDead}} … {{/if}}');
+		console.error('        ├ {{sighting.deadCondition}} — Zustand (fertiges Label)');
+		console.error('        ├ {{sighting.deadSize}} cm   — Körperlänge in Zentimetern');
+		console.error('        └ {{#if sighting.deadPhoneContact}} … {{else}} … {{/if}}');
+		console.error('            └ Meeresmuseum telefonisch informiert (beide Fälle nennen)');
+		console.error('');
 		console.error('    Bewusst verwerfen: erneut mit --force aufrufen.');
 		return 1;
 	}


### PR DESCRIPTION
## Warum

`npm run config:refresh-email-template` (aus #741) **läuft auf dem Produktionshost nicht**: Das Runtime-Image kopiert nur `build/`, `node_modules`, `package.json`, `drizzle` und zwei `scripts/`-Dateien — `src/tools/` ist nicht enthalten ([Dockerfile:98](../blob/main/Dockerfile#L98)).

Und der naheliegende Ausweg fällt ebenfalls weg: Das auf dem DMM-Host tatsächlich laufende Compose gibt für `db` **keinen Port frei**, die Datenbank hängt nur im internen Netz `ostsee_internal`. Weder ein `psql` vom Host noch ein SSH-Tunnel erreichen sie — es geht nur durch den Container. (Das `docker-compose.production.yml` im Repo veröffentlicht `127.0.0.1:5432` und weicht damit vom Ist-Zustand ab.)

## Was drin ist

`scripts/migrations/2026-08-04-notification-email-totfund.sql`, nach dem Muster der beiden bestehenden Dateien in dem Verzeichnis. Es bildet die Sicherheitsregel des Werkzeugs nach, statt einfach zu überschreiben:

```sql
WHERE key = 'notification.email.template'
  AND encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') = ANY (ARRAY[…])
```

Geschrieben wird also nur, wenn der gespeicherte Wert einer der jemals ausgelieferten Stände ist. Ein im Admin-Bereich angepasster Text trifft keinen Eintrag, bleibt unangetastet und wird von der Schluss-Abfrage im Klartext gemeldet — `UPDATE 0` allein wäre nicht von „schon aktuell" zu unterscheiden. Idempotent, weil der aktuelle Hash bewusst nicht unter den erlaubten Ausgangswerten steht.

Der Aufruf steht im Kopf der Datei (scp → `sudo -v` → `docker compose exec -T db psql … < datei`).

## Verifikation

Der Vorlagentext ist aus der Konstanten erzeugt, nicht abgetippt. Dass er den Weg durch die SQL-Datei und den Postgres-Parser unverändert übersteht, ist dreifach geprüft — alle drei ergeben `aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763`:

1. SHA-256 der Konstanten in `notificationEmailDefault.ts`
2. SHA-256 des Literals, aus der fertigen `.sql` zurückgelesen
3. `encode(sha256(convert_to(…)))` desselben Literals, gerechnet von einer echten Postgres-Instanz

Dazu ein Lauf gegen die lokale Datenbank, die bereits auf dem Zielstand steht: `UPDATE 0` + „OK — Vorlage ist auf dem aktuellen Stand". Die Idempotenz ist damit an einer echten Datenbank belegt.

**Nicht geprobt** ist der schreibende Pfad (alter Seed → neuer Stand); dafür hätte ich die Dev-Datenbank zurückdrehen müssen. Die Hash-Bedingung selbst ist verifiziert: die Spalte `hash_vorher` liefert exakt den Wert, den auch das Node-Werkzeug für dieselbe Zeile berechnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)