### PR TITLE
fix(test): let the E2E webServer and a local dev server share port 4000

### DIFF
--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -172,6 +172,66 @@ false`, und der Job startet seinen eigenen Server im eigenen Container. Der
 Identitäts-Check läuft dort trotzdem mit, damit ein versehentlich entferntes Plugin
 auffällt, statt die Prüfung still abzuschalten.
 
+## `CI=1` lokal: Adressfamilie, nicht Port (behoben 2026-08-04)
+
+Bis zum 2026-08-04 brach `CI=1 npx playwright test` bei parallel laufendem
+`npm run dev` mit `Timed out waiting 120000ms from config.webServer` ab — ohne jeden
+Hinweis auf die Ursache. Es hat zweimal zu Fehldiagnosen geführt: einmal wurde der
+Timeout für einen Testfehler gehalten, einmal wurde ein `git stash`-Vergleich wertlos,
+weil der Lauf gar nicht erst startete.
+
+**Es war keine Portkollision** — deshalb half die Portvergabe pro Worktree hier nicht:
+
+| Prozess                                        | Bind                             |
+| ---------------------------------------------- | -------------------------------- |
+| `npm run dev` (`vite.config.ts`, `localhost`)  | nur `[::1]:4000` (IPv6-Loopback) |
+| E2E-webServer (`vite.config.ci.ts`, `0.0.0.0`) | nur `*:4000` (IPv4-Wildcard)     |
+
+Zwei Adressfamilien, kein Zusammenstoß: **beide** Server binden erfolgreich, `strictPort`
+schlägt nie an. `strictPort` schützt nur innerhalb _einer_ Familie — die stille Annahme,
+es decke jede Doppelbelegung ab, war falsch.
+
+Der Fehler steckte in der Gegenrichtung: `playwright.config.ts` wartete auf
+`http://localhost:4000`, und `localhost` löst auf macOS zuerst nach `::1` auf. Der
+Readiness-Poll landete also beim fremden **HTTPS**-Dev-Server, bekam auf Klartext-HTTP nie
+eine gültige Antwort — und lief die vollen 120 s. Der eigene E2E-Server stand die ganze
+Zeit fertig daneben, nur unter `127.0.0.1` statt unter `localhost`.
+
+Nachmessen lässt sich das so — die Spalte hinter `TCP` ist der Punkt:
+
+```bash
+lsof -nP -iTCP:4000 -sTCP:LISTEN
+```
+
+Behoben in [`src/tools/dev-server-identity.ts`](../src/tools/dev-server-identity.ts):
+`CI_DEV_HOST` und `ciDevPort()` sind jetzt die **eine** Quelle, aus der
+`vite.config.ci.ts` seinen Bind und `playwright.config.ts` seine Warte-Adresse beziehen;
+`loopbackHostFor()` leitet die Loopback-Adresse aus dem Bind ab, statt `localhost` zu
+raten. Beide Server laufen seitdem nebeneinander — verifiziert: `npm run dev` auf
+`[::1]:4000` und `CI=1 npx playwright test --project=chromium e2e/homepage.test.ts`
+gleichzeitig, 7 passed. Nebeneffekt: Weil Playwright jetzt die Adresse abfragt, die der
+Server auch bedient, greift dessen eigene Vorabprüfung wieder und meldet eine echte
+Doppelbelegung **sofort** statt nach 120 s:
+
+```
+Error: http://127.0.0.1:4000 is already used, make sure that nothing is running
+on the port/url or set reuseExistingServer:true in config.webServer.
+```
+
+Zwei Dinge, die dabei auffielen und beim nächsten Mal Zeit sparen:
+
+- **`e2e/global-setup.ts` kann diesen Fall nicht abfangen.** Playwright startet den
+  webServer **vor** dem `globalSetup`; bei einem webServer-Timeout läuft `globalSetup`
+  nie an (nachgemessen: keine seiner Ausgaben erscheint). Die Identitätsprüfung dort
+  bleibt für den lokalen `reuseExistingServer`-Pfad richtig und wichtig — als Wache gegen
+  webServer-Timeouts ist sie strukturell zu spät.
+- **`vite.config.ci.ts` ignorierte `VITE_DEV_PORT`**, obwohl `playwright.config.ts` es an
+  den webServer durchreicht. Der Port ist jetzt über `ciDevPort()` wirklich steuerbar:
+
+```bash
+CI=1 VITE_DEV_PORT=4300 npx playwright test --project=chromium
+```
+
 ## Geteilte Ressourcen — Vorsicht
 
 Alle Worktrees zeigen über den `.env`-Symlink auf **dieselbe** Datenbank und dieselben

