### PR TITLE
fix(ui): let labels and titles wrap instead of widening the whole page

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -250,9 +250,18 @@ translateZ(0) }` in `app.css`: alle drei Routen rot, alle sechs Dialoge benannt.
 setzen, nach jedem Schritt `document.documentElement.scrollWidth` messen und in
 den Teilbaum absteigen, dessen Ausblenden den Überlauf beseitigt. Das liefert
 den kleinsten Verursacher statt einer Liste mitgezogener Elternelemente.
-Messen muss man dafür in einem echten 360-px-Viewport (Playwright-Skript
-**im Repo-Verzeichnis**, sonst fehlt `@playwright/test`); Chrome selbst lässt
-sich nicht so schmal ziehen.
+Messen muss man dafür in einem echten 360-px-Viewport; Chrome selbst lässt sich
+nicht so schmal ziehen.
+
+**Das Verfahren steht als `findHorizontalOverflow` in `e2e/helpers/overflow.ts`**
+— kein Wegwerf-Skript mehr nötig. `expectNoHorizontalOverflow(page, kontext)`
+misst und benennt bei einem Befund den Verursacher samt Pfad. Ein Detail, das
+beim Nachbauen von Hand regelmäßig fehlt: Ein einzelnes Kind auszublenden
+genügt nicht, sobald zwei Bereiche unabhängig voneinander zu breit sind — dann
+endet der Abstieg am gemeinsamen Elternelement. Der Helfer blendet deshalb im
+zweiten Durchgang alle Geschwister aus und steigt in jeden Zweig ab, der für
+sich allein noch überläuft. Angewendet in `e2e/horizontal-overflow.spec.ts`
+(Meldeformular, alle vier Schritte, ab 320 px).
 
 ---
 

--- a/e2e/footer-layout.spec.ts
+++ b/e2e/footer-layout.spec.ts
@@ -49,20 +49,13 @@ test.describe('Footer — Anordnung', () => {
 		expect(await gruppenZeilen(page), 'Gruppen stapeln sich, obwohl Platz da ist').toBe(1);
 	});
 
-	/* Der Auslöser des Vorgänger-Bugs: zwischen 768px und ~890px passte die
+	/* Der Auslöser des Vorgänger-Bugs — zwischen 768px und ~890px passte die
 	   Linkzeile nicht mehr, das Dokument wurde breiter als der Viewport und die
-	   ganze Seite ließ sich seitlich schieben — der Schritt-Stepper darüber
-	   wurde mit angeschnitten. */
-	test('das Dokument wird auf keiner Breite breiter als das Fenster', async ({ page }) => {
-		for (const breite of [360, 390, 640, 768, 890, 1024, 1280]) {
-			await page.setViewportSize({ width: breite, height: 900 });
-			await page.goto('/');
-			const ueberlauf = await page.evaluate(
-				() => document.documentElement.scrollWidth - document.documentElement.clientWidth
-			);
-			expect(ueberlauf, `horizontaler Überlauf bei ${breite}px`).toBeLessThanOrEqual(0);
-		}
-	});
+	   ganze Seite ließ sich seitlich schieben — wird seit dem 2026-08-04 in
+	   `e2e/horizontal-overflow.spec.ts` geprüft. Der Wächter stand hier, deckte
+	   aber nur Schritt 1 im Grundzustand ab und ließ genau deshalb einen echten
+	   Überlauf durch (Begründung im neuen Spec). Er gehört nicht mehr zum
+	   Footer: geprüft werden alle vier Schritte, aufgeklappt, ab 320px. */
 
 	/**
 	 * GitHub und „Deutsches Meeresmuseum" waren `btn btn-ghost btn-xs` und

--- a/e2e/helpers/overflow.ts
+++ b/e2e/helpers/overflow.ts
@@ -1,0 +1,199 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Horizontalen Überlauf messen — und den Verursacher benennen.
+ *
+ * Die reine Messung (`documentElement.scrollWidth - clientWidth`) sagt nur, DASS
+ * das Dokument breiter ist als das Fenster. Bei einem Befund steht man dann vor
+ * einem Baum aus tausend Elementen, von denen ein paar Dutzend die volle
+ * Dokumentbreite melden — alle mitgezogen, keines davon die Ursache.
+ *
+ * `findHorizontalOverflow` blendet deshalb Teilbäume aus und misst nach jedem
+ * Schritt neu. Auf jeder Ebene gilt:
+ *
+ * 1. Beseitigt das Ausblenden **eines** Kindes den Überlauf, steckt die Ursache
+ *    allein dort — der Abstieg geht in diesem Kind weiter.
+ * 2. Sonst wird jedes Kind einzeln geprüft, indem alle Geschwister ausgeblendet
+ *    werden: Läuft es dann immer noch über, ist es ein **eigenständiger**
+ *    Verursacher. Ohne diesen zweiten Durchgang endet der Abstieg an dem
+ *    gemeinsamen Elternelement, sobald zwei Bereiche unabhängig voneinander zu
+ *    breit sind — und man bekommt einen 320px breiten Wrapper genannt statt der
+ *    beiden Zeilen darin.
+ * 3. Qualifiziert sich kein Kind, ist der Knoten selbst das kleinste Element,
+ *    das den Überlauf erklärt.
+ *
+ * **Der Abstieg läuft nur im Fehlerfall.** Ohne Überlauf kehrt die Funktion vor
+ * dem ersten `display: none` zurück. Das ist nicht nur eine Ersparnis: In
+ * Schritt 1 steht die OpenLayers-Karte, und Aus- und Wiedereinblenden ihres
+ * Containers löst Resize-Verarbeitung aus. Ein grüner Lauf fasst die Karte
+ * deshalb nicht an; ein roter perturbiert sie, aber dann ist der Befund bereits
+ * gemessen und die Diagnose läuft ohnehin auf einen Abbruch zu.
+ *
+ * Gefunden hat dieses Verfahren die Zeile „GPS-Eingabeformat" in
+ * `LocationInput.svelte` (behoben in 8a4ef750): ein `<select>` neben seinem
+ * Label in einer Flex-Zeile, das als Flex-Item mit `min-width: auto` nicht unter
+ * die Breite seiner längsten Option schrumpft — zusammen rund 420 px harte
+ * Mindestbreite, die sich bis zum Seiten-Wrapper durchdrückte.
+ */
+
+export type OverflowVerursacher = {
+	/** Kurzbeschreibung des Elements: Tag, id, data-testid, erste Klassen. */
+	beschreibung: string;
+	/** Breite des Elements in Pixeln. */
+	breite: number;
+	/** Abstiegspfad von `<body>` bis hierher. */
+	pfad: string[];
+};
+
+export type OverflowBefund = {
+	/** Wie viele Pixel das Dokument breiter ist als das Fenster. `<= 0` heißt: kein Überlauf. */
+	ueberlauf: number;
+	/** Die kleinsten Elemente, die den Überlauf erklären — leer, wenn es keinen gibt. */
+	verursacher: OverflowVerursacher[];
+};
+
+export async function findHorizontalOverflow(page: Page): Promise<OverflowBefund> {
+	return page.evaluate(() => {
+		const wurzel = document.documentElement;
+		const messen = () => wurzel.scrollWidth - wurzel.clientWidth;
+
+		const ueberlauf = messen();
+		if (ueberlauf <= 0) return { ueberlauf, verursacher: [] };
+
+		/** Knapp, aber wiedererkennbar: Tag, id, data-testid und die ersten Klassen. */
+		const beschreiben = (element: Element): string => {
+			const id = element.id ? `#${element.id}` : '';
+			const testid = element.getAttribute('data-testid');
+			const klassen = (element.getAttribute('class') ?? '')
+				.split(/\s+/)
+				.filter(Boolean)
+				.slice(0, 4)
+				.map((klasse) => `.${klasse}`)
+				.join('');
+			return `${element.tagName.toLowerCase()}${id}${testid ? `[data-testid="${testid}"]` : ''}${klassen}`;
+		};
+
+		/** Nur Elemente mit `style`-Property lassen sich ausblenden (HTML und SVG). */
+		const stylebar = (element: Element): element is HTMLElement | SVGElement =>
+			element instanceof HTMLElement || element instanceof SVGElement;
+
+		const gemerkt = new Map<Element, string>();
+		const ausblenden = (element: HTMLElement | SVGElement) => {
+			gemerkt.set(element, element.style.display);
+			element.style.display = 'none';
+		};
+		const zuruecksetzen = (element: HTMLElement | SVGElement) => {
+			element.style.display = gemerkt.get(element) ?? '';
+			gemerkt.delete(element);
+		};
+
+		/* Obergrenzen: reine Sicherheitsnetze. Ein DOM, das 60 Ebenen tief liegt
+		   oder 8 unabhängige Überläufe hat, ist kein Testbefund mehr, sondern ein
+		   eigenes Problem — und die Suche ist pro Ebene quadratisch in der Zahl der
+		   Kinder. */
+		const MAX_TIEFE = 60;
+		const MAX_BEFUNDE = 8;
+
+		/**
+		 * Vorbedingung: Das Ausblenden von `knoten` beseitigt im aktuellen
+		 * Sichtbarkeitszustand den Überlauf — er ist also diesem Teilbaum
+		 * zuzurechnen. Der Zweig für mehrere Verursacher stellt sie für den
+		 * Abstieg eigens her, indem er die Geschwister währenddessen ausgeblendet
+		 * lässt; ohne das gälte sie ab dem ersten verzweigten Abstieg nicht mehr.
+		 */
+		const suchen = (knoten: Element, pfad: string[]): OverflowVerursacherIntern[] => {
+			const selbst = () => [
+				{
+					beschreibung: beschreiben(knoten),
+					breite: Math.round(knoten.getBoundingClientRect().width),
+					pfad
+				}
+			];
+			if (pfad.length >= MAX_TIEFE) return selbst();
+
+			const kinder = Array.from(knoten.children).filter(stylebar);
+			if (kinder.length === 0) return selbst();
+
+			/* Läuft der Knoten auch ohne jeden Inhalt über, ist seine eigene Box zu
+			   breit (feste Breite, Padding, Rahmen) — dann führt jeder Abstieg in
+			   ein Kind nur von der Ursache weg. */
+			kinder.forEach(ausblenden);
+			const ohneKinder = messen();
+			kinder.forEach(zuruecksetzen);
+			if (ohneKinder > 0) return selbst();
+
+			// 1. Ein einzelnes Kind erklärt den Überlauf allein.
+			for (const kind of kinder) {
+				ausblenden(kind);
+				// Das Lesen von `scrollWidth` erzwingt ein Layout — der Wert gilt also
+				// wirklich für den ausgeblendeten Zustand.
+				const ohneKind = messen();
+				zuruecksetzen(kind);
+				if (ohneKind <= 0) return suchen(kind, [...pfad, beschreiben(kind)]);
+			}
+
+			/* 2. Mehrere Kinder laufen unabhängig voneinander über. Bei genau einem
+			   Kind läuft dieser Zweig auf „das Kind ist es" hinaus — richtig so:
+			   Schritt 1 hat dann nur deshalb nicht gegriffen, weil anderswo im
+			   Dokument ein zweiter Überlauf steht. */
+			const ergebnisse: OverflowVerursacherIntern[] = [];
+			for (const kind of kinder) {
+				const geschwister = kinder.filter((anderes) => anderes !== kind);
+				geschwister.forEach(ausblenden);
+				if (messen() > 0) ergebnisse.push(...suchen(kind, [...pfad, beschreiben(kind)]));
+				geschwister.forEach(zuruecksetzen);
+			}
+
+			return ergebnisse.length > 0 ? ergebnisse : selbst();
+		};
+
+		type OverflowVerursacherIntern = { beschreibung: string; breite: number; pfad: string[] };
+
+		const verursacher = suchen(document.body, [beschreiben(document.body)]).slice(0, MAX_BEFUNDE);
+		return { ueberlauf, verursacher };
+	});
+}
+
+/**
+ * Behauptet, dass das Dokument nicht breiter ist als das Fenster.
+ *
+ * `kontext` beschreibt den geprüften Zustand (Breite, Schritt, aufgeklappte
+ * Bereiche) und steht in der Fehlermeldung — ohne ihn wäre bei einem Lauf über
+ * mehrere Breiten und Schritte nicht erkennbar, welcher Zustand gerissen ist.
+ */
+export async function expectNoHorizontalOverflow(page: Page, kontext: string): Promise<void> {
+	const befund = await findHorizontalOverflow(page);
+
+	const meldung =
+		befund.ueberlauf > 0
+			? [
+					`Horizontaler Überlauf bei ${kontext}: ${befund.ueberlauf}px.`,
+					...befund.verursacher.map(
+						(eintrag) =>
+							`Verursacher: ${eintrag.beschreibung} (${eintrag.breite}px breit)\n  Pfad: ${eintrag.pfad.join(' > ')}`
+					)
+				].join('\n')
+			: kontext;
+
+	expect(befund.ueberlauf, meldung).toBeLessThanOrEqual(0);
+}
+
+/**
+ * Klappt jede Disclosure im Dokument auf und liefert deren Anzahl.
+ *
+ * Der Sinn des Ganzen: Ein zugeklapptes `<details>` hat keine Layout-Box, sein
+ * Inhalt kann also nicht überlaufen — genau deshalb war der GPS-Format-Fehler
+ * jahrelang unsichtbar. Geprüft werden muss der aufgeklappte Zustand.
+ *
+ * Bewusst über alle `<details>` statt über eine Aufzählung von Test-IDs: Eine
+ * neue Disclosure ist damit automatisch mit abgedeckt. Die Bereiche, die nicht
+ * an einem `<details>` hängen, sondern an Formularwerten (Totfund, Motorfrage),
+ * schaltet der Spec einzeln.
+ */
+export async function openAllDetails(page: Page): Promise<number> {
+	return page.evaluate(() => {
+		const disclosures = Array.from(document.querySelectorAll('details'));
+		for (const disclosure of disclosures) disclosure.open = true;
+		return disclosures.length;
+	});
+}

