### PR TITLE
fix(report): move the ship count below the weather fields

### DIFF
--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -115,8 +115,8 @@
 	     werden, und `shipCount` ist das einzige Feld darin, das der Abruf nie
 	     füllt. Direkt unter diesem Satz las es sich wie ein Wetterfeld. Die
 	     Feldliste in `formConfig.ts` (Schritt `observations`) trägt dieselbe
-	     Reihenfolge — `scrollToFirstError` und `findStepForErrors` laufen sie
-	     ab, um zum ersten fehlerhaften Feld zu springen. -->
+	     Reihenfolge — `scrollToFirstError` läuft sie ab, um zum ersten
+	     fehlerhaften Feld zu springen. -->
 	{#if !adminMode}
 		<div class="mt-4 grid grid-cols-1 gap-4">
 			<FormField name="shipCount" />

--- a/src/lib/report/components/sections/Environment.svelte
+++ b/src/lib/report/components/sections/Environment.svelte
@@ -66,19 +66,6 @@
 		Sobald Position und Datum gesetzt sind, werden Wetterdaten automatisch vorgeschlagen.
 	</p>
 
-	<!-- `shipCount` fragt laut Schema nach der Anzahl ANDERER Schiffe in näherer
-	     Umgebung — Störungskontext wie Seegang und Sichtweite, keine Angabe zum
-	     eigenen Boot des Melders (Task 12, zog aus `BoatInfo.svelte` hierher
-	     um). Nur im Meldeformular: Die Admin-Maske zeigt das Feld bereits
-	     admin-only in `OptionalSightingDetails.svelte` — `BoatInfo` bindet sie
-	     nicht ein, `Environment` dagegen schon, ein zweites `shipCount` stünde
-	     hier doppelt im selben Formular. -->
-	{#if !adminMode}
-		<div class="mb-4 grid grid-cols-1 gap-4">
-			<FormField name="shipCount" />
-		</div>
-	{/if}
-
 	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 		<!-- Sea State -->
 		<FormField name="seaState" />
@@ -114,6 +101,27 @@
 			<FormField name="windDirection" />
 		{/if}
 	</div>
+
+	<!-- `shipCount` fragt laut Schema nach der Anzahl ANDERER Schiffe in näherer
+	     Umgebung — Störungskontext wie Seegang und Sichtweite, keine Angabe zum
+	     eigenen Boot des Melders (Task 12, zog aus `BoatInfo.svelte` hierher
+	     um). Nur im Meldeformular: Die Admin-Maske zeigt das Feld bereits
+	     admin-only in `OptionalSightingDetails.svelte` — `BoatInfo` bindet sie
+	     nicht ein, `Environment` dagegen schon, ein zweites `shipCount` stünde
+	     hier doppelt im selben Formular.
+
+	     Es steht hinter der Windstärke und nicht mehr an erster Stelle: Die
+	     Karte kündigt oben an, dass Wetterdaten automatisch vorgeschlagen
+	     werden, und `shipCount` ist das einzige Feld darin, das der Abruf nie
+	     füllt. Direkt unter diesem Satz las es sich wie ein Wetterfeld. Die
+	     Feldliste in `formConfig.ts` (Schritt `observations`) trägt dieselbe
+	     Reihenfolge — `scrollToFirstError` und `findStepForErrors` laufen sie
+	     ab, um zum ersten fehlerhaften Feld zu springen. -->
+	{#if !adminMode}
+		<div class="mt-4 grid grid-cols-1 gap-4">
+			<FormField name="shipCount" />
+		</div>
+	{/if}
 
 	<!-- Weather Data Fetcher - Auto-fetch when environment section is visible -->
 	{#if latitude && longitude && sightingDate}

--- a/src/lib/report/components/sections/Environment.svelte.test.ts
+++ b/src/lib/report/components/sections/Environment.svelte.test.ts
@@ -56,9 +56,9 @@ describe('sections/Environment — shipCount als Störungskontext', () => {
  * `windForce`, also ans Ende der vom Abruf befüllten Felder.
  *
  * Die Liste in `formConfig.ts` (Schritt `observations`) muss dieselbe
- * Reihenfolge tragen — `scrollToFirstError` und `findStepForErrors` laufen sie
- * ab, um zum ersten fehlerhaften Feld zu springen. Geprüft wird das in
- * `formConfig.test.ts`; hier zählt, was der Melder wirklich sieht.
+ * Reihenfolge tragen — `scrollToFirstError` läuft sie ab, um zum ersten
+ * fehlerhaften Feld zu springen. Geprüft wird das in `formConfig.test.ts`;
+ * hier zählt, was der Melder wirklich sieht.
  */
 describe('sections/Environment — Feldreihenfolge in der Karte', () => {
 	it('stellt shipCount hinter die vom Wetter-Abruf befüllten Felder', () => {

--- a/src/lib/report/components/sections/Environment.svelte.test.ts
+++ b/src/lib/report/components/sections/Environment.svelte.test.ts
@@ -20,6 +20,18 @@ import Environment from './Environment.svelte';
  * `Environment` träfe im Admin-Formular auf dasselbe Feld ein zweites Mal —
  * die Admin-Maske darf sich laut Auftrag nicht ändern.
  */
+/**
+ * DOM-Reihenfolge statt Pixel-Position: `FormField` wrapt jedes Feld in
+ * `<div data-field={name}>`. `querySelectorAll('[data-field]')` liefert damit
+ * die tatsächliche Render-Reihenfolge und bei einer Regression eine lesbare
+ * Namensliste (Präzedenz: `AnimalInfo.svelte.test.ts`).
+ */
+function fieldOrder(): string[] {
+	return Array.from(document.querySelectorAll<HTMLElement>('[data-field]')).map(
+		(el) => el.dataset.field ?? ''
+	);
+}
+
 describe('sections/Environment — shipCount als Störungskontext', () => {
 	it('zeigt die Anzahl anderer Schiffe bei den Umweltbedingungen', async () => {
 		renderWithFormContext(Environment, {});
@@ -33,5 +45,34 @@ describe('sections/Environment — shipCount als Störungskontext', () => {
 		renderWithFormContext(Environment, { props: { adminMode: true } });
 
 		expect(document.querySelector<HTMLElement>('[data-testid="field-shipCount"]')).toBeNull();
+	});
+});
+
+/**
+ * Die Karte kündigt oben an: „Sobald Position und Datum gesetzt sind, werden
+ * Wetterdaten automatisch vorgeschlagen." `shipCount` ist das einzige Feld
+ * darin, das der Wetter-Abruf NIE füllt — an erster Stelle direkt unter diesem
+ * Satz las es sich für den Melder wie ein Wetterfeld. Es gehört deshalb hinter
+ * `windForce`, also ans Ende der vom Abruf befüllten Felder.
+ *
+ * Die Liste in `formConfig.ts` (Schritt `observations`) muss dieselbe
+ * Reihenfolge tragen — `scrollToFirstError` und `findStepForErrors` laufen sie
+ * ab, um zum ersten fehlerhaften Feld zu springen. Geprüft wird das in
+ * `formConfig.test.ts`; hier zählt, was der Melder wirklich sieht.
+ */
+describe('sections/Environment — Feldreihenfolge in der Karte', () => {
+	it('stellt shipCount hinter die vom Wetter-Abruf befüllten Felder', () => {
+		renderWithFormContext(Environment, {});
+
+		expect(fieldOrder()).toEqual(['seaState', 'visibility', 'windForce', 'shipCount']);
+	});
+
+	// Gegenprobe: Die Admin-Maske bindet dieselbe Komponente ein und darf sich
+	// laut Auftrag nicht verändern. Sie zeigt `shipCount` über
+	// `OptionalSightingDetails` und dafür zusätzlich `windDirection`.
+	it('lässt die Admin-Reihenfolge unverändert', () => {
+		renderWithFormContext(Environment, { props: { adminMode: true } });
+
+		expect(fieldOrder()).toEqual(['seaState', 'visibility', 'windForce', 'windDirection']);
 	});
 });

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -467,3 +467,41 @@ describe('getFormSteps mit Beobachtungsort', () => {
 		}
 	});
 });
+
+/**
+ * `shipCount` zog mit Task 12 aus „Boot-/Schiffsinformationen" in die Karte
+ * „Umweltbedingungen" — fachlich richtig, es ist Störungskontext wie Seegang
+ * und Sichtweite. Es landete dabei aber an der ERSTEN Stelle der Karte, direkt
+ * unter dem Satz „Sobald Position und Datum gesetzt sind, werden Wetterdaten
+ * automatisch vorgeschlagen." — als einziges Feld, das der Wetter-Abruf nie
+ * füllt. Es steht deshalb jetzt hinter `windForce`.
+ *
+ * Diese Liste ist dabei nicht kosmetisch: `scrollToFirstError` und
+ * `findStepForErrors` laufen sie ab, um zum ersten fehlerhaften Feld zu
+ * springen. Weicht sie von der Render-Reihenfolge ab, springt die Navigation
+ * an ein anderes Feld als das oberste sichtbare. Die Render-Reihenfolge selbst
+ * prüft `Environment.svelte.test.ts`.
+ */
+describe('formStepsConfig — Umweltfelder in Render-Reihenfolge', () => {
+	const observationsStep = formStepsConfig.find((step) => step.id === 'observations');
+
+	it('führt die Umweltfelder in der Reihenfolge der Karte', () => {
+		const fields = observationsStep?.fields ?? [];
+		const umwelt = ['seaState', 'visibility', 'windForce', 'shipCount'];
+
+		expect(fields.filter((name) => umwelt.includes(name))).toEqual(umwelt);
+	});
+
+	it('listet shipCount hinter windForce', () => {
+		const fields = observationsStep?.fields ?? [];
+		const windIndex = fields.indexOf('windForce');
+		const shipCountIndex = fields.indexOf('shipCount');
+
+		// Beide Fundstellen ausdrücklich absichern: `indexOf` liefert für ein
+		// fehlendes Feld -1, und -1 ist kleiner als jeder gültige Index — der
+		// Vergleich allein liefe grün durch, gerade wenn das Feld ganz fehlt.
+		expect(windIndex).toBeGreaterThanOrEqual(0);
+		expect(shipCountIndex).toBeGreaterThanOrEqual(0);
+		expect(windIndex).toBeLessThan(shipCountIndex);
+	});
+});

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -215,7 +215,9 @@ describe('formStepsConfig — Medien-Upload auf Schritt 2', () => {
 	// gesehen hat, soll das Bild hochladen können, statt zu raten. Die
 	// Reihenfolge im Markup prüft `Step2SightingDetails.svelte.test.ts`; hier
 	// zählt, dass die Config dieselbe Geschichte erzählt — sie bestimmt die
-	// Reihenfolge, in der `findStepForErrors` Felder abläuft.
+	// Reihenfolge, in der `scrollToFirstError` Felder abläuft. (Nicht
+	// `findStepForErrors` — das liest nur die Zugehörigkeit zum Schritt, wie
+	// im Block „Umweltfelder in Render-Reihenfolge" unten ausgeführt.)
 	it('listet die Medien-Dateifelder vor species', () => {
 		const fields = sightingDetailsStep?.fields ?? [];
 		const mediaIndex = fields.indexOf('mediaFile');

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -476,32 +476,27 @@ describe('getFormSteps mit Beobachtungsort', () => {
  * automatisch vorgeschlagen." — als einziges Feld, das der Wetter-Abruf nie
  * füllt. Es steht deshalb jetzt hinter `windForce`.
  *
- * Diese Liste ist dabei nicht kosmetisch: `scrollToFirstError` und
- * `findStepForErrors` laufen sie ab, um zum ersten fehlerhaften Feld zu
- * springen. Weicht sie von der Render-Reihenfolge ab, springt die Navigation
- * an ein anderes Feld als das oberste sichtbare. Die Render-Reihenfolge selbst
- * prüft `Environment.svelte.test.ts`.
+ * Diese Liste ist dabei nicht kosmetisch: `scrollToFirstError`
+ * (`$lib/utils/fieldNavigation`) läuft sie ab, um zum ersten fehlerhaften Feld
+ * zu springen — `StepNavigation.svelte` baut das `fieldOrder`-Argument aus
+ * genau dieser Config. Weicht sie von der Render-Reihenfolge ab, springt die
+ * Navigation an ein anderes Feld als das oberste sichtbare. `findStepForErrors`
+ * ist davon NICHT betroffen: es prüft mit `fields.includes(...)` nur die
+ * Zugehörigkeit zum Schritt und ist gegenüber der Position darin unempfindlich.
+ *
+ * Die Render-Reihenfolge selbst prüft `Environment.svelte.test.ts`.
  */
 describe('formStepsConfig — Umweltfelder in Render-Reihenfolge', () => {
 	const observationsStep = formStepsConfig.find((step) => step.id === 'observations');
 
+	// Ein `toEqual` auf die gefilterte Liste statt zweier Index-Vergleiche: Es
+	// belegt Vorhandensein UND Reihenfolge in einem. Fehlt ein Feld ganz, ist
+	// die gefilterte Liste kürzer und der Vergleich schlägt fehl — die sonst
+	// nötigen `indexOf`-Wächter gegen die stille -1 erübrigen sich damit.
 	it('führt die Umweltfelder in der Reihenfolge der Karte', () => {
 		const fields = observationsStep?.fields ?? [];
 		const umwelt = ['seaState', 'visibility', 'windForce', 'shipCount'];
 
 		expect(fields.filter((name) => umwelt.includes(name))).toEqual(umwelt);
-	});
-
-	it('listet shipCount hinter windForce', () => {
-		const fields = observationsStep?.fields ?? [];
-		const windIndex = fields.indexOf('windForce');
-		const shipCountIndex = fields.indexOf('shipCount');
-
-		// Beide Fundstellen ausdrücklich absichern: `indexOf` liefert für ein
-		// fehlendes Feld -1, und -1 ist kleiner als jeder gültige Index — der
-		// Vergleich allein liefe grün durch, gerade wenn das Feld ganz fehlt.
-		expect(windIndex).toBeGreaterThanOrEqual(0);
-		expect(shipCountIndex).toBeGreaterThanOrEqual(0);
-		expect(windIndex).toBeLessThan(shipCountIndex);
 	});
 });

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -84,8 +84,10 @@ export const formStepsConfig: FormStep[] = [
 			// benutzte — obwohl Aufnahmen die wertvollste Einzelangabe der Meldung
 			// sind. Schritt 2 ist Pflichtschritt.
 			//
-			// Die Reihenfolge in dieser Liste ist nicht kosmetisch: `findStepForErrors`
-			// läuft sie ab, um zum ersten fehlerhaften Feld zu springen.
+			// Die Reihenfolge in dieser Liste ist nicht kosmetisch: `scrollToFirstError`
+			// läuft sie ab, um zum ersten fehlerhaften Feld zu springen. (Nicht
+			// `findStepForErrors` — das liest nur die Zugehörigkeit zum Schritt,
+			// siehe die Feldliste von `observations` weiter unten.)
 			'mediaFile',
 			'mediaUpload',
 			// `mediaConsent` steht hier bewusst NICHT mehr: Es steht seit dem

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -132,10 +132,15 @@ export const formStepsConfig: FormStep[] = [
 			'behavior',
 			'behaviorText',
 			'reaction',
-			'shipCount',
+			// Reihenfolge wie in `Environment.svelte`: `shipCount` steht hinter der
+			// Windstärke, nicht davor — es ist das einzige Feld der Karte, das der
+			// Wetter-Abruf nie füllt (Begründung dort). Diese Liste ist nicht
+			// kosmetisch: `scrollToFirstError` und `findStepForErrors` laufen sie ab,
+			// um zum ersten fehlerhaften Feld zu springen.
 			'seaState',
 			'visibility',
 			'windForce',
+			'shipCount',
 			'shipName',
 			'homePort',
 			'boatType'

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -132,14 +132,17 @@ export const formStepsConfig: FormStep[] = [
 			'behavior',
 			'behaviorText',
 			'reaction',
-			// Reihenfolge wie in `Environment.svelte`: `shipCount` steht hinter der
-			// Windstärke, nicht davor — es ist das einzige Feld der Karte, das der
-			// Wetter-Abruf nie füllt (Begründung dort). Diese Liste ist nicht
-			// kosmetisch: `scrollToFirstError` und `findStepForErrors` laufen sie ab,
-			// um zum ersten fehlerhaften Feld zu springen.
+			// Die Reihenfolge dieser vier folgt `Environment.svelte` und ist nicht
+			// kosmetisch: `scrollToFirstError` läuft die Liste ab, um zum ersten
+			// fehlerhaften Feld zu springen (`fieldNavigation.ts` — die Aufrufstelle
+			// baut `fieldOrder` in `StepNavigation.svelte` aus genau dieser Config).
+			// `findStepForErrors` liest daraus dagegen nur die Zugehörigkeit zum
+			// Schritt, nicht die Position darin.
 			'seaState',
 			'visibility',
 			'windForce',
+			// Hinter der Windstärke, nicht davor: das einzige Feld der Karte, das
+			// der Wetter-Abruf nie füllt — Begründung in `Environment.svelte`.
 			'shipCount',
 			'shipName',
 			'homePort',


### PR DESCRIPTION
## Warum

`shipCount` — „Anzahl **anderer** Schiffe in näherer Umgebung" — ist mit #773 aus der Karte „Boot-/Schiffsinformationen" in „Umweltbedingungen" gezogen. Fachlich richtig: Es ist Störungskontext wie Seegang und Sichtweite, keine Angabe zum eigenen Boot des Melders.

Nur die Position innerhalb der Karte wurde dabei nicht mitbedacht. Das Feld landete an **erster** Stelle, direkt unter dem Einleitungssatz „Sobald Position und Datum gesetzt sind, werden Wetterdaten automatisch vorgeschlagen." — als einziges Feld der Karte, das der Wetter-Abruf nie füllt. An dieser Stelle liest es sich für den Melder wie ein Wetterfeld.

## Was sich ändert

`shipCount` steht jetzt hinter `windForce`, also ans Ende der vom Wetter-Abruf befüllten Felder:

| vorher | nachher |
| --- | --- |
| Anzahl anderer Schiffe | Seegang · Sichtbedingungen |
| Seegang · Sichtbedingungen | Windstärke |
| Windstärke | Anzahl anderer Schiffe |

Die Feldliste des Schritts `observations` in `formConfig.ts` zieht gleichlaufend mit — sie ist nicht kosmetisch: `scrollToFirstError` läuft sie ab, um zum ersten fehlerhaften Feld zu springen (`StepNavigation.svelte` baut das `fieldOrder`-Argument aus genau dieser Config).

Beschriftung, Hilfetext und Icon kommen unverändert aus dem Yup-Schema (`.label()`/`.meta()`); im Markup steht nichts davon.

## Was ausdrücklich gleich bleibt

- **Die Admin-Maske.** `AdminSightingEditForm.svelte` bindet dieselbe Komponente ein, zeigt `shipCount` aber über `OptionalSightingDetails.svelte`. Der Block bleibt deshalb hinter `{#if !adminMode}` gegattert; ein Rendering-Test pinnt die Admin-Reihenfolge als Gegenprobe fest.
- **Der automatische Wetter-Abruf.** `WeatherDataFetcher` mit `autoFetch` ist unberührt und rendert weiterhin unterhalb der Felder.

## Tests

Test-First, beide vorher rot:

- `Environment.svelte.test.ts` — Rendering-Test über `[data-field]` (Präzedenz `AnimalInfo.svelte.test.ts`): die DOM-Reihenfolge ist die Aussage, nicht die Liste allein. Dazu die Admin-Gegenprobe.
- `formConfig.test.ts` — die Config trägt dieselbe Reihenfolge.

`npm run test:unit:client` 514/514 · `npm run test:quick` 3575/3575 · `svelte-autofixer` ohne Befund.

## Im Browser gegengeprüft

Gegen den Dev-Server bis Schritt 3 durchgeklickt: Die Karte liest Seegang / Sichtbedingungen → Windstärke → Anzahl anderer Schiffe, und der automatische Wetter-Abruf rendert mit echten Daten darunter (54° 15′ N, 12° 06′ E).

## Zweiter Commit: Korrektur einer Kommentar-Aussage

Das Review hat eine Behauptung gefunden, die ich an vier Stellen wiederholt hatte: `scrollToFirstError` **und** `findStepForErrors` liefen die Feldliste ab. Nur die erste Hälfte stimmt — `findStepForErrors.ts:26` prüft mit `step.fields.includes(field)` ausschließlich die Zugehörigkeit zum Schritt und ist gegenüber der Position darin unempfindlich. So stehengelassen hätte der Kommentar eine Kopplung erfunden, die es nicht gibt.

Dabei ist auch der Test `listet shipCount hinter windForce` entfallen: Das `toEqual` auf die gefilterte Liste darüber belegt Vorhandensein und Reihenfolge in einem, die `indexOf`-Wächter hätten nur greifen können, wenn dieser Test schon rot war.

## Nebenbefund, nicht Teil dieses PRs

Beim Durchklicken fiel auf, dass das Radio „Motor lief" bei `boatDrive` (Schritt 2) im DOM `value="undefined"` trägt. Wer es wählt, bleibt mit einer rohen Yup-Meldung auf Schritt 2 stehen und kann die Angabe nicht machen. Separat abgelegt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)