### PR TITLE
docs(report): move the media comments from step 3 to step 2

### DIFF
--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -36,7 +36,7 @@
 		 * einem Button (verschachtelte Interaktion) und ein Klick öffnete den
 		 * Dateidialog zweimal.
 		 *
-		 * Ohne die Prop bleibt alles wie bisher (Schritt 3, Admin-Maske).
+		 * Ohne die Prop bleibt alles wie bisher (Schritt 2, Admin-Maske).
 		 */
 		actionLabel = undefined,
 		/**

--- a/src/lib/report/components/form/UploadNotice.svelte
+++ b/src/lib/report/components/form/UploadNotice.svelte
@@ -22,7 +22,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { UPLOAD_NOTICE } from '$lib/form/consent/uploadNotice';
 
-	// Die Komponente steht zweimal im Formular (Schritt 1 und Schritt 3). Eine
+	// Die Komponente steht zweimal im Formular (Schritt 1 und Schritt 2). Eine
 	// feste ID wäre im DOM doppelt und machte `aria-labelledby` unbrauchbar.
 	const titleId = $props.id();
 

--- a/src/lib/report/components/form/UploadNotice.svelte.test.ts
+++ b/src/lib/report/components/form/UploadNotice.svelte.test.ts
@@ -71,7 +71,7 @@ describe('UploadNotice', () => {
 	});
 
 	it('benennt zwei gleichzeitige Instanzen getrennt', () => {
-		// Die Komponente steht im Formular zweimal (Schritt 1 und Schritt 3). Mit
+		// Die Komponente steht im Formular zweimal (Schritt 1 und Schritt 2). Mit
 		// einer festen ID zeigten beide `aria-labelledby` auf dasselbe Element.
 		render(UploadNotice);
 		render(UploadNotice);

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -126,7 +126,7 @@
 		 * ~600 px Karte, ohne erkennbaren Unterschied, welche bedienbar ist. Ohne
 		 * Karte tritt an ihre Stelle die kompakte Bestätigungszeile.
 		 *
-		 * Default `true` wie bisher; `sections/Media.svelte` (Schritt 3 und
+		 * Default `true` wie bisher; `sections/Media.svelte` (Schritt 2 und
 		 * Admin-Maske) erreicht diesen Zweig mit `enableGPSExtraction={false}`
 		 * ohnehin nicht. Gleiches Muster wie `showNoGpsWarning`.
 		 */
@@ -185,7 +185,7 @@
 		// Positions-Schritts (positionPanelState.ts). Mit `isPositionStep`
 		// stempelte die zuerst gemountete Dropzone ihre eigene Herkunft auf alle
 		// wiederhergestellten Dateien — nach einem Reload auf Schritt 1 galten
-		// Schritt-3-Medien als Positions-Foto, nach einem Reload auf Schritt 2+
+		// Schritt-2-Medien als Positions-Foto, nach einem Reload auf Schritt 2+
 		// verlor das echte Positions-Foto seinen Hinweis (positionFileOrigin.ts).
 		const positionUids = loadPositionUids();
 
@@ -210,7 +210,7 @@
 	 * Schritten geteilt. Im Positions-Schritt zählen deshalb nur die Dateien
 	 * dieses Schritts — dieselbe Eingrenzung, die `photoStatus`
 	 * (`positionPanelState.ts`) für das Panel vornimmt. Ohne sie zeigte Schritt 1
-	 * nach einem Reload ein Foto aus Schritt 3 als „das Positions-Foto" und
+	 * nach einem Reload ein Foto aus Schritt 2 als „das Positions-Foto" und
 	 * ersetzte die Dropzone damit vollständig.
 	 *
 	 * Im Medien-Schritt bleibt es beim ganzen Store: Dort ist die Galerie
@@ -342,7 +342,7 @@
 		// Gezählt wird über `ownedMediaFiles` und nicht über den ganzen Store —
 		// dieselbe Eingrenzung, mit der `positionMediaFile` und `handleClear` schon
 		// arbeiten. Vorher zählte hier der ganze `mediaStore` gegen `maxFiles`: Im
-		// Positions-Schritt (`maxFiles: 1`) belegte damit jedes Medium aus Schritt 3
+		// Positions-Schritt (`maxFiles: 1`) belegte damit jedes Medium aus Schritt 2
 		// den einzigen Platz, der Ersetzen-Zweig löschte nichts (die fremde Datei
 		// gehört ihm nicht) und der Upload endete in „Nur 0 von 1 Dateien können
 		// hinzugefügt werden (Maximum: 1)". Im Medien-Schritt sind beide Mengen