--- a/e2e/helpers/adminSession.ts
+++ b/e2e/helpers/adminSession.ts
@@ -139,11 +139,12 @@ export async function seedAdminSession(context: BrowserContext, baseURL: string)
 
 	/* sameSite bewusst 'Lax' statt des 'None', das die App produziert.
 	   'None' verlangt im Browser zwingend das Secure-Flag, und der CI-Dev-Server
-	   läuft über plain http (vite.config.ci.ts lässt basicSsl weg, playwright.config.ts
-	   zeigt in CI auf http://127.0.0.1:4000). 'Lax' entkoppelt das Fixture von
-	   dieser Frage und reicht vollständig aus: Die Attribute steuern nur, WANN
-	   der Browser den Cookie mitsendet, und die Tests navigieren ausschließlich
-	   direkt auf die eigene Origin. Der Server liest nur den Wert.
+	   läuft über plain http (vite.config.ci.ts lässt basicSsl weg). Entscheidend ist
+	   allein das Schema — Host und Port stehen hier bewusst nicht, sie kommen aus
+	   playwright.config.ts und sind über VITE_DEV_PORT verschiebbar. 'Lax' entkoppelt
+	   das Fixture von dieser Frage und reicht vollständig aus: Die Attribute steuern
+	   nur, WANN der Browser den Cookie mitsendet, und die Tests navigieren
+	   ausschließlich direkt auf die eigene Origin. Der Server liest nur den Wert.
 
 	   Dass die App selbst 'None' braucht, ist eine Anforderung der
 	   iframe-Einbettung auf meeresmuseum.de und wird hier nicht mitgetestet. */

--- a/e2e/helpers/adminSession.ts
+++ b/e2e/helpers/adminSession.ts
@@ -140,7 +140,7 @@ export async function seedAdminSession(context: BrowserContext, baseURL: string)
 	/* sameSite bewusst 'Lax' statt des 'None', das die App produziert.
 	   'None' verlangt im Browser zwingend das Secure-Flag, und der CI-Dev-Server
 	   läuft über plain http (vite.config.ci.ts lässt basicSsl weg, playwright.config.ts
-	   zeigt in CI auf http://localhost:4000). 'Lax' entkoppelt das Fixture von
+	   zeigt in CI auf http://127.0.0.1:4000). 'Lax' entkoppelt das Fixture von
 	   dieser Frage und reicht vollständig aus: Die Attribute steuern nur, WANN
 	   der Browser den Cookie mitsendet, und die Tests navigieren ausschließlich
 	   direkt auf die eigene Origin. Der Server liest nur den Wert.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
-import { worktreeDevPort } from './src/tools/dev-server-identity';
+import {
+	CI_DEV_HOST,
+	ciDevPort,
+	devPortFromEnv,
+	loopbackHostFor,
+	worktreeDevPort
+} from './src/tools/dev-server-identity';
 
 /**
  * Lokal bekommt jedes Arbeitsverzeichnis seinen eigenen Port.
@@ -10,17 +16,28 @@ import { worktreeDevPort } from './src/tools/dev-server-identity';
  * 4000 *und* 4001 einem fremden Branch gehörten. Ein manuell gesetztes `VITE_DEV_PORT`
  * hat weiterhin Vorrang (nützlich, um den Abbruch in `e2e/global-setup.ts` vorzuführen).
  *
- * CI bleibt bei 4000: dort läuft genau ein Job in einem eigenen Container. Der Port
- * steht dort bewusst *hier* und wird nicht aus dem Hash abgeleitet — sonst bekäme der
- * Server ein `VITE_DEV_PORT`, das nur deshalb folgenlos bleibt, weil
- * `vite.config.ci.ts` den Port hart auf 4000 setzt. Zieht jemand die CI-Config später
- * mit `vite.config.ts` gleich, liefe der Server auf dem Hash-Port, während Playwright
- * auf 4000 wartet — Ausgang wäre ein webServer-Timeout ohne verwertbare Meldung.
+ * CI bleibt bei 4000: dort läuft genau ein Job in einem eigenen Container. Port und Host
+ * kommen aus `dev-server-identity` — derselben Quelle, aus der `vite.config.ci.ts` seinen
+ * Bind bezieht. Beide Seiten aus einer Quelle zu speisen ist hier keine Kosmetik: Der
+ * webServer-Timeout vom 2026-08-04 entstand genau daran, dass sie es nicht waren.
  */
