### PR TITLE
fix(a11y): mark the remaining conditionally required fields as required

### DIFF
--- a/src/lib/report/components/sections/DeadAnimal.svelte
+++ b/src/lib/report/components/sections/DeadAnimal.svelte
@@ -29,7 +29,19 @@
 
 	<!-- These fields will be loaded from constants in the future -->
 	<div class="space-y-4">
-		<FormField name="deadCondition" />
+		<!-- `required` als Override, weil die Pflicht im Schema in einem
+		     `when('isDead')` steckt und `describe()` das nicht sieht — derselbe Fall
+		     wie `waterway` in LocationDescription.svelte. Unbedingt `true`: Diese
+		     Section rendert ausschließlich innerhalb von `{#if $form.isDead}`
+		     (AnimalInfo.svelte), also genau unter der Bedingung, die das Schema
+		     prüft — und `adminSightingSchema` lockert sie nicht. Ohne den Override
+		     lief der Melder ohne Sternchen und ohne `aria-required` in „Bitte geben
+		     Sie den Zustand des toten Tieres an.".
+
+		     Die beiden Nachbarfelder bekommen ihn bewusst NICHT: `deadSize` hat zwar
+		     ein `when()`, setzt darin aber beide Zweige auf `notRequired()`, und
+		     `deadSex` hat das Museum am 2026-08-04 samt Pflicht abbestellt. -->
+		<FormField name="deadCondition" required={true} />
 
 		<!-- Das Geschlecht beim Totfund ist seit 2026-08-04 nur noch in der
 		     Admin-Maske sichtbar (C4) — ohne adminMode steht deadSize allein und

--- a/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
+++ b/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
@@ -36,6 +36,11 @@ function field(name: string): HTMLElement | null {
 	return document.querySelector<HTMLElement>(`[data-testid="field-${name}"]`);
 }
 
