### PR TITLE
fix(report): hide the dead-find fields from step validation in the alive branch

### DIFF
--- a/src/lib/report/fieldsOutsideReportKind.test.ts
+++ b/src/lib/report/fieldsOutsideReportKind.test.ts
@@ -57,24 +57,31 @@ describe('fieldsOutsideReportKind', () => {
 	});
 
 	/**
-	 * Kein Vollständigkeits-Cross-Check über `getFormSteps` für die `'alive'`-
-	 * Richtung: `FOREIGN_TO_ALIVE` ist eine handgepflegte Liste, weil
-	 * `getFormSteps` die Totfund-Felder in keinem Zweig aus der Schritt-
-	 * Konfiguration entfernt (Begründung im Kopf von `fieldsOutsideReportKind.ts`)
-	 * — es gibt dort keine einzige Quelle, gegen die sich das ohne Umbau von
-	 * `formConfig.ts` prüfen ließe. Diese Prüfung ist deshalb die billigere,
-	 * erreichbare Absicherung: Jedes Feld aus der handgepflegten Liste muss
-	 * wenigstens ein echtes Schema-Feld sein, das in der Schritt-Konfiguration
-	 * auch tatsächlich vorkommt — ein Tippfehler oder eine spätere Umbenennung
-	 * in `formConfig.ts` fällt damit auf. Eine Aussage über VOLLSTÄNDIGKEIT
-	 * (fehlt dort ein Feld, das eigentlich dazugehört) trifft sie nicht.
+	 * Seit dem 2026-08-06 gibt es die handgepflegte `FOREIGN_TO_ALIVE`-Liste
+	 * nicht mehr: `getFormSteps` entfernt die Totfund-Felder über
+	 * `HIDDEN_WHEN_ALIVE` selbst aus dem Lebend-Zweig, und beide Richtungen
+	 * fallen hier aus derselben Quelle an. Die Erwartungswerte oben bleiben
+	 * trotzdem feste Literale (B4) — nachgerechnet mit der Formel der
+	 * Implementierung könnten sie per Konstruktion nie rot werden.
+	 *
+	 * Diese Prüfung bleibt als billige Zusatzabsicherung: Was hier
+	 * herausfällt, muss in beiden Richtungen ein Feld sein, das in der
+	 * Schritt-Konfiguration überhaupt vorkommt. Ein Tippfehler in einer der
+	 * `HIDDEN_WHEN_*`-Listen — die `getFormSteps` still ignorieren würde, weil
+	 * sie nur filtert — fällt damit auf.
 	 */
