### PR TITLE
fix(a11y): show the validation state on checkbox and toggle fields

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -358,12 +358,91 @@ Das Formular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, mit 
   `hasError` → `radio-error` (`BaseRadio.svelte`). Die native `required`-Angabe bleibt am
   Input: sie ist dort gültig und trägt die Constraint-Validierung.
 
-  `radio-error`/`radio-success` **ersetzen** dabei `radio-primary`, sie ergänzen es nicht —
-  alle drei setzen dieselbe DaisyUI-Variable (`--input-color`) auf derselben Ebene und mit
-  derselben Spezifität. Stünden zwei am Element, entschiede die Reihenfolge im
-  DaisyUI-Stylesheet statt der im `class`-Attribut.
+  Wie `radio-error`/`radio-success` gebaut werden, steht im Abschnitt „Zustands-Optik der
+  Auswahl-Controls" unten — die Regel gilt für Checkbox und Toggle genauso.
 
 - Fehlermeldungen mit `role="alert"` und `aria-live="polite"`, referenziert über `aria-describedby` — und nur dann referenziert, wenn das Element tatsächlich gerendert ist.
+
+---
+
+## Zustands-Optik der Auswahl-Controls
+
+Checkbox, Radio und Toggle zeigen den Validierungszustand über eine DaisyUI-Zustandsklasse.
+`FieldRenderer` reicht dafür `hasError`/`isValid` durch; die Komponente baut daraus **genau
+eine** Klasse, aufgebaut wie das `stateClass` in `BaseRadio`:
+
+```js
+const stateClass = hasError ? 'checkbox-error' : isValid ? 'checkbox-success' : 'checkbox-primary';
+```
+
+**Die Zustandsklasse ersetzt `*-primary`, sie ergänzt es nicht.** Alle drei setzen dieselbe
+DaisyUI-Variable (`--input-color`) auf derselben Ebene (`daisyui.l1.l2`) und mit derselben
+Spezifität. Stünden zwei am Element, entschiede die Reihenfolge im DaisyUI-Stylesheet statt
+der im `class`-Attribut.
+
+Der Neutralfall unterscheidet sich dabei bewusst von den Textfeldern: `BaseInput`/`BaseSelect`
+setzen dort `''`, die Auswahl-Controls `*-primary`. Das ist keine Inkonsistenz zum
+Aufräumen — ein Feld ohne Zustandsklasse sieht bei DaisyUI richtig aus, eine Checkbox ohne
+`checkbox-primary` verlöre dagegen ihre Markenfarbe.
+
+**Ein Prop, das die Komponente nicht annimmt, fällt still weg.** Genau so entstand der Fall:
+`hasError`/`isValid` standen seit jeher in `commonFieldProps` und gingen über
+`checkboxProps`/`toggleProps` hinaus — `BaseCheckbox` und `BaseToggle` deklarierten sie nur
+nie, ihre Klasse stand hart auf `checkbox checkbox-primary` bzw. `toggle toggle-primary`. Ein
+Feld mit Validierungsfehler sah dadurch aus wie ein fehlerfreies, ohne dass irgendwo etwas
+brach. Ein Test an der Komponente allein bemerkt das nicht — er merkt nicht, wenn der Renderer
+aufhört, die Props zu setzen. Die Strecke gehört deshalb in `FieldRenderer.svelte.test.ts`
+mitgetestet.
+
+### Der Toggle braucht zusätzlich einen `app.css`-Override
+
+`checkbox-*` und `radio-*` setzen `--input-color` unbedingt; ihr Rahmen ist damit in **beiden**
+Zuständen gefärbt. `toggle-error` und `toggle-success` tun das nicht — verifiziert in
+`node_modules/daisyui/daisyui.css` (5.7.4) und im Browser nachgemessen:
+
+```css
+.toggle-error {
+	@layer daisyui.l1.l2 {
+		&:checked,
+		&[aria-checked='true'] {
+			--input-color: var(--color-error);
+		}
+	}
+}
+```
+
+Die Farbe greift also nur im **eingeschalteten** Zustand. Der wahrscheinlichste Fehlerfall
+eines Pflicht-Toggles ist aber der ausgeschaltete („muss zugestimmt werden") — dort rendert
+ein `toggle-error` byte-identisch zu einem nackten `toggle`. Das Radio-Muster blind zu
+übernehmen wäre für genau den Fall, um den es geht, optisch wirkungslos.
+
+Den ausgeschalteten Zustand färbt deshalb ein Override in `src/app.css` (ungelayert, schlägt
+damit DaisyUIs `@layer` — dieselbe Mechanik wie beim Fokus-Override):
+
+```css
+.toggle-error:not(:checked) {
+	--input-color: var(--color-error);
+}
+```
+
+Drei Punkte dazu:
+
+- **Theme-Token, kein Hex und keine Palettenfarbe.** `e2e/design-tokens.spec.ts` scannt aktiv
+  dagegen; der Override gehört nach `app.css` (einzige Source of Truth für DaisyUI-Overrides),
+  nicht in die Komponente.
+- **Ein roter AUS-Toggle liest sich nicht als „an".** Die Unterscheidung trägt die
+  Knopfposition (`grid-template-columns` 0fr 1fr 1fr ↔ 1fr 1fr 0fr) und der Track-Hintergrund
+  (transparent ↔ base-100), nicht die Farbe. Beides bleibt unangetastet.
+- **Kontrast:** auf `base-100` misst `--color-error` 6,05:1 und `--color-success` 3,81:1.
+  Rahmen und Knopf sind grafische Objekte — WCAG 1.4.11 verlangt dort 3:1, nicht die 4,5:1 für
+  Text. Für **Text** reicht `--color-success` weiterhin nicht.
+
+Abgesichert durch `e2e/form-a11y.spec.ts` → „Fehler-Optik am ausgeschalteten Toggle". Der Test
+misst die **Wirkung** (welche Farbe kommt heraus) statt die Existenz einer CSS-Regel — eine
+Regel-Assertion wäre eine zweite Quelle neben `app.css` und würde mit ihr altern. Er enthält
+eine Gegenprobe, die DaisyUIs Default zurückholt und verlangt, dass Fehler- und Normalzustand
+dann ununterscheidbar werden; ohne sie belegte das Grün nur, dass zwei Farben verschieden sind
+— nicht, dass der Override das bewirkt.
 
 ---
 

--- a/e2e/form-a11y.spec.ts
+++ b/e2e/form-a11y.spec.ts
@@ -449,6 +449,148 @@ test.describe('Accessibility — text-error auf Buttons', () => {
 	});
 });
 