+/** Das Pflicht-Sternchen der Feld-Pipeline, auf ein Feld eingegrenzt. */
+function requiredMark(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-field="${name}"] [aria-label="Pflichtfeld"]`);
+}
+
 describe('sections/DeadAnimal — Geschlecht nur im Admin-Modus', () => {
 	it('zeigt das Geschlecht-Feld NICHT im Meldeformular (ohne adminMode)', () => {
 		renderDeadAnimal();
@@ -73,4 +78,42 @@ describe('sections/DeadAnimal — Geschlecht nur im Admin-Modus', () => {
 			expect(field(name)).not.toBeNull();
 		}
 	);
+});
+
+/**
+ * `deadCondition` ist laut Schema Pflicht, sobald `isDead` gesetzt ist
+ * (`.when('isDead', { is: true, then: … required(…) })`). `FieldRenderer` sieht
+ * das nicht: Es liest `required` aus `sightingSchema.describe()`, und dort ist
+ * ein `when()` nicht abgebildet. Ohne den `required`-Override an `FormField`
+ * steht das Feld ohne Sternchen und ohne `aria-required` da — bis der Melder
+ * „Weiter" drückt und „Bitte geben Sie den Zustand des toten Tieres an."
+ * bekommt.
+ *
+ * Der Override ist hier unbedingt `true`: Diese Section rendert ausschließlich
+ * innerhalb von `{#if $form.isDead}` (`AnimalInfo.svelte`), also genau unter der
+ * Bedingung, die das Schema prüft. Und sie gilt in **beiden** Masken —
+ * `adminSightingSchema` lockert `deadCondition` nicht.
+ */
+describe('sections/DeadAnimal — Zustand als konditionales Pflichtfeld', () => {
+	it.each([
+		['Meldeformular', undefined],
+		['Admin-Maske', true]
+	])('markiert den Zustand im %s als Pflichtfeld', (_label, adminMode) => {
+		renderDeadAnimal(adminMode === undefined ? {} : { adminMode });
+
+		expect(requiredMark('deadCondition')).not.toBeNull();
+		expect(field('deadCondition')?.getAttribute('aria-required')).toBe('true');
+	});
+
+	/**
+	 * Gegenprobe: Die beiden Nachbarfelder sind unter denselben Bedingungen
+	 * ausdrücklich optional (`deadSize` hat ein `when()`, das in beiden Zweigen
+	 * `notRequired()` setzt; `deadSex` hat das Museum am 2026-08-04 samt Pflicht
+	 * abbestellt). Ein pauschal auf die Section gesetzter Override fiele hier auf.
+	 */
+	it.each(['deadSize', 'deadSex'])('markiert %s weiterhin NICHT als Pflichtfeld', (name) => {
+		renderDeadAnimal({ adminMode: true });
+
+		expect(requiredMark(name)).toBeNull();
+	});
 });

--- a/src/lib/report/components/sections/Location.svelte
+++ b/src/lib/report/components/sections/Location.svelte
@@ -51,6 +51,22 @@
 		Das Meldeformular ist davon nicht betroffen — es nutzt
 		`position/LocationDescription.svelte` und zeigt seit A2.4 nur `waterway`.
 	-->
-	<FormField name="waterway" />
+	<!--
+		`required` als Override, weil die Pflicht im Schema in einem
+		`when('hasPosition')` steckt und `describe()` das nicht sieht — dieselbe
+		Aufrufstelle-für-Aufrufstelle-Pflicht wie im Meldeformular
+		(`position/LocationDescription.svelte`), und `adminSightingSchema` lockert
+		das Feld nicht.
+
+		Hier muss der Override KONDITIONAL sein, anders als bei `deadCondition` oder
+		`boatDrive`: Dort rendert der umgebende Zweig ohnehin nur unter der
+		Schema-Bedingung, hier steht das Feld nach dem Kommentar oben bewusst
+		unabhängig von `hasPosition` im Markup. Ein festes `true` zeigte also auch
+		dann ein Sternchen, wenn Koordinaten vorliegen und niemand eine Beschreibung
+		verlangt.
+
+		`seaMark` bleibt ohne Override — es hat kein `when()` und ist nie Pflicht.
+	-->
+	<FormField name="waterway" required={hasPosition !== true} />
 	<FormField name="seaMark" />
 </SectionCard>

--- a/src/lib/report/components/sections/Location.svelte.test.ts
+++ b/src/lib/report/components/sections/Location.svelte.test.ts
@@ -45,6 +45,11 @@ function field(name: string): HTMLInputElement | null {
 	return document.querySelector<HTMLInputElement>(`[data-testid="field-${name}"]`);
 }
 
+/** Das Pflicht-Sternchen der Feld-Pipeline, auf ein Feld eingegrenzt. */
+function requiredMark(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-field="${name}"] [aria-label="Pflichtfeld"]`);
+}
+
 describe('sections/Location — Admin-Maske', () => {
 	it('zeigt ohne GPS-Position weiterhin BEIDE Ortsfelder', () => {
 		renderAdminLocation({ hasPosition: false });
@@ -87,5 +92,44 @@ describe('sections/Location — Admin-Maske', () => {
 			expect(field(name)?.disabled, name).toBe(false);
 			expect(field(name)?.readOnly, name).toBe(false);
 		}
+	});
+});
+
+/**
+ * Die Ortsbeschreibung ist Pflicht, solange keine GPS-Position vorliegt
+ * (`waterway.when('hasPosition', { is: (v) => v !== true, … })`) — und zwar in
+ * beiden Masken, `adminSightingSchema` lockert das Feld nicht.
+ *
+ * `FieldRenderer` sieht ein `when()` in `describe()` nicht, deshalb braucht jede
+ * Aufrufstelle den `required`-Override. Im Meldeformular ist er gesetzt
+ * (`position/LocationDescription.svelte`); hier fehlte er.
+ *
+ * **Anders als bei `deadCondition` oder `boatDrive` muss er konditional sein.**
+ * Dort rendert der umgebende Zweig ohnehin nur unter der Schema-Bedingung, hier
+ * steht das Feld seit dem 2026-08-02 bewusst unabhängig von `hasPosition` im
+ * Markup (Kommentar in `Location.svelte`). Ein festes `required={true}` würde
+ * also auch dann ein Sternchen zeigen, wenn Koordinaten vorliegen und niemand
+ * eine Beschreibung verlangt.
+ */
+describe('sections/Location — Ortsbeschreibung als konditionales Pflichtfeld', () => {
+	it('markiert die Ortsbeschreibung ohne GPS-Position als Pflicht', () => {
+		renderAdminLocation({ hasPosition: false });
+
+		expect(requiredMark('waterway')).not.toBeNull();
+		expect(field('waterway')?.getAttribute('aria-required')).toBe('true');
+	});
+
+	it('markiert sie MIT GPS-Position nicht als Pflicht', () => {
+		renderAdminLocation({ hasPosition: true, latitude: 54.5, longitude: 13.5 });
+
+		expect(requiredMark('waterway')).toBeNull();
+		expect(field('waterway')?.getAttribute('aria-required')).toBeNull();
+	});
+
+	/** Das Seezeichen ist in keinem Fall Pflicht — es hat gar kein `when()`. */
+	it.each([true, false])('lässt das Seezeichen bei hasPosition=%s optional', (hasPosition) => {
+		renderAdminLocation({ hasPosition });
+
+		expect(requiredMark('seaMark')).toBeNull();
 	});
 });

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -51,8 +51,18 @@
 	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
 		<FormField name="sightingFrom" />
 		{#if String($form.sightingFrom) === String(SightingFromEnum.OTHER)}
+			<!-- `required` als Override, weil die Pflicht im Schema in einem
+			     `when('sightingFrom')` steckt und `describe()` das nicht sieht —
+			     derselbe Fall wie `boatDrive` unten.
+
+			     Anders als dort ist der Wert hier NICHT unbedingt `true`, obwohl
+			     dieser Zweig nur bei „Sonstiges" rendert: `adminSightingSchema` baut
+			     das Feld ausdrücklich als `notRequired()` neu auf, weil 1.120
+			     Bestandszeilen `vonwo = 0` ohne Freitext tragen und sonst nicht mehr
+			     speicherbar wären. In der Admin-Maske würde ein Sternchen also eine
+			     Pflicht behaupten, die beim Speichern niemand prüft. -->
 			<div transition:slide>
-				<FormField name="sightingFromText" />
+				<FormField name="sightingFromText" required={!adminMode} />
 			</div>
 		{/if}
 	</div>
@@ -61,8 +71,16 @@
 			{#if adminMode}
 				<!-- Admin-Maske: volle Antriebsauswahl aus dem Schema. Die feinere
 				     Bedeutung von "Segel", "Treibend" und "Vor Anker" bleibt hier
-				     erhalten, damit Altbestand unverändert nachbearbeitet werden kann. -->
-				<FormField name="boatDrive" />
+				     erhalten, damit Altbestand unverändert nachbearbeitet werden kann.
+
+				     `required` wie im Meldeformular-Zweig unten und aus demselben
+				     Grund: Die Pflicht steckt in einem `when('sightingFrom')`, das
+				     `describe()` nicht sieht, und `adminSightingSchema` lockert sie
+				     nicht. Unbedingt `true`, weil dieser Zweig ausschließlich bei
+				     Segelschiff oder Motorboot rendert. Dass der Wert beim Bearbeiten
+				     meist vorbefüllt ist, ändert daran nichts — im Altbestand steht
+				     `bootsantrieb` auch bei Bootsmeldungen leer. -->
+				<FormField name="boatDrive" required={true} />
 				{#if String($form.boatDrive) === String(BoatDriveEnum.OTHER)}
 					<!-- Freitext nur in der Admin-Maske: `OTHER` ist im Meldeformular
 					     seit PR 4 nicht mehr wählbar, kann aber im Altbestand stehen. -->

--- a/src/lib/report/components/sections/SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/SightingDetails.svelte.test.ts
@@ -1,0 +1,99 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+import type { FormContext, SightingFormData } from '$lib/types';
+import SightingDetails from './SightingDetails.svelte';
+
+/**
+ * Konditionale Pflichtfelder: `sightingFromText` und `boatDrive` sind im
+ * Yup-Schema nur unter einer Bedingung Pflicht (`when('sightingFrom')`).
+ * `FieldRenderer` leitet die Markierung aber aus `describe()` ab, und dort ist
+ * ein `when()` nicht sichtbar — ohne den `required`-Override an `FormField`
+ * zeigt das Feld weder Sternchen noch `aria-required`, obwohl „Weiter" daran
+ * scheitert (design-system.md, „Formularfeld-Muster").
+ *
+ * **Die beiden Felder liegen dabei unterschiedlich:**
+ *
+ * - `boatDrive` ist in **beiden** Masken Pflicht, sobald von Segelschiff oder
+ *   Motorboot gemeldet wird — `adminSightingSchema` lockert es nicht. Der
+ *   Meldeformular-Zweig hat den Override seit `479ef33c`; der Admin-Zweig
+ *   rendert unter derselben Bedingung und braucht ihn genauso.
+ * - `sightingFromText` ist **nur im Meldeformular** Pflicht.
+ *   `adminSightingSchema` baut das Feld ausdrücklich als `notRequired()` neu
+ *   auf, weil 1.120 Bestandszeilen `vonwo = 0` ohne Freitext tragen. Ein
+ *   unbedingtes `required={true}` wäre in der Admin-Maske also eine Lüge über
+ *   die Validierung — der Override hängt hier an `adminMode`.
+ */
+function renderSightingDetails(
+	overrides: Partial<SightingFormData> = {},
+	props: { adminMode?: boolean } = {}
+): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(SightingDetails, { props, context: new Map([[formContextKey, context]]) });
+}
+
+/** Das Pflicht-Sternchen der Feld-Pipeline, auf ein Feld eingegrenzt. */
+function requiredMark(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-field="${name}"] [aria-label="Pflichtfeld"]`);
+}
+
+function field(name: string): HTMLElement | null {
+	return document.querySelector<HTMLElement>(`[data-testid="field-${name}"]`);
+}
+
+describe('sections/SightingDetails — sightingFromText als konditionales Pflichtfeld', () => {
+	it('markiert den Freitext im Meldeformular als Pflicht, wenn "Sonstiges" gewählt ist', () => {
+		renderSightingDetails({ sightingFrom: SightingFromEnum.OTHER });
+
+		expect(field('sightingFromText')).not.toBeNull();
+		expect(requiredMark('sightingFromText')).not.toBeNull();
+		expect(field('sightingFromText')?.getAttribute('aria-required')).toBe('true');
+	});
+
+	/**
+	 * Der Gegenprobe-Fall: In der Admin-Maske gilt `adminSightingSchema`, dort
+	 * ist der Freitext optional. Ein Sternchen würde hier eine Pflicht behaupten,
+	 * die beim Speichern niemand prüft.
+	 */
+	it('markiert den Freitext in der Admin-Maske NICHT als Pflicht', () => {
+		renderSightingDetails({ sightingFrom: SightingFromEnum.OTHER }, { adminMode: true });
+
+		expect(field('sightingFromText')).not.toBeNull();
+		expect(requiredMark('sightingFromText')).toBeNull();
+		expect(field('sightingFromText')?.getAttribute('aria-required')).toBeNull();
+	});
+});
+
+describe('sections/SightingDetails — boatDrive in der Admin-Maske', () => {
+	it.each([
+		['Segelschiff', SightingFromEnum.SAILBOAT],
+		['Motorboot', SightingFromEnum.MOTORBOAT]
+	])('markiert den Bootsantrieb bei "%s" als Pflicht', (_label, sightingFrom) => {
+		renderSightingDetails({ sightingFrom }, { adminMode: true });
+
+		expect(field('boatDrive')).not.toBeNull();
+		expect(requiredMark('boatDrive')).not.toBeNull();
+		expect(field('boatDrive')?.getAttribute('aria-required')).toBe('true');
+	});
+
+	/**
+	 * Bei Land/Fähre/Sonstiges verlangt das Schema keinen Antrieb — der ganze
+	 * Block rendert dann gar nicht, es kann also auch keine falsche Markierung
+	 * stehenbleiben.
+	 */
+	it('zeigt den Bootsantrieb bei "Land" gar nicht erst', () => {
+		renderSightingDetails({ sightingFrom: SightingFromEnum.LAND }, { adminMode: true });
+
+		expect(document.querySelector('[data-field="boatDrive"]')).toBeNull();
+	});
+});