-	it('jedes im Lebend-Zweig ausgeblendete Feld existiert tatsächlich in der Schritt-Konfiguration', () => {
-		const allFields = new Set(formStepsConfig.flatMap((step) => step.fields));
-		for (const field of fieldsOutsideReportKind('alive')) {
-			expect(allFields.has(field)).toBe(true);
+	it.each(['alive', 'dead'] as const)(
+		'jedes im Zweig "%s" ausgeblendete Feld existiert tatsächlich in der Schritt-Konfiguration',
+		(kind) => {
+			const allFields = new Set(formStepsConfig.flatMap((step) => step.fields));
+			const foreign = fieldsOutsideReportKind(kind);
+
+			expect(foreign.length).toBeGreaterThan(0);
+			for (const field of foreign) {
+				expect(allFields.has(field)).toBe(true);
+			}
 		}
-	});
+	);
 
 	it('ist rein — zweimaliger Aufruf mit demselben Zweig liefert dieselbe Liste', () => {
 		expect(fieldsOutsideReportKind('alive')).toEqual(fieldsOutsideReportKind('alive'));

--- a/src/lib/report/fieldsOutsideReportKind.ts
+++ b/src/lib/report/fieldsOutsideReportKind.ts
@@ -3,23 +3,6 @@ import type { ReportKind } from '$lib/report/reportKind';
 import type { SightingFormData } from '$lib/types';
 
 /**
- * Totfund-Felder, die im Lebend-Zweig nicht hingehören.
- *
- * Ohne Gegenstück in `getFormSteps`: Die Felder werden dort in keinem Zweig
- * aus der Schritt-Konfiguration entfernt — im Meldeformular blendet einzig
- * `AnimalInfo.svelte` den `DeadAnimal`-Block per
- * `{#if isDeadFinding($form.isDead)}` optisch aus. Eine einzige Quelle für
- * beide Richtungen (siehe unten) ist deshalb hier nicht möglich, ohne
- * `getFormSteps` mit anzufassen — das wäre eine Änderung an der
- * Schritt-Validierung, die dieser Task nicht verlangt.
- */
-const FOREIGN_TO_ALIVE: (keyof SightingFormData)[] = [
-	'deadCondition',
-	'deadSize',
-	'deadPhoneContact'
-];
-
-/**
  * Felder, die NICHT in den angegebenen Zweig gehören — unabhängig davon, ob
  * und wie oft vorher gewechselt wurde. Ein `behavior`, das im Formularzustand
  * steht, während der Melder im Totfund-Zweig ist, ginge beim Absenden mit ans
@@ -36,12 +19,18 @@ const FOREIGN_TO_ALIVE: (keyof SightingFormData)[] = [
  * zweigfremde Daten aus einer älteren Sitzung im localStorage liegen, den ein
  * Wechsel-Vergleich nie sähe, und ist idempotent.
  *
- * Für den Totfund-Zweig aus `getFormSteps` abgeleitet (einzige Quelle: genau
- * die Felder, die dort beim Totfund aus der Schritt-Konfiguration verschwinden)
- * statt einer zweiten, von Hand gepflegten Liste.
+ * Für BEIDE Zweige aus `getFormSteps` abgeleitet (einzige Quelle: genau die
+ * Felder, die dort im jeweils anderen Zweig aus der Schritt-Konfiguration
+ * verschwinden) statt einer zweiten, von Hand gepflegten Liste. Bis zum
+ * 2026-08-06 ging das nur für den Totfund-Zweig: `getFormSteps` kannte nur
+ * `HIDDEN_WHEN_DEAD`, die Totfund-Felder blendete allein das Markup aus, und
+ * `FOREIGN_TO_ALIVE` stand hier als handgepflegtes Literal daneben. Mit
+ * `HIDDEN_WHEN_ALIVE` (`formConfig.ts`) ist die Schritt-Konfiguration in beide
+ * Richtungen symmetrisch — und die Liste hier fällt in beide Richtungen aus
+ * derselben Quelle an.
  *
- * Abschlussreview B4: Der Vergleich läuft bewusst gegen `getFormSteps({ isDead: false })`
- * und NICHT gegen `formStepsConfig` direkt. `getFormSteps` bildet mittlerweile
+ * Abschlussreview B4: Der Vergleich läuft bewusst zwischen den beiden
+ * `getFormSteps`-Aufrufen und NICHT gegen `formStepsConfig` direkt. `getFormSteps` bildet mittlerweile
  * drei Achsen ab — Totfund (`isDead`), Beobachtungsort (`sightingFrom`) und
  * Medien-Upload (`uploadedFiles`, über `hasUploadedMedia`) — und diese Funktion
  * darf ausschließlich die erste beantworten. Ein Diff gegen `formStepsConfig`
@@ -57,11 +46,14 @@ const FOREIGN_TO_ALIVE: (keyof SightingFormData)[] = [
  * außen vor, solange sie nicht von `isDead` abhängt — keine Anpassung hier nötig.
  */
 export function fieldsOutsideReportKind(kind: ReportKind): (keyof SightingFormData)[] {
-	if (kind === 'alive') {
-		return [...FOREIGN_TO_ALIVE];
-	}
-
 	const keptWhenAlive = getFormSteps({ isDead: false }).flatMap((step) => step.fields);
-	const keptWhenDead = new Set(getFormSteps({ isDead: true }).flatMap((step) => step.fields));
-	return keptWhenAlive.filter((field) => !keptWhenDead.has(field)) as (keyof SightingFormData)[];
+	const keptWhenDead = getFormSteps({ isDead: true }).flatMap((step) => step.fields);
+
+	// Was der ANDERE Zweig führt und dieser nicht: die Felder, die im aktuellen
+	// Zweig nichts verloren haben.
+	const [kept, foreign] =
+		kind === 'alive' ? [keptWhenAlive, keptWhenDead] : [keptWhenDead, keptWhenAlive];
+	const keptSet = new Set(kept);
+
+	return foreign.filter((field) => !keptSet.has(field)) as (keyof SightingFormData)[];
 }

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -117,9 +117,17 @@ describe('formStepsConfig — Geschlecht beim Totfund nur in der Admin-Maske', (
 		expect(sightingDetailsStep?.fields).not.toContain('deadSex');
 	});
 
-	// Gegenprobe: Nur `deadSex` verschwindet, die übrigen Totfund-Felder
-	// bleiben Teil des Melde-Schritts. `isDead` steht hier NICHT mehr —
-	// Task 7 nimmt es ebenfalls heraus, siehe die eigene Beschreibung unten.
+	// Gegenprobe: Nur `deadSex` verschwindet aus der Schritt-Konfiguration, die
+	// übrigen Totfund-Felder bleiben Teil des Melde-Schritts. `isDead` steht
+	// hier NICHT mehr — Task 7 nimmt es ebenfalls heraus, siehe die eigene
+	// Beschreibung unten.
+	//
+	// Geprüft wird `formStepsConfig`, also der ungefilterte Bestand: Ob die drei
+	// Felder im konkreten Zweig auch validiert werden, entscheidet seit
+	// `HIDDEN_WHEN_ALIVE` erst `getFormSteps` — dazu die eigene Beschreibung
+	// „getFormSteps — Totfund-Felder nur im Totfund-Zweig" weiter unten. Der
+	// Unterschied ist der springende Punkt dieser Gegenprobe: `deadSex` ist
+	// dauerhaft draußen, die drei hier nur zweigabhängig.
 	it.each(['deadCondition', 'deadSize', 'deadPhoneContact'])(
 		'behält %s im Schritt "sighting-details"',
 		(name) => {
@@ -371,6 +379,40 @@ describe('getFormSteps', () => {
 		expect(fields).not.toContain('behavior');
 		expect(fields).not.toContain('behaviorText');
 		expect(fields).not.toContain('reaction');
+	});
+
+	/**
+	 * Gegenrichtung zu `HIDDEN_WHEN_DEAD`: Ein lebendes Tier hat keinen
+	 * Verwesungszustand und keine Bergungslänge. Die drei Felder waren bis
+	 * hierher NUR im Markup ausgeblendet (`AnimalInfo.svelte`, `{#if
+	 * isDeadFinding($form.isDead)}`) und blieben im Lebend-Zweig trotzdem
+	 * validiert — genau die Hälfte-ohne-die-andere, vor der die Kopfkommentare
+	 * von `HIDDEN_WHEN_DEAD`/`HIDDEN_WHEN_FROM_LAND` warnen. Praktisch spürbar
+	 * wurde das bei `deadSize`: Dessen `min(0)`/`max(300)`/`integer()` hängen
+	 * NICHT an `isDead` und hätten „Weiter" auf Schritt 2 wegen eines Feldes
+	 * gesperrt, das der Melder im Lebend-Zweig nicht sehen und nicht
+	 * korrigieren kann.
+	 */
+	it('entfernt im Lebend-Zweig genau die drei Totfund-Felder', () => {
+		const fields = fieldsOf(getFormSteps({ isDead: false }));
+		expect(fields).not.toContain('deadCondition');
+		expect(fields).not.toContain('deadSize');
+		expect(fields).not.toContain('deadPhoneContact');
+	});
+
+	it('behält die drei Totfund-Felder beim Totfund', () => {
+		const fields = fieldsOf(getFormSteps({ isDead: true }));
+		expect(fields).toEqual(
+			expect.arrayContaining(['deadCondition', 'deadSize', 'deadPhoneContact'])
+		);
+	});
+
+	// Wie bei den Verhaltensfeldern: Der Zweig kommt auch als DB-Zahl oder
+	// Storage-String an. Ein `'1'` darf die Totfund-Felder nicht wegräumen.
+	it('behält die Totfund-Felder auch bei isDead als Zahl oder String', () => {
+		expect(fieldsOf(getFormSteps({ isDead: 1 }))).toContain('deadCondition');
+		expect(fieldsOf(getFormSteps({ isDead: '1' }))).toContain('deadCondition');
+		expect(fieldsOf(getFormSteps({ isDead: 0 }))).not.toContain('deadCondition');
 	});
 
 	it('lässt beim Totfund Wetter, Anzahl anderer Schiffe und Entfernung stehen', () => {

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -245,6 +245,47 @@ export function isDeadFinding(value: unknown): boolean {
 const HIDDEN_WHEN_DEAD = ['behavior', 'behaviorText', 'reaction'] as const;
 
 /**
+ * Die Gegenrichtung: Felder, die im Lebend-Zweig entfallen. Ein lebendes Tier
+ * hat keinen Verwesungszustand, keine am Strand gemessene Körperlänge und
+ * niemanden, der deswegen schon beim Meeresmuseum angerufen hätte.
+ *
+ * Nachgezogen am 2026-08-06. Bis dahin blendete diese Felder ausschließlich
+ * das Markup aus (`sections/AnimalInfo.svelte`, `{#if isDeadFinding($form.isDead)}`
+ * um den `DeadAnimal`-Block) — die Schritt-Konfiguration führte sie in BEIDEN
+ * Zweigen. Das ist genau die „nur eine Hälfte"-Lage, vor der der Kopf von
+ * `HIDDEN_WHEN_DEAD` oben warnt, nur in der selteneren Richtung: sichtbar
+ * nichts, validiert trotzdem.
+ *
+ * Folgenlos war das nicht bloß theoretisch. `deadSize` trägt
+ * `integer()`/`min(0)`/`max(300)` UNBEDINGT — sein `when('isDead')` ist ein
+ * No-op (`notRequired()` in beiden Zweigen), am Zustand des Tieres hängt bei
+ * diesem Feld also gar nichts. Ein zweigfremder Wert im Formular-Zustand (aus
+ * dem localStorage einer früheren Sitzung) hätte damit „Weiter" auf Schritt 2
+ * gesperrt, mit einem Fehler an einem Feld, das der Melder im Lebend-Zweig
+ * weder sieht noch erreichen kann. Praktisch abgefangen hat das bisher
+ * `fieldsOutsideReportKind` (räumt dieselben Felder beim Start aus dem
+ * Zustand) — aber als zweite, unabhängig gepflegte Absicherung, nicht als
+ * Regel an der Stelle, an der die Validierung entsteht.
+ *
+ * Dieselbe „halbe Miete"-Warnung gilt hier deshalb weiter: Eintrag hier UND die
+ * Bedingung im Markup, beide über `isDeadFinding` — Markup-Seite ist
+ * `sections/AnimalInfo.svelte`. Die Felder selbst liegen in
+ * `sections/DeadAnimal.svelte` und bleiben unverändert, die Admin-Maske zeigt
+ * sie über denselben Block weiter (sie ruft `getFormSteps` gar nicht auf,
+ * sondern validiert gegen `adminSightingSchema`).
+ *
+ * `deadSex` und `isDead` fehlen in der Liste, weil sie in `formStepsConfig`
+ * ohnehin nicht mehr stehen (Begründungen dort) — ein Eintrag hier wäre
+ * wirkungslos.
+ *
+ * **Nicht exportiert**, anders als `HIDDEN_WHEN_FROM_LAND`: Der zweite
+ * Interessent, `fieldsOutsideReportKind.ts`, leitet seit dieser Änderung BEIDE
+ * Zweige aus `getFormSteps` ab (Differenz der beiden Aufrufe) statt aus den
+ * Listen selbst. Ein Export wäre eine zweite Quelle für dieselbe Aussage.
+ */
+const HIDDEN_WHEN_ALIVE = ['deadCondition', 'deadSize', 'deadPhoneContact'] as const;
+
+/**
  * Felder, die das EIGENE Wasserfahrzeug betreffen. Sie entfallen, wenn von Land
  * gemeldet wurde.
  *
@@ -375,6 +416,8 @@ export function getFormSteps(data: FormStepsInput): FormStep[] {
 	const hidden = new Set<string>();
 	if (isDeadFinding(data.isDead)) {
 		HIDDEN_WHEN_DEAD.forEach((field) => hidden.add(field));
+	} else {
+		HIDDEN_WHEN_ALIVE.forEach((field) => hidden.add(field));
 	}
 	if (isFromLand(data.sightingFrom)) {
 		HIDDEN_WHEN_FROM_LAND.forEach((field) => hidden.add(field));
@@ -383,10 +426,10 @@ export function getFormSteps(data: FormStepsInput): FormStep[] {
 		hidden.add('mediaConsent');
 	}
 
-	if (hidden.size === 0) {
-		return formStepsConfig;
-	}
-
+	// Kein `if (hidden.size === 0) return formStepsConfig` mehr: Seit
+	// `HIDDEN_WHEN_ALIVE` beantwortet der Totfund-Zweig oben BEIDE Richtungen,
+	// und damit ist die Menge nie leer — der Schnellpfad war ab da toter Code,
+	// der in dieser Datei wie eine begründete Entscheidung gelesen worden wäre.
 	return formStepsConfig.map((step) => ({
 		...step,
 		fields: step.fields.filter((field) => !hidden.has(field))


### PR DESCRIPTION
## Problem

`deadCondition`, `deadSize` and `deadPhoneContact` were hidden by **markup only** — `sections/AnimalInfo.svelte:74` gates the `DeadAnimal` block on `{#if isDeadFinding($form.isDead)}`, while `getFormSteps` kept all three in `sighting-details` for **both** branches.

That is exactly the "nur eine Hälfte" situation the `HIDDEN_WHEN_DEAD` header warns about (`.claude/rules/forms.md`, *Zwei-Hälften-Regel*), in the rarer direction: **invisible, but validated anyway**.

It was reachable, not just theoretical. `deadSize` carries `integer()`/`min(0)`/`max(300)` **unconditionally** — its `when('isDead')` is a no-op (`notRequired()` in both branches). A branch-foreign value in the form state would have locked "Weiter" on step 2 with an error on a field the reporter can neither see nor reach in the alive branch, and no visible message explaining why. What has been catching that so far is `fieldsOutsideReportKind` clearing the same fields at mount — a second, independently maintained safety net rather than a rule at the place where the validation is decided.

## Change

- **`formConfig.ts`** — new `HIDDEN_WHEN_ALIVE = ['deadCondition', 'deadSize', 'deadPhoneContact']`, applied as the `else` branch of the existing `isDeadFinding` check. Deliberately **not** exported (unlike `HIDDEN_WHEN_FROM_LAND`): the only other interested party derives from `getFormSteps` instead, so there is no second source for the same statement.
- **`formConfig.ts`** — dropped the `if (hidden.size === 0) return formStepsConfig` fast path. With both directions answered it can never be taken; in this file it would have read as a deliberate decision.
- **`fieldsOutsideReportKind.ts`** — both directions now fall out of the diff of the two `getFormSteps` calls; the hand-maintained `FOREIGN_TO_ALIVE` literal and the doc comment explaining why it had to exist are gone. The B4 reasoning (compare the two `getFormSteps` calls, never `formStepsConfig`, so the independent `mediaConsent` axis cancels out) is preserved and still holds.

## Explicitly untouched

- **Admin edit form** — `AdminSightingEditForm.svelte` imports neither `formConfig` nor `getFormSteps`; it validates against `adminSightingSchema` and renders sections directly. `DeadAnimal.svelte` is unchanged and still reached through the same `isDeadFinding` gate, so the admin mask keeps showing all fields.
- **Legacy REST API** — `field-mapping.ts` maps the `totfund_*` columns and never goes through `getFormSteps`.
- **Yup schema** and the DB columns.

## Verification

| Check | Result |
| --- | --- |
| `npm run test:quick` (lint + type-check + svelte-check + unit) | 3578/3578 |
| client browser tests (`vitest --project client`) | 512/512, 48 files |
| e2e `report-kind-choice.spec.ts` + `form-ux.spec.ts` | 25/25 |

Test-first: the two new `getFormSteps` cases were red before the implementation. The `fieldsOutsideReportKind` expectations stay fixed literals (B4) rather than being recomputed with the implementation's own formula, and its completeness check now covers both branches with a non-empty guard.

One follow-up was filed separately rather than folded in here: `deadSize`'s `when('isDead')` is the schema's only no-op `when()` and could be dropped — a schema change outside this change's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)