### PR TITLE
feat(ui): reach the background page from the menu, named as the museum asked

### DIFF
--- a/e2e/navbar-structure.spec.ts
+++ b/e2e/navbar-structure.spec.ts
@@ -84,14 +84,28 @@ test.describe('TopBar — Struktur und Umbruchfreiheit', () => {
 			await page.goto('/');
 			const menu = page.locator('header ul.menu-horizontal');
 
-			/* Vier statt sieben: Meldung, Karte, Bestimmungshilfe + „Verwaltung".
-			   API-Docs sind kein Ziel für Museumsbesuchende und stehen als
-			   „Dokumentation" weiterhin im Footer. */
-			await expect(menu.locator('> li')).toHaveCount(4);
+			/* Fünf statt sieben: Meldung, Karte, Bestimmungshilfe, Hintergrund +
+			   „Verwaltung". API-Docs sind kein Ziel für Museumsbesuchende und stehen
+			   als „Dokumentation" weiterhin im Footer.
+
+			   „Hintergrund" kam am 2026-08-05 dazu (Wunsch des Museums nach einer
+			   Seite mit den Erklärtexten). Die Zahl steht hier ausdrücklich und wird
+			   nicht gelockert: Ein vierter Produktlink ist genau die Last, die den
+			   Umbruch dieser Navigation ausgelöst hatte — der Umbruchtest über
+			   1024/1280/1440px darüber ist der eigentliche Wächter dafür. */
+			await expect(menu.locator('> li')).toHaveCount(5);
 			await expect(menu.getByRole('link', { name: 'Meldung' })).toBeVisible();
 			await expect(menu.getByRole('link', { name: 'Karte' })).toBeVisible();
 			await expect(menu.getByRole('link', { name: 'Bestimmungshilfe' })).toBeVisible();
+			await expect(menu.getByRole('link', { name: 'Hintergrund' })).toBeVisible();
 			await expect(menu.getByRole('link', { name: 'API-Docs' })).toHaveCount(0);
+
+			/* Ein Ziel, ein Name: Der Footer führt dieselbe Seite: Stünde dort
+			   weiterhin „Über uns", trüge `/about` zwei Namen. */
+			await expect(menu.getByRole('link', { name: 'Hintergrund' })).toHaveAttribute(
+				'href',
+				'/about'
+			);
 
 			/* Die drei Admin-Ziele sind erreichbar — aber erst nach dem Aufklappen,
 			   damit sie die oberste Ebene nicht mehr belasten. */
@@ -247,7 +261,9 @@ test.describe('TopBar — Struktur und Umbruchfreiheit', () => {
 		await page.goto('/');
 
 		const menu = page.locator('header ul.menu-horizontal');
-		await expect(menu.locator('> li')).toHaveCount(3);
+		/* Die vier Produktlinks ohne die Admin-Gruppe: Meldung, Karte,
+		   Bestimmungshilfe, Hintergrund. */
+		await expect(menu.locator('> li')).toHaveCount(4);
 		await expect(menu.getByRole('group')).toHaveCount(0);
 		expect(await menueZeilen(page)).toBe(1);
 	});

--- a/src/lib/components/PublicFooter.svelte
+++ b/src/lib/components/PublicFooter.svelte
@@ -33,7 +33,10 @@
 				<a href="/" class="link link-hover py-3">Meldung</a>
 				<a href="/map" class="link link-hover py-3">Sichtungskarte</a>
 				<a href="/bestimmungshilfe" class="link link-hover py-3">Bestimmungshilfe</a>
-				<a href="/about" class="link link-hover py-3">Über uns</a>
+				<!-- „Hintergrund" wie in der Navigation: Ein Ziel trägt einen Namen —
+				     „Über uns" hier und „Hintergrund" oben wären zwei Namen für
+				     dieselbe Seite. -->
+				<a href="/about" class="link link-hover py-3">Hintergrund</a>
 			</nav>
 
 			<!--

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -48,6 +48,26 @@
 			Bestimmungshilfe
 		</a>
 	</li>
+	<!--
+		„Hintergrund" statt „Über uns" (Wunsch des Museums, 2026-08-05): Die Seite
+		soll die Erklärtexte zur Arbeit tragen, und genau das steht dort bereits —
+		Citizen Science, Mission, Datenschutz. Eine eigene Route `/hintergrund`
+		wäre eine zweite Seite mit demselben Inhalt gewesen.
+
+		Der Footer führt dieselbe Seite unter demselben Namen; ein Ziel trägt
+		einen Namen. Der Wortlaut ist bewusst der des Menüs und nicht der der
+		Seitenüberschrift („Über Ostsee-Tiere") — das Museum hat den Begriff
+		vorgegeben, und beide Formulierungen meinen dasselbe.
+
+		Was der Link NICHT löst: Im iframe auf meeresmuseum.de ist diese
+		Navigation ausgeblendet (`isNotIFrame` unten), die Seite ist dort also
+		weiterhin unerreichbar. Deshalb bleiben die Erklärtexte zusätzlich im
+		Formular (`FormHelp.svelte`) — dieselbe Abwägung wie bei der
+		Bestimmungshilfe. Belege: docs/IFRAME_EINBETTUNG.md
+	-->
+	<li>
+		<a href="/about" class={currentPath === '/about' ? 'active font-medium' : ''}> Hintergrund </a>
+	</li>
 {/snippet}
 
 {#snippet adminItems()}

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -13,31 +13,33 @@
 		name="keywords"
 		content="Dokumentation, API, OpenAPI, Entwickler, Anleitung, Ostsee-Tiere, Integration"
 	/>
-	
+
 	<!-- Open Graph -->
 	<meta property="og:title" content="Dokumentation - Ostsee-Tiere" />
-	<meta 
-		property="og:description" 
-		content="Übersicht über die verfügbare Dokumentation der Ostsee-Tiere Plattform" 
+	<meta
+		property="og:description"
+		content="Übersicht über die verfügbare Dokumentation der Ostsee-Tiere Plattform"
 	/>
 	<meta property="og:type" content="website" />
-	
+
 	<!-- Twitter Card -->
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:title" content="Dokumentation - Ostsee-Tiere" />
-	<meta 
-		name="twitter:description" 
-		content="Übersicht über die verfügbare Dokumentation der Ostsee-Tiere Plattform" 
+	<meta
+		name="twitter:description"
+		content="Übersicht über die verfügbare Dokumentation der Ostsee-Tiere Plattform"
 	/>
 </svelte:head>
 
 <div class="mx-auto max-w-4xl">
 	<div class="mb-8 text-center">
-		<h1 class="mb-4 text-4xl font-bold flex items-center justify-center gap-3">
+		<h1 class="mb-4 flex items-center justify-center gap-3 text-4xl font-bold">
 			<Icon icon="lucide:book-open" width="40" height="40" class="text-primary" />
 			Dokumentation
 		</h1>
-		<p class="text-lg text-base-content/70">Willkommen zur Dokumentation der Ostsee-Tiere Plattform</p>
+		<p class="text-base-content/70 text-lg">
+			Willkommen zur Dokumentation der Ostsee-Tiere Plattform
+		</p>
 	</div>
 
 	<div class="grid gap-6 md:grid-cols-2">
@@ -49,13 +51,13 @@
 					API-Dokumentation
 					<div class="badge badge-primary">Interactive</div>
 				</h2>
-				<p class="text-sm text-base-content/70">
+				<p class="text-base-content/70 text-sm">
 					Umfassende OpenAPI-Dokumentation mit interaktiver Schnittstelle. Testen Sie alle Endpunkte
 					direkt im Browser.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Verfügbare APIs:</h3>
-					<ul class="space-y-1 text-xs text-base-content/70">
+					<ul class="text-base-content/70 space-y-1 text-xs">
 						<li>• Sichtungen verwalten</li>
 						<li>• Dateien hochladen</li>
 						<li>• Datenexport (CSV, JSON, XML, KML)</li>
@@ -78,21 +80,21 @@
 					Erste Schritte
 					<div class="badge badge-secondary">Guide</div>
 				</h2>
-				<p class="text-sm text-base-content/70">Schnelleinstieg für Entwickler und API-Nutzer.</p>
+				<p class="text-base-content/70 text-sm">Schnelleinstieg für Entwickler und API-Nutzer.</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Öffentliche Endpunkte:</h3>
 					<div class="space-y-2">
-						<div class="rounded bg-base-200 p-2 text-xs">
+						<div class="bg-base-200 rounded p-2 text-xs">
 							<code class="text-info-strong">GET /api/sightings</code>
-							<span class="ml-2 text-base-content/60">Öffentliche Sichtungen</span>
+							<span class="text-base-content/60 ml-2">Öffentliche Sichtungen</span>
 						</div>
-						<div class="rounded bg-base-200 p-2 text-xs">
+						<div class="bg-base-200 rounded p-2 text-xs">
 							<code class="text-info-strong">POST /api/sightings</code>
-							<span class="ml-2 text-base-content/60">Neue Sichtung melden</span>
+							<span class="text-base-content/60 ml-2">Neue Sichtung melden</span>
 						</div>
-						<div class="rounded bg-base-200 p-2 text-xs">
+						<div class="bg-base-200 rounded p-2 text-xs">
 							<code class="text-info-strong">POST /api/files/upload</code>
-							<span class="ml-2 text-base-content/60">Dateien hochladen</span>
+							<span class="text-base-content/60 ml-2">Dateien hochladen</span>
 						</div>
 					</div>
 				</div>
@@ -110,13 +112,13 @@
 					OpenAPI Spezifikation
 					<div class="badge badge-accent">Download</div>
 				</h2>
-				<p class="text-sm text-base-content/70">
+				<p class="text-base-content/70 text-sm">
 					Laden Sie die vollständige OpenAPI-Spezifikation herunter für die Verwendung in Tools wie
 					Postman, Insomnia oder zur Code-Generierung.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Formate:</h3>
-					<ul class="space-y-1 text-xs text-base-content/70">
+					<ul class="text-base-content/70 space-y-1 text-xs">
 						<li>• YAML (empfohlen)</li>
 						<li>• JSON (über API)</li>
 						<li>• Code-Generierung unterstützt</li>
@@ -138,12 +140,12 @@
 					Authentifizierung
 					<div class="badge badge-warning">Admin</div>
 				</h2>
-				<p class="text-sm text-base-content/70">
+				<p class="text-base-content/70 text-sm">
 					Für Admin-Funktionen ist eine Authentifizierung über Auth0 erforderlich.
 				</p>
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold">Authentifizierungs-Flow:</h3>
-					<ol class="list-inside list-decimal space-y-1 text-xs text-base-content/70">
+					<ol class="text-base-content/70 list-inside list-decimal space-y-1 text-xs">
 						<li>Login-Endpunkt aufrufen</li>
 						<li>Auth0-Flow durchlaufen</li>
 						<li>Session-Cookie wird gesetzt</li>
@@ -161,34 +163,35 @@
 
 	<!-- Quick Links Section -->
 	<div class="bg-base-200 mt-12 rounded-lg p-6">
-		<h2 class="mb-4 text-2xl font-semibold flex items-center gap-2">
+		<h2 class="mb-4 flex items-center gap-2 text-2xl font-semibold">
 			<Icon icon="lucide:zap" width="24" height="24" class="text-primary" />
 			Schnellzugriff
 		</h2>
 		<div class="grid gap-4 md:grid-cols-3">
 			<div class="text-center">
-				<a href="/map" class="btn btn-ghost btn-lg w-full flex flex-col items-center">
+				<a href="/map" class="btn btn-ghost btn-lg flex w-full flex-col items-center">
 					<Icon icon="lucide:map" width="32" height="32" class="text-primary mb-2" />
 					<span class="text-sm">Karte anzeigen</span>
 				</a>
 			</div>
 			<div class="text-center">
-				<a href="/" class="btn btn-ghost btn-lg w-full flex flex-col items-center">
+				<a href="/" class="btn btn-ghost btn-lg flex w-full flex-col items-center">
 					<Icon icon="lucide:pen-line" width="32" height="32" class="text-primary mb-2" />
 					<span class="text-sm">Sichtung melden</span>
 				</a>
 			</div>
 			<div class="text-center">
-				<a href="/about" class="btn btn-ghost btn-lg w-full flex flex-col items-center">
+				<a href="/about" class="btn btn-ghost btn-lg flex w-full flex-col items-center">
 					<Icon icon="lucide:shield-check" width="32" height="32" class="text-primary mb-2" />
-					<span class="text-sm">Über uns</span>
+					<!-- „Hintergrund" wie in Navigation und Footer — ein Ziel, ein Name. -->
+					<span class="text-sm">Hintergrund</span>
 				</a>
 			</div>
 		</div>
 	</div>
 
 	<!-- Project Information -->
-	<div class="mt-8 text-center text-sm text-base-content/60">
+	<div class="text-base-content/60 mt-8 text-center text-sm">
 		<p>
 			Die Ostsee-Tiere Plattform ermöglicht es Bürgern, Forschern und Naturbeobachtern, ihre
 			Sichtungen von Walen, Robben und anderen Meerestieren zu melden.


### PR DESCRIPTION
Setzt den Wunsch nach einer „Hintergrund"-Seite um — **ohne neue Seite**, weil die Prüfung den Wunsch umgedreht hat.

## Was die Prüfung ergab

| Kandidat | Inhalt | Eignung |
| --- | --- | --- |
| `FormHelp` (287 Z.) | zu ~4/5 **Ausfüllhilfe** (vier Karten „Schritt 1 … 4" mit Feldtipps); nur zwei Blöcke sind Hintergrund | ist gar nicht das, was das Museum verschieben wollte |
| `/about` (568 Z.) | Mission, HELCOM/ASCOBANS, Citizen Science, Datenschutz, Technik | **ist bereits die Hintergrundseite** |
| `/bestimmungshilfe` (66 Z.) | Artbestimmung + Totfund-/Datennutzungs-Hinweis | falscher Ort — wird mitten in der Meldung geöffnet |

Eine Route `/hintergrund` wäre eine zweite Seite mit demselben Inhalt gewesen. Stattdessen bekommt `/about` den Namen, den das Museum verwendet: Der Eintrag stand bisher **nur** als Footer-Link „Über uns" und steht jetzt in der Hauptnavigation zwischen Bestimmungshilfe und der Verwaltungsgruppe. Footer und `/docs` ziehen den Wortlaut mit — ein Ziel, ein Name.

## Der Punkt, der dabei wichtiger ist als der Menüeintrag

**Auf meeresmuseum.de läuft die App im iframe, und dort blenden Navbar *und* Footer aus** (`isNotIFrame`). Die Seite bleibt für die Mehrheit der Nutzer unerreichbar — auch mit diesem Link.

Texte aus dem Formular auf eine Seite zu verschieben hieße also: für die meisten Nutzer sind sie danach weg. Deshalb bleibt `FormHelp` unverändert im Formular — dieselbe Abwägung, die das Museum am 2026-08-04 schon für die Bestimmungshilfe getroffen hat. Belege: `docs/IFRAME_EINBETTUNG.md`, Kommentar in `FormHelp.svelte:144`.

## Der Umbruch-Wächter

Ein vierter Produktlink ist genau die Last, die diese Navigation schon einmal umbrechen ließ (Begründung im Code: „sieben gleichrangige Links waren die Last, die den Umbruch auslöste"). Die Zahl in `navbar-structure.spec.ts` ist deshalb **bewusst hochgesetzt und nicht gelockert**; der eigentliche Wächter ist der Umbruchtest über 1024/1280/1440 px.

Er läuft grün: einzeilig und ohne horizontalen Überlauf auf allen drei Breiten, als Admin, mit geöffneter Verwaltungsgruppe.

## Prüfung

| Gate | Ergebnis |
| --- | --- |
| `lint` / `type-check` / `check` | 0 Fehler, 2.109 Dateien |
| `test:unit:client` | 422 / 422 |
| E2E (`navbar-structure`, `footer-layout`, `about-page`, `horizontal-overflow`, `modal-overflow`) | 26 / 26 |

Test-first: erst die Erwartung in `navbar-structure.spec.ts` angehoben (rot), dann den Link gebaut. Ein zweiter Test („ohne Admin-Rechte gibt es keine Verwaltungsgruppe") zählte die Einträge ebenfalls und ist mitgezogen.

Im Browser gegengeprüft: „Hintergrund" steht in Desktop- und Burger-Menü, `/about` lädt und trägt die Erklärtexte.

## Bewusst nicht geändert

Die Seite heißt weiterhin „Über Ostsee-Tiere" (h1, von `about-page.spec.ts` festgenagelt) und trägt den Dokumenttitel „Über uns". „Hintergrund" ist das Navigationswort und liest sich als Ebene über dieser Überschrift. Die Seite selbst umzubenennen wäre eine Inhaltsentscheidung, keine Folge eines neuen Menüeintrags — sagen Sie Bescheid, wenn das Museum das will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)