### PR TITLE
fix(a11y): mark the coordinates as required when a position is given

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -292,9 +292,20 @@ Schritt unvollständig ist".
 
 Alle Felder laufen über `FormField` → `FieldRenderer` (`src/lib/report/components/form/fields/`). Kein Feld baut Label, Fehleranzeige oder ARIA selbst.
 
+**Genau eine Ausnahme: die Koordinaten.** `latitude`/`longitude` sind in `LocationInput.svelte` handgebaute Inputs — je nach GPS-Eingabeformat zwei bis sechs Stück, für die es kein einzelnes Schema-Feld gäbe. Die Pipeline kann diesen Fall nicht abdecken, die Regeln unten gelten dort aber trotzdem: Das `required`-Prop der Komponente ist die eine Quelle für Sternchen **und** `aria-required`, in allen drei Formaten. Wer dort ein Feld ergänzt, muss beides mitbringen.
+
+**Was der Marker dort jeweils leistet, unterscheidet sich zwischen den zwei Aufrufstellen** — nicht aus Versehen, sondern weil `hasPosition` an beiden Orten etwas anderes ist:
+
+| Aufrufstelle                                    | `hasPosition`                                             | Wirkung des Sternchens                                                       |
+| ----------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Admin-Maske (`sections/Location.svelte`)        | echtes Bedienelement (`<FormField name="hasPosition" />`) | steht am noch leeren Feld und kündigt die Pflicht an                         |
+| Meldeformular (`position/PositionPanel.svelte`) | aus den Koordinaten abgeleitet (`syncHasPosition`)        | erscheint erst, wenn beide Koordinaten gefüllt sind, und bestätigt sie damit |
+
+Im Meldeformular geht der Marker einem Validierungsfehler also nie voraus. Das ist die richtige Aussage und keine Lücke: Ohne Position ist die Ortsbeschreibung die gleichwertige Alternative — ein Sternchen am leeren Koordinatenfeld behauptete eine Pflicht, die dort nicht besteht. Die Pflicht liegt dann sichtbar auf `waterway` (`LocationDescription.svelte`). Wer hier „repariert", dass der Marker zu spät kommt, macht aus zwei Wegen einen.
+
 - Label, Hilfetext, Platzhalter, Icon, Optionen und Feldtyp kommen aus dem Yup-Schema (`.label()` / `.meta({...})` in `src/lib/form/validation/sightingSchema.ts`), nicht aus dem Template.
 - Pflicht-Markierung (`*`) und `aria-required` stammen aus **derselben** Variable in `FieldRenderer`. Nie eines von beidem separat setzen — sonst driften optische und semantische Pflicht auseinander.
-- **Konditionale Pflichten** (Yup `when()`) sind aus `describe()` nicht ableitbar. Dafür den `required`-Override an `FormField` setzen — Beispiel `waterway` in `src/lib/report/components/form/position/LocationDescription.svelte`: `<FormField name="waterway" required={waterwayRequired} />`.
+- **Konditionale Pflichten** (Yup `when()`) sind aus `describe()` nicht ableitbar. Dafür den `required`-Override an `FormField` setzen — Beispiel `waterway` in `src/lib/report/components/form/position/LocationDescription.svelte`: `<FormField name="waterway" required={waterwayRequired} />`. Für die Koordinaten übernimmt das `required`-Prop von `LocationInput` dieselbe Rolle; gesetzt wird es an beiden Aufrufstellen aus `hasPosition` — der Bedingung, an der auch `latitude.when(...)` hängt.
 - Neues Feld: im Schema definieren **und** in `formStepsConfig` (`src/lib/report/formConfig.ts`) dem richtigen Schritt zuordnen — sonst greift weder Schritt-Validierung noch Fehler-Navigation.
 - `data-testid="field-<name>"` entsteht automatisch; keine eigenen Test-IDs an Feldern vergeben.
 - Fehler **nie** beim Betreten eines Schritts anzeigen — erst nach einem gescheiterten „Weiter"-Versuch (`StepNavigation.svelte` / `stepNavigationState.ts`).

