### PR TITLE
test(ui): guard that closed .modal dialogs stay out of the flow

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -201,6 +201,61 @@ Ein `alert-soft` zusätzlich zu setzen ist überflüssig; die Klassen `alert-inf
 
 ---
 
+## Geschlossene `.modal`-Dialoge sind kein Überlauf-Verdacht
+
+Wer horizontalen Überlauf sucht und die Breiten im DOM misst, stolpert
+zuverlässig über die Dialoge: DaisyUI blendet `.modal` **nicht** per
+`display: none` aus, sondern über `visibility: hidden` — ein geschlossener
+Dialog steht also weiter im DOM, hat eine Box und ist regelmäßig breiter als
+sein Elternelement. Gemessen auf `/` bei 360 px (2026-08-04): der
+`upload-notice-dialog` 360 px bei 250 px Elternbreite, das Bild-Modal aus
+`SpeciesIdentificationHelp` 294 px bei 230 px.
+
+**Das ist folgenlos.** `.modal` ist `position: fixed; inset: 0` — der Dialog ist
+aus dem Fluss genommen, sein umschließender Block ist der Viewport, und er
+zählt damit nicht in `documentElement.scrollWidth`. Belegt statt vermutet: der
+Dialog per `style.width = '3000px'` aufgeblasen und zusätzlich um 2000 px nach
+rechts geschoben — `scrollWidth` blieb in beiden Fällen bei 360. Ein
+Kontroll-`div` derselben Breite **im** Fluss hob ihn sofort auf 3000. Dasselbe
+gilt für den geöffneten Dialog (Top-Layer, weiterhin `fixed`).
+
+Die Breite an den Elternkontext zu binden wäre also eine wirkungslose Änderung.
+Beim Überlauf-Suchen gehören Dialoge übersprungen.
+
+**Die eine Bedingung, die das umdreht:** Bekommt ein _Vorfahr_ eine Eigenschaft,
+die einen umschließenden Block für `position: fixed` aufspannt — `transform`,
+`filter`, `backdrop-filter`, `perspective`, `will-change`, `contain`,
+`container-type` —, wird der Dialog flussrelativ und zählt mit. Derselbe
+3000-px-Dialog trieb `scrollWidth` mit einem `transform: translateZ(0)` am
+Elternelement auf 3055. `backdrop-filter` kommt in `SpeciesIdentificationHelp`
+nur am `.modal-backdrop` vor, also an einem Nachfahren, und ist damit
+unkritisch.
+
+**Abgesichert ist das durch `e2e/modal-overflow.spec.ts`** — auf `/`,
+`/bestimmungshilfe` und `/admin`, also an fünf der sechs
+`class="modal"`-Fundstellen (`MediaModal` hängt hinter `{#if selectedMedia}` an
+der Sichtungs-Detailansicht und steht auf keiner Route im Ruhezustand im DOM).
+Ebenfalls nicht abgedeckt sind `hover:`-Zustände — der Test misst den
+Ruhezustand, derselbe Vorbehalt wie beim Token-Scan in `design-system.md`.
+Der Test fragt **nicht** die
+sieben Eigenschaften ab — eine solche Liste wäre eine zweite Quelle neben der
+Spezifikation und altert mit ihr. Er misst die Wirkung: Dialog auf 3000 px
+aufblasen, `scrollWidth` vorher/nachher vergleichen. Jede Route fährt zusätzlich
+eine Gegenprobe, die dem Elternelement ein `transform` verpasst und verlangt,
+dass der Überlauf dann **auftritt** — sonst wäre das Grün eines konformen
+Bestands ohne Aussage. Vorgeführt am 2026-08-04 mit einem `main { transform:
+translateZ(0) }` in `app.css`: alle drei Routen rot, alle sechs Dialoge benannt.
+
+**Was stattdessen funktioniert:** Teilbäume nacheinander auf `display: none`
+setzen, nach jedem Schritt `document.documentElement.scrollWidth` messen und in
+den Teilbaum absteigen, dessen Ausblenden den Überlauf beseitigt. Das liefert
+den kleinsten Verursacher statt einer Liste mitgezogener Elternelemente.
+Messen muss man dafür in einem echten 360-px-Viewport (Playwright-Skript
+**im Repo-Verzeichnis**, sonst fehlt `@playwright/test`); Chrome selbst lässt
+sich nicht so schmal ziehen.
+
+---
+
 ## Layout-Variablen
 
 Radien und Größen kommen aus dem Theme, nicht aus Utility-Klassen:

