### PR TITLE
fix(ci): balance the e2e shards on measured step duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,10 +482,7 @@ jobs:
             e2e/form-submit.spec.ts
             e2e/form-ux.spec.ts
             e2e/form-a11y.spec.ts
-            e2e/form-position.spec.ts
-            e2e/form-position-photo.spec.ts
             e2e/form-autosave.spec.ts
-            e2e/form-field-mode.spec.ts
           )
 
           # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des
@@ -505,10 +502,16 @@ jobs:
             e2e/meldung-wording.spec.ts
             # Trotz `form`-Präfix hier: teilt sich mit dem Schwester-Spec
             # map-pan-zoom.spec.ts das Messwerkzeug (e2e/helpers/mapCanvas.ts).
-            # Fällt nicht unter das Glob und steht deshalb einzeln. Kostet ~17 s;
-            # `map` bleibt damit bei rund 170 s und unter `form` (190 s), die
-            # Job-Laufzeit ändert sich also nicht.
+            # Fällt nicht unter das Glob und steht deshalb einzeln.
             e2e/form-map-pan-zoom.spec.ts
+            # Ebenfalls trotz `form`-Präfix hier, aber aus dem Laufzeit-Grund
+            # oben und nicht wegen geteilten Werkzeugs: Beide prüfen die Karte
+            # im Meldeformular — ein Tippen setzt die Koordinaten, ein Foto mit
+            # EXIF-GPS setzt Position, Datum und Uhrzeit, und die
+            # Bereichsprüfung schlägt außerhalb der Ostsee an. Das ist dieselbe
+            # Komponente, die die map-*-Specs fahren.
+            e2e/form-position.spec.ts
+            e2e/form-position-photo.spec.ts
           )
 
           # design-tokens.spec.ts gehört hierher, nicht zu form: es prüft das
@@ -535,18 +538,56 @@ jobs:
             e2e/form-stepper.spec.ts
             e2e/form-stepper-affordance.spec.ts
             e2e/videoUpload.spec.ts
+            # Aus demselben Laufzeit-Grund, und thematisch bei modal-overflow
+            # zu Hause: Der Spec prüft den ortsfesten Balken gegen Viewport und
+            # scroll-padding — Layout, nicht Formularlogik.
+            e2e/form-field-mode.spec.ts
           )
 
           # Der Rückstand von 14 Specs ist abgearbeitet: 13 davon liefen am
           # 2026-08-05 lokal dreimal hintereinander durch (82 Tests je Lauf,
           # kein Fehlschlag, kein Flake) und stehen jetzt in `map` bzw. `smoke`.
           #
