### PR TITLE
feat(report): rework the report form from the museum's feedback

### DIFF
--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -54,7 +54,7 @@ This is a dated status, not a standing guarantee — re-check whether further cl
 | `schiffsname`               | Ship name                                                                                                    | String (64)                         | No, Yes if schiffnamensnennung = 1 |
 | `heimathafen`               | Home port                                                                                                    | String (64)                         | No                                 |
 | `bootstyp`                  | Boat type                                                                                                    | String (64)                         | No                                 |
-| `bootsantrieb`              | Boat drive (5 = no boat, see note below)                                                                     | Integer-Range, 0-5                  | No                                 |
+| `bootsantrieb`              | Boat drive (5 = no boat, 6 = motor off, see notes below)                                                     | Integer-Range, 0-6                  | No                                 |
 | `bootsantrieb_text`         | Other boat drive (when bootsantrieb = 0)                                                                     | Text                                | No                                 |
 | `strasse`                   | Street                                                                                                       | String (64)                         | No                                 |
 | `plz`                       | ZIP code                                                                                                     | String (5)                          | No                                 |
@@ -148,7 +148,8 @@ JSON Object with the following structure:
 		"2": "Segel",
 		"3": "treibend",
 		"4": "vor Anker",
-		"5": "Kein Boot"
+		"5": "Kein Boot",
+		"6": "Motor aus"
 	},
 	"eingangskanal": {
 		"0": "Web",
@@ -473,6 +474,42 @@ Antrieb nur niemand angegeben hat — dort ist `5` streng genommen zu stark.
 Bewusst in Kauf genommen: Ein eigener Wert „Antrieb unbekannt" wäre eine dritte
 Vertragsänderung an derselben Spalte, und eine erfundene Antriebsart wiegt
 schwerer als „kein Boot" bei einem Kajak.
+
+## Abweichung von der Ursprungs-PDF: `bootsantrieb = 6`
+
+Die Original-Spezifikation kennt für `bootsantrieb` nur den Bereich **0–4**.
+Seit dem 2026-08-04 gibt es zusätzlich **`6` = „Motor aus"**.
+
+**Warum:** Das Deutsche Meeresmuseum hat die Folgefrage zum Antrieb im
+Meldeformular auf „Motor an / Motor aus" verengt — es geht dort allein um
+Motorgeräusche, und Laien können den Antrieb eines fremden Bootes ohnehin selten
+benennen. „Motor an" bleibt `1` („Motor") und ist damit vergleichbar zum
+Altbestand. Für „Motor aus" gab es **keinen** passenden vorhandenen Wert:
+`3` („treibend") und `4` („vor Anker") behaupten fachlich etwas anderes als ein
+Motorboot mit abgeschaltetem Motor, und für die Einordnung von Unterwasserlärm
+ist das ein Unterschied. Einen dieser Werte wiederzuverwenden hieße, dem Melder
+eine Aussage unterzuschieben, die er nie gemacht hat.
+
+**Auswirkung auf Clients:**
+
+- `GET /rest_sichtungen/antworten.json` liefert einen zusätzlichen Schlüssel
+  `"6": "Motor aus"`. Clients, die die Liste dynamisch rendern, brauchen keine
+  Änderung; Clients mit fest verdrahteter Tabelle zeigen für `6` keinen Text an
+  und müssen den Wert nachtragen.
+- `POST /rest_sichtungen` bleibt unverändert: Der Schreibpfad validiert
+  `bootsantrieb` ohne Bereichsprüfung (`yup.number().nullable().optional()` in
+  `src/lib/legacy-api/yup-validation.ts`), nimmt `6` also ohne Anpassung an.
+  Bestehende Werte behalten ihre Bedeutung — es wurde nichts umnummeriert.
+- `GET /sichtungen/showreports.json` **liefert `bootsantrieb` gar nicht aus**.
+  Eine `6` in der Datenbank erreicht die angebundene iOS-App (`OstSeeTiere/8`)
+  also nie; auch `isLegacyFlagSet` wertet den Wert nicht aus. **Kein laufender
+  Client bricht.**
+
+**Die Werte 0–4 bleiben auswählbar** — allerdings nur noch in der Admin-Maske.
+Das öffentliche Meldeformular bietet ausschließlich `1` und `6` an; `5` entsteht
+weiterhin ausschließlich serverseitig. `bootsantrieb_text` hängt an `0` und ist
+damit ebenfalls auf die Admin-Maske beschränkt, bleibt für den Altbestand und
+den Legacy-Schreibpfad aber unverändert erhalten.
 
 ## Abweichung von der Ursprungs-PDF: `windrichtung` akzeptiert englische Abkürzungen
 