+// ── Zustands-Optik am ausgeschalteten Toggle ───────────────────────────────
+
+/**
+ * `toggle-error` und `toggle-success` färben von sich aus **nur den
+ * eingeschalteten** Toggle — verifiziert in `daisyui.css` (5.7.4) und im
+ * Browser gemessen:
+ *
+ *     .toggle-error{@layer daisyui.l1.l2{&:checked,&[aria-checked=true]{…}}}
+ *
+ * Der wahrscheinlichste Fehlerfall eines Pflicht-Toggles ist aber der
+ * **ausgeschaltete** („muss zugestimmt werden"). Ohne Nachhilfe wäre die
+ * Fehler-Optik dort also wirkungslos — ein `toggle-error` am ausgeschalteten
+ * Element rendert byte-identisch zu einem nackten `toggle`. Den Unterschied
+ * macht der Override in `src/app.css`.
+ *
+ * Der Test muss im Browser laufen: `--input-color` ist ein `color-mix(in oklab,
+ * …)` über `oklch()`-Werten und wird erst nach dem Gamut-Mapping nach sRGB als
+ * Farbe lesbar. Und er misst die **Wirkung** (welche Farbe kommt heraus), nicht
+ * die Existenz einer CSS-Regel — eine Regel-Assertion wäre eine zweite Quelle
+ * neben `app.css` und würde mit ihr altern.
+ */
+const AUSGESCHALTETE_TOGGLES = [
+	{ zustand: 'error', klasse: 'toggle toggle-error' },
+	{ zustand: 'success', klasse: 'toggle toggle-success' }
+] as const;
+
+/** Legt die Proben als echte, ausgeschaltete `<input type="checkbox">` in die Seite. */
+async function toggleProbenAnlegen(page: import('@playwright/test').Page) {
+	await page.evaluate(
+		(klassen: string[]) => {
+			const host = document.createElement('div');
+			host.id = 'toggle-proben';
+			host.style.cssText = 'position:fixed;top:0;left:0;visibility:hidden;pointer-events:none';
+			for (const klasse of ['toggle toggle-primary', ...klassen]) {
+				const el = document.createElement('input');
+				el.type = 'checkbox';
+				el.className = klasse;
+				el.checked = false;
+				el.dataset.probe = klasse.split(' ')[1];
+				host.appendChild(el);
+			}
+			document.body.appendChild(host);
+		},
+		AUSGESCHALTETE_TOGGLES.map((t) => t.klasse)
+	);
+}
+
+test.describe('Accessibility — Fehler-Optik am ausgeschalteten Toggle', () => {
+	for (const { zustand, klasse } of AUSGESCHALTETE_TOGGLES) {
+		test(`toggle-${zustand} färbt den ausgeschalteten Toggle`, async ({ page }) => {
+			const formPage = new FormPage(page);
+			await formPage.goto();
+			await toggleProbenAnlegen(page);
+
+			// `.toggle` setzt `border: … solid currentColor` und `color:
+			// var(--input-color)` — die gemessene Vordergrundfarbe IST damit die
+			// Farbe von Rahmen und Knopf.
+			const [zustandsFarbe, primaryFarbe] = await measureContrast(page, [
+				{
+					name: `${klasse} ausgeschaltet`,
+					selector: `[data-probe="toggle-${zustand}"]`,
+					backdrop: 'var(--color-base-100)'
+				},
+				{
+					name: 'toggle-primary ausgeschaltet',
+					selector: '[data-probe="toggle-primary"]',
+					backdrop: 'var(--color-base-100)'
+				}
+			]);
+
+			// Das ist der eigentliche Regressionsschutz: Ohne den Override in
+			// `app.css` sind beide Farben identisch, und der Nutzer sieht am
+			// fehlerhaften Feld exakt dasselbe wie am fehlerfreien.
+			expect(
+				zustandsFarbe.foreground,
+				`toggle-${zustand} ausgeschaltet misst ${zustandsFarbe.foreground}, ` +
+					`toggle-primary ${primaryFarbe.foreground} — der Zustand ist unsichtbar`
+			).not.toBe(primaryFarbe.foreground);
+		});
+
+		test(`toggle-${zustand} erreicht ausgeschaltet WCAG 1.4.11 auf base-100`, async ({ page }) => {
+			const formPage = new FormPage(page);
+			await formPage.goto();
+			await toggleProbenAnlegen(page);
+
+			// 3:1 für grafische Objekte und Begrenzungen von Bedienelementen —
+			// nicht 4,5:1: Rahmen und Knopf eines Toggles sind kein Text.
+			const [gemessen] = await measureContrast(page, [
+				{
+					name: `${klasse} ausgeschaltet auf base-100`,
+					selector: `[data-probe="toggle-${zustand}"]`,
+					backdrop: 'var(--color-base-100)'
+				}
+			]);
+
+			expect(
+				gemessen.ratio,
+				`${gemessen.name}: ${gemessen.foreground} auf ${gemessen.background} = ${formatRatio(gemessen.ratio)}:1`
+			).toBeGreaterThanOrEqual(3);
+		});
+	}
+
+	/**
+	 * Gegenprobe. Ohne sie wäre das Grün der Tests oben ohne Aussage: Es belegte
+	 * nur, dass zwei Farben verschieden sind — nicht, dass der Override das
+	 * bewirkt. Hier wird DaisyUIs Default per `addStyleTag` (ebenfalls ungelayert,
+	 * später im Dokument, gewinnt damit) zurückgeholt; die Ungleichheit MUSS dann
+	 * verschwinden.
+	 */
+	test('ohne den Override wären Fehler- und Normalzustand ununterscheidbar', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+		await page.addStyleTag({
+			content: `.toggle-error:not(:checked), .toggle-success:not(:checked) {
+				--input-color: color-mix(in oklab, var(--color-base-content) 50%, #0000);
+			}`
+		});
+		await toggleProbenAnlegen(page);
+
+		const [fehler, erfolg, primary] = await measureContrast(page, [
+			{
+				name: 'toggle-error ohne Override',
+				selector: '[data-probe="toggle-error"]',
+				backdrop: 'var(--color-base-100)'
+			},
+			{
+				name: 'toggle-success ohne Override',
+				selector: '[data-probe="toggle-success"]',
+				backdrop: 'var(--color-base-100)'
+			},
+			{
+				name: 'toggle-primary',
+				selector: '[data-probe="toggle-primary"]',
+				backdrop: 'var(--color-base-100)'
+			}
+		]);
+
+		expect(fehler.foreground).toBe(primary.foreground);
+		expect(erfolg.foreground).toBe(primary.foreground);
+	});
+});
+
 // ── Touch-Target der Hinweis-Buttons in der Feld-Pipeline ──────────────────
 
 /**

--- a/src/app.css
+++ b/src/app.css
@@ -409,6 +409,48 @@ summary.btn {
 	--size: var(--control-size);
 }
 
+/* Zustands-Optik am AUSGESCHALTETEN Toggle.
+
+   DaisyUI färbt `toggle-error`/`toggle-success` ausschließlich im
+   eingeschalteten Zustand — nachgelesen in node_modules/daisyui/daisyui.css
+   (5.7.4) und im Browser nachgemessen:
+
+     .toggle-error{@layer daisyui.l1.l2{&:checked,&[aria-checked=true]{
+       --input-color:var(--color-error)}}}
+
+   Ein ausgeschalteter `toggle-error` rendert damit byte-identisch zu einem
+   nackten `toggle` (Rahmen und Knopf `oklab(0.15 … / 0.5)`). Für Checkbox und
+   Radio stimmt das nicht — die beziehen ihren Rahmen unbedingt aus
+   `--input-color` und brauchen deshalb keinen Override.
+
+   Der wahrscheinlichste Fehlerfall eines Pflicht-Toggles ist aber gerade der
+   ausgeschaltete („muss zugestimmt werden"). Ohne diese Regel wäre die
+   Fehler-Optik dort wirkungslos: `BaseToggle` emittierte `toggle-error`, und
+   der Nutzer sähe am fehlerhaften Feld exakt dasselbe wie am fehlerfreien.
+
+   Ungelayert und deshalb stärker als DaisyUIs `@layer daisyui.l1.l2` — dieselbe
+   Mechanik wie beim Fokus-Override oben. Im eingeschalteten Zustand greift die
+   Regel nicht, dort bleibt DaisyUI zuständig.
+
+   Dass ein roter AUS-Toggle nicht als „an" missverstanden wird, trägt nicht die
+   Farbe, sondern die Knopfposition: `.toggle` schaltet dafür
+   `grid-template-columns` (0fr 1fr 1fr ↔ 1fr 1fr 0fr) und den Track-Hintergrund
+   (transparent ↔ base-100). Beides bleibt hier unangetastet.
+
+   Kontrast auf base-100: error 6,05:1, success 3,81:1 — Rahmen und Knopf sind
+   grafische Objekte, für die WCAG 1.4.11 3:1 verlangt.
+
+   Abgesichert durch e2e/form-a11y.spec.ts → „Fehler-Optik am ausgeschalteten
+   Toggle", inklusive Gegenprobe, die DaisyUIs Default zurückholt und verlangt,
+   dass die Zustände dann ununterscheidbar werden. */
+.toggle-error:not(:checked) {
+	--input-color: var(--color-error);
+}
+
+.toggle-success:not(:checked) {
+	--input-color: var(--color-success);
+}
+
 /* Die 44px trägt das umschließende <label>, nicht das Control.
    WCAG 2.5.5 verlangt ein Ziel dieser Größe, kein Bedienelement dieser Größe
    — und das Label ist in BaseCheckbox/BaseToggle ohnehin der Klickbereich

--- a/src/lib/report/components/form/fields/BaseCheckbox.svelte
+++ b/src/lib/report/components/form/fields/BaseCheckbox.svelte
@@ -10,6 +10,8 @@
 		checked?: boolean;
 		label?: string;
 		size?: FieldSize;
+		hasError?: boolean;
+		isValid?: boolean;
 		icon?: string;
 		valueText?: string;
 		onchange?: (event: Event) => void;
@@ -29,6 +31,8 @@
 		checked = $bindable(),
 		label = '',
 		size = 'md',
+		hasError = false,
+		isValid = false,
 		icon = undefined,
 		valueText = undefined,
 		onchange = undefined,
@@ -44,10 +48,25 @@
 	}: Props = $props();
 
 	// Dynamic CSS classes - pure DaisyUI
+	//
+	// Der Zustand ersetzt `checkbox-primary`, er ergänzt es nicht: Alle drei
+	// Klassen setzen dieselbe DaisyUI-Variable (`--input-color`) auf derselben
+	// Ebene und mit derselben Spezifität. Stünden zwei davon am Element,
+	// entschiede die Reihenfolge im DaisyUI-Stylesheet, welche gewinnt — nicht
+	// die im `class`-Attribut. Aufbau deshalb wie `stateClass` in BaseRadio.
+	//
+	// Anders als beim Toggle greift das hier in beiden Zuständen: `.checkbox`
+	// bezieht seinen Rahmen unbedingt aus `var(--input-color)`, eine nicht
+	// angehakte Pflicht-Checkbox zeigt den Fehler also von selbst.
 	let checkboxClasses = $derived.by(() => {
-		const base = 'checkbox checkbox-primary';
+		const base = 'checkbox';
+		const stateClass = hasError
+			? 'checkbox-error'
+			: isValid
+				? 'checkbox-success'
+				: 'checkbox-primary';
 		const sizeClass = size === 'sm' ? 'checkbox-sm' : size === 'lg' ? 'checkbox-lg' : '';
-		return [base, sizeClass].filter(Boolean).join(' ');
+		return [base, stateClass, sizeClass].filter(Boolean).join(' ');
 	});
 </script>
 

--- a/src/lib/report/components/form/fields/BaseCheckbox.svelte.test.ts
+++ b/src/lib/report/components/form/fields/BaseCheckbox.svelte.test.ts
@@ -1,0 +1,138 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, it, expect } from 'vitest';
+import { page } from 'vitest/browser';
+import BaseCheckbox from './BaseCheckbox.svelte';
+
+/**
+ * `BaseCheckbox` setzte seine Klasse hart auf `checkbox checkbox-primary` und
+ * nahm `hasError`/`isValid` gar nicht erst als Props an — `FieldRenderer` reichte
+ * beide über `checkboxProps` durch, in der Komponente fielen sie still weg. Ein
+ * Feld mit Validierungsfehler sah damit aus wie ein fehlerfreies.
+ *
+ * Diese Datei sichert die Zustands-Optik ab, analog zu `BaseRadio.svelte.test.ts`.
+ */
+describe('BaseCheckbox', () => {
+	function checkboxOf(container: HTMLElement): HTMLInputElement {
+		const el = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		if (!el) throw new Error('Kein Checkbox-Input gerendert');
+		return el;
+	}
+
+	/**
+	 * `checkbox-error`/`checkbox-success` **ersetzen** `checkbox-primary`, sie
+	 * ergänzen es nicht: Alle drei setzen dieselbe DaisyUI-Variable
+	 * (`--input-color`) auf derselben Ebene (`daisyui.l1.l2`) und mit derselben
+	 * Spezifität. Stünden zwei am Element, entschiede die Reihenfolge im
+	 * DaisyUI-Stylesheet, nicht die im `class`-Attribut.
+	 */
+	describe('Fehler-Optik', () => {
+		it('nutzt checkbox-error statt checkbox-primary bei hasError', async () => {
+			const screen = render(BaseCheckbox, { label: 'Totfund', hasError: true });
+
+			const box = checkboxOf(screen.container);
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+			expect(box.classList.contains('checkbox-primary')).toBe(false);
+		});
+
+		it('nutzt checkbox-success statt checkbox-primary bei isValid', async () => {
+			const screen = render(BaseCheckbox, { label: 'Totfund', isValid: true });
+
+			const box = checkboxOf(screen.container);
+			expect(box.classList.contains('checkbox-success')).toBe(true);
+			expect(box.classList.contains('checkbox-primary')).toBe(false);
+		});
+
+		it('bleibt ohne Zustand auf checkbox-primary', async () => {
+			const screen = render(BaseCheckbox, { label: 'Totfund' });
+
+			const box = checkboxOf(screen.container);
+			expect(box.classList.contains('checkbox-primary')).toBe(true);
+			expect(box.classList.contains('checkbox-error')).toBe(false);
+			expect(box.classList.contains('checkbox-success')).toBe(false);
+		});
+
+		it('zeigt den Fehler-Zustand auch dann, wenn isValid gleichzeitig gesetzt ist', async () => {
+			const screen = render(BaseCheckbox, {
+				label: 'Totfund',
+				hasError: true,
+				isValid: true
+			});
+
+			const box = checkboxOf(screen.container);
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+			expect(box.classList.contains('checkbox-success')).toBe(false);
+		});
+
+		/**
+		 * Der Fehler-Zustand darf nicht am Häkchen hängen: Der wahrscheinlichste
+		 * Fehlerfall einer Pflicht-Checkbox ist die **nicht** angehakte
+		 * („muss zugestimmt werden"). `.checkbox` bezieht seinen Rahmen unbedingt
+		 * aus `var(--input-color)` — anders als der Toggle, dessen Zustandsklassen
+		 * nur unter `:checked` greifen (siehe `BaseToggle.svelte.test.ts`).
+		 */
+		it('trägt den Fehler-Zustand auch ohne Häkchen', async () => {
+			const screen = render(BaseCheckbox, {
+				label: 'Totfund',
+				checked: false,
+				hasError: true
+			});
+
+			const box = checkboxOf(screen.container);
+			expect(box.checked).toBe(false);
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+		});
+	});
+
+	/** Die Größen-Klasse darf durch den Zustands-Zweig nicht verloren gehen. */
+	describe('Größen', () => {
+		it('behält die Größen-Klasse neben dem Fehler-Zustand', async () => {
+			const screen = render(BaseCheckbox, {
+				label: 'Totfund',
+				size: 'sm' as const,
+				hasError: true
+			});
+
+			const box = checkboxOf(screen.container);
+			expect(box.classList.contains('checkbox-sm')).toBe(true);
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+		});
+	});
+
+	/**
+	 * Anders als beim Radio sind `aria-invalid`/`aria-required` hier gültig:
+	 * `role="checkbox"` unterstützt beide, `svelte-check` akzeptiert sie. Sie
+	 * bleiben deshalb am Input — die Zustands-Klasse tritt daneben, nicht an
+	 * ihre Stelle.
+	 */
+	describe('ARIA bleibt am Input', () => {
+		it('setzt aria-invalid und behält daneben die Fehler-Optik', async () => {
+			const screen = render(BaseCheckbox, {
+				label: 'Totfund',
+				hasError: true,
+				'aria-invalid': true
+			});
+
+			const box = checkboxOf(screen.container);
+			expect(box.getAttribute('aria-invalid')).toBe('true');
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+		});
+
+		it('setzt aria-required', async () => {
+			const screen = render(BaseCheckbox, {
+				label: 'Totfund',
+				required: true,
+				'aria-required': true
+			});
+
+			expect(checkboxOf(screen.container).getAttribute('aria-required')).toBe('true');
+		});
+	});
+
+	describe('Beschriftung', () => {
+		it('zeigt das Label', async () => {
+			render(BaseCheckbox, { label: 'Totfund bestätigt' });
+
+			await expect.element(page.getByText('Totfund bestätigt')).toBeVisible();
+		});
+	});
+});