--- a/e2e/modal-overflow.spec.ts
+++ b/e2e/modal-overflow.spec.ts
@@ -137,10 +137,27 @@ const openRoute = async ({ page, context, request, baseURL }: Fixtures, route: G
 		throw new Error(`${route.path} antwortet mit ${status} — hier stimmt etwas anderes nicht.`);
 	}
 
-	if (route.auth && (status === 401 || status === 403)) {
+	if (!route.auth) return;
+
+	/* Ein Auth0-Redirect landet auf einer fremden Origin und antwortet dabei mit
+	   200 — der Statuscode oben sieht das nicht. Ohne diese Prüfung liefe der
+	   Test auf der Login-Seite, fände dort null Dialoge und fiele über
+	   `minDialogs` mit „zu wenige Dialoge" statt mit der Ursache. */
+	if (!page.url().startsWith(baseURL ?? '')) {
+		throw new Error(
+			`${route.path} hat auf ${page.url()} umgeleitet — das Session-Cookie wurde nicht akzeptiert. ` +
+				'Prüfe DATABASE_POSTGRES_URL und COOKIE_NAME in .env und ob die sessions-Tabelle ' +
+				'migriert ist (siehe e2e/helpers/adminSession.ts).'
+		);
+	}
+
+	/* 401/403 bleiben auf derselben URL und liefern Status < 500 — die Prüfung
+	   oben greift dafür nicht. Cookie akzeptiert, aber `roles` reicht nicht. */
+	if (status === 401 || status === 403) {
 		throw new Error(
 			`${route.path} antwortet mit ${status} — die Session gilt, aber die Rolle reicht nicht. ` +
-				'Siehe e2e/helpers/adminSession.ts.'
+				'Die roles-Spalte der Session-Zeile aus e2e/helpers/adminSession.ts muss die von ' +
+				'requireUserRole geforderte Rolle enthalten.'
 		);
 	}
 };

