### PR TITLE
fix(report): stop step 2 promising a GPS position transfer it never does

### DIFF
--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -69,7 +69,20 @@
 		config, // Datei-Validierungskonfiguration (Größe, Typen, etc.)
 		enableGPSExtraction = false, // GPS-Extraktionsmodus aktivieren (für Position-Schritt)
 		title, // Optionaler Titel für die Dropzone
-		additionalText = 'GPS-Daten werden beim Upload verarbeitet',
+		/**
+		 * Zusatz unter dem Dropzone-Titel.
+		 *
+		 * Default bewusst leer: Bis zum 2026-08-04 stand hier „GPS-Daten werden
+		 * beim Upload verarbeitet" — eine Aussage, die genau der Aufrufer NICHT
+		 * erbte, der sie einlöst (`PositionPanel` überschreibt sie), während sie
+		 * `sections/Media.svelte` mit `enableGPSExtraction={false}` versprach.
+		 * Dort führt kein Codepfad zu `applyExifPosition`, die Position blieb
+		 * also unberührt.
+		 *
+		 * Was der Aufrufer mit den Daten tut, kann diese Komponente nicht wissen —
+		 * ein Zusatz dazu gehört deshalb an die Aufrufstelle, nicht in den Default.
+		 */
+		additionalText = '',
 		/**
 		 * Eigener Warnhinweis „Keine GPS-Daten im Foto" (nur im GPS-Modus sichtbar).
 		 *

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
@@ -336,3 +336,32 @@ describe('DropzoneEnhanced — sichtbarer Auslöser', () => {
 		openDialog.mockRestore();
 	});
 });
+
+/**
+ * Der Zusatz unter dem Dropzone-Titel darf keine Positionsübernahme versprechen,
+ * die der Aufrufer nicht leistet.
+ *
+ * Bis zum 2026-08-04 war „GPS-Daten werden beim Upload verarbeitet" der Default
+ * dieser Komponente. Sie erbte damit ausgerechnet der Aufrufer, der GPS NICHT
+ * auswertet (`sections/Media.svelte`, `enableGPSExtraction={false}` — dort führt
+ * kein Pfad zu `applyExifPosition`), während `PositionPanel` als einziger echter
+ * GPS-Aufrufer den Zusatz mit `additionalText=""` überschrieb.
+ *
+ * Geprüft wird deshalb der Default, nicht ein durchgereichter Wert: Ein Aufrufer,
+ * der nichts angibt, darf nichts versprechen. Was er selbst hineinschreibt, ist
+ * seine Aussage und seine Verantwortung.
+ */
+describe('DropzoneEnhanced — Default-Zusatz verspricht kein GPS', () => {
+	it('rendert ohne eigenen Zusatz keine Aussage über GPS-Daten', async () => {
+		renderDropzone([], { maxFiles: 10, enableGPSExtraction: false });
+
+		// Auf die gerenderte Fläche gewartet, sonst wäre die Assertion leer-grün.
+		await vi.waitUntil(() =>
+			Array.from(document.querySelectorAll('*')).find((candidate) =>
+				candidate.textContent?.includes('Klicken oder Drag & Drop')
+			)
+		);
+
+		expect(document.body.textContent).not.toMatch(/GPS/i);
+	});
+});

--- a/src/lib/report/components/form/position/PositionPanel.svelte
+++ b/src/lib/report/components/form/position/PositionPanel.svelte
@@ -296,14 +296,14 @@
 		</summary>
 		<div class="collapse-content">
 			<!-- `data-testid="photo-position-card"` bleibt: `form-position-photo.spec.ts`
-			     grenzt darüber den File-Input gegen die Medien-Dropzone aus Schritt 3
+			     grenzt darüber den File-Input gegen die Medien-Dropzone aus Schritt 2
 			     ab. Die Hero-Optik (`border-primary bg-primary/5`) ist dagegen weg —
 			     der Foto-Weg ist nicht mehr die Hauptaktion. -->
 			<div class="text-base-content" data-testid="photo-position-card">
 				<p class="text-base-content/70 mb-3 text-sm">
 					Wenn Ihr Foto GPS-Daten enthält, übernehmen wir daraus Position, Datum und Uhrzeit. Das
 					Bild dient hier nur der Positionsbestimmung — weitere Fotos und Videos können Sie in