--- a/src/lib/report/components/form/fields/BaseToggle.svelte
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte
@@ -10,6 +10,8 @@
 		checked?: boolean;
 		label?: string;
 		size?: FieldSize;
+		hasError?: boolean;
+		isValid?: boolean;
 		icon?: string;
 		valueText?: string;
 		onchange?: (event: Event) => void;
@@ -29,6 +31,8 @@
 		checked = $bindable(),
 		label = '',
 		size = 'md',
+		hasError = false,
+		isValid = false,
 		icon = undefined,
 		valueText = undefined,
 		onchange = undefined,
@@ -44,10 +48,24 @@
 	}: Props = $props();
 
 	// Dynamic CSS classes
+	//
+	// Der Zustand ersetzt `toggle-primary`, er ergänzt es nicht: Alle drei
+	// Klassen setzen dieselbe DaisyUI-Variable (`--input-color`) auf derselben
+	// Ebene und mit derselben Spezifität. Stünden zwei davon am Element,
+	// entschiede die Reihenfolge im DaisyUI-Stylesheet, welche gewinnt — nicht
+	// die im `class`-Attribut. Aufbau deshalb wie `stateClass` in BaseRadio.
+	//
+	// Achtung, hier weicht der Toggle von Radio und Checkbox ab: `toggle-error`
+	// und `toggle-success` greifen bei DaisyUI NUR unter `:checked`. Die Klasse
+	// allein ließe damit ausgerechnet den wahrscheinlichsten Fehlerfall — den
+	// ausgeschalteten Pflicht-Toggle — unverändert grau. Den ausgeschalteten
+	// Zustand färbt deshalb ein Override in `src/app.css` (dort begründet,
+	// gemessen in `e2e/form-a11y.spec.ts`).
 	let toggleClasses = $derived.by(() => {
-		const base = 'toggle toggle-primary';
+		const base = 'toggle';
+		const stateClass = hasError ? 'toggle-error' : isValid ? 'toggle-success' : 'toggle-primary';
 		const sizeClass = size === 'sm' ? 'toggle-sm' : size === 'lg' ? 'toggle-lg' : '';
-		return [base, sizeClass].filter(Boolean).join(' ');
+		return [base, stateClass, sizeClass].filter(Boolean).join(' ');
 	});
 </script>
 

