### PR TITLE
style(report): say "Meldung" instead of "Sichtung" for the reporting act

### DIFF
--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -295,7 +295,7 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 		await expect(page.getByRole('heading', { name: /Vielen Dank/i })).toBeVisible({
 			timeout: 10000
 		});
-		await expect(page.getByText(/erfolgreich gemeldet/i)).toBeVisible();
+		await expect(page.getByText(/erfolgreich übermittelt/i)).toBeVisible();
 	});
 
 	test('API-Fehler: Server gibt 500 zurück — Formular bleibt auf Step 4', async ({ page }) => {

--- a/e2e/meldung-wording.spec.ts
+++ b/e2e/meldung-wording.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Wortwahl im Meldeformular — Änderungswunsch A5.3 des Deutschen Meeresmuseums.
+ *
+ * **Der Befund:** Die Texte rund um den Vorgang „etwas melden" sagten
+ * durchgängig „Sichtung". Eine Sichtung ist die Beobachtung eines lebenden
+ * Tieres; gemeldet wird über dasselbe Formular aber auch ein Totfund. Wer einen
+ * toten Schweinswal am Strand findet, las auf Schritt 4 „Bestätigung Ihrer
+ * Sichtungsmeldung" und auf der Erfolgsseite „Ihre Sichtung wurde erfolgreich
+ * gemeldet" — beides passt nicht zu dem, was er gerade getan hat.
+ *
+ * **Was dieser Test NICHT verlangt:** dass das Wort „Sichtung" verschwindet. An
+ * den meisten Stellen ist es fachlich richtig — die Sichtungskarte, die
+ * Sichtungsdaten, das Sichtungsdatum, „Alle Sichtungen auf der Karte". Ein
+ * Scan, der das Wort pauschal verbietet, wäre deshalb falsch und würde beim
+ * ersten Treffer zu einer schlechteren Formulierung führen. Geprüft werden
+ * stattdessen die konkreten Stellen, an denen das Wort für den **Vorgang**
+ * stand.
+ *
+ * **Zur Einwilligungsfläche:** Der Rahmentext in `RequiredConsent.svelte` ist
+ * mitgezogen; `PRIVACY_CONSENT_VERSION` steht deshalb auf `2026-08-04`. Der
+ * Ankreuztext selbst (`privacyConsent.helpText`) ist unberührt — er sagt
+ * „Sichtungsdaten", und das ist die Bezeichnung der Daten, nicht des Vorgangs.
+ * Die drei übrigen gepinnten Texte (`nameConsent`, `shipNameConsent`,
+ * `mediaConsent`) sind ebenfalls unverändert.
+ *
+ * Das hat **nichts** mit A5.2 zu tun: A5.2 ist der Datenschutz-Einleitungssatz
+ * weiter oben auf demselben Schritt, dessen Ersatzfassung das Museum noch
+ * freigeben muss. Die Fassungskennung ist eine reine Nachweis-Mechanik.
+ */
+import { expect, test, type Page } from '@playwright/test';
+import { FormPage } from './pages/FormPage';
+import {
+	expectCurrentStep,
+	fillStep1,
+	fillStep2,
+	fillStep4,
+	waitForNextEnabled
+} from './helpers/form-helpers';
+
+/** Führt das Formular bis Schritt 4 (Kontaktdaten). */
+async function gotoStep4(formPage: FormPage, page: Page): Promise<void> {
+	await fillStep1(formPage);
+	await waitForNextEnabled(page);
+	await formPage.clickNext();
+	await fillStep2(formPage);
+	await waitForNextEnabled(page);
+	await formPage.clickNext();
+	await formPage.skipStep();
+	await expectCurrentStep(page, /Kontaktdaten/i);
+}
+
+test.describe('A5.3 — „Meldung" statt „Sichtung"', () => {
+	test('Hilfeblock spricht von einer wertvollen Meldung', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await expect(
+			page.getByText('Hilfe & Tipps für eine wertvolle Meldung', { exact: false })
+		).toBeVisible();
+	});
+
+	test('Schritt 4 benennt Bestätigung und Speicherung als Meldung', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await gotoStep4(formPage, page);
+
+		await expect(page.getByText('Bestätigung Ihrer Meldung')).toBeVisible();
+		await expect(page.getByText(/Ihre Meldung wird auch ohne/i)).toBeVisible();
+
+		// Der Rahmen der Pflicht-Einwilligung — die Fläche direkt über dem
+		// Absenden-Knopf, also die letzte, die vor dem Absenden gelesen wird.
+		await expect(page.getByText(/um Ihre Meldung zu speichern/i)).toBeVisible();
+		await expect(
+			page.getByText(/Ohne diese Zustimmung kann Ihre Meldung nicht gespeichert werden/i)
+		).toBeVisible();
+
+		// Der Ankreuztext zur Gerätespeicherung sagt dasselbe wie der Absatz
+		// darüber; vorher stand hier „bei zukünftigen Sichtungsmeldungen"
+		// unmittelbar unter „bei zukünftigen Meldungen".
+		await expect(
+			page.getByText(/bei zukünftigen Meldungen automatisch zu verwenden/i)
+		).toBeVisible();
+
+		// Gegenprobe: keine alte Formulierung bleibt auf dem Schritt stehen.
+		await expect(page.getByText('Bestätigung Ihrer Sichtungsmeldung')).toHaveCount(0);
+		await expect(page.getByText(/Ihre Sichtung/)).toHaveCount(0);
+		await expect(page.getByText(/Sichtungsmeldung/)).toHaveCount(0);
+	});
+
+	test('Erfolgsseite spricht durchgängig von der Meldung', async ({ page }) => {
+		await page.route('**/api/sightings', (route) => {
+			route.fulfill({
+				status: 201,
+				contentType: 'application/json',
+				body: JSON.stringify({ success: true, id: 42, referenceId: 'REF-42' })
+			});
+		});
+
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await gotoStep4(formPage, page);
+		await fillStep4(formPage);
+		await formPage.clickSubmit();
+
+		await expect(page.getByRole('heading', { name: /Vielen Dank/i })).toBeVisible({
+			timeout: 10000
+		});
+
+		await expect(page.getByText('Ihre Meldung wurde erfolgreich übermittelt')).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Ihre Meldung' })).toBeVisible();
+		await expect(page.getByText(/Ihre Meldung erscheint nach Prüfung/i)).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Weitere Meldung abgeben' })).toBeVisible();
+
+		// „Alle Sichtungen auf der Karte" bleibt bewusst stehen: dort steht das
+		// Wort für die Daten, nicht für den Vorgang.
+		await expect(page.getByRole('link', { name: /Alle Sichtungen auf der Karte/i })).toBeVisible();
+	});
+});