-          # Verteilt wurde nach gemessener Dauer, nicht nach Thema. Maßgeblich
-          # ist die Summe der Test-Laufzeiten, weil der Job seriell fährt
-          # (`workers: 1`): form 190 s, map 153 s, smoke 152 s — vorher
-          # 190/78/75. `form` hat bewusst nichts abbekommen; der Shard war schon
-          # der längste, und die Job-Laufzeit ist die des längsten. Wer dort
-          # etwas hinzufügt, misst vorher.
+          # Verteilt wurde nach gemessener Dauer, nicht nach Thema. `form` hat
+          # dabei bewusst nichts abbekommen; der Shard war schon der längste,
+          # und die Job-Laufzeit ist die des längsten.
+          #
+          # **Womit gemessen wird.** Maßgeblich ist die Schrittdauer „Run E2E
+          # tests" aus GitHub Actions selbst:
+          #
+          #   gh api "repos/jansinger/ostsee-tiere/actions/runs/<id>/jobs" --jq \
+          #     '.jobs[] | select(.name|startswith("E2E Tests")) | [.name,
+          #      ((.steps[]|select(.name=="Run E2E tests")
+          #        |(((.completed_at|fromdate)-(.started_at|fromdate))|tostring)))]|@tsv'
+          #
+          # **Nicht** die Summe der `result.duration` aus `--reporter=json`, mit
+          # der die Aufteilung bis hierher gerechnet wurde. Playwright rechnet
+          # `beforeAll` keinem Test zu, und fast alle map-Specs bauen ihre Seite
+          # genau dort auf (`test.describe.serial` + geteilte Page, siehe
+          # map-accessibility.spec.ts: 0,4 s für 18 Tests). Die Summe lässt
+          # `map` dadurch um ein Vielfaches zu billig aussehen. Gemessen an den
+          # echten Schrittdauern stand hier nicht 190/153/152, sondern nach #766
+          # form 205 s, smoke 128 s, map 122 s — und E2E Tests (form) war mit
+          # 258 s die Wanduhr des **gesamten** Workflows, nächstlängster Job
+          # 171 s.
+          #
+          # Ein einziger lokaler Lauf über alle Shards misst die Shards übrigens
+          # nicht: In CI ist jeder Shard ein eigener Job mit kaltem
+          # `node_modules/.vite`, lokal ist der Dep-Cache warm — die erste Datei
+          # trägt sonst die Kaltstartkosten aller anderen. Pro Shard mit eigenem,
+          # frisch gestartetem Dev-Server messen; lokale Wanduhr × Shard-Faktor
+          # (gemessen: form 1,35 · map 1,29 · smoke 1,37) trifft die
+          # CI-Schrittdauer eines **unveränderten** Shards gut.
+          #
+          # Was dieser Faktor **nicht** kann: die Kosten eines verschobenen Specs
+          # vorhersagen. Die Verschiebung hier war auf 157/158/155 geschätzt und
+          # kam bei 152/169/161 heraus — `form` fast genau, beide aufnehmenden
+          # Shards rund 10 s darüber. Der Grund ist derselbe wie oben: Der
+          # aufnehmende Shard zahlt die Vite-Kaltkompilierung der Routen, die er
+          # vorher nicht gefahren ist, noch einmal. Wer verschiebt, plant den
+          # Aufschlag ein und prüft danach an der echten Schrittdauer nach.
+          #
+          # Wer hier etwas hinzufügt oder verschiebt, misst vorher — so.
           #
           # Der Rückstand ist damit vollständig abgearbeitet: form-map-pan-zoom
           # .spec.ts, der letzte verbliebene Eintrag, steht seit dem 2026-08-05


### PR DESCRIPTION
Folgt auf #766. Dort stand am Ende der Hinweis, `form-a11y.spec.ts` (51 s) aus `form` herauszunehmen würde die Spitze von 190 s auf ~178 s bringen. Dieser PR ist die Nachmessung dazu — und sie fällt anders aus als erwartet, in beide Richtungen.

> **Rebase-Hinweis:** Auf #767 und #768 rebast. Die Zuordnung wurde dabei gegen den neuen Stand **neu gerechnet**, nicht nur textuell übernommen: #768 hat `map` um `form-map-pan-zoom.spec.ts` erweitert, das verschiebt das Optimum.

## Die Zahlen aus #766 waren zu niedrig, und zwar ungleichmäßig

Die Tabelle in #766 beruht auf der Summe der `result.duration` aus Playwrights JSON-Reporter. Diese Summe unterschlägt `beforeAll`: Playwright rechnet die Zeit keinem Test zu. Fast alle map-Specs bauen ihre Seite aber genau dort auf — `test.describe.serial` plus geteilte Page und `setupMapPage` (`map-accessibility.spec.ts`, `map-time-slider.spec.ts`). `map-accessibility.spec.ts` meldet dadurch **0,4 s für 18 Tests**. Der map-Shard erscheint so um ein Vielfaches zu billig.

Maßgeblich ist stattdessen die Schrittdauer „Run E2E tests" aus GitHub Actions selbst. Stand `main` (Lauf [30984523432](https://github.com/jansinger/ostsee-tiere/actions/runs/30984523432), der Merge von #768):

| Shard | Schritt | Job |
| --- | --- | --- |
| form | **209 s** | **252 s** |
| map | 133 s | 175 s |
| smoke | 131 s | 177 s |

**E2E Tests (form) war mit 252 s die Wanduhr des gesamten Workflows** — der nächstlängste Job lief 177 s, `Validate` 142 s.

## `form-a11y.spec.ts` bleibt, wo es ist

Zwei Gründe, jeder für sich ausreichend:

1. **Es geht rechnerisch nicht auf.** Die 139/178/178 aus #766 setzen voraus, dass sich die 51 s teilen lassen. Die Datei ist unteilbar. Ganz nach `map` ergibt 162/180/131, ganz nach `smoke` 162/133/178 — beides hilft, beides balanciert schlecht.
2. **Es ist die formularnächste Datei im Shard.** `FormPage`, `fillStep1/fillStep2`, Step-Indikator, Consent-Block, Touch-Targets im `FieldRenderer`.

## Stattdessen: drei Specs, die thematisch ohnehin woanders hingehören

| Spec | von → nach | Begründung |
| --- | --- | --- |
| `form-position.spec.ts` | form → **map** | Karte im Meldeformular: ein Tippen setzt die Koordinaten |
| `form-position-photo.spec.ts` | form → **map** | Foto mit EXIF-GPS setzt Position, Datum, Uhrzeit; Bereichsprüfung außerhalb der Ostsee |
| `form-field-mode.spec.ts` | form → **smoke** | ortsfester Balken gegen Viewport und `scroll-padding` — Layout, wie `modal-overflow.spec.ts` dort schon |

Das ist keine Ausnahme von der Konvention, sondern die Konvention: `map` trägt seit #766 Admin- und Offline-Specs, `smoke` die beiden Stepper-Specs, und der Kommentar dort sagt es ausdrücklich — Zuordnung nach gemessener Dauer, erst danach nach Thema.

## Ergebnis, gemessen auf diesem Branch

Nicht geschätzt, sondern der CI-Lauf dieses PRs ([30985737019](https://github.com/jansinger/ostsee-tiere/actions/runs/30985737019)):

| Shard | Schritt vorher | Schritt danach | Job vorher | Job danach |
| --- | --- | --- | --- | --- |
| form | 209 s | **152 s** | 252 s | **199 s** |
| smoke | 131 s | **161 s** | 177 s | **202 s** |
| map | 133 s | **169 s** | 175 s | **219 s** |

**Spitzen-Job 252 s → 219 s, also −33 s (rund 13 %).** Die drei Shards liegen jetzt 17 s auseinander statt 78 s.

Zur Ehrlichkeit: geschätzt waren 157/158/155, herausgekommen ist 152/169/161. `form` traf fast genau, **beide aufnehmenden Shards lagen rund 10 s über der Schätzung** — der aufnehmende Shard zahlt die Vite-Kaltkompilierung der Routen, die er vorher nicht gefahren ist, noch einmal. Der Kommentar im Workflow hält diese Grenze jetzt fest, damit die nächste Verschiebung den Aufschlag einplant.

## Wie gemessen wurde

Ein einzelner lokaler Lauf über alle Shards misst die Shards **nicht**: In CI ist jeder Shard ein eigener Job mit kaltem `node_modules/.vite`, lokal ist der Dep-Cache warm und wird aus dem Haupt-Repo geteilt. Gemessen wurde deshalb pro Shard mit eigenem, frisch gestartetem Dev-Server, Wanduhr, ohne `CI=1` (also auf dem Worktree-eigenen Port). Der Faktor lokal → CI wurde gegen `main` geprüft: form 1,35 · map 1,29 · smoke 1,37.

## Verifikation

Der `run:`-Block wurde aus dem YAML extrahiert und **wörtlich** unter `bash` ausgeführt — nur `npm` als Funktion gestubbt. Die Vollständigkeitsprüfung aus #767 lief dabei echt mit (`npx playwright test --list`):

- `bash -n` läuft durch
- jeder Shard wählt genau seine Liste: form 4, map 19, smoke 14 — zusammen 37 und damit alle gesammelten Specs, `unassigned` bleibt leer. Nichts fehlt, nichts läuft doppelt
- Negativ-Probe: einen Eintrag entfernt → `::error::Diese Specs stehen in keinem Shard…`, Exit 1. Die Prüfung schweigt also nicht bloß
- unbekannter Shard-Name → Exit 1
- das Glob `e2e/map-*.spec.ts` expandiert weiterhin korrekt neben den literalen Einträgen

Alle drei Zusammenstellungen liefen lokal grün (54 + 113 + 171 = 338 Tests) und in CI grün. Kein Test kommt hinzu, fällt weg oder ändert sich; die Änderung betrifft ausschließlich `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