-const devPort = process.env.CI
-	? 4000
-	: Number(process.env.VITE_DEV_PORT) || worktreeDevPort(process.cwd());
-const baseURL = `${process.env.CI ? 'http' : 'https'}://localhost:${devPort}`;
+const devPort = process.env.CI ? ciDevPort() : (devPortFromEnv() ?? worktreeDevPort(process.cwd()));
+
+/**
+ * Der Host, unter dem Playwright auf den Server wartet, muss zu dessen Bind passen.
+ *
+ * In CI bindet `vite.config.ci.ts` auf `CI_DEV_HOST` (IPv4-Wildcard); `localhost` löst auf
+ * macOS aber zuerst nach `::1` auf und traf damit nicht den eigenen Server, sondern einen
+ * dort zufällig lauschenden — bei parallelem `npm run dev` den fremden HTTPS-Dev-Server.
+ * Auf dessen Klartext-HTTP-Antwort wartete Playwright die vollen 120 s. `loopbackHostFor`
+ * leitet die Adresse aus dem Bind ab, statt sie zu raten.
+ *
+ * Lokal bleibt es bei `localhost`: Dort bindet `vite.config.ts` selbst auf `localhost`,
+ * und das Dev-Zertifikat ist auf diesen Namen ausgestellt.
+ */
+const baseURL = process.env.CI
+	? `http://${loopbackHostFor(CI_DEV_HOST)}:${devPort}`
+	: `https://localhost:${devPort}`;
 
 export default defineConfig({
 	globalSetup: './e2e/global-setup.ts',

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -7,12 +7,16 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
+	CI_DEV_HOST,
 	DEV_IDENTITY_PATH,
 	assertServerIdentity,
+	ciDevPort,
 	createNodeIdentityFetch,
 	describePortOwner,
+	devPortFromEnv,
 	devServerIdentity,
 	devTrustAnchors,
+	loopbackHostFor,
 	worktreeDevPort
 } from './dev-server-identity';
 
@@ -159,6 +163,80 @@ describe('describePortOwner', () => {
 	});
 });
 
