### PR TITLE
test(ui): wait for the disclosure end state before probing modal overflow

### DIFF
--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -246,8 +246,8 @@ dass der Überlauf dann **auftritt** — sonst wäre das Grün eines konformen
 Bestands ohne Aussage. Davor klappt er jede Disclosure auf und wartet auf deren
 Endzustand (Begründung im Abschnitt darunter); bleibt eine Dialogposition
 dauerhaft abgeschnitten, bricht er ab, statt sie trivial zu bestehen.
-Vorgeführt am 2026-08-04 mit einem `main { transform:
-translateZ(0) }` in `app.css`: alle drei Routen rot, alle sechs Dialoge benannt.
+Vorgeführt am 2026-08-04 mit einem `main { transform: translateZ(0) }` in
+`app.css`: alle drei Routen rot, alle sechs Dialoge benannt.
 
 ### Ein `.collapse` schluckt den Überlauf, solange die Animation läuft
 

--- a/.claude/rules/daisyui.md
+++ b/.claude/rules/daisyui.md
@@ -243,8 +243,43 @@ Spezifikation und altert mit ihr. Er misst die Wirkung: Dialog auf 3000 px
 aufblasen, `scrollWidth` vorher/nachher vergleichen. Jede Route fährt zusätzlich
 eine Gegenprobe, die dem Elternelement ein `transform` verpasst und verlangt,
 dass der Überlauf dann **auftritt** — sonst wäre das Grün eines konformen