--- a/src/lib/report/components/form/fields/BaseToggle.svelte.test.ts
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte.test.ts
@@ -101,10 +101,16 @@ describe('BaseToggle', () => {
 	});
 
 	/**
-	 * Anders als beim Radio sind `aria-invalid`/`aria-required` hier gültig:
-	 * `role="switch"` unterstützt beide, `svelte-check` akzeptiert sie. Sie
-	 * bleiben deshalb am Input — die Zustands-Klasse tritt daneben, nicht an
-	 * ihre Stelle.
+	 * Anders als beim Radio sind `aria-invalid`/`aria-required` hier gültig und
+	 * `svelte-check` akzeptiert sie. Sie bleiben deshalb am Input — die
+	 * Zustands-Klasse tritt daneben, nicht an ihre Stelle.
+	 *
+	 * Der Toggle ist eine gestylte Checkbox: `<input type="checkbox">` ohne
+	 * `role`-Attribut, seine implizite Rolle ist damit `checkbox` — nicht
+	 * `switch`. Für die Aussage oben ändert das nichts, beide Rollen
+	 * unterstützen die zwei Attribute. Wer den Toggle später auf
+	 * `role="switch"` umstellt (was `aria-checked` nach sich zöge), muss diese
+	 * Zeilen deshalb nicht anfassen.
 	 */
 	describe('ARIA bleibt am Input', () => {
 		it('setzt aria-invalid und behält daneben die Fehler-Optik', async () => {

--- a/src/lib/report/components/form/fields/BaseToggle.svelte.test.ts
+++ b/src/lib/report/components/form/fields/BaseToggle.svelte.test.ts
@@ -1,0 +1,140 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, it, expect } from 'vitest';
+import { page } from 'vitest/browser';
+import BaseToggle from './BaseToggle.svelte';
+
+/**
+ * `BaseToggle` setzte seine Klasse hart auf `toggle toggle-primary` und nahm
+ * `hasError`/`isValid` gar nicht erst als Props an — `FieldRenderer` reichte
+ * beide über `toggleProps` durch, in der Komponente fielen sie still weg.
+ *
+ * Für die Klassen-Emission gilt dasselbe wie bei Radio und Checkbox. Dass die
+ * Klasse im **ausgeschalteten** Zustand überhaupt Farbe trägt, ist dagegen
+ * nicht DaisyUIs Verhalten, sondern kommt aus einem Override in `src/app.css`
+ * — abgesichert in `e2e/form-a11y.spec.ts`, nicht hier (eine Klassenliste
+ * belegt keine Optik).
+ */
+describe('BaseToggle', () => {
+	function toggleOf(container: HTMLElement): HTMLInputElement {
+		const el = container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+		if (!el) throw new Error('Kein Toggle-Input gerendert');
+		return el;
+	}
+
+	/**
+	 * `toggle-error`/`toggle-success` **ersetzen** `toggle-primary`, sie ergänzen
+	 * es nicht: Alle drei setzen dieselbe DaisyUI-Variable (`--input-color`) auf
+	 * derselben Ebene (`daisyui.l1.l2`) und mit derselben Spezifität. Stünden
+	 * zwei am Element, entschiede die Reihenfolge im DaisyUI-Stylesheet, nicht
+	 * die im `class`-Attribut.
+	 */
+	describe('Fehler-Optik', () => {
+		it('nutzt toggle-error statt toggle-primary bei hasError', async () => {
+			const screen = render(BaseToggle, { label: 'Totfund', hasError: true });
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+			expect(toggle.classList.contains('toggle-primary')).toBe(false);
+		});
+
+		it('nutzt toggle-success statt toggle-primary bei isValid', async () => {
+			const screen = render(BaseToggle, { label: 'Totfund', isValid: true });
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.classList.contains('toggle-success')).toBe(true);
+			expect(toggle.classList.contains('toggle-primary')).toBe(false);
+		});
+
+		it('bleibt ohne Zustand auf toggle-primary', async () => {
+			const screen = render(BaseToggle, { label: 'Totfund' });
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.classList.contains('toggle-primary')).toBe(true);
+			expect(toggle.classList.contains('toggle-error')).toBe(false);
+			expect(toggle.classList.contains('toggle-success')).toBe(false);
+		});
+
+		it('zeigt den Fehler-Zustand auch dann, wenn isValid gleichzeitig gesetzt ist', async () => {
+			const screen = render(BaseToggle, {
+				label: 'Totfund',
+				hasError: true,
+				isValid: true
+			});
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+			expect(toggle.classList.contains('toggle-success')).toBe(false);
+		});
+
+		/**
+		 * Der wahrscheinlichste Fehlerfall eines Pflicht-Toggles ist der
+		 * **ausgeschaltete** („muss zugestimmt werden"). Die Klasse muss deshalb
+		 * unabhängig von `checked` am Element stehen — dass sie dort auch Farbe
+		 * trägt, leistet der `app.css`-Override.
+		 */
+		it('trägt den Fehler-Zustand auch im ausgeschalteten Zustand', async () => {
+			const screen = render(BaseToggle, {
+				label: 'Totfund',
+				checked: false,
+				hasError: true
+			});
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.checked).toBe(false);
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+		});
+	});
+
+	/** Die Größen-Klasse darf durch den Zustands-Zweig nicht verloren gehen. */
+	describe('Größen', () => {
+		it('behält die Größen-Klasse neben dem Fehler-Zustand', async () => {
+			const screen = render(BaseToggle, {
+				label: 'Totfund',
+				size: 'sm' as const,
+				hasError: true
+			});
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.classList.contains('toggle-sm')).toBe(true);
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+		});
+	});
+
+	/**
+	 * Anders als beim Radio sind `aria-invalid`/`aria-required` hier gültig:
+	 * `role="switch"` unterstützt beide, `svelte-check` akzeptiert sie. Sie
+	 * bleiben deshalb am Input — die Zustands-Klasse tritt daneben, nicht an
+	 * ihre Stelle.
+	 */
+	describe('ARIA bleibt am Input', () => {
+		it('setzt aria-invalid und behält daneben die Fehler-Optik', async () => {
+			const screen = render(BaseToggle, {
+				label: 'Totfund',
+				hasError: true,
+				'aria-invalid': true
+			});
+
+			const toggle = toggleOf(screen.container);
+			expect(toggle.getAttribute('aria-invalid')).toBe('true');
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+		});
+
+		it('setzt aria-required', async () => {
+			const screen = render(BaseToggle, {
+				label: 'Totfund',
+				required: true,
+				'aria-required': true
+			});
+
+			expect(toggleOf(screen.container).getAttribute('aria-required')).toBe('true');
+		});
+	});
+
+	describe('Beschriftung', () => {
+		it('zeigt das Label', async () => {
+			render(BaseToggle, { label: 'Totfund' });
+
+			await expect.element(page.getByText('Totfund')).toBeVisible();
+		});
+	});
+});

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte.test.ts
@@ -653,6 +653,92 @@ describe('FieldRenderer', () => {
 		});
 	});
 
