### PR TITLE
fix(report): drop the stale help text and the doubled icon on the motor question

### DIFF
--- a/src/lib/report/components/form/fields/BaseRadio.svelte
+++ b/src/lib/report/components/form/fields/BaseRadio.svelte
@@ -1,16 +1,19 @@
 <!--
   Base radio button group component
   Independent of form context, accepts all props directly
+
+  Kein `icon`-Prop: Das Feld-Icon gehört einmal an die Gruppe und wird von
+  `FieldRenderer` in die Legende gesetzt. Hier stand es innerhalb der
+  Options-Schleife — bei der Motorfrage mit ihren zwei Optionen also zweimal
+  derselbe Blitz untereinander.
 -->
 <script lang="ts">
 	import type { FieldOption, FieldSize } from '$lib/types';
-	import Icon from '$lib/components/Icon.svelte';
 
 	interface Props {
 		value?: string | number;
 		options?: FieldOption[];
 		size?: FieldSize;
-		icon?: string;
 		onchange?: (event: Event) => void;
 		// Common input attributes
 		id?: string;
@@ -25,7 +28,6 @@
 		value = $bindable(),
 		options = [],
 		size = 'md',
-		icon = undefined,
 		onchange = undefined,
 		id,
 		name,
@@ -51,9 +53,6 @@
 			<label
 				class="hover:bg-base-200/50 flex cursor-pointer justify-start gap-3 rounded-lg py-2 transition-colors"
 			>
-				{#if icon !== undefined}
-					<Icon aria-hidden="true" {icon} width="16" class="text-base-content/60 flex-shrink-0" />
-				{/if}
 				<input
 					type="radio"
 					name={name || id || `radio-group-${index}`}

--- a/src/lib/report/components/form/fields/BaseRadio.svelte.test.ts
+++ b/src/lib/report/components/form/fields/BaseRadio.svelte.test.ts
@@ -1,0 +1,83 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, it, expect } from 'vitest';
+import { page } from 'vitest/browser';
+import BaseRadio from './BaseRadio.svelte';
+import { PUBLIC_BOAT_DRIVE_OPTIONS } from '$lib/report/formOptions/boatDrive';
+
+/**
+ * `BaseRadio` war bis zur Motorfrage (PR 4, 2026-08-04) ein nie ausgeführter
+ * Codepfad — kein einziges Feld des Sichtungsformulars nutzte `type: 'radio'`.
+ * Diese Datei sichert das Verhalten ab, auf das sich `FieldRenderer` verlässt.
+ */
+describe('BaseRadio', () => {
+	const options = PUBLIC_BOAT_DRIVE_OPTIONS;
+
+	describe('Optionsliste', () => {
+		it('rendert einen Radio-Input pro Option', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive' });
+
+			expect(screen.container.querySelectorAll('input[type="radio"]')).toHaveLength(options.length);
+			await expect.element(page.getByText('Motor lief', { exact: true })).toBeVisible();
+			await expect.element(page.getByText('Motor lief nicht')).toBeVisible();
+		});
+
+		it('rendert gar nichts ohne Optionen', async () => {
+			const screen = render(BaseRadio, { options: [], name: 'boatDrive' });
+
+			expect(screen.container.querySelector('input[type="radio"]')).toBeNull();
+		});
+
+		it('bindet alle Optionen unter denselben name — sonst wäre es keine Gruppe', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive' });
+
+			const namen = [...screen.container.querySelectorAll('input[type="radio"]')].map((radio) =>
+				radio.getAttribute('name')
+			);
+			expect(new Set(namen)).toEqual(new Set(['boatDrive']));
+		});
+
+		it('hängt den Optionswert an die data-testid, damit E2E die Optionen unterscheiden kann', async () => {
+			render(BaseRadio, { options, name: 'boatDrive', 'data-testid': 'field-boatDrive' });
+
+			await expect.element(page.getByTestId('field-boatDrive-1')).toBeInTheDocument();
+			await expect.element(page.getByTestId('field-boatDrive-6')).toBeInTheDocument();
+		});
+	});
+
+	describe('Auswahl', () => {
+		it('markiert die Option, die dem übergebenen Wert entspricht', async () => {
+			render(BaseRadio, { options, name: 'boatDrive', value: 6 });
+
+			await expect.element(page.getByRole('radio', { name: 'Motor lief nicht' })).toBeChecked();
+			await expect
+				.element(page.getByRole('radio', { name: 'Motor lief', exact: true }))
+				.not.toBeChecked();
+		});
+
+		it('markiert nichts, solange kein Wert gesetzt ist', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive' });
+
+			expect(screen.container.querySelector('input[type="radio"]:checked')).toBeNull();
+		});
+	});
+
+	describe('Feld-Icon', () => {
+		it('zeichnet kein Icon — das gehört einmal an die Legende, nicht in jede Optionszeile', async () => {
+			// `icon` ist bewusst KEIN Prop von BaseRadio (mehr): Die Komponente gab
+			// es innerhalb der `{#each options}`-Schleife aus, bei zwei Optionen
+			// stand derselbe Blitz also zweimal untereinander. `FieldRenderer`
+			// rendert es jetzt einmal in der Legende der Radiogruppe — so wie
+			// BaseInput/BaseSelect es einmal am Feld zeigen.
+			//
+			// Der Cast hält genau den Rückfall fest: Wer den Prop wieder ergänzt
+			// und pro Option ausgibt, lässt diesen Test scheitern.
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				icon: 'lucide:zap'
+			} as never);
+
+			expect(screen.container.querySelectorAll('svg')).toHaveLength(0);
+		});
+	});
+});

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -27,7 +27,8 @@
 		required: requiredOverride = undefined,
 		label: labelOverride = undefined,
 		type: typeOverride = undefined,
