### PR TITLE
test(report): pull the duplicated form-context setup into one helper

### DIFF
--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -64,6 +64,32 @@ describe('Button', () => {
 **Hinweis:** Projekt nutzt `vitest-browser-svelte` v2 + `page` API, NICHT `@testing-library/svelte`.
 In v2 werden Props direkt als zweites Argument übergeben — **kein `{ props: {...} }` Wrapper** (v1-Syntax).
 
+**Ausnahme: sobald ein `context` mitgegeben wird.** Dann ist das zweite Argument das
+Optionen-Objekt, und die Props müssen wieder unter den `props`-Schlüssel — sonst gelten
+sie als unbekannte Svelte-Optionen und kommen nie an der Komponente an.
+
+### Formular-Komponenten: `renderWithFormContext`
+
+Jede Komponente unterhalb von `Form.svelte` braucht den Form-Context (`FormField` wirft
+ohne ihn beim ersten Feld). Den Aufbau nicht abschreiben, sondern
+`src/lib/report/components/testing/renderWithFormContext.testutil.ts` nutzen — er kapselt
+auch die `props`-Ausnahme von oben:
+
+```typescript
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+
+// Startwerte über `overrides`, Props typgeprüft über `props`
+renderWithFormContext(DeadAnimal, { overrides: { isDead: true }, props: { adminMode: true } });
+
+// Rückgabe ist der gebaute Context — für Tests, die danach `form`/`mediaStore` prüfen
+const context = renderWithFormContext(DropzoneEnhanced, { props, mediaStore });
+```
+
+Der Helper heißt `.testutil.ts`, nicht `.ts`: `vitest.config.ts` nimmt `src/lib/**/*.ts`
+in die Coverage auf und schließt nur `**/*.testutil.ts` aus. Ohne das Suffix zählt ein
+Test-Helfer als ungedeckter Produktionscode (Präzedenz:
+`src/lib/server/datetime/withTimeZone.testutil.ts`).
+
 ### Mocking
 
 ```typescript

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
@@ -1,4 +1,3 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 
@@ -21,10 +20,8 @@ vi.mock('$lib/utils/client/fileAnalysis', () => ({
 		exifData: undefined
 	})
 }));
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData, UploadedFileInfo, ValidationPreset } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { FormContext, UploadedFileInfo, ValidationPreset } from '$lib/types';
 import { MediaFile, type MediaStore } from '$lib/utils/media/MediaFile.svelte';
 import { markPositionFile } from './positionFileOrigin';
 import DropzoneEnhanced from './DropzoneEnhanced.svelte';
@@ -82,17 +79,11 @@ function renderDropzone(
 	seededMediaFiles: MediaFile[] = []
 ): { mediaStore: MediaStore; form: FormContext['form'] } {
 	const mediaStore: MediaStore = { mediaFiles: seededMediaFiles };
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, uploadedFiles: files } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore
-	} as unknown as FormContext;
 
-	render(DropzoneEnhanced, {
+	const context = renderWithFormContext(DropzoneEnhanced, {
+		overrides: { uploadedFiles: files },
 		props: { referenceId: 'ref-1', config: CONFIG, ...props },
-		context: new Map([[formContextKey, context]])
+		mediaStore
 	});
 
 	return { mediaStore, form: context.form };

--- a/src/lib/report/components/form/position/LocationDescription.svelte.test.ts
+++ b/src/lib/report/components/form/position/LocationDescription.svelte.test.ts
@@ -1,10 +1,7 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
 import { flushSync, tick } from 'svelte';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
 import LocationDescription from './LocationDescription.svelte';
 
 /**
@@ -21,15 +18,7 @@ import LocationDescription from './LocationDescription.svelte';
  * Feldwert abgeleitet wird.
  */
 function renderWithForm(overrides: Partial<SightingFormData> = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(LocationDescription, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(LocationDescription, { overrides });
 }
 
 function field(name: string): HTMLInputElement {

--- a/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
+++ b/src/lib/report/components/form/position/PositionPanel.svelte.test.ts
@@ -1,9 +1,6 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
 import PositionPanel from './PositionPanel.svelte';
 
 /**
@@ -21,15 +18,7 @@ import PositionPanel from './PositionPanel.svelte';
  * deshalb zusammen mit den Koordinaten.
  */
 function renderPositionPanel(overrides: Partial<SightingFormData> = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(PositionPanel, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(PositionPanel, { overrides });
 }
 
 function requiredMarkIn(inputId: string): Element | null {

--- a/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
+++ b/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
@@ -1,9 +1,6 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
 import AnimalInfo from './AnimalInfo.svelte';
 
 /**
@@ -23,15 +20,7 @@ import AnimalInfo from './AnimalInfo.svelte';
  * Namensliste statt einer Bitmaske liefert.
  */
 function renderAnimalInfo(overrides: Partial<SightingFormData> = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(AnimalInfo, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(AnimalInfo, { overrides });
 }
 
 function fieldOrder(): string[] {
@@ -124,15 +113,10 @@ describe('sections/AnimalInfo — Artfrage folgt dem Totfund-Schalter', () => {
  */
 describe('sections/AnimalInfo — adminMode wird an DeadAnimal durchgereicht', () => {
 	function renderWithAdminMode(adminMode: boolean): void {
-		const context = {
-			...createForm<SightingFormData>({
-				initialValues: { ...initialFormState, isDead: true, deadCondition: 1 } as SightingFormData,
-				onSubmit: () => undefined
-			}),
-			mediaStore: { mediaFiles: [] }
-		} as unknown as FormContext;
-
-		render(AnimalInfo, { props: { adminMode }, context: new Map([[formContextKey, context]]) });
+		renderWithFormContext(AnimalInfo, {
+			overrides: { isDead: true, deadCondition: 1 },
+			props: { adminMode }
+		});
 	}
 
 	it('zeigt deadSex NICHT ohne adminMode', () => {

--- a/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
+++ b/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
@@ -1,9 +1,5 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import DeadAnimal from './DeadAnimal.svelte';
 
 /**
@@ -19,17 +15,7 @@ import DeadAnimal from './DeadAnimal.svelte';
  * setzt `adminMode={true}`.
  */
 function renderDeadAnimal(props: { adminMode?: boolean } = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, isDead: true } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
-	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
-	render(DeadAnimal, { props, context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(DeadAnimal, { overrides: { isDead: true }, props });
 }
 
 function field(name: string): HTMLElement | null {

--- a/src/lib/report/components/sections/Location.svelte.test.ts
+++ b/src/lib/report/components/sections/Location.svelte.test.ts
@@ -1,9 +1,6 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
 import Location from './Location.svelte';
 
 /**
@@ -30,15 +27,7 @@ import Location from './Location.svelte';
  * vorhandener Datensatz korrigiert, nicht eine Meldung erfasst.
  */
 function renderAdminLocation(overrides: Partial<SightingFormData> = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(Location, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(Location, { overrides });
 }
 
 function field(name: string): HTMLInputElement | null {

--- a/src/lib/report/components/sections/Media.svelte.test.ts
+++ b/src/lib/report/components/sections/Media.svelte.test.ts
@@ -1,9 +1,5 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import Media from './Media.svelte';
 
 /**
@@ -18,17 +14,7 @@ import Media from './Media.svelte';
  * bedienbar bleiben — sonst kann niemand mehr einwilligen.
  */
 function renderMedia(props: { adminMode?: boolean } = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
-	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
-	render(Media, { props, context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(Media, { props });
 }
 
 function consentInput(): HTMLInputElement {

--- a/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/OptionalSightingDetails.svelte.test.ts
@@ -1,9 +1,5 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import OptionalSightingDetails from './OptionalSightingDetails.svelte';
 
 /**
@@ -18,17 +14,7 @@ import OptionalSightingDetails from './OptionalSightingDetails.svelte';
  * vom Default `0` ab (gemessen 2026-08-04, `verteilung != 0`).
  */
 function renderDetails(props: { adminMode?: boolean } = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	// Sobald `context` mitgegeben wird, verlangt die Render-API die Props unter
-	// dem `props`-Schlüssel — sonst gelten sie als unbekannte Svelte-Optionen.
-	render(OptionalSightingDetails, { props, context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(OptionalSightingDetails, { props });
 }
 
 function field(name: string): HTMLElement | null {

--- a/src/lib/report/components/sections/SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/SightingDetails.svelte.test.ts
@@ -1,10 +1,7 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
-import type { FormContext, SightingFormData } from '$lib/types';
+import type { SightingFormData } from '$lib/types';
 import SightingDetails from './SightingDetails.svelte';
 
 /**
@@ -31,15 +28,7 @@ function renderSightingDetails(
 	overrides: Partial<SightingFormData> = {},
 	props: { adminMode?: boolean } = {}
 ): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(SightingDetails, { props, context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(SightingDetails, { overrides, props });
 }
 
 /** Das Pflicht-Sternchen der Feld-Pipeline, auf ein Feld eingegrenzt. */

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
@@ -1,9 +1,6 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
 import Step2SightingDetails from './Step2SightingDetails.svelte';
 
 /**
@@ -18,15 +15,7 @@ import Step2SightingDetails from './Step2SightingDetails.svelte';
  *    Beobachtung.** Die Entscheidung dazu steht in `$lib/report/wording`.
  */
 function renderStep2(overrides: Partial<SightingFormData> = {}): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(Step2SightingDetails, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(Step2SightingDetails, { overrides });
 }
 
 /**

--- a/src/lib/report/components/steps/Step3Observations.svelte.test.ts
+++ b/src/lib/report/components/steps/Step3Observations.svelte.test.ts
@@ -1,9 +1,5 @@
-import { render } from 'vitest-browser-svelte';
 import { describe, expect, it } from 'vitest';
-import { createForm } from '$lib/form/createForm';
-import { key as formContextKey } from '$lib/report/formContext';
-import { initialFormState } from '$lib/report/formConfig';
-import type { FormContext, SightingFormData } from '$lib/types';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import Step3Observations from './Step3Observations.svelte';
 
 /**
@@ -17,15 +13,7 @@ import Step3Observations from './Step3Observations.svelte';
  * „Schritt überspringen"-Knopf.
  */
 function renderStep3(): void {
-	const context = {
-		...createForm<SightingFormData>({
-			initialValues: { ...initialFormState } as SightingFormData,
-			onSubmit: () => undefined
-		}),
-		mediaStore: { mediaFiles: [] }
-	} as unknown as FormContext;
-
-	render(Step3Observations, { context: new Map([[formContextKey, context]]) });
+	renderWithFormContext(Step3Observations);
 }
 
 describe('Step3Observations — Medien sind auf Schritt 2 gewandert', () => {

--- a/src/lib/report/components/testing/renderWithFormContext.testutil.ts
+++ b/src/lib/report/components/testing/renderWithFormContext.testutil.ts
@@ -1,0 +1,76 @@
+import { render } from 'vitest-browser-svelte';
+import type { ComponentOptions } from 'vitest-browser-svelte/pure';
+import type { Component } from 'svelte';
+import { createForm } from '$lib/form/createForm';
+import { initialFormState } from '$lib/report/formConfig';
+import { key as formContextKey } from '$lib/report/formContext';
+import type { MediaStore } from '$lib/utils/media/MediaFile.svelte';
+import type { FormContext, SightingFormData } from '$lib/types';
+
+export interface FormContextRenderOptions<P extends Record<string, unknown>> {
+	/** Startwerte, die `initialFormState` überschreiben. */
+	overrides?: Partial<SightingFormData>;
+	/**
+	 * Props der Komponente. Sobald ein Context mitgegeben wird, verlangt die
+	 * Render-API sie unter dem `props`-Schlüssel — sonst gelten sie als
+	 * unbekannte Svelte-Optionen.
+	 */
+	props?: NoInfer<P>;
+	/**
+	 * Vorbefüllter Medien-Store. Default ist ein leerer — wer den Store nach dem
+	 * Rendern prüft, gibt ihn hier mit und behält so die Referenz darauf.
+	 */
+	mediaStore?: MediaStore;
+}
+
+/**
+ * Rendert eine Formular-Komponente mit dem Context, den sonst `Form.svelte`
+ * aufbaut (`createForm` + `mediaStore`, siehe `.claude/rules/forms.md`).
+ *
+ * Jede Komponente unterhalb von `Form.svelte` braucht ihn: `FormField` wirft
+ * ohne Context beim ersten Feld, auch wenn der Test etwas ganz anderes prüft.
+ * Vorher stand dieser Aufbau in elf Testdateien wörtlich gleich.
+ *
+ * **Der Context selbst wird ohne Cast gebaut.** `FormContext` ist
+ * `FormApi<SightingFormData>` plus `mediaStore`, und `MediaStore` ist
+ * `{ mediaFiles: MediaFile[] }` — ein leerer Store erfüllt den Typ wirklich und
+ * wird nicht per `as unknown as` dazu erklärt. Fehlte dem Objekt hier etwas,
+ * fiele das jetzt auf, statt vom Cast verdeckt zu werden.
+ *
+ * **Props werden geprüft, anders als bei `render` selbst.** Dessen
+ * Komponenten-Parameter ist ein bedingter Typ (`ComponentImport<C>`), aus dem
+ * `C` nicht inferiert werden kann — der Generic fällt auf seine Schranke und
+ * damit auf `any`. Hier bindet `component: Component<P>` das `P` direkt an die
+ * Komponente; ein Tippfehler im Prop-Namen fällt deshalb auf. Das `NoInfer` an
+ * `props` ist dafür nachweislich nicht nötig (ohne es meldet `svelte-check`
+ * denselben Fehler an derselben Stelle) und steht nur als Absicherung da, damit
+ * das übergebene Objekt `P` nie mitbestimmen kann.
+ *
+ * Zurück kommt der gebaute Context, damit ein Test nach dem Rendern an `form`
+ * oder `mediaStore` kommt. Die meisten Aufrufstellen ignorieren ihn.
+ */
+export function renderWithFormContext<P extends Record<string, unknown>>(
+	component: Component<P>,
+	{ overrides = {}, props, mediaStore = { mediaFiles: [] } }: FormContextRenderOptions<P> = {}
+): FormContext {
+	const formContext: FormContext = {
+		...createForm<SightingFormData>({
+			// Der Spread mit `Partial<…>` weitet jedes überschriebene Feld um
+			// `undefined`; der Cast betrifft nur die Startwerte, nicht den Context.
+			initialValues: { ...initialFormState, ...overrides } as SightingFormData,
+			onSubmit: () => undefined
+		}),
+		mediaStore
+	};
+
+	const context = new Map([[formContextKey, formContext]]);
+	const options = props === undefined ? { context } : { props, context };
+
+	// Der eine verbliebene Cast. `ComponentOptions<Component<P>>` löst sich mit
+	// generischem `P` nicht auf (es steckt ein `Parameters<typeof mount<…>>`
+	// darin), TypeScript kann das Optionen-Objekt deshalb gegen nichts prüfen.
+	// Betroffen ist nur die Render-API — Context und Props sind oben typisiert.
+	render(component, options as ComponentOptions<Component<P>>);
+
+	return formContext;
+}


### PR DESCRIPTION
## Warum

Elf Browser-Komponententests des Meldeformulars bauten den Form-Context von Hand auf — jedes Mal derselbe Block, jedes Mal mit `as unknown as FormContext`.

## Der Cast war nie nötig

`FormContext` ist `FormApi<SightingFormData>` plus `mediaStore`, und `MediaStore` ist schlicht `{ mediaFiles: MediaFile[] }`. Ein leerer Store erfüllt den Typ also wirklich. Der neue Helper baut den Context als normales typisiertes Objekt; fehlte ihm künftig etwas, fällt das auf, statt vom Cast verdeckt zu werden.

## Bonus: Props werden jetzt geprüft

`render` prüft sie nicht. Sein Komponenten-Parameter ist ein bedingter Typ (`ComponentImport<C>`), aus dem `C` nicht inferiert werden kann — der Generic fällt auf seine Schranke und damit auf `any`. Im Helper bindet `component: Component<P>` das `P` direkt an die Komponente. Ein Tippfehler im Prop-Namen oder ein falscher Typ scheitert jetzt an `svelte-check`; verifiziert mit `@ts-expect-error`-Sonden gegen `Media.svelte`.

## Ein Cast bleibt — im Helper, begründet

Mit generischem `P` löst sich `ComponentOptions<Component<P>>` nicht auf (darin steckt ein `Parameters<typeof mount<…>>`), TypeScript kann das Optionen-Objekt gegen nichts prüfen. Betrifft nur die Render-API; Context und Props sind darüber typisiert.

## `.testutil.ts`, nicht `.ts`

`vitest.config.ts` nimmt `src/lib/**/*.ts` in die Coverage auf und schließt nur `**/*.testutil.ts` aus. Ohne das Suffix landet der Helper als ungedeckter „Produktionscode" im Report — mit 0 %, und zwar dauerhaft, weil ihn nur Client-Tests importieren, die Coverage aber über das Server-Projekt läuft. Präzedenz im Repo: `src/lib/server/datetime/withTimeZone.testutil.ts`. Nach der Umbenennung empirisch geprüft: kein Treffer mehr in `coverage-final.json`.

## Umfang

- Neu: `src/lib/report/components/testing/renderWithFormContext.testutil.ts`
- Umgestellt: 11 Testdateien (die 9 der ursprünglichen Liste plus `PositionPanel` und `DropzoneEnhanced`, die denselben Block trugen)
- `.claude/rules/testing-patterns.md`: der Sonderfall „mit `context` müssen Props unter den `props`-Schlüssel" stand bisher als Kommentar in den Testdateien und wäre sonst verloren gegangen
- Netto −134 Zeilen; `formContextKey` taucht in `src/` nur noch in `formContext.ts` und im Helper auf

**Testnamen und Assertions sind unverändert** — sie sind die Regressionswächter für mehrere Museums-Änderungswünsche.

## Verifikation

| Check | Ergebnis |
| --- | --- |
| `npm run test:unit:client` | 38 Dateien, 393 Tests grün |
| `npm run test:quick` | 233 Dateien, 3503 Tests grün |
| `svelte-check` | 2108 Dateien, 0 Fehler |
| `tsc --noEmit` | sauber |
| ESLint | 0 Fehler (2 Vorbestandswarnungen in unberührter Datei) |

Ein Baseline-Lauf über `git stash` ergab vor der Änderung ebenfalls 38/393 — Anzahl und Namen sind identisch. (Die im Auftrag genannten 337 Tests waren veraltet.)

## Offen, bewusst nicht angefasst

`src/lib/report/components/form/Form.svelte:51` baut den Context im Produktionscode weiterhin mit demselben Cast. Ob er dort ebenso entfallen kann, ist eine eigene Prüfung — der Aufruf nutzt `createForm` ohne expliziten Generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)