-Bestands ohne Aussage. Vorgeführt am 2026-08-04 mit einem `main { transform:
+Bestands ohne Aussage. Davor klappt er jede Disclosure auf und wartet auf deren
+Endzustand (Begründung im Abschnitt darunter); bleibt eine Dialogposition
+dauerhaft abgeschnitten, bricht er ab, statt sie trivial zu bestehen.
+Vorgeführt am 2026-08-04 mit einem `main { transform:
 translateZ(0) }` in `app.css`: alle drei Routen rot, alle sechs Dialoge benannt.
+
+### Ein `.collapse` schluckt den Überlauf, solange die Animation läuft
+
+Wer im Teilbaum einer DaisyUI-Disclosure misst, misst unter Umständen gar
+nichts. `.collapse-content` trägt **für die gesamte Dauer** der
+Aufklapp-Animation `overflow-x: clip` und schaltet erst im Endzustand auf
+`visible`. Gemessen auf `/` bei 360 px (2026-08-04, Foto-Disclosure aus
+`PositionPanel.svelte`):
+
+| Zustand                         | `grid-template-rows` (2. Spur) | `overflow-x` | `de.scrollWidth` |
+| ------------------------------- | ------------------------------ | ------------ | ---------------- |
+| zugeklappt                      | `0px`                          | `clip`       | 360              |
+| direkt nach `details.open=true` | `7.3px`                        | `clip`       | 360              |
+| nach Animationsende (~800 ms)   | `304px`                        | `visible`    | **3053**         |
+
+In diesem Fenster kann **kein** Element darin `documentElement.scrollWidth`
+bewegen — auch kein gewöhnliches `div` mit `width: 3000px` im Fluss. Wer direkt
+nach `open = true` misst, landet immer darin und hält das Ergebnis
+fälschlich für eine Aussage über das gemessene Element. Genau so verlor
+`modal-overflow.spec.ts` seine Gegenprobe, als der `upload-notice-dialog` mit
+PR #746 in diese Disclosure zog.
+
+**Konsequenz für jede Überlauf-Suche, auch für `e2e/helpers/overflow.ts`:** Der
+Bisect-Abstieg endet an der `.collapse` und misst darunter ins Leere — ein
+Verursacher im Inneren bleibt unsichtbar, solange die Animation läuft oder die
+Disclosure zu ist. Vor dem Messen deshalb aufklappen **und auf den Endzustand
+warten**. Belastbar ist dabei nur die _Wirkung_: per `expect.poll` ein
+3000-px-`div` im Fluss an die fragliche Stelle hängen und warten, bis es
+`scrollWidth` bewegt. Die Höhe von `.collapse-content` taugt als Bedingung
+nicht — sie wächst früher, als das `clip` verschwindet. Ein globales
+`transition: none !important` per `addStyleTag` hat den Endzustand ebenfalls
+nicht hergestellt.
 
 **Was stattdessen funktioniert:** Teilbäume nacheinander auf `display: none`
 setzen, nach jedem Schritt `document.documentElement.scrollWidth` messen und in

--- a/e2e/modal-overflow.spec.ts
+++ b/e2e/modal-overflow.spec.ts
@@ -54,6 +54,34 @@ import { seedAdminSession } from './helpers/adminSession';
  * Wäre die Sonde stumpf (Dialog nicht gefunden, Stil nicht angekommen,
  * `scrollWidth` an einem anderen Element gelesen), bliebe sie auch dabei
  * still und der Test fiele auf.
+ *
+ * **Warum vorher jede Disclosure aufgeklappt wird:** Seit PR #746 steht der
+ * `upload-notice-dialog` auf `/` in der Foto-Disclosure von
+ * `PositionPanel.svelte`. DaisyUIs `.collapse-content` trägt für die **gesamte
+ * Dauer** der Aufklapp-Animation `overflow-x: clip` und schaltet erst im
+ * Endzustand auf `visible` — gemessen bei 360 px: zugeklappt `clip`, direkt
+ * nach `open = true` `clip` (2. Grid-Spur bereits 7,3 px), nach ~800 ms
+ * `visible` und `scrollWidth` 360 → 3053. In diesem Fenster kann **kein**
+ * Element im Teilbaum `documentElement.scrollWidth` bewegen: Ein gewöhnliches
+ * `div` mit 3000 px an der Dialogposition bleibt dort genauso still wie der
+ * `position: fixed`-Dialog. Die Gegenprobe schlug deshalb nicht mehr an, und
+ * das Grün der Hauptprüfung war wertlos — nicht weil die Regel brach, sondern
+ * weil der Teilbaum nichts durchließ.
+ *
+ * **Worauf gewartet wird — die Wirkung, nicht eine Hilfsgröße:** Gewartet wird
+ * per `expect.poll` darauf, dass ein im Fluss eingehängtes 3000-px-`div` an der
+ * Dialogposition `scrollWidth` **bewegt**. Das ist genau die Fähigkeit, die die
+ * Gegenprobe danach braucht. Ein Warten auf die Höhe von `.collapse-content`
+ * wäre zu schwach (sie wächst früher, als das `clip` verschwindet), ein
+ * `waitForTimeout` verboten (`.claude/rules/testing.md`), und das Abschalten
+ * aller Transitions per `addStyleTag` hat den Zustand nicht hergestellt. Die
+ * Wirkungs-Sonde hält außerdem, falls DaisyUI den Mechanismus austauscht.
+ *
+ * **Und sie ist zugleich die Vakuum-Sperre:** Ein Dialog in einem
+ * abgeschnittenen Teilbaum erfüllt „zählt nicht in `scrollWidth` mit" trivial —
+ * dort belegt das Grün der Hauptprüfung nichts über `position: fixed`. Bewegt
+ * die Sonde `scrollWidth` an einer Dialogposition dauerhaft nicht, bricht der
+ * Test deshalb mit Nennung dieser Position ab, statt still grün zu werden.
  */
 
 /* Der Fall ist ein Mobil-Fall: 360 px ist die Breite, bei der die Frage
@@ -162,13 +190,36 @@ const openRoute = async ({ page, context, request, baseURL }: Fixtures, route: G
 	}
 };
 
+interface Probe {
+	readonly label: string;
+	readonly before: number;
+	readonly after: number;
+}
+
 interface Measurement {
 	readonly dialogCount: number;
+	/**
+	 * Dialogpositionen, an denen ein gewöhnliches 3000-px-`div` **im Fluss**
+	 * `scrollWidth` nicht bewegt — dort ist die Hauptprüfung ohne Aussage.
+	 * Erwartet: leer, sobald die Aufklapp-Animationen durch sind.
+	 */
+	readonly deadPositions: readonly Probe[];
 	/** Ein Eintrag je Dialog, der `scrollWidth` bewegt hat — erwartet: leer. */
-	readonly contributing: readonly { label: string; before: number; after: number }[];
+	readonly contributing: readonly Probe[];
 	/** Gegenprobe: `scrollWidth` mit `transform` am Elternelement. */
-	readonly control: { label: string; before: number; after: number } | null;
+	readonly control: Probe | null;
 }
+
+/**
+ * Klappt jede Disclosure der Seite auf.
+ *
+ * Ohne das steht der `upload-notice-dialog` auf `/` in einer zugeklappten
+ * `.collapse` und kann von dort aus nichts bewegen — siehe Kopfkommentar.
+ */
+const openDisclosures = (page: Page): Promise<void> =>
+	page.evaluate(() => {
+		for (const d of document.querySelectorAll<HTMLDetailsElement>('details')) d.open = true;
+	});
 
 const measure = (page: Page): Promise<Measurement> =>
 	page.evaluate(() => {
@@ -192,8 +243,32 @@ const measure = (page: Page): Promise<Measurement> =>
 			return { before, after };
 		};
 
-		const contributing: { label: string; before: number; after: number }[] = [];
+		/* Dieselbe Breite, aber an einem gewöhnlichen `div` im Fluss und an
+		   derselben Stelle im Baum. Was hier still bleibt, kann auch der Dialog
+		   nicht bewegen — dann misst die Hauptprüfung nichts. */
+		const probeFlow = (d: HTMLDialogElement) => {
+			const parent = d.parentElement;
+			if (!parent) return { before: de.scrollWidth, after: de.scrollWidth };
+			const probe = document.createElement('div');
+			/* `min-width` und `flex: none` zusätzlich zur `width`: In einem Flex-
+			   oder Grid-Container schrumpft eine reine Breitenangabe auf den
+			   verfügbaren Platz, und die Sonde wäre aus dem falschen Grund still. */
+			probe.style.cssText = 'width:3000px;min-width:3000px;height:1px;flex:none';
+			const before = de.scrollWidth;
+			parent.insertBefore(probe, d);
+			const after = de.scrollWidth;
+			probe.remove();
+			return { before, after };
+		};
+
+		const deadPositions: Probe[] = [];
+		const contributing: Probe[] = [];
 		dialogs.forEach((d, i) => {
+			const flow = probeFlow(d);
+			if (flow.after <= flow.before) {
+				deadPositions.push({ label: label(d, i), ...flow });
+				return;
+			}
 			const { before, after } = blowUp(d);
 			if (after > before) contributing.push({ label: label(d, i), before, after });
 		});
@@ -211,7 +286,7 @@ const measure = (page: Page): Promise<Measurement> =>
 			control = { label: label(first, 0), before, after };
 		}
 
-		return { dialogCount: dialogs.length, contributing, control };
+		return { dialogCount: dialogs.length, deadPositions, contributing, control };
 	});
 
 test.describe('Modal-Dialoge — kein Beitrag zum horizontalen Überlauf', () => {
@@ -224,7 +299,38 @@ test.describe('Modal-Dialoge — kein Beitrag zum horizontalen Überlauf', () =>
 		}) => {
 			await openRoute({ page, context, request, baseURL }, route);
 
-			const { dialogCount, contributing, control } = await measure(page);
+			/* Gewartet wird auf die Wirkung: Erst wenn ein 3000-px-`div` im Fluss
+			   an *jeder* Dialogposition `scrollWidth` bewegt, hat die Messung
+			   darunter überhaupt eine Aussage. Solange eine Aufklapp-Animation
+			   läuft, klippt `.collapse-content` und die Sonde bleibt still.
+
+			   Das Aufklappen steht mit *in* der Schleife und nicht davor: Eine
+			   Disclosure, die erst nach der Hydration dazukommt, bliebe sonst zu,
+			   und der Poll könnte nur noch ins Timeout laufen. Auf ein bereits
+			   offenes `<details>` wirkt der Handgriff nicht — er startet keine
+			   Animation neu. */
+			let last: Measurement | undefined;
+			await expect
+				.poll(
+					async () => {
+						await openDisclosures(page);
+						return (last = await measure(page)).deadPositions.map((p) => p.label);
+					},
+					{
+						message:
+							`${route.path}: An diesen Dialogpositionen bewegt selbst ein gewöhnliches ` +
+							'3000-px-`div` im Fluss `documentElement.scrollWidth` nicht. Der Teilbaum ' +
+							'schneidet also ab (`overflow-x: clip|hidden|auto`) — dort erfüllt jeder Dialog ' +
+							'„zählt nicht mit" trivial, und ein Grün wäre ohne Aussage. Häufigste Ursache: ' +
+							'eine `.collapse` mitten in der Aufklapp-Animation (dann ist es ein Timing-' +
+							'Problem dieses Tests), sonst ein dauerhaft klippender Vorfahr (dann gehört der ' +
+							'Dialog dort heraus oder die Route hier ausgetragen).',
+						timeout: 10_000
+					}
+				)
+				.toEqual([]);
+
+			const { dialogCount, contributing, control } = last!;
 
 			expect(
 				dialogCount,


### PR DESCRIPTION
## Problem

`e2e/modal-overflow.spec.ts` schlug auf `main` fehl — Route `/`, seit #746:

```
/: Die Gegenprobe an "upload-notice-dialog" hat NICHT angeschlagen (360 → 360).
```

Es geht **nicht** um `position: fixed`. Seit #746 steht der `upload-notice-dialog` im `.collapse-content` der Foto-Disclosure von `PositionPanel.svelte`. DaisyUIs `.collapse-content` trägt für die **gesamte Dauer** der Aufklapp-Animation `overflow-x: clip` und schaltet erst im Endzustand auf `visible`:

| Zustand | `grid-template-rows` (2. Spur) | `overflow-x` | `de.scrollWidth` |
| --- | --- | --- | --- |
| zugeklappt | `0px` | `clip` | 360 |
| direkt nach `open = true` | `7.3px` | `clip` | 360 |
| nach Animationsende (~800 ms) | `304px` | `visible` | **3053** |

In diesem Fenster bewegt **nichts** im Teilbaum `documentElement.scrollWidth` — auch kein gewöhnliches 3000-px-`div` im Fluss. Die Gegenprobe schlug deshalb nicht mehr an, und das Grün der Hauptprüfung darüber war wertlos.

## Lösung

Der Spec klappt jede Disclosure auf und wartet per `expect.poll` auf die **Wirkung**: Ein im Fluss eingehängtes 3000-px-`div` an jeder Dialogposition muss `scrollWidth` bewegen. Das ist genau die Fähigkeit, die die Gegenprobe danach braucht, und es hält auch, falls DaisyUI den Mechanismus austauscht.

Verworfen wurden: `waitForTimeout` (verboten, `.claude/rules/testing.md`), das Warten auf die `.collapse-content`-Höhe (zu schwach — sie wächst früher, als das `clip` verschwindet) und ein globales `transition: none !important` per `addStyleTag` (stellte den Endzustand nicht her).

Dieselbe Sonde ist zugleich die **Vakuum-Sperre**: Ein Dialog in einem abgeschnittenen Teilbaum erfüllt „zählt nicht mit" trivial. Bleibt eine Position dauerhaft tot, bricht der Test mit Nennung dieser Position ab, statt still grün zu werden. Die Meldung unterscheidet Timing-Ursache von dauerhaft klippendem Vorfahr.

Das Aufklappen steht mit in der Poll-Schleife, damit eine spät hinzukommende Disclosure nicht ins Timeout führt; auf ein bereits offenes `<details>` wirkt der Handgriff nicht.

## Verifikation

- **Grün:** `CI=1 npx playwright test --project=chromium` → 333 passed.
- **Sperre wirkt:** Mit auskommentiertem `openDisclosures` fällt `/` mit der neuen Meldung und benennt beide toten Positionen (`upload-notice-dialog`, `dialog[1]`) — rot statt still grün.
- **Hauptprüfung ist nicht vakuum-grün:** Mit `main { transform: translateZ(0) }` in `app.css` fallen alle drei Routen und benennen alle sechs Dialoge.

## Doku

`.claude/rules/daisyui.md` bekommt den Befund unter „Geschlossene `.modal`-Dialoge sind kein Überlauf-Verdacht" als eigenen Abschnitt — er ist für **jede** künftige Überlauf-Suche relevant: `e2e/helpers/overflow.ts` misst in einer `.collapse` ebenfalls ins Leere, der Bisect-Abstieg endet dort.

## Nebenbefund (nicht in diesem PR)

Der Dialog in `SpeciesIdentificationHelp.svelte:483` hat weder `aria-labelledby` noch `aria-label` — ein Modal ohne zugänglichen Namen (WCAG 4.1.2). Deshalb erscheint er in Testmeldungen nur als `dialog[0]`/`dialog[1]`, während die Admin-Dialoge ihre Titel nennen. `UploadNotice.svelte` macht es richtig vor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)