--- a/scripts/migrations/2026-08-04-notification-email-meldung.sql
+++ b/scripts/migrations/2026-08-04-notification-email-meldung.sql
@@ -1,65 +1,61 @@
-/**
- * notificationEmailDefault.ts — Standard-Vorlage der Benachrichtigungs-Mail
- *
- * **Warum als eigenes Modul und nicht als Literal in `configInitializer.ts`:**
- * Dieselbe Zeichenkette wird an zwei Stellen gebraucht — beim Seeden nach
- * `app_config` und vom Nachzieh-Werkzeug `src/tools/refresh-email-template.ts`,
- * das einen unveränderten Seed in einer bestehenden Installation auf den
- * aktuellen Stand hebt. Das Modul hat deshalb bewusst **keine Importe**: so lässt
- * es sich aus einem `tsx`-Skript ohne SvelteKit-Alias-Auflösung laden.
- *
- * **Der Ostsee-Status kommt aus dem Kontext, nicht aus den Flags.** Die Vorlage
- * verzweigt über `sighting.balticSea` (siehe `balticSeaEmailContext.ts`) — ein
- * Wert, der aus derselben Funktion stammt wie die Anzeige im Admin-Bereich.
- * Wer hier wieder `{{#if sighting.inBalticSeaGeo}}` einbaut, prüft die grobe
- * Bounding Box und weist damit Meldungen aus dem Hamburger Hafen als Ostsee aus
- * (Fehler 4 in `docs/OSTSEE_FLAGS.md`).
- *
- * **Wer diese Vorlage ändert, muss den Seed nachziehen.** Der in `app_config`
- * gespeicherte Wert gewinnt gegen diesen Default
- * (`ConfigRepository.getString(…, NOTIFICATION_EMAIL_DEFAULT_TEMPLATE)`) — eine Änderung hier
- * wirkt auf keine bestehende Installation. Ablauf und Fingerabdruck-Liste:
- * `src/tools/refresh-email-template.ts`.
- */
-/**
- * SHA-256 aller Vorlagen, die dieses Projekt jemals als Default **ausgeliefert**
- * hat — jüngste zuerst. Ein in `app_config` gespeicherter Wert, dessen Hash hier
- * steht, ist ein unveränderter Seed und darf nachgezogen werden; jeder andere
- * Wert ist ein angepasster Kundentext und wird nicht angefasst.
- *
- * **Wer `NOTIFICATION_EMAIL_DEFAULT_TEMPLATE` ändert, trägt den Hash des alten
- * Stands hier oben ein.** Fehlt er, hält `src/tools/refresh-email-template.ts`
- * jeden frisch geseedeten Bestand für angepasst und zieht ihn nie wieder nach.
- * `notificationEmailDefault.test.ts` erzwingt das: der Test pinnt den Hash des
- * aktuellen Stands und schlägt bei jeder Änderung fehl.
- */
-export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
-	// Stand bis 2026-08-04: nannte den Vorgang durchgehend „Sichtung"
-	// („Neue Sichtung eingegangen", „diese Sichtung besonders sorgfältig",
-	// „Sichtung im Admin-Bereich prüfen"). Über dasselbe Formular wird auch ein
-	// Totfund gemeldet — Änderungswunsch A5.3 des Deutschen Meeresmuseums.
-	'aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763',
-	// Stand bis 2026-08-04: ohne Totfund-Abschnitt. `isDead`, `deadCondition`
-	// und `deadSize` lagen im Kontext, wurden aber von keiner ausgelieferten
-	// Vorlage gerendert — die Mail zu einem Totfund war von der zu einer
-	// lebenden Sichtung nicht zu unterscheiden.
-	'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
-	// Stand bis 2026-07-30: Foto-Hinweis wortidentisch, aber „rebuilter
-	// iOS-Client" statt der im Projekt sonst üblichen Formulierung „neu
-	// gebauter iOS-Client" (siehe .claude/rules/legacy-api.md).
-	'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
-	// Stand bis 2026-07-30: ohne Hinweis auf ein per E-Mail nachgereichtes
-	// Foto (neu gebauter iOS-Client `OstSeeTiere/8` setzt `aufnahmeHochladen`,
-	// kann aber keine Datei hochladen).
-	'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
-	// Stand bis 2026-07-30: verzweigte über `inBalticSeaGeo` (Bounding Box) und
-	// zeigte einer Meldung aus dem Hamburger Hafen „Ostsee ✓".
-	'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
-	// Stand vor der Umstellung auf emailTokens.ts (hartcodierte Hex-Farben).
-	'ba2a26024338b19b441c6b5aa2d6b8d66aea611fa474952952d859b0c40d46bc'
-] as const;
+-- Zieht die geseedete Benachrichtigungs-Vorlage auf den Stand mit „Meldung" statt
+-- „Sichtung" (Änderungswunsch A5.3 des Deutschen Meeresmuseums).
+--
+-- Hintergrund: `app_config.notification.email.template` gewinnt gegen den
+-- Code-Default (`ConfigRepository.getString(…, NOTIFICATION_EMAIL_DEFAULT_TEMPLATE)`).
+-- Ohne diesen Lauf verschickt die Installation die Mail weiter mit „Neue Sichtung
+-- eingegangen" — eine Formulierung, die den Totfund sprachlich ausschließt,
+-- obwohl derselbe Vorgang ihn auslöst.
+--
+-- Der Betreff („Neue Meldung: <REF>") steht dagegen im Code (`emailService.ts`)
+-- und zieht mit dem Deployment automatisch mit; er braucht diesen Lauf nicht.
+--
+-- Das Gegenstück zu `npm run config:refresh-email-template`, für Hosts, auf denen
+-- kein Checkout liegt (das Runtime-Image enthält `src/tools/` nicht).
+--
+-- Aufruf auf dem DMM-Host: Die Datenbank veröffentlicht dort keinen Port, sie
+-- hängt nur im internen Docker-Netz `ostsee_internal`. Weder ein psql vom Host
+-- noch ein SSH-Tunnel erreichen sie — der Weg führt durch den Container:
+--
+--   scp scripts/migrations/2026-08-04-notification-email-meldung.sql dmm:/tmp/
+--   ssh dmm
+--   cd /opt/ostsee-tiere
+--   sudo -v   # Passwort vorab, damit die Eingabeumleitung unten nicht mit dem
+--             # Prompt konkurriert
+--   sudo docker compose exec -T db psql -U postgres -d ostsee \
+--     < /tmp/2026-08-04-notification-email-meldung.sql
+--
+-- `psql -U postgres` im Container braucht kein Passwort (lokale Socket-
+-- Verbindung, `trust` in der pg_hba des Images). Erwartete Ausgabe: `UPDATE 1`
+-- und die OK-Meldung; bei `UPDATE 0` entscheidet die Schluss-Abfrage, ob der
+-- Stand schon aktuell oder der Text angepasst ist.
+--
+-- Sicherheit: Die UPDATE-Bedingung prüft den SHA-256 des gespeicherten Werts gegen
+-- die Liste der jemals ausgelieferten Stände. Ein im Admin-Bereich angepasster
+-- Text trifft keinen Eintrag und bleibt unangetastet — der Lauf meldet dann
+-- `UPDATE 0` und die Schluss-Abfrage sagt es im Klartext.
+--
+-- Idempotent: Ein zweiter Lauf ändert nichts (der aktuelle Stand steht bewusst
+-- nicht in der Liste der erlaubten Ausgangswerte).
+--
+-- Diese Datei ist aus `NOTIFICATION_EMAIL_DEFAULT_TEMPLATE` erzeugt; die Nutzlast
+-- ist byte-identisch mit der Konstante.
 
-export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
+BEGIN;
+
+-- 1. Ist-Zustand vor der Änderung
+SELECT
+	updated_by,
+	updated_at,
+	length(value #>> '{}') AS zeichen,
+	encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS hash_vorher
+FROM app_config
+WHERE key = 'notification.email.template';
+
+-- 2. Nachziehen — nur, wenn der gespeicherte Wert ein unveränderter Seed ist
+UPDATE app_config
+SET
+	value = to_jsonb($tpl$<!DOCTYPE html>
 <html lang="de">
 <head>
 	<meta charset="UTF-8">
@@ -264,4 +260,31 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		<p style="margin: 8px 0 0 0;">Diese E-Mail wurde automatisch generiert am {{currentDate}} um {{currentTime}}</p>
 	</div>
 </body>
-</html>`;
+</html>$tpl$::text),
+	updated_by = 'refresh-email-template-sql',
+	updated_at = NOW()
+WHERE key = 'notification.email.template'
+	AND encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') = ANY (ARRAY[
+		'aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763',
+		'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
+		'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
+		'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
+		'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
+		'ba2a26024338b19b441c6b5aa2d6b8d66aea611fa474952952d859b0c40d46bc'
+	]);
+
+-- 3. Ergebnis im Klartext
+SELECT CASE
+	WHEN h = '2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392'
+		THEN 'OK — Vorlage ist auf dem aktuellen Stand (Vorgang heisst Meldung).'
+	ELSE 'ACHTUNG — kein bekannter Seed, es wurde nichts geaendert. Angepasster Text, Hash: ' || h
+END AS ergebnis
+FROM (
+	SELECT encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS h
+	FROM app_config
+	WHERE key = 'notification.email.template'
+) t;
+
+COMMIT;
+
+-- Laufende Instanzen halten die alte Vorlage bis zu 5 Minuten im Config-Cache.

--- a/scripts/migrations/2026-08-04-notification-email-meldung.sql
+++ b/scripts/migrations/2026-08-04-notification-email-meldung.sql
@@ -276,7 +276,7 @@ WHERE key = 'notification.email.template'
 -- 3. Ergebnis im Klartext
 SELECT CASE
 	WHEN h = '2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392'
-		THEN 'OK — Vorlage ist auf dem aktuellen Stand (Vorgang heisst Meldung).'
+		THEN 'OK — Vorlage ist auf dem aktuellen Stand (Vorgang wird als Meldung bezeichnet).'
 	ELSE 'ACHTUNG — kein bekannter Seed, es wurde nichts geaendert. Angepasster Text, Hash: ' || h
 END AS ergebnis
 FROM (

--- a/src/lib/form/consent/consentVersions.ts
+++ b/src/lib/form/consent/consentVersions.ts
@@ -27,5 +27,18 @@ export const NAME_CONSENT_VERSION = '2025-08-12';
 /** Fassung des Textes zu `shipNameConsent` (Veröffentlichung des Schiffsnamens). */
 export const SHIP_NAME_CONSENT_VERSION = '2025-08-12';
 
-/** Fassung des Textes zu `privacyConsent` (Pflicht-Einwilligung der Meldung). */
-export const PRIVACY_CONSENT_VERSION = '2026-07-28';
+/**
+ * Fassung des Textes zu `privacyConsent` (Pflicht-Einwilligung der Meldung).
+ *
+ * Auf 2026-08-04 gehoben, obwohl der **Ankreuztext** (`meta.helpText`)
+ * unverändert ist: Geändert wurde der Rahmentext in `RequiredConsent.svelte`
+ * („um Ihre Meldung zu speichern", „Ohne diese Zustimmung kann Ihre Meldung
+ * nicht gespeichert werden" — vorher jeweils „Sichtung", Änderungswunsch A5.3).
+ * Der Geltungsbereich der Kennung ist die gelesene Einwilligungsfläche, nicht
+ * die Zeichenkette im Schema; `consentTextVersions.test.ts` sagt das im
+ * Kopfkommentar ausdrücklich, kann es aber nicht prüfen.
+ *
+ * Der gepinnte Hash in jenem Test bleibt deshalb korrekt und unverändert — er
+ * deckt nur den `helpText` ab.
+ */
+export const PRIVACY_CONSENT_VERSION = '2026-08-04';

--- a/src/lib/form/validation/consentTexts.test.ts
+++ b/src/lib/form/validation/consentTexts.test.ts
@@ -91,6 +91,9 @@ describe('Einwilligungstexte', () => {
 		});
 
 		it('nennt ihn in keinem der beiden „Sichtungsmeldung"', () => {
+			// Kleingeschrieben, weil `textOf` den Text bereits normalisiert — wie in
+			// den Blöcken darüber. Der Regex greift damit auf „Sichtungsmeldung"
+			// und „Sichtungsmeldungen" gleichermaßen.
 			expect(textOf('persistentDataConsent')).not.toMatch(/sichtungsmeldung/);
 		});
 	});

--- a/src/lib/form/validation/consentTexts.test.ts
+++ b/src/lib/form/validation/consentTexts.test.ts
@@ -68,4 +68,30 @@ describe('Einwilligungstexte', () => {
 			expect(field && 'optional' in field ? field.optional : false).toBe(true);
 		});
 	});
+
+	/**
+	 * `persistentDataConsent` beschreibt denselben Vorgang zweimal — einmal im
+	 * Ankreuztext (`helpText`), einmal im Tooltip (`valueText`). Beide standen
+	 * bis A5.3 auseinander: „bei zukünftigen **Sichtungs**meldungen" gegen „bei
+	 * zukünftigen **Meldungen**".
+	 *
+	 * Anders als die vier Einwilligungen mit Fassungskennung trägt dieses Feld
+	 * **keinen** Nachweis nach Art. 7 DSGVO: Es kommt weder in
+	 * `consentVersions.ts` noch in `mapFormToSighting.ts` oder `schema.ts` vor
+	 * und steuert allein, ob die Kontaktdaten im Browser-Speicher überleben
+	 * (`localStorage.ts`). Eine Umformulierung entwertet hier also keine
+	 * gespeicherte Kennung — es gibt keine.
+	 */
+	describe('persistentDataConsent — Ankreuztext und Tooltip sagen dasselbe', () => {
+		it('nennt den Vorgang in beiden Texten „Meldung"', () => {
+			const meta = metaOf('persistentDataConsent');
+
+			expect(meta.helpText).toMatch(/zukünftigen Meldungen/);
+			expect(meta.valueText).toMatch(/zukünftigen Meldungen/);
+		});
+
+		it('nennt ihn in keinem der beiden „Sichtungsmeldung"', () => {
+			expect(textOf('persistentDataConsent')).not.toMatch(/sichtungsmeldung/);
+		});
+	});
 });

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -1248,7 +1248,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.label('Kontaktdaten dauerhaft speichern')
 		.meta({
 			helpText:
-				'Ich stimme zu, dass meine Kontaktdaten dauerhaft auf diesem Gerät gespeichert werden, um sie bei zukünftigen Sichtungsmeldungen automatisch zu verwenden. Ohne diese Zustimmung werden die Daten beim Schließen des Browsers gelöscht.',
+				'Ich stimme zu, dass meine Kontaktdaten dauerhaft auf diesem Gerät gespeichert werden, um sie bei zukünftigen Meldungen automatisch zu verwenden. Ohne diese Zustimmung werden die Daten beim Schließen des Browsers gelöscht.',
 			valueText: 'Ermöglicht automatisches Ausfüllen bei zukünftigen Meldungen',
 			icon: Archive,
 			type: 'checkbox'

--- a/src/lib/report/components/FormHelp.svelte
+++ b/src/lib/report/components/FormHelp.svelte
@@ -52,7 +52,7 @@
 		<details class="collapse">
 			<summary class="collapse-title flex cursor-pointer items-center gap-2 text-sm font-medium">
 				<Icon icon="lucide:circle-help" width="16" class="text-info-strong" />
-				Hilfe & Tipps für eine wertvolle Sichtungsmeldung
+				Hilfe & Tipps für eine wertvolle Meldung
 			</summary>
 			<div class="collapse-content text-base-content/80 text-sm">
 				<div class="space-y-4 pt-4">
@@ -63,7 +63,7 @@
 								Warum ist Ihre Meldung wichtig?
 							</h4>
 							<p class="mt-1">
-								Jede Sichtung hilft Wissenschaftlern dabei, Wanderrouten zu verstehen, Populationen
+								Jede Meldung hilft Wissenschaftlern dabei, Wanderrouten zu verstehen, Populationen
 								zu überwachen und Schutzmaßnahmen zu entwickeln. Ihre Beobachtung trägt direkt zum
 								Artenschutz bei!
 							</p>

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -46,7 +46,11 @@
 				/>
 			</h1>
 
-			<p class="text-base-content/80 text-xl">Ihre Sichtung wurde erfolgreich gemeldet</p>
+			<!-- „Meldung … übermittelt" statt „Sichtung … gemeldet" (A5.3): Über
+			     dieses Formular wird auch ein Totfund gemeldet, und „Sichtung"
+			     schloss diesen Fall sprachlich aus. „Übermittelt" statt
+			     „gemeldet", weil „Ihre Meldung wurde gemeldet" doppelt sagt. -->
+			<p class="text-base-content/80 text-xl">Ihre Meldung wurde erfolgreich übermittelt</p>
 		</div>
 
 		<!-- Success Details -->
@@ -88,11 +92,11 @@
 							<h3 class="font-semibold">Fotos und Videos</h3>
 							<p class="text-base-content/70 text-sm">
 								{#if submittedData?.mediaUpload}
-									Ihre Aufnahmen wurden übermittelt und werden gemeinsam mit Ihrer Sichtung geprüft.
+									Ihre Aufnahmen wurden übermittelt und werden gemeinsam mit Ihrer Meldung geprüft.
 								{/if}
 								Waren Aufnahmen zu groß für den Upload, senden Sie sie bitte an
 								<a class="link" href="mailto:{MEDIA_FALLBACK_EMAIL}">{MEDIA_FALLBACK_EMAIL}</a> — mit
-								Datum und Uhrzeit der Sichtung, damit wir sie zuordnen können.
+								Datum und Uhrzeit Ihrer Beobachtung, damit wir sie zuordnen können.
 							</p>
 						</div>
 					</div>
@@ -119,7 +123,7 @@
 						<div>
 							<h3 class="font-semibold">Daten einsehen</h3>
 							<p class="text-base-content/70 text-sm">
-								Ihre Sichtung erscheint nach Prüfung auf der
+								Ihre Meldung erscheint nach Prüfung auf der
 								<a href="/map" class="link link-primary">interaktiven Karte</a>
 							</p>
 						</div>
@@ -132,7 +136,7 @@
 		{#if submittedData}
 			<div class="card bg-base-100 mb-8 shadow-lg">
 				<div class="card-body">
-					<h2 class="card-title mb-4">Ihre gemeldete Sichtung</h2>
+					<h2 class="card-title mb-4">Ihre Meldung</h2>
 					<div class="mb-4 grid grid-cols-1 gap-1 text-sm">
 						<div>
 							<span class="font-medium">Referenz-ID:</span>
@@ -140,7 +144,7 @@
 						</div>
 						<span class="text-base-content/70 text-xs">
 							(Bitte geben Sie die ID bei Rückfragen an unser Team an. Die ID hilft bei der
-							Zuordnung Ihrer Sichtung)
+							Zuordnung Ihrer Meldung)
 						</span>
 					</div>
 					<div class="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
@@ -170,7 +174,7 @@
 		<!-- Action Buttons -->
 		<div class="flex flex-col justify-center gap-4 md:flex-row">
 			<button onclick={handleNewReport} class="btn btn-primary btn-lg">
-				Weitere Sichtung melden
+				Weitere Meldung abgeben
 			</button>
 
 			<button onclick={handleReturnHome} class="btn btn-outline btn-lg">

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -20,8 +20,8 @@
 				Erforderliche Zustimmung zur Datenverwendung
 			</h4>
 			<p class="text-base-content/80 text-sm">
-				<strong>Diese Zustimmung ist erforderlich</strong>, um Ihre Sichtung zu speichern und für
-				die wissenschaftliche Forschung zu nutzen.
+				<strong>Diese Zustimmung ist erforderlich</strong>, um Ihre Meldung zu speichern und für die
+				wissenschaftliche Forschung zu nutzen.
 			</p>
 		</div>
 
@@ -58,7 +58,14 @@
 		<div class="border-primary/30 bg-primary/5 rounded-lg border p-4">
 			<FormField name="privacyConsent" />
 			<p class="text-primary/70 mt-2 text-xs">
-				<strong>Ohne diese Zustimmung kann Ihre Sichtung nicht gespeichert werden.</strong>
+				<!--
+					„Meldung", nicht „Sichtung" (A5.3): Über dieses Formular wird auch ein
+					Totfund gemeldet. Diese Fläche ist Rahmentext um die Einwilligung, nicht
+					der Ankreuztext selbst — sie hängt trotzdem an der Fassungskennung
+					(consentTextVersions.test.ts erklärt, warum kein Test das erzwingt).
+					PRIVACY_CONSENT_VERSION steht deshalb auf 2026-08-04.
+				-->
+				<strong>Ohne diese Zustimmung kann Ihre Meldung nicht gespeichert werden.</strong>
 				Sie können diese Zustimmung jederzeit per E-Mail an datenschutz@meeresmuseum.de widerrufen.
 				<!--
 					Art. 13 DSGVO verlangt die Datenschutzhinweise dort, wo die Daten erhoben

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -80,7 +80,7 @@
 				Ihre E-Mail-Adresse ist erforderlich für:
 			</p>
 			<ul class="list-inside list-disc space-y-1 text-xs">
-				<li>Bestätigung Ihrer Sichtungsmeldung</li>
+				<li>Bestätigung Ihrer Meldung</li>
 				<li>Wichtige Rückfragen zur Datenqualität</li>
 				<li>Information über wissenschaftliche Ergebnisse (optional)</li>
 			</ul>
@@ -93,7 +93,7 @@
 					</p>
 					<p>
 						Ihre Kontaktdaten werden nach erfolgreicher Übermittlung lokal gespeichert und bei der
-						nächsten Sichtungsmeldung automatisch ausgefüllt.
+						nächsten Meldung automatisch ausgefüllt.
 					</p>
 
 					{#if hasSavedContactData}
@@ -162,7 +162,7 @@
 				Optionale Veröffentlichung Ihres Namens
 			</h4>
 			<p class="text-base-content/70 mb-4 text-sm">
-				Diese Einverständniserklärungen sind <strong>optional</strong>. Ihre Sichtung wird auch ohne
+				Diese Einverständniserklärungen sind <strong>optional</strong>. Ihre Meldung wird auch ohne
 				diese Zustimmungen gespeichert.
 			</p>
 
@@ -179,7 +179,7 @@
 			</h4>
 			<p class="text-base-content/70 mb-4 text-sm">
 				Möchten Sie, dass Ihre Kontaktdaten auch nach dem Schließen des Browser-Fensters erhalten
-				bleiben? Dies erspart Ihnen das erneute Eingeben bei zukünftigen Sichtungsmeldungen.
+				bleiben? Dies erspart Ihnen das erneute Eingeben bei zukünftigen Meldungen.
 			</p>
 
 			<div class="space-y-3">

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -385,7 +385,11 @@ describe('EmailService', () => {
 			expect(mockTransporter.sendMail).toHaveBeenCalledWith(
 				expect.objectContaining({
 					to: 'admin@ostsee-tiere.de',
-					subject: expect.stringContaining('REF-42')
+					// Der Betreff nennt den Vorgang „Meldung" (A5.3): derselbe
+					// Vorgang entsteht bei einem Totfund wie bei einem lebenden
+					// Tier, und der Betreff ist die einzige Zeile, die im
+					// Posteingang ohne Öffnen sichtbar ist.
+					subject: 'Neue Meldung: REF-42'
 				})
 			);
 		});

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -437,7 +437,11 @@ export class EmailService {
 				to: config.recipient,
 				cc: recipientsOrUndefined(config.cc),
 				bcc: recipientsOrUndefined(config.bcc),
-				subject: `Neue Sichtung: ${referenceId}`,
+				// „Meldung", nicht „Sichtung": Derselbe Vorgang entsteht bei einem
+				// Totfund wie bei einem lebenden Tier (A5.3). Der Betreff ist die
+				// einzige Zeile, die im Posteingang ohne Öffnen sichtbar ist — er
+				// darf den Totfund nicht sprachlich ausschließen.
+				subject: `Neue Meldung: ${referenceId}`,
 				html: htmlContent,
 				text: this.htmlToText(htmlContent)
 			};

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -157,10 +157,11 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	 * Sichtung. Ein Totfund ist der Fall, der eine Rückmeldung braucht (Bergung,
 	 * Beprobung).
 	 *
-	 * Der Betreff bleibt unverändert „Neue Sichtung: <REF>" — erkennbar ist der
-	 * Totfund also erst beim Öffnen der Mail, nicht schon in der Übersicht des
-	 * Posteingangs. Ein Betreff-Präfix wäre eine eigene Entscheidung (Mailfilter
-	 * beim DMM) und gehört nicht in diese Vorlage.
+	 * Der Betreff nennt den Totfund nicht („Neue Meldung: <REF>", seit A5.3
+	 * — davor „Neue Sichtung: <REF>") — erkennbar ist der Totfund also erst beim
+	 * Öffnen der Mail, nicht schon in der Übersicht des Posteingangs. Ein
+	 * Betreff-Präfix wäre eine eigene Entscheidung (Mailfilter beim DMM) und
+	 * gehört nicht in diese Vorlage.
 	 */
 	describe('Totfund', () => {
 		function renderDeadFind(dead: {
@@ -277,6 +278,49 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	});
 });
 
+/**
+ * Wortwahl (Änderungswunsch A5.3 des Deutschen Meeresmuseums).
+ *
+ * Die Mail beschreibt einen **Vorgang**, der genauso von einem Totfund
+ * ausgelöst wird wie von der Beobachtung eines lebenden Tieres. „Neue Sichtung
+ * eingegangen" schloss den Totfund sprachlich aus — und zwar an der Stelle, die
+ * der Empfänger zuerst liest.
+ *
+ * Gemeint ist ausschließlich diese Bedeutung. Wo das Wort für die Beobachtung
+ * selbst steht (`sightingDate` → „Datum", die Sichtungskarte, die
+ * Sichtungsdaten), bleibt es stehen; dieser Test verlangt deshalb kein
+ * vollständiges Verschwinden von „Sichtung", sondern prüft die konkreten
+ * Textbausteine.
+ *
+ * **Die Überschrift „🔍 Sichtungsdetails" bleibt bewusst stehen.** Darunter
+ * stehen Datum, Tierart, Anzahl, Entfernung und Verhalten — die Beobachtung,
+ * nicht der Vorgang. Sie trägt denselben Namen wie die gleichnamige Sektion im
+ * Meldeformular (`sections/SightingDetails.svelte`), und beide gehören
+ * zusammen umbenannt oder gar nicht. Der Totfund steht in dieser Mail ohnehin
+ * als eigener Block darunter. Sollte das Museum die Überschrift dennoch
+ * anders wollen, ist das ein eigener Vorgang inkl. Fassungs-Hash und
+ * SQL-Nachzug (`scripts/migrations/`).
+ */
+describe('Wortwahl — „Meldung" für den Vorgang', () => {
+	const VORGANGS_TEXTE = [
+		'Neue Meldung eingegangen',
+		'Bitte prüfen Sie diese Meldung besonders sorgfältig.',
+		'Meldung im Admin-Bereich prüfen'
+	];
+
+	it.each(VORGANGS_TEXTE)('nennt den Vorgang „Meldung": %s', (text) => {
+		expect(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE).toContain(text);
+	});
+
+	it.each([
+		'Neue Sichtung eingegangen',
+		'diese Sichtung besonders sorgfältig',
+		'Sichtung im Admin-Bereich prüfen'
+	])('bezeichnet den Vorgang nicht mehr als „Sichtung": %s', (text) => {
+		expect(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE).not.toContain(text);
+	});
+});
+
 describe('Fingerabdruck des ausgelieferten Stands', () => {
 	/**
 	 * Dieser Test ist ein **Zwang, keine Zusicherung über den Inhalt**: Der Seed
@@ -296,7 +340,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763');
+		expect(hash).toBe('2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {


### PR DESCRIPTION
Setzt **A5.3** aus den Änderungswünschen des Deutschen Meeresmuseums um: Die Nutzertexte sagen „Meldung" statt „Sichtung", wo das Wort den Vorgang „etwas melden" bezeichnet.

**Warum:** Über dasselbe Formular wird auch ein Totfund gemeldet. „Sichtung" ist die Beobachtung eines lebenden Tieres — wer einen toten Schweinswal am Strand findet, las auf Schritt 4 „Bestätigung Ihrer Sichtungsmeldung" und danach „Ihre Sichtung wurde erfolgreich gemeldet". Beides passt nicht zu dem, was er getan hat.

Der Punkt hing im Dokument hinter der Trennung von Tot- und Lebendfund (C1), ist davon aber unabhängig und hier als reiner Text-PR umgesetzt.

## Geändert (Wort steht für den Vorgang)

| Ort | Vorher → Nachher |
| --- | --- |
| `Step4Contact.svelte` | „Bestätigung Ihrer Sichtungsmeldung" → „…Ihrer Meldung"; „nächsten Sichtungsmeldung" → „nächsten Meldung"; „Ihre Sichtung wird auch ohne…" → „Ihre Meldung…"; „zukünftigen Sichtungsmeldungen" → „zukünftigen Meldungen" |
| `SubmissionSuccess.svelte` | „Ihre Sichtung wurde erfolgreich gemeldet" → „Ihre Meldung wurde erfolgreich übermittelt"; „Ihre gemeldete Sichtung" → „Ihre Meldung"; Foto-, Karten- und Referenz-ID-Text; Button „Weitere Sichtung melden" → „Weitere Meldung abgeben" |
| `FormHelp.svelte` | „…für eine wertvolle Sichtungsmeldung" → „…für eine wertvolle Meldung"; „Jede Sichtung hilft" → „Jede Meldung hilft" |
| `RequiredConsent.svelte` | „um Ihre Sichtung zu speichern" / „Ohne diese Zustimmung kann Ihre Sichtung nicht gespeichert werden" → „Meldung" |
| `sightingSchema.ts` | `persistentDataConsent.helpText`: „bei zukünftigen Sichtungsmeldungen" → „…Meldungen" |
| `notificationEmailDefault.ts` | `<title>`, H1 „Neue Meldung eingegangen", Spam-Hinweis, Admin-Button, Footer |
| `emailService.ts` | Betreff „Neue Sichtung: REF" → „Neue Meldung: REF" |

„erfolgreich **übermittelt**" statt „gemeldet", weil „Ihre Meldung wurde gemeldet" doppelt sagt. Bei der Foto-Nachreichung steht jetzt „Datum und Uhrzeit Ihrer **Beobachtung**" — „Meldung" wäre dort inhaltlich falsch, das ist der Beobachtungs-, nicht der Absendezeitpunkt.

## Nicht mechanisch ersetzt

Wo das Wort die Beobachtung oder die Daten bezeichnet, bleibt es stehen: Sichtungskarte, Sichtungsdaten, „Alle Sichtungen auf der Karte", „Zeitpunkt der Sichtung", „Standort der Sichtung", `sightingDate`, die Statistikzahlen im Hilfeblock, `🔍 Sichtungsdetails` in der Mail. Bei den Ereignis-Bezügen wäre „Meldung" schlicht falsch; die neutrale Fassung („Beobachtung") gehört zur Tot-/Lebendfund-Trennung C1, nicht hierher.

Feldnamen, Schema-Schlüssel, DB-Spalten, API-Felder, Testids und die Legacy-API sind unberührt. `docs/LEGACY_API_SPECIFICATION.md` ebenfalls.

## ⚠️ Nach dem Deployment: SQL auf dem Produktions-Host ausführen

Die geseedete Vorlage in `app_config` gewinnt gegen den Code-Default — ohne diesen Lauf verschickt die Installation die Mail weiter mit „Neue Sichtung eingegangen".

```
scp scripts/migrations/2026-08-04-notification-email-meldung.sql dmm:/tmp/
ssh dmm
cd /opt/ostsee-tiere
sudo -v
sudo docker compose exec -T db psql -U postgres -d ostsee < /tmp/2026-08-04-notification-email-meldung.sql
```

Aus der Konstante erzeugt (Nutzlast byte-identisch, per SHA-256 gegengeprüft), schreibt nur bei unverändertem Seed, idempotent — ein im Admin-Bereich angepasster Text bleibt unangetastet und wird im Klartext gemeldet. Der alte Hash steht jetzt in `PREVIOUS_SHIPPED_TEMPLATE_HASHES`. Der Betreff kommt aus dem Code und zieht mit dem Deployment automatisch mit.

## Einwilligungsfläche

`PRIVACY_CONSENT_VERSION` steht auf `2026-08-04`, weil der Rahmentext in `RequiredConsent.svelte` mitgezogen ist — der Geltungsbereich der Kennung ist die gelesene Einwilligungsfläche, nicht die Zeichenkette im Schema (so sagt es der Kopfkommentar von `consentTextVersions.test.ts`, prüfen kann er es nicht). Der gepinnte Hash bleibt gültig und unverändert: er deckt nur `privacyConsent.helpText` ab, und der ist unberührt. `nameConsent`, `shipNameConsent` und `mediaConsent` ebenfalls unverändert.

`persistentDataConsent` trägt gar keine Fassungskennung — es steht in keiner Version-Konstante, nicht in `mapFormToSighting.ts` und nicht in `schema.ts`, sondern steuert allein die Browser-Speicherung. Es widersprach sich bisher selbst: `helpText` sagte „Sichtungsmeldungen", `valueText` desselben Feldes „Meldungen".

## Tests

Test-First: `notificationEmailDefault.test.ts` (Wortwahl, 6 Fehlschläge vorab bestätigt), `consentTexts.test.ts` (`persistentDataConsent`) und `e2e/meldung-wording.spec.ts` mit Gegenprobe — auf Schritt 4 dürfen `/Ihre Sichtung/` und `/Sichtungsmeldung/` null Treffer haben, „Alle Sichtungen auf der Karte" muss stehen bleiben.

- `npm run test:quick` — 232 Dateien, 3446 Tests grün (die 2 Lint-Warnungen sind Altbestand in `src/tests/contract/helpers/createEvent.ts`)
- `CI=1 npx playwright test --project=chromium` — 306 grün

Eine bestehende Assertion in `form-submit.spec.ts` musste von `/erfolgreich gemeldet/` auf `/erfolgreich übermittelt/`.

## Offen (Entscheidung des Museums)

- **H1 „Sichtung von Meeressäugetieren melden"** (`ModernReportForm.svelte`) — vom Museum in #669 selbst so gewünscht, deshalb hier nicht angefasst. **Empfehlung: nachziehen** — Navbar sagt „Meldung", Footer „Meldeplattform für Meerestiere"; die H1 ist jetzt die auffälligste verbliebene Stelle, die den Totfund ausschließt. Zieht zwei E2E-Assertions in `bestimmungshilfe.spec.ts` mit.
- **A5.2** (Datenschutz-Einleitungssatz auf Schritt 4) bleibt unverändert offen — davon unabhängig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
