### PR TITLE
fix(a11y): move radio group aria-invalid/aria-required to the group

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -334,6 +334,24 @@ Das Formular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, mit 
 - Labels statt Platzhaltertexte. Ein `placeholder` ist Beispiel, nie Ersatz für das Label.
 - Dekorative Icons bekommen `aria-hidden="true"`; informationstragende Icons brauchen ein `aria-label` am fokussierbaren Element.
 - Radiogruppen als `fieldset`/`legend`, nicht als `label[for]` auf mehrere Inputs.
+- **`aria-invalid` und `aria-required` einer Radiogruppe gehören an die Gruppe, nicht an die
+  einzelnen Radios.** ARIA 1.2 hat beide aus den globalen Zuständen entfernt; `role="radio"`
+  unterstützt sie seither nicht — `svelte-check` meldet sie am `<input type="radio">` als
+  a11y-Warnung. Getragen werden sie vom `fieldset`, das dafür seine implizite Rolle `group`
+  (die sie ebenfalls nicht unterstützt) mit `role="radiogroup"` überschreibt und sich per
+  `aria-labelledby` an seiner Legend benennt. So umgesetzt in `FieldRenderer.svelte`.
+
+  Das ist die Ausnahme von der Regel „Pflicht-Sternchen und `aria-required` aus derselben
+  Variable": Dieselbe Variable, aber zwei Elemente — Sternchen in der Caption, `aria-required`
+  am fieldset. Den Fehler-**Zustand** bekommen die Radios trotzdem, nur als Optik über
+  `hasError` → `radio-error` (`BaseRadio.svelte`). Die native `required`-Angabe bleibt am
+  Input: sie ist dort gültig und trägt die Constraint-Validierung.
+
+  `radio-error`/`radio-success` **ersetzen** dabei `radio-primary`, sie ergänzen es nicht —
+  alle drei setzen dieselbe DaisyUI-Variable (`--input-color`) auf derselben Ebene und mit
+  derselben Spezifität. Stünden zwei am Element, entschiede die Reihenfolge im
+  DaisyUI-Stylesheet statt der im `class`-Attribut.
+
 - Fehlermeldungen mit `role="alert"` und `aria-live="polite"`, referenziert über `aria-describedby` — und nur dann referenziert, wenn das Element tatsächlich gerendert ist.
 
 ---

--- a/src/lib/report/components/form/fields/BaseRadio.svelte
+++ b/src/lib/report/components/form/fields/BaseRadio.svelte
@@ -14,6 +14,8 @@
 		value?: string | number;
 		options?: FieldOption[];
 		size?: FieldSize;
+		hasError?: boolean;
+		isValid?: boolean;
 		onchange?: (event: Event) => void;
 		// Common input attributes
 		id?: string;
@@ -28,6 +30,8 @@
 		value = $bindable(),
 		options = [],
 		size = 'md',
+		hasError = false,
+		isValid = false,
 		onchange = undefined,
 		id,
 		name,
@@ -40,10 +44,17 @@
 	let hasOptions = $derived(options && options.length > 0);
 
 	// Dynamic CSS classes
+	//
+	// Der Zustand ersetzt `radio-primary`, er ergänzt es nicht: Alle drei Klassen
+	// setzen dieselbe DaisyUI-Variable (`--input-color`) auf derselben Ebene und
+	// mit derselben Spezifität. Stünden zwei davon am Element, entschiede die
+	// Reihenfolge im DaisyUI-Stylesheet, welche gewinnt — nicht die im
+	// `class`-Attribut. Aufbau deshalb wie `stateClass` in BaseInput/BaseSelect.
 	let radioClasses = $derived.by(() => {
-		const base = 'radio radio-primary';
+		const base = 'radio';
+		const stateClass = hasError ? 'radio-error' : isValid ? 'radio-success' : 'radio-primary';
 		const sizeClass = size === 'sm' ? 'radio-sm' : size === 'lg' ? 'radio-lg' : '';
-		return [base, sizeClass].filter(Boolean).join(' ');
+		return [base, stateClass, sizeClass].filter(Boolean).join(' ');
 	});
 </script>
 
