### PR TITLE
fix(ci): stop E2E specs from silently running in no shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,19 @@ jobs:
             # `*.config.ts` heute schon einfängt — dieser Filter soll die
             # E2E-Eingaben vollständig benennen, nicht auf einen Zufallstreffer
             # bauen.
+            #
+            # `.github/workflows/ci.yml` gehört aus demselben Grund dazu: Der
+            # `e2e`-Job trägt die Shard-Aufteilung selbst, und eine Änderung
+            # daran ist eine Änderung an den E2E-Eingaben. Ohne diesen Eintrag
+            # überspringt ein PR, der nur die Shards umbaut, ausgerechnet den
+            # Job, den er umbaut — die Zuordnung eines Specs wäre dann erst nach
+            # dem Merge auf `main` das erste Mal gelaufen.
             e2e:
               - 'e2e/**'
               - 'playwright.config.ts'
               - 'vite.config.ci.ts'
               - 'scripts/seed-e2e.ts'
+              - '.github/workflows/ci.yml'
             docs:
               - '*.md'
               - 'docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,39 +457,111 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
+      # Die Specs stehen einzeln da, weil die drei Shards parallel laufen und
+      # ähnlich lang brauchen sollen — ein Verzeichnis je Shard gäbe das nicht
+      # her. Der Preis war bisher, dass ein neu angelegter Spec in keiner Liste
+      # stand und damit **nirgends** lief. Genau so konnte #749 einen roten
+      # Wächter auf `main` hinterlassen, ohne dass eine Prüfung anschlug; beim
+      # Aufräumen fielen 14 weitere Specs auf, die nie in CI gelaufen sind.
+      # Der Vollständigkeits-Abgleich unten macht aus „vergessen" einen
+      # Fehlschlag — die Aufzählung bleibt, ihr stiller Ausfall nicht.
       - name: Run E2E tests
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          form=(
+            e2e/form-submit.spec.ts
+            e2e/form-ux.spec.ts
+            e2e/form-a11y.spec.ts
+            e2e/form-position.spec.ts
+            e2e/form-position-photo.spec.ts
+            e2e/form-autosave.spec.ts
+            e2e/form-field-mode.spec.ts
+          )
+
+          map=(e2e/map-*.spec.ts)
+
+          # design-tokens.spec.ts gehört hierher, nicht zu form: es prüft das
+          # Theme, nicht das Formular. Läuft gegen /styleguide, das der
+          # dev-Guard nur im Entwicklungsmodus freigibt — der Shard startet
+          # ohnehin `vite dev` (playwright.config.ts).
+          #
+          # modal-overflow.spec.ts aus demselben Grund: Es prüft Layout über
+          # /, /bestimmungshilfe und /admin, nicht das Formular.
+          smoke=(
+            e2e/basic.test.ts
+            e2e/homepage.test.ts
+            e2e/about-page.spec.ts
+            e2e/auth.spec.ts
+            e2e/design-tokens.spec.ts
+            e2e/modal-overflow.spec.ts
+          )
+
+          # Specs, die bis heute in keinem Shard standen. Das war kein Beschluss,
+          # sondern ein Versehen — die Listen oben muss man beim Anlegen eines
+          # Specs von Hand pflegen, und das ist hier 14-mal unterblieben. Sie
+          # stehen als Rückstand hier, damit der Abgleich darunter greifen kann,
+          # **nicht** weil ihr Ausschluss geprüft wäre.
+          #
+          # Wer einen davon in einen Shard zieht, lässt ihn vorher laufen.
+          # form-map-pan-zoom.spec.ts ist der bekannte Sonderfall: von sich aus
+          # flaky (Subpixel-Vergleiche nach Pan/Zoom), gehört erst nach einer
+          # Stabilisierung in einen Shard.
+          unassigned=(
+            e2e/admin-edit-preserves-record.spec.ts
+            e2e/admin-table-verified-column.spec.ts
+            e2e/app-shell-height.spec.ts
+            e2e/bestimmungshilfe.spec.ts
+            e2e/footer-layout.spec.ts
+            e2e/form-map-pan-zoom.spec.ts
+            e2e/form-stepper-affordance.spec.ts
+            e2e/form-stepper.spec.ts
+            e2e/horizontal-overflow.spec.ts
+            e2e/meldung-wording.spec.ts
+            e2e/navbar-structure.spec.ts
+            e2e/seo-meta.spec.ts
+            e2e/submit-offline.spec.ts
+            e2e/videoUpload.spec.ts
+          )
+
+          # Ein Spec, der in keiner der vier Listen steht, ist neu und beim
+          # Anlegen vergessen worden. Die Dateimuster sind dieselben, die
+          # playwright.config.ts fährt (testDir: 'e2e', testIgnore:
+          # '**/helpers/**') — deshalb ohne Rekursion.
+          known=" ${form[*]} ${map[*]} ${smoke[*]} ${unassigned[*]} "
+          missing=()
+          for spec in e2e/*.spec.ts e2e/*.test.ts; do
+            case "$known" in
+              *" $spec "*) ;;
+              *) missing+=("$spec") ;;
+            esac
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Diese Specs stehen in keinem Shard und würden nirgends laufen: ${missing[*]}"
+            echo "Bitte in .github/workflows/ci.yml einem Shard (form/map/smoke) zuordnen."
+            exit 1
+          fi
+
           case "${{ matrix.shard }}" in
-            form)
-              npm run test:e2e -- \
-                e2e/form-submit.spec.ts \
-                e2e/form-ux.spec.ts \
-                e2e/form-a11y.spec.ts \
-                e2e/form-position.spec.ts \
-                e2e/form-position-photo.spec.ts \
-                e2e/form-autosave.spec.ts \
-                e2e/form-field-mode.spec.ts
-              ;;
-            map)
-              npm run test:e2e -- e2e/map-*.spec.ts
-              ;;
-            smoke)
-              # design-tokens.spec.ts gehört hierher, nicht zu form: es prüft das
-              # Theme, nicht das Formular. Läuft gegen /styleguide, das der
-              # dev-Guard nur im Entwicklungsmodus freigibt — der Shard startet
-              # ohnehin `vite dev` (playwright.config.ts).
-              npm run test:e2e -- \
-                e2e/basic.test.ts \
-                e2e/homepage.test.ts \
-                e2e/about-page.spec.ts \
-                e2e/auth.spec.ts \
-                e2e/design-tokens.spec.ts
-              ;;
+            form) specs=("${form[@]}") ;;
+            map) specs=("${map[@]}") ;;
+            smoke) specs=("${smoke[@]}") ;;
             *)
               echo "Unknown shard: ${{ matrix.shard }}"
               exit 1
               ;;
           esac
+
+          # Ohne diese Schranke wäre ein leer gelaufenes Glob (nullglob) ein
+          # `npm run test:e2e --` ohne Argumente — und das startet die gesamte
+          # Suite statt des Shards.
+          if [ ${#specs[@]} -eq 0 ]; then
+            echo "::error::Shard ${{ matrix.shard }} hat keine Specs ermittelt."
+            exit 1
+          fi
+
+          npm run test:e2e -- "${specs[@]}"
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,17 +526,34 @@ jobs:
           )
 
           # Ein Spec, der in keiner der vier Listen steht, ist neu und beim
-          # Anlegen vergessen worden. Die Dateimuster sind dieselben, die
-          # playwright.config.ts fährt (testDir: 'e2e', testIgnore:
-          # '**/helpers/**') — deshalb ohne Rekursion.
+          # Anlegen vergessen worden.
+          #
+          # Gesucht wird **rekursiv** und mit denselben Endungen, die Playwright
+          # per Default sammelt — `testDir: 'e2e'` steigt in Unterordner ab, und
+          # ein Spec in `e2e/irgendwas/` liefe lokal, in CI aber nirgends und
+          # fiele einem Abgleich nur über `e2e/*.spec.ts` nicht auf. `helpers/`
+          # bleibt außen vor, weil playwright.config.ts es per `testIgnore`
+          # ausnimmt: Die Dateien dort sind Vitest-Tests, die vitest.config.ts
+          # einsammelt.
+          # `find` und kein Glob: Ein `**`-Muster bräuchte `shopt -s globstar`
+          # und die Endungsliste `extglob` — und extglob wirkt erst zur
+          # Laufzeit, womit `bash -n` das Skript nicht mehr prüfen kann.
           known=" ${form[*]} ${map[*]} ${smoke[*]} ${unassigned[*]} "
           missing=()
-          for spec in e2e/*.spec.ts e2e/*.test.ts; do
+          while IFS= read -r spec; do
             case "$known" in
               *" $spec "*) ;;
               *) missing+=("$spec") ;;
             esac
-          done
+          done < <(
+            find e2e -type f \
+              \( -name '*.spec.ts' -o -name '*.test.ts' \
+                 -o -name '*.spec.tsx' -o -name '*.test.tsx' \
+                 -o -name '*.spec.js' -o -name '*.test.js' \
+                 -o -name '*.spec.jsx' -o -name '*.test.jsx' \) \
+              -not -path 'e2e/helpers/*' \
+              | sort
+          )
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::Diese Specs stehen in keinem Shard und würden nirgends laufen: ${missing[*]}"
             echo "Bitte in .github/workflows/ci.yml einem Shard (form/map/smoke) zuordnen."


### PR DESCRIPTION
> **Umfang seit dem Rebase deutlich kleiner.** Der ursprüngliche Befund 1 (der
> Wächter selbst) ist inzwischen mit #757 auf `main` behoben — und zwar besser
> als in meiner Fassung. Ich habe meinen Spec-Commit deshalb beim Rebase
> **fallen gelassen**. Übrig bleibt Befund 2, der auf `main` nach wie vor offen
> ist. Der PR fasst jetzt nur noch `.github/workflows/ci.yml` an.

## Das Problem

`e2e/modal-overflow.spec.ts` stand in **keinem** CI-Shard. Genau deshalb konnte
#749 einen roten Wächter auf `main` hinterlassen, ohne dass eine Prüfung
anschlug — und es brauchte #757, um ihn wieder in Ordnung zu bringen. Die
Aufzählung der Specs je Shard muss man beim Anlegen von Hand pflegen, und wenn
das jemand vergisst, ist die Folge nicht „läuft im falschen Shard", sondern
„läuft nirgends" — lautlos.

## Was sich ändert

- `modal-overflow.spec.ts` läuft jetzt im `smoke`-Shard (Layout über `/`,
  `/bestimmungshilfe` und `/admin` — nicht Formular, dieselbe Begründung wie bei
  `design-tokens.spec.ts` daneben).
- Die Aufzählung **bleibt** — die drei Shards laufen parallel und sollen ähnlich
  lang brauchen, ein Verzeichnis je Shard gäbe das nicht her. Ihr **stiller**
  Ausfall bleibt nicht: Der Schritt gleicht alle Spec-Dateien gegen die Listen ab
  und bricht mit Nennung der Datei ab, sobald eine in keiner steht.
- Dazu eine Schranke gegen ein leer gelaufenes Glob: Ohne sie wäre
  `npm run test:e2e --` ohne Argumente ein Lauf der **gesamten** Suite statt des
  Shards.

## Der Nebenbefund: 14 weitere Specs liefen nie in CI

Beim Aufräumen fielen 14 weitere Specs auf, die noch nie in einem Shard standen.
Sie stehen als `unassigned` mit Begründung im Schritt — ausdrücklich als
**Rückstand, nicht als geprüfter Ausschluss**.

Ich habe sie bewusst **nicht** ungeprüft in einen Shard gekehrt:
`form-map-pan-zoom.spec.ts` ist von sich aus flaky (Subpixel-Vergleiche nach
Pan/Zoom) und färbte CI rot. Das Zuordnen gehört in einen eigenen PR, mit einem
Lauf je Spec.

## Für Reviewer

**Warum `find` und kein Glob.** Die erste Fassung des rekursiven Abgleichs nutzte
`shopt -s globstar extglob` mit `@(spec|test)`. Das bricht `bash -n`: extglob
wirkt erst zur Laufzeit, der reine Syntax-Check scheitert am Muster. In der
Action wäre es vermutlich gelaufen, aber ein Wächter, dessen Skript man nicht
mehr prüfen kann, ist ein schlechter Tausch. `find` braucht keine Shell-Optionen.

**`ci.yml` ist nicht prettier-formatiert.** Ein `prettier --write` schrieb die
ganze Datei um (Quote-Stil); zurückgenommen, der Diff enthält keine
Fremdänderungen.

## Nachtrag: der E2E-Job lief für diesen PR gar nicht

Beim Prüfen der eigenen Checks fiel auf, dass `E2E Tests` auf „skipping" stand —
der `e2e`-Pfadfilter nannte `e2e/**` und die Configs, nicht aber die
Workflow-Datei selbst. Ein PR, der nur die Shard-Aufteilung umbaut, übersprang
damit ausgerechnet den Job, den er umbaut: Die Zuordnung von
`modal-overflow.spec.ts` wäre erst nach dem Merge auf `main` das erste Mal
gelaufen.

Dieselbe Fehlerklasse wie der Rest des PRs, deshalb hier mit behoben. Seitdem
laufen die drei Shards für diesen PR — und der `smoke`-Shard hat
`modal-overflow.spec.ts` nachweislich mit ausgeführt (100 passed).

## Verifikation

Skript aus der YAML extrahiert und trocken gefahren, vier Fälle:

| Fall | Erwartung | Ergebnis |
| --- | --- | --- |
| Grundzustand | grün, `smoke` = 6 Specs | Exit 0 ✅ |
| Spec in `e2e/nested/` | Abbruch mit Dateiname | Exit 1 ✅ |
| Datei unter `e2e/helpers/` | ignoriert (Vitest-Tests) | Exit 0 ✅ |
| Neuer Spec auf oberster Ebene | Abbruch mit Dateiname | Exit 1 ✅ |

Dazu: `bash -n` grün, Shards lösen korrekt auf (`form` 7, `map` 10, `smoke` 6),
unbekannter Shard Exit 1. Und weil dieser PR `modal-overflow.spec.ts` erstmals in
CI schickt, der Spec in der `main`-Fassung lokal gegengeprüft: **3 passed, drei
Läufe hintereinander.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