-					Schritt 3 hochladen.
+					Schritt 2 hochladen.
 				</p>
 
 				{#if gpsPhotoConfig}
@@ -313,9 +313,11 @@
 
 					     `compact` + leerer `additionalText`: Die Beschriftung der Disclosure
 					     und der Satz darüber sagen bereits, worum es geht und dass GPS
-					     ausgelesen wird. Der Dropzone-Titel „Foto hochladen" und der
-					     Default-Zusatz „GPS-Daten werden beim Upload verarbeitet" waren
-					     die dritte und vierte Formulierung derselben Aussage. -->
+					     ausgelesen wird — ein Zusatz an der Dropzone wäre die dritte
+					     Formulierung derselben Aussage. Bleibt explizit stehen, obwohl der
+					     Default seit dem 2026-08-04 ebenfalls leer ist: Diese Stelle ist die
+					     einzige, die GPS wirklich übernimmt, und soll ihren Text selbst
+					     bestimmen statt ihn von einem Default zu erben. -->
 					<DropzoneEnhanced
 						{referenceId}
 						maxFiles={1}

--- a/src/lib/report/components/sections/Media.svelte
+++ b/src/lib/report/components/sections/Media.svelte
@@ -104,7 +104,21 @@
 		</p>
 		<ul class="list-inside list-disc space-y-1 text-xs">
 			<li><strong>Artbestimmung:</strong> Auch unscharfe Aufnahmen können helfen</li>
-			<li><strong>GPS-Daten:</strong> Automatische Positionserkennung aus Fotos</li>
+			<!-- Bis zum 2026-08-04 stand hier „Automatische Positionserkennung aus
+			     Fotos". Das löst dieser Schritt nicht ein: Die Dropzone unten läuft mit
+			     `enableGPSExtraction={false}`, und `applyExifPosition` hängt in
+			     `DropzoneEnhanced` am selben Wächter — die Positionsangabe aus Schritt 1
+			     bleibt also unberührt. Ausgelesen und gespeichert werden die Metadaten
+			     trotzdem (client-seitig für die Anzeige, serverseitig nach
+			     `sichtungen_dateien.exif_daten`), und genau das sagt der Satz jetzt.
+
+			     Der zweite Halbsatz ist kein Beiwerk: Ohne ihn liest sich der erste als
+			     Ankündigung, dass ein beliebiges der zehn Fotos die eigene Eingabe
+			     überschreibt. -->
+			<li>
+				<strong>Metadaten:</strong> GPS-Position und Aufnahmezeit aus dem Foto helfen bei der Einordnung
+				— Ihre Angaben aus Schritt 1 bleiben davon unberührt
+			</li>
 			<li>
 				<strong>Formate:</strong>
 				{formatDescription} ({maxSizeDescription})

--- a/src/lib/report/components/sections/Media.svelte.test.ts
+++ b/src/lib/report/components/sections/Media.svelte.test.ts
@@ -143,3 +143,47 @@ describe('Media — Einleitungstext nach der Fassung des Museums', () => {
 		expect(document.querySelector('[data-testid="upload-notice-trigger"]')).not.toBeNull();
 	});
 });
+
+/**
+ * Dieser Abschnitt versprach bis zum 2026-08-04 an zwei Stellen eine
+ * Positionsübernahme, die er nicht leistet: „Automatische Positionserkennung aus
+ * Fotos" in der Vorteilsliste und „GPS-Daten werden beim Upload verarbeitet" als
+ * Default-Zusatz aus `DropzoneEnhanced`.
+ *
+ * Eingelöst wird beides nicht: Die Dropzone hier läuft mit
+ * `enableGPSExtraction={false}`, und `applyExifPosition` hängt in
+ * `DropzoneEnhanced` am selben Wächter (`isPositionStep`). Die Koordinaten aus
+ * Schritt 1 bleiben unberührt — GPS übernimmt ausschließlich `PositionPanel`.
+ *
+ * Geprüft wird deshalb die **Abwesenheit** der Zusage, nicht der neue Wortlaut:
+ * Wie der Abschnitt seinen Nutzen beschreibt, darf das Museum jederzeit
+ * umformulieren; dass er dabei keine Positionsübernahme behauptet, nicht. Das
+ * Muster fängt bewusst die Sache und nicht den alten Satz — eine Assertion auf
+ * dessen Wortlaut wäre grün, sobald jemand dasselbe Versprechen anders
+ * formuliert.
+ *
+ * Den zweiten Satz deckt dieser Test NICHT ab, und der Versuch wäre eine Falle:
+ * Die Dropzone hängt an `{#if uploadConfig}` und damit an `getUploadConfig()`,
+ * das hier nie auflöst — eine Assertion auf ihren Zusatz wäre auch mit dem alten
+ * Default grün (vorgeführt am 2026-08-04). Sie steht deshalb dort, wo sie beißt:
+ * `DropzoneEnhanced.svelte.test.ts` → „Default-Zusatz verspricht kein GPS".
+ */
+describe('Media — keine Zusage einer Positionsübernahme', () => {
+	it('kündigt keine automatische Positionserkennung an', () => {
+		renderMedia();
+
+		expect(document.body.textContent).not.toMatch(/automatisch\w*\s+Position/i);
+	});
+
+	/**
+	 * Die Gegenprobe zu den beiden Verboten: Ohne sie wären sie auch dann grün,
+	 * wenn der Abschnitt gar nichts mehr zu Metadaten sagt — und der Hinweis,
+	 * dass die eigene Eingabe unangetastet bleibt, ist genau der Satz, der die
+	 * Sorge „ein Foto überschreibt meine Position" ausräumt.
+	 */
+	it('sagt stattdessen, dass die eigene Positionsangabe unberührt bleibt', () => {
+		renderMedia();
+
+		expect(document.body.textContent).toMatch(/Schritt 1 bleiben davon unberührt/i);
+	});
+});


