### PR TITLE
feat(admin): give the sighting detail view the same actions as the table

### DIFF
--- a/.claude/rules/email.md
+++ b/.claude/rules/email.md
@@ -19,9 +19,33 @@ Regeln für den Email-Versand via nodemailer.
 // Hauptfunktionen
 EmailService.sendNewSightingNotification(sightingId: number): Promise<boolean>
 EmailService.sendTestEmail(recipient?: string): Promise<boolean>
+EmailService.findNotificationBlocker(): Promise<NotificationBlocker | null>
 EmailService.initialize(test = false): Promise<void>
 EmailService.resetTransporter(): void
 ```
+
+### Die Test-Mail beweist nichts über die Benachrichtigung
+
+`sendTestEmail()` ruft `ensureTransporter(true)` und geht damit bewusst an zwei
+Sperren vorbei, die für die Sichtungs-Benachrichtigung gelten. Die beiden Wege
+sind deshalb **nicht** austauschbar:
+
+| Voraussetzung                  | Benachrichtigung | Test-Mail (`/admin/settings`) |
+| ------------------------------ | ---------------- | ----------------------------- |
+| `notification.email.enabled`   | erforderlich     | **umgangen** (`test = true`)  |
+| SMTP-Verbindung                | erforderlich     | erforderlich                  |
+| `notification.email.recipient` | erforderlich     | Formularfeld schlägt ihn      |
+
+Eine ankommende Test-Mail bei stiller Benachrichtigung ist also der
+Normalzustand, solange der Schalter aus ist — kein Widerspruch und kein Bug.
+Genau daran ist der Button „Benachrichtigung an Team" in `/admin` gescheitert.
+
+**`findNotificationBlocker()` benennt die erste fehlende Voraussetzung** und ist
+die einzige Stelle, an der die drei Gates stehen — `sendEmailNotification()`
+benutzt sie selbst, damit Diagnose und Abbruch nicht auseinanderlaufen können.
+`POST /api/admin/test-email` übersetzt das Ergebnis in die Fehlermeldung. Alle
+drei Gründe werden auf `warn` geloggt, der Abschalter stand bis 2026-08-05 auf
+`debug` und war im Normalbetrieb unsichtbar.
 
 ### Transporter-Lebenszyklus
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,13 @@ jobs:
             e2e/form-ux.spec.ts
             e2e/form-a11y.spec.ts
             e2e/form-autosave.spec.ts
+            # Thematisch bei den beiden anderen Admin-Specs in `map` — steht
+            # hier nach derselben Regel, die die dort begründet: Nach #769 misst
+            # `form` 152 s und ist damit der kürzeste Shard, `map` mit 169 s der
+            # längste. Der Spec wiegt lokal 9 s; er gehört an den kurzen Shard.
+            # Der Aufschlag für die kalt kompilierte /admin-Route ist dabei
+            # eingeplant (Begründung weiter unten bei `smoke`).
+            e2e/admin-detail-actions.spec.ts
           )
 
           # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des

--- a/e2e/admin-detail-actions.spec.ts
+++ b/e2e/admin-detail-actions.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test';
+import { config as loadEnv } from 'dotenv';
+import postgres from 'postgres';
+import { DistanceEnum } from '../src/lib/report/formOptions/distance';
+import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * admin-detail-actions.spec.ts — die Detailansicht trägt dieselben Aktionen wie
+ * die Tabellenzeile.
+ *
+ * **Der Anlass:** In `/admin` hat jede Zeile vier Aktionen (Details, Test-E-Mail,
+ * Spam-Check, Löschen). Öffnete man die Sichtung, blieben davon nur Spam-Check
+ * und Bearbeiten — zum Löschen musste man zurück in die Tabelle und die Zeile
+ * dort wiederfinden. Genau dabei erwischt man die falsche.
+ *
+ * **Warum das Löschen bis zum Ende gefahren wird:** Die Detailansicht ist der
+ * einzige Ort, an dem der Datensatz unter den eigenen Füßen verschwindet. Die
+ * Tabelle lädt danach nur neu; hier muss die Seite die gelöschte Sichtung
+ * verlassen, sonst steht der Admin vor einem 404. Ein Test, der nur die Existenz
+ * des Buttons prüft, ginge an dem Teil vorbei, der schiefgehen kann.
+ *
+ * Eigene Testzeile mit `kommentar_intern = 'e2e-seed'`, Begründung wie in
+ * `admin-edit-preserves-record.spec.ts`.
+ */
+
+/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
+   e2e/helpers/adminSession.ts. */
+loadEnv();
+
+const SEED_MARKER = 'e2e-seed';
+
+function connect() {
+	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
+	if (!databaseUrl) {
+		throw new Error(
+			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
+				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
+		);
+	}
+	return postgres(databaseUrl, { max: 1 });
+}
+
+async function createSighting(referenceId: string): Promise<number> {
+	const sql = connect();
+	try {
+		const [row] = await sql<{ id: number }[]>`
+			INSERT INTO sichtungen (
+				sichtungsdatum, created, tierart, anzahl_gesamt,
+				vonwo, entfernung, referenz_id,
+				vorname, name, email,
+				datenschutz_einverstaendnis, kommentar_intern
+			) VALUES (
+				'2024-06-01T08:30:00.000Z', NOW(), 1, 2,
+				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${referenceId},
+				'Erika', 'Mustermann', 'erika.e2e@example.invalid',
+				1, ${SEED_MARKER}
+			)
+			RETURNING id
+		`;
+		return Number(row!.id);
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+async function countSighting(id: number): Promise<number> {
+	const sql = connect();
+	try {
+		const rows = await sql`SELECT id FROM sichtungen WHERE id = ${id}`;
+		return rows.length;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+async function removeSighting(id: number): Promise<void> {
+	const sql = connect();
+	try {
+		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+/** Die Mail-Aktion — beschriftet nach Empfänger, nicht nach „Test" (#621). */
+const MAIL_ACTION = 'Benachrichtigung zu dieser Sichtung an das Team senden';
+
+test.describe('Admin-Detailansicht — Aktionen', () => {
+	const createdIds: number[] = [];
+
+	test.afterEach(async () => {
+		while (createdIds.length > 0) {
+			await removeSighting(createdIds.pop()!);
+		}
+	});
+
+	test('bietet dieselben Aktionen wie die Tabellenzeile', async ({ page, context, baseURL }) => {
+		await seedAdminSession(context, baseURL!, ['superadmin']);
+		const id = await createSighting('e2e-detail-aktionen');
+		createdIds.push(id);
+
+		await page.goto(`/admin/${id}`);
+
+		await expect(page.getByRole('button', { name: 'Spam-Check für diese Sichtung' })).toBeVisible();
+		await expect(page.getByRole('button', { name: MAIL_ACTION })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sichtung löschen' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Sichtung bearbeiten' })).toBeVisible();
+	});
+
+	/**
+	 * Die Mail geht an das Team-Postfach und ist dort von einer echten Neu-Meldung
+	 * nicht zu unterscheiden — deshalb `superadmin`. Das Gate steht am Endpunkt
+	 * (`admin.contract.test.ts`); hier wird geprüft, dass ein Admin das
+	 * Bedienelement gar nicht erst angeboten bekommt. Die übrigen drei Aktionen
+	 * bleiben ihm, sonst prüfte der Test nur eine leere Seite.
+	 */
+	test('zeigt einem Admin ohne superadmin die Mail-Aktion nicht', async ({
+		page,
+		context,
+		baseURL
+	}) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+		const id = await createSighting('e2e-detail-rolle');
+		createdIds.push(id);
+
+		await page.goto(`/admin/${id}`);
+
+		await expect(page.getByRole('button', { name: 'Sichtung löschen' })).toBeVisible();
+		await expect(page.getByRole('button', { name: MAIL_ACTION })).toHaveCount(0);
+	});
+
+	test('löscht die Sichtung und verlässt die Seite', async ({ page, context, baseURL }) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+		const id = await createSighting('e2e-detail-loeschen');
+		createdIds.push(id);
+
+		await page.goto(`/admin/${id}`);
+		await page.getByRole('button', { name: 'Sichtung löschen' }).click();
+
+		// Ohne Bestätigung wird nichts gelöscht (design-system.md).
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible();
+		await dialog.getByRole('button', { name: 'Löschen' }).click();
+
+		await expect(page).toHaveURL(/\/admin$/);
+		expect(await countSighting(id)).toBe(0);
+	});
+});

--- a/e2e/helpers/adminSession.ts
+++ b/e2e/helpers/adminSession.ts
@@ -86,8 +86,17 @@ const ABSOLUTE_HOURS = 12;
  * Legt ein gültiges Admin-Session-Cookie in den Browser-Context.
  *
  * Muss vor dem ersten `page.goto()` auf eine geschützte Route laufen.
+ *
+ * `roles` ist überschreibbar, weil einzelne Bedienelemente `superadmin`
+ * verlangen (die Mail-Aktion in `/admin`, siehe admin-detail-actions.spec.ts).
+ * Der Default bleibt `['admin']` — die Rolle, in der der Admin-Bereich täglich
+ * benutzt wird, und damit die richtige Grundannahme für jeden anderen Spec.
  */
-export async function seedAdminSession(context: BrowserContext, baseURL: string): Promise<void> {
+export async function seedAdminSession(
+	context: BrowserContext,
+	baseURL: string,
+	roles: string[] = ['admin']
+): Promise<void> {
 	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
 	if (!databaseUrl) {
 		throw new Error(
@@ -126,7 +135,7 @@ export async function seedAdminSession(context: BrowserContext, baseURL: string)
 			VALUES (
 				${tokenHash},
 				${ADMIN_SUB},
-				${sql.array(['admin'])},
+				${sql.array(roles)},
 				${sql.json(ADMIN_CLAIMS)},
 				${expiresAt},
 				${absoluteExpiresAt}

--- a/src/lib/components/admin/sightingActions.test.ts
+++ b/src/lib/components/admin/sightingActions.test.ts
@@ -7,7 +7,7 @@
  * `deleteSighting` meldet den Ausgang zurück, statt selbst zu navigieren — die
  * Tabelle lädt neu, die Detailansicht muss die gelöschte Sichtung verlassen.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const toastCalls = vi.hoisted(() => ({
 	info: vi.fn(() => 'toast-id'),
@@ -23,17 +23,32 @@ vi.mock('$lib/logger', () => ({
 
 import { deleteSighting, sendTestEmail } from './sightingActions';
 
+/*
+ * `vi.stubGlobal` statt einer Zuweisung an `globalThis.fetch`: Vitest merkt sich
+ * den Originalwert, `vi.unstubAllGlobals()` unten stellt ihn wieder her. Eine
+ * Zuweisung bliebe für die ganze Worker-Instanz stehen und wirkte in jede
+ * nachfolgende Testdatei hinein. Dieselbe Form wie in submitSightingForm.test.ts
+ * und configStore.test.ts.
+ */
 function mockFetch(response: { ok: boolean; body: unknown }) {
 	const fetchMock = vi.fn().mockResolvedValue({
 		ok: response.ok,
 		json: async () => response.body
 	});
-	globalThis.fetch = fetchMock as unknown as typeof fetch;
+	vi.stubGlobal('fetch', fetchMock);
 	return fetchMock;
+}
+
+function failingFetch() {
+	vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 }
 
 beforeEach(() => {
 	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
 });
 
 describe('sendTestEmail', () => {
@@ -65,7 +80,7 @@ describe('sendTestEmail', () => {
 	});
 
 	it('meldet einen Netzwerkfehler, statt ihn zu verschlucken', async () => {
-		globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+		failingFetch();
 
 		await sendTestEmail(42);
 
@@ -99,7 +114,7 @@ describe('deleteSighting', () => {
 	});
 
 	it('meldet false bei einem Netzwerkfehler', async () => {
-		globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+		failingFetch();
 
 		await expect(deleteSighting(7)).resolves.toBe(false);
 

--- a/src/lib/components/admin/sightingActions.test.ts
+++ b/src/lib/components/admin/sightingActions.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Die beiden Sichtungs-Aktionen aus der Admin-Tabelle („Interne Benachrichtigung
+ * testweise senden", „Eintrag löschen") liegen hier, weil sie ab sofort an zwei
+ * Aufrufstellen hängen: Tabelle und Detailansicht. Doppelt gepflegt wären es zwei
+ * Fehlermeldungs-Dialekte für denselben Vorgang.
+ *
+ * `deleteSighting` meldet den Ausgang zurück, statt selbst zu navigieren — die
+ * Tabelle lädt neu, die Detailansicht muss die gelöschte Sichtung verlassen.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toastCalls = vi.hoisted(() => ({
+	info: vi.fn(() => 'toast-id'),
+	success: vi.fn(),
+	error: vi.fn(),
+	remove: vi.fn()
+}));
+
+vi.mock('$lib/stores/toastState.svelte', () => ({ toast: toastCalls }));
+vi.mock('$lib/logger', () => ({
+	createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })
+}));
+
+import { deleteSighting, sendTestEmail } from './sightingActions';
+
+function mockFetch(response: { ok: boolean; body: unknown }) {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: response.ok,
+		json: async () => response.body
+	});
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+	return fetchMock;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('sendTestEmail', () => {
+	it('sendet an den Admin-Endpunkt und meldet Erfolg', async () => {
+		const fetchMock = mockFetch({ ok: true, body: { success: true, message: 'gesendet' } });
+
+		await sendTestEmail(42);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/admin/test-email',
+			expect.objectContaining({ method: 'POST' })
+		);
+		const init = fetchMock.mock.calls[0]![1] as RequestInit;
+		expect(JSON.parse(init.body as string)).toEqual({
+			sightingId: 42,
+			testType: 'sighting'
+		});
+		expect(toastCalls.success).toHaveBeenCalled();
+	});
+
+	it('räumt den Lade-Toast auch im Fehlerfall ab', async () => {
+		mockFetch({ ok: false, body: { success: false, error: 'kaputt' } });
+
+		await sendTestEmail(42);
+
+		expect(toastCalls.remove).toHaveBeenCalledWith('toast-id');
+		expect(toastCalls.error).toHaveBeenCalled();
+		expect(toastCalls.success).not.toHaveBeenCalled();
+	});
+
+	it('meldet einen Netzwerkfehler, statt ihn zu verschlucken', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+		await sendTestEmail(42);
+
+		expect(toastCalls.remove).toHaveBeenCalledWith('toast-id');
+		expect(toastCalls.error).toHaveBeenCalled();
+	});
+});
+
+describe('deleteSighting', () => {
+	it('löscht über die Sichtungs-API und meldet Erfolg zurück', async () => {
+		const fetchMock = mockFetch({ ok: true, body: { success: true } });
+
+		await expect(deleteSighting(7)).resolves.toBe(true);
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'/api/sightings/7',
+			expect.objectContaining({ method: 'DELETE' })
+		);
+		expect(toastCalls.success).toHaveBeenCalled();
+	});
+
+	it('meldet false, wenn der Server ablehnt', async () => {
+		mockFetch({ ok: false, body: { error: 'nicht erlaubt' } });
+
+		await expect(deleteSighting(7)).resolves.toBe(false);
+
+		expect(toastCalls.error).toHaveBeenCalledWith(
+			'nicht erlaubt',
+			expect.objectContaining({ title: 'Fehler' })
+		);
+	});
+
+	it('meldet false bei einem Netzwerkfehler', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+		await expect(deleteSighting(7)).resolves.toBe(false);
+
+		expect(toastCalls.error).toHaveBeenCalled();
+	});
+});

--- a/src/lib/components/admin/sightingActions.ts
+++ b/src/lib/components/admin/sightingActions.ts
@@ -1,0 +1,103 @@
+/**
+ * Sichtungs-Aktionen des Admin-Bereichs, geteilt zwischen Tabelle (`/admin`) und
+ * Detailansicht (`/admin/[id]`).
+ *
+ * Beide Funktionen erledigen Toast und Logging selbst — was danach passiert, ist
+ * dagegen von der Aufrufstelle abhängig: Die Tabelle lädt ihre Daten neu, die
+ * Detailansicht muss die gelöschte Sichtung verlassen. `deleteSighting` gibt den
+ * Ausgang deshalb zurück und navigiert nicht.
+ */
+import { createLogger } from '$lib/logger';
+import { toast } from '$lib/stores/toastState.svelte';
+
+const logger = createLogger('adminSightingActions');
+
+/**
+ * Tooltip der Mail-Aktion — an einer Stelle, weil er an drei Bedienelementen
+ * hängt (Tabelle, Karten-Layout, Detailansicht).
+ *
+ * Er nennt den Empfänger ausdrücklich: Die frühere Beschriftung „Interne
+ * Benachrichtigung testweise senden" ließ offen, wer die Mail bekommt, und
+ * genau diese Lücke war der Anlass für #621 — die Erfolgsmeldung las sich, als
+ * wäre die meldende Person angeschrieben worden.
+ */
+export const TEST_EMAIL_HINT =
+	'Verschickt die interne Benachrichtigung zu dieser Sichtung erneut an die konfigurierte Empfänger-Adresse des Teams — nicht an die meldende Person.';
+
+/**
+ * Schickt die interne Benachrichtigung zu einer Sichtung testweise an die
+ * konfigurierte Empfänger-Adresse — nicht an die meldende Person (#621).
+ */
+export async function sendTestEmail(sightingId: number): Promise<void> {
+	const loadingToastId = toast.info('E-Mail wird gesendet...', { duration: 0 });
+
+	try {
+		const response = await fetch('/api/admin/test-email', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json'
+			},
+			body: JSON.stringify({
+				sightingId,
+				testType: 'sighting'
+			})
+		});
+
+		const result = await response.json();
+
+		if (result.success) {
+			toast.success(result.message || 'Test-E-Mail wurde erfolgreich gesendet', {
+				title: 'E-Mail gesendet',
+				duration: 5000
+			});
+		} else {
+			toast.error(result.error || 'Fehler beim Senden der Test-E-Mail', {
+				title: 'Fehler',
+				dismissible: true
+			});
+		}
+	} catch (error) {
+		logger.error({ error, sightingId }, 'Error sending test email');
+		toast.error('Netzwerkfehler beim Senden der Test-E-Mail', {
+			title: 'Verbindungsfehler',
+			dismissible: true
+		});
+	} finally {
+		// Auch im Fehlerfall: sonst bleibt der Lade-Toast wegen duration 0 stehen.
+		toast.remove(loadingToastId);
+	}
+}
+
+/** Löscht eine Sichtung. Gibt zurück, ob der Server sie tatsächlich gelöscht hat. */
+export async function deleteSighting(id: number): Promise<boolean> {
+	try {
+		const response = await fetch(`/api/sightings/${id}`, {
+			method: 'DELETE',
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		});
+
+		if (response.ok) {
+			const result = await response.json();
+			logger.info({ id, result }, 'Sichtung erfolgreich gelöscht');
+			toast.success('Sichtung wurde gelöscht', { duration: 5000 });
+			return true;
+		}
+
+		const error = await response.json();
+		logger.error({ id, error }, 'Fehler beim Löschen der Sichtung');
+		toast.error(error.error || 'Sichtung konnte nicht gelöscht werden', {
+			title: 'Fehler',
+			dismissible: true
+		});
+		return false;
+	} catch (error) {
+		logger.error({ id, error }, 'Netzwerkfehler beim Löschen');
+		toast.error('Netzwerkfehler beim Löschen der Sichtung', {
+			title: 'Verbindungsfehler',
+			dismissible: true
+		});
+		return false;
+	}
+}

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -306,6 +306,56 @@ describe('EmailService', () => {
 	// ---------------------------------------------------------------------------
 	// sendNewSightingNotification
 	// ---------------------------------------------------------------------------
+	/**
+	 * Warum es diese Funktion gibt: `sendNewSightingNotification` gibt bei allen
+	 * drei Abbruchgründen dasselbe `false` zurück, und der Grund stand nur im
+	 * Log — der Abschalter sogar nur auf `debug`. Ein Admin sah „Fehler beim
+	 * Senden" und fand nichts. Besonders irreführend, weil die Test-Mail in den
+	 * Einstellungen mit `test = true` an genau diesen Sperren vorbeigeht: Sie
+	 * kommt an, während die Sichtungs-Benachrichtigung stumm scheitert.
+	 *
+	 * Die Reihenfolge ist dieselbe wie im Versand, weil beide dieselbe Funktion
+	 * benutzen — sonst nennte die Diagnose einen anderen Grund als den, an dem
+	 * der Versand tatsächlich abbrach.
+	 */
+	describe('findNotificationBlocker()', () => {
+		it('meldet den Abschalter, wenn Benachrichtigungen deaktiviert sind', async () => {
+			setupConfigRepositoryMocks({ enabled: false });
+
+			await expect(EmailService.findNotificationBlocker()).resolves.toBe('disabled');
+		});
+
+		it('meldet den fehlenden Empfänger', async () => {
+			setupConfigRepositoryMocks({ enabled: true, recipient: '' });
+
+			await expect(EmailService.findNotificationBlocker()).resolves.toBe('recipient-missing');
+		});
+
+		it('meldet die fehlende SMTP-Verbindung', async () => {
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: '' });
+
+			await expect(EmailService.findNotificationBlocker()).resolves.toBe('transport-unavailable');
+		});
+
+		it('meldet null, wenn nichts im Weg steht', async () => {
+			setupConfigRepositoryMocks({ enabled: true, smtpHost: 'smtp.example.com' });
+			await EmailService.initialize(false);
+
+			await expect(EmailService.findNotificationBlocker()).resolves.toBeNull();
+		});
+
+		/**
+		 * Der Abschalter zuerst: Ist er aus, sagt ein zusätzlich fehlender
+		 * Empfänger nichts über die Ursache — er ist dann nur noch nicht
+		 * eingetragen worden.
+		 */
+		it('nennt den Abschalter vor dem fehlenden Empfänger', async () => {
+			setupConfigRepositoryMocks({ enabled: false, recipient: '' });
+
+			await expect(EmailService.findNotificationBlocker()).resolves.toBe('disabled');
+		});
+	});
+
 	describe('sendNewSightingNotification()', () => {
 		it('gibt false zurück wenn Sichtung nicht in DB gefunden', async () => {
 			vi.mocked(db.select).mockReturnValue({

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -58,6 +58,15 @@ function escape(value: string): string {
 }
 
 /**
+ * Grund, aus dem eine Sichtungs-Benachrichtigung nicht verschickt wird.
+ *
+ * `disabled` ist der Schalter `notification.email.enabled`, an dem
+ * `sendTestEmail()` bewusst vorbeigeht — die häufigste Ursache dafür, dass die
+ * Test-Mail ankommt und die Benachrichtigung nicht.
+ */
+export type NotificationBlocker = 'disabled' | 'transport-unavailable' | 'recipient-missing';
+
+/**
  * Macht aus einer Empfängerliste den Wert, den nodemailer erwartet: die
  * bereinigte Liste, oder `undefined` wenn nichts konfiguriert ist.
  *
@@ -362,6 +371,37 @@ export class EmailService {
 	}
 
 	/**
+	 * Prüft die drei Voraussetzungen des Benachrichtigungs-Versands und benennt
+	 * die erste, die fehlt. `null` heißt: nichts steht im Weg.
+	 *
+	 * Der Versand selbst benutzt dieselbe Funktion — die Reihenfolge der Gründe
+	 * ist damit garantiert dieselbe, und eine Diagnose kann nicht auf einen
+	 * anderen Grund zeigen als den, an dem der Versand abbrach.
+	 *
+	 * **Warum das nötig wurde:** Alle drei Abbrüche gaben nach außen dasselbe
+	 * `false`, und der häufigste — der Abschalter — stand nur auf `debug` im Log.
+	 * Für einen Admin war das ununterscheidbar von einem SMTP-Fehler. Verschärft
+	 * dadurch, dass `sendTestEmail()` mit `test = true` bewusst an Abschalter und
+	 * Transporter-Gate vorbeigeht: Die Test-Mail aus `/admin/settings` kommt an,
+	 * während die Sichtungs-Benachrichtigung stumm scheitert.
+	 */
+	static async findNotificationBlocker(): Promise<NotificationBlocker | null> {
+		const enabled = await ConfigRepository.getBoolean('notification.email.enabled', false);
+
+		if (!enabled) {
+			return 'disabled';
+		}
+
+		if (!(await this.ensureTransporter())) {
+			return 'transport-unavailable';
+		}
+
+		const config = await this.getEmailConfig();
+
+		return config.recipient ? null : 'recipient-missing';
+	}
+
+	/**
 	 * Consolidated email sending logic
 	 */
 	private static async sendEmailNotification(
@@ -371,25 +411,23 @@ export class EmailService {
 		balticSea: BalticSeaEmailContext
 	): Promise<boolean> {
 		try {
-			const enabled = await ConfigRepository.getBoolean('notification.email.enabled', false);
+			const blocker = await this.findNotificationBlocker();
 
-			if (!enabled) {
-				logger.debug('Email notifications disabled');
+			if (blocker) {
+				// `warn` auch für den Abschalter: Bis 2026-08-05 stand er auf
+				// `debug` und war im Normalbetrieb unsichtbar — eine ausbleibende
+				// Benachrichtigung zeigt sonst nirgends etwas an.
+				logger.warn({ blocker, referenceId }, 'Sighting notification not sent');
 				return false;
 			}
 
 			const transporter = await this.ensureTransporter();
-
-			if (!transporter) {
-				logger.warn('Email service not available, notification not sent');
-				return false;
-			}
-
-			// Get email configuration
 			const config = await this.getEmailConfig();
 
-			if (!config.recipient) {
-				logger.warn('Email notification recipient not configured');
+			if (!transporter) {
+				// Kann nach der Prüfung oben nur eintreten, wenn die Verbindung
+				// dazwischen verworfen wurde. TypeScript braucht die Klammer ohnehin.
+				logger.warn('Email service not available, notification not sent');
 				return false;
 			}
 

--- a/src/lib/types/Pagination.ts
+++ b/src/lib/types/Pagination.ts
@@ -22,4 +22,11 @@ export interface PageData {
 	 * Filter, damit er im Dashboard-Kopf immer sichtbar ist.
 	 */
 	pendingPhotoAnnouncements?: number;
+	/**
+	 * Kommt aus `admin/+layout.server.ts` und liegt damit an jeder Admin-Seite
+	 * an. Steuert die Bedienelemente für `POST /api/admin/test-email`, das
+	 * `superadmin` verlangt. Optional, weil der Typ auch außerhalb des
+	 * Admin-Layouts verwendet wird.
+	 */
+	isSuperAdmin?: boolean;
 }

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -1,4 +1,4 @@
-import { requireUserRole } from '$lib/server/auth/auth';
+import { isSuperAdminUser, requireUserRole } from '$lib/server/auth/auth';
 import { getBuildInfo } from '$lib/server/startup/versionInfo';
 import type { PublicUser } from '$lib/types/User';
 import type { LayoutServerLoad } from './$types';
@@ -22,6 +22,11 @@ export const load = (async ({ locals, url }) => {
 		user: adminUser,
 		// Server-computed admin status - no client-side role checking needed
 		isAdmin: true, // We know user is admin since requireUserRole passed
+		// Ein einzelnes Flag statt der Rollenliste: Die Bedienelemente für
+		// `POST /api/admin/test-email` sollen nur Superadmins sehen, und das
+		// Frontend bekommt weiterhin keine Rollen (siehe oben). Dieselbe Form
+		// wie in admin/settings/+page.server.ts.
+		isSuperAdmin: isSuperAdminUser(locals.user),
 		buildInfo: getBuildInfo()
 	};
 }) satisfies LayoutServerLoad;

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -2,6 +2,11 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
 	import ExportModal from '$lib/components/admin/ExportModal.svelte';
+	import {
+		deleteSighting,
+		sendTestEmail,
+		TEST_EMAIL_HINT
+	} from '$lib/components/admin/sightingActions';
 	import DeleteDialog from '$lib/components/ui/Dialog/DeleteDialog.svelte';
 	import { createLogger } from '$lib/logger';
 	import BaseToggle from '$lib/report/components/form/fields/BaseToggle.svelte';
@@ -210,76 +215,10 @@
 		goto(detailUrl.toString());
 	}
 
-	async function sendTestEmail(sightingId: number) {
-		try {
-			// Show loading toast
-			const loadingToastId = toast.info('E-Mail wird gesendet...', { duration: 0 });
-
-			const response = await fetch('/api/admin/test-email', {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json'
-				},
-				body: JSON.stringify({
-					sightingId,
-					testType: 'sighting'
-				})
-			});
-
-			// Remove loading toast
-			toast.remove(loadingToastId);
-
-			const result = await response.json();
-
-			if (result.success) {
-				toast.success(result.message || 'Test-E-Mail wurde erfolgreich gesendet', {
-					title: 'E-Mail gesendet',
-					duration: 5000
-				});
-			} else {
-				toast.error(result.error || 'Fehler beim Senden der Test-E-Mail', {
-					title: 'Fehler',
-					dismissible: true
-				});
-			}
-		} catch (error) {
-			logger.error({ error }, 'Error sending test email');
-			toast.error('Netzwerkfehler beim Senden der Test-E-Mail', {
-				title: 'Verbindungsfehler',
-				dismissible: true
-			});
-		}
-	}
-
-	async function deleteSighting(id: number): Promise<void> {
-		try {
-			const response = await fetch(`/api/sightings/${id}`, {
-				method: 'DELETE',
-				headers: {
-					'Content-Type': 'application/json'
-				}
-			});
-
-			if (response.ok) {
-				const result = await response.json();
-				logger.info({ id, result }, 'Sichtung erfolgreich gelöscht');
-				toast.success('Sichtung wurde gelöscht', { duration: 5000 });
-				// Reload data via SvelteKit's invalidation instead of full page reload
-				await invalidateAll();
-			} else {
-				const error = await response.json();
-				logger.error({ id, error }, 'Fehler beim Löschen der Sichtung');
-				toast.error(error.error || 'Sichtung konnte nicht gelöscht werden', {
-					title: 'Fehler',
-					dismissible: true
-				});
-			}
-		} catch (error) {
-			logger.error({ id, error }, 'Netzwerkfehler beim Löschen');
-			toast.error('Netzwerkfehler beim Löschen der Sichtung', {
-				title: 'Verbindungsfehler',
-				dismissible: true
-			});
+	async function removeSighting(id: number): Promise<void> {
+		if (await deleteSighting(id)) {
+			// Reload data via SvelteKit's invalidation instead of full page reload
+			await invalidateAll();
 		}
 	}
 
@@ -699,14 +638,19 @@
 						>
 							<Icon icon="lucide:eye" class="h-4 w-4" />
 						</button>
-						<button
-							class="btn btn-ghost btn-sm"
-							onclick={() => sendTestEmail(sighting.id)}
-							title="Interne Benachrichtigung testweise senden"
-							aria-label="Interne Benachrichtigung testweise senden"
-						>
-							<Icon icon="lucide:mail" class="h-4 w-4" />
-						</button>
+						<!-- Nur Superadmins: Der Klick erzeugt im Team-Postfach eine Mail, die
+						     von einer echten Neu-Meldung nicht zu unterscheiden ist. Das Gate
+						     steht zusätzlich am Endpunkt — hier verschwindet nur das Bedienelement. -->
+						{#if data.isSuperAdmin}
+							<button
+								class="btn btn-ghost btn-sm"
+								onclick={() => sendTestEmail(sighting.id)}
+								title={TEST_EMAIL_HINT}
+								aria-label="Benachrichtigung zu dieser Sichtung an das Team senden"
+							>
+								<Icon icon="lucide:mail" class="h-4 w-4" />
+							</button>
+						{/if}
 						<button
 							class="btn btn-ghost btn-sm"
 							onclick={() => checkSpam(sighting.id)}
@@ -986,14 +930,17 @@
 										>
 											<Icon icon="lucide:eye" class="h-4 w-4" />
 										</button>
-										<button
-											class="btn btn-ghost btn-xs"
-											onclick={() => sendTestEmail(sighting.id)}
-											title="Interne Benachrichtigung testweise senden"
-											aria-label="Interne Benachrichtigung testweise senden"
-										>
-											<Icon icon="lucide:mail" class="h-4 w-4" />
-										</button>
+										<!-- Nur Superadmins — Begründung an der Kartenansicht weiter oben. -->
+										{#if data.isSuperAdmin}
+											<button
+												class="btn btn-ghost btn-xs"
+												onclick={() => sendTestEmail(sighting.id)}
+												title={TEST_EMAIL_HINT}
+												aria-label="Benachrichtigung zu dieser Sichtung an das Team senden"
+											>
+												<Icon icon="lucide:mail" class="h-4 w-4" />
+											</button>
+										{/if}
 										<button
 											class="btn btn-ghost btn-xs"
 											onclick={() => checkSpam(sighting.id)}
@@ -1087,7 +1034,7 @@
 		bind:show={showDeleteDialog}
 		onConfirm={() => {
 			if (sightingToDelete) {
-				deleteSighting(sightingToDelete.id);
+				removeSighting(sightingToDelete.id);
 			}
 		}}
 		onCancel={() => {

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -1,12 +1,45 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import AdminSightingView from '$lib/components/admin/AdminSightingView.svelte';
+	import {
+		deleteSighting,
+		sendTestEmail,
+		TEST_EMAIL_HINT
+	} from '$lib/components/admin/sightingActions';
 	import Icon from '$lib/components/Icon.svelte';
+	import DeleteDialog from '$lib/components/ui/Dialog/DeleteDialog.svelte';
 	import type { SpamCheckResult } from '$lib/types/spam';
 
 	let { data } = $props();
 
 	let sighting = $derived(data.sighting);
+
+	let showDeleteDialog = $state(false);
+	let emailPending = $state(false);
+
+	function editSighting() {
+		goto(`/admin/${sighting.id}/edit`);
+	}
+
+	async function handleTestEmail() {
+		// Wächter statt `disabled`: Die Schaltfläche bleibt fokussierbar, wer per
+		// Tastatur arbeitet verliert seine Position nicht (design-system.md).
+		if (emailPending) return;
+		emailPending = true;
+		try {
+			await sendTestEmail(sighting.id);
+		} finally {
+			emailPending = false;
+		}
+	}
+
+	async function handleDelete() {
+		// Die Sichtung, die diese Seite anzeigt, existiert nach dem Löschen nicht
+		// mehr — zurück zur Tabelle statt auf einen 404 zu warten.
+		if (await deleteSighting(sighting.id)) {
+			await goto('/admin');
+		}
+	}
 
 	let spamCheck = $state<{
 		loading: boolean;
@@ -17,11 +50,6 @@
 		result: null,
 		error: null
 	});
-
-	function editSighting() {
-		// Logic to edit the sighting
-		goto(`/admin/${sighting.id}/edit`);
-	}
 
 	async function runSpamCheck() {
 		spamCheck.loading = true;
@@ -71,9 +99,9 @@
 	/>
 </svelte:head>
 
-<div class="mb-0 flex items-center justify-between">
+<div class="mb-0 flex flex-wrap items-center justify-between gap-2">
 	<h2 class="text-xl font-bold">Sichtung Details</h2>
-	<div class="flex gap-2">
+	<div class="flex flex-wrap gap-2">
 		<button
 			class="btn btn-ghost btn-sm"
 			onclick={runSpamCheck}
@@ -88,6 +116,34 @@
 			{/if}
 			Spam-Check
 		</button>
+		<!-- Nur Superadmins: Der Klick erzeugt im Team-Postfach eine Mail, die von
+		     einer echten Neu-Meldung nicht zu unterscheiden ist. Das Gate steht
+		     zusätzlich am Endpunkt — hier verschwindet nur das Bedienelement. -->
+		{#if data.isSuperAdmin}
+			<button
+				class="btn btn-ghost btn-sm"
+				onclick={handleTestEmail}
+				aria-disabled={emailPending}
+				title={TEST_EMAIL_HINT}
+				aria-label="Benachrichtigung zu dieser Sichtung an das Team senden"
+			>
+				{#if emailPending}
+					<span class="loading loading-spinner loading-xs"></span>
+				{:else}
+					<Icon icon="lucide:mail" class="mr-1 h-4 w-4" />
+				{/if}
+				Benachrichtigung an Team
+			</button>
+		{/if}
+		<button
+			class="btn btn-outline btn-error btn-sm"
+			onclick={() => (showDeleteDialog = true)}
+			title="Eintrag löschen"
+			aria-label="Sichtung löschen"
+		>
+			<Icon icon="lucide:trash-2" class="mr-1 h-4 w-4" />
+			Löschen
+		</button>
 		<button
 			class="btn btn-primary btn-sm"
 			onclick={editSighting}
@@ -99,7 +155,13 @@
 		</button>
 	</div>
 </div>
-<div class="mb-4 text-sm text-base-content/70">
+
+<DeleteDialog
+	bind:show={showDeleteDialog}
+	onConfirm={handleDelete}
+	onCancel={() => (showDeleteDialog = false)}
+/>
+<div class="text-base-content/70 mb-4 text-sm">
 	Referenz-ID: {sighting.referenceId}
 </div>
 

--- a/src/routes/api/admin/test-email/+server.ts
+++ b/src/routes/api/admin/test-email/+server.ts
@@ -1,14 +1,45 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
-import { EmailService } from '$lib/server/services/emailService';
+import { EmailService, type NotificationBlocker } from '$lib/server/services/emailService';
 import { createLogger } from '$lib/logger.server';
 import { requireUserRole } from '$lib/server/auth/auth';
 
 const logger = createLogger('api:test-email');
 
+/**
+ * Übersetzt den Abbruchgrund in einen Satz, der sagt, was zu tun ist.
+ *
+ * Der Abschalter braucht dabei den Zusatz zur Test-Mail: Dass die eine ankommt
+ * und die andere nicht, ist kein Widerspruch, sondern Absicht —
+ * `sendTestEmail()` geht mit `test = true` bewusst an diesem Schalter vorbei,
+ * damit sich SMTP prüfen lässt, bevor man die Benachrichtigungen scharf
+ * schaltet.
+ */
+function describeBlocker(blocker: NotificationBlocker | null): string {
+	switch (blocker) {
+		case 'disabled':
+			return 'E-Mail-Benachrichtigungen sind abgeschaltet (Einstellungen → „E-Mail-Benachrichtigungen aktiviert"). Die Test-Mail in den Einstellungen geht trotzdem — sie umgeht diesen Schalter bewusst.';
+		case 'recipient-missing':
+			return 'Es ist keine Empfänger-Adresse konfiguriert (Einstellungen → „Empfänger-Adresse").';
+		case 'transport-unavailable':
+			return 'Keine SMTP-Verbindung. Bitte SMTP-Einstellungen prüfen und dort die Test-Mail auslösen.';
+		default:
+			// Kein Blocker, trotzdem kein Versand: Sichtung nicht gefunden, oder der
+			// SMTP-Versand selbst ist gescheitert. Beides steht als `error` im Log.
+			return 'Die Sichtung wurde nicht gefunden, oder der Versand ist fehlgeschlagen. Details stehen im Server-Log.';
+	}
+}
+
 export const POST: RequestHandler = async ({ request, locals, url }) => {
 	// SECURITY: Must be outside try/catch so redirect(302) propagates correctly
-	requireUserRole(url, locals.user, ['admin', 'superadmin']);
+	//
+	// Nur `superadmin`, obwohl der Rest von /api/admin bei ['admin','superadmin']
+	// liegt: Dieser Endpunkt verschickt in `testType: 'sighting'` dieselbe interne
+	// Benachrichtigung wie eine echte Neu-Meldung — im Team-Postfach ist sie von
+	// einer solchen nicht zu unterscheiden. Er diagnostiziert die
+	// Mail-Konfiguration und gehört damit zu /api/config/init und
+	// /api/config/reset, nicht zum Tagesgeschäft.
+	requireUserRole(url, locals.user, ['superadmin']);
 
 	try {
 		logger.debug(
@@ -43,13 +74,13 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 					message: `Interne Benachrichtigung zu Sichtung ${sightingId} wurde an die konfigurierte Empfänger-Adresse gesendet`
 				});
 			} else {
-				return json(
-					{
-						success: false,
-						error: 'E-Mail konnte nicht gesendet werden. Bitte prüfen Sie die Konfiguration.'
-					},
-					{ status: 500 }
-				);
+				// Ohne diese Abfrage bekam der Admin denselben Satz für drei völlig
+				// verschiedene Ursachen, und die häufigste (der Abschalter) stand
+				// nur auf `debug` im Log — „Fehlermeldung, aber nichts im Log".
+				const blocker = await EmailService.findNotificationBlocker();
+				logger.warn({ sightingId, blocker }, 'Test sighting email not sent');
+
+				return json({ success: false, error: describeBlocker(blocker) }, { status: 500 });
 			}
 		} else {
 			// Validate recipient email format

--- a/src/tests/contract/admin.contract.test.ts
+++ b/src/tests/contract/admin.contract.test.ts
@@ -7,7 +7,8 @@ import { asApiResponse } from './helpers/asApiResponse';
 vi.mock('$lib/server/services/emailService', () => ({
 	EmailService: {
 		sendTestEmail: vi.fn().mockResolvedValue(true),
-		sendNewSightingNotification: vi.fn().mockResolvedValue(true)
+		sendNewSightingNotification: vi.fn().mockResolvedValue(true),
+		findNotificationBlocker: vi.fn().mockResolvedValue(null)
 	}
 }));
 
@@ -78,6 +79,49 @@ describe('Contract: POST /api/admin/test-email', () => {
 		const apiRes = await asApiResponse(res, event);
 
 		expect(apiRes.status).toBe(400);
+		expect(apiRes).toSatisfyApiSpec();
+	});
+
+	/**
+	 * Der Endpunkt verschickt eine Mail, die im Team-Postfach von einer echten
+	 * Neu-Meldung nicht zu unterscheiden ist — er ist Diagnose der
+	 * Mail-Konfiguration und gehört damit zu `/api/config/init` und
+	 * `/api/config/reset`, nicht zum Tagesgeschäft eines Admins.
+	 */
+	it('verlangt die Rolle superadmin', async () => {
+		const { requireUserRole } = vi.mocked(await import('$lib/server/auth/auth'));
+		const event = createEvent('/api/admin/test-email', {
+			method: 'POST',
+			locals: { user: mockAdminUser },
+			body: { testType: 'simple', recipient: 'test@example.com' }
+		});
+
+		await testEmailPOST(event);
+
+		expect(requireUserRole).toHaveBeenCalledWith(expect.anything(), mockAdminUser, ['superadmin']);
+	});
+
+	/**
+	 * Der Abschalter ist die häufigste Ursache und zugleich die verwirrendste:
+	 * Die Test-Mail in den Einstellungen geht an ihm vorbei und kommt an. Wer
+	 * dann „E-Mail konnte nicht gesendet werden. Bitte prüfen Sie die
+	 * Konfiguration." liest, sucht am falschen Ende.
+	 */
+	it('nennt den Abschalter als Grund, statt pauschal auf die Konfiguration zu verweisen', async () => {
+		const { EmailService } = vi.mocked(await import('$lib/server/services/emailService'));
+		vi.mocked(EmailService.sendNewSightingNotification).mockResolvedValueOnce(false);
+		vi.mocked(EmailService.findNotificationBlocker).mockResolvedValueOnce('disabled');
+
+		const event = createEvent('/api/admin/test-email', {
+			method: 'POST',
+			locals: { user: mockAdminUser },
+			body: { testType: 'sighting', sightingId: 42 }
+		});
+		const res = await testEmailPOST(event);
+		const apiRes = await asApiResponse(res, event);
+
+		expect(apiRes.status).toBe(500);
+		expect((apiRes.body as { error: string }).error).toMatch(/abgeschaltet/);
 		expect(apiRes).toSatisfyApiSpec();
 	});
 

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1037,7 +1037,14 @@ paths:
       tags:
         - admin
       summary: Admin Test-E-Mail senden
-      description: Sendet eine Test-E-Mail für eine Sichtung oder eine einfache Test-E-Mail (Admin-Berechtigung erforderlich)
+      description: |
+        Sendet eine Test-E-Mail für eine Sichtung oder eine einfache Test-E-Mail.
+
+        **Erfordert die Rolle `superadmin`** — anders als der übrige `/api/admin`-Bereich,
+        der `admin` genügen lässt. Mit `testType: sighting` verschickt der Endpunkt
+        dieselbe interne Benachrichtigung wie eine echte Neu-Meldung; im Team-Postfach
+        ist sie von einer solchen nicht zu unterscheiden. Empfänger ist immer die
+        konfigurierte Adresse aus `notification.email.recipient`, nie die meldende Person.
       security:
         - adminAuth: []
       requestBody:


### PR DESCRIPTION
## Was

Die Detailansicht einer Sichtung (`/admin/[id]`) hatte nur zwei der vier Aktionen, die eine Tabellenzeile anbietet. Zum Löschen musste man zurück in die Tabelle und die Zeile dort wiederfinden — genau dabei erwischt man die falsche.

Jetzt: **Spam-Check · Benachrichtigung an Team · Löschen · Bearbeiten**.

| Aktion | Tabelle | Detailansicht | Anmerkung |
| --- | --- | --- | --- |
| Details anzeigen | ✅ | — | man ist bereits dort |
| Benachrichtigung an Team | ✅ | ✅ **neu** | nur `superadmin`, siehe unten |
| Spam-Check | ✅ | ✅ | |
| Löschen | ✅ | ✅ **neu** | mit Bestätigungsdialog |
| Bearbeiten | — | ✅ | detailansichts-eigen |
| „Geprüft“-Toggle | Spalte | — | CLAUDE.md verbietet ein zweites Freigabe-Bedienelement |

## Warum die Mail-Aktion jetzt `superadmin` verlangt

Mit `testType: sighting` verschickt `POST /api/admin/test-email` **dieselbe interne Benachrichtigung wie eine echte Neu-Meldung** — im Team-Postfach sind die beiden nicht zu unterscheiden. Wer sie aus Neugier auslöst, erzeugt eine Meldung, die es nicht gibt. Damit gehört der Endpunkt zu `/api/config/init` und `/api/config/reset`, nicht ins Tagesgeschäft eines Admins. Das Gate steht am Endpunkt **und** in der UI (`isSuperAdmin`-Flag aus `admin/+layout.server.ts` — ein Boolean, keine Rollenliste ans Frontend).

Beschriftung nach Empfänger statt nach „Test“: Das alte „Interne Benachrichtigung testweise senden“ ließ offen, wer die Mail bekommt — genau die Lücke hinter #621.

## Der stille Fehlschlag dahinter

Beim Testen kam der Button gar nicht durch: Fehlermeldung ja, Logeintrag nein.

`sendEmailNotification` bricht an drei Voraussetzungen ab und gab für alle dasselbe `false` zurück; die häufigste — der Schalter `notification.email.enabled` — stand nur auf `logger.debug` und war im Normalbetrieb unsichtbar. Die API übersetzte das in „Bitte prüfen Sie die Konfiguration“.

Besonders irreführend, weil die Test-Mail aus `/admin/settings` weiter ankommt: `sendTestEmail()` geht mit `ensureTransporter(true)` bewusst an diesem Schalter vorbei.

| Voraussetzung | Benachrichtigung | Test-Mail (Settings) |
| --- | --- | --- |
| `notification.email.enabled` | erforderlich | **umgangen** |
| SMTP-Verbindung | erforderlich | erforderlich |
| `notification.email.recipient` | erforderlich | Formularfeld schlägt ihn |

`EmailService.findNotificationBlocker()` ist jetzt die einzige Stelle, an der die drei Gates stehen — der Versandpfad benutzt sie selbst, die Diagnose kann also keinen anderen Grund nennen als den, an dem der Versand abbrach. Alle drei Gründe auf `warn`, die Fehlermeldung sagt, wo man schaut.

## Für Reviewer

- **`sightingActions.ts`** ist die geteilte Logik. `deleteSighting` gibt den Ausgang zurück statt zu navigieren: die Tabelle lädt neu, die Detailansicht muss die gelöschte Sichtung verlassen.
- **`seedAdminSession`** nimmt jetzt optional Rollen entgegen, Default bleibt `['admin']` — kein bestehender Spec ändert sein Verhalten.
- **`ci.yml`:** Der neue E2E-Spec liegt im `form`-Shard (nach #769 der kürzeste, 152 s gegen 169 s bei `map`), nicht bei den anderen Admin-Specs. Ohne Zuordnung wäre der Vollständigkeits-Wächter rot.
- **OpenAPI** nachgezogen (Rollenanforderung + Empfängerhinweis).

## Verifikation

- `npm run test:quick` — 3516 Tests grün, lint/type-check/svelte-check sauber
- `e2e/admin-detail-actions.spec.ts` — 3/3 grün: Superadmin sieht vier Aktionen, Admin sieht die Mail-Aktion nicht, Löschen läuft bis zum Verlassen der Seite durch
- Fehlermeldung am laufenden System geprüft (lokale DB hat `enabled = false`): der Klick meldet jetzt den Abschalter samt Hinweis auf die Test-Mail

Alle neuen Tests wurden RED→GREEN gefahren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)