--- a/e2e/modal-overflow.spec.ts
+++ b/e2e/modal-overflow.spec.ts
@@ -1,0 +1,244 @@
+import {
+	expect,
+	test,
+	type APIRequestContext,
+	type BrowserContext,
+	type Page
+} from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * modal-overflow.spec.ts — geschlossene `.modal`-Dialoge bleiben aus dem Fluss
+ *
+ * **Der Befund, den dieser Test konserviert:** DaisyUI blendet `.modal` nicht
+ * per `display: none` aus, sondern über `visibility` — ein geschlossener Dialog
+ * steht also weiter im DOM und misst sich regelmäßig breiter als sein
+ * Elternelement. Bei der Suche nach horizontalem Überlauf sieht das jedes Mal
+ * nach dem Verursacher aus. Ist es nicht: `.modal` ist `position: fixed;
+ * inset: 0`, der Dialog ist aus dem Fluss genommen und zählt nicht in
+ * `documentElement.scrollWidth`. Hergeleitet und mit Messwerten belegt in
+ * `.claude/rules/daisyui.md` → „Geschlossene `.modal`-Dialoge sind kein
+ * Überlauf-Verdacht".
+ *
+ * **Warum das trotzdem einen Wächter braucht:** Die Aussage gilt nur, solange
+ * kein *Vorfahr* einen umschließenden Block für `position: fixed` aufspannt.
+ * `transform`, `filter`, `backdrop-filter`, `perspective`, `will-change`,
+ * `contain` und `container-type` tun das — und keine davon sieht an der
+ * Aufrufstelle nach einer Layout-Entscheidung aus. Ein `will-change: transform`
+ * an einer Karte, in der ein Dialog steht, oder ein `contain` an einem
+ * Listen-Container macht jeden Dialog darunter flussrelativ und damit
+ * überlauffähig. Der Bruch entsteht dann weit weg von der Datei, in der er sich
+ * auswirkt.
+ *
+ * **Was der Wächter nicht sieht: `hover:`-Zustände.** Gemessen wird der
+ * Ruhezustand, und dort taucht ein Hover-Transform in `getComputedStyle` nie
+ * auf — derselbe Vorbehalt, den `design-system.md` für den Token-Scan
+ * festhält. Das ist keine theoretische Lücke: `app.css` setzt global
+ * `.btn:hover:not(:disabled) { transform: translateY(-1px) }`, dazu steht ein
+ * `hover:scale-105` in `SightingsMapView.svelte`. Heute ist kein
+ * `dialog.modal` Nachfahre eines solchen Elements; wer einen Dialog künftig in
+ * eine Karte mit Hover-Transform hängt, bekommt von hier keine Warnung.
+ *
+ * **Warum gemessen und nicht die CSS-Eigenschaften abgefragt:** Eine Liste der
+ * sieben Eigenschaften wäre eine zweite Quelle neben der Spezifikation und
+ * altert mit ihr — `container-type` kam später dazu, die nächste Ergänzung
+ * käme still an diesem Test vorbei. Stattdessen wird die *Wirkung* geprüft:
+ * Dialog auf 3000 px aufblasen, `scrollWidth` vorher/nachher vergleichen.
+ * Das erwischt jede Ursache, auch die noch nicht erfundene.
+ *
+ * **Warum jede Route eine Gegenprobe fährt:** Ein Scan über einen konformen
+ * Bestand belegt nichts über die Regel — dieselbe Begründung, aus der die
+ * Klassen-Regeln in `helpers/bannedClasses.ts` gegen konstruierte Beispiele
+ * laufen. Hier heißt das: Auf derselben Seite wird dem Elternelement ein
+ * `transform` verpasst und verlangt, dass der Überlauf dann **auftritt**.
+ * Wäre die Sonde stumpf (Dialog nicht gefunden, Stil nicht angekommen,
+ * `scrollWidth` an einem anderen Element gelesen), bliebe sie auch dabei
+ * still und der Test fiele auf.
+ */
+
+/* Der Fall ist ein Mobil-Fall: 360 px ist die Breite, bei der die Frage
+   überhaupt aufkam. Ein 3000 px breiter Dialog würde zwar auch auf einem
+   Desktop-Viewport überlaufen — aber ein Wächter soll die Bedingung fahren,
+   unter der das Problem real wird, nicht eine bequemere. */
+test.use({ viewport: { width: 360, height: 780 } });
+
+interface GuardRoute {
+	readonly path: string;
+	readonly auth: boolean;
+	readonly needsDb: boolean;
+	/** Untergrenze, damit eine Route ohne Dialoge nicht still grün wird. */
+	readonly minDialogs: number;
+}
+
+/* Gemessen am 2026-08-04. Die Zahlen sind Untergrenzen, keine Sollwerte — ein
+   zusätzlicher Dialog auf einer Route ist kein Testfehler, ein verschwundener
+   schon: Ohne diese Schranke prüfte der Test auf einer dialoglosen Seite nichts
+   und meldete trotzdem grün.
+
+   `/map` und `/about` stehen bewusst nicht hier — sie enthalten keinen Dialog.
+
+   **Was ungedeckt bleibt:** `MediaModal.svelte`. Der Dialog hängt hinter
+   `{#if selectedMedia}` an der Detailansicht einer Sichtung und steht auf
+   keiner Route im Ruhezustand im DOM. Die übrigen fünf
+   `class="modal"`-Fundstellen sind abgedeckt: UploadNotice und
+   SpeciesIdentificationHelp auf `/`, DeleteDialog, ExportModal und die
+   Spam-Analyse auf `/admin`. */
+const ROUTES: readonly GuardRoute[] = [
+	{ path: '/', auth: false, needsDb: false, minDialogs: 2 },
+	{ path: '/bestimmungshilfe', auth: false, needsDb: false, minDialogs: 1 },
+	{ path: '/admin', auth: true, needsDb: true, minDialogs: 3 }
+];
+
+type Fixtures = {
+	page: Page;
+	context: BrowserContext;
+	request: APIRequestContext;
+	baseURL: string | undefined;
+};
+
+let databaseProbe: Promise<boolean> | undefined;
+const databaseAvailable = (request: APIRequestContext) => {
+	databaseProbe ??= request
+		.get('/api/map/sightings', { timeout: 10_000 })
+		.then((response) => response.ok())
+		.catch(() => false);
+	return databaseProbe;
+};
+
+/* Dieselben Wächter wie in `design-tokens.spec.ts`: Auth0-Redirect und
+   SvelteKit-Fehlerseite liefern beide ein DOM ohne Dialoge — ohne die Prüfungen
+   wäre der Lauf auf /admin grün, ohne die Seite je gesehen zu haben. Die
+   `minDialogs`-Schranke unten fängt das zwar auch ab, meldete dann aber
+   „zu wenige Dialoge" statt der eigentlichen Ursache. */
+const openRoute = async ({ page, context, request, baseURL }: Fixtures, route: GuardRoute) => {
+	if (route.needsDb && !(await databaseAvailable(request))) {
+		if (process.env.CI) {
+			throw new Error(
+				`${route.path} braucht eine Datenbank, und /api/map/sightings antwortet nicht. ` +
+					'In CI ist das ein Fehler: Der `e2e`-Job startet einen Postgres-Service, wendet die ' +
+					'Migrationen an und legt Testdaten an (ci.yml).'
+			);
+		}
+		test.skip(
+			true,
+			`${route.path} braucht eine Datenbank, und /api/map/sightings antwortet nicht. Lokal: npm run db:start && npm run db:push.`
+		);
+	}
+
+	if (route.auth) {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+		await seedAdminSession(context, baseURL);
+	}
+
+	const response = await page.goto(route.path);
+	const status = response?.status() ?? 0;
+
+	if (status >= 500) {
+		throw new Error(`${route.path} antwortet mit ${status} — hier stimmt etwas anderes nicht.`);
+	}
+
+	if (route.auth && (status === 401 || status === 403)) {
+		throw new Error(
+			`${route.path} antwortet mit ${status} — die Session gilt, aber die Rolle reicht nicht. ` +
+				'Siehe e2e/helpers/adminSession.ts.'
+		);
+	}
+};
+
+interface Measurement {
+	readonly dialogCount: number;
+	/** Ein Eintrag je Dialog, der `scrollWidth` bewegt hat — erwartet: leer. */
+	readonly contributing: readonly { label: string; before: number; after: number }[];
+	/** Gegenprobe: `scrollWidth` mit `transform` am Elternelement. */
+	readonly control: { label: string; before: number; after: number } | null;
+}
+
+const measure = (page: Page): Promise<Measurement> =>
+	page.evaluate(() => {
+		const de = document.documentElement;
+		const dialogs = [...document.querySelectorAll<HTMLDialogElement>('dialog.modal')];
+
+		const label = (d: HTMLDialogElement, i: number) =>
+			d.dataset.testid ?? d.getAttribute('aria-labelledby') ?? `dialog[${i}]`;
+
+		/* Aufblasen statt Vorhandenes messen: Die realen Breiten liegen heute
+		   knapp am Viewport und wären als Sonde zu schwach — 3000 px kann kein
+		   Layout unbemerkt schlucken. `scrollWidth` wird als Differenz gelesen,
+		   nicht gegen `clientWidth`: Eine Route, die schon anderweitig überläuft,
+		   soll hier keinen Fehlalarm auslösen (und keinen verdecken). */
+		const blowUp = (d: HTMLDialogElement) => {
+			const saved = d.style.cssText;
+			const before = de.scrollWidth;
+			d.style.width = '3000px';
+			const after = de.scrollWidth;
+			d.style.cssText = saved;
+			return { before, after };
+		};
+
+		const contributing: { label: string; before: number; after: number }[] = [];
+		dialogs.forEach((d, i) => {
+			const { before, after } = blowUp(d);
+			if (after > before) contributing.push({ label: label(d, i), before, after });
+		});
+
+		/* Gegenprobe am ersten Dialog der Seite: Mit einem umschließenden Block
+		   am Elternelement MUSS derselbe Handgriff `scrollWidth` bewegen. */
+		let control: Measurement['control'] = null;
+		const first = dialogs[0];
+		if (first?.parentElement) {
+			const parent = first.parentElement;
+			const savedParent = parent.style.cssText;
+			parent.style.transform = 'translateZ(0)';
+			const { before, after } = blowUp(first);
+			parent.style.cssText = savedParent;
+			control = { label: label(first, 0), before, after };
+		}
+
+		return { dialogCount: dialogs.length, contributing, control };
+	});
+
+test.describe('Modal-Dialoge — kein Beitrag zum horizontalen Überlauf', () => {
+	for (const route of ROUTES) {
+		test(`${route.path}: geschlossene .modal-Dialoge bleiben aus dem Fluss`, async ({
+			page,
+			context,
+			request,
+			baseURL
+		}) => {
+			await openRoute({ page, context, request, baseURL }, route);
+
+			const { dialogCount, contributing, control } = await measure(page);
+
+			expect(
+				dialogCount,
+				`${route.path} rendert nur ${dialogCount} statt mindestens ${route.minDialogs} \`dialog.modal\`. ` +
+					'Der Test hätte damit nichts geprüft und wäre trotzdem grün geworden. Entweder ist ein ' +
+					'Dialog verschwunden (dann die Untergrenze in ROUTES anpassen) oder die Seite hat nicht ' +
+					'vollständig gerendert.'
+			).toBeGreaterThanOrEqual(route.minDialogs);
+
+			expect(
+				control,
+				`${route.path}: Gegenprobe konnte nicht gefahren werden — kein Dialog mit Elternelement gefunden.`
+			).not.toBeNull();
+
+			expect(
+				control!.after,
+				`${route.path}: Die Gegenprobe an "${control?.label}" hat NICHT angeschlagen ` +
+					`(${control?.before} → ${control?.after}). Mit einem \`transform\` am Elternelement muss ein ` +
+					'3000 px breiter Dialog den Überlauf erzeugen. Tut er das nicht, misst die Sonde etwas ' +
+					'anderes als gedacht — und ihr Grün oben ist wertlos.'
+			).toBeGreaterThan(control!.before);
+
+			expect(
+				contributing,
+				`${route.path}: ${contributing.length} Dialog(e) zählen in documentElement.scrollWidth mit — ` +
+					`${contributing.map((c) => `${c.label} (${c.before} → ${c.after})`).join(', ')}. ` +
+					'Ein `.modal` ist `position: fixed` und darf das nicht. Ursache ist fast immer ein neuer ' +
+					'umschließender Block an einem Vorfahren: transform, filter, backdrop-filter, perspective, ' +
+					'will-change, contain oder container-type. Hintergrund in .claude/rules/daisyui.md → ' +
+					'„Geschlossene `.modal`-Dialoge sind kein Überlauf-Verdacht".'
+			).toEqual([]);
+		});
+	}
+});