@@ -512,7 +512,7 @@
 
 			// Nur die eigenen Dateien (siehe `ownedMediaFiles`). Im Positions-Schritt
 			// ist „Neu auswählen" der einzige Ausweg aus der Foto-Karte; unbegrenzt
-			// gedacht löschte dieser eine Klick auch die Medien aus Schritt 3 —
+			// gedacht löschte dieser eine Klick auch die Medien aus Schritt 2 —
 			// serverseitig und ohne Rückfrage. Im Medien-Schritt bleibt „Alle
 			// löschen" unverändert alles.
 			const removed = ownedMediaFiles;
@@ -640,7 +640,7 @@
 										{:then}
 											<!-- Remove button. `min-h-11 min-w-11` hält das 44-px-Touch-Target
 											     (design-system.md); der Button ist absolut positioniert und
-											     kann das Datei-Grid in Schritt 3 deshalb nicht umbrechen.
+											     kann das Datei-Grid in Schritt 2 deshalb nicht umbrechen.
 											     `btn-error:hover` war eine tote Klasse — diese Schreibweise
 											     erzeugt Tailwind nicht (Variante wäre `hover:…`). -->
 											<button
@@ -973,7 +973,7 @@
 
 		     `title` rechnet mit `ownedMediaFiles` wie das Datei-Limit oben: Über den
 		     ganzen Store gezählt hieß die Fläche im Positions-Schritt „Foto
-		     ersetzen", sobald irgendwo ein Medium aus Schritt 3 lag — auch wenn
+		     ersetzen", sobald irgendwo ein Medium aus Schritt 2 lag — auch wenn
 		     dieser Schritt gar kein Foto hat. Das trifft nicht nur die Beschriftung,
 		     sondern über `zoneTriggerAttributes` auch den zugänglichen Namen der
 		     Fläche (WCAG 4.1.2). -->

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte.test.ts
@@ -35,10 +35,10 @@ import DropzoneEnhanced from './DropzoneEnhanced.svelte';
  * bereits vorhandene Dateien übersprungen werden, gewann schlicht die Dropzone,
  * die zuerst mountete:
  *
- * - Reload auf Schritt 1 mit Medien aus Schritt 3 → alle galten als
+ * - Reload auf Schritt 1 mit Medien aus Schritt 2 → alle galten als
  *   Positions-Foto, und das Panel behauptete „In diesem Foto sind keine
  *   GPS-Daten gespeichert", obwohl in Schritt 1 nie eines lag.