-		options: optionsOverride = undefined
+		options: optionsOverride = undefined,
+		helpText: helpTextOverride = undefined
 	}: {
 		fieldConfig: yup.SchemaDescription;
 		name?: string;
@@ -65,6 +66,16 @@
 		 * `undefined` = Ableitung aus dem Schema (Default).
 		 */
 		options?: FieldOption[] | undefined;
+		/**
+		 * Überschreibt den aus `meta.helpText` abgeleiteten Hilfetext. Nötig,
+		 * wenn ein `label`/`type`-Override die Frage so verändert, dass der
+		 * Schema-Hilfetext sie nicht mehr beantwortet — z.B. `boatDrive`:
+		 * „Welcher Antrieb wurde verwendet?" passt zur Admin-Auswahl, nicht zur
+		 * Ja/Nein-Motorfrage im Meldeformular.
+		 * `null` = bewusst kein Hilfetext (dann auch nicht in
+		 * `aria-describedby`), `undefined` = Ableitung aus dem Schema (Default).
+		 */
+		helpText?: string | null | undefined;
 	} = $props();
 
 	// Bindable values for different component types
@@ -156,7 +167,9 @@
 		const meta = fieldConfig.meta || {};
 		return {
 			options: optionsOverride ?? meta.options,
-			helpText: meta.helpText,
+			// Kein `??`: `null` ist hier die ausdrückliche Ansage „kein Hilfetext"
+			// und darf nicht auf den Schema-Text zurückfallen.
+			helpText: helpTextOverride === undefined ? meta.helpText : helpTextOverride,
 			valueText: meta.valueText,
 			type: typeOverride ?? meta.type ?? fieldConfig.type,
 			icon: meta.icon,
@@ -261,8 +274,12 @@
 	});
 
 	let radioProps = $derived.by(() => {
+		// Ohne `icon`: Eine Radiogruppe hat kein einzelnes Control, an dem das
+		// Feld-Icon sitzen könnte — es steht deshalb an der Legende (siehe
+		// caption-Snippet). `BaseRadio` würde es sonst pro Option ausgeben.
+		const { icon: _icon, ...withoutIcon } = commonFieldProps;
 		const props = {
-			...commonFieldProps,
+			...withoutIcon,
 			options: metaValues.options ?? []
 		};
 		return props;
@@ -293,6 +310,14 @@
 		class="text-base-content block font-medium"
 		style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
 	>
+		<!-- Feld-Icon der Radiogruppe. BaseInput und BaseSelect setzen es links
+		     ins Control; eine Radiogruppe hat kein solches Control, also steht es
+		     hier an der Legende — einmal pro Feld, nicht einmal pro Option. -->
+		{#if isRadioGroup && metaValues.icon}
+			<span class="mr-1.5 inline-flex align-middle" aria-hidden="true">
+				<Icon icon={metaValues.icon} width="16" class="text-base-content/60" />
+			</span>
+		{/if}
 		{label}
 		{#if required}
 			<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -313,6 +313,136 @@ describe('FieldRenderer', () => {
 			await expect.element(page.getByRole('combobox')).toBeVisible();
 			await expect.element(page.getByText('Motor lief nicht')).not.toBeInTheDocument();
 		});
+
+		/**
+		 * Nacharbeit zu PR 4: Der Schema-Hilfetext ("Welcher Antrieb wurde
+		 * während der Sichtung verwendet?") gehört zur Admin-Maske mit ihrer
+		 * vollen Antriebsauswahl. Im Meldeformular steht darüber eine
+		 * Ja/Nein-Frage — der Text beantwortet dort etwas, das gar nicht gefragt
+		 * wird. `undefined` erbt weiterhin aus dem Schema, ein String ersetzt,
+		 * `null` unterdrückt.
+		 */
+		describe('helpText-Override', () => {
+			it('unterdrückt den Schema-Hilfetext bei helpText={null}', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveSelectFieldConfig,
+					name: 'boatDrive',
+					value: null,
+					type: 'radio',
+					options: publicBoatDriveOptions,
+					helpText: null
+				});
+
+				expect(screen.container.querySelector('#field-boatDrive-help')).toBeNull();
+				await expect
+					.element(page.getByText('Welcher Antrieb wurde während der Sichtung verwendet?'))
+					.not.toBeInTheDocument();
+			});
+
+			it('nimmt den unterdrückten Hilfetext auch aus aria-describedby heraus', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveSelectFieldConfig,
+					name: 'boatDrive',
+					value: null,
+					type: 'radio',
+					options: publicBoatDriveOptions,
+					helpText: null
+				});
+
+				const radios = screen.container.querySelectorAll('input[type="radio"]');
+				expect(radios.length).toBeGreaterThan(0);
+				radios.forEach((radio) => {
+					expect(radio.getAttribute('aria-describedby') ?? '').not.toContain(
+						'field-boatDrive-help'
+					);
+				});
+			});
+
+			it('ersetzt den Schema-Hilfetext durch einen übergebenen String', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveSelectFieldConfig,
+					name: 'boatDrive',
+					value: null,
+					type: 'radio',
+					options: publicBoatDriveOptions,
+					helpText: 'Nur Motorgeräusche zählen.'
+				});
+
+				const helpElement = screen.container.querySelector('#field-boatDrive-help');
+				expect(helpElement?.textContent).toContain('Nur Motorgeräusche zählen.');
+				expect(helpElement?.textContent).not.toContain('Welcher Antrieb');
+			});
+
+			it('nutzt ohne Override weiterhin den Schema-Hilfetext', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveSelectFieldConfig,
+					name: 'boatDrive',
+					value: null,
+					type: 'radio',
+					options: publicBoatDriveOptions
+				});
+
+				const helpElement = screen.container.querySelector('#field-boatDrive-help');
+				expect(helpElement?.textContent).toContain(
+					'Welcher Antrieb wurde während der Sichtung verwendet?'
+				);
+			});
+		});
+
+		/**
+		 * Nacharbeit zu PR 4: `BaseRadio` gab das Feld-Icon innerhalb der
+		 * Options-Schleife aus — bei zwei Optionen stand derselbe Blitz zweimal
+		 * untereinander. Das Icon gehört einmal an die Gruppe, so wie es bei
+		 * Select und Text einmal am Feld steht.
+		 */
+		describe('Feld-Icon bei Radiogruppen', () => {
+			const boatDriveRadioFieldConfig = makeFieldConfig({
+				label: 'Bootsantrieb',
+				optional: false,
+				type: 'number',
+				meta: {
+					type: 'radio',
+					icon: 'lucide:zap',
+					options: PUBLIC_BOAT_DRIVE_OPTIONS
+				}
+			});
+
+			it('rendert das Feld-Icon genau einmal, nicht pro Option', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveRadioFieldConfig,
+					name: 'boatDrive',
+					value: null
+				});
+
+				// Zwei Optionen, aber nur ein Icon im gesamten Feld.
+				expect(screen.container.querySelectorAll('input[type="radio"]')).toHaveLength(2);
+				expect(screen.container.querySelectorAll('svg')).toHaveLength(1);
+			});
+
+			it('setzt das Icon in die Legende der Gruppe', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveRadioFieldConfig,
+					name: 'boatDrive',
+					value: null
+				});
+
+				expect(screen.container.querySelector('legend svg')).not.toBeNull();
+			});
+
+			it('rendert kein Icon in den Optionszeilen', async () => {
+				const screen = render(FieldRenderer, {
+					fieldConfig: boatDriveRadioFieldConfig,
+					name: 'boatDrive',
+					value: null
+				});
+
+				const optionRows = screen.container.querySelectorAll('label:has(input[type="radio"])');
+				expect(optionRows.length).toBe(2);
+				optionRows.forEach((row) => {
+					expect(row.querySelector('svg')).toBeNull();
+				});
+			});
+		});
 	});
 
 	describe('Häkchen nur bei berührten Feldern', () => {
@@ -469,7 +599,8 @@ describe('FieldRenderer', () => {
 		it.each([
 			['text', 'text'],
 			['select', 'select'],
-			['textarea', 'textarea']
+			['textarea', 'textarea'],
+			['radio', 'radio']
 		])('blendet das dekorative Feld-Icon aus (%s)', async (_name, fieldType) => {
 			const screen = render(FieldRenderer, {
 				fieldConfig: makeFieldConfig({

--- a/src/lib/report/components/form/fields/FormField.svelte
+++ b/src/lib/report/components/form/fields/FormField.svelte
@@ -22,7 +22,8 @@
 		required = undefined,
 		label = undefined,
 		type = undefined,
-		options = undefined
+		options = undefined,
+		helpText = undefined
 	}: {
 		name: keyof Omit<SightingFormData, 'uploadedFiles'>;
 		disabled?: boolean;
@@ -50,6 +51,13 @@
 		 * `type`-Override. Ohne Angabe gilt weiterhin `meta.options`.
 		 */
 		options?: FieldOption[] | undefined;
+		/**
+		 * Optionaler Override des Hilfetexts — nötig, wenn ein `label`/`type`-
+		 * Override die Frage so verändert, dass der Schema-Hilfetext sie nicht
+		 * mehr beantwortet. `null` unterdrückt den Hilfetext ganz; ohne Angabe
+		 * gilt weiterhin `meta.helpText`.
+		 */
+		helpText?: string | null | undefined;
 	} = $props();
 
 	const context = getFormContext();
@@ -108,6 +116,7 @@
 		{label}
 		{type}
 		{options}
+		{helpText}
 		onchange={handleChange}
 	/>
 </div>

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -85,12 +85,20 @@
 				     Wert verlangt. Ohne den Override liefe ein Melder ohne Sternchen
 				     und ohne `aria-required` in „Bitte wählen Sie den Bootsantrieb
 				     aus." — die Admin-Maske hat dasselbe Loch, dort aber mit
-				     vorbefülltem Wert. -->
+				     vorbefülltem Wert.
+
+				     `helpText={null}`, weil der Schema-Hilfetext („Welcher Antrieb
+				     wurde während der Sichtung verwendet?") zur vollen Auswahl der
+				     Admin-Maske gehört und die Ja/Nein-Frage hier nicht beantwortet.
+				     Ein Ersatztext wäre überflüssig: Die Frage ist mit ihren zwei
+				     Optionen selbsterklärend, und dass es um Unterwasserlärm geht,
+				     steht bereits im `valueText`-Tooltip desselben Feldes. -->
 				<FormField
 					name="boatDrive"
 					label="Lief während der Sichtung ein Motor?"
 					type="radio"
 					options={PUBLIC_BOAT_DRIVE_OPTIONS}
+					helpText={null}
 					required={true}
 				/>
 			{/if}


### PR DESCRIPTION
Zwei Nacharbeiten zu 479ef33c, beide dort bekannt und bewusst ausgelassen, um jenen PR nicht auszuweiten.

## 1. Hilfetext — weggelassen, nicht ersetzt

Der Schema-Hilfetext („Welcher Antrieb wurde während der Sichtung verwendet?") beantwortet eine Frage, die das Meldeformular nicht mehr stellt. `FormField`/`FieldRenderer` bekommen dafür den vierten Override neben `label`/`type`/`options`, nach demselben Muster gebaut:

| Wert | Wirkung |
|---|---|
| `undefined` | Ableitung aus `meta.helpText` (Default, unverändert) |
| String | ersetzt den Schema-Text |
| `null` | kein Hilfetext — und dann auch nicht in `aria-describedby` |

Die Aufrufstelle übergibt **`null`**, keinen Ersatztext. „Lief während der Sichtung ein Motor?" mit „Motor lief" / „Motor lief nicht" braucht keine Erläuterung, und das Einzige, was ein Hilfetext ergänzen könnte — dass es um Unterwasserlärm geht — steht bereits im `valueText`-Tooltip desselben Feldes. Ein Text, der die Frage wiederholt und den Tooltip doppelt, gehört nicht ergänzt, sondern weggelassen. Die Admin-Maske behält den Schema-Text, wo die volle Antriebsauswahl ihn richtig macht.

Umgesetzt mit `helpTextOverride === undefined ? meta.helpText : helpTextOverride` statt `??` — sonst fiele `null` auf den Schema-Text zurück und der Override wäre wirkungslos.

## 2. Feld-Icon — einmal an der Gruppe

`BaseRadio` gab das Icon innerhalb der `{#each options}`-Schleife aus; bei zwei Optionen stand derselbe Blitz zweimal untereinander. Es sitzt jetzt einmal an der Legende, gerendert von `FieldRenderer`. `BaseInput`/`BaseSelect` setzen es aus demselben Grund einmal ans Feld — die haben nur ein Control, in das es hineinpasst, eine Radiogruppe nicht. Der `icon`-Prop ist ganz aus `BaseRadio` verschwunden statt ungenutzt stehen zu bleiben.

## Tests

`BaseRadio` war bis zur Motorfrage ein nie ausgeführter Codepfad — vorher nutzte kein Schema-Feld `type: 'radio'`. Es bekommt eine eigene Testdatei für den Gruppenvertrag, auf den sich `FieldRenderer` verlässt: ein Input pro Option, gemeinsamer `name`, Test-IDs pro Option, Auswahl über den Wert — plus einen Wächter, der rot wird, falls das Icon pro Option zurückkommt.

Sieben Tests waren rot, bevor der Code kam.

## Abnahme

- `npm run test:quick` — grün (lint, type-check, svelte-check, 3472 Unit-Tests)
- `npm run test:unit:client` — 331 grün
- `npx playwright test --project=chromium` — 321 grün
- Im Browser geprüft: ein Blitz an der Frage, zwei Radios ohne Icon, kein Hilfetext-Element, `aria-describedby` leer; Auswahl hält (`6` = `MOTOR_OFF` in DOM und Store)

## Bekannt, bewusst nicht in diesem PR

`BaseRadio` ist die einzige `Base*`-Feldkomponente, die `aria-invalid` und `aria-required` weder entgegennimmt noch ausgibt — `FieldRenderer` baut beide in `commonFieldProps`, dort fallen sie still weg. Seit `boatDrive` im öffentlichen Formular ein Pflicht-Radiofeld ist, wird das sichtbar: Die Fehlermeldung erscheint korrekt und ist verknüpft, aber die Inputs tragen kein `aria-invalid="true"` und bekommen keine Fehler-Optik. Vorbestehend und von diesem Diff unberührt; gehört mit eigenem Test in einen eigenen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)