### PR TITLE
fix(ui): stop the about page forcing a 411px document on every viewport

### DIFF
--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -66,3 +66,51 @@ test.describe('About Page', () => {
 		).toHaveCount(0);
 	});
 });
+
+/**
+ * Eigenes `describe`, weil der Viewport *vor* dem `goto` stehen muss — das
+ * `beforeEach` oben navigiert bereits in der Standardgröße.
+ *
+ * Gemessen am 2026-08-04 bei 360px: `scrollWidth` 411 gegen `clientWidth` 360.
+ * Die Seite ließ sich damit auf jedem verbreiteten Telefon seitlich schieben,
+ * und zwar über die volle Höhe — nicht nur an dem Element, das zu breit war.
+ * Derselbe Fehler wie in `footer-layout.spec.ts` („das Dokument wird auf keiner
+ * Breite breiter als das Fenster"), nur auf einer anderen Route; der Test ist
+ * bewusst gleich gebaut, damit beide Stellen dieselbe Zusage tragen.
+ *
+ * Die 411px waren eine **feste Untergrenze**, kein Verhalten bei 360px: Der Wert
+ * stand bei jedem Viewport, auch bei 320px. Vier Ursachen, alle in
+ * `src/routes/about/+page.svelte` behoben und dort einzeln begründet — jede war
+ * erst sichtbar, nachdem die vorherige weg war (Messung: `width: min-content` pro
+ * Element, weil jedes Blockkind auf die Elternbreite gestreckt wird und die
+ * gemessene Breite deshalb nichts über den Bedarf aussagt):
+ *
+ * | # | Ursache                                            | Untergrenze danach |
+ * | - | -------------------------------------------------- | ------------------ |
+ * | 1 | Partner-Linkzeile ohne `flex-wrap` (299px)         | 411 → 363          |
+ * | 2 | Handlungsaufforderung pauschal `p-12` + `border-2` | 363 → 338          |
+ * | 3 | DaisyUI-`nowrap` auf `.stat-desc` (158px)          | 338 → 326          |
+ * | 4 | Seitencontainer pauschal `p-6`                     | 326 → 310          |
+ *
+ * **Untergrenze jetzt 310px.** Die 320px stehen deshalb in der Liste — mit rund
+ * 10px Luft, nicht auf der Schwelle balancierend. Nach unten ist damit Schluss:
+ * Die nächste Grenze wäre der Knopf „Tiere bestimmen" mit 194px min-content, und
+ * die ließe sich nur noch durch Eingriffe in die Beschriftung oder die
+ * Button-Größe verschieben.
+ */
+test.describe('About Page — Layout in schmalen Viewports', () => {
+	test('das Dokument wird auf keiner Breite breiter als das Fenster', async ({ page }) => {
+		for (const breite of [320, 360, 390, 414]) {
+			await page.setViewportSize({ width: breite, height: 780 });
+			await page.goto('/about', { waitUntil: 'networkidle' });
+			await expect(page.getByRole('heading', { name: 'Über Ostsee-Tiere', level: 1 })).toBeVisible({
+				timeout: 15000
+			});
+
+			const ueberlauf = await page.evaluate(
+				() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+			);
+			expect(ueberlauf, `horizontaler Überlauf bei ${breite}px`).toBeLessThanOrEqual(0);
+		}
+	});
+});

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -33,7 +33,14 @@
 	/>
 </svelte:head>
 
-<div class="mx-auto max-w-5xl p-6">
+<!-- Innenabstand schaltet bei `md` (Breakpoint-Vertrag in
+     .claude/rules/design-system.md). Bei 320px zählt das: die Seite stapelt drei
+     Innenabstände übereinander — dieser hier, der des Handlungsaufforderungs-
+     Blocks und die 16px, die DaisyUI dem `hero-content` mitgibt. Zusammen blieben
+     von 320px nur 192px für den Inhalt. Die 8px pro Seite, die `p-4` hier spart,
+     kommen jedem Abschnitt der Seite zugute, nicht nur dem einen, der gerade die
+     Untergrenze bestimmt. -->
+<div class="mx-auto max-w-5xl p-4 md:p-6">
 	<!-- Hero Section -->
 	<div class="mb-16 text-center">
 		<div class="mb-8 flex flex-1 justify-center">