+describe('loopbackHostFor', () => {
+	it('übersetzt Wildcard-Binds in eine Loopback-Adresse derselben Familie', () => {
+		expect(loopbackHostFor('0.0.0.0')).toBe('127.0.0.1');
+		expect(loopbackHostFor('::')).toBe('[::1]');
+	});
+
+	it('lässt bereits konkrete Hosts unangetastet', () => {
+		expect(loopbackHostFor('localhost')).toBe('localhost');
+		expect(loopbackHostFor('127.0.0.1')).toBe('127.0.0.1');
+	});
+
+	/**
+	 * Beide Aufrufer setzen das Ergebnis direkt in eine URL ein. Ein nacktes
+	 * IPv6-Literal ergäbe dort `http://::1:4000` — die Klammern gehören deshalb hierher
+	 * und nicht an die Aufrufstellen.
+	 */
+	it('klammert IPv6-Literale für den Einsatz in einer URL', () => {
+		expect(loopbackHostFor('::1')).toBe('[::1]');
+		expect(loopbackHostFor('fe80::1')).toBe('[fe80::1]');
+		expect(loopbackHostFor('[::1]')).toBe('[::1]');
+	});
+
+	/**
+	 * Der Kern des Befunds vom 2026-08-04: `localhost` ist **keine** gültige Antwort für
+	 * einen Bind auf `0.0.0.0`. Auf macOS löst `localhost` zuerst nach `::1` auf — einer
+	 * Adresse, die der IPv4-Wildcard nie bedient.
+	 */
+	it('gibt für 0.0.0.0 nicht localhost zurück', () => {
+		expect(loopbackHostFor('0.0.0.0')).not.toBe('localhost');
+	});
+});
+
+describe('devPortFromEnv', () => {
+	/**
+	 * Die eine Stelle, an der `VITE_DEV_PORT` gelesen wird. Vorher parsten drei Aufrufer
+	 * die Variable verschieden: `parseInt('4300abc')` ergab 4300, `Number(…)` ergibt
+	 * `NaN`. Dass der Wert überall gleich verstanden wird, ist hier keine Kosmetik — der
+	 * Port muss auf beiden Seiten derselbe sein.
+	 */
+	it('gibt null zurück, wenn nichts Brauchbares dasteht', () => {
+		expect(devPortFromEnv({})).toBeNull();
+		expect(devPortFromEnv({ VITE_DEV_PORT: '' })).toBeNull();
+		expect(devPortFromEnv({ VITE_DEV_PORT: 'auto' })).toBeNull();
+		expect(devPortFromEnv({ VITE_DEV_PORT: '0' })).toBeNull();
+		expect(devPortFromEnv({ VITE_DEV_PORT: '4300abc' })).toBeNull();
+	});
+
+	it('liefert einen gesetzten Port', () => {
+		expect(devPortFromEnv({ VITE_DEV_PORT: '4123' })).toBe(4123);
+	});
+});
+
+describe('ciDevPort', () => {
+	it('nimmt 4000, solange nichts anderes gesetzt ist', () => {
+		expect(ciDevPort({})).toBe(4000);
+	});
+
+	/**
+	 * `playwright.config.ts` reicht `VITE_DEV_PORT` an den webServer durch. Solange
+	 * `vite.config.ci.ts` den Port hart auf 4000 setzte, war diese Übergabe wirkungslos —
+	 * ein stiller Widerspruch zwischen dem Port, auf den Playwright wartet, und dem, auf
+	 * dem der Server steht.
+	 */
+	it('folgt VITE_DEV_PORT', () => {
+		expect(ciDevPort({ VITE_DEV_PORT: '4123' })).toBe(4123);
+	});
+
+	it('ignoriert unbrauchbare Werte statt NaN weiterzureichen', () => {
+		expect(ciDevPort({ VITE_DEV_PORT: '' })).toBe(4000);
+		expect(ciDevPort({ VITE_DEV_PORT: 'auto' })).toBe(4000);
+		expect(ciDevPort({ VITE_DEV_PORT: '0' })).toBe(4000);
+	});
+});
+
 /**
  * Diese Tests machen echtes Netz-I/O (TLS-Handshake, Socket-Auf- und Abbau). Unter der
  * Last der vollen Suite reichen die 5 s Default nicht: gemessen fiel der HTTPS-Test in
@@ -166,6 +244,86 @@ describe('describePortOwner', () => {
  * deshalb mehr Zeit statt Test entschärfen.
  */
 const IO_TIMEOUT = 20_000;