### PR DESCRIPTION
## Was war falsch

Der Medien-Abschnitt auf Schritt 2 machte zwei Zusagen, die kein Codepfad einlöst:

1. In der Vorteilsliste: „**GPS-Daten:** Automatische Positionserkennung aus Fotos"
2. An der Dropzone: „GPS-Daten werden beim Upload verarbeitet" — geerbt aus dem `additionalText`-Default in `DropzoneEnhanced`

`sections/Media.svelte` rendert die Dropzone mit `enableGPSExtraction={false}`, und `applyExifPosition` hängt am selben `isPositionStep`-Wächter. Die Koordinaten aus Schritt 1 werden dort nie angefasst.

Die Ironie beim Default: Ihn erbte ausgerechnet der Aufrufer, der GPS **nicht** auswertet — `PositionPanel`, der einzige, der es tut, überschrieb ihn mit `additionalText=""`.

## Was jetzt dasteht

EXIF wird weiterhin gelesen und gespeichert (client-seitig fürs Datei-Grid, serverseitig nach `sichtungen_dateien.exif_daten`). Genau das sagt die Liste jetzt:

> **Metadaten:** GPS-Position und Aufnahmezeit aus dem Foto helfen bei der Einordnung — Ihre Angaben aus Schritt 1 bleiben davon unberührt

Der zweite Halbsatz ist kein Beiwerk: Ohne ihn liest sich der erste als Ankündigung, dass eins von zehn Fotos die eigene Eingabe überschreibt.

## Änderungen

- **`DropzoneEnhanced`** — Default `additionalText` ist jetzt leer. Die Komponente kann nicht wissen, ob ihr Aufrufer GPS auswertet; die Zusage gehört an die Aufrufstelle. `PositionPanel` behält sein explizites `additionalText=""`, statt den neuen Default zu erben.
- **`PositionPanel`** — Die Foto-Disclosure verwies für weitere Uploads noch auf „Schritt 3"; der Medien-Abschnitt liegt seit d407ea3f auf Schritt 2.

## Tests

Zwei Guards, beide gegen die alten Texte rot vorgeführt:

- `Media.svelte.test.ts` → „keine Zusage einer Positionsübernahme" (Abwesenheit der Zusage, nicht der neue Wortlaut — das Museum darf umformulieren)
- `DropzoneEnhanced.svelte.test.ts` → „Default-Zusatz verspricht kein GPS"

Die Dropzone-Zusage lässt sich **nicht** aus dem Media-Test prüfen: Deren Dropzone hängt an `{#if uploadConfig}`, das dort nie auflöst — eine Assertion darauf wäre auch mit dem alten Default grün. Genau das ist beim Bauen aufgefallen und steht als Warnung im Test-Kommentar.

`npm run test:quick` (233 Dateien / 3503 Tests) und `npm run test:unit:client` (38 / 396) grün. Zusätzlich im Browser verifiziert: Schritt 1 verweist auf Schritt 2, Schritt 2 zeigt die Metadaten-Zeile, die Dropzone dort trägt keinen GPS-Zusatz mehr.

## Offen (bewusst nicht hier)

Rund 18 weitere Kommentare und Testbeschreibungen beziffern den Medien-Schritt noch als „Schritt 3" (u. a. `DropzoneEnhanced.svelte:129`, `UnifiedDropzone.svelte:39`, `discardFormUploads.ts:40`). Reine Kommentar-Pflege, separat abgelegt — inklusive der Ausnahme `formConfig.ts:75`, wo „Schritt 3" bewusst im Rückblick steht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)