@@ -107,7 +114,12 @@
 							<div class="stat">
 								<div class="stat-title text-xs">Sichtungen seit</div>
 								<div class="stat-value text-primary text-2xl">{data.earliestSightingYear}</div>
-								<div class="stat-desc">in unserer Datenbank</div>
+								<!-- Umbrechbar aus demselben Grund wie die Kacheln im
+								     Handlungsaufforderungs-Block weiter unten. Diese hier bestimmt die
+								     Untergrenze der Seite derzeit nicht — aber sie steht unter
+								     derselben DaisyUI-Regel, und die nächste Textänderung würde den
+								     Überlauf sonst erneut aufmachen. -->
+								<div class="stat-desc whitespace-normal">in unserer Datenbank</div>
 							</div>
 						</div>
 					{/if}
@@ -210,7 +222,15 @@
 				Zentren für Meeresforschung und -bildung in Deutschland. Seit über 70 Jahren widmen wir uns
 				der Erforschung und dem Schutz der marinen Lebensräume.
 			</p>
-			<div class="flex justify-center gap-4">
+			<!-- `flex-wrap` ist hier nicht Kosmetik, sondern der Grund für einen
+			     Überlauf der ganzen Seite: Buttons tragen `white-space: nowrap`, zwei
+			     davon nebeneinander ergaben eine min-content-Breite von 299px. Mit den
+			     64px `p-8` dieser Fläche und den 48px `p-6` des Seitencontainers war das
+			     Dokument damit auf *jedem* Viewport mindestens 411px breit — bei 360px
+			     ließ sich die Seite über ihre volle Höhe seitlich schieben. Die beiden
+			     anderen Linkzeilen der Seite (Technik, Handlungsaufforderungen) haben
+			     `flex-wrap` von Anfang an; nur diese hier fehlte. -->
+			<div class="flex flex-wrap justify-center gap-4">
 				<a
 					href="https://www.deutsches-meeresmuseum.de"
 					target="_blank"
@@ -434,8 +454,14 @@
 		</div>
 	</div>
 	<!-- Call to Action -->
+	<!-- Innenabstand schaltet bei `md`, nicht pauschal `p-12`: Die 48px pro Seite
+	     waren der zweite Grund für den Überlauf bei 360px — zusammen mit den 4px
+	     `border-2` blieben von 312px verfügbarer Breite nur 208px für den Inhalt,
+	     der aber 238px braucht. Die Grenze ist `md` gemäß Breakpoint-Vertrag in
+	     .claude/rules/design-system.md (dort schalten die Innenabstände), und `p-6`
+	     entspricht dem Seitencontainer. -->
 	<div
-		class="hero from-primary/10 via-secondary/10 to-accent/10 border-primary/20 rounded-2xl border-2 bg-gradient-to-br p-12"
+		class="hero from-primary/10 via-secondary/10 to-accent/10 border-primary/20 rounded-2xl border-2 bg-gradient-to-br p-6 md:p-12"
 	>
 		<div class="hero-content text-center">
 			<div class="max-w-4xl">
@@ -481,7 +507,13 @@
 							<div class="stat-value text-primary">
 								{new Intl.NumberFormat('de-DE').format(data.totalSightings)}
 							</div>