--- a/e2e/horizontal-overflow.spec.ts
+++ b/e2e/horizontal-overflow.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test';
+import { expectNoHorizontalOverflow, openAllDetails } from './helpers/overflow';
+import { expectCurrentStep, fillStep1, fillStep2 } from './helpers/form-helpers';
+import { FormPage } from './pages/FormPage';
+import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
+
+/**
+ * horizontal-overflow.spec.ts — das Dokument darf auf keiner Breite breiter
+ * werden als das Fenster.
+ *
+ * Der Wächter stand bis zum 2026-08-04 in `footer-layout.spec.ts` und prüfte
+ * genau eine Ansicht: Schritt 1 im Grundzustand, ab 360px. Damit hat er den
+ * bisher einzigen echten Überlauf **nicht** gefunden — die Zeile
+ * „GPS-Eingabeformat" in `LocationInput.svelte` lag hinter einem zugeklappten
+ * `<details>` und hatte gar keine Layout-Box. Ein zugeklappter Bereich kann
+ * nicht überlaufen; der Test war aus dem falschen Grund grün, bis die
+ * Koordinateneingabe dauerhaft sichtbar wurde (8a4ef750). Auf 360px lief das
+ * Dokument dann um 109px über.
+ *
+ * Daraus folgen die drei Erweiterungen:
+ * - **alle vier Schritte**, nicht nur der erste,
+ * - **aufgeklappte Bereiche** — jede Disclosure offen, dazu die Blöcke, die an
+ *   Formularwerten hängen (Totfund, Motorfrage),
+ * - **ab 320px**, der realistischen Untergrenze.
+ *
+ * Bei einem Befund nennt `expectNoHorizontalOverflow` das kleinste Element,
+ * dessen Ausblenden den Überlauf beseitigt (Verfahren siehe
+ * `helpers/overflow.ts`) — die nackte Pixelzahl von früher taugte zum
+ * Diagnostizieren nicht.
+ */
+
+/* 320px ist die schmalste realistisch bediente Breite (iPhone SE 1. Gen. /
+   Android-Kleingeräte), 890px die Breite, bei der der Vorgänger-Bug im Footer
+   aufschlug. */
+const BREITEN = [320, 360, 390, 640, 768, 890, 1024, 1280];
+
+test.describe('Layout — horizontaler Überlauf', () => {
+	/* Ein Lauf geht durch alle vier Schritte und baut dabei die Karte auf; die
+	   30s des Projekt-Defaults reichen dafür auf einem kalten Dev-Server nicht. */
+	test.setTimeout(90_000);
+
+	for (const breite of BREITEN) {
+		test(`kein Überlauf auf ${breite}px — alle Schritte, alles aufgeklappt`, async ({ page }) => {
+			await page.setViewportSize({ width: breite, height: 900 });
+			const formPage = new FormPage(page);
+			await formPage.goto();
+
+			// ── Schritt 1: Position & Zeitpunkt ────────────────────────────────
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 1`);
+
+			/* Die Foto-Disclosure wird ausdrücklich einzeln erwartet: `openAllDetails`
+			   arbeitet über alle `<details>` und bliebe still, wenn ausgerechnet
+			   dieser Bereich verschwindet oder seine Test-ID verliert. */
+			const fotoDisclosure = page.locator('[data-testid="photo-position-disclosure"]');
+			await expect(fotoDisclosure).toBeAttached();
+
+			await openAllDetails(page);
+			await expect(fotoDisclosure).toHaveAttribute('open', '');
+			// Ortsbeschreibung — ohne Koordinaten von Anfang an offen, hier nur belegt.
+			await expect(page.locator('[data-testid="field-waterway"]')).toBeVisible();
+			await expect(page.locator('[data-testid="photo-position-card"]')).toBeVisible();
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 1, alles aufgeklappt`);
+
+			// ── Schritt 2: Angaben zum Tier ────────────────────────────────────
+			await fillStep1(formPage);
+			await formPage.clickNext();
+			await expectCurrentStep(page, /Angaben zum Tier/i);
+
+			await openAllDetails(page);
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 2`);
+
+			/* Totfund-Block und Motorfrage sind an Formularwerte gebunden, nicht an
+			   ein `<details>` — sie existieren im Grundzustand gar nicht im DOM. */
+			await fillStep2(formPage);
+			await page.locator('[data-testid="field-isDead"]').check();
+			await formPage.selectSightingFrom(SightingFromEnum.MOTORBOAT);
+			await expect(page.locator('[data-testid="field-deadCondition"]')).toBeVisible();
+			await expect(page.locator('[data-testid="field-boatDrive-1"]')).toBeVisible();
+			await openAllDetails(page);
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 2, Totfund + Motorfrage`);
+
+			/* Zurück in den gültigen Zustand: `deadCondition` und `boatDrive` sind in
+			   dieser Kombination Pflicht und hielten den Schritt sonst fest. */
+			await page.locator('[data-testid="field-isDead"]').uncheck();
+			await formPage.selectSightingFrom(SightingFromEnum.LAND);
+
+			// ── Schritt 3: Weitere Informationen ───────────────────────────────
+			await formPage.clickNext();
+			await expectCurrentStep(page, /Weitere Informationen/i);
+
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 3`);
+			await openAllDetails(page);
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 3, alles aufgeklappt`);
+
+			// ── Schritt 4: Kontaktdaten ────────────────────────────────────────
+			await formPage.clickNext();
+			await expectCurrentStep(page, /Kontaktdaten/i);
+
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 4`);
+			await openAllDetails(page);
+			await expectNoHorizontalOverflow(page, `${breite}px · Schritt 4, alles aufgeklappt`);
+		});
+	}
+
+	/**
+	 * Dieselbe Prüfung ohne Silbentrennung.
+	 *
+	 * Die Feld-Beschriftungen tragen `hyphens: auto` (`FieldRenderer.svelte`,
+	 * `BaseToggle.svelte`, …). Chromes Trennmuster kommen aus Wörterbüchern, die
+	 * auf Headless-CI-Images fehlen können — dort ist `hyphens: auto` still
+	 * wirkungslos und die Mindestbreite jedes Labels wächst auf sein längstes
+	 * Wort. Ohne diesen Test wäre der Unterschied zwischen „hier grün" und „in CI
+	 * rot" nicht sichtbar: Auf macOS trennt die Engine immer.
+	 *
+	 * Gemessen hat er sich bezahlt gemacht — mit dem damaligen `break-word` lief
+	 * Schritt 3 auf 320px um 11px über, obwohl derselbe Zustand mit Trennung
+	 * grün war.
+	 */
+	test('kein Überlauf auf 320px, auch ohne Silbentrennung', async ({ page }) => {
+		const ohneTrennung = '* { hyphens: manual !important; -webkit-hyphens: manual !important; }';
+
+		await page.setViewportSize({ width: 320, height: 900 });
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		/* Nach jedem Schrittwechsel neu: Der Schritt-Inhalt wird ausgetauscht, das
+		   `<style>`-Tag bleibt zwar im `<head>`, aber ein zweiter Aufruf kostet
+		   nichts und macht die Reihenfolge unabhängig von dieser Annahme. */
+		await page.addStyleTag({ content: ohneTrennung });
+		await openAllDetails(page);
+		await expectNoHorizontalOverflow(page, '320px ohne Silbentrennung · Schritt 1');
+
+		await fillStep1(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Angaben zum Tier/i);
+		await page.addStyleTag({ content: ohneTrennung });
+		await openAllDetails(page);
+		await expectNoHorizontalOverflow(page, '320px ohne Silbentrennung · Schritt 2');
+
+		await fillStep2(formPage);
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Weitere Informationen/i);
+		await page.addStyleTag({ content: ohneTrennung });
+		await openAllDetails(page);
+		await expectNoHorizontalOverflow(page, '320px ohne Silbentrennung · Schritt 3');
+
+		await formPage.clickNext();
+		await expectCurrentStep(page, /Kontaktdaten/i);
+		await page.addStyleTag({ content: ohneTrennung });
+		await openAllDetails(page);
+		await expectNoHorizontalOverflow(page, '320px ohne Silbentrennung · Schritt 4');
+	});
+});

--- a/src/app.css
+++ b/src/app.css
@@ -178,6 +178,50 @@ body {
 	font-size: var(--text-body);
 }
 
+/* Feld-Beschriftungen dürfen umbrechen.
+
+   DaisyUI gibt `.label` ein `white-space: nowrap`. Das passt zu kurzen
+   Beschriftungen neben einem Eingabefeld — die Beschriftungen hier sind aber
+   ganze Fragen („Von wo aus wurde die Sichtung gemacht?", aus `.label()` im
+   Yup-Schema), dazu Pflicht-Sternchen und Hilfe-Schaltfläche in derselben
+   Zeile. Ohne Umbruch ist die Mindestbreite eines Felds damit die Breite seines
+   längsten Satzes: gemessen 309px für die Frage oben, plus 48px Karten- und
+   48px Seitenpolster.
+
+   Sichtbar wird das als Überlauf des ganzen Dokuments, nicht als abgeschnittene
+   Beschriftung: Der Seiten-Wrapper ist ein Flex-Item mit `mx-auto`, und ein
+   Flex-Item mit automatischem Rand streckt sich nicht auf die Containerbreite,
+   sondern auf seinen Inhalt. Die Mindestbreite des breitesten Labels drückt
+   sich so bis zum `<html>` durch — auf 320px um 48px, auf 360px um 8px. Gefunden
+   von `e2e/horizontal-overflow.spec.ts`.
+
+   `anywhere` und nicht `break-word`: Nur `anywhere` senkt auch die
+   **Mindest**breite, und genau die ist hier das Problem. Sichtbar wird der
+   Unterschied erst ohne Silbentrennung: `FieldRenderer` und `BaseToggle` geben
+   dem Beschriftungstext `hyphens: auto` mit, und Chromes Trennmuster hängen an
+   Wörterbüchern, die auf Headless-CI-Images fehlen können. Nachgestellt (alle
+   Elemente auf `hyphens: manual`) läuft Schritt 3 auf 320px mit `break-word`
+   um 11px über, mit `anywhere` nicht. Eine Layoutgrenze darf nicht davon
+   abhängen, ob ein Trennmuster-Wörterbuch installiert ist.
+
+   Im Normalfall ist der Unterschied unsichtbar: Trennstellen aus `hyphens: auto`
+   werden zuerst genutzt, `anywhere` greift erst, wenn ein Wort auch dann nicht
+   passt.
+
+   Die Regel gilt bewusst app-weit und nicht nur für das Meldeformular: Sie
+   erreicht rund 40 Fundstellen, darunter die Admin-Filter, die Karten-Panels und
+   `/styleguide`. Die Admin-Maske läuft über dieselbe Feld-Pipeline und trägt
+   dieselben langen Beschriftungen — eine Eingrenzung auf `/` würde ausgerechnet
+   das Formular auslassen, in dem sie korrigiert werden. Für kurze Labels
+   („Zeitraum von") ändert sich nichts, solange ihre Spalte breit genug ist;
+   `anywhere` bricht erst, wenn sonst nichts mehr geht. Abgesichert ist bisher
+   nur `/` (`e2e/horizontal-overflow.spec.ts`) — Admin und Karte sind auf 320px
+   ungeprüft. */
+.label {
+	white-space: normal;
+	overflow-wrap: anywhere;
+}
+
 /* ===== Einbettungs-Modi =====
    Vorher ein Boolean (isNotIFrame). Drei benannte Modi machen die Absicht
    lesbar und erlauben eine serverseitige Entscheidung über data-embed. */

--- a/src/lib/report/components/form/fields/BaseCheckbox.svelte
+++ b/src/lib/report/components/form/fields/BaseCheckbox.svelte
@@ -73,7 +73,7 @@
 		/>
 		<span
 			class="min-w-0 flex-1 text-left font-medium"
-			style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
+			style="overflow-wrap: anywhere; hyphens: auto;"
 		>
 			{label}
 			{#if required}

--- a/src/lib/report/components/form/fields/BaseToggle.svelte
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte
@@ -73,7 +73,7 @@
 		/>
 		<span
 			class="min-w-0 flex-1 text-left font-medium"
-			style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
+			style="overflow-wrap: anywhere; hyphens: auto;"
 		>
 			{label}
 			{#if required}

--- a/src/lib/report/components/form/fields/Checkbox.svelte
+++ b/src/lib/report/components/form/fields/Checkbox.svelte
@@ -25,14 +25,14 @@
 		<div class="min-w-0 flex-1 text-left">
 			<span
 				class="font-medium"
-				style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
+				style="overflow-wrap: anywhere; hyphens: auto;"
 			>
 				{label}
 			</span>
 			{#if helpText}
 				<p
 					class="text-base-content/60 mt-1 text-left text-xs"
-					style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
+					style="overflow-wrap: anywhere; hyphens: auto;"
 				>
 					{helpText}
 				</p>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -305,11 +305,15 @@
 </script>
 
 <!-- Caption-Inhalt (Label-Text, Pflichtfeld-Markierung, Status, Info-Tooltip) -->
+<!-- `overflow-wrap: anywhere` statt des früheren `break-word` (ebenso in
+     BaseCheckbox, BaseToggle und Checkbox): Nur `anywhere` senkt die
+     Mindestbreite des Textes und macht das Layout damit unabhängig davon, ob
+     `hyphens: auto` greift. Chromes Trennmuster hängen an Wörterbüchern, die auf
+     Headless-CI-Images fehlen — nachgestellt lief Schritt 3 auf 320px sonst um
+     11px über. Ausführliche Begründung am `.label`-Block in `src/app.css`;
+     abgesichert durch `e2e/horizontal-overflow.spec.ts`. -->
 {#snippet caption()}
-	<span
-		class="text-base-content block font-medium"
-		style="word-wrap: break-word; overflow-wrap: break-word; hyphens: auto;"
-	>
+	<span class="text-base-content block font-medium" style="overflow-wrap: anywhere; hyphens: auto;">
 		<!-- Feld-Icon der Radiogruppe. BaseInput und BaseSelect setzen es links
 		     ins Control; eine Radiogruppe hat kein solches Control, also steht es
 		     hier an der Legende — einmal pro Feld, nicht einmal pro Option. -->
@@ -345,7 +349,8 @@
 		     Damit das trägt, darf am Label/Legend kein `overflow-hidden` stehen:
 		     es klippt nicht nur den überstehenden Teil der Trefferfläche, sondern
 		     auch die Tooltip-Blase selbst. Horizontal hält `w-full` zusammen mit
-		     dem `overflow-wrap: break-word` der Caption-Span. -->
+		     dem `overflow-wrap` der Caption-Span (seit 2026-08-04 `anywhere`,
+		     Begründung dort). -->
 		{#if metaValues.valueText}
 			<span class="tooltip tooltip-left ml-2 inline-block" data-tip={metaValues.valueText}>
 				<button

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -105,9 +105,13 @@
 		<Icon icon="lucide:mail" width="20" class="text-info-strong" aria-hidden="true" />
 		<span class="text-sm">
 			Ist eine Aufnahme zu groß für den Upload? Senden Sie die Meldung trotzdem ab und schicken Sie
-			die Datei anschließend an <a class="link" href="mailto:{MEDIA_FALLBACK_EMAIL}"
-				>{MEDIA_FALLBACK_EMAIL}</a
-			>.
+			<!-- `wrap-anywhere`: Die Adresse ist ein einziges Wort von 207px und damit
+			     die Mindestbreite dieses Alerts. Auf 320px schob sie das Dokument um
+			     60px über den Fensterrand hinaus (`e2e/horizontal-overflow.spec.ts`) —
+			     ein Alert kann seinem Inhalt nicht ausweichen, und der Seiten-Wrapper
+			     wächst als Flex-Item mit `mx-auto` mit. -->
+			die Datei anschließend an
+			<a class="link wrap-anywhere" href="mailto:{MEDIA_FALLBACK_EMAIL}">{MEDIA_FALLBACK_EMAIL}</a>.
 		</span>
 	</div>
 </SectionCard>

--- a/src/lib/report/components/sections/SectionCard.svelte
+++ b/src/lib/report/components/sections/SectionCard.svelte
@@ -28,7 +28,19 @@
 {#if variant === 'card'}
 	<div class="card bg-base-200 shadow-raised">
 		<div class="card-body">
-			<h3 class="card-title text-section flex items-center gap-2">
+			<!-- `wrap-anywhere`: Der Titel steht als anonymes Flex-Item neben dem
+			     Icon und kann deshalb nicht unter seine Mindestbreite schrumpfen.
+			     „Boot-/Schiffsinformationen" misst so 229px und drückte die ganze
+			     Seite auf 320px um 60px auseinander — der Seiten-Wrapper ist ein
+			     Flex-Item mit `mx-auto` und wächst mit seinem Inhalt statt mit dem
+			     Fenster. `wrap-anywhere` senkt die Mindestbreite auf ein Zeichen;
+			     gebrochen wird trotzdem nur, wenn der Titel sonst nicht passt (ab
+			     360px also gar nicht). `hyphens: auto` allein würde hier nicht
+			     genügen: Chromes Trennmuster hängen an Wörterbüchern, die auf
+			     Headless-CI-Images fehlen können, und eine Layoutgrenze darf davon
+			     nicht abhängen (dieselbe Begründung wie am `.label`-Block in
+			     `src/app.css`). Gefunden von `e2e/horizontal-overflow.spec.ts`. -->
+			<h3 class="card-title text-section flex items-center gap-2 wrap-anywhere">
 				<Icon {icon} width="20" class="text-primary" aria-hidden="true" />
 				{title}
 			</h3>
@@ -37,7 +49,8 @@
 	</div>
 {:else}
 	<div class="border-base-300 bg-base-200/50 rounded-box border p-3 md:p-4">
-		<h3 class="text-section mb-3 flex items-center gap-2 font-semibold">
+		<!-- `wrap-anywhere` wie in der `card`-Variante oben. -->
+		<h3 class="text-section mb-3 flex items-center gap-2 font-semibold wrap-anywhere">
 			<Icon {icon} width="20" class="text-primary" aria-hidden="true" />
 			{title}
 		</h3>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -957,9 +957,10 @@
 								</td>
 							{/if}
 							{#if columnVisibility.verified}
-								<!-- whitespace-nowrap: BaseToggle gibt seinem Label `overflow-wrap: break-word`
-								     und `hyphens: auto` mit — im Formular richtig, hier nicht: Die Tabelle
-								     staucht die Spalte damit unter die Wortbreite und trennt „Ge-/prüft".
+								<!-- whitespace-nowrap: BaseToggle gibt seinem Label `overflow-wrap: anywhere`
+								     und `hyphens: auto` mit (bis 2026-08-04 `break-word`) — im Formular
+								     richtig, hier nicht: Die Tabelle staucht die Spalte damit unter die
+								     Wortbreite und trennt „Ge-/prüft".
 								     Die Sperre steht an der Zelle und nicht in der Komponente, damit lange
 								     Labels in der Bearbeitungsmaske weiter umbrechen dürfen. -->
 								<td class="whitespace-nowrap">


### PR DESCRIPTION
## Warum

`e2e/footer-layout.spec.ts` prüfte, dass das Dokument nie breiter wird als das Fenster — und hat den bisher einzigen echten Überlauf trotzdem nicht gefunden: Die Zeile „GPS-Eingabeformat" lag hinter einem zugeklappten `<details>` und hatte gar keine Layout-Box. Ein zugeklappter Bereich kann nicht überlaufen; der Test war aus dem falschen Grund grün.

Dieser PR erweitert den Wächter auf alle vier Schritte, aufgeklappte Bereiche und 320px — und behebt die drei Überläufe, die dabei herauskamen.

## Gemeinsame Ursache

Der Seiten-Wrapper ist ein Flex-Item mit `mx-auto`, und ein Flex-Item mit automatischem Rand streckt sich nicht auf die Containerbreite, sondern auf seinen Inhalt. Die Mindestbreite von irgendetwas im Formular drückt damit bis zum `<html>` durch, und die Seite lässt sich seitlich schieben.

## Die drei Befunde

| # | Fundstelle | Wirkung |
| - | ---------- | ------- |
| 1 | DaisyUIs `.label` mit `white-space: nowrap` — die Beschriftungen hier sind ganze Fragen („Von wo aus wurde die Sichtung gemacht?" = 309px) | Schritt 2: 48px auf 320px, 8px auf 360px |
| 2 | „Boot-/Schiffsinformationen" als anonymes Flex-Item neben seinem Icon; `sichtungen@meeresmuseum.de` als ein 207px-Wort im Alert | Schritt 3: 60px auf 320px |
| 3 | Abhängigkeit von `hyphens: auto` — Chromes Trennmuster kommen aus Wörterbüchern, die auf Headless-CI-Images fehlen können | Schritt 3 ohne Trennung: 11px auf 320px |

Zu (1): Die Regel gilt bewusst app-weit. Die Admin-Maske läuft über dieselbe Feld-Pipeline und trägt dieselben langen Beschriftungen — eine Eingrenzung auf `/` würde ausgerechnet das Formular auslassen, in dem sie korrigiert werden.

Zu (3): Deshalb `overflow-wrap: anywhere` statt `break-word` — nur `anywhere` senkt auch die **Mindest**breite. Wo Silbentrennung funktioniert, ändert sich nichts: Deren Trennstellen werden zuerst genutzt.

## Der neue Wächter

`e2e/horizontal-overflow.spec.ts` + `e2e/helpers/overflow.ts`. Pro Breite (320, 360, 390, 640, 768, 890, 1024, 1280) ein Durchlauf durch alle vier Schritte, jeweils im Grundzustand und mit **jedem** `<details>` geöffnet; Totfund-Block und Motorfrage werden über die Formularwerte geschaltet. Dazu ein Lauf mit abgeschalteter Silbentrennung, damit der Unterschied zwischen „hier grün" und „in CI rot" nicht unsichtbar bleibt.

Bei einem Befund nennt die Meldung den Verursacher statt einer nackten Pixelzahl — `findHorizontalOverflow` blendet Teilbäume aus und misst neu, und steigt in den ab, dessen Ausblenden den Überlauf beseitigt. Der zweite Durchgang (alle Geschwister ausblenden) ist nötig, um bei zwei unabhängig zu breiten Bereichen nicht am gemeinsamen Elternelement zu enden.

Gegenprobe mit zurückgedrehtem `8a4ef750`:

```
Horizontaler Überlauf bei 320px · Schritt 1: 31px.
Verursacher: select#gps-format.select.ml-auto.w-auto (191px breit)
  Pfad: body > … > div.card.bg-base-200 > … > select#gps-format
```

Der Abstieg läuft nur im Fehlerfall — ein grüner Lauf fasst die OpenLayers-Karte auf Schritt 1 nicht an.

## Geprüft

- `CI=1 npx playwright test --project=chromium` → **329 passed**
- `npm run test:quick` → 3472 Unit-Tests grün
- Optisch auf 320px und 390px (Schritt 2 und 3): auf 390px bricht nichts um, auf 320px umbrechen Titel und Mailadresse sauber

## Offen

Admin und Karte sind auf 320px weiterhin ungeprüft — der Spec fährt nur `/`. Im `.label`-Block in `src/app.css` als Grenze notiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)