--- a/src/lib/report/components/form/LocationInput.svelte
+++ b/src/lib/report/components/form/LocationInput.svelte
@@ -15,6 +15,7 @@
 		collapsibleCoordinates = false,
 		enableMapGps = true,
 		coordinatesHint = null,
+		required = false,
 		onchange = () => {}
 	} = $props<{
 		mode?: 'dms' | 'dm' | 'dd';
@@ -53,6 +54,22 @@
 		 * auf die der Satz sich bezieht.
 		 */
 		coordinatesHint?: string | null;
+		/**
+		 * Sind die Koordinaten hier Pflichtfelder?
+		 *
+		 * Im Yup-Schema hängt das an `hasPosition`
+		 * (`latitude.when('hasPosition', { is: true, … })`) — eine konditionale
+		 * Regel, die aus `describe()` nicht ableitbar ist. Diese Felder laufen
+		 * zudem als einzige des Formulars nicht über `FormField` →
+		 * `FieldRenderer`, das Sternchen und `aria-required` sonst zentral aus
+		 * EINER Variablen erzeugt. Das Prop ist deshalb hier die eine Quelle für
+		 * beides (`.claude/rules/design-system.md`, „Formularfeld-Muster");
+		 * gesetzt wird es an den Aufrufstellen aus `hasPosition`.
+		 *
+		 * Default `false`: Ohne Aussage über `hasPosition` behauptet die
+		 * Komponente keine Pflicht.
+		 */
+		required?: boolean;
 		onchange?: EventListener | null;
 	}>();
 
@@ -190,6 +207,32 @@
 	}
 </script>
 