--- a/e2e/form-map-pan-zoom.spec.ts
+++ b/e2e/form-map-pan-zoom.spec.ts
@@ -81,17 +81,18 @@ async function mapPoint(page: Page, relX = 0.25, relY = 0.78) {
 }
 
 /**
- * Öffnet die Karte und setzt eine Position **über die Koordinatenfelder**.
+ * Setzt eine Position **über die Koordinatenfelder**.
  *
  * Bewusst nicht per Klick in die Karte: Der würde den Fokus ins Ziel-Element
  * legen und damit genau die Bedingung herstellen, die diese Tests als fehlend
  * nachweisen wollen. Der Wert ist der Kartenmittelpunkt, damit `setMapCenter`
  * die Ansicht nicht zusätzlich verschiebt.
+ *
+ * Aufzuklappen gibt es seit PR 3 nichts mehr — Karte und Koordinatenfelder
+ * stehen auf Schritt 1 dauerhaft offen.
  */
 async function oeffneKarteMitMarker(page: Page): Promise<void> {
-	const disclosure = page.locator('[data-testid="map-disclosure"]');
-	await disclosure.locator('summary').click();
-	await expect(disclosure).toHaveAttribute('open', '');
+	await expect(page.locator('.ol-map-container')).toBeVisible();
 
 	// `press('Tab')` gehört dazu: `LocationInput.svelte` übernimmt die Zahl im
 	// `onchange`-Handler, und der feuert an einem `type="number"`-Feld erst beim

--- a/e2e/form-position-photo.spec.ts
+++ b/e2e/form-position-photo.spec.ts
@@ -54,12 +54,34 @@ const fixture = (name: string): string =>
  * `click()` auf die Dropzone würde dagegen den nativen Dateidialog öffnen.
  * Eingegrenzt auf `photo-position-card`, damit der Selektor nicht versehentlich
  * die Medien-Dropzone aus Schritt 3 trifft.
+ *
+ * Seit PR 3 liegt die Dropzone in einer zugeklappten Disclosure. Das stört
+ * `setInputFiles` nicht — der Input ist im DOM, nur nicht sichtbar, und
+ * Sichtbarkeit braucht die Methode ohnehin nicht. Dass der Weg auch nach
+ * echtem Aufklappen funktioniert, prüft ein eigener Test weiter unten.
  */
 async function uploadPositionPhoto(page: Page, fileName: string): Promise<void> {
 	const input = page.locator('[data-testid="photo-position-card"] input[type="file"]');
 	// Die Dropzone erscheint erst, wenn `getUploadConfig()` beantwortet ist.
 	await input.waitFor({ state: 'attached' });
 	await input.setInputFiles(fixture(fileName));
+}
+
+/**
+ * Klappt die Foto-Disclosure auf, falls sie noch zu ist.
+ *
+ * Nötig für jede Assertion auf `toBeVisible()` innerhalb der Disclosure: Der
+ * Inhalt eines geschlossenen `<details>` hat keine Layout-Box und gilt damit
+ * als unsichtbar. Idempotent, damit Tests den Helfer auch dann aufrufen können,
+ * wenn sie vorher schon selbst aufgeklappt haben — ein zweiter Klick auf das
+ * `<summary>` würde sonst wieder zuklappen.
+ */
+async function oeffnePhotoDisclosure(page: Page): Promise<void> {
+	const disclosure = page.locator('[data-testid="photo-position-disclosure"]');
+	if ((await disclosure.getAttribute('open')) === null) {
+		await disclosure.locator('summary').click();
+	}
+	await expect(disclosure).toHaveAttribute('open', '');
 }
 
 /** Liest den Wert eines Koordinatenfeldes als Zahl (leer → NaN). */
@@ -72,8 +94,9 @@ async function coordinateValue(page: Page, id: 'latitude' | 'longitude'): Promis
  *
  * Seit dem 2026-07-31 stehen sie offen unter der Karte
  * (`collapsibleCoordinates={false}`, Wunsch des Deutschen Meeresmuseums) — es
- * gibt also nichts mehr aufzuklappen. Gemountet werden sie weiterhin erst mit
- * offener Karten-Disclosure; die klappt bei neuer Position von selbst auf.
+ * gibt also nichts mehr aufzuklappen. Seit PR 3 gilt das auch für die Karte
+ * selbst: Sie ist dauerhaft gemountet, die frühere Karten-Disclosure gibt es
+ * nicht mehr.
  */
 async function awaitCoordinateFields(page: Page): Promise<void> {
 	await expect(page.locator('#latitude')).toBeVisible();
@@ -97,9 +120,10 @@ test.describe('PositionPanel — Foto-Upload mit EXIF', () => {
 	test('Zustand B: Foto mit GPS übernimmt Position, Datum und Uhrzeit', async ({ page }) => {
 		await uploadPositionPhoto(page, 'photo-with-gps.jpg');
 
-		// Die Karte klappt auf der steigenden Flanke von selbst auf — erstes
-		// beobachtbares Zeichen, dass Koordinaten im Formular angekommen sind.
-		await expect(page.locator('[data-testid="map-disclosure"]')).toHaveAttribute('open', '', {
+		// Der Marker erscheint, sobald `hasPosition` steht — erstes beobachtbares
+		// Zeichen, dass Koordinaten im Formular angekommen sind. Vor PR 3 war es
+		// das Aufklappen der Karten-Disclosure; die gibt es nicht mehr.
+		await expect(page.locator('.ol-map-container')).toHaveAttribute('data-position', 'set', {
 			timeout: 15000
 		});
 
@@ -134,7 +158,8 @@ test.describe('PositionPanel — Foto-Upload mit EXIF', () => {
 		await expect(page.locator('[data-testid="photo-no-gps"]')).toHaveCount(0);
 	});
 
-	test('Zustand C: Foto ohne GPS zeigt den Hinweis mit beiden Auswegen', async ({ page }) => {
+	test('Zustand C: Foto ohne GPS zeigt den Hinweis mit dem Ausweg', async ({ page }) => {
+		await oeffnePhotoDisclosure(page);
 		await uploadPositionPhoto(page, 'photo-without-gps.jpg');
 
 		// Der Hinweis entsteht ausschließlich dadurch, dass `DropzoneEnhanced`
@@ -145,7 +170,9 @@ test.describe('PositionPanel — Foto-Upload mit EXIF', () => {
 		const noGps = page.locator('[data-testid="photo-no-gps"]');
 		await expect(noGps).toBeVisible({ timeout: 15000 });
 
-		await expect(page.locator('[data-testid="exit-to-map"]')).toBeVisible();
+		// Nur noch ein Ausweg: „Auf Karte wählen" ist mit PR 3 entfallen, weil die
+		// Karte sichtbar darüber steht und der Button nichts mehr bewirkt hätte.
+		await expect(page.locator('[data-testid="exit-to-map"]')).toHaveCount(0);
 		await expect(page.locator('[data-testid="exit-to-description"]')).toBeVisible();
 
 		// Ohne GPS ist die Aufnahmezeit das Einzige, was EXIF noch beisteuern
@@ -158,31 +185,29 @@ test.describe('PositionPanel — Foto-Upload mit EXIF', () => {
 		await expect(page.locator('[data-testid="field-sightingTime"]')).toHaveValue(EXIF_TIME);
 		await expect(page.locator('[data-testid="photo-datetime-applied"]')).toBeVisible();
 
-		// Ohne GPS bleibt die Position leer: Die Karte klappt nicht von selbst
-		// auf, und das Fahrwasser bleibt Pflichtfeld.
-		await expect(page.locator('[data-testid="map-disclosure"]')).not.toHaveAttribute('open', '');
+		// Ohne GPS bleibt die Position leer: Die Karte zeigt keinen Marker, und
+		// das Fahrwasser bleibt Pflichtfeld.
+		await expect(page.locator('.ol-map-container')).toHaveAttribute('data-position', 'unset');
 		await expect(page.locator('[data-testid="field-waterway"]')).toHaveAttribute(
 			'aria-required',
 			'true'
 		);
 	});
 
-	test('Zustand C: „Auf Karte wählen" öffnet die Karte', async ({ page }) => {
+	test('Zustand C: die Karte steht bereits sichtbar über dem Hinweis', async ({ page }) => {
+		await oeffnePhotoDisclosure(page);
 		await uploadPositionPhoto(page, 'photo-without-gps.jpg');
 		await expect(page.locator('[data-testid="photo-no-gps"]')).toBeVisible({ timeout: 15000 });
 
-		const disclosure = page.locator('[data-testid="map-disclosure"]');
-		await expect(disclosure).not.toHaveAttribute('open', '');
-
-		await page.locator('[data-testid="exit-to-map"]').click();
-
-		await expect(disclosure).toHaveAttribute('open', '');
-		// Der Ausweg soll dorthin führen, wo man wirklich etwas tun kann — die
-		// Koordinatenfelder werden erst mit offener Karte gemountet.
+		// Der frühere Ausweg „Auf Karte wählen" führte in eine Disclosure, die es
+		// nicht mehr gibt. Die Karte und die Koordinatenfelder liegen offen über
+		// dem Hinweis — es gibt nichts mehr zu öffnen.
+		await expect(page.locator('.ol-map-container')).toBeVisible();
 		await expect(page.locator('#latitude')).toBeVisible();
 	});
 
 	test('Zustand C: „Seegebiet beschreiben" fokussiert das Fahrwasser-Feld', async ({ page }) => {
+		await oeffnePhotoDisclosure(page);
 		await uploadPositionPhoto(page, 'photo-without-gps.jpg');
 		await expect(page.locator('[data-testid="photo-no-gps"]')).toBeVisible({ timeout: 15000 });
 
@@ -194,10 +219,39 @@ test.describe('PositionPanel — Foto-Upload mit EXIF', () => {
 		await expect(page.locator('[data-testid="location-description"]')).toBeVisible();
 	});
 
+	// ── PR 3: Der Foto-Weg liegt jetzt in einer zugeklappten Disclosure ───────
+	//
+	// Der Umbau verschiebt Dropzone, „kein GPS"-Zustand und UploadNotice in ein
+	// <details>. Das ist die einzige Zusicherung, die dabei wirklich neu ist:
+	// hinter der Disclosure funktioniert der EXIF-Pfad unverändert weiter.
+	test('nach dem Aufklappen setzt ein Foto mit GPS weiterhin Koordinaten und hasPosition', async ({
+		page
+	}) => {
+		await oeffnePhotoDisclosure(page);
+
+		await uploadPositionPhoto(page, 'photo-with-gps.jpg');
+
+		// `data-position` hängt an `hasPosition` — erstes beobachtbares Zeichen,
+		// dass die EXIF-Auswertung durch ist und beide Werte im Formular stehen.
+		await expect(page.locator('.ol-map-container')).toHaveAttribute('data-position', 'set', {
+			timeout: 15000
+		});
+
+		expect(await coordinateValue(page, 'latitude')).toBeCloseTo(54.31, 3);
+		expect(await coordinateValue(page, 'longitude')).toBeCloseTo(12.09, 3);
+
+		// Gegenprobe auf `hasPosition` im Formular statt nur auf der Karte: Das
+		// Fahrwasser verliert seine Pflicht (`waterway.when('hasPosition', …)`),
+		// und `BaseInput.svelte:65` entfernt das Attribut dabei ganz.
+		await expect
+			.poll(() => page.locator('[data-testid="field-waterway"]').getAttribute('aria-required'))
+			.toBeNull();
+	});
+
 	test('Foto mit GPS außerhalb der Ostsee löst die Bereichsprüfung aus', async ({ page }) => {
 		await uploadPositionPhoto(page, 'photo-gps-outside-baltic.jpg');
 
-		await expect(page.locator('[data-testid="map-disclosure"]')).toHaveAttribute('open', '', {
+		await expect(page.locator('.ol-map-container')).toHaveAttribute('data-position', 'set', {
 			timeout: 15000
 		});
 		await awaitCoordinateFields(page);

--- a/e2e/form-position.spec.ts
+++ b/e2e/form-position.spec.ts
@@ -20,16 +20,19 @@ test.describe('PositionAndTime — Single-Panel-Positionseingabe', () => {
 		await expect(page.locator('[data-testid="field-sightingTime"]')).toBeVisible();
 	});
 
-	test('zeigt den Foto-Weg prominent und ohne Methodenwahl', async ({ page }) => {
-		await expect(page.locator('[data-testid="photo-position-card"]')).toBeVisible();
+	test('zeigt den Foto-Weg aufklappbar und ohne Methodenwahl', async ({ page }) => {
+		// Seit PR 3 liegt der Foto-Weg in einer zugeklappten Disclosure; die
+		// Karte darüber ist die Hauptaktion. Der Inhalt existiert im DOM, ist
+		// aber erst nach dem Aufklappen sichtbar.
+		await expect(page.locator('[data-testid="photo-position-disclosure"]')).toBeVisible();
 
 		// Die Methodenwahl ist ersatzlos entfallen.
 		await expect(page.locator('#method-photo')).toHaveCount(0);
 		await expect(page.locator('#method-map')).toHaveCount(0);
 		await expect(page.locator('#method-manual')).toHaveCount(0);
 
-		// Der Standort-Button ist im Startzustand sichtbar — er darf nicht in der
-		// zugeklappten Karte verschwinden (Spec, Zustand A).
+		// Der Standort-Button ist im Startzustand sichtbar — er darf in keiner
+		// Disclosure verschwinden (Spec, Zustand A).
 		await expect(page.locator('[data-testid="use-current-position"]')).toBeVisible();
 
 		// Zustand C (Foto ohne GPS) ist nur nach einem Upload erreichbar — im
@@ -54,22 +57,11 @@ test.describe('PositionAndTime — Single-Panel-Positionseingabe', () => {
 		);
 	});
 
-	test('Karte ist initial zugeklappt und lässt sich öffnen', async ({ page }) => {
-		const disclosure = page.locator('[data-testid="map-disclosure"]');
-		await expect(disclosure).toBeVisible();
-		// Korrektur ggü. Brief: ein zugeklapptes <details> ist selbst weiterhin
-		// sichtbar (nur der Inhalt ist per content-visibility versteckt) — der
-		// Zustand gehört ans `open`-Attribut, nicht an toBeVisible().
-		await expect(disclosure).not.toHaveAttribute('open', '');
-
-		// LocationInput (und damit die Koordinatenfelder-Disclosure) wird erst
-		// gemountet, wenn die Karten-Disclosure offen ist
-		// (PositionPanel.svelte: `{#if mapOpen}` im collapse-content). Vor dem
-		// Öffnen existiert das Element also gar nicht.
-		await expect(page.locator('[data-testid="coordinate-fields"]')).toHaveCount(0);
-
-		await disclosure.locator('summary').click();
-		await expect(disclosure).toHaveAttribute('open', '');
+	test('Koordinatenfelder liegen offen unter der Karte', async ({ page }) => {
+		// Die Karten-Disclosure ist mit PR 3 entfallen — die Karte steht
+		// dauerhaft offen. Dass sie ohne Klick da ist, prüft die Gruppe
+		// „Karte oben, Foto-GPS in der Disclosure" weiter unten.
+		await expect(page.locator('[data-testid="map-disclosure"]')).toHaveCount(0);
 
 		// Die Koordinatenfelder stehen seit dem 2026-07-31 offen unter der Karte
 		// (`collapsibleCoordinates={false}`, Wunsch des Deutschen Meeresmuseums).
@@ -107,6 +99,62 @@ test.describe('PositionAndTime — Single-Panel-Positionseingabe', () => {
 	});
 });
 
+// ── PR 3: Karte nach oben, Foto-GPS in eine Disclosure ─────────────────────
+//
+// Der Foto-Weg war bis hierher die Hero-Karte des Schritts und die Karte lag
+// eingeklappt darunter. Auf Wunsch des Museums ist es jetzt umgekehrt: Karte
+// und Koordinatenfelder stehen dauerhaft offen, der Foto-Weg liegt in einer
+// zugeklappten Disclosure. Diese Gruppe deckt genau die neue Zusicherung ab.
+
+test.describe('PositionAndTime — Karte oben, Foto-GPS in der Disclosure', () => {
+	test.beforeEach(async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+	});
+
+	test('Karte und Koordinatenfelder sind ohne Klick sichtbar', async ({ page }) => {
+		await expect(page.locator('.ol-map-container')).toBeVisible();
+		await expect(page.locator('#latitude')).toBeVisible();
+		await expect(page.locator('#longitude')).toBeVisible();
+	});
+
+	test('die Foto-Disclosure ist zugeklappt und lässt sich öffnen', async ({ page }) => {
+		const disclosure = page.locator('[data-testid="photo-position-disclosure"]');
+		await expect(disclosure).toBeVisible();
+		// Ein zugeklapptes <details> ist selbst weiterhin sichtbar — der Zustand
+		// gehört ans `open`-Attribut, nicht an toBeVisible().
+		await expect(disclosure).not.toHaveAttribute('open', '');
+
+		await disclosure.locator('summary').click();
+		await expect(disclosure).toHaveAttribute('open', '');
+		await expect(page.locator('[data-testid="photo-position-card"]')).toBeVisible();
+	});
+
+	test('DOM-Reihenfolge: Standort-Button vor Karte vor Foto-Disclosure', async ({ page }) => {
+		await expect(page.locator('.ol-map-container')).toBeVisible();
+
+		const reihenfolge = await page.evaluate(() => {
+			const selektoren = [
+				'[data-testid="use-current-position"]',
+				'.ol-map-container',
+				'[data-testid="photo-position-disclosure"]'
+			];
+			const knoten = selektoren.map((selektor) => document.querySelector(selektor));
+			if (knoten.some((element) => element === null)) return null;
+			// Paarweise: folgt Element n+1 im Dokument auf Element n?
+			return knoten
+				.slice(1)
+				.map((element, index) =>
+					Boolean(
+						knoten[index]!.compareDocumentPosition(element!) & Node.DOCUMENT_POSITION_FOLLOWING
+					)
+				);
+		});
+
+		expect(reihenfolge).toEqual([true, true]);
+	});
+});
+
 // ── Karte: Tippen setzt die Position ───────────────────────────────────────
 //
 // Vor diesem Test setzte nur das Ziehen des Markers eine Koordinate. Auf dem
@@ -123,11 +171,7 @@ test.describe('PositionAndTime — Karte reagiert auf Tippen', () => {
 	});
 
 	test('Karte startet ohne Marker und ein Tippen setzt die Koordinaten', async ({ page }) => {
-		const disclosure = page.locator('[data-testid="map-disclosure"]');
-		await disclosure.locator('summary').click();
-		await expect(disclosure).toHaveAttribute('open', '');
-
-		const map = disclosure.locator('.ol-map-container');
+		const map = page.locator('.ol-map-container');
 		await expect(map).toBeVisible();
 
 		// Zustand A: keine Position gewählt — kein Marker, und der Hinweis sagt es.
@@ -157,10 +201,9 @@ test.describe('PositionAndTime — Karte reagiert auf Tippen', () => {
 	test('Hinweis unter der Karte nennt keinen GPS-Button (den es hier nicht gibt)', async ({
 		page
 	}) => {
-		const disclosure = page.locator('[data-testid="map-disclosure"]');
-		await disclosure.locator('summary').click();
+		await expect(page.locator('.ol-map-container')).toBeVisible();
 
-		await expect(disclosure.locator('.gps-control')).toHaveCount(0);
+		await expect(page.locator('.gps-control')).toHaveCount(0);
 		await expect(page.locator('[data-testid="map-hint"]')).not.toContainText(/GPS/i);
 	});
 });

--- a/e2e/form-ux.spec.ts
+++ b/e2e/form-ux.spec.ts
@@ -128,15 +128,21 @@ test.describe('AnimalInfo — isDead Conditional Rendering', () => {
 		await expect(page.locator('[data-field="deadSize"]')).not.toBeVisible();
 	});
 
-	test('isDead=true zeigt DeadAnimal-Felder', async ({ page }) => {
+	test('isDead=true zeigt DeadAnimal-Felder, aber nicht deadSex (Museum hat das Feld am 2026-08-04 abbestellt — C4)', async ({
+		page
+	}) => {
 		// Toggle isDead
 		const toggle = page.locator('[data-testid="field-isDead"]');
 		await toggle.check();
 
 		// Dead animal fields should appear
 		await expect(page.locator('[data-field="deadCondition"]')).toBeVisible({ timeout: 3000 });
-		await expect(page.locator('[data-field="deadSex"]')).toBeVisible();
 		await expect(page.locator('[data-field="deadSize"]')).toBeVisible();
+
+		// deadSex bleibt Schema-Feld für die Admin-Maske, ist im Meldeformular
+		// aber auch bei isDead=true nicht mehr erreichbar — anders als
+		// deadCondition/deadSize, die weiterhin sichtbar werden.
+		await expect(page.locator('[data-field="deadSex"]')).not.toBeVisible();
 	});
 
 	test('isDead zurück auf false versteckt DeadAnimal-Felder', async ({ page }) => {

--- a/e2e/form-ux.spec.ts
+++ b/e2e/form-ux.spec.ts
@@ -107,6 +107,51 @@ test.describe('StepNavigation — Error-UX', () => {
 	});
 });
 
+// ── PR 4: Bootsantrieb als Motor-an/aus-Frage ───────────────────────────────
+
+/**
+ * `fillStep2` wählt bewusst „Land", damit die Antriebsfrage gar nicht erscheint —
+ * dadurch lief bis PR 4 kein E2E-Fall durch den Boot-Pfad. Dieser Test schließt
+ * die Lücke: Bei Motorboot ist `boatDrive` Pflicht, und seit dem 2026-08-04 wird
+ * die Frage als Zwei-Optionen-Radiogruppe gestellt („Motor lief" = 1,
+ * „Motor lief nicht" = 6) statt als Select mit fünf Antriebsarten.
+ */
+test.describe('SightingDetails — Motorfrage bei Motorboot', () => {
+	test('Motorboot fragt nach dem Motor und lässt den Schritt danach abschließen', async ({
+		page
+	}) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		await fillStep1(formPage);
+		await waitForNextEnabled(page);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Angaben zum Tier/i);
+
+		await formPage.selectSpecies(0);
+		await formPage.fillTotalCount(2);
+		await formPage.selectDistance(1);
+
+		// Solange „Land" gewählt ist, gibt es keine Antriebsfrage.
+		await expect(page.locator('[data-field="boatDrive"]')).not.toBeVisible();
+
+		await formPage.selectSightingFrom(2); // Motorboot
+		await expect(page.locator('[data-field="boatDrive"]')).toBeVisible({ timeout: 3000 });
+
+		// Genau zwei Antworten, keine Auswahlliste, kein Freitext für „Sonstiger Antrieb".
+		await expect(page.locator('[data-field="boatDrive"] input[type="radio"]')).toHaveCount(2);
+		await expect(page.locator('[data-testid="field-boatDrive"]')).toHaveCount(0);
+		await expect(page.locator('[data-field="boatDriveText"]')).not.toBeVisible();
+
+		await formPage.selectBoatDrive(6); // Motor lief nicht
+		await expect(page.locator('[data-testid="field-boatDrive-6"]')).toBeChecked();
+
+		await waitForNextEnabled(page);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Weitere Informationen/i);
+	});
+});
+
 // ── Phase 2C: isDead Conditional Rendering ──────────────────────────────────
 
 test.describe('AnimalInfo — isDead Conditional Rendering', () => {

--- a/e2e/pages/FormPage.ts
+++ b/e2e/pages/FormPage.ts
@@ -98,8 +98,16 @@ export class FormPage {
 		await this.page.locator('[data-testid="field-sightingFrom"]').selectOption(String(index));
 	}
 
-	async selectBoatDrive(index: number) {
-		await this.page.locator('[data-testid="field-boatDrive"]').selectOption(String(index));
+	/**
+	 * Answers the motor question that appears for Segelschiff/Motorboot.
+	 *
+	 * Since PR 4 (2026-08-04) this is a two-option radio group, not a select —
+	 * BaseRadio.svelte suffixes the testid per option (`field-boatDrive-<value>`).
+	 * The argument is therefore the stored `BoatDriveEnum` value: `1` = Motor
+	 * lief, `6` = Motor lief nicht. The full drive list stays in the admin form.
+	 */
+	async selectBoatDrive(value: number) {
+		await this.page.locator(`[data-testid="field-boatDrive-${value}"]`).check();
 	}
 
 	// ── Step 4: Kontaktdaten ─────────────────────────────────────────────────

--- a/legacy-inbox/data/antworten.de.json
+++ b/legacy-inbox/data/antworten.de.json
@@ -88,7 +88,8 @@
 		"2": "Segel",
 		"3": "Treibend",
 		"4": "Vor Anker",
-		"5": "Kein Boot"
+		"5": "Kein Boot",
+		"6": "Motor aus"
 	},
 	"eingangskanal": {
 		"0": "Web",

--- a/legacy-inbox/data/antworten.en.json
+++ b/legacy-inbox/data/antworten.en.json
@@ -88,7 +88,8 @@
 		"2": "Segel",
 		"3": "Treibend",
 		"4": "Vor Anker",
-		"5": "Kein Boot"
+		"5": "Kein Boot",
+		"6": "Motor aus"
 	},
 	"eingangskanal": {
 		"0": "Web",

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -86,7 +86,7 @@
 
 			<Location />
 			<DateTime />
-			<AnimalInfo />
+			<AnimalInfo adminMode={true} />
 			<SightingDetails />
 		</div>
 

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -87,7 +87,7 @@
 			<Location />
 			<DateTime />
 			<AnimalInfo adminMode={true} />
-			<SightingDetails />
+			<SightingDetails adminMode={true} />
 		</div>
 
 		<!-- Rechte Spalte - Zusatzinformationen -->

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -507,21 +507,18 @@ export const sightingSchemaBase = yup.object().shape({
 
 	/**
 	 * Geschlecht des toten Tieres
-	 * Erforderlich, wenn isDead = true
+	 * Das Museum hat das Geschlecht am 2026-08-04 aus dem Meldeformular abbestellt
+	 * (Analyse-Punkt C4): Laien können es am Strand kaum bestimmen, das Feld
+	 * lieferte überwiegend „Unbekannt". Die Pflicht musste dabei zwingend mit weg —
+	 * sonst wäre nach dem Entfernen des Markups keine Totfund-Meldung mehr
+	 * absendbar gewesen. Das Feld bleibt optional für die Admin-Maske im Schema.
 	 */
 	deadSex: yup
 		.number()
 		.transform((value) => (isNaN(value) ? undefined : value))
-		.when('isDead', {
-			is: true,
-			then: (schema) =>
-				schema
-					.required('Bitte geben Sie das Geschlecht des toten Tieres an.')
-					.test('is-valid-dead-sex', 'Bitte wählen Sie ein gültiges Geschlecht.', (value) =>
-						isValidSex(String(value))
-					),
-			otherwise: (schema) => schema.notRequired()
-		})
+		.test('is-valid-dead-sex', 'Bitte wählen Sie ein gültiges Geschlecht.', (value) =>
+			value === undefined ? true : isValidSex(String(value))
+		)
 		.label('Geschlecht (Totfund)')
 		.meta({
 			helpText: 'Falls erkennbar',

--- a/src/lib/form/validation/sightingSchemaBoatDrive.test.ts
+++ b/src/lib/form/validation/sightingSchemaBoatDrive.test.ts
@@ -107,6 +107,54 @@ describe('sightingSchema - boatDrive (Befund U3)', () => {
 	});
 });
 
+/**
+ * PR 4 (Museum, 2026-08-04): "Motor an / Motor aus" ersetzt im Meldeformular die
+ * fünf Antriebsarten bei Motorboot/Segelschiff. "Motor aus" bekommt einen neuen
+ * Enum-Wert `BoatDriveEnum.MOTOR_OFF = 6`.
+ *
+ * Die Pflicht bei Segelschiff/Motorboot und die Optionalität bei Land/Fähre/
+ * Sonstiges bleiben unverändert bestehen — siehe die Tests oben, die genau das
+ * bereits mit dem alten Wertebereich (0-5) absichern. Hier wird nur ergänzt,
+ * dass der neue Wert `6` dieselbe Validierung besteht.
+ */
+describe('sightingSchema - boatDrive (PR 4 — Motor an/aus, Wert 6)', () => {
+	it('besteht die Validierung mit MOTOR_OFF ("Motor aus"), wenn von einem Motorboot gemeldet wird', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.MOTORBOAT,
+			boatDrive: BoatDriveEnum.MOTOR_OFF
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('besteht die Validierung mit MOTOR_OFF, wenn von einem Segelschiff gemeldet wird', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: BoatDriveEnum.MOTOR_OFF
+		});
+		expect(fehler).toBeNull();
+	});
+
+	it('bleibt bei Motorboot/Segelschiff ohne Wert weiterhin Pflicht — auch nach Einführung von 6', async () => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom: SightingFromEnum.MOTORBOAT,
+			boatDrive: undefined
+		});
+		expect(fehler).toBe('Bitte wählen Sie den Bootsantrieb aus.');
+	});
+
+	it.each([
+		['Land', SightingFromEnum.LAND],
+		['Fähre', SightingFromEnum.FERRY],
+		['Sonstiges', SightingFromEnum.OTHER]
+	])('bleibt bei "%s" optional — auch nach Einführung von 6', async (_label, sightingFrom) => {
+		const fehler = await fieldError('boatDrive', {
+			sightingFrom,
+			boatDrive: undefined
+		});
+		expect(fehler).toBeNull();
+	});
+});
+
 describe('sightingSchema - Schritt-2-Validierung (Zusammenspiel boatDrive/sightingFrom)', () => {
 	it('Schritt 2 ist gültig ohne boatDrive, wenn von Land gemeldet wird', async () => {
 		const pickedSchema = sightingSchema.pick(['sightingFrom', 'boatDrive']);

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -13,6 +13,7 @@ import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 import { DistributionEnum } from '$lib/report/formOptions/distribution';
 import { AnimalBehaviorEnum } from '$lib/report/formOptions/animalBehavior';
 import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
+import { AnimalConditionEnum } from '$lib/report/formOptions/animalCondition';
 
 // Kein Mock nötig — sightingSchema importiert weder $lib/logger noch $lib/report/formConfig
 
@@ -232,6 +233,93 @@ describe('sightingSchema - Sonstiges-Textfeld-Validierung', () => {
 				boatDriveText: null
 			});
 			expect(hatFehler).toBe(false);
+		});
+	});
+
+	// ── deadSex — Analyse-Punkt C4 ────────────────────────────────────────────
+	//
+	// Das Deutsche Meeresmuseum hat das Geschlecht beim Totfund am 2026-08-04
+	// aus dem Meldeformular abbestellt (PR 2, Teil b, siehe
+	// docs/MEERESMUSEUM_FORMULAR_PLAN_2026-08-04.md). Der technische Blocker:
+	// `deadSex` ist heute über `.when('isDead', { is: true, then: required })`
+	// Pflichtfeld, sobald `isDead` gesetzt ist. Würde nur das Markup entfernt
+	// (`<FormField name="deadSex" />` hinter `{#if adminMode}`), wäre danach
+	// KEINE Totfund-Meldung mehr absendbar — das Feld existiert im DOM des
+	// Meldeformulars nicht mehr, die Validierung verlangt es aber weiterhin.
+	//
+	// Dieser Test ist deshalb VOR der Schema-Änderung absichtlich ROT: Ein
+	// sonst gültiger Datensatz mit `isDead: true` und ohne `deadSex` muss die
+	// Validierung bestehen. Grün wird er erst, wenn der `.when('isDead', …)`
+	// Block bei `deadSex` in sightingSchema.ts ersatzlos entfernt ist (Feld
+	// bleibt optional, `.test('is-valid-dead-sex')`, Label und `meta` bleiben
+	// unverändert — die Admin-Maske rendert daraus weiter).
+	describe('deadSex — entfällt als Pflichtfeld bei Totfund (C4, 2026-08-04)', () => {
+		const validesteBasis = {
+			referenceId: 'test-ref-dead-sex',
+			firstName: 'Jane',
+			lastName: 'Doe',
+			email: 'jane@example.com',
+			privacyConsent: true,
+			species: 0,
+			totalCount: 1,
+			distance: 1,
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: BoatDriveEnum.MOTOR,
+			entryChannel: 0,
+			hasPosition: true,
+			latitude: 54.5,
+			longitude: 13.5,
+			sightingDate: new Date().toISOString().split('T')[0]
+		};
+
+		async function validatesFully(formData: Record<string, unknown>): Promise<boolean> {
+			try {
+				await sightingSchema.validate(formData, { abortEarly: false });
+				return true;
+			} catch {
+				return false;
+			}
+		}
+
+		it('validiert einen sonst gültigen Totfund OHNE deadSex erfolgreich (der Blocker)', async () => {
+			const totfundOhneGeschlecht = {
+				...validesteBasis,
+				isDead: true,
+				deadCondition: AnimalConditionEnum.FRESH_BEGINNING_DECOMPOSITION
+				// deadSex bewusst NICHT gesetzt — genau der Fall, den das
+				// entfernte Markup danach erzeugt.
+			};
+
+			expect(await validatesFully(totfundOhneGeschlecht)).toBe(true);
+		});
+
+		it('validiert deadSex jetzt einzeln (validateAt) ohne Fehler — Schema-Änderung gelandet', async () => {
+			// Vor der Schema-Änderung warf dieselbe Zeile mit /Geschlecht/ (siehe
+			// Git-Historie dieser Datei) — genau das war der Blocker, den der Test
+			// oben in dieser describe-Gruppe reproduziert. Nach dem Entfernen des
+			// `.when('isDead', …)`-Blocks bei `deadSex` validiert das Feld einzeln
+			// erfolgreich, wie hier festgehalten.
+			await expect(sightingSchema.validateAt('deadSex', { isDead: true })).resolves.not.toThrow();
+		});
+
+		it('deadCondition bleibt bei isDead=true weiterhin Pflichtfeld', async () => {
+			// Gegenprobe zum Blocker-Test: Die Schema-Änderung darf ausschließlich
+			// `deadSex` betreffen. Würde `deadCondition` versehentlich mit
+			// entschärft, wiche die Änderung weiter auf als vom Museum verlangt.
+			const totfundOhneZustand = {
+				...validesteBasis,
+				isDead: true,
+				deadSex: 1
+				// deadCondition bewusst NICHT gesetzt
+			};
+
+			expect(await validatesFully(totfundOhneZustand)).toBe(false);
+		});
+
+		it('deadCondition-Fehler bleibt am eigenen Feld bestehen (validateAt)', async () => {
+			await expect(sightingSchema.validateAt('deadCondition', { isDead: true })).rejects.toThrow(
+				/Zustand/
+			);
 		});
 	});
 });

--- a/src/lib/legacy-api/types.ts
+++ b/src/lib/legacy-api/types.ts
@@ -68,7 +68,7 @@ export interface LegacySightingRequest {
 	schiffsname?: string; // Ship name
 	heimathafen?: string; // Home port
 	bootstyp?: string; // Boat type
-	bootsantrieb?: number; // Boat drive (0-4)
+	bootsantrieb?: number; // Boat drive (0-6; 5 = no boat, 6 = motor off — see LEGACY_API_SPECIFICATION.md)
 	bootsantrieb_text?: string; // Other boat drive text (when bootsantrieb = 0)
 
 	// Contact information

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -191,9 +191,24 @@
 </script>
 
 {#snippet coordinateFields()}
-	<div class="mb-4 flex items-center justify-between">
+	<!-- Unterhalb `md` stehen Beschriftung und Auswahl untereinander, darüber
+	     nebeneinander. Als einzeilige Flex-Zeile setzte dieser Block die
+	     Mindestbreite der ganzen Seite: Ein `<select>` ist so breit wie seine
+	     längste Option („Grad, Minute, Sekunde (z.B. 54° 30' 15\" N)"), und als
+	     Flex-Item mit `min-width: auto` schrumpft es nicht darunter. Zusammen mit
+	     dem Label ergab das rund 420 px — auf einem 360-px-Telefon lief das
+	     Dokument dadurch um gut 100 px über und die ganze Seite ließ sich seitlich
+	     schieben (`e2e/footer-layout.spec.ts`).
+
+	     Aufgefallen ist es erst, als die Koordinateneingabe dauerhaft sichtbar
+	     wurde. Vorher lag sie in einem zugeklappten `<details>` und hatte gar
+	     keine Layout-Box — der Überlauf war die ganze Zeit da, nur unsichtbar.
+
+	     `min-w-0` gehört zwingend dazu: Ohne das Aufheben von `min-width: auto`
+	     bleibt das Select auch in der gestapelten Fassung zu breit. -->
+	<div class="mb-4 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
 		<label class="label" for="gps-format">GPS-Eingabeformat</label>
-		<select id="gps-format" class="select ml-auto w-auto" bind:value={mode}>
+		<select id="gps-format" class="select w-full min-w-0 md:ml-auto md:w-auto" bind:value={mode}>
 			<option value="dd">Dezimalgrad (z.B. 54.5042° N)</option>
 			<option value="dm">Grad, Dezimalminute (z.B. 54° 30.25' N)</option>
 			<option value="dms">Grad, Minute, Sekunde (z.B. 54° 30' 15" N)</option>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -4,7 +4,7 @@
 -->
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
-	import type { FieldSize, FieldVariant } from '$lib/types';
+	import type { FieldOption, FieldSize, FieldVariant } from '$lib/types';
 	import * as yup from 'yup';
 	import BaseCheckbox from './BaseCheckbox.svelte';
 	import BaseInput from './BaseInput.svelte';
@@ -24,7 +24,10 @@
 		size = 'md',
 		variant = 'default',
 		onchange = undefined,
-		required: requiredOverride = undefined
+		required: requiredOverride = undefined,
+		label: labelOverride = undefined,
+		type: typeOverride = undefined,
+		options: optionsOverride = undefined
 	}: {
 		fieldConfig: yup.SchemaDescription;
 		name?: string;
@@ -42,6 +45,26 @@
 		 * `undefined` = Ableitung aus dem Schema (Default).
 		 */
 		required?: boolean | undefined;
+		/**
+		 * Überschreibt die aus `fieldConfig.label` abgeleitete Beschriftung, wenn
+		 * dieselbe Schema-Spalte in zwei Kontexten unterschiedlich gefragt wird.
+		 * `undefined` = Ableitung aus dem Schema (Default).
+		 */
+		label?: string | undefined;
+		/**
+		 * Überschreibt den aus `meta.type` abgeleiteten Feldtyp. Nötig, wenn
+		 * dasselbe Schema-Feld je nach Kontext anders bedient wird — z.B.
+		 * `boatDrive`: Select mit allen Antriebsarten in der Admin-Maske,
+		 * Zwei-Optionen-Radiogruppe im Meldeformular.
+		 * `undefined` = Ableitung aus dem Schema (Default).
+		 */
+		type?: string | undefined;
+		/**
+		 * Überschreibt die aus `meta.options` abgeleitete Optionsliste. Gehört
+		 * fachlich zum `type`-Override und wird meist zusammen mit ihm gesetzt.
+		 * `undefined` = Ableitung aus dem Schema (Default).
+		 */
+		options?: FieldOption[] | undefined;
 	} = $props();
 
 	// Bindable values for different component types
@@ -69,7 +92,25 @@
 				'radio'
 			].includes(normalizedType)
 		) {
-			numberValue = typeof value === 'boolean' ? '' : (value ?? '');
+			const next = typeof value === 'boolean' ? '' : (value ?? '');
+
+			// Radiogruppen brauchen den Wert als ZAHL, alle anderen nicht.
+			//
+			// `BaseRadio` bindet per `bind:group`, und das vergleicht strikt gegen
+			// die Optionswerte — die sind Zahlen. Der Formular-Store trägt aber
+			// nach `handleChange` den String aus dem DOM-Event ("6"), weil
+			// `createForm` das Event liest und nicht den hier gesetzten Wert.
+			// Ohne Angleichung findet die Gruppe ihren eigenen gerade gesetzten
+			// Wert nicht wieder und springt zurück auf „nichts gewählt": Der
+			// Melder klickt, und der Punkt bleibt leer.
+			//
+			// Beim `<select>` fällt dieselbe Verkettung nicht auf, weil dessen
+			// DOM-Wert ohnehin ein String ist und der Browser die Auswahl hält —
+			// deshalb ist das erst mit dem ersten Radiofeld des Formulars
+			// aufgetreten (`boatDrive`, PR 4). `next !== ''` schützt davor, dass
+			// „nichts gewählt" über `Number('')` zu einer echten 0 wird — bei
+			// `BoatDriveEnum.OTHER = 0` wäre das eine falsche Antwort.
+			numberValue = normalizedType === 'radio' && next !== '' ? Number(next) : next;
 		}
 	});
 
@@ -114,10 +155,10 @@
 	let metaValues = $derived.by(() => {
 		const meta = fieldConfig.meta || {};
 		return {
-			options: meta.options,
+			options: optionsOverride ?? meta.options,
 			helpText: meta.helpText,
 			valueText: meta.valueText,
-			type: meta.type || fieldConfig.type,
+			type: typeOverride ?? meta.type ?? fieldConfig.type,
 			icon: meta.icon,
 			rows: meta.rows,
 			placeholder: meta.placeholder,
@@ -127,7 +168,7 @@
 		};
 	});
 	let hasOptions = $derived(metaValues.options && metaValues.options.length > 0);
-	let label = $derived(fieldConfig.label);
+	let label = $derived(labelOverride ?? fieldConfig.label);
 
 	// State computations
 	let hasError = $derived(!!error && error.length > 0);

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -2,6 +2,7 @@ import { render } from 'vitest-browser-svelte';
 import { describe, it, expect } from 'vitest';
 import { page } from 'vitest/browser';
 import FieldRenderer from './FieldRenderer.svelte';
+import { PUBLIC_BOAT_DRIVE_OPTIONS } from '$lib/report/formOptions/boatDrive';
 import type * as yup from 'yup';
 
 // Mock field configs that mirror the real schema's .describe() output
@@ -199,6 +200,118 @@ describe('FieldRenderer', () => {
 			});
 
 			await expect.element(page.getByLabelText('Pflichtfeld')).not.toBeInTheDocument();
+		});
+	});
+
+	/**
+	 * PR 4 (Museum, 2026-08-04): `boatDrive` bleibt im Schema ein 6-Werte-Select
+	 * (für die Admin-Maske), soll im Meldeformular aber nur noch als
+	 * Zwei-Optionen-Radiogruppe ("Motor lief" / "Motor lief nicht") erscheinen —
+	 * ohne eigenes Markup in der Section (design-system.md: Label,
+	 * Pflicht-Sternchen, `aria-describedby` müssen aus der Feld-Pipeline kommen).
+	 * Dafür bekommen `FormField`/`FieldRenderer` zwei neue Overrides, analog zum
+	 * bereits vorhandenen `required`-Override: `type` und `options`.
+	 */
+	describe('type/options-Override (PR 4 — Bootsantrieb "Motor an/aus")', () => {
+		// Bootsantrieb, wie ihn das Schema für die Admin-Maske beschreibt: ein
+		// Select mit allen fünf/sechs Werten.
+		const boatDriveSelectFieldConfig = makeFieldConfig({
+			label: 'Bootsantrieb',
+			optional: false,
+			meta: {
+				type: 'select',
+				helpText: 'Welcher Antrieb wurde während der Sichtung verwendet?',
+				selectPlaceholder: 'Bitte wählen...',
+				options: [
+					{ value: 0, label: 'Sonstiger Bootsantrieb' },
+					{ value: 1, label: 'Motor' },
+					{ value: 2, label: 'Segel' },
+					{ value: 3, label: 'Treibend' },
+					{ value: 4, label: 'Vor Anker' }
+				]
+			}
+		});
+
+		// Die echte Konstante, nicht eine Kopie: So fällt hier auf, wenn die
+		// öffentliche Auswahl aus `formOptions/boatDrive.ts` wegdriftet.
+		const publicBoatDriveOptions = PUBLIC_BOAT_DRIVE_OPTIONS;
+
+		it('rendert bei type="radio" + eigenen options eine Radiogruppe mit genau diesen Optionen', async () => {
+			render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			await expect.element(page.getByText('Motor lief nicht')).toBeVisible();
+			await expect.element(page.getByRole('radio').first()).toBeVisible();
+		});
+
+		it('zeigt die Schema-Select-Optionen NICHT mehr, wenn options überschrieben wurde', async () => {
+			render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			await expect.element(page.getByText('Treibend')).not.toBeInTheDocument();
+			await expect.element(page.getByText('Vor Anker')).not.toBeInTheDocument();
+			await expect.element(page.getByRole('combobox')).not.toBeInTheDocument();
+		});
+
+		it('behält Label und Pflicht-Sternchen aus dem Schema, auch mit Override', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			// Gezielt die Legend der Radiogruppe (nicht per getByText('Bootsantrieb'),
+			// das mit "Sonstiger Bootsantrieb" mehrdeutig würde, solange der
+			// Options-Override noch nicht greift und das Schema-Select weiterhin
+			// mitrendert wird).
+			const legend = screen.container.querySelector('legend');
+			expect(legend?.textContent).toContain('Bootsantrieb');
+			await expect.element(page.getByLabelText('Pflichtfeld')).toBeVisible();
+		});
+
+		it('verknüpft aria-describedby weiterhin mit dem Hilfetext, auch mit Override', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			const helpElement = screen.container.querySelector('#field-boatDrive-help');
+			expect(helpElement).not.toBeNull();
+			expect(helpElement?.textContent).toContain(
+				'Welcher Antrieb wurde während der Sichtung verwendet?'
+			);
+
+			const radios = screen.container.querySelectorAll('input[type="radio"]');
+			expect(radios.length).toBeGreaterThan(0);
+			radios.forEach((radio) => {
+				expect(radio.getAttribute('aria-describedby')).toContain('field-boatDrive-help');
+			});
+		});
+
+		it('rendert ohne Override weiterhin das Schema-Select (Admin-Maske)', async () => {
+			render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null
+			});
+
+			await expect.element(page.getByRole('combobox')).toBeVisible();
+			await expect.element(page.getByText('Motor lief nicht')).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/lib/report/components/form/fields/FormField.svelte
+++ b/src/lib/report/components/form/fields/FormField.svelte
@@ -6,6 +6,7 @@
 	import { createLogger } from '$lib/logger';
 	import { sightingSchemaFields } from '$lib/report/formConfig';
 	import { getFormContext } from '$lib/report/formContext';
+	import type { FieldOption } from '$lib/types';
 	import type { SightingFormData } from '$lib/types/Form';
 	import { untrack } from 'svelte';
 	import * as yup from 'yup';
@@ -18,7 +19,10 @@
 		disabled = false,
 		size = 'md',
 		variant = 'default',
-		required = undefined
+		required = undefined,
+		label = undefined,
+		type = undefined,
+		options = undefined
 	}: {
 		name: keyof Omit<SightingFormData, 'uploadedFiles'>;
 		disabled?: boolean;
@@ -30,6 +34,22 @@
 		 * Ohne Angabe gilt weiterhin die Ableitung aus dem Yup-Schema.
 		 */
 		required?: boolean | undefined;
+		/**
+		 * Optionaler Override der Beschriftung, wenn dieselbe Schema-Spalte in
+		 * zwei Kontexten unterschiedlich gefragt wird (Meldeformular vs.
+		 * Admin-Maske). Ohne Angabe gilt weiterhin das `.label()` des Schemas.
+		 */
+		label?: string | undefined;
+		/**
+		 * Optionaler Override des Feldtyps (z.B. `'radio'` statt des
+		 * Schema-`'select'`). Ohne Angabe gilt weiterhin `meta.type`.
+		 */
+		type?: string | undefined;
+		/**
+		 * Optionaler Override der Optionsliste — gehört fachlich zum
+		 * `type`-Override. Ohne Angabe gilt weiterhin `meta.options`.
+		 */
+		options?: FieldOption[] | undefined;
 	} = $props();
 
 	const context = getFormContext();
@@ -85,6 +105,9 @@
 		{size}
 		{variant}
 		{required}
+		{label}
+		{type}
+		{options}
 		onchange={handleChange}
 	/>
 </div>

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { get } from 'svelte/store';
 	import { getFormContext } from '$lib/report/formContext';
 	import { getUploadConfig } from '$lib/stores/configStore';
@@ -14,11 +13,7 @@
 	import SectionCard from '$lib/report/components/sections/SectionCard.svelte';
 	import LocationDescription from './LocationDescription.svelte';
 	import { requestCurrentPosition } from './geolocation';
-	import {
-		photoStatus,
-		shouldOpenMapOnCoordinateChange,
-		shouldWarnAboutMissingGps
-	} from './positionPanelState';
+	import { photoStatus, shouldWarnAboutMissingGps } from './positionPanelState';
 
 	const { form, handleChange, mediaStore } = getFormContext();
 
@@ -40,34 +35,13 @@
 	const longitude = $derived(toCoordinate($form.longitude));
 	const latitude = $derived(toCoordinate($form.latitude));
 
-	// Nur für die Karten-Automatik. Bewusst NICHT als Guard für VerifyLocation:
-	// Ein separater Boolean verengt die Typen im Template nicht (svelte-check
-	// kennt kein Aliased-Narrowing über `$derived`), VerifyLocation bekäme also
-	// `number | undefined` und fiele still auf seine Default-Koordinaten
-	// (54.5/13.5) zurück. Der Guard unten prüft deshalb direkt auf `undefined`.
+	// Nur für `shouldWarnAboutMissingGps`. Bewusst NICHT als Guard für
+	// VerifyLocation: Ein separater Boolean verengt die Typen im Template nicht
+	// (svelte-check kennt kein Aliased-Narrowing über `$derived`), VerifyLocation
+	// bekäme also `number | undefined` und fiele still auf seine
+	// Default-Koordinaten (54.5/13.5) zurück. Der Guard unten prüft deshalb
+	// direkt auf `undefined`.
 	const coordinatesPresent = $derived(latitude !== undefined && longitude !== undefined);
-
-	// Karte: automatisch aufklappen, sobald eine Position NEU entsteht — danach
-	// gehört der Zustand dem Nutzer (er darf zuklappen, ohne dass es zurückspringt).
-	let mapOpen = $state(false);
-	// `hadCoordinates` ist reiner Vorzustands-Speicher, keine Eingabe des Effects.
-	// Würde es hier normal gelesen, wäre es Abhängigkeit DES Effects, der es selbst
-	// schreibt — der Effect liefe ein zweites Mal und die steigende Flanke wäre
-	// nicht mehr eindeutig. `untrack` hält die einzige Abhängigkeit bei
-	// `coordinatesPresent` (gleiches Muster wie LocationInput.svelte:41-48).
-	let hadCoordinates = $state(false);
-	$effect(() => {
-		const present = coordinatesPresent;
-		if (
-			shouldOpenMapOnCoordinateChange(
-				present,
-				untrack(() => hadCoordinates)
-			)
-		) {
-			mapOpen = true;
-		}
-		hadCoordinates = present;
-	});
 
 	// GPS-Foto-Konfiguration: Server-Config, aber nur Bilder und genau eine Datei.
 	let gpsPhotoConfig = $state<ValidationPreset | null>(null);
@@ -131,15 +105,6 @@
 		syncHasPosition();
 	}
 
-	let mapSummary = $state<HTMLElement | null>(null);
-
-	/** Öffnet die Karte und setzt den Fokus dorthin — nicht nur scrollen. */
-	function openMap(): void {
-		mapOpen = true;
-		mapSummary?.focus();
-		mapSummary?.scrollIntoView({ block: 'center' });
-	}
-
 	/**
 	 * Springt zur Ortsbeschreibung und fokussiert das Fahrwasser-Feld.
 	 *
@@ -174,7 +139,7 @@
 	let locationError = $state<string | null>(null);
 
 	/**
-	 * Übernimmt den Gerätestandort und öffnet die Karte zur Kontrolle.
+	 * Übernimmt den Gerätestandort ins Formular.
 	 *
 	 * Der Button bleibt währenddessen fokussierbar (nur `aria-disabled`), weil
 	 * `disabled` ihn aus der Tab-Reihenfolge nimmt und der Browser den Fokus
@@ -199,7 +164,6 @@
 		setField('latitude', result.latitude);
 		setField('longitude', result.longitude);
 		syncHasPosition();
-		mapOpen = true;
 	}
 </script>
 
@@ -208,115 +172,15 @@
 	     zwei Zeilen später in der Hero-Karte fast wörtlich noch einmal. -->
 	<p class="text-base-content/70 mb-4 text-sm">Wo haben Sie das Tier gesehen?</p>
 
-	<!-- Hero: Foto mit GPS. Tint-Fläche trägt bewusst text-base-content,
-	     NICHT text-primary-content (weiß auf hellblau ≈ 1,3:1). -->
-	<div
-		class="border-primary bg-primary/5 text-base-content rounded-lg border-2 p-4 md:p-6"
-		data-testid="photo-position-card"
-	>
-		<h4 class="mb-1 flex items-center gap-2 font-semibold">
-			<Icon aria-hidden="true" icon="lucide:camera" width="20" class="text-primary" />
-			Foto mit GPS hochladen
-		</h4>
-		<p class="text-base-content/70 mb-3 text-sm">
-			Der schnellste Weg: Position, Datum und Uhrzeit werden automatisch übernommen.
-		</p>
+	<!-- Der Standort-Button steht bewusst ganz oben: Er ist der schnellste Weg
+	     für alle, die vor Ort melden, und braucht anders als die Karte darunter
+	     keine Feinarbeit mit dem Finger.
 
-		{#if gpsPhotoConfig}
-			<!-- `showNoGpsWarning={false}`: Der Fall wird unten ausführlicher erklärt
-			     (Zustand C). Ohne das Abschalten stünden zwei Warn-Alerts mit
-			     derselben Aussage direkt übereinander.
-
-			     `compact` + leerer `additionalText`: Die Überschrift dieser Karte
-			     und der Satz darüber sagen bereits, worum es geht und dass GPS
-			     ausgelesen wird. Der Dropzone-Titel „Foto hochladen" und der
-			     Default-Zusatz „GPS-Daten werden beim Upload verarbeitet" waren
-			     die dritte und vierte Formulierung derselben Aussage. -->
-			<DropzoneEnhanced
-				{referenceId}
-				maxFiles={1}
-				config={gpsPhotoConfig}
-				enableGPSExtraction={true}
-				showNoGpsWarning={false}
-				showPositionMap={false}
-				onExifDateTimeApplied={(applied) => (exifDateTimeApplied = applied)}
-				actionLabel="Foto auswählen"
-				compact={true}
-				additionalText=""
-			/>
-		{:else}
-			<div class="skeleton h-32 w-full"></div>
-		{/if}
-
-		<!-- Zustand C: Foto ohne EXIF-GPS.
-
-		     Bewusst `'no-gps'` und nicht „kein GPS im Formular": Während der
-		     Auswertung meldet `photoStatus` `'analyzing'` und hier steht nichts.
-		     Sonst würde ein Foto MIT GPS im Moment des Drops für GPS-los erklärt
-		     und die Behauptung Sekundenbruchteile später zurückgenommen — mit
-		     `role="status"` sagt ein Screenreader sie inzwischen an.
-
-		     Die zweite Bedingung (`coordinatesPresent`) steckt in
-		     `shouldWarnAboutMissingGps`: Solange das Panel Koordinaten anzeigt,
-		     darf es ihr Fehlen nicht behaupten. -->
-		{#if shouldWarnAboutMissingGps(status, coordinatesPresent)}
-			<div class="alert alert-warning mt-4" role="status" data-testid="photo-no-gps">
-				<Icon aria-hidden="true" icon="lucide:circle-alert" width="20" class="shrink-0" />
-				<div>
-					<p class="text-sm">
-						In diesem Foto sind keine GPS-Daten gespeichert. Das ist häufig — viele Kameras und
-						weitergeleitete Bilder enthalten keine Position. Das Foto ist trotzdem wertvoll und
-						bleibt erhalten.
-					</p>
-					<!-- Nur wenn es wirklich passiert ist: `exifDateTimeApplied` kommt aus
-					     DropzoneEnhanced. Ein Gate auf `$form.sightingDate` wäre immer wahr
-					     (Schema-Default `berlinToday()`). -->
-					{#if exifDateTimeApplied}
-						<p class="mt-2 text-sm" data-testid="photo-datetime-applied">
-							Datum und Uhrzeit konnten übernommen werden.
-						</p>
-					{/if}
-					<div class="mt-3 flex flex-wrap gap-2">
-						<button
-							type="button"
-							class="btn btn-outline btn-sm min-h-11"
-							onclick={openMap}
-							data-testid="exit-to-map"
-						>
-							Auf Karte wählen
-						</button>
-						<button
-							type="button"
-							class="btn btn-outline btn-sm min-h-11"
-							onclick={focusDescription}
-							data-testid="exit-to-description"
-						>
-							Seegebiet beschreiben
-						</button>
-					</div>
-				</div>
-			</div>
-		{/if}
-
-		<!-- BEWUSST unter der Dropzone und bewusst als Auslöser statt als Alert:
-		     Die Hero-Karte begann auf einem 812-px-Gerät erst bei 659 px, und
-		     dazwischen standen ~150 px Datenschutz-Prosa. Der Wortlaut ist
-		     unverkürzt eine Ebene tiefer erreichbar (`UploadNotice.svelte`) und
-		     kostet hier nur noch eine Zeile. -->
-		<div class="mt-2">
-			<UploadNotice />
-		</div>
-	</div>
-
-	<!-- Der Standort-Button steht bewusst ÜBER dem Trenner und damit direkt
-	     neben dem Foto-Weg: Er ist für alle, die vor Ort melden, der zweite
-	     schnelle Weg zur Position — vorher stand er unter dem Trenner in einer
-	     Reihe mit der Karte und wirkte wie eine Nebensache.
-
-	     Eigener Button statt des OpenLayers-GPS-Controls: Die Karte startet
-	     zugeklappt, im Startzustand gäbe es sonst gar keinen sichtbaren
-	     GPS-Button. Beschriftung und Fehlerpfad liegen so außerdem in unserer
-	     Hand — beides ist im Karten-Control nicht erreichbar.
+	     Eigener Button statt des OpenLayers-GPS-Controls: Beschriftung und
+	     Fehlerpfad liegen so in unserer Hand — beides ist im Karten-Control nicht
+	     erreichbar. (Der frühere Grund, die zugeklappte Karte hätte im
+	     Startzustand gar keinen sichtbaren GPS-Button, ist mit der dauerhaft
+	     sichtbaren Karte entfallen; der Rest der Begründung trägt weiterhin.)
 
 	     NICHT `btn-primary`: Die einzige Primäraktion des Schritts ist „Weiter"
 	     (Button-Hierarchie, `.claude/rules/design-system.md`). Die Betonung
@@ -325,7 +189,7 @@
 	     `py-4`/`text-base` an dieser einen Aufrufstelle. -->
 	<button
 		type="button"
-		class="btn btn-outline btn-lg mt-4 w-full"
+		class="btn btn-outline btn-lg w-full"
 		onclick={useCurrentPosition}
 		aria-disabled={locating}
 		data-testid="use-current-position"
@@ -355,55 +219,161 @@
 		</div>
 	{/if}
 
-	<div class="divider text-base-content/70 text-support mt-6 mb-3">
-		oder Position auf der Karte setzen
-	</div>
+	<!-- „oder" trennt hier zwei gleichrangige Wege zur Position: den Standort des
+	     Geräts darüber und die Karte darunter. Der Trenner hieß bis zum Umbau
+	     „oder Position auf der Karte setzen" — das war eine Ankündigung dessen,
+	     was hinter der zugeklappten Disclosure lag. Die Karte steht jetzt offen
+	     darunter und kündigt sich selbst an; übrig bleiben muss nur noch das
+	     „oder". -->
+	<div class="divider text-base-content/70 text-support mt-6 mb-3">oder</div>
 
-	<details class="bg-base-100 collapse" bind:open={mapOpen} data-testid="map-disclosure">
-		<!-- `<summary>` ist nativ fokussierbar — kein `tabindex` nötig. -->
-		<summary bind:this={mapSummary} class="collapse-title min-h-11 py-3 text-sm font-medium">
-			Position auf Karte wählen
-		</summary>
-		<div class="collapse-content">
-			<!--
-				Erst mounten, wenn die Disclosure offen ist: Für die Mehrheit, die die
-				Karte nie aufklappt, entsteht so keine OpenLayers-Instanz und es werden
-				keine Kacheln geladen.
+	<!--
+		Karte und Koordinatenfelder stehen dauerhaft offen — auf Wunsch des
+		Museums ist die Karte das Haupt-Bedienelement dieses Schritts und liegt
+		nicht mehr hinter einer Disclosure.
 
-				Nicht der Grund: eine „leer rendernde" Karte. OpenLayers beobachtet das
-				Ziel-Element seit jeher mit einem ResizeObserver
-				(node_modules/ol/Map.js:449 in ol 10.9.0) und ruft `updateSize()` selbst
-				auf, sobald der Container Ausdehnung bekommt — eine im geschlossenen
-				<details> erzeugte Karte würde sich also von allein korrigieren.
-			-->
-			<!-- `collapsibleCoordinates={false}`: Die Koordinaten-Eingabe lag bis
-			     hierher hinter einer zweiten Disclosure („Koordinaten eingeben")
-			     und war damit zwei Klicks tief. Auf Wunsch des Museums steht sie
-			     jetzt offen unter der Karte.
+		Damit entfällt auch der frühere Grund für das Lazy-Mounting: Solange die
+		Karte zugeklappt startete, sparte das `if`-Gate auf `mapOpen` für die
+		Mehrheit die OpenLayers-Instanz und die Kacheln. Jetzt baut jeder Aufruf
+		von Schritt 1 die Karte auf, auch auf Mobilfunk. Das ist die Konsequenz des
+		Wunsches, kein Versehen — falls die Last auffällt, ist der nächste Schritt
+		ein Mount beim ersten Sichtbarwerden (`IntersectionObserver`) und nicht
+		die Rückkehr zur Disclosure.
+	-->
+	<!-- `collapsibleCoordinates={false}`: Die Koordinaten-Eingabe lag bis
+	     zum 2026-07-31 hinter einer zweiten Disclosure („Koordinaten eingeben")
+	     und war damit zwei Klicks tief. Auf Wunsch des Museums steht sie
+	     offen unter der Karte.
 
-			     `enableMapGps={false}` muss dabei ausdrücklich mit: Beides hing
-			     früher an `collapsibleCoordinates`, ein `false` allein brächte
-			     also das Karten-GPS-Control zurück — neben dem Button „Mein
-			     aktueller Standort" oben wären das zwei Bedienelemente für
-			     dieselbe Aktion (design-system.md). -->
-			{#if mapOpen}
-				<LocationInput
-					{latitude}
-					{longitude}
-					collapsibleCoordinates={false}
-					enableMapGps={false}
-					coordinatesHint="Bitte tragen Sie die GPS-Koordinaten ein, wenn diese nicht automatisch über die Karte übernommen werden konnten."
-					onchange={handleLocationChange}
-				/>
-			{/if}
-		</div>
-	</details>
+	     `enableMapGps={false}` muss dabei ausdrücklich mit: Beides hing
+	     früher an `collapsibleCoordinates`, ein `false` allein brächte
+	     also das Karten-GPS-Control zurück — neben dem Button „Mein
+	     aktueller Standort" oben wären das zwei Bedienelemente für
+	     dieselbe Aktion (design-system.md). -->
+	<LocationInput
+		{latitude}
+		{longitude}
+		collapsibleCoordinates={false}
+		enableMapGps={false}
+		coordinatesHint="Bitte tragen Sie die GPS-Koordinaten ein, wenn diese nicht automatisch über die Karte übernommen werden konnten."
+		onchange={handleLocationChange}
+	/>
 
-	<!-- Bewusst AUSSERHALB der Disclosure: Klappt der Nutzer die Karte zu, während
-	     Koordinaten gesetzt sind, muss die Ostsee-Prüfung sichtbar bleiben. -->
 	{#if latitude !== undefined && longitude !== undefined}
 		<VerifyLocation {longitude} {latitude} />
 	{/if}
+
+	<!-- Der Foto-Weg bleibt, aber eingeklappt: Er ist für die Position ein
+	     Sonderfall (nur Bilder mit GPS-EXIF liefern etwas), stand aber als
+	     Hero-Karte über allem anderen.
+
+	     Bewusst KEIN `bind:open` — ein gebundener Zustand schriebe ein von außen
+	     gesetztes `open` sofort zurück, und die Disclosure ließe sich später
+	     nicht mehr aufklappen (dieselbe Begründung wie bei `LocationDescription`,
+	     siehe `focusDescription`). -->
+	<!-- `collapse-arrow`: Ohne den Pfeil ist die zugeklappte Zeile eine graue
+	     Fläche mit Text und sieht nicht nach Bedienelement aus. Die alte
+	     Karten-Disclosure kam ohne aus, weil sie sich bei jeder neu entstandenen
+	     Position selbst öffnete — dieser Aufklapper tut das nicht und muss
+	     deshalb von sich aus als bedienbar erkennbar sein. -->
+	<details class="bg-base-100 collapse-arrow collapse mt-6" data-testid="photo-position-disclosure">
+		<!-- `<summary>` ist nativ fokussierbar — kein `tabindex` nötig. -->
+		<summary class="collapse-title min-h-11 py-3 text-sm font-medium">
+			GPS-Position und Zeit aus einem Bild übernehmen
+		</summary>
+		<div class="collapse-content">
+			<!-- `data-testid="photo-position-card"` bleibt: `form-position-photo.spec.ts`
+			     grenzt darüber den File-Input gegen die Medien-Dropzone aus Schritt 3
+			     ab. Die Hero-Optik (`border-primary bg-primary/5`) ist dagegen weg —
+			     der Foto-Weg ist nicht mehr die Hauptaktion. -->
+			<div class="text-base-content" data-testid="photo-position-card">
+				<p class="text-base-content/70 mb-3 text-sm">
+					Wenn Ihr Foto GPS-Daten enthält, übernehmen wir daraus Position, Datum und Uhrzeit. Das
+					Bild dient hier nur der Positionsbestimmung — weitere Fotos und Videos können Sie in
+					Schritt 3 hochladen.
+				</p>
+
+				{#if gpsPhotoConfig}
+					<!-- `showNoGpsWarning={false}`: Der Fall wird unten ausführlicher erklärt
+					     (Zustand C). Ohne das Abschalten stünden zwei Warn-Alerts mit
+					     derselben Aussage direkt übereinander.
+
+					     `compact` + leerer `additionalText`: Die Beschriftung der Disclosure
+					     und der Satz darüber sagen bereits, worum es geht und dass GPS
+					     ausgelesen wird. Der Dropzone-Titel „Foto hochladen" und der
+					     Default-Zusatz „GPS-Daten werden beim Upload verarbeitet" waren
+					     die dritte und vierte Formulierung derselben Aussage. -->
+					<DropzoneEnhanced
+						{referenceId}
+						maxFiles={1}
+						config={gpsPhotoConfig}
+						enableGPSExtraction={true}
+						showNoGpsWarning={false}
+						showPositionMap={false}
+						onExifDateTimeApplied={(applied) => (exifDateTimeApplied = applied)}
+						actionLabel="Foto auswählen"
+						compact={true}
+						additionalText=""
+					/>
+				{:else}
+					<div class="skeleton h-32 w-full"></div>
+				{/if}
+
+				<!-- Zustand C: Foto ohne EXIF-GPS.
+
+				     Bewusst `'no-gps'` und nicht „kein GPS im Formular": Während der
+				     Auswertung meldet `photoStatus` `'analyzing'` und hier steht nichts.
+				     Sonst würde ein Foto MIT GPS im Moment des Drops für GPS-los erklärt
+				     und die Behauptung Sekundenbruchteile später zurückgenommen — mit
+				     `role="status"` sagt ein Screenreader sie inzwischen an.
+
+				     Die zweite Bedingung (`coordinatesPresent`) steckt in
+				     `shouldWarnAboutMissingGps`: Solange das Panel Koordinaten anzeigt,
+				     darf es ihr Fehlen nicht behaupten. -->
+				{#if shouldWarnAboutMissingGps(status, coordinatesPresent)}
+					<div class="alert alert-warning mt-4" role="status" data-testid="photo-no-gps">
+						<Icon aria-hidden="true" icon="lucide:circle-alert" width="20" class="shrink-0" />
+						<div>
+							<p class="text-sm">
+								In diesem Foto sind keine GPS-Daten gespeichert. Das ist häufig — viele Kameras und
+								weitergeleitete Bilder enthalten keine Position. Das Foto ist trotzdem wertvoll und
+								bleibt erhalten.
+							</p>
+							<!-- Nur wenn es wirklich passiert ist: `exifDateTimeApplied` kommt aus
+							     DropzoneEnhanced. Ein Gate auf `$form.sightingDate` wäre immer wahr
+							     (Schema-Default `berlinToday()`). -->
+							{#if exifDateTimeApplied}
+								<p class="mt-2 text-sm" data-testid="photo-datetime-applied">
+									Datum und Uhrzeit konnten übernommen werden.
+								</p>
+							{/if}
+							<!-- Nur noch ein Ausweg: „Auf Karte wählen" führte in eine Disclosure,
+							     die es nicht mehr gibt — die Karte steht sichtbar darüber, der
+							     Button hätte nichts mehr bewirkt (design-system.md). -->
+							<div class="mt-3">
+								<button
+									type="button"
+									class="btn btn-outline btn-sm min-h-11"
+									onclick={focusDescription}
+									data-testid="exit-to-description"
+								>
+									Seegebiet beschreiben
+								</button>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				<!-- BEWUSST unter der Dropzone und bewusst als Auslöser statt als Alert:
+				     Der Wortlaut ist unverkürzt eine Ebene tiefer erreichbar
+				     (`UploadNotice.svelte`) und kostet hier nur noch eine Zeile —
+				     ausgeschrieben standen an dieser Stelle ~150 px Datenschutz-Prosa. -->
+				<div class="mt-2">
+					<UploadNotice />
+				</div>
+			</div>
+		</div>
+	</details>
 </SectionCard>
 
 <LocationDescription />

--- a/src/lib/report/components/form/position/positionPanelState.test.ts
+++ b/src/lib/report/components/form/position/positionPanelState.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
 	descriptionCollapsed,
 	photoStatus,
-	shouldOpenMapOnCoordinateChange,
 	shouldWarnAboutMissingGps,
 	type PositionCapableFile
 } from './positionPanelState';
@@ -88,19 +87,9 @@ describe('photoStatus — Eingrenzung auf den Positions-Schritt', () => {
 	});
 });
 
-describe('shouldOpenMapOnCoordinateChange', () => {
-	it('öffnet, wenn eine Position neu entsteht', () => {
-		expect(shouldOpenMapOnCoordinateChange(true, false)).toBe(true);
-	});
-
-	it('öffnet nicht erneut, solange die Position bestehen bleibt', () => {
-		expect(shouldOpenMapOnCoordinateChange(true, true)).toBe(false);
-	});
-
-	it('öffnet nicht, wenn die Position entfällt', () => {
-		expect(shouldOpenMapOnCoordinateChange(false, true)).toBe(false);
-	});
-});
+// `shouldOpenMapOnCoordinateChange` ist mit PR 3 entfallen: Die Karte steht
+// dauerhaft offen, es gibt keine Disclosure mehr, die auf der steigenden Flanke
+// aufklappen könnte.
 
 /**
  * Seit dem Zusammenlegen der Ortsbeschreibung (Wunsch des Deutschen

--- a/src/lib/report/components/form/position/positionPanelState.ts
+++ b/src/lib/report/components/form/position/positionPanelState.ts
@@ -75,19 +75,6 @@ export function shouldWarnAboutMissingGps(
 	return status === 'no-gps' && !coordinatesPresent;
 }
 
-/**
- * True auf der steigenden Flanke: genau dann, wenn eine Position NEU entsteht.
- *
- * Nicht `hasCoordinates || wasEverExpanded` — das würde `open` erzwingen und dem
- * Nutzer das Zuklappen der Karte unmöglich machen.
- */
-export function shouldOpenMapOnCoordinateChange(
-	hasCoordinates: boolean,
-	hadCoordinates: boolean
-): boolean {
-	return hasCoordinates && !hadCoordinates;
-}
-
 /** True, wenn der Wert ein nicht-leerer (getrimmter) String ist. */
 function isFilledText(value: unknown): boolean {
 	return typeof value === 'string' && value.trim().length > 0;

--- a/src/lib/report/components/sections/AnimalInfo.svelte
+++ b/src/lib/report/components/sections/AnimalInfo.svelte
@@ -5,27 +5,47 @@
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
 
+	let { adminMode = false }: { adminMode?: boolean } = $props();
+
 	const { form } = getFormContext();
 </script>
 
 <!-- Animal Information Section -->
 <SectionCard title="Tierinformationen" icon="lucide:eye">
+	<!-- Die Totfund-Frage steht ganz oben, weil das Museum sie am Kartenende für
+	     übersehbar hielt. Sie entscheidet außerdem, ob der Detailblock darunter
+	     erscheint — als letztes Feld stand der Auslöser hinter seiner Wirkung.
+
+	     Hervorgehoben wird über Position und Erhebung, NICHT über den
+	     Warn-Tint: Der gehört dem Totfund-Block in DeadAnimal.svelte, der
+	     unmittelbar darunter sitzt. Zwei gleich aussehende Warnflächen
+	     übereinander hätten die untere entwertet — und im Regelfall (lebendes
+	     Tier) sähe jede Meldung nach Warnung aus, obwohl nichts zu warnen ist.
+	     Eine hellere Platte auf der base-200-Karte trägt hier weiter als Farbe.
+
+	     Das Totenkopf-Icon am Schalter kommt aus dem Schema (`meta.icon`), die
+	     Beschriftung aus der Feld-Pipeline — beides gehört nicht hierher. -->
+	<div
+		class="bg-base-100 border-base-300 rounded-lg border p-4"
+		style="box-shadow: var(--shadow-raised)"
+	>
+		<FormField name="isDead" />
+	</div>
+
+	<!-- Dead Animal Additional Fields — unmittelbar unter dem Schalter, nicht
+	     mehr am Kartenende. -->
+	{#if $form.isDead}
+		<DeadAnimal {adminMode} />
+	{/if}
+
 	<!-- Species Selection -->
-	<FormField name="species" />
+	<div class="mt-4">
+		<FormField name="species" />
+	</div>
 
 	<!-- Animal Count -->
 	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-2">
 		<FormField name="totalCount" />
 		<FormField name="juvenileCount" />
 	</div>
-
-	<!-- Dead/Alive Status -->
-	<div class="mt-4">
-		<FormField name="isDead" />
-	</div>
-
-	<!-- Dead Animal Additional Fields -->
-	{#if $form.isDead}
-		<DeadAnimal></DeadAnimal>
-	{/if}
 </SectionCard>

--- a/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
+++ b/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
@@ -1,0 +1,120 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import AnimalInfo from './AnimalInfo.svelte';
+
+/**
+ * PR 2, Teil a (docs/MEERESMUSEUM_FORMULAR_PLAN_2026-08-04.md): „Totfund erstmal
+ * so lassen, aber prominenter platzieren" — `isDead` rückt an die erste Stelle
+ * der Karte „Tierinformationen", der Totfund-Detailblock (`DeadAnimal`) folgt
+ * unmittelbar darauf, statt am Ende der Karte zu stehen (heute: drei Felder von
+ * seinem Auslöser entfernt).
+ *
+ * DOM-Reihenfolge statt Pixel-Position: `FormField` wraps jedes Feld in
+ * `<div data-field={name}>` (siehe FormField.svelte:77) — dieselben Attribute,
+ * die `e2e/form-ux.spec.ts` schon für die Sichtbarkeit abfragt
+ * (`[data-field="deadCondition"]`). `querySelectorAll('[data-field]')` liefert
+ * damit die tatsächliche Render-Reihenfolge ohne Layout-Messung; das ist
+ * robuster als `compareDocumentPosition` an zwei Einzelknoten, weil es die
+ * volle Kette auf einmal prüft und bei einer Regression eine lesbare
+ * Namensliste statt einer Bitmaske liefert.
+ */
+function renderAnimalInfo(overrides: Partial<SightingFormData> = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(AnimalInfo, { context: new Map([[formContextKey, context]]) });
+}
+
+function fieldOrder(): string[] {
+	return Array.from(document.querySelectorAll<HTMLElement>('[data-field]')).map(
+		(el) => el.dataset.field ?? ''
+	);
+}
+
+describe('sections/AnimalInfo — Totfund prominent platziert (PR 2, Teil a)', () => {
+	it('rendert isDead als allererstes Feld der Karte — auch ohne Totfund', () => {
+		renderAnimalInfo({ isDead: false });
+
+		expect(fieldOrder()[0]).toBe('isDead');
+	});
+
+	it('rendert isDead im DOM vor species', () => {
+		renderAnimalInfo({ isDead: false });
+
+		const order = fieldOrder();
+		expect(order.indexOf('isDead')).toBeLessThan(order.indexOf('species'));
+	});
+
+	it('rendert bei isDead=true den Totfund-Detailblock unmittelbar nach dem Schalter', () => {
+		renderAnimalInfo({ isDead: true, deadCondition: 1 });
+
+		const order = fieldOrder();
+		const isDeadIndex = order.indexOf('isDead');
+
+		// "Unmittelbar" heißt: das direkt folgende Feld gehört zu DeadAnimal
+		// (deadCondition ist dort das erste gerenderte Feld) — nicht species
+		// oder totalCount, die heute dazwischenstehen.
+		expect(order[isDeadIndex + 1]).toBe('deadCondition');
+	});
+
+	it('rendert den Totfund-Detailblock NICHT mehr am Ende der Karte', () => {
+		renderAnimalInfo({ isDead: true, deadCondition: 1 });
+
+		const order = fieldOrder();
+		// deadPhoneContact ist das letzte Feld von DeadAnimal. Stünde der Block
+		// weiterhin am Kartenende (heutiger Stand), kämen species/totalCount
+		// VOR ihm. Nach der Umsortierung müssen sie NACH dem Block folgen.
+		const lastDeadAnimalField = order.indexOf('deadPhoneContact');
+		expect(order.indexOf('species')).toBeGreaterThan(lastDeadAnimalField);
+		expect(order.indexOf('totalCount')).toBeGreaterThan(lastDeadAnimalField);
+	});
+
+	it('lässt species und die Zähler-Felder in ihrer bisherigen Reihenfolge', () => {
+		renderAnimalInfo({ isDead: false });
+
+		const order = fieldOrder();
+		expect(order.indexOf('species')).toBeLessThan(order.indexOf('totalCount'));
+		expect(order.indexOf('totalCount')).toBeLessThan(order.indexOf('juvenileCount'));
+	});
+});
+
+/**
+ * `adminMode` wird von `AnimalInfo` nur durchgereicht (PR 2, Teil b) — die
+ * Fach-Entscheidung, ob `deadSex` erscheint, trifft `DeadAnimal` selbst
+ * (siehe DeadAnimal.svelte.test.ts). Hier wird nur die Weitergabe geprüft,
+ * analog zu OptionalSightingDetails.svelte.test.ts / Location.svelte.test.ts.
+ */
+describe('sections/AnimalInfo — adminMode wird an DeadAnimal durchgereicht', () => {
+	function renderWithAdminMode(adminMode: boolean): void {
+		const context = {
+			...createForm<SightingFormData>({
+				initialValues: { ...initialFormState, isDead: true, deadCondition: 1 } as SightingFormData,
+				onSubmit: () => undefined
+			}),
+			mediaStore: { mediaFiles: [] }
+		} as unknown as FormContext;
+
+		render(AnimalInfo, { props: { adminMode }, context: new Map([[formContextKey, context]]) });
+	}
+
+	it('zeigt deadSex NICHT ohne adminMode', () => {
+		renderWithAdminMode(false);
+
+		expect(document.querySelector('[data-testid="field-deadSex"]')).toBeNull();
+	});
+
+	it('zeigt deadSex MIT adminMode={true}', () => {
+		renderWithAdminMode(true);
+
+		expect(document.querySelector('[data-testid="field-deadSex"]')).not.toBeNull();
+	});
+});

--- a/src/lib/report/components/sections/DeadAnimal.svelte
+++ b/src/lib/report/components/sections/DeadAnimal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
+
+	let { adminMode = false }: { adminMode?: boolean } = $props();
 </script>
 
 <div class="bg-warning/10 border-warning/20 mt-6 rounded-lg border p-4">
@@ -29,10 +31,18 @@
 	<div class="space-y-4">
 		<FormField name="deadCondition" />
 
-		<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-			<FormField name="deadSex" />
+		<!-- Das Geschlecht beim Totfund ist seit 2026-08-04 nur noch in der
+		     Admin-Maske sichtbar (C4) — ohne adminMode steht deadSize allein und
+		     zieht auf die volle Breite, statt in der leeren Zweier-Spalte zu
+		     hängen. -->
+		{#if adminMode}
+			<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<FormField name="deadSex" />
+				<FormField name="deadSize" />
+			</div>
+		{:else}
 			<FormField name="deadSize" />
-		</div>
+		{/if}
 
 		<FormField name="deadPhoneContact" />
 	</div>

--- a/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
+++ b/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
@@ -1,0 +1,76 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import DeadAnimal from './DeadAnimal.svelte';
+
+/**
+ * `deadSex` (Geschlecht beim Totfund) verlässt das Meldeformular — das Museum hat
+ * es am 2026-08-04 abbestellt (Analyse-Punkt C4,
+ * docs/MEERESMUSEUM_FORMULAR_PLAN_2026-08-04.md, PR 2 Teil b). Anders als bei
+ * `distribution`/`OptionalSightingDetails.svelte` bleiben die drei übrigen Felder
+ * dieser Section (`deadCondition`, `deadSize`, `deadPhoneContact`) in **beiden**
+ * Modi sichtbar — nur `deadSex` verschwindet ohne `adminMode`.
+ *
+ * `DeadAnimal` bekommt dafür wie `OptionalSightingDetails` eine `adminMode`-Prop
+ * (Default `false`); `AnimalInfo` reicht sie durch, `AdminSightingEditForm.svelte`
+ * setzt `adminMode={true}`.
+ */
+function renderDeadAnimal(props: { adminMode?: boolean } = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, isDead: true } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
+	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
+	render(DeadAnimal, { props, context: new Map([[formContextKey, context]]) });
+}
+
+function field(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-testid="field-${name}"]`);
+}
+
+describe('sections/DeadAnimal — Geschlecht nur im Admin-Modus', () => {
+	it('zeigt das Geschlecht-Feld NICHT im Meldeformular (ohne adminMode)', () => {
+		renderDeadAnimal();
+
+		expect(field('deadSex')).toBeNull();
+	});
+
+	it('zeigt das Geschlecht-Feld in der Admin-Maske (adminMode)', () => {
+		renderDeadAnimal({ adminMode: true });
+
+		expect(field('deadSex')).not.toBeNull();
+	});
+
+	/**
+	 * Abgrenzung zum Präzedenzfall PR #669 (siehe Location.svelte.test.ts,
+	 * OptionalSightingDetails.svelte.test.ts): Dort verschwand ein Feld komplett
+	 * hinter `adminMode`. Hier gilt das NUR für `deadSex` — die übrigen drei
+	 * Felder der Section sind für Melder unverändert Pflicht bzw. sichtbar und
+	 * dürfen durch die Prop nicht mitgenommen werden.
+	 */
+	it.each(['deadCondition', 'deadSize', 'deadPhoneContact'])(
+		'zeigt %s weiterhin OHNE adminMode',
+		(name) => {
+			renderDeadAnimal();
+
+			expect(field(name)).not.toBeNull();
+		}
+	);
+
+	it.each(['deadCondition', 'deadSize', 'deadPhoneContact'])(
+		'zeigt %s auch MIT adminMode',
+		(name) => {
+			renderDeadAnimal({ adminMode: true });
+
+			expect(field(name)).not.toBeNull();
+		}
+	);
+});

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte
@@ -8,8 +8,12 @@
 
 <!-- Sighting Details Section -->
 <SectionCard title="Weitere Sichtungsdetails" icon="lucide:activity">
-	<!-- Distribution -->
-	<FormField name="distribution" />
+	<!-- Das Museum hat „Verteilung der Tiere" am 2026-08-04 aus dem Meldeformular
+	     abbestellt: Sie lässt sich aus der Anzahl der Tiere erschließen. Die
+	     Admin-Maske behält das Feld, weil dort der Bestand korrigiert wird. -->
+	{#if adminMode}
+		<FormField name="distribution" />
+	{/if}
 
 	<!-- `shipCount` steht im Meldeformular jetzt in `BoatInfo.svelte`: Die Anzahl
 	     umliegender Schiffe gehört zu den Boot-/Schiffsangaben, nicht zwischen

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
@@ -1,0 +1,50 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import OptionalSightingDetails from './OptionalSightingDetails.svelte';
+
+/**
+ * `distribution` (Verteilung der Tiere) verlässt den Melde-Schritt `observations`
+ * und bleibt nur in der **Admin-Maske**. Der Test hält denselben Präzedenzfall fest
+ * wie `Location.svelte.test.ts`: In PR #669 hat eine Feld-Entfernung im
+ * Meldeformular der Admin-Maske drei Felder mit weggenommen, weil beide dieselbe
+ * Komponente teilten — hier ist es dieselbe Komponente (`OptionalSightingDetails`),
+ * die per `adminMode`-Flag unterscheidet. Die Admin-Maske braucht das Feld, um den
+ * kompletten Bestand pflegen zu können: `verteilung` (DB-Spalte, `integer` `.default(0)`
+ * `.notNull()`) trägt auf allen 19.887 Zeilen einen Wert; auf 4.758 davon weicht er
+ * vom Default `0` ab (gemessen 2026-08-04, `verteilung != 0`).
+ */
+function renderDetails(props: { adminMode?: boolean } = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
+	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
+	render(OptionalSightingDetails, { props, context: new Map([[formContextKey, context]]) });
+}
+
+function field(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-testid="field-${name}"]`);
+}
+
+describe('sections/OptionalSightingDetails — Verteilung nur im Admin-Modus', () => {
+	it('zeigt das Verteilungsfeld NICHT im Meldeformular (ohne adminMode)', () => {
+		renderDetails();
+
+		expect(field('distribution')).toBeNull();
+	});
+
+	it('zeigt das Verteilungsfeld in der Admin-Maske (adminMode)', () => {
+		renderDetails({ adminMode: true });
+
+		expect(field('distribution')).not.toBeNull();
+	});
+});

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getFormContext } from '$lib/report/formContext';
-	import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
+	import { BoatDriveEnum, PUBLIC_BOAT_DRIVE_OPTIONS } from '$lib/report/formOptions/boatDrive';
 	import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
@@ -11,6 +11,8 @@
 		shouldResetBoatDrive,
 		type TrackedSightingFromValue
 	} from './boatDriveReset';
+
+	const { adminMode = false }: { adminMode?: boolean } = $props();
 
 	const { form, updateField } = getFormContext();
 
@@ -56,11 +58,41 @@
 	</div>
 	{#if showsBoatDrive}
 		<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1" transition:slide>
-			<FormField name="boatDrive" />
-			{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
-				<div transition:slide>
-					<FormField name="boatDriveText" />
-				</div>
+			{#if adminMode}
+				<!-- Admin-Maske: volle Antriebsauswahl aus dem Schema. Die feinere
+				     Bedeutung von "Segel", "Treibend" und "Vor Anker" bleibt hier
+				     erhalten, damit Altbestand unverändert nachbearbeitet werden kann. -->
+				<FormField name="boatDrive" />
+				{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
+					<!-- Freitext nur in der Admin-Maske: `OTHER` ist im Meldeformular
+					     seit PR 4 nicht mehr wählbar, kann aber im Altbestand stehen. -->
+					<div transition:slide>
+						<FormField name="boatDriveText" />
+					</div>
+				{/if}
+			{:else}
+				<!-- Meldeformular: nur noch "Motor lief / Motor lief nicht" (PR 4,
+				     Museum 2026-08-04) — es geht allein um Motorgeräusche. Radio statt
+				     Schalter, weil ein Toggle keinen unbeantworteten Zustand kennt und
+				     `boatDrive` bei Segelschiff/Motorboot Pflichtfeld ist. Label, Stern,
+				     ARIA und `data-testid` kommen weiterhin aus der Feld-Pipeline.
+
+				     `required` als Override, weil die Pflicht im Schema in einem
+				     `when('sightingFrom')` steckt und `describe()` das nicht sieht —
+				     derselbe Fall wie `waterway` in LocationDescription.svelte. Hier
+				     ist es unbedingt `true`: Dieser Zweig rendert ausschließlich bei
+				     Segelschiff oder Motorboot, also genau dann, wenn das Schema den
+				     Wert verlangt. Ohne den Override liefe ein Melder ohne Sternchen
+				     und ohne `aria-required` in „Bitte wählen Sie den Bootsantrieb
+				     aus." — die Admin-Maske hat dasselbe Loch, dort aber mit
+				     vorbefülltem Wert. -->
+				<FormField
+					name="boatDrive"
+					label="Lief während der Sichtung ein Motor?"
+					type="radio"
+					options={PUBLIC_BOAT_DRIVE_OPTIONS}
+					required={true}
+				/>
 			{/if}
 		</div>
 	{/if}

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -115,6 +115,31 @@ describe('formStepsConfig — Geschlecht beim Totfund nur in der Admin-Maske', (
 	});
 });
 
+/**
+ * `boatDriveText` (Beschreibung eines "sonstigen" Antriebs) hängt an
+ * `BoatDriveEnum.OTHER`, das im Meldeformular nach PR 4 (Museum, 2026-08-04)
+ * nicht mehr wählbar ist — dort gibt es nur noch "Motor an" (`MOTOR = 1`) und
+ * "Motor aus" (`MOTOR_OFF = 6`). Schema-Eintrag und DB-Spalte bleiben
+ * unverändert — die Admin-Maske zeigt weiterhin den vollen Bootsantrieb
+ * inklusive `boatDriveText`; hier wird nur geprüft, dass der Melde-Schritt
+ * "sighting-details" das Feld nicht mehr führt.
+ */
+describe('formStepsConfig — boatDriveText nur in der Admin-Maske (PR 4)', () => {
+	const sightingDetailsStep = formStepsConfig.find((step) => step.id === 'sighting-details');
+
+	it('führt boatDriveText nicht mehr im Schritt "sighting-details"', () => {
+		expect(sightingDetailsStep?.fields).not.toContain('boatDriveText');
+	});
+
+	it('behält boatDrive im Schritt "sighting-details" — nur die Textbeschreibung entfällt', () => {
+		expect(sightingDetailsStep?.fields).toContain('boatDrive');
+	});
+
+	it('kennt boatDriveText im Schema weiterhin, damit die Admin-Maske es schreiben kann', () => {
+		expect(sightingSchemaFields.boatDriveText).toBeDefined();
+	});
+});
+
 describe('waterway — Beschriftung deckt beide bisherigen Felder ab', () => {
 	const waterwayMeta = meta('waterway');
 	const copy = [describeField('waterway').label, waterwayMeta.helpText, waterwayMeta.placeholder]

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -86,6 +86,35 @@ describe('formStepsConfig — Verteilung nur in der Admin-Maske', () => {
 	});
 });
 
+/**
+ * `deadSex` (Geschlecht beim Totfund) bleibt nur in der Admin-Maske —
+ * `sections/DeadAnimal.svelte` zeigt das Feld dort ausschließlich hinter
+ * `adminMode` (PR 2, Teil b — Analyse-Punkt C4, Museum am 2026-08-04
+ * abbestellt). Schema-Eintrag, DB-Spalte (`totfund_geschlecht`) und
+ * `formOptions/sex.ts` bleiben unverändert; hier wird nur geprüft, dass der
+ * Melde-Schritt "sighting-details" das Feld nicht mehr führt.
+ */
+describe('formStepsConfig — Geschlecht beim Totfund nur in der Admin-Maske', () => {
+	const sightingDetailsStep = formStepsConfig.find((step) => step.id === 'sighting-details');
+
+	it('führt deadSex nicht mehr im Schritt "sighting-details"', () => {
+		expect(sightingDetailsStep?.fields).not.toContain('deadSex');
+	});
+
+	// Gegenprobe: Nur `deadSex` verschwindet, die übrigen Totfund-Felder
+	// bleiben Teil des Melde-Schritts.
+	it.each(['isDead', 'deadCondition', 'deadSize', 'deadPhoneContact'])(
+		'behält %s im Schritt "sighting-details"',
+		(name) => {
+			expect(sightingDetailsStep?.fields).toContain(name);
+		}
+	);
+
+	it('kennt deadSex im Schema weiterhin, damit die Admin-Maske es schreiben kann', () => {
+		expect(sightingSchemaFields.deadSex).toBeDefined();
+	});
+});
+
 describe('waterway — Beschriftung deckt beide bisherigen Felder ab', () => {
 	const waterwayMeta = meta('waterway');
 	const copy = [describeField('waterway').label, waterwayMeta.helpText, waterwayMeta.placeholder]

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -67,6 +67,25 @@ describe('sightingSchema — seaMark bleibt erhalten', () => {
  * Fahrwasser-Beschriftung zurück, verlöre das zusammengelegte Feld genau den
  * Aspekt, für den `seaMark` da war — die Orientierungspunkte.
  */
+/**
+ * `distribution` (Verteilung der Tiere) bleibt nur in der Admin-Maske —
+ * `sections/OptionalSightingDetails.svelte` zeigt das Feld dort ausschließlich
+ * hinter `adminMode` (wie schon `shipCount`). Schema-Eintrag, DB-Spalte
+ * (`verteilung`) und `formOptions/distribution.ts` bleiben unverändert; hier
+ * wird nur geprüft, dass der Melde-Schritt das Feld nicht mehr führt.
+ */
+describe('formStepsConfig — Verteilung nur in der Admin-Maske', () => {
+	const observationsStep = formStepsConfig.find((step) => step.id === 'observations');
+
+	it('führt distribution nicht mehr im Schritt "observations"', () => {
+		expect(observationsStep?.fields).not.toContain('distribution');
+	});
+
+	it('führt distributionText nicht mehr im Schritt "observations"', () => {
+		expect(observationsStep?.fields).not.toContain('distributionText');
+	});
+});
+
 describe('waterway — Beschriftung deckt beide bisherigen Felder ab', () => {
 	const waterwayMeta = meta('waterway');
 	const copy = [describeField('waterway').label, waterwayMeta.helpText, waterwayMeta.placeholder]

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -79,7 +79,10 @@ export const formStepsConfig: FormStep[] = [
 			'boatDriveText',
 			'isDead',
 			'deadCondition',
-			'deadSex',
+			// `deadSex` steht hier bewusst NICHT mehr: Das Museum hat das Geschlecht
+			// beim Totfund am 2026-08-04 aus dem Meldeformular abbestellt (C4) —
+			// Laien können es am Strand kaum bestimmen. Schema-Eintrag und DB-Spalte
+			// `totfund_geschlecht` bleiben — die Admin-Maske schreibt es weiter.
 			'deadSize',
 			'deadPhoneContact'
 		]

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -76,7 +76,10 @@ export const formStepsConfig: FormStep[] = [
 			'sightingFrom',
 			'sightingFromText',
 			'boatDrive',
-			'boatDriveText',
+			// `boatDriveText` steht hier bewusst NICHT mehr: Es hängt an
+			// `BoatDriveEnum.OTHER`, und das Meldeformular bietet seit dem 2026-08-04
+			// nur noch "Motor lief"/"Motor lief nicht" an (PR 4). Schema-Eintrag und
+			// DB-Spalte `bootsantrieb_text` bleiben — die Admin-Maske schreibt es weiter.
 			'isDead',
 			'deadCondition',
 			// `deadSex` steht hier bewusst NICHT mehr: Das Museum hat das Geschlecht

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -89,8 +89,10 @@ export const formStepsConfig: FormStep[] = [
 		title: 'Weitere Informationen',
 		description: 'Details zu Verhalten und Umweltbedingungen',
 		fields: [
-			'distribution',
-			'distributionText',
+			// `distribution`/`distributionText` stehen hier bewusst NICHT mehr: Das
+			// Museum hat das Feld am 2026-08-04 aus dem Meldeformular abbestellt —
+			// es lässt sich aus der Anzahl der Tiere erschließen. Schema-Eintrag und
+			// DB-Spalte `verteilung` bleiben — die Admin-Maske schreibt es weiter.
 			'behavior',
 			'behaviorText',
 			'reaction',

--- a/src/lib/report/formOptions/boatDrive.test.ts
+++ b/src/lib/report/formOptions/boatDrive.test.ts
@@ -4,7 +4,8 @@ import {
 	boatDriveLabels,
 	getBoatDriveLabel,
 	getBoatDriveOptions,
-	isValidBoatDrive
+	isValidBoatDrive,
+	PUBLIC_BOAT_DRIVE_OPTIONS
 } from './boatDrive';
 
 /**
@@ -49,8 +50,66 @@ describe('BoatDriveEnum.NONE', () => {
 			BoatDriveEnum.MOTOR,
 			BoatDriveEnum.SAIL,
 			BoatDriveEnum.DRIFTING,
-			BoatDriveEnum.ANCHORED
+			BoatDriveEnum.ANCHORED,
+			BoatDriveEnum.MOTOR_OFF
 		]);
+	});
+});
+
+/**
+ * Hintergrund (PR 4, Museum am 2026-08-04): Bei Motorboot/Segelschiff wird die
+ * Folgefrage zum Antrieb auf "Motor an / Motor aus" verengt. "Motor an" bleibt
+ * `MOTOR = 1`; "Motor aus" bekommt einen eigenen Wert `MOTOR_OFF = 6`, weil
+ * DRIFTING/ANCHORED etwas fachlich anderes behaupten (treibend/vor Anker), was
+ * ein Melder mit "Motor aus" nie gesagt hat.
+ */
+describe('BoatDriveEnum.MOTOR_OFF (PR 4 — Motor an/aus)', () => {
+	it('existiert als eigener Wert 6', () => {
+		expect(BoatDriveEnum.MOTOR_OFF).toBe(6);
+	});
+
+	it('gilt als gültiger Wert (Yup-Validierung, Legacy-Antworten-Tabelle)', () => {
+		expect(isValidBoatDrive(BoatDriveEnum.MOTOR_OFF)).toBe(true);
+		expect(isValidBoatDrive(String(BoatDriveEnum.MOTOR_OFF))).toBe(true);
+	});
+
+	it('wird von getBoatDriveLabel als "Motor aus" aufgelöst statt als "Unbekannt" zu enden', () => {
+		expect(getBoatDriveLabel(BoatDriveEnum.MOTOR_OFF)).toBe('Motor aus');
+	});
+
+	it('erscheint in den auswählbaren Optionen (Admin-Auswahl leitet sich aus Object.values ab)', () => {
+		const values = getBoatDriveOptions().map((option) => option.value);
+		expect(values).toContain(BoatDriveEnum.MOTOR_OFF);
+
+		const entry = getBoatDriveOptions().find((option) => option.value === BoatDriveEnum.MOTOR_OFF);
+		expect(entry?.label).toBe('Motor aus');
+	});
+
+	it('lässt NONE (5) weiterhin außerhalb der auswählbaren Optionen — kein neuer dritter Zustand', () => {
+		const values = getBoatDriveOptions().map((option) => option.value);
+		expect(values).not.toContain(BoatDriveEnum.NONE);
+	});
+});
+
+/**
+ * Die öffentliche Zweier-Auswahl im Meldeformular. Sie ist bewusst eine eigene
+ * Konstante und keine gefilterte Sicht auf `getBoatDriveOptions()`: die Labels
+ * ("Motor lief" statt "Motor") sind auf die Frage zugeschnitten.
+ */
+describe('PUBLIC_BOAT_DRIVE_OPTIONS (Meldeformular)', () => {
+	it('bietet genau zwei Antworten an — Motor an und Motor aus', () => {
+		expect(PUBLIC_BOAT_DRIVE_OPTIONS).toEqual([
+			{ value: BoatDriveEnum.MOTOR, label: 'Motor lief' },
+			{ value: BoatDriveEnum.MOTOR_OFF, label: 'Motor lief nicht' }
+		]);
+	});
+
+	it('enthält keinen der feineren Alt-Werte, die nur die Admin-Maske führt', () => {
+		const values = PUBLIC_BOAT_DRIVE_OPTIONS.map((option) => option.value);
+		expect(values).not.toContain(BoatDriveEnum.OTHER);
+		expect(values).not.toContain(BoatDriveEnum.SAIL);
+		expect(values).not.toContain(BoatDriveEnum.DRIFTING);
+		expect(values).not.toContain(BoatDriveEnum.ANCHORED);
 	});
 });
 

--- a/src/lib/report/formOptions/boatDrive.ts
+++ b/src/lib/report/formOptions/boatDrive.ts
@@ -20,7 +20,19 @@ export enum BoatDriveEnum {
 	 * (`mapFormToSighting`) und ist bewusst **nicht** auswählbar — im Formular
 	 * erscheint das Antriebsfeld nur bei Segelschiff/Motorboot.
 	 */
-	NONE = 5
+	NONE = 5,
+	/**
+	 * Motor war während der Sichtung abgeschaltet.
+	 *
+	 * **Warum ein neuer Wert und nicht `DRIFTING`/`ANCHORED`:** Ein Motorboot mit
+	 * abgeschaltetem Motor als "treibend" zu speichern wäre eine Aussage, die der
+	 * Melder nie gemacht hat — für die Einordnung von Unterwasserlärm ist
+	 * "treibend" etwas anderes als "vor Anker". Die Alt-Werte 0–4 behalten
+	 * deshalb ihre feinere Bedeutung und bleiben in der Admin-Maske wählbar; im
+	 * Meldeformular gibt es seit PR 4 (Museum, 2026-08-04) nur noch
+	 * `MOTOR`/`MOTOR_OFF` (siehe `PUBLIC_BOAT_DRIVE_OPTIONS`).
+	 */
+	MOTOR_OFF = 6
 }
 
 /**
@@ -32,7 +44,8 @@ export const boatDriveLabels: Record<BoatDriveEnum, string> = {
 	[BoatDriveEnum.SAIL]: 'Segel',
 	[BoatDriveEnum.DRIFTING]: 'Treibend',
 	[BoatDriveEnum.ANCHORED]: 'Vor Anker',
-	[BoatDriveEnum.NONE]: 'Kein Boot'
+	[BoatDriveEnum.NONE]: 'Kein Boot',
+	[BoatDriveEnum.MOTOR_OFF]: 'Motor aus'
 };
 
 export type BoatDrive = BoatDriveEnum;
@@ -56,6 +69,18 @@ const boatDriveOptions: Array<{ value: number; label: string }> = SELECTABLE_BOA
 	(value) => ({ value, label: boatDriveLabels[value] })
 );
 export const getBoatDriveOptions = (): Array<{ value: number; label: string }> => boatDriveOptions;
+
+/**
+ * Die im **Meldeformular** angebotene Zweier-Auswahl (PR 4, Museum 2026-08-04).
+ *
+ * Es geht dort allein um Motorgeräusche; die feinere Unterscheidung der
+ * Alt-Werte bleibt der Admin-Maske vorbehalten, die weiterhin
+ * `getBoatDriveOptions()` verwendet.
+ */
+export const PUBLIC_BOAT_DRIVE_OPTIONS = [
+	{ value: BoatDriveEnum.MOTOR, label: 'Motor lief' },
+	{ value: BoatDriveEnum.MOTOR_OFF, label: 'Motor lief nicht' }
+];
 
 /**
  * Hilfsfunktion zum Abrufen des Labels für einen bestimmten Enum-Wert

--- a/src/routes/rest_sichtungen/antworten.json/frozen.test.ts
+++ b/src/routes/rest_sichtungen/antworten.json/frozen.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+import { BoatDriveEnum } from '$lib/report/formOptions/boatDrive';
 import { GET } from './+server';
 
 /**
@@ -33,5 +34,24 @@ describe('Frozen antworten.json', () => {
 		expect(await frozenFile('antworten.en.json')).toEqual(
 			await routeResponse('/en/rest_sichtungen/antworten.json')
 		);
+	});
+});
+
+/**
+ * PR 4 (Museum, 2026-08-04): `BoatDriveEnum` bekommt einen sechsten Wert
+ * `MOTOR_OFF = 6` ("Motor aus"). Dieser Endpunkt baut `bootsantrieb` direkt aus
+ * `BoatDriveEnum` (`+server.ts:152`) — ein neuer Enum-Wert erscheint dort also
+ * automatisch als zusätzlicher Eintrag "6".
+ *
+ * Merke für künftige Enum-Erweiterungen: Ein neuer Wert macht auch die beiden
+ * `toEqual`-Verträge oben ("Frozen antworten.json") rot, bis
+ * `npm run generate:antworten` gelaufen ist und die Fixtures
+ * (`legacy-inbox/data/antworten.de.json` / `.en.json`) mit committet wurden.
+ * Die Fixtures werden nie von Hand editiert.
+ */
+describe('antworten.json — bootsantrieb "Motor aus" (PR 4)', () => {
+	it('führt einen Eintrag "6" mit dem Label "Motor aus"', async () => {
+		const response = await routeResponse('/rest_sichtungen/antworten.json');
+		expect(response.bootsantrieb[String(BoatDriveEnum.MOTOR_OFF)]).toBe('Motor aus');
 	});
 });


### PR DESCRIPTION
## Problem

Das Deutsche Meeresmuseum hat am 2026-08-04 auf die Änderungswunsch-Analyse geantwortet. Vier Punkte betrafen das Meldeformular direkt:

- **Verteilung der Tiere** ist entbehrlich — sie lässt sich aus der Anzahl erschließen.
- **Der Totfund-Schalter wird übersehen.** Er stand als letztes Feld der Tierinformationen, also hinter dem Block, den er aufklappt.
- **Das Geschlecht beim Totfund** liefert von Laien am Strand fast nur „Unbekannt".
- **Der Bootsantrieb fragt zu viel.** Fachlich zählt allein, ob es Motorgeräusche gab.
- **Der Foto-GPS-Weg ist zu prominent.** Er stand als Hero-Karte über allem, während die Karte selbst hinter einer zugeklappten Disclosure lag.

Der vollständige Plan mit Begründungen, Legacy-Folgen und dem Stand aller übrigen Analyse-Punkte liegt in `docs/MEERESMUSEUM_FORMULAR_PLAN_2026-08-04.md`.

## Änderung

Vier Commits, einzeln abnehmbar:

**`feat(report): drop the animal distribution field`** — `distribution` wandert hinter `adminMode`. Die Admin-Maske behält es; 4.758 von 19.887 Zeilen tragen einen Wert abseits des Spalten-Defaults. Ohne Formularwert schreibt `mapFormToSighting` `DistributionEnum.UNKNOWN` statt der alten stillen `0`.

**`feat(report): lead with the dead-find question and drop its sex field`** — Der Schalter steht jetzt zuoberst, der Detailblock unmittelbar darunter. Hervorgehoben über Position und Erhebung, **nicht** über den Warn-Tint: Der gehört dem Totfund-Block darunter, und im Regelfall — lebendes Tier — sähe sonst jede Meldung nach Warnung aus. Das Geschlecht verschwindet aus dem Meldeformular und bleibt im Admin. Seine konditionale Pflicht musste zwingend mit weg, sonst wäre keine Totfund-Meldung mehr absendbar gewesen. Keine Migration: `totfund_geschlecht` ist `smallint default(0) notNull` und `SexEnum.UNKNOWN` ist 0.

**`feat(report): ask whether the motor ran instead of which drive was used`** — Öffentlich zwei Radios, im Admin die volle Auswahl. „Motor lief" bleibt `MOTOR = 1`, „Motor lief nicht" bekommt `MOTOR_OFF = 6` statt `DRIFTING` oder `ANCHORED` recycelt zu bekommen — ein Motorboot mit abgeschaltetem Motor als „treibend" zu speichern wäre eine Aussage, die der Melder nie gemacht hat. `FormField`/`FieldRenderer` bekommen dafür `type`/`options`/`label`-Overrides nach dem Muster des vorhandenen `required`-Overrides. Legacy: `antworten.json` bekommt einen Eintrag, die eingefrorenen Fixtures sind neu erzeugt, die Spezifikation dokumentiert die Abweichung wie schon bei `bootsantrieb = 5`. `showreports.json` liefert das Feld nicht aus — die `6` erreicht den iOS-Client nie.

**`feat(report): put the map first and fold the GPS photo away`** — Standort-Button → Karte mit offenen Koordinatenfeldern → Ostsee-Prüfung → eingeklappt „GPS-Position und Zeit aus einem Bild übernehmen". Die Karte wird dadurch nicht mehr lazy gemountet; das ist die bewusste Folge daraus, sie zum Haupt-Bedienelement zu machen.

## Zwei Fehler, die dabei aufgefallen sind — beide älter als diese Änderung

**Der Radio-Renderer konnte keinen Wert halten.** `BaseRadio` bindet per `bind:group`, das strikt gegen die numerischen Optionswerte vergleicht; `createForm.handleChange` legt aber den String aus dem DOM-Event ab. Die Gruppe fand ihren eigenen gerade gesetzten Wert nicht wieder und sprang zurück auf „nichts gewählt" — die Motorfrage wäre unbeantwortbar gewesen. Bis hierher nutzte **kein einziges** Schema-Feld `type: 'radio'`, der Pfad war also nie ausgeführt worden. Beim `<select>` fällt dieselbe Verkettung nicht auf, weil dessen DOM-Wert ohnehin ein String ist.

**Horizontaler Überlauf auf schmalen Geräten.** Die Zeile „GPS-Eingabeformat" in `LocationInput.svelte` war eine einzeilige Flex-Zeile; ein `<select>` ist so breit wie seine längste Option und schrumpft als Flex-Item nicht darunter. Rund 420 px harte Mindestbreite, durchgedrückt bis zum Seiten-Wrapper — auf 360 px ließ sich die **ganze Seite** um 109 px seitlich schieben. Der Fehler lag die ganze Zeit da, unsichtbar, solange die Koordinateneingabe in einem zugeklappten `<details>` ohne Layout-Box saß: `e2e/footer-layout.spec.ts` war aus dem falschen Grund grün. Per `git stash` gegengeprüft. Behoben durch Stapeln unterhalb `md` plus `min-w-0`; gemessen bei 320/360/390/768 px.

## Prüfung

- `npm run test:quick` — 3.472 Tests grün, `svelte-check` 0 Fehler
- `CI=1 npx playwright test --project=chromium` — 321 Tests grün, nach dem Rebase auf `main` (`59173112`) wiederholt
- Im Browser über alle betroffenen Zustände durchgeklickt: Totfund an/aus, Motorfrage bei Motorboot, Foto-Aufklapper zu und offen, Positions-Schritt bei 360 px und 1280 px

## Anschlussarbeiten

Sechs Befunde sind als eigene Aufgaben ausgelagert, darunter ein Audit aller konditionalen Pflichtfelder ohne Sternchen (dieselbe Fehlerklasse wie bei `boatDrive`) und die Erweiterung des Überlauf-Guards auf aufgeklappte Bereiche und alle vier Schritte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)