+
+/**
+ * Die Regressionstests zum webServer-Timeout vom 2026-08-04.
+ *
+ * Der Fehler entstand daran, dass ein E2E-Server auf `CI_DEV_HOST` (IPv4-Wildcard) band,
+ * Playwright aber `localhost` abfragte — auf macOS zuerst `[::1]`, wo der HTTPS-Dev-Server
+ * lag. Zwei Adressfamilien heißt: kein Zusammenstoß, `strictPort` schlägt nie an. Genau
+ * deshalb half die Portvergabe pro Worktree nicht — es gab nie eine Kollision, die sie
+ * hätte entschärfen können.
+ *
+ * Bewusst **ohne** `listen(…, 'localhost')` im Aufbau: Welche Familie daraus wird, ist
+ * betriebssystemabhängig (macOS liefert `::1` zuerst, Linux üblicherweise `127.0.0.1`).
+ * Ein Test, der darauf baut, prüfte je nach Host etwas anderes — und wäre in CI auf
+ * `ubuntu-latest` rot. Die Adressfamilien stehen deshalb explizit da.
+ */
+describe('Dev-Server und E2E-Server auf demselben Port', () => {
+	/** Bindet einen Server, der seinen Namen zurückgibt. */
+	async function listen(name: string, host: string, port = 0): Promise<http.Server> {
+		const server = http.createServer((_req, res) => res.end(name));
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(port, host, resolve);
+		});
+		return server;
+	}
+
+	/**
+	 * Die Eigenschaft, auf der die Behebung beruht — gilt auf jedem Host, unabhängig von
+	 * Namensauflösung und IPv6-Verfügbarkeit.
+	 */
+	it(
+		'erreicht einen Server auf CI_DEV_HOST unter loopbackHostFor(CI_DEV_HOST)',
+		async () => {
+			const e2e = await listen('E2E', CI_DEV_HOST);
+			const { port } = e2e.address() as AddressInfo;
+			try {
+				const response = await fetch(`http://${loopbackHostFor(CI_DEV_HOST)}:${port}/`);
+				expect(await response.text()).toBe('E2E');
+			} finally {
+				await new Promise((resolve) => e2e.close(resolve));
+			}
+		},
+		IO_TIMEOUT
+	);
+
+	it(
+		'teilt sich den Port mit einem Dev-Server auf [::1] und trifft trotzdem den eigenen',
+		async (ctx) => {
+			// Zuerst der Dev-Server auf Port 0: Der Kernel wählt, die Nummer wird
+			// zurückgelesen. Kein Schließen-und-neu-Binden, damit dazwischen niemand den
+			// Port wegschnappen kann (vgl. die Flakiness der legacy-inbox-Tests).
+			let dev: http.Server;
+			try {
+				dev = await listen('DEV', '::1');
+			} catch {
+				// Ohne IPv6-Loopback ist die Konstellation nicht herstellbar. Überspringen
+				// statt eine Prüfung vortäuschen, die gar nicht stattgefunden hat.
+				ctx.skip();
+				return;
+			}
+			const { port } = dev.address() as AddressInfo;
+
+			let e2e: http.Server | undefined;
+			try {
+				// Der zweite Bind muss durchgehen — er ist der Kern des Befunds.
+				e2e = await listen('E2E', CI_DEV_HOST, port);
+
+				const response = await fetch(`http://${loopbackHostFor(CI_DEV_HOST)}:${port}/`);
+				expect(await response.text()).toBe('E2E');
+			} finally {
+				// Über eine Konstante, weil TypeScript die Prüfung sonst nicht in den
+				// Callback hinein verengt (`e2e` ist ein `let`).
+				const started = e2e;
+				if (started) await new Promise((resolve) => started.close(resolve));
+				await new Promise((resolve) => dev.close(resolve));
+			}
+		},
+		IO_TIMEOUT
+	);
+});
 
 describe('createNodeIdentityFetch', () => {
 	/**

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -44,6 +44,73 @@ export const DEV_IDENTITY_PATH = '/__dev-server-identity';
 const PORT_RANGE_START = 41_000;
 const PORT_RANGE_SIZE = 4_000;
 
+/**
+ * Host, auf den der E2E-Dev-Server bindet (`vite.config.ci.ts`).
+ *
+ * Der Wildcard ist dort gewollt — in CI muss der Server auch von außerhalb des
+ * Containers erreichbar sein. Er steht hier und nicht in der Vite-Config, damit
+ * `playwright.config.ts` die Gegenstelle daraus ableiten kann statt sie zu wiederholen:
+ * Bind-Adresse und Abfrage-Adresse müssen zusammenpassen, und genau das ist am
+ * 2026-08-04 auseinandergelaufen (siehe `loopbackHostFor`).
+ */
+export const CI_DEV_HOST = '0.0.0.0';
+
+/** Fallback-Port des E2E-Dev-Servers, wenn `VITE_DEV_PORT` nichts vorgibt. */
+const CI_DEV_PORT_DEFAULT = 4000;
+
+/**
+ * Liest `VITE_DEV_PORT` — oder `null`, wenn dort nichts Brauchbares steht.
+ *
+ * Die **eine** Stelle, an der die Variable ausgewertet wird. Vorher taten das drei
+ * Aufrufer verschieden (`parseInt` in `vite.config.ts`, `Number(…) ||` in
+ * `playwright.config.ts`, gar nicht in `vite.config.ci.ts`), und `parseInt('4300abc')`
+ * ergibt 4300, wo `Number` `NaN` liefert. Bei einem Wert, der auf beiden Seiten
+ * derselbe sein muss, ist das kein Stilproblem: Auseinanderlaufende Ports sind genau
+ * der Fehler, der am 2026-08-04 120 s Timeout ohne Meldung gekostet hat.
+ */
+export function devPortFromEnv(env: NodeJS.ProcessEnv = process.env): number | null {
+	const explicit = Number(env.VITE_DEV_PORT);
+	return Number.isInteger(explicit) && explicit > 0 ? explicit : null;
+}
+
+/**
+ * Port des E2E-Dev-Servers.
+ *
+ * `playwright.config.ts` reicht `VITE_DEV_PORT` an den webServer durch; `vite.config.ci.ts`
+ * setzte den Port aber hart auf 4000 und ignorierte die Übergabe. Beide Seiten lesen
+ * jetzt denselben Wert, damit der Port, auf den Playwright wartet, und der Port, auf dem
+ * der Server steht, nicht auseinanderlaufen können.
+ */
+export function ciDevPort(env: NodeJS.ProcessEnv = process.env): number {
+	return devPortFromEnv(env) ?? CI_DEV_PORT_DEFAULT;
+}
+
+/**
+ * Adresse, unter der ein auf `bindHost` gebundener Server tatsächlich antwortet.
+ *
+ * Hintergrund — der webServer-Timeout vom 2026-08-04, zweimal fehldiagnostiziert:
+ * `npm run dev` bindet über `host: 'localhost'` nur `[::1]`, der E2E-Server über
+ * `CI_DEV_HOST` nur den IPv4-Wildcard. Zwei Adressfamilien, **keine** Kollision — beide
+ * Server starten, `strictPort` schlägt nie an. Playwright fragte aber
+ * `http://localhost:4000` ab, und `localhost` löst auf macOS zuerst nach `::1` auf: Der
+ * Readiness-Poll landete beim fremden HTTPS-Dev-Server, bekam auf Klartext-HTTP nie eine
+ * gültige Antwort und lief 120 s in den Timeout — ohne jeden Hinweis auf die Ursache.
+ *
+ * Deshalb wird der Wildcard hier explizit auf eine Loopback-Adresse **derselben Familie**
+ * abgebildet. `localhost` ist für `0.0.0.0` die falsche Antwort: Die Auflösung hängt an
+ * DNS-Reihenfolge und Betriebssystem, nicht an dem, was der Server gebunden hat. Dasselbe
+ * Muster ist unter Node ≥ 17 auch in Dual-Stack-Containern eine bekannte Falle — die
+ * Festlegung härtet CI also mit, statt nur lokal zu reparieren.
+ */
+export function loopbackHostFor(bindHost: string): string {
+	if (bindHost === '0.0.0.0') return '127.0.0.1';
+	if (bindHost === '::') return '[::1]';
+	// Beide Aufrufer setzen das Ergebnis direkt in eine URL ein — ein nacktes
+	// IPv6-Literal ergäbe dort `http://::1:4000`. Die Klammern gehören deshalb hierher.
+	if (bindHost.includes(':') && !bindHost.startsWith('[')) return `[${bindHost}]`;
+	return bindHost;
+}
+
 /** Entfernt abschließende Schrägstriche, damit Pfadvarianten denselben Port ergeben. */
 function normalizeRoot(root: string): string {
 	return root.replace(/\/+$/, '');
@@ -194,13 +261,30 @@ export function devServerIdentity(): Plugin {
 			 * `configureServer` *zurückgegebene* Post-Hook-Funktion wäre dafür untauglich:
 			 * Vite ruft sie synchron auf und wartet ein Promise nicht ab.)
 			 *
-			 * Bewusst nur ausgeben, nie selbst werfen: Die Garantie liefert `strictPort`.
+			 * Bewusst nur ausgeben, nie selbst werfen — den Abbruch leistet `strictPort`.
+			 * Dessen Reichweite ist allerdings kleiner als lange angenommen: Er greift nur
+			 * innerhalb *einer* Adressfamilie. Ein Dev-Server auf `[::1]` und ein
+			 * E2E-Server auf dem IPv4-Wildcard teilen sich denselben Port völlig
+			 * geräuschlos (siehe `loopbackHostFor`) — dort gibt es keinen Zusammenstoß,
+			 * den eine Meldung ankündigen könnte.
+			 *
 			 * Und bewusst nicht unter Vitest — dessen Vite-Server bindet den Port gar
 			 * nicht, jede Meldung wäre dort ein Fehlalarm im Testlauf.
 			 */
 			if (process.env.VITEST) return;
-			const { port, https: useHttps } = server.config.server;
-			const origin = `${useHttps ? 'https' : 'http'}://localhost:${port}`;
+			const { port, https: useHttps, host } = server.config.server;
+			/*
+			 * Über `loopbackHostFor`, nicht fest über `localhost`: Sonst fragte der
+			 * E2E-Server (Bind auf `CI_DEV_HOST`) ausgerechnet `::1` ab — eine Adresse, die
+			 * er nie bedient. Die Diagnose liefe dann am eigentlichen Konkurrenten vorbei.
+			 *
+			 * `host: true` heißt bei Vite „alle Schnittstellen": Es reicht `undefined` an
+			 * `listen` durch, womit Node `::` bindet (Dual-Stack, bedient auch IPv4).
+			 * Deshalb hier `'::'` und nicht `CI_DEV_HOST` — sonst zöge eine spätere
+			 * Änderung an der Konstanten diesen Zweig stillschweigend mit.
+			 */
+			const bindHost = host === true ? '::' : typeof host === 'string' ? host : 'localhost';
+			const origin = `${useHttps ? 'https' : 'http'}://${loopbackHostFor(bindHost)}:${port}`;
 			// Kurzer Timeout: Ist der Port frei, antwortet der Connect sofort mit
 			// ECONNREFUSED — der Wert greift nur bei einem hängenden Fremdprozess.
 			const owner = await describePortOwner(origin, createNodeIdentityFetch(1500));

--- a/vite.config.ci.ts
+++ b/vite.config.ci.ts
@@ -8,7 +8,7 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
-import { devServerIdentity } from './src/tools/dev-server-identity';
+import { CI_DEV_HOST, ciDevPort, devServerIdentity } from './src/tools/dev-server-identity';
 import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 /**
@@ -48,8 +48,16 @@ export default defineConfig({
 		stableDepHash()
 	],
 	server: {
-		host: '0.0.0.0',
-		port: 4000,
+		/*
+		 * Host und Port kommen aus `src/tools/dev-server-identity.ts`, weil
+		 * `playwright.config.ts` daraus die Adresse ableitet, an der es auf den Server
+		 * wartet. Standen sie hier als Literale, konnten Bind-Adresse und Abfrage-Adresse
+		 * auseinanderlaufen — genau das war die Ursache des webServer-Timeouts vom
+		 * 2026-08-04 (`0.0.0.0` gebunden, `localhost` → `::1` abgefragt).
+		 */
+		host: CI_DEV_HOST,
+		// Vorher hart 4000 — das von playwright.config.ts gesetzte VITE_DEV_PORT lief damit ins Leere.
+		port: ciDevPort(),
 		strictPort: true,
 		// Disable HMR overlay for CI
 		hmr: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
-import { devServerIdentity } from './src/tools/dev-server-identity';
+import { devPortFromEnv, devServerIdentity } from './src/tools/dev-server-identity';
 import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 const certFile = fileURLToPath(new URL('./certs/localhost.pem', import.meta.url));
@@ -55,7 +55,9 @@ export default defineConfig({
 	],
 	server: {
 		host: 'localhost',
-		port: parseInt(process.env.VITE_DEV_PORT || '4000'),
+		// Über `devPortFromEnv`, damit `VITE_DEV_PORT` hier nicht anders verstanden wird
+		// als in playwright.config.ts (`parseInt('4300abc')` ergab 4300, `Number` NaN).
+		port: devPortFromEnv() ?? 4000,
 		/**
 		 * Ohne `strictPort` weicht Vite bei belegtem Port still auf den nächsten aus.
 		 * Das ist hier immer ein Fehlerzustand, nie eine brauchbare Rückfallebene:


### PR DESCRIPTION
## Problem

`CI=1 npx playwright test` aborted with `Timed out waiting 120000ms from config.webServer` whenever `npm run dev` was running — with no hint at the cause. On 2026-08-04 that led to two misdiagnoses: once the timeout was taken for a test failure, once a `git stash` comparison became worthless because the run never started.

## Ursache — keine Portkollision

Deshalb half die Portvergabe pro Worktree hier nicht:

| Prozess | Bind |
|---|---|
| `npm run dev` (`vite.config.ts`, `host: 'localhost'`) | nur `[::1]:4000` |
| E2E-webServer (`vite.config.ci.ts`, `host: '0.0.0.0'`) | nur `*:4000` (IPv4-Wildcard) |

Zwei Adressfamilien, kein Zusammenstoß: **beide** Server binden erfolgreich, `strictPort` schlägt nie an. `strictPort` greift nur innerhalb *einer* Familie — die stille Annahme, es decke jede Doppelbelegung ab, war falsch.

Der Fehler saß in der Gegenrichtung: Playwright wartete auf `http://localhost:4000`, und `localhost` löst auf macOS zuerst nach `::1` auf. Der Readiness-Poll landete beim fremden **HTTPS**-Dev-Server, bekam auf Klartext-HTTP nie eine gültige Antwort und lief die vollen 120 s — während der eigene E2E-Server fertig unter `127.0.0.1` danebenstand.

Belegt durch ein isoliertes Bind-Experiment mit echten Sockets und `lsof -nP -iTCP:4000 -sTCP:LISTEN`. Die naheliegende erste Hypothese (`strictPort` bricht ab) hatte sich vorher widerlegt.

## Behebung

`CI_DEV_HOST` und `ciDevPort()` sind jetzt die **eine** Quelle, aus der `vite.config.ci.ts` seinen Bind und `playwright.config.ts` seine Warte-Adresse bezieht; `loopbackHostFor()` leitet die Loopback-Adresse aus dem Bind ab, statt `localhost` zu raten. Beide Server laufen seitdem nebeneinander.

Nebeneffekt: Weil Playwright jetzt die Adresse abfragt, die der Server auch bedient, greift dessen eigene Vorabprüfung wieder und meldet eine echte Doppelbelegung **sofort** statt nach 120 s.

Unterwegs mitbehoben:

- `vite.config.ci.ts` ignorierte das von `playwright.config.ts` gesetzte `VITE_DEV_PORT` — der Port ist jetzt wirklich steuerbar (`CI=1 VITE_DEV_PORT=4300 …`).
- `VITE_DEV_PORT` wurde an drei Stellen verschieden geparst (`parseInt('4300abc')` → 4300, `Number` → `NaN`). Alle Aufrufer gehen über `devPortFromEnv()`.
- Die Port-Eigentümer-Abfrage im `devServerIdentity`-Plugin fragte `localhost` ab, auch wenn der Server auf `0.0.0.0` band — sie lief damit am eigentlichen Konkurrenten vorbei.

## Warum `e2e/global-setup.ts` unverändert bleibt

Playwright startet den webServer **vor** dem `globalSetup`; bei einem webServer-Timeout läuft es nie an. Nachgemessen mit einer Minimal-Config — keine seiner Ausgaben erscheint. Die Identitätsprüfung dort bleibt für den lokalen `reuseExistingServer`-Pfad richtig, als Wache gegen webServer-Timeouts ist sie strukturell zu spät.

## Verifikation

- Reproduktion mit laufendem `npm run dev` auf 4000: **7 passed (14.2 s)** — vorher 120 s Timeout.
- Voller Lauf auf nachweislich ruhiger Maschine: **314 passed, 1 flaky, 1 failed**. Der flaky Fall ist der bekannt instabile `form-map-pan-zoom`; der Fehlschlag (`form-ux.spec.ts`) besteht isoliert 11/11.
- Unit **3457/3457**, `type-check` sauber, `lint` nur zwei vorbestehende Warnungen in fremder Datei.
- Dev-Server-Rauchtest nach der `vite.config.ts`-Änderung: startet, bindet `VITE_DEV_PORT` und liefert aus dem richtigen Worktree.

> [!NOTE]
> Drei frühere Vollläufe waren rot (49 bzw. 138 Fehlschläge) — **auch der Baseline-Lauf ohne diese Änderungen**. Ursache war ein paralleler E2E-Lauf aus einem anderen Worktree; im dritten Lauf verschwand der Dev-Server mitten drin (176× `ERR_CONNECTION_REFUSED`). Erst der Lauf mit Prozess-Wachhund, der null fremde Prozesse bestätigte, war aussagekräftig. Wer hier einen roten Vollauf sieht, sollte zuerst die betroffene Datei isoliert wiederholen.

## Doku

`docs/WORKTREES.md` bekommt einen Abschnitt mit Messwerten, dem `lsof`-Befehl zum Nachprüfen und dem `VITE_DEV_PORT`-Ausweg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)