+<!-- Pflicht-Markierung für die beschrifteten Koordinatenfelder.
+
+     Bewusst EIN Snippet für alle drei Eingabeformate: Jedes Format rendert
+     eigene Labels, und ein Sternchen, das nur im Dezimalgrad-Zweig steht, wäre
+     für jeden weg, der auf „Grad, Minute, Sekunde" umstellt. Markup und
+     `aria-label` sind absichtlich identisch mit `FieldRenderer.svelte` — für
+     Nutzer wie für Tests darf sich die Pflicht hier nicht anders anfühlen als
+     an jedem anderen Feld, auch wenn die Pipeline eine andere ist.
+
+     Zwei Punkte, an denen die Nachbildung bewusst genau bleibt bzw. bewusst
+     abweicht:
+
+     - `aria-required={required || undefined}` lässt das Attribut im Nein-Fall
+       ganz weg statt `aria-required="false"` zu schreiben — genau wie
+       `BaseInput.svelte` es für jedes andere Feld tut.
+     - Das NATIVE `required`-Attribut setzen wir hier absichtlich NICHT, obwohl
+       `FieldRenderer` es durchreicht. Es aktivierte die Constraint-Validierung
+       des Browsers, und die verweigert das Absenden lautlos — dieselbe Falle,
+       an der `step="0.0001"` an diesen Feldern schon einmal hing (Kommentar am
+       Dezimalgrad-Feld unten). Ob eine Koordinate fehlt, entscheidet Yup. -->
+{#snippet requiredMark()}
+	{#if required}
+		<span class="text-error ml-1 text-sm" aria-label="Pflichtfeld">*</span>
+	{/if}
+{/snippet}
+
 {#snippet coordinateFields()}
 	<!-- Unterhalb `md` stehen Beschriftung und Auswahl untereinander, darüber
 	     nebeneinander. Als einzeilige Flex-Zeile setzte dieser Block die
@@ -216,9 +259,14 @@
 	</div>
 
 	{#if mode === 'dms'}
+		<!-- `aria-required` sitzt nur am Grad-Feld, nicht an Minuten und Sekunden:
+		     Das Label mit dem Sternchen gehört über `for` genau zu diesem Feld, und
+		     die beiden anderen dürfen leer bleiben — `part()` reicht sie als NaN
+		     weiter, die Konverter lesen das als 0. Eine Pflicht-Ansage dort wäre
+		     eine falsche Aussage. Gilt genauso im Format „Grad, Dezimalminute". -->
 		<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 			<div>
-				<label class="label" for="dms-lat-deg">Breite (N)</label>
+				<label class="label" for="dms-lat-deg">Breite (N){@render requiredMark()}</label>
 				<div class="flex gap-2">
 					<div>
 						<input
@@ -228,6 +276,7 @@
 							min="0"
 							max="90"
 							placeholder="Grad"
+							aria-required={required || undefined}
 							bind:value={dms.latitude.deg}
 							onchange={updateFromFields}
 						/>
@@ -255,7 +304,7 @@
 				</div>
 			</div>
 			<div>
-				<label class="label" for="dms-lon-deg">Länge (E)</label>
+				<label class="label" for="dms-lon-deg">Länge (E){@render requiredMark()}</label>
 				<div class="flex gap-2">
 					<div>
 						<input
@@ -265,6 +314,7 @@
 							min="0"
 							max="180"
 							placeholder="Grad"
+							aria-required={required || undefined}
 							bind:value={dms.longitude.deg}
 							onchange={updateFromFields}
 						/>
@@ -295,7 +345,7 @@
 	{:else if mode === 'dm'}
 		<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 			<div>
-				<label class="label" for="dm-lat-deg">Breite (N)</label>
+				<label class="label" for="dm-lat-deg">Breite (N){@render requiredMark()}</label>
 				<div class="flex gap-2">
 					<div>
 						<input
@@ -305,6 +355,7 @@
 							min="0"
 							max="90"
 							placeholder="Grad"
+							aria-required={required || undefined}
 							bind:value={dm.latitude.deg}
 							onchange={updateFromFields}
 						/>
@@ -323,7 +374,7 @@
 				</div>
 			</div>
 			<div>
-				<label class="label" for="dm-lon-deg">Länge (E)</label>
+				<label class="label" for="dm-lon-deg">Länge (E){@render requiredMark()}</label>
 				<div class="flex gap-2">
 					<div>
 						<input
@@ -333,6 +384,7 @@
 							min="0"
 							max="180"
 							placeholder="Grad"
+							aria-required={required || undefined}
 							bind:value={dm.longitude.deg}
 							onchange={updateFromFields}
 						/>
@@ -354,7 +406,7 @@
 	{:else}
 		<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
 			<div>
-				<label class="label" for="latitude">Breite (N)</label>
+				<label class="label" for="latitude">Breite (N){@render requiredMark()}</label>
 				<!-- step deckt die volle Spaltengenauigkeit ab: `gps_breite` ist
 				     numeric(8,6). Mit dem früheren step="0.0001" wies die
 				     Constraint-Validierung des Browsers jede Bestandskoordinate mit
@@ -369,12 +421,13 @@
 					max="90"
 					step="0.000001"
 					placeholder="Dezimalgrad"
+					aria-required={required || undefined}
 					bind:value={ddLatitude}
 					onchange={onDecimalChange}
 				/>
 			</div>
 			<div>
-				<label class="label" for="longitude">Länge (E)</label>
+				<label class="label" for="longitude">Länge (E){@render requiredMark()}</label>
 				<input
 					id="longitude"
 					class="input w-full"
@@ -383,6 +436,7 @@
 					max="180"
 					step="0.000001"
 					placeholder="Dezimalgrad"
+					aria-required={required || undefined}
 					bind:value={ddLongitude}
 					onchange={onDecimalChange}
 				/>

--- a/src/lib/report/components/form/LocationInput.svelte.test.ts
+++ b/src/lib/report/components/form/LocationInput.svelte.test.ts
@@ -242,6 +242,10 @@ describe('LocationInput — Pflicht-Markierung der Koordinaten', () => {
 	 * Begründung über `COORDINATE_FIELDS`. Ohne diese Gegenprobe wäre ein
 	 * pauschales `aria-required` auf allen sechs Inputs vom Test nicht zu
 	 * unterscheiden.
+	 *
+	 * `toBeNull()` wie im Nein-Fall oben: Diese Inputs sollen das Attribut gar
+	 * nicht tragen. Ein eingeschlichenes `aria-required="false"` wäre zwar
+	 * harmlos, würde die Parität zu `BaseInput.svelte` aber unbemerkt aufgeben.
 	 */
 	it('lässt Minuten und Sekunden auch bei required ohne Pflicht-Ansage', async () => {
 		render(LocationInput, { mode: 'dms', required: true, enableMapGps: false });
@@ -252,7 +256,7 @@ describe('LocationInput — Pflicht-Markierung der Koordinaten', () => {
 
 		for (const label of ['Breite Minuten', 'Breite Sekunden', 'Länge Minuten', 'Länge Sekunden']) {
 			const input = document.querySelector(`[aria-label="${label}"]`);
-			expect(input?.getAttribute('aria-required'), label).not.toBe('true');
+			expect(input?.getAttribute('aria-required') ?? null, label).toBeNull();
 		}
 	});
 });

--- a/src/lib/report/components/form/LocationInput.svelte.test.ts
+++ b/src/lib/report/components/form/LocationInput.svelte.test.ts
@@ -150,3 +150,109 @@ describe('LocationInput — Hinweistext nennt den GPS-Button nur wenn er da ist'
 		expect(mapHintText()).toMatch(/GPS-Button/i);
 	});
 });
+
+/**
+ * Pflicht-Markierung der Koordinaten.
+ *
+ * `latitude`/`longitude` sind im Yup-Schema konditionale Pflichtfelder
+ * (`.when('hasPosition', { is: true, … })`). Anders als jedes andere Feld laufen
+ * sie NICHT über `FormField` → `FieldRenderer`, das Sternchen und
+ * `aria-required` sonst zentral aus einer Variablen erzeugt — es sind rohe
+ * Inputs. Ohne das `required`-Prop hier trüge die Koordinaten-Eingabe deshalb
+ * weder eine sichtbare noch eine maschinenlesbare Pflicht, während die
+ * Validierung sie einfordert.
+ *
+ * Geprüft wird über ALLE drei Eingabeformate, weil jedes seine eigenen Labels
+ * und Inputs rendert: Ein Sternchen nur im Dezimalgrad-Zweig wäre für jeden,
+ * der auf „Grad, Minute, Sekunde" umstellt, wieder weg.
+ *
+ * Das Attribut sitzt am beschrifteten Feld — dem Grad-Feld bzw. dem
+ * Dezimalgrad-Feld. Minuten und Sekunden bleiben ohne: sie dürfen leer bleiben
+ * (`part()` reicht sie als NaN weiter, die Konverter lesen das als 0), eine
+ * Pflicht-Ansage dort wäre schlicht falsch.
+ */
+const COORDINATE_FIELDS = [
+	{ mode: 'dd' as const, latitude: 'latitude', longitude: 'longitude' },
+	{ mode: 'dm' as const, latitude: 'dm-lat-deg', longitude: 'dm-lon-deg' },
+	{ mode: 'dms' as const, latitude: 'dms-lat-deg', longitude: 'dms-lon-deg' }
+];
+
+function requiredMarkIn(inputId: string): Element | null {
+	return document.querySelector(`label[for="${inputId}"] [aria-label="Pflichtfeld"]`);
+}
+
+function ariaRequiredOf(inputId: string): string | null {
+	return document.getElementById(inputId)?.getAttribute('aria-required') ?? null;
+}
+
+describe('LocationInput — Pflicht-Markierung der Koordinaten', () => {
+	for (const { mode, latitude, longitude } of COORDINATE_FIELDS) {
+		it(`markiert Breite und Länge im Format "${mode}" als Pflicht, wenn required gesetzt ist`, async () => {
+			render(LocationInput, { mode, required: true, enableMapGps: false });
+
+			await expect.poll(() => document.getElementById(latitude), { timeout: 5000 }).not.toBeNull();
+
+			for (const inputId of [latitude, longitude]) {
+				expect(requiredMarkIn(inputId), `Sternchen an ${inputId}`).not.toBeNull();
+				expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).toBe('true');
+			}
+		});
+
+		/**
+		 * `toBeNull()` und nicht `.not.toBe('true')`: Im Nein-Fall soll das
+		 * Attribut ganz fehlen, nicht als `aria-required="false"` dastehen — so
+		 * hält es `BaseInput.svelte` (`restProps.required || undefined`) für jedes
+		 * andere Feld des Formulars. Beides wäre gültiges ARIA; die schärfere
+		 * Assertion hält die Gleichheit fest, statt sie nur zu behaupten.
+		 */
+		it(`lässt Breite und Länge im Format "${mode}" ohne required unmarkiert`, async () => {
+			render(LocationInput, { mode, enableMapGps: false });
+
+			await expect.poll(() => document.getElementById(latitude), { timeout: 5000 }).not.toBeNull();
+
+			for (const inputId of [latitude, longitude]) {
+				expect(requiredMarkIn(inputId), `Sternchen an ${inputId}`).toBeNull();
+				expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).toBeNull();
+			}
+		});
+	}
+
+	/**
+	 * Sternchen und `aria-required` stammen aus derselben Variable
+	 * (`.claude/rules/design-system.md`: „Nie eines von beidem separat setzen").
+	 * Der Test hält fest, dass es keinen Zwischenzustand gibt, in dem nur eines
+	 * von beidem gesetzt ist — die häufigste Art, wie die zwei auseinanderdriften.
+	 */
+	it('setzt Sternchen und aria-required immer gemeinsam', async () => {
+		render(LocationInput, { mode: 'dms', required: true, enableMapGps: false });
+
+		await expect
+			.poll(() => document.getElementById('dms-lat-deg'), { timeout: 5000 })
+			.not.toBeNull();
+
+		const marks = document.querySelectorAll('[aria-label="Pflichtfeld"]').length;
+		const flagged = document.querySelectorAll('input[aria-required="true"]').length;
+
+		expect(marks).toBe(2);
+		expect(flagged).toBe(2);
+	});
+
+	/**
+	 * Die Minuten- und Sekundenfelder tragen keine eigene Pflicht — siehe die
+	 * Begründung über `COORDINATE_FIELDS`. Ohne diese Gegenprobe wäre ein
+	 * pauschales `aria-required` auf allen sechs Inputs vom Test nicht zu
+	 * unterscheiden.
+	 */
+	it('lässt Minuten und Sekunden auch bei required ohne Pflicht-Ansage', async () => {
+		render(LocationInput, { mode: 'dms', required: true, enableMapGps: false });
+
+		await expect
+			.poll(() => document.querySelector('[aria-label="Breite Minuten"]'), { timeout: 5000 })
+			.not.toBeNull();
+
+		for (const label of ['Breite Minuten', 'Breite Sekunden', 'Länge Minuten', 'Länge Sekunden']) {
+			const input = document.querySelector(`[aria-label="${label}"]`);
+			expect(input?.getAttribute('aria-required'), label).not.toBe('true');
+		}
+	});
+});

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -43,6 +43,18 @@
 	// direkt auf `undefined`.
 	const coordinatesPresent = $derived(latitude !== undefined && longitude !== undefined);
 
+	/**
+	 * Pflicht-Markierung der Koordinatenfelder.
+	 *
+	 * Liest `hasPosition` und NICHT `coordinatesPresent`, obwohl beide in diesem
+	 * Panel dasselbe bedeuten (`syncHasPosition`): Die Schema-Regel lautet
+	 * `latitude.when('hasPosition', { is: true, … })`, und das Sternchen soll
+	 * genau die Bedingung spiegeln, an der die Validierung hängt — sonst driften
+	 * die beiden auseinander, sobald ein weiterer Schreiber des Flags dazukommt
+	 * (die EXIF-Auswertung in `DropzoneEnhanced` ist bereits einer).
+	 */
+	const positionRequired = $derived($form.hasPosition === true);
+
 	// GPS-Foto-Konfiguration: Server-Config, aber nur Bilder und genau eine Datei.
 	let gpsPhotoConfig = $state<ValidationPreset | null>(null);
 	$effect(() => {
@@ -255,6 +267,7 @@
 		{longitude}
 		collapsibleCoordinates={false}
 		enableMapGps={false}
+		required={positionRequired}
 		coordinatesHint="Bitte tragen Sie die GPS-Koordinaten ein, wenn diese nicht automatisch über die Karte übernommen werden konnten."
 		onchange={handleLocationChange}
 	/>

--- a/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
+++ b/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
@@ -1,0 +1,70 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import PositionPanel from './PositionPanel.svelte';
+
+/**
+ * Deckt nur die Verdrahtung der konditionalen Koordinaten-Pflicht ab.
+ *
+ * `latitude`/`longitude` sind laut Schema Pflicht, sobald `hasPosition` gesetzt
+ * ist. Sie laufen als einzige Felder des Formulars nicht über `FormField` →
+ * `FieldRenderer` (rohe Inputs in `LocationInput.svelte`), das Sternchen und
+ * `aria-required` sonst zentral aus einer Variablen erzeugt — die Pflicht wird
+ * hier als Prop durchgereicht. Wie sie in den drei Eingabeformaten dargestellt
+ * wird, prüft `LocationInput.svelte.test.ts`.
+ *
+ * `hasPosition` ist im Meldeformular kein Bedienelement, sondern wird aus den
+ * Koordinaten abgeleitet (`syncHasPosition`) — die beiden Fälle unten setzen es
+ * deshalb zusammen mit den Koordinaten.
+ */
+function renderPositionPanel(overrides: Partial<SightingFormData> = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(PositionPanel, { context: new Map([[formContextKey, context]]) });
+}
+
+function requiredMarkIn(inputId: string): Element | null {
+	return document.querySelector(`label[for="${inputId}"] [aria-label="Pflichtfeld"]`);
+}
+
+function ariaRequiredOf(inputId: string): string | null {
+	return document.getElementById(inputId)?.getAttribute('aria-required') ?? null;
+}
+
+describe('PositionPanel — Pflicht-Markierung der Koordinaten', () => {
+	it('markiert die Koordinaten, sobald eine Position vorliegt', async () => {
+		renderPositionPanel({ hasPosition: true, latitude: 54.5, longitude: 13.5 });
+
+		await expect.poll(() => document.getElementById('latitude'), { timeout: 5000 }).not.toBeNull();
+
+		for (const inputId of ['latitude', 'longitude']) {
+			expect(requiredMarkIn(inputId), `Sternchen an ${inputId}`).not.toBeNull();
+			expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).toBe('true');
+		}
+	});
+
+	/**
+	 * Ohne Position ist die Ortsbeschreibung die Alternative — dann tragen die
+	 * Koordinaten keine Pflicht, sondern `waterway` (siehe
+	 * `LocationDescription.svelte.test.ts`).
+	 */
+	it('lässt die Koordinaten ohne Position unmarkiert', async () => {
+		renderPositionPanel({ hasPosition: false, latitude: undefined, longitude: undefined });
+
+		await expect.poll(() => document.getElementById('latitude'), { timeout: 5000 }).not.toBeNull();
+
+		for (const inputId of ['latitude', 'longitude']) {
+			expect(requiredMarkIn(inputId), `Sternchen an ${inputId}`).toBeNull();
+			expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).not.toBe('true');
+		}
+	});
+});

--- a/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
+++ b/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
@@ -56,6 +56,13 @@ describe('PositionPanel — Pflicht-Markierung der Koordinaten', () => {
 	 * Ohne Position ist die Ortsbeschreibung die Alternative — dann tragen die
 	 * Koordinaten keine Pflicht, sondern `waterway` (siehe
 	 * `LocationDescription.svelte.test.ts`).
+	 *
+	 * `toBeNull()` und nicht `.not.toBe('true')`: Im Nein-Fall soll das Attribut
+	 * ganz fehlen statt als `aria-required="false"` dazustehen — so hält es
+	 * `BaseInput.svelte` (`restProps.required || undefined`) für jedes andere
+	 * Feld. Dieselbe Assertion wie in `LocationInput.svelte.test.ts`; eine
+	 * laxere hier ließe die Verdrahtung ein `false` durchreichen, das die
+	 * Komponententests längst verbieten.
 	 */
 	it('lässt die Koordinaten ohne Position unmarkiert', async () => {
 		renderPositionPanel({ hasPosition: false, latitude: undefined, longitude: undefined });
@@ -64,7 +71,7 @@ describe('PositionPanel — Pflicht-Markierung der Koordinaten', () => {
 
 		for (const inputId of ['latitude', 'longitude']) {
 			expect(requiredMarkIn(inputId), `Sternchen an ${inputId}`).toBeNull();
-			expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).not.toBe('true');
+			expect(ariaRequiredOf(inputId), `aria-required an ${inputId}`).toBeNull();
 		}
 	});
 });

--- a/src/lib/report/components/sections/Location.svelte
+++ b/src/lib/report/components/sections/Location.svelte
@@ -27,7 +27,12 @@
 	<!-- GPS Coordinates (shown when hasPosition = true) -->
 	{#if hasPosition}
 		<div class="mt-4 grid grid-cols-1 gap-4 md:grid-cols-1">
-			<LocationInput {latitude} {longitude} onchange={handleChange} />
+			<!-- `required={hasPosition}` statt eines festen `true`: Das Sternchen an
+			     den Koordinaten und die Schema-Regel
+			     (`latitude.when('hasPosition', …)`) sollen aus derselben Größe
+			     kommen wie das `{#if}` darüber. Wer die Bedingung des Blocks später
+			     ändert, ändert damit auch die Pflicht-Markierung mit. -->
+			<LocationInput {latitude} {longitude} required={hasPosition} onchange={handleChange} />
 
 			{#if latitude !== undefined && longitude !== undefined}
 				<VerifyLocation {longitude} {latitude} />

--- a/src/lib/report/components/sections/Location.svelte.test.ts
+++ b/src/lib/report/components/sections/Location.svelte.test.ts
@@ -88,4 +88,29 @@ describe('sections/Location — Admin-Maske', () => {
 			expect(field(name)?.readOnly, name).toBe(false);
 		}
 	});
+
+	/**
+	 * Die Koordinaten sind laut Schema Pflicht, sobald `hasPosition` gesetzt ist
+	 * (`latitude.when('hasPosition', { is: true, … })`). Sie laufen aber nicht
+	 * über `FormField` → `FieldRenderer`, das Sternchen und `aria-required` sonst
+	 * zentral setzt — `LocationInput` bekommt die Pflicht deshalb als Prop
+	 * durchgereicht. Dieser Test hält die Verdrahtung fest; die Darstellung in
+	 * allen drei Eingabeformaten prüft `LocationInput.svelte.test.ts`.
+	 */
+	it('markiert die Koordinaten als Pflicht, sobald die Position angegeben wird', async () => {
+		renderAdminLocation({ hasPosition: true, latitude: 54.5, longitude: 13.5 });
+
+		await expect.poll(() => document.getElementById('latitude'), { timeout: 5000 }).not.toBeNull();
+
+		for (const inputId of ['latitude', 'longitude']) {
+			expect(
+				document.querySelector(`label[for="${inputId}"] [aria-label="Pflichtfeld"]`),
+				`Sternchen an ${inputId}`
+			).not.toBeNull();
+			expect(
+				document.getElementById(inputId)?.getAttribute('aria-required'),
+				`aria-required an ${inputId}`
+			).toBe('true');
+		}
+	});
 });


### PR DESCRIPTION
## Problem

`latitude`/`longitude` sind im Yup-Schema konditionale Pflichtfelder (`.when('hasPosition', { is: true, … })`), trugen aber **weder Sternchen noch `aria-required`** — als einzige Pflichtfelder des Formulars.

Der Grund ist strukturell: Anders als jedes andere Feld laufen sie nicht über `FormField` → `FieldRenderer`, das beides zentral aus **einer** Variablen erzeugt. Es sind handgebaute Inputs in `LocationInput.svelte` — je nach GPS-Eingabeformat zwei bis sechs Stück, für die es kein einzelnes Schema-Feld gäbe. Es fehlte also schlicht die Stelle, an der man ein `required` hätte übergeben können.

Damit ist die letzte Lücke derselben Fehlerklasse geschlossen, die zuvor für `waterway`, `deadCondition`, `sightingFromText` und `boatDrive` über den dokumentierten `required`-Override an den `FormField`-Aufrufstellen behoben wurde.

## Lösung

`LocationInput` bekommt ein `required`-Prop, das **die eine Quelle** für Sternchen und `aria-required` ist (`.claude/rules/design-system.md`: „Nie eines von beidem separat setzen"). Ein gemeinsames `{#snippet requiredMark()}` bedient alle drei Eingabeformate — ein Sternchen nur im Dezimalgrad-Zweig wäre für jeden weg, der auf „Grad, Minute, Sekunde" umstellt.

Zwei bewusste Detailentscheidungen:

- **Nur das beschriftete Feld wird markiert** — das Grad- bzw. Dezimalgrad-Feld, auf das das Label per `for` zeigt. Minuten und Sekunden bleiben frei: Sie dürfen leer bleiben (`part()` reicht sie als NaN weiter, die Konverter lesen das als 0), eine Pflicht-Ansage dort wäre eine falsche Aussage.
- **Kein natives `required`-Attribut**, obwohl `FieldRenderer` es durchreicht. Es aktivierte die Constraint-Validierung des Browsers, und die verweigert das Absenden *lautlos* — dieselbe Falle, an der `step="0.0001"` an genau diesen Feldern schon einmal hing. Ob eine Koordinate fehlt, entscheidet Yup.

## Die zwei Aufrufstellen verhalten sich unterschiedlich — absichtlich

Beide leiten das Prop aus `hasPosition` ab, der Bedingung, an der auch die Schema-Regel hängt. Was der Marker leistet, unterscheidet sich trotzdem, weil `hasPosition` an beiden Orten etwas anderes ist:

| Aufrufstelle | `hasPosition` | Wirkung |
| --- | --- | --- |
| Admin-Maske (`sections/Location.svelte`) | echtes Bedienelement | Sternchen steht am noch leeren Feld und **kündigt** die Pflicht an |
| Meldeformular (`position/PositionPanel.svelte`) | aus den Koordinaten abgeleitet (`syncHasPosition`) | Sternchen erscheint, sobald beide Koordinaten gefüllt sind, und **bestätigt** sie |

Im Meldeformular geht der Marker einem Validierungsfehler also nie voraus. Das ist die richtige Aussage: Ohne Position ist die Ortsbeschreibung die gleichwertige Alternative, und ein Sternchen am leeren Koordinatenfeld behauptete eine Pflicht, die dort nicht besteht — die Pflicht liegt dann sichtbar auf `waterway`. Der Unterschied ist in `.claude/rules/design-system.md` festgehalten, damit er nicht als Bug gelesen wird.

**Der Weg „nur Text, keine GPS-Position" bleibt unverändert.** Am Schema wurde nichts geändert; `stepValidation.test.ts` („returns true when hasPosition is false but a waterway description is provided") belegt das weiterhin.

## Tests (test-first)

Vor der Implementierung geschrieben, RED verifiziert (6 Fehlschläge), danach GREEN — und im Review durch Stashen der Implementierung gegengeprüft.

- `LocationInput.svelte.test.ts` — positiver und negativer Fall **je Eingabeformat**; ein Test, dass Sternchen-Anzahl und `aria-required`-Anzahl übereinstimmen (kein Zwischenzustand, in dem nur eines gesetzt ist); Gegenprobe, dass Minuten/Sekunden frei bleiben — ohne sie wäre ein pauschales `aria-required` auf allen sechs Inputs vom Test nicht zu unterscheiden.
- `Location.svelte.test.ts` und neu `PositionPanel.svelte.test.ts` — die Verdrahtung an beiden Aufrufstellen.
- Der Nein-Fall prüft `toBeNull()` statt `.not.toBe('true')`: Das Attribut soll ganz fehlen, wie `BaseInput.svelte` es für jedes andere Feld hält.

## Verifikation

- `npm run lint` — 0 Fehler (2 vorbestehende `any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`, nicht angefasst)
- `npm run type-check` — sauber
- `npm run check` — 2101 Dateien, 0 Fehler, 0 Warnungen
- `npx vitest run --project=client src/lib/report/components/` — 15 Dateien, 150 Tests grün (echter Chromium, kein JSDOM)
- `npm run test:unit` — 232 Dateien, 3472 Tests grün

Keine Screenshot-Verifikation: Port 4000 war von einem anderen Worktree belegt, und das Projekt lässt nur diesen einen Port zu. Die Komponententests rendern in einem echten Browser, die Assertions laufen also gegen tatsächliches DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)