### PR TITLE
feat(report): rework step 2 from the museum's feedback — media upload, dead-find wording

### DIFF
--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -336,12 +336,11 @@ test.describe('Accessibility — Alert-Kontrast', () => {
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Angaben zum Tier/i);
 
+		// Der Test bleibt auf Schritt 2. Die Medien-Dropzone lag bis zum
+		// 2026-08-04 auf Schritt 3; seit dem Umzug (Wunsch des Museums) gibt es
+		// dort keine mehr, und `ModernReportForm` rendert immer nur den aktuellen
+		// Schritt — ein weiteres `clickNext()` liefe hier in einen Timeout.
 		await fillStep2(formPage);
-		await expect(page.getByRole('button', { name: /Nächster Schritt/i })).toBeEnabled({
-			timeout: 3000
-		});
-		await formPage.clickNext();
-		await expectCurrentStep(page, /Weitere Informationen/i);
 
 		// Grenze aus der Laufzeit-Konfiguration lesen statt eine feste Byte-Zahl zu
 		// raten — dieselbe Quelle, die `videoUpload.spec.ts` schon nutzt.

--- a/e2e/form-position-photo.spec.ts
+++ b/e2e/form-position-photo.spec.ts
@@ -53,7 +53,9 @@ const fixture = (name: string): string =>
  * (`UnifiedDropzone.svelte`) — `setInputFiles` braucht keine Sichtbarkeit, ein
  * `click()` auf die Dropzone würde dagegen den nativen Dateidialog öffnen.
  * Eingegrenzt auf `photo-position-card`, damit der Selektor nicht versehentlich
- * die Medien-Dropzone aus Schritt 3 trifft.
+ * die Medien-Dropzone trifft (die liegt seit dem 2026-08-04 auf Schritt 2, davor
+ * auf Schritt 3 — für diesen Selektor ändert das nichts, beide Schritte sind
+ * nicht Schritt 1).
  *
  * Seit PR 3 liegt die Dropzone in einer zugeklappten Disclosure. Das stört
  * `setInputFiles` nicht — der Input ist im DOM, nur nicht sichtbar, und

--- a/src/lib/report/components/sections/AnimalInfo.svelte
+++ b/src/lib/report/components/sections/AnimalInfo.svelte
@@ -4,10 +4,17 @@
 	import { getFormContext } from '$lib/report/formContext';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
+	import { speciesQuestion } from '$lib/report/wording';
 
 	let { adminMode = false }: { adminMode?: boolean } = $props();
 
 	const { form } = getFormContext();
+
+	// Beim Totfund fragt das Artfeld nach dem, was gefunden wurde (Wunsch des
+	// Museums). Über den `label`-Override an `FormField` — derselbe Weg, den PR 4
+	// für den Bootsantrieb gebaut hat: Eine Schema-Spalte, in zwei Zuständen
+	// unterschiedlich gefragt, ohne das `.label()` des Schemas anzufassen.
+	const speciesLabel = $derived(speciesQuestion($form.isDead));
 </script>
 
 <!-- Animal Information Section -->
@@ -40,7 +47,7 @@
 
 	<!-- Species Selection -->
 	<div class="mt-4">
-		<FormField name="species" />
+		<FormField name="species" label={speciesLabel} />
 	</div>
 
 	<!-- Animal Count -->

--- a/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
+++ b/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
@@ -88,6 +88,35 @@ describe('sections/AnimalInfo — Totfund prominent platziert (PR 2, Teil a)', (
 });
 
 /**
+ * „Welche Tierart haben Sie gefunden?" — Wunsch des Museums für den Totfund.
+ * Das Artfeld liegt in derselben Karte wie der Totfund-Schalter und kann ihm
+ * deshalb folgen; die Zuordnung selbst steht in `$lib/report/wording`.
+ *
+ * Geprüft wird das gerenderte `<label>`, nicht das Schema-`.label()`: Der
+ * Wortlaut kommt hier über den `label`-Override an `FormField` (derselbe Weg,
+ * den PR 4 für den Bootsantrieb gebaut hat), das Schema bleibt unverändert.
+ */
+describe('sections/AnimalInfo — Artfrage folgt dem Totfund-Schalter', () => {
+	function speciesLabel(): string {
+		const field = document.querySelector<HTMLElement>('[data-field="species"]');
+		if (!field) throw new Error('Feld "species" nicht im DOM');
+		return field.querySelector('label')?.textContent ?? '';
+	}
+
+	it('fragt bei einer Sichtung, was gesehen wurde', () => {
+		renderAnimalInfo({ isDead: false });
+
+		expect(speciesLabel()).toContain('Welche Tierart haben Sie gesehen?');
+	});
+
+	it('fragt beim Totfund, was gefunden wurde', () => {
+		renderAnimalInfo({ isDead: true, deadCondition: 1 });
+
+		expect(speciesLabel()).toContain('Welche Tierart haben Sie gefunden?');
+	});
+});
+
+/**
  * `adminMode` wird von `AnimalInfo` nur durchgereicht (PR 2, Teil b) — die
  * Fach-Entscheidung, ob `deadSex` erscheint, trifft `DeadAnimal` selbst
  * (siehe DeadAnimal.svelte.test.ts). Hier wird nur die Weitergabe geprüft,

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -56,7 +56,47 @@
 </script>
 
 <!-- Media Section -->
-<SectionCard title="Fotos und Videos" icon="lucide:camera">
+<!-- „(optional)" steht im Titel, weil der Abschnitt seit dem 2026-08-04 auf dem
+     Pflichtschritt 2 liegt: Zwischen lauter Pflichtfeldern liest sich eine
+     Dropzone sonst wie eine weitere Bedingung fürs Weiterkommen. Wortlaut aus
+     der Vorlage des Museums.
+
+     Der Titel nennt Videos fest, obwohl `allowsVideo` unten prüft, ob die
+     Konfiguration sie zulässt: Er ist eine Überschrift, kein Versprechen — was
+     tatsächlich angenommen wird, sagt `formatDescription` eine Zeile tiefer und
+     passt sich an. Der Fließtext daneben ist bewusst formatneutral gehalten. -->
+<SectionCard title="Fotos/Videos hochladen (optional)" icon="lucide:camera">
+	<!-- Der Einwilligungssatz der Vorlage („Mit dem Hochladen … stimmen Sie deren
+	     Speicherung zu") steht hier bewusst NICHT: Denselben Vorgang beschreibt
+	     `UPLOAD_NOTICE` an der Dropzone darunter genauer — sofortige Übertragung,
+	     Zweckbindung auf die fachliche Prüfung, automatische Löschung nicht
+	     abgeschickter Meldungen, spätere eigene Entscheidung über eine
+	     Veröffentlichung. Eine zweite, kürzere Fassung daneben wäre keine
+	     Zusammenfassung, sondern eine abweichende Aussage; aus demselben Grund
+	     hält `UploadNotice.svelte` den Wortlaut unverkürzt im Dialog.
+
+	     Die zweite Einwilligung der Vorlage („ausschließlich intern") ist nicht
+	     gebaut — sie bräuchte Schema-Feld, DB-Spalte und zwei Nachweisspalten.
+	     Ohne sie IST der unangekreuzte Zustand die interne Nutzung, was
+	     `mediaConsent.valueText` bereits sagt.
+
+	     Nur im Meldeformular: In der Admin-Maske (`AdminSightingEditForm.svelte`
+	     rendert `<Media adminMode={true} />`) fordert „Bitte wählen Sie unten
+	     aus …" zu etwas auf, das das Feld darunter mit `disabled={adminMode}`
+	     gerade sperrt — und widerspräche dem Hinweis, dass nur die meldende
+	     Person diese Einwilligung erteilen kann.
+
+	     „Aufnahmen" statt „Fotos und Videos": Welche Formate tatsächlich
+	     angenommen werden, hängt an der Laufzeit-Konfiguration und steht in der
+	     Liste darunter (`formatDescription`). Ein fester Satz im Fließtext würde
+	     Videos auch dann versprechen, wenn `allowedTypes` keine enthält. Das
+	     Wort ist zugleich das, was der Abschnitt sonst durchgehend verwendet. -->
+	{#if !adminMode}
+		<p class="text-base-content/70 mb-4 text-sm">
+			Sie können Aufnahmen zu Ihrer Meldung hochladen. Bitte wählen Sie unten aus, ob wir sie
+			zusätzlich für Veröffentlichungen nutzen dürfen.
+		</p>
+	{/if}
 	<div class="text-base-content/70 mb-4 text-sm">
 		<p class="mb-2 flex items-center gap-2 font-medium">
 			<Icon icon="lucide:camera" width="16" class="text-primary" aria-hidden="true" />

--- a/src/lib/report/components/sections/Media.svelte.test.ts
+++ b/src/lib/report/components/sections/Media.svelte.test.ts
@@ -66,3 +66,80 @@ describe('Media — Einwilligung zur Veröffentlichung', () => {
 		expect(document.body.textContent).toMatch(/meldende|melderin|melder|betroffene/i);
 	});
 });
+
+/**
+ * Der Einleitungstext folgt der Fassung des Museums — mit einer bewussten
+ * Auslassung.
+ *
+ * Das Dokument schlägt vor: „Mit dem Hochladen Ihrer Fotos stimmen Sie deren
+ * Speicherung durch das Deutsche Meeresmuseum zu." Genau das steht schon an
+ * jeder Dropzone, und zwar genauer: `UPLOAD_NOTICE` nennt die sofortige
+ * Übertragung, die Zweckbindung auf die fachliche Prüfung, die automatische
+ * Löschung nicht abgeschickter Meldungen und die spätere eigene Entscheidung
+ * über eine Veröffentlichung. Eine zweite, kürzere Fassung daneben wäre keine
+ * Zusammenfassung, sondern eine abweichende Aussage über denselben Vorgang —
+ * dieselbe Begründung, aus der `UploadNotice.svelte` den vollen Wortlaut in
+ * einem Dialog hält statt ihn zu kürzen.
+ *
+ * Übernommen sind deshalb Titel, Einladungssatz und der Verweis auf die
+ * Einwilligung darunter. Die zweite Einwilligung („ausschließlich intern"),
+ * die das Dokument zusätzlich vorsieht, ist bewusst nicht gebaut: Sie bräuchte
+ * ein Schema-Feld, eine DB-Spalte und zwei Nachweisspalten. Ohne sie ist der
+ * unangekreuzte Zustand die interne Nutzung — was `mediaConsent.valueText`
+ * bereits sagt.
+ */
+describe('Media — Einleitungstext nach der Fassung des Museums', () => {
+	it('kündigt den Abschnitt als optional an', () => {
+		renderMedia();
+
+		expect(document.body.textContent).toContain('Fotos/Videos hochladen (optional)');
+	});
+
+	it('lädt zum Hochladen ein', () => {
+		renderMedia();
+
+		expect(document.body.textContent).toMatch(/Sie können Aufnahmen zu Ihrer Meldung hochladen/i);
+	});
+
+	/**
+	 * Auf einen Ausschnitt des neuen Satzes geprüft, nicht auf das Wort
+	 * „Veröffentlichung" allein: Das steht bereits im Schema-Label von
+	 * `mediaConsent` („Veröffentlichung meiner Aufnahmen"), ein Test darauf wäre
+	 * auch ohne den neuen Absatz grün.
+	 */
+	it('verweist auf die Auswahl zur Veröffentlichung darunter', () => {
+		renderMedia();
+
+		expect(document.body.textContent).toMatch(/Bitte wählen Sie unten aus/i);
+	});
+
+	/**
+	 * Der Absatz gilt nur im Meldeformular. In der Admin-Maske fordert
+	 * „Bitte wählen Sie unten aus …" zu etwas auf, das direkt darunter gesperrt
+	 * ist — und widerspricht damit dem Hinweis, dass nur die meldende Person
+	 * diese Einwilligung erteilen kann.
+	 */
+	it('fordert den Admin nicht zu einer Auswahl auf, die dort gesperrt ist', () => {
+		renderMedia({ adminMode: true });
+
+		expect(document.body.textContent).not.toMatch(/Bitte wählen Sie unten aus/i);
+	});
+
+	/**
+	 * Der Kern der Auslassung: Der Einwilligungssatz gehört in den
+	 * Datenschutzhinweis, nicht ein zweites Mal in den Fließtext. Bräche das
+	 * auf, stünden zwei unterschiedlich formulierte Aussagen über die
+	 * Speicherung im selben Abschnitt.
+	 */
+	it('behauptet keine Einwilligung durch das Hochladen selbst', () => {
+		renderMedia();
+
+		expect(document.body.textContent).not.toMatch(/Mit dem Hochladen .*stimmen Sie/i);
+	});
+
+	it('behält den Datenschutzhinweis an der Dropzone', () => {
+		renderMedia();
+
+		expect(document.querySelector('[data-testid="upload-notice-trigger"]')).not.toBeNull();
+	});
+});

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte
@@ -7,20 +7,28 @@
 </script>
 
 <!-- Sighting Details Section -->
-<SectionCard title="Weitere Sichtungsdetails" icon="lucide:activity">
-	<!-- Das Museum hat „Verteilung der Tiere" am 2026-08-04 aus dem Meldeformular
-	     abbestellt: Sie lässt sich aus der Anzahl der Tiere erschließen. Die
-	     Admin-Maske behält das Feld, weil dort der Bestand korrigiert wird. -->
-	{#if adminMode}
-		<FormField name="distribution" />
-	{/if}
+<!-- Die Karte als Ganzes hängt an `adminMode`, nicht mehr nur ihre Felder: Beide
+     Felder sind inzwischen admin-only — `distribution` seit dem 2026-08-04,
+     `shipCount` seit dem Umzug nach `BoatInfo.svelte`. Im Meldeformular blieb
+     dadurch eine Karte mit Überschrift, Rahmen und Abstand übrig, in der nichts
+     stand; `SectionCard` rendert seinen Titel unbedingt und kennt keinen
+     Leer-Zustand.
 
-	<!-- `shipCount` steht im Meldeformular jetzt in `BoatInfo.svelte`: Die Anzahl
-	     umliegender Schiffe gehört zu den Boot-/Schiffsangaben, nicht zwischen
-	     die Beobachtungsdetails. Die Admin-Maske bindet `BoatInfo` nicht ein und
-	     bekommt das Feld deshalb hier — sonst wäre es dort ersatzlos weg
-	     (5.539 Datensätze mit Inhalt). -->
-	{#if adminMode}
+     Der innere Schutz bleibt trotzdem sinnvoll: Bindet jemand die Sektion später
+     wieder ins Meldeformular ein, zeigt sie dort nicht still zwei Felder, die
+     das Museum abbestellt hat. -->
+{#if adminMode}
+	<SectionCard title="Weitere Sichtungsdetails" icon="lucide:activity">
+		<!-- Das Museum hat „Verteilung der Tiere" am 2026-08-04 aus dem Meldeformular
+		     abbestellt: Sie lässt sich aus der Anzahl der Tiere erschließen. Die
+		     Admin-Maske behält das Feld, weil dort der Bestand korrigiert wird. -->
+		<FormField name="distribution" />
+
+		<!-- `shipCount` steht im Meldeformular jetzt in `BoatInfo.svelte`: Die Anzahl
+		     umliegender Schiffe gehört zu den Boot-/Schiffsangaben, nicht zwischen
+		     die Beobachtungsdetails. Die Admin-Maske bindet `BoatInfo` nicht ein und
+		     bekommt das Feld deshalb hier — sonst wäre es dort ersatzlos weg
+		     (5.539 Datensätze mit Inhalt). -->
 		<FormField name="shipCount" />
-	{/if}
-</SectionCard>
+	</SectionCard>
+{/if}

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
@@ -48,3 +48,38 @@ describe('sections/OptionalSightingDetails — Verteilung nur im Admin-Modus', (
 		expect(field('distribution')).not.toBeNull();
 	});
 });
+
+/**
+ * Beide Felder dieser Sektion sind inzwischen `adminMode`-only — `distribution`
+ * seit PR #746, `shipCount` seit dem Umzug nach `BoatInfo.svelte`. Übrig blieb im
+ * Meldeformular eine Karte mit Überschrift, Rahmen und Abstand, in der nichts
+ * stand: `SectionCard` rendert seinen Titel unbedingt und kennt keinen
+ * Leer-Zustand.
+ *
+ * Der Fehler ist nicht bei der einzelnen Feld-Entfernung entstanden, sondern
+ * beim Zusammentreffen von zweien — genau die Klasse, die eine Feld-Prüfung
+ * nicht sieht: `field('distribution') === null` war die ganze Zeit erfüllt,
+ * während der Nutzer eine leere Karte vor sich hatte. Geprüft wird deshalb die
+ * **Hülle**, nicht der Inhalt.
+ */
+describe('sections/OptionalSightingDetails — keine leere Karte im Meldeformular', () => {
+	function cardHeading(): HTMLElement | null {
+		return (
+			Array.from(document.querySelectorAll<HTMLElement>('h3')).find((heading) =>
+				heading.textContent?.includes('Weitere Sichtungsdetails')
+			) ?? null
+		);
+	}
+
+	it('rendert ohne adminMode gar keine Karte', () => {
+		renderDetails();
+
+		expect(cardHeading()).toBeNull();
+	});
+
+	it('rendert mit adminMode die Karte samt Überschrift', () => {
+		renderDetails({ adminMode: true });
+
+		expect(cardHeading()).not.toBeNull();
+	});
+});

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -5,6 +5,7 @@
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
+	import { detailsSectionTitle } from '$lib/report/wording';
 	import {
 		NOT_YET_TRACKED,
 		isBoatSightingFrom,
@@ -15,6 +16,11 @@
 	const { adminMode = false }: { adminMode?: boolean } = $props();
 
 	const { form, updateField } = getFormContext();
+
+	// „Statt Sichtungsdetails ‚Funddetails' einfügen" (Wunsch des Museums für den
+	// Totfund). Gilt auch in der Admin-Maske — dort kommt `isDead` aus dem
+	// geladenen Datensatz, und ein Totfund heißt auch dort ein Fund.
+	const cardTitle = $derived(detailsSectionTitle($form.isDead));
 
 	/** Sichtung erfolgte von einem Boot mit Antrieb (Segelschiff/Motorboot) aus. */
 	const showsBoatDrive = $derived(isBoatSightingFrom($form.sightingFrom));
@@ -47,7 +53,7 @@
 </script>
 
 <!-- Sighting Details Section -->
-<SectionCard title="Sichtungsdetails" icon="lucide:activity">
+<SectionCard title={cardTitle} icon="lucide:activity">
 	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
 		<FormField name="sightingFrom" />
 		{#if String($form.sightingFrom) === String(SightingFromEnum.OTHER)}

--- a/src/lib/report/components/sections/SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/SightingDetails.svelte.test.ts
@@ -97,3 +97,35 @@ describe('sections/SightingDetails — boatDrive in der Admin-Maske', () => {
 		expect(document.querySelector('[data-field="boatDrive"]')).toBeNull();
 	});
 });
+
+/**
+ * „Statt Sichtungsdetails ‚Funddetails' einfügen" — Wunsch des Museums für den
+ * Totfund. Die Karte reagiert auf den Totfund-Schalter, der auf Schritt 2 über
+ * ihr steht; die Zuordnung selbst liegt in `$lib/report/wording`.
+ *
+ * Gilt auch in der Admin-Maske: Dort kommt `isDead` aus dem geladenen
+ * Datensatz, und ein Totfund heißt auch dort ein Fund.
+ */
+describe('sections/SightingDetails — Kartentitel folgt dem Totfund-Schalter', () => {
+	it('heißt bei einer Sichtung „Sichtungsdetails"', () => {
+		renderSightingDetails({ isDead: false });
+
+		expect(document.body.textContent).toContain('Sichtungsdetails');
+	});
+
+	it('heißt beim Totfund „Funddetails"', () => {
+		renderSightingDetails({ isDead: true });
+
+		const text = document.body.textContent ?? '';
+		expect(text).toContain('Funddetails');
+		expect(text).not.toContain('Sichtungsdetails');
+	});
+
+	// Gegenprobe über die Admin-Maske: Der Titel hängt am Datensatz, nicht am
+	// Modus — sonst führe die Sachbearbeitung einen Totfund unter „Sichtung".
+	it('heißt beim Totfund auch in der Admin-Maske „Funddetails"', () => {
+		renderSightingDetails({ isDead: true }, { adminMode: true });
+
+		expect(document.body.textContent).toContain('Funddetails');
+	});
+});

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import AnimalInfo from '$lib/report/components/sections/AnimalInfo.svelte';
+	import Media from '$lib/report/components/sections/Media.svelte';
 	import SightingDetails from '$lib/report/components/sections/SightingDetails.svelte';
 	import Icon from '$lib/components/Icon.svelte';
+	import { getFormContext } from '$lib/report/formContext';
+	import { observationQuestion } from '$lib/report/wording';
+
+	const { form } = getFormContext();
+
+	const question = $derived(observationQuestion($form.isDead));
 </script>
 
 <div class="space-y-6 md:space-y-8">
@@ -16,8 +23,13 @@
 			</div>
 		</div>
 		<h2 class="text-base-content text-xl font-bold md:text-2xl">Angaben zum Tier</h2>
+		<!-- Beim Totfund fragt der Kopf nach einem Fund statt nach einer Beobachtung
+		     (Wunsch des Museums). Der Rest des Satzes gilt für beide Fälle — er
+		     nennt Tierart und Anzahl, nicht den Vorgang. Die Zuordnung steht in
+		     `$lib/report/wording`, damit sie beim Bau der getrennten Formulare
+		     nicht an drei Stellen auseinanderläuft. -->
 		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
-			<strong>Was haben Sie beobachtet?</strong> Bitte geben Sie
+			<strong>{question}</strong> Bitte geben Sie
 			<strong>Tierart und Anzahl</strong>
 			an. Bei Unsicherheit wählen Sie „Unbekannte Walart" bzw. „Unbekannte Robbenart" — auch Schätzungen
 			sind wertvoll und unterstützen die Populationsforschung.
@@ -25,6 +37,12 @@
 	</div>
 
 	<!-- Step Content -->
+	<!-- Der Medien-Upload steht VOR den Tierangaben (Wunsch des Museums): Wer
+	     unsicher ist, welche Art er gesehen hat, soll das Bild hochladen können,
+	     statt zu raten. Er lag bis zum 2026-08-04 auf Schritt 3 unter dem
+	     „Schritt überspringen"-Knopf und war damit für jeden unsichtbar, der ihn
+	     benutzte. -->
+	<Media />
 	<AnimalInfo />
 	<SightingDetails />
 </div>

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
@@ -1,0 +1,81 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import Step2SightingDetails from './Step2SightingDetails.svelte';
+
+/**
+ * Zwei Wünsche des Museums treffen sich auf diesem Schritt:
+ *
+ * 1. **Der Medien-Upload gehört hierher, vor die Tierangaben.** Er stand auf
+ *    Schritt 3 unter dem prominenten „Schritt überspringen"-Knopf — wer den
+ *    nutzte, sah die Foto-Frage nie. Und wer unsicher ist, welche Art er
+ *    gesehen hat, soll das Bild hochladen können, bevor er sich auf eine Art
+ *    festlegt.
+ * 2. **Beim Totfund fragt der Kopf nach einem Fund, nicht nach einer
+ *    Beobachtung.** Die Entscheidung dazu steht in `$lib/report/wording`.
+ */
+function renderStep2(overrides: Partial<SightingFormData> = {}): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(Step2SightingDetails, { context: new Map([[formContextKey, context]]) });
+}
+
+/**
+ * Render-Reihenfolge über `[data-field]` statt über Pixel — dieselbe Technik
+ * wie in `sections/AnimalInfo.svelte.test.ts`, samt lesbarer Namensliste bei
+ * einer Regression.
+ */
+function fieldOrder(): string[] {
+	return Array.from(document.querySelectorAll<HTMLElement>('[data-field]')).map(
+		(el) => el.dataset.field ?? ''
+	);
+}
+
+describe('Step2SightingDetails — Medien-Upload vor den Tierangaben', () => {
+	it('rendert die Medien-Einwilligung im DOM vor der Artauswahl', () => {
+		renderStep2();
+
+		const order = fieldOrder();
+		expect(order.indexOf('mediaConsent')).toBeGreaterThanOrEqual(0);
+		expect(order.indexOf('species')).toBeGreaterThanOrEqual(0);
+		expect(order.indexOf('mediaConsent')).toBeLessThan(order.indexOf('species'));
+	});
+
+	it('kündigt den Upload als optional an — der Schritt selbst ist Pflicht', () => {
+		renderStep2();
+
+		expect(document.body.textContent).toContain('Fotos/Videos hochladen (optional)');
+	});
+});
+
+describe('Step2SightingDetails — Ansprache bei Sichtung und Totfund', () => {
+	it('fragt bei einer Sichtung nach der Beobachtung', () => {
+		renderStep2({ isDead: false });
+
+		expect(document.body.textContent).toContain('Was haben Sie beobachtet?');
+	});
+
+	it('fragt beim Totfund nach dem Fund', () => {
+		renderStep2({ isDead: true, deadCondition: 1 });
+
+		expect(document.body.textContent).toContain('Was haben Sie gefunden?');
+		expect(document.body.textContent).not.toContain('Was haben Sie beobachtet?');
+	});
+
+	// Der Rest des Einleitungstextes ist für beide Fälle richtig und bleibt
+	// unverändert — er nennt Tierart und Anzahl, nicht den Vorgang.
+	it('behält den Hinweis auf Tierart und Anzahl in beiden Fällen', () => {
+		renderStep2({ isDead: true, deadCondition: 1 });
+
+		expect(document.body.textContent).toContain('Tierart und Anzahl');
+	});
+});

--- a/src/lib/report/components/steps/Step3Observations.svelte
+++ b/src/lib/report/components/steps/Step3Observations.svelte
@@ -7,12 +7,10 @@
 	import Behavior from '$lib/report/components/sections/Behavior.svelte';
 	import BoatInfo from '$lib/report/components/sections/BoatInfo.svelte';
 	import Environment from '$lib/report/components/sections/Environment.svelte';
-	import Media from '$lib/report/components/sections/Media.svelte';
 	import { getFormContext } from '$lib/report/formContext';
 	import { scrollToElement } from '$lib/utils/fieldNavigation';
 
 	import Icon from '$lib/components/Icon.svelte';
-	import OptionalSightingDetails from '$lib/report/components/sections/OptionalSightingDetails.svelte';
 
 	const logger = createLogger('report:Step3Observations');
 	const formContext = getFormContext();
@@ -52,10 +50,13 @@
 			</div>
 		</div>
 		<h2 class="text-base-content text-xl font-bold md:text-2xl">Weitere Informationen</h2>
+		<!-- „Fotos/Videos" stand hier, solange der Upload auf diesem Schritt lag.
+		     Seit dem 2026-08-04 steht er auf Schritt 2 — der Halbsatz verspräche
+		     sonst etwas, das einen Schritt weiter vorne liegt, und das ausgerechnet
+		     direkt über dem „Schritt überspringen"-Knopf. -->
 		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
-			Diese Details sind <strong>optional, aber extrem wertvoll</strong> für die Forschung!
-			Verhaltensinformationen, Umweltbedingungen und <strong>Fotos/Videos</strong> helfen bei der Artbestimmung
-			und dem Verständnis der Meeressäuger.
+			Diese Details sind <strong>optional, aber extrem wertvoll</strong> für die Forschung! Verhaltensinformationen
+			und Umweltbedingungen helfen bei der Artbestimmung und dem Verständnis der Meeressäuger.
 		</p>
 
 		<!-- Skip Button prominent oben platziert -->
@@ -75,10 +76,12 @@
 		<div class="divider text-xs opacity-70">oder Details hinzufügen</div>
 	</div>
 
-	<Media></Media>
+	<!-- `Media` steht seit dem 2026-08-04 auf Schritt 2 (`Step2SightingDetails`).
 
-	<OptionalSightingDetails></OptionalSightingDetails>
-
+	     `OptionalSightingDetails` ist hier ersatzlos entfallen: Beide Felder der
+	     Sektion sind admin-only, sie hätte im Meldeformular nur noch eine leere
+	     Karte mit Überschrift beigetragen. Die Komponente selbst bleibt — die
+	     Admin-Maske bindet sie ein und braucht beide Felder für den Bestand. -->
 	<Behavior></Behavior>
 
 	<Environment></Environment>

--- a/src/lib/report/components/steps/Step3Observations.svelte.test.ts
+++ b/src/lib/report/components/steps/Step3Observations.svelte.test.ts
@@ -1,0 +1,71 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { createForm } from '$lib/form/createForm';
+import { key as formContextKey } from '$lib/report/formContext';
+import { initialFormState } from '$lib/report/formConfig';
+import type { FormContext, SightingFormData } from '$lib/types';
+import Step3Observations from './Step3Observations.svelte';
+
+/**
+ * Die Gegenprobe zu `Step2SightingDetails.svelte.test.ts`: Was auf Schritt 2
+ * angekommen ist, darf auf Schritt 3 nicht zusätzlich stehen.
+ *
+ * Der Einleitungstext gehört mit umgezogen. Er warb für „Verhaltensinformationen,
+ * Umweltbedingungen und **Fotos/Videos**" — eine Aufzählung dessen, was der
+ * Schritt enthält. Bliebe der Halbsatz stehen, verspräche der Kopf etwas, das
+ * einen Schritt weiter vorne liegt, und das ausgerechnet direkt über dem
+ * „Schritt überspringen"-Knopf.
+ */
+function renderStep3(): void {
+	const context = {
+		...createForm<SightingFormData>({
+			initialValues: { ...initialFormState } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	} as unknown as FormContext;
+
+	render(Step3Observations, { context: new Map([[formContextKey, context]]) });
+}
+
+describe('Step3Observations — Medien sind auf Schritt 2 gewandert', () => {
+	it('rendert die Medien-Einwilligung nicht mehr', () => {
+		renderStep3();
+
+		expect(document.querySelector('[data-field="mediaConsent"]')).toBeNull();
+	});
+
+	it('nennt Fotos/Videos nicht mehr in der Einleitung', () => {
+		renderStep3();
+
+		expect(document.body.textContent).not.toContain('Fotos/Videos');
+	});
+
+	// Gegenprobe: Der Schritt behält, was ihn ausmacht — sonst prüfte der Test
+	// oben nur, dass die Komponente überhaupt nichts rendert.
+	it('wirbt weiterhin mit Verhalten und Umweltbedingungen', () => {
+		renderStep3();
+
+		const text = document.body.textContent ?? '';
+		expect(text).toContain('Verhaltensinformationen');
+		expect(text).toContain('Umweltbedingungen');
+	});
+});
+
+/**
+ * Die Karte „Weitere Sichtungsdetails" stand im Meldeformular leer da: Beide
+ * Felder sind `adminMode`-only (`distribution` seit PR #746, `shipCount` seit
+ * dem Umzug nach `BoatInfo`), die Karte selbst wurde aber unbedingt gerendert.
+ *
+ * Der Test sitzt bewusst **auch** hier und nicht nur an der Sektion selbst: Die
+ * Sektion schützt sich inzwischen zwar selbst, aber der Fehler war ein Fehler
+ * der Einbindung — Schritt 3 hat eine Komponente gerendert, die für ihn nichts
+ * mehr zu zeigen hatte.
+ */
+describe('Step3Observations — keine leere Sichtungsdetail-Karte', () => {
+	it('zeigt die Karte „Weitere Sichtungsdetails" nicht mehr', () => {
+		renderStep3();
+
+		expect(document.body.textContent).not.toContain('Weitere Sichtungsdetails');
+	});
+});

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -140,6 +140,58 @@ describe('formStepsConfig — boatDriveText nur in der Admin-Maske (PR 4)', () =
 	});
 });
 