### PR DESCRIPTION
`FieldRenderer` leitet die Pflicht-Markierung aus der statischen Schema-Beschreibung ab (`fieldConfig.optional === false`). Ein Yup-`when()` ist in `describe()` nicht sichtbar — jedes Feld, dessen Pflicht in einem `when()` steckt, zeigt deshalb **weder Sternchen noch `aria-required`**, obwohl die Validierung es verlangt. Der Melder erfährt erst nach dem abgelehnten „Weiter", dass das Feld Pflicht war.

Für genau diesen Fall gibt es den `required`-Override an `FormField` (`design-system.md`, „Formularfeld-Muster"). Er war nur dort gesetzt, wo jemand daran gedacht hat. Dieser PR arbeitet das Schema systematisch durch.

## Befund

Sieben `when()`-Blöcke in `sightingSchema.ts`:

| Feld | Bedingung | Aufrufstelle | Stand |
|---|---|---|---|
| `latitude` / `longitude` | `hasPosition === true` | **kein `FormField`** — Handmarkup in `LocationInput.svelte` | siehe unten |
| `waterway` | `hasPosition !== true` | `LocationDescription.svelte` (Meldeformular) | war gesetzt |
| | | `Location.svelte` (Admin) | **Lücke → behoben** |
| `deadCondition` | `isDead === true` | `DeadAnimal.svelte` | **Lücke → behoben** |
| `deadSize` | `isDead` | — | kein Fund: beide Zweige `notRequired()` |
| `sightingFromText` | `sightingFrom = OTHER` | `SightingDetails.svelte` | **Lücke → behoben** |
| `boatDrive` | Segelschiff/Motorboot | `SightingDetails.svelte`, Meldeformular-Zweig | war gesetzt (`479ef33c`) |
| | | `SightingDetails.svelte`, Admin-Zweig | **Lücke → behoben** |

## Warum zwei der vier Overrides konditional sind

Wo der umgebende Zweig ohnehin nur unter der Schema-Bedingung rendert, ist `true` richtig — so bei `deadCondition` (`{#if $form.isDead}` in `AnimalInfo.svelte`) und beim Admin-`boatDrive` (rendert nur bei Segelschiff/Motorboot). Bei `boatDrive` trägt das „ist ja vorbefüllt"-Argument nicht: Im Altbestand steht `bootsantrieb` auch bei Bootsmeldungen leer.

Zwei Felder liegen anders:

- **`waterway` in der Admin-Maske** steht seit dem 2026-08-02 bewusst *unabhängig* von `hasPosition` im Markup (902 von 1.033 Datensätzen mit Seezeichen tragen zugleich Koordinaten). Ein festes `true` zeigte also auch mit Koordinaten ein Sternchen → `required={hasPosition !== true}`.
- **`sightingFromText`** ist der Fall, in dem Meldeformular und Admin-Maske fachlich auseinanderfallen: `adminSightingSchema` baut das Feld ausdrücklich als `notRequired()` neu auf, weil 1.120 Bestandszeilen `vonwo = 0` ohne Freitext tragen und sonst nicht mehr speicherbar wären. Ein unbedingtes `true` hätte dort eine Pflicht behauptet, die beim Speichern niemand prüft → `required={!adminMode}`.

Für die anderen drei Felder wurde gegengeprüft, dass `adminSightingSchema` sie **nicht** lockert — es fasst nur `totalCount`, `juvenileCount`, `distance` und `sightingFromText` an.

## Nicht behoben: `latitude` / `longitude`

Beide tragen dieselbe konditionale Pflicht, laufen aber **nicht** über die Feld-Pipeline — `LocationInput.svelte` schreibt seine `<label>`/`<input>`-Paare für drei GPS-Formate von Hand, es gibt also keinen Override zu setzen. Im Meldeformular folgenlos (`PositionPanel` setzt `hasPosition` genau dann, wenn Koordinaten existieren), in der Admin-Maske erreichbar (`hasPosition` ist dort ein Schalter). Das zu schließen hieße, die Koordinateneingabe in die Pipeline zu heben — eigener PR.

## Tests

Test-First, je Fundstelle ein Komponententest plus Gegenprobe an den Nachbarfeldern ohne `when()` (`deadSize`, `deadSex`, `seaMark`, `waterway`-mit-Position, `sightingFromText`-im-Admin) — die schlügen an, wenn jemand einen Override pauschal auf eine Section setzt.

- `npm run test:quick` — grün (232 Dateien, 3472 Tests)
- `npm run test:unit:client` — grün (34 Dateien, 329 Tests)
- Playwright chromium, Worktree-Port mit Identitätsprüfung — **321/321 grün**

Ein zusätzlicher `CI=1`-Lauf (fester Port 4000) ist **nicht** verwertbar: Port 4000 wurde mitten im Lauf von einem anderen Worktree übernommen, 15 Tests scheiterten an `ERR_CONNECTION_REFUSED`. Keine einzige Assertion ist fehlgeschlagen, und keiner der Fehlschläge berührt die geänderten Komponenten. Details im PR-Thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