@@ -53,6 +64,13 @@
 			<label
 				class="hover:bg-base-200/50 flex cursor-pointer justify-start gap-3 rounded-lg py-2 transition-colors"
 			>
+				<!-- Kein `aria-invalid`/`aria-required` am einzelnen Radio: ARIA 1.2 hat beide
+				     aus den globalen Zuständen genommen, und `role="radio"` (hier implizit)
+				     unterstützt sie nicht — `svelte-check` meldet das als a11y-Warnung.
+				     Getragen werden sie von der Gruppe, dem `fieldset[role="radiogroup"]`
+				     in `FieldRenderer`. Der Fehler-Zustand kommt hier nur als Optik an
+				     (`radio-error`), die native `required`-Angabe bleibt für die
+				     Constraint-Validierung. -->
 				<input
 					type="radio"
 					name={name || id || `radio-group-${index}`}

--- a/src/lib/report/components/form/fields/BaseRadio.svelte.test.ts
+++ b/src/lib/report/components/form/fields/BaseRadio.svelte.test.ts
@@ -12,6 +12,10 @@ import { PUBLIC_BOAT_DRIVE_OPTIONS } from '$lib/report/formOptions/boatDrive';
 describe('BaseRadio', () => {
 	const options = PUBLIC_BOAT_DRIVE_OPTIONS;
 
+	function radiosOf(container: HTMLElement): HTMLInputElement[] {
+		return Array.from(container.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+	}
+
 	describe('Optionsliste', () => {
 		it('rendert einen Radio-Input pro Option', async () => {
 			const screen = render(BaseRadio, { options, name: 'boatDrive' });
@@ -78,6 +82,142 @@ describe('BaseRadio', () => {
 			} as never);
 
 			expect(screen.container.querySelectorAll('svg')).toHaveLength(0);
+		});
+	});
+
+	/**
+	 * `aria-invalid` und `aria-required` gehören NICHT an das einzelne Radio.
+	 * ARIA 1.2 hat beide aus den globalen Zuständen entfernt; unterstützt werden
+	 * sie von `role="radiogroup"`, nicht von `role="radio"` — `svelte-check`
+	 * meldet die Attribute am `<input type="radio">` als a11y-Warnung.
+	 *
+	 * Getragen werden sie deshalb vom `fieldset[role="radiogroup"]` in
+	 * `FieldRenderer` (dort getestet). Dieser Test hält die Entscheidung fest,
+	 * damit sie nicht in gutem Glauben wieder an die Inputs wandert.
+	 */
+	describe('ARIA-Zustände liegen an der Gruppe, nicht am einzelnen Radio', () => {
+		it('setzt kein aria-invalid am Input, auch nicht bei hasError', async () => {
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				'data-testid': 'field-boatDrive',
+				hasError: true
+			});
+
+			const radios = radiosOf(screen.container);
+			expect(radios).toHaveLength(options.length);
+			radios.forEach((radio) => {
+				expect(radio.hasAttribute('aria-invalid')).toBe(false);
+			});
+		});
+
+		it('setzt kein aria-required am Input, auch nicht bei required', async () => {
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				'data-testid': 'field-boatDrive',
+				required: true
+			});
+
+			const radios = radiosOf(screen.container);
+			expect(radios).toHaveLength(options.length);
+			radios.forEach((radio) => {
+				expect(radio.hasAttribute('aria-required')).toBe(false);
+			});
+		});
+
+		/**
+		 * Die native `required`-Angabe bleibt: Sie ist auf `<input type="radio">`
+		 * gültig, trägt die Constraint-Validierung und wird vom Browser ohnehin
+		 * als „required" in den Accessibility-Baum gemappt.
+		 */
+		it('behält die native required-Angabe am Input', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive', required: true });
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.required).toBe(true);
+			});
+		});
+
+		it('reicht aria-describedby an jedes Radio durch', async () => {
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				'aria-describedby': 'field-boatDrive-error'
+			});
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.getAttribute('aria-describedby')).toBe('field-boatDrive-error');
+			});
+		});
+	});
+
+	/**
+	 * DaisyUI hat für Radios kein `input-error`-Äquivalent im Wortsinn, wohl aber
+	 * `radio-error`. Die Klasse setzt dieselbe Variable wie `radio-primary`
+	 * (`--input-color`), auf derselben Ebene und mit derselben Spezifität —
+	 * stünden beide am Element, entschiede die Reihenfolge im Stylesheet und
+	 * nicht die im `class`-Attribut. Der Zustand muss deshalb GENAU EINE der
+	 * Klassen emittieren, analog zum `stateClass` in `BaseInput`/`BaseSelect`.
+	 */
+	describe('Fehler-Optik', () => {
+		it('nutzt radio-error statt radio-primary bei hasError', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive', hasError: true });
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.classList.contains('radio-error')).toBe(true);
+				expect(radio.classList.contains('radio-primary')).toBe(false);
+			});
+		});
+
+		it('nutzt radio-success statt radio-primary bei isValid', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive', isValid: true });
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.classList.contains('radio-success')).toBe(true);
+				expect(radio.classList.contains('radio-primary')).toBe(false);
+			});
+		});
+
+		it('bleibt ohne Zustand auf radio-primary', async () => {
+			const screen = render(BaseRadio, { options, name: 'boatDrive' });
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.classList.contains('radio-primary')).toBe(true);
+				expect(radio.classList.contains('radio-error')).toBe(false);
+				expect(radio.classList.contains('radio-success')).toBe(false);
+			});
+		});
+
+		it('zeigt den Fehler-Zustand auch dann, wenn isValid gleichzeitig gesetzt ist', async () => {
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				hasError: true,
+				isValid: true
+			});
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.classList.contains('radio-error')).toBe(true);
+				expect(radio.classList.contains('radio-success')).toBe(false);
+			});
+		});
+	});
+
+	/** Die Größen-Klasse darf durch den Zustands-Zweig nicht verloren gehen. */
+	describe('Größen', () => {
+		it('behält die Größen-Klasse neben dem Fehler-Zustand', async () => {
+			const screen = render(BaseRadio, {
+				options,
+				name: 'boatDrive',
+				size: 'sm' as const,
+				hasError: true
+			});
+
+			radiosOf(screen.container).forEach((radio) => {
+				expect(radio.classList.contains('radio-sm')).toBe(true);
+				expect(radio.classList.contains('radio-error')).toBe(true);
+			});
 		});
 	});
 });

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -215,6 +215,7 @@
 	let helpId = $derived(`${fieldId}-help`);
 	let errorId = $derived(`${fieldId}-error`);
 	let descriptionId = $derived(`${fieldId}-desc`);