--- a/src/lib/report/components/form/UploadNotice.svelte
+++ b/src/lib/report/components/form/UploadNotice.svelte
@@ -45,6 +45,16 @@
 	<span>Datenschutzhinweis</span>
 </button>
 
+<!-- Dieser Dialog misst sich im DOM breiter als sein Elternelement, auch
+     geschlossen: DaisyUI blendet `.modal` über `visibility` aus, nicht über
+     `display`. Bei der Suche nach horizontalem Überlauf sieht das nach einem
+     Verursacher aus — ist aber keiner. `.modal` ist `position: fixed; inset: 0`
+     und zählt nicht in `documentElement.scrollWidth`; am 2026-08-04 mit 3000 px
+     Breite gegengemessen, der Wert blieb bei 360. Die Breite hier an den
+     Elternkontext zu binden wäre wirkungslos. Messwerte, die eine Ausnahme
+     bilden, und das Verfahren, das den echten Verursacher findet:
+     `.claude/rules/daisyui.md` → „Geschlossene `.modal`-Dialoge sind kein
+     Überlauf-Verdacht". -->
 <dialog
 	bind:this={dialogElement}
 	class="modal"


### PR DESCRIPTION
## Worum es geht

Bei der Suche nach dem horizontalen Überlauf (behoben in `8a4ef750`) tauchte ein Nebenbefund auf: Geschlossene `.modal`-Dialoge messen sich im DOM breiter als ihr Elternelement. DaisyUI blendet sie über `visibility` aus, nicht über `display` — sie liegen also weiterhin im Layout. Die Frage war, ob das zum Überlauf beitragen **kann**.

