### PR TITLE
fix(report): announce a photo only when none is attached yet

### DIFF
--- a/scripts/migrations/2026-08-05-notification-email-foto-ankuendigung.sql
+++ b/scripts/migrations/2026-08-05-notification-email-foto-ankuendigung.sql
@@ -1,70 +1,66 @@
-/**
- * notificationEmailDefault.ts — Standard-Vorlage der Benachrichtigungs-Mail
- *
- * **Warum als eigenes Modul und nicht als Literal in `configInitializer.ts`:**
- * Dieselbe Zeichenkette wird an zwei Stellen gebraucht — beim Seeden nach
- * `app_config` und vom Nachzieh-Werkzeug `src/tools/refresh-email-template.ts`,
- * das einen unveränderten Seed in einer bestehenden Installation auf den
- * aktuellen Stand hebt. Das Modul hat deshalb bewusst **keine Importe**: so lässt
- * es sich aus einem `tsx`-Skript ohne SvelteKit-Alias-Auflösung laden.
- *
- * **Der Ostsee-Status kommt aus dem Kontext, nicht aus den Flags.** Die Vorlage
- * verzweigt über `sighting.balticSea` (siehe `balticSeaEmailContext.ts`) — ein
- * Wert, der aus derselben Funktion stammt wie die Anzeige im Admin-Bereich.
- * Wer hier wieder `{{#if sighting.inBalticSeaGeo}}` einbaut, prüft die grobe
- * Bounding Box und weist damit Meldungen aus dem Hamburger Hafen als Ostsee aus
- * (Fehler 4 in `docs/OSTSEE_FLAGS.md`).
- *
- * **Wer diese Vorlage ändert, muss den Seed nachziehen.** Der in `app_config`
- * gespeicherte Wert gewinnt gegen diesen Default
- * (`ConfigRepository.getString(…, NOTIFICATION_EMAIL_DEFAULT_TEMPLATE)`) — eine Änderung hier
- * wirkt auf keine bestehende Installation. Ablauf und Fingerabdruck-Liste:
- * `src/tools/refresh-email-template.ts`.
- */
-/**
- * SHA-256 aller Vorlagen, die dieses Projekt jemals als Default **ausgeliefert**
- * hat — jüngste zuerst. Ein in `app_config` gespeicherter Wert, dessen Hash hier
- * steht, ist ein unveränderter Seed und darf nachgezogen werden; jeder andere
- * Wert ist ein angepasster Kundentext und wird nicht angefasst.
- *
- * **Wer `NOTIFICATION_EMAIL_DEFAULT_TEMPLATE` ändert, trägt den Hash des alten
- * Stands hier oben ein.** Fehlt er, hält `src/tools/refresh-email-template.ts`
- * jeden frisch geseedeten Bestand für angepasst und zieht ihn nie wieder nach.
- * `notificationEmailDefault.test.ts` erzwingt das: der Test pinnt den Hash des
- * aktuellen Stands und schlägt bei jeder Änderung fehl.
- */
-export const PREVIOUS_SHIPPED_TEMPLATE_HASHES = [
-	// Stand bis 2026-08-05: verzweigte den Foto-Hinweis über
-	// `sighting.mediaUpload`. Das Web-Formular setzt dieses Flag genau dann,
-	// wenn eine Datei hochgeladen wurde — die Mail kündigte deshalb bei jedem
-	// angehängten Foto ein noch nachkommendes an (in preprod aufgefallen).
-	'2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392',
-	// Stand bis 2026-08-04: nannte den Vorgang durchgehend „Sichtung"
-	// („Neue Sichtung eingegangen", „diese Sichtung besonders sorgfältig",
-	// „Sichtung im Admin-Bereich prüfen"). Über dasselbe Formular wird auch ein
-	// Totfund gemeldet — Änderungswunsch A5.3 des Deutschen Meeresmuseums.
-	'aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763',
-	// Stand bis 2026-08-04: ohne Totfund-Abschnitt. `isDead`, `deadCondition`
-	// und `deadSize` lagen im Kontext, wurden aber von keiner ausgelieferten
-	// Vorlage gerendert — die Mail zu einem Totfund war von der zu einer
-	// lebenden Sichtung nicht zu unterscheiden.
-	'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
-	// Stand bis 2026-07-30: Foto-Hinweis wortidentisch, aber „rebuilter
-	// iOS-Client" statt der im Projekt sonst üblichen Formulierung „neu
-	// gebauter iOS-Client" (siehe .claude/rules/legacy-api.md).
-	'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
-	// Stand bis 2026-07-30: ohne Hinweis auf ein per E-Mail nachgereichtes
-	// Foto (neu gebauter iOS-Client `OstSeeTiere/8` setzt `aufnahmeHochladen`,
-	// kann aber keine Datei hochladen).
-	'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
-	// Stand bis 2026-07-30: verzweigte über `inBalticSeaGeo` (Bounding Box) und
-	// zeigte einer Meldung aus dem Hamburger Hafen „Ostsee ✓".
-	'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
-	// Stand vor der Umstellung auf emailTokens.ts (hartcodierte Hex-Farben).
-	'ba2a26024338b19b441c6b5aa2d6b8d66aea611fa474952952d859b0c40d46bc'
-] as const;
+-- Zieht die geseedete Benachrichtigungs-Vorlage auf den Stand, in dem der
+-- Foto-Hinweis über `photoAnnouncementPending` verzweigt statt über
+-- `sighting.mediaUpload`.
+--
+-- Hintergrund: Das Web-Formular setzt `aufnahmeHochladen` genau dann, wenn eine
+-- Datei hochgeladen wurde (`ModernReportForm.svelte`), und `saveSighting`
+-- verknüpft sie in derselben Transaktion — vor dem Versand der Mail. Die alte
+-- Vorlage verzweigte über dieses Flag und kündigte deshalb bei **jedem** über
+-- das Formular hochgeladenen Foto ein noch per E-Mail nachkommendes an
+-- („📷 Foto angekündigt … es kommt separat per E-Mail nach"). Aufgefallen an
+-- zwei Testmeldungen in preprod, die ihr Bild angehängt hatten.
+--
+-- Der Kontextwert `photoAnnouncementPending` steht im Code (`emailService.ts`)
+-- und zieht mit dem Deployment automatisch mit. Ohne diesen Lauf verzweigt die
+-- gespeicherte Vorlage aber weiter über `sighting.mediaUpload` — der Hinweis
+-- bliebe also falsch.
+--
+-- Das Gegenstück zu `npm run config:refresh-email-template`, für Hosts, auf denen
+-- kein Checkout liegt (das Runtime-Image enthält `src/tools/` nicht).
+--
+-- Aufruf auf dem DMM-Host: Die Datenbank veröffentlicht dort keinen Port, sie
+-- hängt nur im internen Docker-Netz `ostsee_internal`. Weder ein psql vom Host
+-- noch ein SSH-Tunnel erreichen sie — der Weg führt durch den Container:
+--
+--   scp scripts/migrations/2026-08-05-notification-email-foto-ankuendigung.sql dmm:/tmp/
+--   ssh dmm
+--   cd /opt/ostsee-tiere
+--   sudo -v   # Passwort vorab, damit die Eingabeumleitung unten nicht mit dem
+--             # Prompt konkurriert
+--   sudo docker compose exec -T db psql -U postgres -d ostsee \
+--     < /tmp/2026-08-05-notification-email-foto-ankuendigung.sql
+--
+-- `psql -U postgres` im Container braucht kein Passwort (lokale Socket-
+-- Verbindung, `trust` in der pg_hba des Images). Erwartete Ausgabe: `UPDATE 1`
+-- und die OK-Meldung; bei `UPDATE 0` entscheidet die Schluss-Abfrage, ob der
+-- Stand schon aktuell oder der Text angepasst ist.
+--
+-- Sicherheit: Die UPDATE-Bedingung prüft den SHA-256 des gespeicherten Werts gegen
+-- die Liste der jemals ausgelieferten Stände. Ein im Admin-Bereich angepasster
+-- Text trifft keinen Eintrag und bleibt unangetastet — der Lauf meldet dann
+-- `UPDATE 0` und die Schluss-Abfrage sagt es im Klartext.
+--
+-- Idempotent: Ein zweiter Lauf ändert nichts (der aktuelle Stand steht bewusst
+-- nicht in der Liste der erlaubten Ausgangswerte).
+--
+-- Diese Datei ist aus `NOTIFICATION_EMAIL_DEFAULT_TEMPLATE` erzeugt; die Nutzlast
+-- ist byte-identisch mit der Konstante.
 
-export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
+BEGIN;
+
+-- 1. Ist-Zustand vor der Änderung
+SELECT
+	updated_by,
+	updated_at,
+	length(value #>> '{}') AS zeichen,
+	encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS hash_vorher
+FROM app_config
+WHERE key = 'notification.email.template';
+
+-- 2. Nachziehen — nur, wenn der gespeicherte Wert ein unveränderter Seed ist
+UPDATE app_config
+SET
+	value = to_jsonb($tpl$<!DOCTYPE html>
 <html lang="de">
 <head>
 	<meta charset="UTF-8">
@@ -274,4 +270,32 @@ export const NOTIFICATION_EMAIL_DEFAULT_TEMPLATE = `<!DOCTYPE html>
 		<p style="margin: 8px 0 0 0;">Diese E-Mail wurde automatisch generiert am {{currentDate}} um {{currentTime}}</p>
 	</div>
 </body>
-</html>`;
+</html>$tpl$::text),
+	updated_by = 'refresh-email-template-sql',
+	updated_at = NOW()
+WHERE key = 'notification.email.template'
+	AND encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') = ANY (ARRAY[
+		'2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392',
+		'aed55e5b04055cc8b30a86bab9e91d3d64f982fbb63c3c202d732bcd87480763',
+		'2444299392fe83096f5a2ebbcd4806c20f4fc1866dd0d13c105066ccfc0dd7f0',
+		'e40a8d357f37192aa47c71cf1883514110b50ed773e98620bbd9110aa3e17390',
+		'7f55d293b7799debff9908e074e8e22c2b87323c98bf7b76cc7ba86186e95a8e',
+		'28cc78828fb2383bf92a3738dc75fc83f57ae041884d790ca877e6f46b9a1c72',
+		'ba2a26024338b19b441c6b5aa2d6b8d66aea611fa474952952d859b0c40d46bc'
+	]);
+
+-- 3. Ergebnis im Klartext
+SELECT CASE
+	WHEN h = '72c4ef86b59a8477be01ab701541369a4a75055b645b79654ecb3d155c4ab46d'
+		THEN 'OK — Vorlage ist auf dem aktuellen Stand (Foto-Hinweis nur bei fehlender Datei).'
+	ELSE 'ACHTUNG — kein bekannter Seed, es wurde nichts geaendert. Angepasster Text, Hash: ' || h
+END AS ergebnis
+FROM (
+	SELECT encode(sha256(convert_to(value #>> '{}', 'UTF8')), 'hex') AS h
+	FROM app_config
+	WHERE key = 'notification.email.template'
+) t;
+
+COMMIT;
+
+-- Laufende Instanzen halten die alte Vorlage bis zu 5 Minuten im Config-Cache.

--- a/src/lib/server/db/sightingFilesRepository.test.ts
+++ b/src/lib/server/db/sightingFilesRepository.test.ts
@@ -5,6 +5,7 @@ import type { UploadedFileInfo } from '$lib/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { sightingFiles } from './schema';
 import {
+	countFilesForSighting,
 	deleteFileByPath,
 	saveUploadedFile,
 	setSightingIdForReferenceId,
@@ -213,6 +214,38 @@ describe('sightingFilesRepository', () => {
 			mockDb.select.mockReturnValue({ from: fromMock });
 
 			const result = await sumFileSizesForReference('ref-leer');
+
+			expect(result).toBe(0);
+			expect(result).not.toBeNaN();
+		});
+	});
+
+	/**
+	 * Zählt die an einer Sichtung hängenden Dateien. Die Benachrichtigungs-Mail
+	 * entscheidet damit, ob der Hinweis „Foto angekündigt, kommt per E-Mail
+	 * nach" überhaupt zutrifft — bei einer Meldung über das Web-Formular ist die
+	 * Datei zum Versandzeitpunkt bereits verknüpft.
+	 */
+	describe('countFilesForSighting', () => {
+		it('sollte die Anzahl der verknüpften Dateien zurückgeben', async () => {
+			const mockDb = db as any;
+			const whereMock = vi.fn().mockResolvedValue([{ count: 2 }]);
+			const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.select.mockReturnValue({ from: fromMock });
+
+			const result = await countFilesForSighting(42);
+
+			expect(result).toBe(2);
+			expect(fromMock).toHaveBeenCalledWith(sightingFiles);
+		});
+
+		it('sollte 0 zurückgeben, wenn keine Zeile zurückkommt', async () => {
+			const mockDb = db as any;
+			const whereMock = vi.fn().mockResolvedValue([]);
+			const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+			mockDb.select.mockReturnValue({ from: fromMock });
+
+			const result = await countFilesForSighting(42);
 
 			expect(result).toBe(0);
 			expect(result).not.toBeNaN();

--- a/src/lib/server/db/sightingFilesRepository.ts
+++ b/src/lib/server/db/sightingFilesRepository.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '$lib/logger.server';
 import type { UploadedFileInfo } from '$lib/types';
-import { eq, sum } from 'drizzle-orm';
+import { count, eq, sum } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { db } from '.';
 import { sightingFiles } from './schema';
@@ -66,6 +66,23 @@ export async function sumFileSizesForReference(referenceId: string): Promise<num
 		.where(eq(sightingFiles.referenceId, referenceId));
 
 	return Number(row?.total ?? 0);
+}
+
+/**
+ * Anzahl der an einer Sichtung hängenden Dateien.
+ *
+ * Aufrufer ist die Benachrichtigungs-Mail: Sie entscheidet damit, ob der
+ * Hinweis „Foto angekündigt, kommt per E-Mail nach" überhaupt zutrifft
+ * (`$lib/utils/media/photoAnnouncement.ts`). Bewusst nicht `loadSightingFiles`
+ * — das lädt EXIF-Daten und baut URLs, für eine Zahl ist das der falsche Weg.
+ */
+export async function countFilesForSighting(sightingId: number): Promise<number> {
+	const [row] = await db
+		.select({ count: count() })
+		.from(sightingFiles)
+		.where(eq(sightingFiles.sightingId, sightingId));
+
+	return Number(row?.count ?? 0);
 }
 
 export async function setSightingIdForReferenceId(

--- a/src/lib/server/services/emailService.test.ts
+++ b/src/lib/server/services/emailService.test.ts
@@ -59,6 +59,10 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
+vi.mock('$lib/server/db/sightingFilesRepository', () => ({
+	countFilesForSighting: vi.fn().mockResolvedValue(0)
+}));
+
 vi.mock('nodemailer', () => ({
 	default: {
 		createTransport: vi.fn()
@@ -91,6 +95,7 @@ vi.mock('$lib/utils/format/dateTime', () => ({
 
 import { ConfigRepository } from '$lib/server/db/configRepository';
 import { db } from '$lib/server/db';
+import { countFilesForSighting } from '$lib/server/db/sightingFilesRepository';
 import nodemailer from 'nodemailer';
 import { readFileSync } from 'fs';
 import {
@@ -170,6 +175,9 @@ function createMockSighting(overrides = {}) {
 		latitude: '54.5',
 		longitude: '12.3',
 		sightingDate: new Date('2024-06-15'),
+		// Nach `NEW_IOS_CLIENT_LAUNCH_DATE` — sonst schlösse die Foto-Ankündigung
+		// schon an der Zeitgrenze aus, und die Tests darüber prüften nichts.
+		created: new Date('2026-08-03T10:00:00.000Z'),
 		juvenileCount: 0,
 		sightingFrom: 1,
 		mediaUpload: null,
@@ -224,6 +232,10 @@ describe('EmailService', () => {
 		} as any);
 		vi.mocked(isUnknownOrMissingSpecies).mockReturnValue(false);
 		vi.mocked(formatLocalDateTime).mockReturnValue('15.06.2024');
+
+		// `clearAllMocks` nimmt auch den Rückgabewert aus der Mock-Fabrik —
+		// ohne diese Zeile liefert der Zähler `undefined` statt einer Zahl.
+		vi.mocked(countFilesForSighting).mockResolvedValue(0);
 	});
 
 	afterEach(() => {
@@ -595,29 +607,23 @@ describe('EmailService', () => {
 		// eintreffende Foto-Mail zuzuordnen ist.
 		// ------------------------------------------------------------------
 		describe('Foto-Ankündigung im Template-Kontext', () => {
-			async function renderMailFor(mediaUpload: unknown): Promise<string> {
+			async function renderMailFor({
+				mediaUpload,
+				attachedFiles = 0,
+				created = new Date('2026-08-03T10:00:00.000Z')
+			}: {
+				mediaUpload: unknown;
+				attachedFiles?: number;
+				created?: Date;
+			}): Promise<string> {
 				vi.mocked(db.select).mockReturnValue({
 					from: vi.fn().mockReturnValue({
 						where: vi.fn().mockReturnValue({
-							limit: vi.fn().mockResolvedValue([createMockSighting({ mediaUpload })])
+							limit: vi.fn().mockResolvedValue([createMockSighting({ mediaUpload, created })])
 						})
 					})
 				} as any);
-
-				// Der globale Mock in `beforeEach` liefert ein festes Objekt ohne
-				// `mediaUpload`. Hier stattdessen wie die echte Implementierung
-				// das Feld unverändert durchreichen (`...restSighting` in
-				// `formatSightingForDisplay`) — sonst prüfte der Test nur den
-				// eigenen Mock, nicht die Verdrahtung von `loadSightingForEmail`.
-				vi.mocked(formatSightingForDisplay).mockImplementation(
-					(input) =>
-						({
-							species: 'Schweinswal',
-							sightingDate: '15.06.2024',
-							coordinatesFormatted: '54.5000° N, 12.3000° O',
-							mediaUpload: input.mediaUpload
-						}) as any
-				);
+				vi.mocked(countFilesForSighting).mockResolvedValue(attachedFiles);
 
 				setupConfigRepositoryMocks({
 					enabled: true,
@@ -625,7 +631,7 @@ describe('EmailService', () => {
 					// Minimale Vorlage — prüft die Verdrahtung, nicht das Layout des
 					// ausgelieferten Textes (das übernimmt notificationEmailDefault.test.ts).
 					template:
-						'<html>{{#if sighting.mediaUpload}}foto-angekuendigt:{{referenceId}}{{/if}}</html>'
+						'<html>{{#if photoAnnouncementPending}}foto-angekuendigt:{{referenceId}}{{/if}}</html>'
 				});
 				await EmailService.initialize(false);
 
@@ -635,22 +641,50 @@ describe('EmailService', () => {
 				return (mailOptions as { html: string }).html;
 			}
 
-			it('reicht ein gesetztes Flag als sighting.mediaUpload an die Vorlage durch', async () => {
-				const html = await renderMailFor(1);
+			it('kündigt das Foto an, wenn das Flag gesetzt und keine Datei angehängt ist', async () => {
+				const html = await renderMailFor({ mediaUpload: 1 });
 
 				expect(html).toContain('foto-angekuendigt:REF-42');
 			});
 
+			// Der Fehlerfall aus preprod: Meldung über das Web-Formular. Dort
+			// setzt `ModernReportForm.svelte` `mediaUpload` genau dann, wenn eine
+			// Datei hochgeladen wurde — und die hängt beim Versand bereits an der
+			// Sichtung (`saveSighting` verknüpft sie in derselben Transaktion).
+			it('lässt den Block weg, wenn bereits eine Datei angehängt ist', async () => {
+				const html = await renderMailFor({ mediaUpload: 1, attachedFiles: 1 });
+
+				expect(html).not.toContain('foto-angekuendigt');
+			});
+
 			it('lässt den Block weg, wenn kein Foto angekündigt wurde', async () => {
-				const html = await renderMailFor(0);
+				const html = await renderMailFor({ mediaUpload: 0 });
 
 				expect(html).not.toContain('foto-angekuendigt');
 			});
 
 			it('lässt den Block bei null (kein Wert in der Zeile) ebenfalls weg', async () => {
-				const html = await renderMailFor(null);
+				const html = await renderMailFor({ mediaUpload: null });
 
 				expect(html).not.toContain('foto-angekuendigt');
+			});
+
+			// Vor dem Start des neuen iOS-Clients bedeutete das Flag nur „der
+			// Melder hatte ein Foto" — siehe photoAnnouncement.ts. Erreichbar ist
+			// der Fall über `import-legacy-inbox.js` und die Admin-Test-Mail.
+			it('lässt den Block bei einer Sichtung aus der Zeit vor dem Client weg', async () => {
+				const html = await renderMailFor({
+					mediaUpload: 1,
+					created: new Date('2024-06-15T10:00:00.000Z')
+				});
+
+				expect(html).not.toContain('foto-angekuendigt');
+			});
+
+			it('zählt die Dateien der geladenen Sichtung', async () => {
+				await renderMailFor({ mediaUpload: 1 });
+
+				expect(countFilesForSighting).toHaveBeenCalledWith(42);
 			});
 		});
 

--- a/src/lib/server/services/emailService.ts
+++ b/src/lib/server/services/emailService.ts
@@ -21,6 +21,8 @@ import {
 } from '$lib/server/templates/balticSeaEmailContext';
 import { emailColorContext } from '$lib/server/templates/emailTokens';
 import { NOTIFICATION_EMAIL_DEFAULT_TEMPLATE } from '$lib/server/templates/notificationEmailDefault';
+import { countFilesForSighting } from '$lib/server/db/sightingFilesRepository';
+import { isPhotoAnnouncementPending } from '$lib/utils/media/photoAnnouncement';
 
 // Dynamic environment variables for Docker runtime
 const NODE_ENV = env.NODE_ENV ?? 'development';
@@ -264,7 +266,8 @@ export class EmailService {
 			sightingData.sightingFormValues,
 			sightingData.referenceId,
 			sightingData.adminUrl,
-			sightingData.balticSea
+			sightingData.balticSea,
+			sightingData.photoAnnouncementPending
 		);
 	}
 
@@ -277,6 +280,7 @@ export class EmailService {
 		referenceId: string;
 		adminUrl: string;
 		balticSea: BalticSeaEmailContext;
+		photoAnnouncementPending: boolean;
 	} | null> {
 		try {
 			const sightingResult = await db
@@ -354,10 +358,26 @@ export class EmailService {
 			const adminUrl = `${getPublicSiteUrl()}/admin/${sightingId}`;
 			const referenceId = sighting.referenceId || `REF-${sightingId}`;
 
+			// Nur zählen, wenn überhaupt ein Foto angekündigt ist — ohne Flag
+			// trägt die Zahl keine Aussage und die Abfrage keinen Zweck.
+			const attachedFileCount = sighting.mediaUpload ? await countFilesForSighting(sightingId) : 0;
+
 			return {
 				sightingFormValues,
 				referenceId,
 				adminUrl,
+				// Dieselbe Aussage wie in der Admin-Detailansicht: „angekündigt und
+				// noch nichts da". Das rohe Flag genügt hier **nicht** — das
+				// Web-Formular setzt es genau dann, wenn eine Datei hochgeladen
+				// wurde (`ModernReportForm.svelte`), und die hängt beim Versand
+				// bereits an der Sichtung (`saveSighting` verknüpft sie in
+				// derselben Transaktion). Über das Flag allein behauptete die Mail
+				// bei jedem angehängten Foto, es käme noch eines per E-Mail nach.
+				photoAnnouncementPending: isPhotoAnnouncementPending(
+					sighting.mediaUpload,
+					attachedFileCount,
+					sighting.created
+				),
 				// Aus der **Rohzeile**, nicht aus `sightingFormValues`: das `!!` oben
 				// verliert den Altsystem-Wert 2 und macht `noPosition` unerreichbar.
 				// Derselbe Aufruf wie in der Admin-Übersicht — der Status entsteht
@@ -408,7 +428,8 @@ export class EmailService {
 		sightingFormValues: SightingFormValues,
 		referenceId: string,
 		adminUrl: string,
-		balticSea: BalticSeaEmailContext
+		balticSea: BalticSeaEmailContext,
+		photoAnnouncementPending: boolean
 	): Promise<boolean> {
 		try {
 			const blocker = await this.findNotificationBlocker();
@@ -452,6 +473,10 @@ export class EmailService {
 				// Der Ostsee-Status liegt unter `sighting.balticSea` — die Vorlage
 				// verzweigt darüber und nicht mehr über die beiden Rohflags.
 				sighting: { ...formattedSighting, balticSea },
+				// Auf oberster Ebene und nicht unter `sighting`: Der Wert steht
+				// für keine Spalte, sondern für den Zustand „angekündigt, noch
+				// nichts da" (siehe `loadSightingForEmail`).
+				photoAnnouncementPending,
 				adminUrl,
 				currentDate: formatLocalDateTime(new Date(), 'date'),
 				currentTime: formatLocalDateTime(new Date(), 'time'),

--- a/src/lib/server/templates/notificationEmailDefault.test.ts
+++ b/src/lib/server/templates/notificationEmailDefault.test.ts
@@ -114,15 +114,22 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 	 * hochladen — es kommt separat per E-Mail nach. Ohne einen Hinweis in
 	 * dieser Mail lässt sich eine später eintreffende Foto-Mail keiner
 	 * Sichtung zuordnen.
+	 *
+	 * **Die Vorlage verzweigt über `photoAnnouncementPending`, nicht über
+	 * `sighting.mediaUpload`.** Das Web-Formular setzt dasselbe Flag, sobald
+	 * eine Datei hochgeladen wurde (`ModernReportForm.svelte`) — über das rohe
+	 * Flag behauptete die Mail dann bei einem angehängten Foto, es käme noch
+	 * eines per E-Mail nach.
 	 */
 	describe('Foto-Ankündigung', () => {
-		function renderWithMediaUpload(mediaUpload: boolean) {
+		function renderWithAnnouncement(photoAnnouncementPending: boolean, mediaUpload = true) {
 			return render({
 				referenceId: 'REF-77',
 				adminUrl: 'https://example.com/admin/1',
 				currentDate: '30.07.2026',
 				currentTime: '12:00',
 				spamCheck: { score: 0, isHighRisk: false, indicators: [] },
+				photoAnnouncementPending,
 				sighting: {
 					species: 'Schweinswal',
 					sightingDate: '30.07.2026',
@@ -135,7 +142,7 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 		}
 
 		it('weist beim Empfänger auf das nachfolgende Foto hin und nennt die Referenz-ID', () => {
-			const html = renderWithMediaUpload(true);
+			const html = renderWithAnnouncement(true);
 
 			expect(html).toContain('Foto angekündigt');
 			// Referenz-ID steht bereits im Kopfbereich — hier zählt, dass sie
@@ -144,7 +151,16 @@ describe('NOTIFICATION_EMAIL_DEFAULT_TEMPLATE — Ostsee-Status', () => {
 		});
 
 		it('lässt den Hinweis weg, wenn kein Foto angekündigt wurde', () => {
-			const html = renderWithMediaUpload(false);
+			const html = renderWithAnnouncement(false, false);
+
+			expect(html).not.toContain('Foto angekündigt');
+		});
+
+		// Der Fehlerfall aus preprod: Meldung über das Web-Formular mit
+		// hochgeladenem Bild. `mediaUpload` ist gesetzt, das Foto liegt aber
+		// bereits vor — es kommt keines mehr per E-Mail nach.
+		it('lässt den Hinweis weg, wenn das Foto bereits angehängt ist', () => {
+			const html = renderWithAnnouncement(false, true);
 
 			expect(html).not.toContain('Foto angekündigt');
 		});
@@ -340,7 +356,7 @@ describe('Fingerabdruck des ausgelieferten Stands', () => {
 			.update(NOTIFICATION_EMAIL_DEFAULT_TEMPLATE, 'utf8')
 			.digest('hex');
 
-		expect(hash).toBe('2527b475241de0f1039f9cca27c920997f6e14bed4bc6ce087689dc6617ed392');
+		expect(hash).toBe('72c4ef86b59a8477be01ab701541369a4a75055b645b79654ecb3d155c4ab46d');
 	});
 
 	it('führt den aktuellen Stand nicht als früheren Stand', () => {

--- a/src/lib/utils/media/photoAnnouncement.ts
+++ b/src/lib/utils/media/photoAnnouncement.ts
@@ -19,12 +19,19 @@
  *
  * **Einzige Stelle, an der dieser Zustand entsteht** — analog zu
  * `getBalticSeaStatus()` in `$lib/utils/geo/balticSeaStatus.ts`. Angeschlossen
- * sind die Admin-Detailansicht (`AdminSightingView.svelte`) und der
+ * sind die Admin-Detailansicht (`AdminSightingView.svelte`), der
  * Datenbank-Filter für die Admin-Arbeitsliste
- * (`$lib/server/db/mediaUploadFilter.ts`). Die Benachrichtigungs-Mail prüft
- * dagegen nur das rohe Flag: beim Versand — unmittelbar nach dem Anlegen der
- * Sichtung — kann noch keine Datei angehängt sein, der Dateizähler wäre dort
- * immer 0 und träfe keine zusätzliche Aussage.
+ * (`$lib/server/db/mediaUploadFilter.ts`) und die Benachrichtigungs-Mail
+ * (`emailService.loadSightingForEmail()`).
+ *
+ * **Die Mail prüfte bis 2026-08-05 nur das rohe Flag**, mit der Begründung,
+ * beim Versand könne noch keine Datei angehängt sein. Das ist falsch: Das
+ * Web-Formular setzt `mediaUpload` genau dann, wenn eine Datei hochgeladen
+ * wurde (`ModernReportForm.svelte`), und `saveSighting` verknüpft sie in
+ * derselben Transaktion, bevor der fire-and-forget-Versand startet. Der
+ * Dateizähler ist dort also gerade nicht 0 — die Mail kündigte bei jedem über
+ * das Formular hochgeladenen Foto ein noch nachkommendes an (in preprod
+ * aufgefallen).
  */
 
 /** Zählt als „gesetzt", egal ob DB-Integer (0/1) oder Formular-Boolean. */


### PR DESCRIPTION
## Problem

Zwei Testmeldungen in preprod haben je ein Bild angehängt — hochgeladen über die GPS-Erkennung, im Medien-Panel und in der Sichtungs-Detailansicht korrekt sichtbar. Die Benachrichtigungs-Mail behauptete trotzdem:

> 📷 **Foto angekündigt:** Der Melder hat laut App ein Foto, kann es aber nicht direkt hochladen — es kommt separat per E-Mail nach. Beim Eintreffen bitte anhand der Referenz-ID … zuordnen.

## Ursache

Die Vorlage verzweigte über das rohe Flag `{{#if sighting.mediaUpload}}`. Begründet war das im Modulkommentar von `photoAnnouncement.ts` mit „beim Versand kann noch keine Datei angehängt sein, der Dateizähler wäre dort immer 0".

Für den Web-Pfad stimmt das nicht:

1. `ModernReportForm.svelte:135` setzt `mediaUpload` **genau dann**, wenn eine Datei hochgeladen wurde.
2. `saveSighting` verknüpft die Dateien in derselben Transaktion (`setSightingIdForReferenceId`).
3. Erst danach startet der fire-and-forget-Versand in `POST /api/sightings`.

Der Zähler ist beim Versand also gerade nicht 0 — jedes über das Formular hochgeladene Foto erzeugte die Ankündigung. Für den iOS-Client (`OstSeeTiere/8`), für den der Hinweis gebaut wurde, bleibt er unverändert richtig: der schickt keine Datei mit.

## Änderung

- **Neu `countFilesForSighting()`** in `sightingFilesRepository.ts` — reine Zahl statt `loadSightingFiles` (das lädt EXIF und baut URLs).
- **`emailService.ts`** berechnet `photoAnnouncementPending` über die bereits vorhandene gemeinsame Funktion `isPhotoAnnouncementPending(flag, dateien, created)` — dieselbe Aussage wie Admin-Detailansicht und Arbeitslisten-Filter, statt einer dritten Herleitung. Gezählt wird nur, wenn das Flag überhaupt gesetzt ist.
- **Vorlage** verzweigt über `{{#if photoAnnouncementPending}}`; Fassungs-Hash gepinnt, alter Hash in `PREVIOUS_SHIPPED_TEMPLATE_HASHES` eingetragen.
- **Modulkommentar in `photoAnnouncement.ts` korrigiert** — die falsche Begründung stand ausdrücklich dort und hätte den Fix sonst wieder eingeladen.

## Tests (TDD, erst rot)

- `emailService.test.ts`: Datei angehängt → kein Hinweis; Flag ohne Datei → Hinweis; `0`/`null` → kein Hinweis; Sichtung von vor dem Client-Start → kein Hinweis; der Zähler wird mit der richtigen ID aufgerufen.
- `notificationEmailDefault.test.ts`: der preprod-Fehlerfall (Flag gesetzt **und** Datei da) rendert den Block nicht.
- `sightingFilesRepository.test.ts`: Zähler inkl. leerer Ergebnismenge.

`npm run test:quick` grün (234 Dateien, 3522 Tests).

## Für den Reviewer / nach dem Merge

Der Seed in `app_config` **gewinnt gegen den Code-Default** — ohne Nachzug bleibt der Hinweis auf preprod und prod falsch:

```bash
npm run config:refresh-email-template
```

Auf Hosts ohne Checkout (das Runtime-Image enthält `src/tools/` nicht) das beiliegende `scripts/migrations/2026-08-05-notification-email-foto-ankuendigung.sql` einspielen; der Aufrufweg steht im Kopf der Datei. Die Nutzlast ist verifiziert byte-identisch mit der Konstante, und ein im Admin-Bereich angepasster Text bleibt unangetastet (Hash-Bedingung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)