### PR TITLE
test(map): fix the form map pan/zoom flakiness and move the spec into a shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,7 +488,16 @@ jobs:
             e2e/form-field-mode.spec.ts
           )
 
-          map=(e2e/map-*.spec.ts)
+          # form-map-pan-zoom.spec.ts steht hier trotz `form`-Präfix: Es prüft
+          # Pan und Zoom der Positions-Karte und teilt sich mit dem
+          # Schwester-Spec e2e/map-pan-zoom.spec.ts das Messwerkzeug
+          # (e2e/helpers/mapCanvas.ts). Es fällt nicht unter das Glob und muss
+          # deshalb einzeln stehen.
+          #
+          # Zeitbudget: Der Shard lag bei 153 s seriell, der Spec kostet ~17 s.
+          # Mit 170 s bleibt `map` unter `form` (190 s) — die Wanduhr des Jobs
+          # ist die des längsten Shards und ändert sich dadurch nicht.
+          map=(e2e/map-*.spec.ts e2e/form-map-pan-zoom.spec.ts)
 
           # design-tokens.spec.ts gehört hierher, nicht zu form: es prüft das
           # Theme, nicht das Formular. Läuft gegen /styleguide, das der
@@ -513,16 +522,24 @@ jobs:
           # **nicht** weil ihr Ausschluss geprüft wäre.
           #
           # Wer einen davon in einen Shard zieht, lässt ihn vorher laufen.