**Kann es nicht.** `.modal` ist `position: fixed; inset: 0`; der Dialog ist aus dem Fluss genommen und zählt nicht in `documentElement.scrollWidth`.

| Test (auf `/`, 360 px) | `documentElement.scrollWidth` |
| --- | --- |
| Ausgangszustand | 360 (kein Überlauf) |
| Dialog auf `width: 3000px` | **360** |
| Dialog zusätzlich 2000 px nach rechts | **360** |
| Kontroll-`div` mit 3000 px **im Fluss** | 3000 |
| Dialog geöffnet (Top-Layer) | 360 |

Die Breite an den Elternkontext zu binden wäre wirkungslos gewesen. **Dieser PR ändert deshalb kein Verhalten** — er hält den Befund fest und sichert die eine Bedingung ab, unter der er kippt.

## Die Bedingung, die es umdreht

Spannt ein *Vorfahr* einen umschließenden Block für `position: fixed` auf — `transform`, `filter`, `backdrop-filter`, `perspective`, `will-change`, `contain`, `container-type` —, wird der Dialog flussrelativ. Derselbe 3000-px-Dialog trieb `scrollWidth` mit einem `transform: translateZ(0)` am Elternelement auf **3055**.

Keine dieser Eigenschaften sieht an der Aufrufstelle nach einer Layout-Entscheidung aus, und der Bruch entstünde weit weg von der Datei, in der er sich auswirkt. Genau dafür ist der Wächter da.