+/**
+ * Der Medien-Upload steht seit dem 2026-08-04 auf Schritt 2 (Wunsch des
+ * Museums: „Foto hochladen als erste Abfrage noch vor Tierinformation").
+ *
+ * Der Grund wiegt schwerer als die Reihenfolge: Schritt 3 trägt ganz oben einen
+ * prominenten „Schritt überspringen"-Knopf, der direkt zu den Kontaktdaten
+ * springt — der Upload stand darunter. Wer den Knopf nutzte, bekam die
+ * Foto-Frage nie zu sehen, obwohl Aufnahmen die wertvollste Einzelangabe der
+ * Meldung sind. Schritt 2 ist Pflichtschritt und nicht überspringbar.
+ *
+ * Geprüft wird die Zuordnung in `formStepsConfig`, nicht nur das Markup: An ihr
+ * hängen Schritt-Validierung (`validateStep`) und Fehler-Navigation
+ * (`findStepForErrors`). Stünde das Feld im Markup auf Schritt 2, in der Config
+ * aber auf Schritt 3, spränge die Fehlernavigation auf den falschen Schritt.
+ */
+describe('formStepsConfig — Medien-Upload auf Schritt 2', () => {
+	const sightingDetailsStep = formStepsConfig.find((step) => step.id === 'sighting-details');
+	const observationsStep = formStepsConfig.find((step) => step.id === 'observations');
+
+	it.each(['mediaFile', 'mediaUpload', 'mediaConsent'])(
+		'führt %s im Schritt "sighting-details"',
+		(name) => {
+			expect(sightingDetailsStep?.fields).toContain(name);
+		}
+	);
+
+	it.each(['mediaFile', 'mediaUpload', 'mediaConsent'])(
+		'führt %s nicht mehr im Schritt "observations"',
+		(name) => {
+			expect(observationsStep?.fields).not.toContain(name);
+		}
+	);
+
+	// Der Upload steht VOR den Tierangaben: Wer unsicher ist, welche Art er
+	// gesehen hat, soll das Bild hochladen können, statt zu raten. Die
+	// Reihenfolge im Markup prüft `Step2SightingDetails.svelte.test.ts`; hier
+	// zählt, dass die Config dieselbe Geschichte erzählt — sie bestimmt die
+	// Reihenfolge, in der `findStepForErrors` Felder abläuft.
+	it('listet die Medien-Felder vor species', () => {
+		const fields = sightingDetailsStep?.fields ?? [];
+		const mediaIndex = fields.indexOf('mediaConsent');
+		const speciesIndex = fields.indexOf('species');
+
+		// Beide Fundstellen ausdrücklich absichern: `indexOf` liefert für ein
+		// fehlendes Feld -1, und -1 ist kleiner als jeder gültige Index — der
+		// Vergleich allein liefe grün durch, gerade wenn das Feld ganz fehlt.
+		expect(mediaIndex).toBeGreaterThanOrEqual(0);
+		expect(speciesIndex).toBeGreaterThanOrEqual(0);
+		expect(mediaIndex).toBeLessThan(speciesIndex);
+	});
+});
+
 describe('waterway — Beschriftung deckt beide bisherigen Felder ab', () => {
 	const waterwayMeta = meta('waterway');
 	const copy = [describeField('waterway').label, waterwayMeta.helpText, waterwayMeta.placeholder]

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -69,6 +69,19 @@ export const formStepsConfig: FormStep[] = [
 		title: 'Angaben zum Tier',
 		description: 'Was haben Sie genau beobachtet?',
 		fields: [
+			// Die Medien-Felder stehen seit dem 2026-08-04 hier und VOR den
+			// Tierangaben (Wunsch des Museums: „Foto hochladen als erste Abfrage noch
+			// vor Tierinformation"). Der Grund wiegt schwerer als die Reihenfolge: Auf
+			// Schritt 3 stand der Upload unter dem prominenten „Schritt
+			// überspringen"-Knopf und blieb damit für jeden unsichtbar, der ihn
+			// benutzte — obwohl Aufnahmen die wertvollste Einzelangabe der Meldung
+			// sind. Schritt 2 ist Pflichtschritt.
+			//
+			// Die Reihenfolge in dieser Liste ist nicht kosmetisch: `findStepForErrors`
+			// läuft sie ab, um zum ersten fehlerhaften Feld zu springen.
+			'mediaFile',
+			'mediaUpload',
+			'mediaConsent',
 			'species',
 			'totalCount',
 			'juvenileCount',
@@ -108,10 +121,9 @@ export const formStepsConfig: FormStep[] = [
 			'windForce',
 			'shipName',
 			'homePort',
-			'boatType',
-			'mediaFile',
-			'mediaUpload',
-			'mediaConsent'
+			'boatType'
+			// `mediaFile`/`mediaUpload`/`mediaConsent` stehen seit dem 2026-08-04 im
+			// Schritt „sighting-details" — Begründung dort.
 		],
 		isOptional: true
 	},

--- a/src/lib/report/wording.test.ts
+++ b/src/lib/report/wording.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { detailsSectionTitle, observationQuestion, speciesQuestion } from './wording';
+
+/**
+ * Das Museum will für den Totfund eine eigene Ansprache („Was haben Sie
+ * gefunden?", „Funddetails"). Die beiden getrennten Formulare, die das Dokument
+ * dafür vorsieht, gibt es noch nicht — der Totfund-Schalter steht aber seit
+ * PR 2 ganz oben auf Schritt 2, und alles darunter kann auf ihn reagieren.
+ *
+ * Die Entscheidung „welches Wort bei welchem Zustand" steht deshalb hier an
+ * EINER Stelle und nicht als Ternär in drei Komponenten: Sie wird beim Bau der
+ * getrennten Formulare wieder gebraucht, und drei Kopien würden bis dahin
+ * auseinanderlaufen.
+ */
+describe('wording — Totfund-Ansprache auf Schritt 2', () => {
+	describe('speciesQuestion', () => {
+		it('fragt bei einer Sichtung nach dem, was gesehen wurde', () => {
+			expect(speciesQuestion(false)).toBe('Welche Tierart haben Sie gesehen?');
+		});
+
+		it('fragt beim Totfund nach dem, was gefunden wurde', () => {
+			expect(speciesQuestion(true)).toBe('Welche Tierart haben Sie gefunden?');
+		});
+	});
+
+	describe('observationQuestion', () => {
+		it('fragt bei einer Sichtung nach der Beobachtung', () => {
+			expect(observationQuestion(false)).toBe('Was haben Sie beobachtet?');
+		});
+
+		it('fragt beim Totfund nach dem Fund', () => {
+			expect(observationQuestion(true)).toBe('Was haben Sie gefunden?');
+		});
+	});
+
+	describe('detailsSectionTitle', () => {
+		it('nennt die Karte bei einer Sichtung „Sichtungsdetails"', () => {
+			expect(detailsSectionTitle(false)).toBe('Sichtungsdetails');
+		});
+
+		it('nennt die Karte beim Totfund „Funddetails"', () => {
+			expect(detailsSectionTitle(true)).toBe('Funddetails');
+		});
+	});
+
+	/**
+	 * `isDead` ist im Schema `boolean().default(false)`. Für den Schalter selbst
+	 * liefert `createForm.handleChange` einen echten Boolean (`target.checked`)
+	 * — der String-Fall entsteht dort also nicht. `undefined` sehr wohl: die
+	 * Admin-Maske füllt das Formular aus einem geladenen Datensatz.
+	 *
+	 * Die String-Werte stehen trotzdem in der Liste. Sie kosten nichts, und die
+	 * Verwechslung ist in genau dieser Codebasis schon einmal teuer gewesen:
+	 * `BaseRadio` verglich strikt gegen Zahlen, während im State der String aus
+	 * dem DOM-Event lag — der Bootsantrieb ließ sich dadurch gar nicht auswählen
+	 * (behoben in PR 4). Ein `if (isDead)` auf `"false"` wäre `true` und drehte
+	 * die Ansprache um.
+	 */
+	describe('duldet die Werte, die tatsächlich im Formular-State stehen', () => {
+		it.each([undefined, null, false, 'false', 0])('behandelt %o als Sichtung', (value) => {
+			expect(observationQuestion(value)).toBe('Was haben Sie beobachtet?');
+		});
+
+		it.each([true, 'true'])('behandelt %o als Totfund', (value) => {
+			expect(observationQuestion(value)).toBe('Was haben Sie gefunden?');
+		});
+	});
+});

--- a/src/lib/report/wording.ts
+++ b/src/lib/report/wording.ts
@@ -1,0 +1,54 @@
+/**
+ * Ansprache im Meldeformular: Sichtung oder Totfund.
+ *
+ * Das Museum will für den Totfund eigene Formulierungen — „Was haben Sie
+ * gefunden?" statt „Was haben Sie beobachtet?", „Funddetails" statt
+ * „Sichtungsdetails". Vorgesehen sind dafür zwei getrennte Formulare hinter
+ * einer Einstiegsseite; die gibt es noch nicht.
+ *
+ * Bis dahin trägt der Totfund-Schalter die Unterscheidung: Er ist das erste Feld
+ * der Karte „Tierinformationen" auf Schritt 2 — seit dem Umzug des Medien-Uploads
+ * steht diese Karte allerdings nicht mehr ganz oben, sondern hinter dem
+ * Upload-Abschnitt. Für die Ansprache reicht das: Der Schalter steht weiterhin
+ * vor allem, was auf ihn reagiert (Artfrage, Detail-Karte), und der Schritt-Kopf
+ * darüber wird von Svelte ohnehin reaktiv nachgezogen. Das deckt
+ * genau die Stellen ab, die das Dokument für Seite 2 nennt — die Totfund-Texte
+ * für Seite 1 („Funddatum", die umgedrehte Marker-Erklärung) bleiben offen,
+ * weil `isDead` dort noch nicht beantwortet ist.
+ *
+ * Die Zuordnung steht hier an EINER Stelle statt als Ternär in drei
+ * Komponenten: Sie wird beim Bau der getrennten Formulare wieder gebraucht, und
+ * drei Kopien liefen bis dahin auseinander.
+ */
+
+/**
+ * `isDead` als Wahrheitswert — ohne die klassische String-Falle.
+ *
+ * Für den Schalter selbst liefert `createForm.handleChange` einen echten
+ * Boolean (`target.checked`). `undefined` kommt trotzdem vor: Die Admin-Maske
+ * füllt das Formular aus einem geladenen Datensatz. Und ein String an einer
+ * solchen Stelle war in dieser Codebasis schon einmal ein echter Fehler
+ * (`BaseRadio` verglich strikt gegen Zahlen, im State lag der String aus dem
+ * DOM-Event — PR 4).
+ */
+function isDeadFinding(isDead: unknown): boolean {
+	if (typeof isDead === 'string') return isDead === 'true';
+	return Boolean(isDead);
+}
+
+/** Beschriftung des Artfeldes auf Schritt 2. */
+export function speciesQuestion(isDead: unknown): string {
+	return isDeadFinding(isDead)
+		? 'Welche Tierart haben Sie gefunden?'
+		: 'Welche Tierart haben Sie gesehen?';
+}
+
+/** Einleitungsfrage im Kopf von Schritt 2. */
+export function observationQuestion(isDead: unknown): string {
+	return isDeadFinding(isDead) ? 'Was haben Sie gefunden?' : 'Was haben Sie beobachtet?';
+}
+
+/** Titel der Karte unter den Tierangaben auf Schritt 2. */
+export function detailsSectionTitle(isDead: unknown): string {
+	return isDeadFinding(isDead) ? 'Funddetails' : 'Sichtungsdetails';
+}


### PR DESCRIPTION
Setzt die noch offenen **Textwünsche** aus `Sichtungs-Webseite_SL.docx` (Deutsches Meeresmuseum) um, soweit sie ohne die getrennten Tot-/Lebendfund-Formulare sinnvoll sind. Nach Abstimmung bleiben bewusst weg: der Foto-GPS-Weg (bleibt wie umgesetzt), „Im Wasser treibend/liegend", und die Drei-Wege-Frage „Museum informiert".

## 1. Medien-Upload auf Schritt 2, vor den Tierangaben

Der Wunsch war die Reihenfolge — der stärkere Grund fiel beim Nachsehen auf: Schritt 3 trägt ganz oben einen prominenten „Schritt überspringen"-Knopf, der direkt zu den Kontaktdaten springt, und der Upload stand **darunter**. Wer ihn benutzte, bekam die Foto-Frage nie zu sehen — ausgerechnet für die wertvollste Einzelangabe der Meldung. Schritt 2 ist Pflichtschritt.

Die Felder wandern auch in `formStepsConfig` mit, nicht nur im Markup: Schritt-Validierung und `findStepForErrors` lesen diese Liste.

**Der Einleitungstext folgt der Vorlage — mit einer bewussten Auslassung.** Der Satz „Mit dem Hochladen Ihrer Fotos stimmen Sie deren Speicherung … zu" steht schon an jeder Dropzone als `UPLOAD_NOTICE`, und zwar genauer (sofortige Übertragung, Zweckbindung, Löschfrist, Veröffentlichung als spätere eigene Entscheidung). Eine zweite, kürzere Fassung daneben wäre keine Zusammenfassung, sondern eine abweichende Aussage über denselben Vorgang.

**Die zweite Einwilligung („ausschließlich intern") ist nicht gebaut** — sie bräuchte Schema-Feld, DB-Spalte und zwei Nachweisspalten. Ohne sie *ist* der unangekreuzte Zustand die interne Nutzung.

## 2. Totfund-Ansprache auf Schritt 2

„Was haben Sie gefunden?", „Welche Tierart haben Sie gefunden?", „Funddetails" — konditional am Totfund-Schalter, der seit #746 das erste Feld der Tier-Karte ist. Die Zuordnung liegt in einem eigenen Modul (`$lib/report/wording`), weil sie beim Bau der getrennten Formulare wieder gebraucht wird.

Die Totfund-Texte für **Schritt 1** („Funddatum", umgedrehte Marker-Erklärung, Ostsee-Hinweis) bleiben bewusst offen: Dort ist `isDead` noch nicht beantwortet, es gäbe keine Bedingung, an die sie sich hängen könnten.

## 3. Leere Karte „Weitere Sichtungsdetails" entfernt

Beim Durchklicken aufgefallen: Die Karte rendert Überschrift, Rahmen und Abstand — und nichts darin. Beide Felder sind inzwischen admin-only (`distribution` seit #746, `shipCount` seit dem Umzug nach `BoatInfo`), `SectionCard` rendert seinen Titel aber unbedingt.

Der Fehler entstand beim **Zusammentreffen zweier** Änderungen und war für die vorhandenen Tests unsichtbar: `field('distribution') === null` war die ganze Zeit erfüllt, während der Nutzer eine leere Karte vor sich hatte. Die neuen Tests prüfen deshalb die Hülle statt des Inhalts. Die Admin-Maske ist unberührt.

## Prüfung

| Gate | Ergebnis |
| --- | --- |
| `lint` | 0 Fehler (2 Warnungen aus dem Altbestand in `src/tests/contract/helpers/`) |
| `type-check` / `check` | sauber, 2.105 Dateien, 0 Fehler |
| `test:unit` | 3.492 / 3.492 |
| `test:unit:client` | 337 / 337 |
| E2E (11 Formular-Specs) | 94 / 94 |

**24 neue Tests**, durchgehend test-first: jeder rote Lauf ist vor der Implementierung gefahren worden. Zwei Tests wären dabei leer durchgelaufen (`indexOf` liefert −1 und ist damit kleiner als jeder gültige Index; `/Veröffentlichung/i` matcht bereits das Schema-Label) — beide sind repariert, bevor sie grün wurden.

**Im Browser gegengeprüft:** Upload-Karte oben auf Schritt 2, Live-Umschalten der drei Totfund-Texte am Schalter, Schritt 3 ohne Medien und ohne die leere Karte.

**Ein E2E-Test war durch den Umzug kaputt und ist mitgezogen:** `form-a11y`s Dropzone-Kontrastprüfung navigierte zu Schritt 3 und wartete dort auf `[data-testid="dropzone-input"]`. `ModernReportForm` rendert nur den aktuellen Schritt, die zwei Dropzone-Aufrufstellen liegen auf Schritt 1 und 2 — der Test wäre in einen Timeout gelaufen. Er bleibt jetzt auf Schritt 2.

## Weiterhin offen aus dem Dokument

Hintergrund-Seite, Einstiegsseite mit den zwei Buttons, zweite Foto-Einwilligung, Trennung Tot-/Lebendfund — und die Freigabe des Datenschutztexts durch das Museum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)