-          # form-map-pan-zoom.spec.ts ist der bekannte Sonderfall: von sich aus
-          # flaky (Subpixel-Vergleiche nach Pan/Zoom), gehört erst nach einer
-          # Stabilisierung in einen Shard.
+          #
+          # form-map-pan-zoom.spec.ts stand hier als „von sich aus flaky
+          # (Subpixel-Vergleiche nach Pan/Zoom)" und läuft seit dem
+          # 2026-08-05 im `map`-Shard. Der Befund stimmte, die Diagnose war
+          # ungenau: Verglichen wurde nicht nach der Geste, sondern **davor** —
+          # eine Vorprüfung `box.y >= 0` auf der Oberkante des Karten-Containers.
+          # `scrollIntoViewIfNeeded` zentriert die Karte, der Sub-Pixel-Rest
+          # daraus macht `box.y` minimal negativ, sobald die 400px hohe Karte die
+          # Fensterhöhe ausfüllt (reproduziert bei 1280×400: `box.y = -0.40625`,
+          # Vorprüfung rot, Geste bei `y = 311.6` und einwandfrei). Sie prüft
+          # jetzt per `elementFromPoint`, ob die Geste die Karte trifft — dieselbe
+          # Frage ohne Fließkomma-Rand. 10 aufeinanderfolgende Läufe grün.
           unassigned=(
             e2e/admin-edit-preserves-record.spec.ts
             e2e/admin-table-verified-column.spec.ts
             e2e/app-shell-height.spec.ts
             e2e/bestimmungshilfe.spec.ts
             e2e/footer-layout.spec.ts
-            e2e/form-map-pan-zoom.spec.ts
             e2e/form-stepper-affordance.spec.ts
             e2e/form-stepper.spec.ts
             e2e/horizontal-overflow.spec.ts

--- a/e2e/form-map-pan-zoom.spec.ts
+++ b/e2e/form-map-pan-zoom.spec.ts
@@ -41,6 +41,37 @@ const DEFAULT_CENTER = { latitude: '54.5', longitude: '13.5' };
 const karte = (page: Page) =>
 	createMapCanvasProbe(page, { selector: '.ol-map-container', stride: 97 });
 
+/** Verschiebung einer Zeige-Geste in CSS-Pixeln; `{0,0}` für Rad und Hover. */
+type Geste = { dx: number; dy: number };
+
+/**
+ * Zwei Messungen gelten als dieselbe Position, wenn sie um weniger als das hier
+ * auseinanderliegen.
+ *
+ * Ein exakter Vergleich taugt nicht: Die Bounding-Box der Karte trägt einen
+ * Sub-Pixel-Rest aus dem Layout (gemessen `x.59375`, also 19/32), und schon eine
+ * Neuberechnung derselben unveränderten Ansicht kann die letzte Nachkommastelle
+ * kippen. Ein halber Pixel ist für eine Maus-Geste ohne Belang — die Schranke
+ * trennt „steht" von „scrollt noch", nicht Pixel von Pixel.
+ */
+const RUHE_TOLERANZ_PX = 0.5;
+
+/**
+ * Prüft per Treffer-Test, ob ein Viewport-Punkt tatsächlich auf der Karte landet.
+ *
+ * Bewusst `elementFromPoint` und kein Koordinaten-Vergleich: Der Test will
+ * wissen, ob die Geste die Karte trifft, und das ist genau diese Frage. Ein
+ * Punkt außerhalb des Fensters liefert `null`, ein von der Sticky-Leiste
+ * verdeckter Punkt liefert die Leiste — beides fällt hier auf, ohne dass
+ * irgendwo eine Fließkommazahl verglichen werden müsste.
+ */
+async function trifftKarte(page: Page, punkt: { x: number; y: number }): Promise<boolean> {
+	return page.evaluate(
+		({ x, y }) => document.elementFromPoint(x, y)?.closest('.ol-map-container') != null,
+		punkt
+	);
+}
+
 /**
  * Punkt in der Karte — abseits der Zoom-Controls (oben links), der Attribution
  * (unten rechts) und vor allem abseits des Markers in der Mitte: Ein Zug, der
@@ -48,36 +79,78 @@ const karte = (page: Page) =>
  * ihn, statt die Karte zu schieben.
  *
  * **Die Karte wird vorher ins Bild geholt und der Scroll abgewartet.** Das
- * Formular scrollt an mehreren Stellen von selbst — `PositionPanel.openMap()`
- * ruft `scrollIntoView`, und jedes fokussierte Feld zieht die Ansicht nach. Wer
- * die Bounding-Box mitten in diese Bewegung liest, bekommt eine Position, die
- * beim Ziehen schon nicht mehr stimmt: Beim Entwickeln dieses Tests lag der
+ * Formular scrollt an mehreren Stellen von selbst — `PositionPanel` ruft
+ * `scrollIntoView`, `scrollToElement` scrollt sogar animiert (`behavior:
+ * 'smooth'`), und jedes fokussierte Feld zieht die Ansicht nach. Wer die
+ * Bounding-Box mitten in diese Bewegung liest, bekommt eine Position, die beim
+ * Ziehen schon nicht mehr stimmt: Beim Entwickeln dieses Tests lag der
  * Startpunkt einmal bei `y = -36`, also außerhalb des Fensters — die Geste ging
  * ins Leere und sah aus wie der Defekt, den der Test sucht.
+ *
+ * `gesture` ist die Verschiebung, die der Aufrufer anschließend zieht. Geprüft
+ * werden **Anfang und Ende** des Zugs: Nur wenn beide auf der Karte liegen,
+ * beweist ein „hat sich bewegt" etwas über die Karte.
+ *
+ * ── Warum hier nicht mehr `box.y >= 0` steht ────────────────────────────────
+ * Diese Datei stand als „von sich aus flaky" in keinem CI-Shard. Der Grund war
+ * genau jene Schranke: `scrollIntoViewIfNeeded` **zentriert** die Karte, und der
+ * dabei entstehende Sub-Pixel-Rest macht `box.y` minimal negativ, sobald die
+ * 400px hohe Karte die Fensterhöhe ausfüllt (gemessen bei 1280×400:
+ * `box.y = -0.40625`, die Schranke schlug an). Der Startpunkt lag dabei bei
+ * `y = 311.6`, mitten im Bild, und der Zug bewegte die Karte einwandfrei — die
+ * Schranke maß also die Oberkante des Containers, während es ihr um die Geste
+ * ging. Der dokumentierte Fehlschlag `-1.125` ist derselbe Rest ein Layout
+ * weiter. Der Treffer-Test oben stellt dieselbe Frage ohne Fließkomma-Rand.
  */
-async function mapPoint(page: Page, relX = 0.25, relY = 0.78) {
+async function mapPoint(
+	page: Page,
+	gesture: Geste = { dx: 0, dy: 0 },
+	relX = 0.25,
+	relY = 0.78
+): Promise<{ x: number; y: number }> {
 	const map = page.locator('.ol-map-container');
 	await map.scrollIntoViewIfNeeded();
 
-	let previous: string | null = null;
-	let current: string | null = null;
+	// Holder-Objekt statt `let`: Eine Zuweisung in der Poll-Closure sieht
+	// TypeScript nicht, eine lokale Variable gälte hinter dem `await` weiterhin
+	// als `null` und bräuchte einen Cast, der die Prüfung nur stillstellt.
+	const ruhig: { box: { x: number; y: number; width: number; height: number } | null } = {
+		box: null
+	};
+	let vorherige: { x: number; y: number } | null = null;
+
 	await expect
 		.poll(
 			async () => {
 				const box = await map.boundingBox();
-				previous = current;
-				current = box ? `${Math.round(box.x)}/${Math.round(box.y)}` : null;
-				return current !== null && current === previous;
+				// `height > 0` gehört dazu: Vor dem Layout der Karte ist die Box da,
+				// aber leer — ein Punkt darin träfe nichts.
+				const steht =
+					box !== null &&
+					box.height > 0 &&
+					vorherige !== null &&
+					Math.abs(box.x - vorherige.x) < RUHE_TOLERANZ_PX &&
+					Math.abs(box.y - vorherige.y) < RUHE_TOLERANZ_PX;
+				vorherige = box;
+				if (steht) ruhig.box = box;
+				return steht;
 			},
 			{ timeout: 10000, intervals: [100, 100, 200, 300], message: 'Karte scrollt noch' }
 		)
 		.toBe(true);
 
-	const box = await map.boundingBox();
-	if (!box) throw new Error('.ol-map-container hat keine Bounding-Box');
-	// Gegenprobe zum Fall oben: Eine Geste außerhalb des Fensters beweist nichts.
-	expect(box.y, 'Karte liegt oberhalb des sichtbaren Bereichs').toBeGreaterThanOrEqual(0);
-	return { x: box.x + box.width * relX, y: box.y + box.height * relY };
+	// Die als ruhig gemessene Box und keine vierte Messung: Ein erneutes
+	// `boundingBox()` läge wieder außerhalb dessen, was der Poll geprüft hat.
+	const box = ruhig.box;
+	if (!box) throw new Error('.ol-map-container hat keine ruhige Bounding-Box');
+
+	const start = { x: box.x + box.width * relX, y: box.y + box.height * relY };
+	const ende = { x: start.x + gesture.dx, y: start.y + gesture.dy };
+
+	expect(await trifftKarte(page, start), 'Geste beginnt nicht auf der Karte').toBe(true);
+	expect(await trifftKarte(page, ende), 'Geste endet nicht auf der Karte').toBe(true);
+
+	return start;
 }
 
 /**
@@ -117,6 +190,9 @@ async function position(page: Page): Promise<{ lat: string; lon: string }> {
 	};
 }
 
+/** Der Zug, den beide Ziehen-Tests fahren — Vorprüfung und Geste aus einer Quelle. */
+const ZUG: Geste = { dx: 120, dy: -90 };
+
 test.describe('Positions-Karte im Formular — Pan und Zoom', () => {
 	test.beforeEach(async ({ page }) => {
 		await blockTileHosts(page, FORM_TILE_HOSTS);
@@ -127,10 +203,10 @@ test.describe('Positions-Karte im Formular — Pan und Zoom', () => {
 
 	test('Ziehen verschiebt die Karte ohne vorherigen Klick', async ({ page }) => {
 		const probe = karte(page);
-		const start = await mapPoint(page);
+		const start = await mapPoint(page, ZUG);
 		const before = await probe.hoverAndSettle(start);
 
-		await probe.drag(start, 120, -90);
+		await probe.drag(start, ZUG.dx, ZUG.dy);
 
 		await probe.expectToMove(
 			before,
@@ -144,9 +220,9 @@ test.describe('Positions-Karte im Formular — Pan und Zoom', () => {
 		const probe = karte(page);
 		const vorher = await position(page);
 
-		const start = await mapPoint(page);
+		const start = await mapPoint(page, ZUG);
 		await probe.hoverAndSettle(start);
-		await probe.drag(start, 120, -90);
+		await probe.drag(start, ZUG.dx, ZUG.dy);
 
 		// `singleclick` feuert nach einem Zug nicht — die Position muss stehen
 		// bleiben, sonst hätte das Schieben die Sichtung verschoben.


### PR DESCRIPTION
## Was

`e2e/form-map-pan-zoom.spec.ts` lief in **keinem** CI-Shard — es stand im `unassigned`-Array des E2E-Schritts, mit der Begründung „von sich aus flaky (Subpixel-Vergleiche nach Pan/Zoom)". Dieser PR behebt die Ursache und zieht den Spec in den `map`-Shard.

## Die Diagnose war an der falschen Stelle

Der Befund stimmte, der vermutete Mechanismus nicht. Die Vergleiche **nach** der Geste messen einen Canvas-Fingerprint hinter `expect.poll` und sind robust. Der Defekt saß in der Vorprüfung **davor**, in `mapPoint()`:

```ts
expect(box.y, 'Karte liegt oberhalb des sichtbaren Bereichs').toBeGreaterThanOrEqual(0);
```

`scrollIntoViewIfNeeded` **zentriert** die Karte, und die Zentrierung trägt einen Sub-Pixel-Rest. Über mehrere Fensterhöhen gemessen gilt exakt:

| Fensterhöhe | `box.y`      | Startpunkt der Geste | Geste im Bild |
| ----------- | ------------ | -------------------- | ------------- |
| 720         | `159.59375`  | `471.6`              | ja            |
| 560         | `79.59375`   | `391.6`              | ja            |
| 440         | `19.59375`   | `331.6`              | ja            |
| **400**     | **`-0.40625`** | **`311.6`**        | **ja**        |

Also `box.y = (Höhe − 400) / 2 − 0.40625`. Die Schranke ist damit ein toleranzfreier Vergleich direkt auf einer Fließkomma-Grenze — und sie misst die **Oberkante des Containers**, während es ihr laut eigenem Kommentar um die **Geste** geht („Eine Geste außerhalb des Fensters beweist nichts").

Bei 1280×400 reproduziert:

```
PROBE guardFired=true    box.y=-0.40625
PROBE gestureWorked=true startY=311.59375
```

Die Vorprüfung schlägt an; der Zug beginnt bei `y = 311.6` mitten im Bild und schiebt die Karte einwandfrei. Ein reiner Falsch-Alarm. Der dokumentierte Wert `-1.125` ist derselbe Rest ein Layout weiter.

## Fix

Ohne Retries, ohne höhere Timeouts:

- **Die Vorprüfung ist jetzt ein Treffer-Test** — `document.elementFromPoint(x, y).closest('.ol-map-container')` — angewandt auf **Anfang und Ende** des Zugs. Das stellt genau die gemeinte Frage („trifft die Geste die Karte?") ganz ohne Fließkomma-Vergleich und erkennt zusätzlich einen von der Sticky-Leiste verdeckten Punkt, was die alte Schranke nicht konnte.
- **Aufrufer übergeben ihre Geste** (`ZUG = { dx: 120, dy: -90 }`), damit geprüfter und gefahrener Weg aus einer Quelle stammen.
- **Der Ruhe-Poll** verglich `Math.round()`-Werte und las danach ein **drittes** `boundingBox()` — der zurückgegebene Wert war also nicht der als ruhig geprüfte. Jetzt: Toleranz von 0,5 px und Rückgabe der validierten Box, plus `height > 0`, damit die Karte nicht mitten im Layout gemessen wird.

## Nachweis

- **10 aufeinanderfolgende grüne Läufe** bei Standard-Fenstergröße (`--workers=1`, wie in CI).
- **4 von 4 grün bei 1280×400** — genau dort, wo die alte Schranke nachweislich anschlug.
- Vollständiger `map`-Shard: **74 passed**.

Zur Vorgeschichte: Auf aktuellem `main` ließ sich der historische Fehlschlag durch bloßes Wiederholen **nicht** mehr auslösen (10 von 10 grün, mit und ohne `--workers=1`). Er hängt an der Fensterhöhe — deshalb die Variation der Viewport-Höhe statt weiterer Wiederholungen.

## Shard-Zuordnung

Nach `map`, nicht `form`: Der Spec teilt sich mit dem Schwester-Spec `e2e/map-pan-zoom.spec.ts` das Messwerkzeug `e2e/helpers/mapCanvas.ts`. Er fällt nicht unter das Glob `e2e/map-*.spec.ts` und steht deshalb einzeln.

**Zeitbudget:** `map` lag bei 153 s seriell, der Spec kostet ~17 s → 170 s, weiterhin unter `form` (190 s). Da die Wanduhr des Jobs die des längsten Shards ist, ändert sie sich nicht.

## Für Reviewer

- Die vier Arrays bleiben vollständig — geprüft, indem der Bash-Code des CI-Schritts extrahiert und lokal ausgeführt wurde: `form 7 / map 11 / smoke 6`, Exit 0 für alle drei. Gegenprobe mit einem Dummy-Spec: Der Wächter schlägt an (`::error::`, Exit 1), die Prüfung ist also wirklich scharf.
- `prettier --check` meldet `.github/workflows/ci.yml` als unformatiert. Das ist **vorbestehend** (durch Stashen verifiziert) und wurde bewusst nicht angefasst, um keinen unzusammenhängenden Riesen-Diff zu erzeugen.
- Ein Kommentar verwies auf `PositionPanel.openMap()`; die Funktion gibt es nicht mehr (`scrollIntoView` steht dort in `focusDescription()`). Nebenbei korrigiert.
- Die übrigen 13 Specs in `unassigned` bleiben unangetastet — dieser PR nimmt sich nur den einen mit dem dokumentierten Flakiness-Befund vor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