+	/**
+	 * `hasError`/`isValid` stehen seit jeher in `commonFieldProps` und gingen über
+	 * `checkboxProps`/`toggleProps` hinaus — nur nahmen `BaseCheckbox` und
+	 * `BaseToggle` sie nicht an, und sie fielen still weg. Genau deshalb reichen
+	 * die Tests an den Komponenten nicht: Sie merken nicht, wenn der Renderer
+	 * aufhört, die Props zu setzen. Diese Gruppe prüft die Strecke.
+	 */
+	describe('Fehler-Optik erreicht Checkbox und Toggle', () => {
+		function controlOf(testId: string): HTMLInputElement {
+			const el = document.querySelector<HTMLInputElement>(`[data-testid="${testId}"]`);
+			if (!el) throw new Error(`Kein Control mit data-testid="${testId}"`);
+			return el;
+		}
+
+		it('reicht hasError als checkbox-error durch', async () => {
+			render(FieldRenderer, {
+				fieldConfig: deadConfirmedFieldConfig,
+				name: 'deadConfirmed',
+				value: false,
+				error: 'Bitte bestätigen'
+			});
+
+			await expect.element(page.getByRole('checkbox')).toBeVisible();
+			const box = controlOf('field-deadConfirmed');
+			expect(box.classList.contains('checkbox-error')).toBe(true);
+			expect(box.classList.contains('checkbox-primary')).toBe(false);
+		});
+
+		it('reicht hasError als toggle-error durch', async () => {
+			render(FieldRenderer, {
+				fieldConfig: isDeadFieldConfig,
+				name: 'isDead',
+				value: false,
+				error: 'Bitte bestätigen'
+			});
+
+			await expect.element(page.getByTestId('field-isDead')).toBeVisible();
+			const toggle = controlOf('field-isDead');
+			expect(toggle.classList.contains('toggle-error')).toBe(true);
+			expect(toggle.classList.contains('toggle-primary')).toBe(false);
+		});
+
+		/** `isValid` = `touched && hasValue && !hasError` (siehe FieldRenderer). */
+		it('reicht isValid als checkbox-success durch', async () => {
+			render(FieldRenderer, {
+				fieldConfig: deadConfirmedFieldConfig,
+				name: 'deadConfirmed',
+				value: true,
+				touched: true
+			});
+
+			await expect.element(page.getByRole('checkbox')).toBeVisible();
+			const box = controlOf('field-deadConfirmed');
+			expect(box.classList.contains('checkbox-success')).toBe(true);
+			expect(box.classList.contains('checkbox-primary')).toBe(false);
+		});
+
+		it('reicht isValid als toggle-success durch', async () => {
+			render(FieldRenderer, {
+				fieldConfig: isDeadFieldConfig,
+				name: 'isDead',
+				value: true,
+				touched: true
+			});
+
+			await expect.element(page.getByTestId('field-isDead')).toBeVisible();
+			const toggle = controlOf('field-isDead');
+			expect(toggle.classList.contains('toggle-success')).toBe(true);
+			expect(toggle.classList.contains('toggle-primary')).toBe(false);
+		});
+
+		it('bleibt im Normalfall auf der primary-Variante', async () => {
+			render(FieldRenderer, {
+				fieldConfig: isDeadFieldConfig,
+				name: 'isDead',
+				value: false
+			});
+
+			await expect.element(page.getByTestId('field-isDead')).toBeVisible();
+			const toggle = controlOf('field-isDead');
+			expect(toggle.classList.contains('toggle-primary')).toBe(true);
+			expect(toggle.classList.contains('toggle-error')).toBe(false);
+			expect(toggle.classList.contains('toggle-success')).toBe(false);
+		});
+	});
+
 	describe('ARIA-Attribute', () => {
 		it('setzt aria-invalid=true bei Fehler', async () => {
 			render(FieldRenderer, {


### PR DESCRIPTION
Folgt PR #752, wo dasselbe für `BaseRadio` gemacht wurde. Beim Review dort fiel auf, dass Checkbox und Toggle dasselbe Defizit haben.

## Problem

`BaseCheckbox` und `BaseToggle` setzten ihre Klasse hart auf `checkbox checkbox-primary` bzw. `toggle toggle-primary` und nahmen `hasError`/`isValid` gar nicht erst als Props an. `FieldRenderer` baut beide seit jeher in `commonFieldProps` und reicht sie über `checkboxProps`/`toggleProps` durch — in den Komponenten fielen sie **still weg**. Ein Feld mit Validierungsfehler sah dadurch aus wie ein fehlerfreies, ohne dass irgendwo etwas brach.

## Die Falle beim Toggle

`checkbox-error`/`checkbox-success` verhalten sich wie die Radio-Varianten. `toggle-error` und `toggle-success` **nicht** — verifiziert in `node_modules/daisyui/daisyui.css` (5.7.4):

```css
.toggle-error{@layer daisyui.l1.l2{&:checked,&[aria-checked=true]{--input-color:var(--color-error)}}}
```

Die Farbe greift nur im eingeschalteten Zustand. Im Browser nachgemessen: ein ausgeschalteter `toggle-error` rendert **byte-identisch** zu einem nackten `toggle` (Rahmen und Knopf `rgb(118, 124, 131)`).

Der wahrscheinlichste Fehlerfall eines Pflicht-Toggles ist aber gerade der ausgeschaltete („muss zugestimmt werden"). Das Radio-Muster blind zu übernehmen wäre für genau den Fall, um den es geht, optisch wirkungslos gewesen.

## Lösung

Beide Komponenten bauen jetzt **genau eine** Zustandsklasse, wie `BaseRadio`. Die Zustandsklasse **ersetzt** `*-primary`, sie ergänzt es nicht: Alle drei setzen `--input-color` auf derselben Ebene mit derselben Spezifität — stünden zwei am Element, entschiede die Reihenfolge im DaisyUI-Stylesheet statt der im `class`-Attribut.

Für den ausgeschalteten Toggle kommt ein ungelayerter Override in `src/app.css` dazu (schlägt damit DaisyUIs `@layer`, dieselbe Mechanik wie beim Fokus-Override):

```css
.toggle-error:not(:checked) {
	--input-color: var(--color-error);
}
```

Nur Theme-Token, kein Hex und keine Palettenfarbe — `e2e/design-tokens.spec.ts` scannt aktiv dagegen.

**Ein roter AUS-Toggle liest sich nicht als „an":** Die Unterscheidung trägt die Knopfposition (`grid-template-columns` 0fr 1fr 1fr ↔ 1fr 1fr 0fr) und der Track-Hintergrund (transparent ↔ base-100), nicht die Farbe. Beides bleibt unangetastet.

**Kontrast** auf base-100: `--color-error` 6,05:1, `--color-success` 3,81:1. Rahmen und Knopf sind grafische Objekte — WCAG 1.4.11 verlangt dort 3:1, nicht die 4,5:1 für Text.

**ARIA ist unangetastet.** Anders als bei `role="radio"` unterstützen `role="checkbox"` und `role="switch"` beide `aria-invalid`/`aria-required`, und `svelte-check` akzeptiert das. Es ging hier ausschließlich um die Optik.

## Tests

Test-first, RED bestätigt (12 Fehlschläge) vor der Implementierung.

- `BaseCheckbox.svelte.test.ts` / `BaseToggle.svelte.test.ts` — neu, Muster nach `BaseRadio.svelte.test.ts`.
- `FieldRenderer.svelte.test.ts` — fünf Tests auf der Strecke Renderer → Komponente. Genau dort entstand das Defizit, und ein Test an der Komponente allein bemerkt nicht, wenn der Renderer aufhört, die Props zu setzen.
- `e2e/form-a11y.spec.ts` — misst die **Wirkung** des Overrides (welche Farbe kommt heraus) statt die Existenz einer CSS-Regel; eine Regel-Assertion wäre eine zweite Quelle neben `app.css` und würde mit ihr altern.

Der E2E-Test enthält eine **Gegenprobe**, die DaisyUIs Default zurückholt und verlangt, dass Fehler- und Normalzustand dann ununterscheidbar werden. Ohne sie belegte das Grün nur, dass zwei Farben verschieden sind — nicht, dass der Override das bewirkt. Zusätzlich direkt verifiziert: mit entferntem Override gehen beide Wächter rot („der Zustand ist unsichtbar").

## Abnahme

| Prüfung | Ergebnis |
| --- | --- |
| `npm run test:quick` | 3503 Tests grün, 0 Lint-Fehler |
| `svelte-check` | 2109 Dateien, **0 Errors, 0 Warnings** |
| `npm run test:unit:client` | 416 Tests grün (40 Dateien) |
| `npx playwright test --project=chromium` | 337 grün, 1 rot |

Der eine rote Test ist `e2e/modal-overflow.spec.ts` auf `/` — und zwar an seiner **eigenen Gegenprobe**, nicht an einer Behauptung dieses PRs. Verifiziert als vorbestehend: Er reproduziert isoliert und schlägt bei komplett gestashtem Arbeitsbaum genauso fehl, also auf dem reinen Stand von d407ea3f. Er ist separat zur Behebung vorgemerkt und gehört nicht in diesen Diff.

## Nebenwirkung, bewusst in Kauf genommen

`src/lib/report/components/form/fields/Checkbox.svelte` ist toter Code (nirgends importiert) und setzt hart `toggle toggle-success`. Der Override färbt sie ausgeschaltet jetzt grün statt neutral. Folgenlos, weil die Datei nicht gerendert wird — das Aufräumen ist separat vorgemerkt.

## Doku

`.claude/rules/design-system.md` bekommt den Abschnitt „Zustands-Optik der Auswahl-Controls" mit der Toggle-Ausnahme; der Radio-Absatz verweist jetzt dorthin, statt die Regel ein zweites Mal zu führen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)