- * - Reload auf Schritt 2+ → das echte Positions-Foto galt als Schritt-3-Medium
+ * - Reload auf Schritt 2+ → das echte Positions-Foto galt als Schritt-2-Medium
  *   und der Hinweis war weg.
  *
  * Die Herkunft wird deshalb neben den Formulardaten persistiert (uid-Menge in
@@ -174,12 +174,12 @@ function restoredMediaFile(uid: string, fromPositionStep: boolean): MediaFile {
  * `mediaStore` gehört dem ganzen Formular. `photoStatus` grenzt deshalb auf
  * `isFromPositionStep` ein — sein Geschwister `positionMediaFile` tat es nicht
  * und fiel auf `mediaFiles[0]` zurück. Nach einem Reload auf Schritt 1, mit
- * Medien nur aus Schritt 3, zeigte Schritt 1 damit ein fremdes Foto als „das
+ * Medien nur aus Schritt 2, zeigte Schritt 1 damit ein fremdes Foto als „das
  * Positions-Foto" und ersetzte die Dropzone vollständig. Einziger Ausweg war
  * „Neu auswählen" — und das löschte serverseitig alle Medien aller Schritte.
  */
 describe('DropzoneEnhanced — Eingrenzung auf den Positions-Schritt', () => {
-	it('zeigt im Positions-Schritt die Dropzone, wenn nur Medien aus Schritt 3 vorliegen', async () => {
+	it('zeigt im Positions-Schritt die Dropzone, wenn nur Medien aus Schritt 2 vorliegen', async () => {
 		renderDropzone([], { maxFiles: 1, enableGPSExtraction: true }, [
 			restoredMediaFile('media-uid', false)
 		]);
@@ -213,13 +213,13 @@ describe('DropzoneEnhanced — Eingrenzung auf den Positions-Schritt', () => {
  * `mediaStore` gehört dem ganzen Formular. `positionMediaFile` und `handleClear`
  * rechnen deshalb nur mit den Dateien DIESES Schritts — `handleFilesAdded` zählte
  * dagegen den ganzen Store gegen `maxFiles`. Im Positions-Schritt (`maxFiles: 1`)
- * belegte damit jedes Medium aus Schritt 3 den einzigen Platz: Der Ersetzen-Zweig
+ * belegte damit jedes Medium aus Schritt 2 den einzigen Platz: Der Ersetzen-Zweig
  * löschte nichts (die fremde Datei gehört ihm nicht), und der Upload endete in
  * „Nur 0 von 1 Dateien können hinzugefügt werden (Maximum: 1)". Sichtbar wurde
  * das nach „Neu auswählen" — das Positions-Foto war weg, der Platz blieb belegt.
  */
 describe('DropzoneEnhanced — Datei-Limit im Positions-Schritt', () => {
-	it('nimmt ein Foto an, obwohl ein Medium aus Schritt 3 im Store liegt', async () => {
+	it('nimmt ein Foto an, obwohl ein Medium aus Schritt 2 im Store liegt', async () => {
 		const { mediaStore } = renderDropzone(
 			[uploadedFile('media-uid')],
 			{ maxFiles: 1, enableGPSExtraction: true },
@@ -267,7 +267,7 @@ describe('DropzoneEnhanced — Datei-Limit im Positions-Schritt', () => {
  * EINE Karte vor: die interaktive.
  *
  * Wie bei `showNoGpsWarning` steckt die Entscheidung in einer Prop mit dem
- * bisherigen Verhalten als Default — Schritt 3 und die Admin-Maske
+ * bisherigen Verhalten als Default — Schritt 2 und die Admin-Maske
  * (`sections/Media.svelte`, beide mit `enableGPSExtraction={false}`) erreichen
  * diesen Zweig ohnehin nicht.
  */

--- a/src/lib/report/components/form/fields/positionFileOrigin.ts
+++ b/src/lib/report/components/form/fields/positionFileOrigin.ts
@@ -7,7 +7,7 @@
  * trägt die Herkunft nicht. Vorher wurde sie deshalb aus der Mount-Reihenfolge
  * geraten: Die zuerst gemountete Dropzone stempelte ihre eigene Herkunft auf
  * ALLE wiederhergestellten Dateien. Beide Richtungen waren falsch — ein Reload
- * auf Schritt 1 machte Schritt-3-Medien zum „Positions-Foto ohne GPS", ein
+ * auf Schritt 1 machte Schritt-2-Medien zum „Positions-Foto ohne GPS", ein
  * Reload auf Schritt 2+ nahm dem echten Positions-Foto seinen Hinweis.
  *
  * Bewusst **neben** den Formulardaten und nicht in ihnen: `uploadedFiles` ist

--- a/src/lib/report/components/form/position/positionPanelState.test.ts
+++ b/src/lib/report/components/form/position/positionPanelState.test.ts
@@ -15,7 +15,7 @@ function makeMediaFile(withGps: boolean, analyzed: boolean = true): PositionCapa
 	return { hasPosition: () => withGps, isAnalyzed: () => analyzed, isFromPositionStep: true };
 }
 
-/** Datei aus Schritt 3 (Medien) — liegt im selben Store, gehört aber nicht hierher. */
+/** Datei aus Schritt 2 (Medien) — liegt im selben Store, gehört aber nicht hierher. */
 function makeMediaStepFile(withGps: boolean, analyzed: boolean = true): PositionCapableFile {
 	return { hasPosition: () => withGps, isAnalyzed: () => analyzed, isFromPositionStep: false };
 }
@@ -64,7 +64,7 @@ describe('photoStatus', () => {
 
 /**
  * `mediaStore` wird einmal pro Formular angelegt (Form.svelte:40) und von allen
- * Schritten geteilt. Ohne Eingrenzung entschiede ein Foto aus Schritt 3
+ * Schritten geteilt. Ohne Eingrenzung entschiede ein Foto aus Schritt 2
  * (Medien) mit darüber, was das Panel in Schritt 1 über „dieses Foto" behauptet.
  */
 describe('photoStatus — Eingrenzung auf den Positions-Schritt', () => {

--- a/src/lib/report/components/form/position/positionPanelState.ts
+++ b/src/lib/report/components/form/position/positionPanelState.ts
@@ -33,7 +33,7 @@ export interface PositionCapableFile {
  *
  * **Nur Dateien des Positions-Schritts zählen.** `mediaStore` wird einmal pro
  * Formular angelegt (Form.svelte:40) und von allen Schritten geteilt; ohne diese
- * Eingrenzung entschieden die Fotos aus Schritt 3 (Medien) darüber mit, was das
+ * Eingrenzung entschieden die Fotos aus Schritt 2 (Medien) darüber mit, was das
  * Panel über „dieses Foto" behauptet — bis hin zur Meldung „In diesem Foto sind
  * keine GPS-Daten gespeichert", obwohl in Schritt 1 gar kein Foto liegt.
  *

--- a/src/lib/report/discardFormUploads.ts
+++ b/src/lib/report/discardFormUploads.ts
@@ -37,7 +37,7 @@ export interface DiscardFormUploadsOptions {
  *
  * **Der Store wird ganz geleert, nicht gefiltert.** Anders als `handleClear` in
  * `DropzoneEnhanced` (PR #716), das sich auf `ownedMediaFiles` beschränkt, weil
- * ein Klick in Schritt 1 nicht die Medien aus Schritt 3 mitnehmen darf: Der
+ * ein Klick in Schritt 1 nicht die Medien aus Schritt 2 mitnehmen darf: Der
  * Reset verwirft ausdrücklich alle Schritte. Ohne das Leeren blieben die
  * Vorschaubilder der gerade gelöschten Dateien stehen — `mediaStore` hängt an
  * `Form.svelte` und überlebt `updateInitialValues`.


### PR DESCRIPTION
## Warum

Seit d407ea3f liegt der Medien-Upload auf **Schritt 2** — `Media.svelte` wird in `Step2SightingDetails.svelte` gerendert, und `formStepsConfig` führt `mediaFile`/`mediaUpload`/`mediaConsent` unter `sighting-details`. Rund 18 Kommentare und Testnamen sprachen weiterhin von „Medien aus Schritt 3".

Besonders störend: Zwei dieser Kommentare beschreiben **dieselbe** Dropzone wie die bereits korrigierten Stellen in `PositionPanel.svelte` — sie widersprachen sich direkt.

## Was

Reine Text-Korrektur in Kommentaren und Testnamen. **Keine Logik geändert**, kein Verhalten, keine Selektoren, keine Testabdeckung.

| Datei | Stellen |
| --- | --- |
| `UnifiedDropzone.svelte` | 1 |
| `discardFormUploads.ts` | 1 |
| `UploadNotice.svelte` + Test | 2 |
| `positionPanelState.ts` + Test | 3 |
| `DropzoneEnhanced.svelte` + Test | 14 |
| `positionFileOrigin.ts` | 1 |

## Vorher verifiziert

`<UploadNotice />` wird an **genau zwei** Stellen gerendert — `Media.svelte:134` (Schritt 2) und `PositionPanel.svelte:387` (Schritt 1). Damit ist „Schritt 1 und Schritt 3" → „Schritt 1 und Schritt 2" belegt und nicht geraten.

Drei Fundstellen kamen über die ursprüngliche Liste hinaus und sind mitkorrigiert, weil sie dieselbe veraltete Aussage tragen:

- `DropzoneEnhanced.svelte.test.ts:41` — steht im **selben** Kommentarblock wie Zeile 38; ohne die Korrektur wäre genau der Widerspruch geblieben, den dieser PR beseitigt
- `DropzoneEnhanced.svelte:188` und `positionFileOrigin.ts:10` — schreiben `Schritt-3-Medien` mit Bindestrich und fielen deshalb durch eine Suche nach „Schritt 3"

## Bewusst nicht angefasst

- `formConfig.ts:75` und `Step2SightingDetails.svelte:42` — sprechen im **Rückblick** von Schritt 3 und sind korrekt
- Alles, was sich auf den weiterhin existierenden Schritt 3 („Weitere Informationen") bezieht: `Step3Observations`, `FormHelp.svelte:164`, `Step4Contact.svelte:136`, die 320px-Layout-Notizen in `app.css` und `FieldRenderer.svelte`, die Step-Navigations-Tests
- `.claude/rules/upload.md:136` — „Schritt 3" nummeriert dort eine Löschsequenz, keinen Formularschritt
- `docs/archive/*` — datierte historische Dokumente
- `e2e/form-position-photo.spec.ts:56` trug die korrigierte Formulierung bereits

**Rest-Ungenauigkeit, bewusst gelassen:** `DropzoneEnhanced.svelte.test.ts:41` und `positionFileOrigin.ts:11` sagen weiter „Reload auf Schritt 2+". Das meinte „jeder Schritt, auf dem die Medien-Dropzone mountet" — heute nur noch Schritt 2, das `+` ist also überflüssig. Falsch ist es nicht.

## Test

Kein neuer Test — reine Kommentar-/Testnamen-Korrektur ohne Verhaltensänderung (Ausnahme nach `.claude/rules/testing.md`).

`npm run test:quick` läuft grün: 233 Test-Dateien, 3503 Tests, Exit 0 (die zwei ESLint-Warnungen stammen aus `src/tests/contract/helpers/createEvent.ts` und sind vorbestehend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)