+	let legendId = $derived(`${fieldId}-legend`);
 
 	// ARIA attributes
 	let ariaDescribedBy = $derived.by(() => {
@@ -273,16 +274,24 @@
 		return props;
 	});
 
+	// Die beiden ARIA-Zustände trägt das `fieldset[role="radiogroup"]`, nicht das
+	// einzelne Radio (Begründung am fieldset im Markup). Sie werden hier bewusst
+	// wieder entfernt, damit sie nicht als tote Props an `BaseRadio` gehen — genau
+	// dort sind sie vorher still verschwunden, weil die Komponente sie nie annahm.
 	let radioProps = $derived.by(() => {
 		// Ohne `icon`: Eine Radiogruppe hat kein einzelnes Control, an dem das
 		// Feld-Icon sitzen könnte — es steht deshalb an der Legende (siehe
 		// caption-Snippet). `BaseRadio` würde es sonst pro Option ausgeben.
-		const { icon: _icon, ...withoutIcon } = commonFieldProps;
-		const props = {
-			...withoutIcon,
+		const {
+			icon: _icon,
+			'aria-invalid': _ariaInvalid,
+			'aria-required': _ariaRequired,
+			...rest
+		} = commonFieldProps;
+		return {
+			...rest,
 			options: metaValues.options ?? []
 		};
-		return props;
 	});
 
 	let checkboxProps = $derived.by(() => {
@@ -393,9 +402,27 @@
 
 <div class={containerClasses}>
 	{#if isRadioGroup}
-		<!-- Radiogruppe: fieldset+legend statt label[for], das ins Leere zeigen würde -->
-		<fieldset class="w-full">
-			<legend class="label w-full pb-1">{@render caption()}</legend>
+		<!-- Radiogruppe: fieldset+legend statt label[for], das ins Leere zeigen würde.
+
+		     `role="radiogroup"` überschreibt die implizite Rolle `group` des
+		     fieldset — nur die Radiogruppe unterstützt `aria-invalid` und
+		     `aria-required`. Beide gehören hierher und NICHT an die einzelnen
+		     Radios: ARIA 1.2 hat sie aus den globalen Zuständen genommen, seither
+		     unterstützt `role="radio"` sie nicht mehr (`svelte-check` meldet es).
+		     Der Fehler-Zustand erreicht die Radios stattdessen als Optik über
+		     `hasError` → `radio-error` in `BaseRadio`.
+
+		     Das `aria-labelledby` auf die Legend ist bewusst explizit: Die
+		     Namensgebung aus dem `<legend>` hängt am fieldset-Element, und mit
+		     überschriebener Rolle ist sie nicht mehr selbstverständlich. -->
+		<fieldset
+			class="w-full"
+			role="radiogroup"
+			aria-labelledby={legendId}
+			aria-invalid={hasError || undefined}
+			aria-required={required || undefined}
+		>
+			<legend id={legendId} class="label w-full pb-1">{@render caption()}</legend>
 			{@render description()}
 			{@render fieldControl()}
 		</fieldset>

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -303,6 +303,136 @@ describe('FieldRenderer', () => {
 			});
 		});
 
+		/**
+		 * Die ARIA-Zustände der Radiogruppe liegen am `fieldset`, nicht an den
+		 * einzelnen Radios: ARIA 1.2 hat `aria-invalid`/`aria-required` aus den
+		 * globalen Zuständen genommen, `role="radio"` unterstützt sie seither
+		 * nicht mehr. Damit das fieldset sie tragen darf, überschreibt es seine
+		 * implizite Rolle `group` mit `radiogroup`.
+		 *
+		 * Ein Test an `BaseRadio` allein bemerkt nicht, wenn `FieldRenderer`
+		 * aufhört, den Zustand zu setzen — deshalb steht das hier.
+		 */
+		it('macht das fieldset zur radiogroup und benennt es über die Legend', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			const group = screen.container.querySelector('fieldset');
+			expect(group?.getAttribute('role')).toBe('radiogroup');
+
+			const legend = screen.container.querySelector('legend');
+			expect(legend?.id).toBeTruthy();
+			expect(group?.getAttribute('aria-labelledby')).toBe(legend?.id);
+		});
+
+		it('setzt aria-invalid=true an der Radiogruppe, wenn ein Fehler anliegt', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions,
+				error: 'Bitte wählen Sie den Bootsantrieb aus.'
+			});
+
+			expect(screen.container.querySelector('fieldset')?.getAttribute('aria-invalid')).toBe('true');
+		});
+
+		it('setzt kein aria-invalid an der Radiogruppe ohne Fehler', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			expect(screen.container.querySelector('fieldset')?.getAttribute('aria-invalid')).not.toBe(
+				'true'
+			);
+		});
+
+		it('setzt aria-required=true an der Radiogruppe (Schema-Pflichtfeld)', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions
+			});
+
+			expect(screen.container.querySelector('fieldset')?.getAttribute('aria-required')).toBe(
+				'true'
+			);
+		});
+
+		/**
+		 * Sternchen und `aria-required` müssen laut `design-system.md` aus
+		 * derselben Variable kommen. Vorher rendete die Caption das Sternchen,
+		 * während die Gruppe kein `aria-required` trug — genau das Driften, das
+		 * die Regel verbietet.
+		 */
+		it('hält Pflicht-Sternchen und aria-required der Radiogruppe zusammen', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions,
+				required: false
+			});
+
+			expect(screen.container.querySelector('[aria-label="Pflichtfeld"]')).toBeNull();
+			expect(screen.container.querySelector('fieldset')?.getAttribute('aria-required')).not.toBe(
+				'true'
+			);
+		});
+
+		/**
+		 * Gegenprobe zur Entscheidung oben: Die Attribute stehen aus
+		 * `commonFieldProps` zwar bereit, dürfen aber nicht an den Radios landen.
+		 */
+		it('setzt die ARIA-Zustände NICHT an den einzelnen Radios', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions,
+				error: 'Bitte wählen Sie den Bootsantrieb aus.'
+			});
+
+			const radios = screen.container.querySelectorAll('input[type="radio"]');
+			expect(radios.length).toBeGreaterThan(0);
+			radios.forEach((radio) => {
+				expect(radio.hasAttribute('aria-invalid')).toBe(false);
+				expect(radio.hasAttribute('aria-required')).toBe(false);
+			});
+		});
+
+		it('gibt der Radiogruppe bei Fehler die Fehler-Optik statt radio-primary', async () => {
+			const screen = render(FieldRenderer, {
+				fieldConfig: boatDriveSelectFieldConfig,
+				name: 'boatDrive',
+				value: null,
+				type: 'radio',
+				options: publicBoatDriveOptions,
+				error: 'Bitte wählen Sie den Bootsantrieb aus.'
+			});
+
+			const radios = screen.container.querySelectorAll('input[type="radio"]');
+			expect(radios.length).toBeGreaterThan(0);
+			radios.forEach((radio) => {
+				expect(radio.classList.contains('radio-error')).toBe(true);
+				expect(radio.classList.contains('radio-primary')).toBe(false);
+			});
+		});
+
 		it('rendert ohne Override weiterhin das Schema-Select (Admin-Maske)', async () => {
 			render(FieldRenderer, {
 				fieldConfig: boatDriveSelectFieldConfig,


### PR DESCRIPTION
## Problem

Seit 479ef33c ist `boatDrive` im öffentlichen Meldeformular eine Radiogruppe und
bei Segelschiff/Motorboot Pflicht. Schlug die Validierung fehl („Bitte wählen Sie
den Bootsantrieb aus."), erschien zwar die Fehlermeldung, aber die Radios trugen
**kein `aria-invalid`** und bekamen **keine Fehler-Optik**.

Ursache: `FieldRenderer` baut `aria-invalid`/`aria-required` in `commonFieldProps`
und reicht sie über `radioProps` durch — `BaseRadio` hatte aber ein geschlossenes
`Props`-Interface ohne diese Schlüssel und ohne Rest-Spread. Beide fielen still weg.
`hasError`/`isValid` verschwanden auf demselben Weg, weshalb die Gruppe überhaupt
keinen Fehler-Zustand zeigte.

Damit driftete auch die Regel aus `design-system.md` auseinander, dass
Pflicht-Sternchen und `aria-required` aus derselben Variable kommen: Das Sternchen
wurde gerendert, `aria-required` nicht.

## Warum die Attribute *nicht* an die einzelnen Radios gehen

Der naheliegende Fix — `aria-invalid`/`aria-required` an jedes
`<input type="radio">` — erzeugt **ungültiges ARIA**. ARIA 1.2 hat beide aus den
globalen Zuständen entfernt; `role="radio"` unterstützt sie seither nicht:

```
WARNING BaseRadio.svelte 78:6 "The attribute 'aria-invalid' is not supported by the role 'radio'"
```

Getragen werden sie von der **Gruppe**. Das `<fieldset>` war schon da, überschreibt
jetzt seine implizite Rolle `group` (die sie ebenfalls nicht unterstützt) mit
`role="radiogroup"` und benennt sich per `aria-labelledby` an seiner Legend.

## Änderungen

- **`BaseRadio.svelte`** — nimmt `hasError`/`isValid` an. Die Zustandsklasse
  **ersetzt** `radio-primary`, statt sie zu ergänzen: `radio-primary`,
  `radio-success` und `radio-error` setzen alle `--input-color` in derselben
  DaisyUI-Ebene (`daisyui.l1.l2`) mit derselben Spezifität — stünden zwei am
  Element, entschiede die Reihenfolge im Stylesheet, nicht die im `class`-Attribut.
  Aufbau damit wie `stateClass` in `BaseInput`/`BaseSelect`.
- **`FieldRenderer.svelte`** — fieldset wird zur `radiogroup` und trägt beide
  ARIA-Zustände; `radioProps` entfernt sie, damit sie nicht als tote Props weiterreisen.
- **Tests** — neue `BaseRadio.svelte.test.ts` (9) + 6 in `FieldRenderer.svelte.test.ts`.
  Test-first geschrieben und **RED bestätigt** (6 failed / 3 passed) vor der
  Implementierung. Mehrere prüfen bewusst die *Abwesenheit* der Attribute an den
  Inputs, damit der Spec-Verstoß nicht in gutem Glauben zurückkommt.
- **`.claude/rules/design-system.md`** — Regel dokumentiert, inkl. der einen Ausnahme
  von „Sternchen und `aria-required` aus derselben Variable": dieselbe Variable, aber
  zwei Elemente.

## Verifikation

| Prüfung | Ergebnis |
|---|---|
| `npm run test:quick` | exit 0 — 3472 passed, svelte-check **0 Errors / 0 Warnings** |
| `npm run test:unit:client` | exit 0 — 332 passed |
| `npx playwright test --project=chromium` | exit 0 — **321 passed** |
| Browser-Check des Fehler-Zustands | `aria-invalid="true"`, `aria-required="true"`, Rahmen `oklch(0.48 0.18 25)` |

Die gemessene Rahmenfarbe ist exakt `--color-error` aus `tokens.css` — die
dokumentierten 6,05:1 auf `base-100`, deutlich über den 3:1 aus WCAG 1.4.11 für
grafische Objekte.

## Anmerkungen für das Review

- **`npm run test:quick` führt diese Tests nicht aus.** Es ist
  `lint && type-check && check && test:unit`, und `test:unit` ist `--project server`.
  Die neuen Komponententests liegen im `client`-Projekt — die Zahl war vor und nach
  dem Hinzufügen identisch (3472). Abdeckung gibt `npm run test:unit:all`.
- **Bewusst nicht mitgeändert:** `BaseCheckbox.svelte:48` und `BaseToggle.svelte:48`
  setzen ebenfalls hart `*-primary` ohne Zustandsklasse, haben also auch keine
  Fehler-Optik. Sie reichen ihre ARIA-Attribute aber korrekt durch und sind derzeit
  keine konditionalen Pflichtfelder — eigener Schritt mit eigenen Tests.
- **Bekannt, keine Regression:** Bei Feldern mit `meta.valueText` (wie `boatDrive`)
  enthält die Legend den Tooltip-Button, dessen `aria-label` in den Gruppennamen
  einfließt. Die implizite Legend-Namensgebung des fieldset wertete vorher denselben
  Teilbaum aus; ein Straffen wäre ein eigenes `aria-labelledby` auf eine Span nur um
  den Labeltext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