## Der Wächter

`e2e/modal-overflow.spec.ts`, auf `/`, `/bestimmungshilfe` und `/admin` bei 360 px.

- **Wirkung statt Eigenschaftsliste.** Der Test fragt die sieben Eigenschaften nicht ab — eine Liste wäre eine zweite Quelle neben der Spezifikation und altert mit ihr (`container-type` kam später dazu). Stattdessen: Dialog auf 3000 px aufblasen, `scrollWidth` vorher/nachher vergleichen. Gelesen wird die Differenz, nicht der Abstand zu `clientWidth` — eine Route, die schon anderweitig überläuft, löst so weder Fehlalarm aus noch verdeckt sie etwas.
- **Gegenprobe je Route.** Grün über einen konformen Bestand belegt nichts über die Regel (dieselbe Begründung wie bei `helpers/bannedClasses.ts`). Jeder Test verpasst dem Elternelement deshalb ein `transform` und verlangt, dass der Überlauf dann **auftritt**.
- **Untergrenze je Route** gegen Vakuum-Grün: Verschwindet ein Dialog oder rendert die Seite nicht (Auth0-Redirect, Fehlerseite), meldet der Test das, statt nichts zu prüfen.

**RED wurde vorgeführt**, mit einer echten CSS-Änderung statt einer Injektion im Test: `main { transform: translateZ(0) }` in `app.css` → alle drei Routen rot, alle sechs Dialoge namentlich in der Meldung. Nach dem Zurücksetzen grün.

## Grenzen — bewusst und vermerkt

- **`MediaModal.svelte` ist ungedeckt.** Der Dialog hängt hinter `{#if selectedMedia}` an der Sichtungs-Detailansicht und steht auf keiner Route im Ruhezustand im DOM. Damit sind fünf der sechs `class="modal"`-Fundstellen abgedeckt.
- **`hover:`-Zustände sieht der Test nicht** — er misst den Ruhezustand, derselbe Vorbehalt, den `design-system.md` für den Token-Scan festhält. Real relevant: `app.css` setzt global `.btn:hover { transform: translateY(-1px) }`. Heute ist kein `dialog.modal` Nachfahre eines solchen Elements.

Beides steht im Spec-Kopf und in der Regel, nicht nur hier.

## Änderungen

| Datei | Was |
| --- | --- |
| `e2e/modal-overflow.spec.ts` | neu — der Wächter |
| `.claude/rules/daisyui.md` | Abschnitt „Geschlossene `.modal`-Dialoge sind kein Überlauf-Verdacht" mit Messwerten und dem Bisect-Verfahren, das den echten Verursacher findet |
| `UploadNotice.svelte` | Markup-Kommentar am gemessenen Dialog (wird beim Kompilieren entfernt), verweist auf die Regel |

Kein Test für den Kommentar und die Regel-Ergänzung — reine Dokumentation, die in `.claude/rules/testing.md` vorgesehene Ausnahme.

## Abnahme

- `npm run test:quick` — 232 Dateien, 3446 Tests, grün
- `CI=1 npx playwright test --project=chromium` — 318 passed, 1 flaky (`form-map-pan-zoom.spec.ts` → „Ziehen verändert die gemeldete Position nicht"; der Spec ist bekanntermaßen von sich aus flaky, lief im Retry grün, unberührt von diesem PR)
- `npm run lint` / `type-check` — sauber (die 2 verbleibenden Warnungen stehen in `src/tests/contract/helpers/createEvent.ts` und sind Altbestand)

## Nebenbefund, nicht in diesem PR

`/about` hat bei 360 px echten horizontalen Überlauf: `scrollWidth` 411 gegen `clientWidth` 360 — und enthält **keinen** Dialog, was die Analyse oben unabhängig bestätigt. Der Bisect endet bei `div.mx-auto.max-w-5xl.p-6`, das selbst 411,39 px misst. Gehört in einen eigenen PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)