-							<div class="stat-desc">freigegebene Sichtungen</div>
+							<!-- `whitespace-normal` hebt DaisyUIs `white-space: nowrap` auf den
+							     Kachel-Zeilen auf. Das ist für kurze Labels gedacht; „Melder-Adressen
+							     insgesamt" in der Kachel darunter misst so 158px und war zusammen mit
+							     dem `padding-inline` der `.stat` (48px) die Untergrenze der ganzen
+							     Seite bei 320px. Wo Platz ist, ändert sich nichts — umbrechbarer Text
+							     bricht erst, wenn er muss. -->
+							<div class="stat-desc whitespace-normal">freigegebene Sichtungen</div>
 						</div>
 					{/if}
 					{#if data.totalObservers != null}
@@ -490,7 +522,7 @@
 							<div class="stat-value text-secondary-strong">
 								{new Intl.NumberFormat('de-DE').format(data.totalObservers)}
 							</div>
-							<div class="stat-desc">Melder-Adressen insgesamt</div>
+							<div class="stat-desc whitespace-normal">Melder-Adressen insgesamt</div>
 						</div>
 					{/if}
 					<!-- Die dritte Kachel („Für die / Wissenschaft / verfügbar") ist


### PR DESCRIPTION
## Problem

`/about` had a hard minimum width of **411px that stood at every viewport**, not just narrow ones. At 360px the page could be dragged sideways over its full height — the overflow was not confined to the element that was too wide.

Reported measurement: `documentElement.scrollWidth` 411 vs. `clientWidth` 360.

## Four causes, stacked

Each only became visible once the previous one was gone. That is why a subtree bisect could not separate them: every block child is stretched to its parent's content width, so the *measured* width says nothing about the *required* width. Measuring `width: min-content` per element does.

| # | Cause | Floor after |
| - | ----- | ----------- |
| 1 | Partner link row `flex justify-center gap-4` **without** `flex-wrap` (299px min-content) | 411 → 363 |
| 2 | Call-to-action block with blanket `p-12` + `border-2` | 363 → 338 |
| 3 | DaisyUI `white-space: nowrap` on `.stat-desc` ("Melder-Adressen insgesamt", 158px) | 338 → 326 |
| 4 | Page container with blanket `p-6` | 326 → **310** |

Buttons carry `white-space: nowrap`, so two side by side with no wrap opportunity was the bulk of it. The page's two other link rows (Technik, call-to-action) had `flex-wrap` from the start — only this one lacked it.

Causes 3 and 4 belong together: at 320px the page stacked three paddings on top of each other — page container, CTA block, and the 16px DaisyUI gives `hero-content` — leaving 192px of content width where the stat tile demanded 206px. Solving 4 as `p-4 md:p-6` rather than shaving the hero further helps every section, not only whichever one currently sets the floor.

Padding breakpoints follow the contract in `.claude/rules/design-system.md`, where inner spacing switches at `md`.

## Result

**Floor is now 310.2px**, so 320px has ~10px of headroom instead of balancing on the threshold. Below that the next limit is the "Tiere bestimmen" button at 194px min-content, which could only be moved by changing its label or its size.

## Verification

- 320 / 360 / 390 / 414 px: `scrollWidth == clientWidth`, overflow 0
- 1280px: paddings are back to `p-6` (24px) and `p-12` (48px) — **desktop unchanged**, the `md` boundary switches as the breakpoint contract prescribes
- Partner buttons wrap onto two lines at their natural widths (164.3 / 182.8px), `scrollWidth == clientWidth` per button — no clipped labels
- CTA checked visually at 320px: "Melder-Adressen insgesamt" wraps onto two lines, tiles and buttons stack cleanly
- `npm run test:quick` — 232 files, 3472 tests green
- `CI=1 npx playwright test --project=chromium` — **322 passed**, no failures, no flakes
- `e2e/design-tokens.spec.ts` (which scans `/about`) — 81 passed

## Test first

`e2e/about-page.spec.ts` covers 320/360/390/414 and is built like its predecessor in `e2e/footer-layout.spec.ts`, so both routes carry the same promise. Confirmed **red** before the fix — overflow 91px at 320px, i.e. exactly the 411px floor — and green after. The cause table sits in the test's docblock so the four classes don't have to be rediscovered one at a time.

## Not addressed (deliberately)

Six further inner paddings on the page still don't switch at `md` (`card-body p-10`, five `p-8`). Not binding — the floor is now guarded by the test rather than by the mechanism — but the breakpoint contract is only partially satisfied on this page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
