### PR TITLE
test(report): pin the read consent surface, not just the schema help text

### DIFF
--- a/src/lib/form/consent/consentSurfaces.svelte.test.ts
+++ b/src/lib/form/consent/consentSurfaces.svelte.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Bindet die Fassungskennungen an die **gelesene Einwilligungsfläche**.
+ *
+ * Die Kennung ist der zweite Teil des Nachweises nach Art. 7 Abs. 1 DSGVO: Der
+ * Zeitstempel sagt **wann**, die Kennung sagt **wozu** eingewilligt wurde. Sie
+ * taugt dafür nur, solange sie sich mit dem Text ändert — eine Kennung, die
+ * beim Umformulieren stehen bleibt, weist der Einwilligung rückwirkend einen
+ * Text zu, den die Meldenden nie gesehen haben.
+ *
+ * **Was „Fläche" heißt.** Nicht der `meta.helpText` aus `sightingSchema.ts`,
+ * sondern alles, was neben dem Ankreuzfeld steht und die Frage beantwortet, wozu
+ * hier zugestimmt wird: Überschrift, Einleitung, Verarbeitungs-Kacheln,
+ * Widerrufshinweis. Ein Hash allein über den `helpText` ist nachweislich zu eng
+ * — in PR #773 änderte sich die Gruppen-Überschrift über `nameConsent` /
+ * `shipNameConsent` von „Optionale Veröffentlichung Ihres Namens" auf „… von
+ * Namen und Aufnahmen", und `mediaConsent` zog samt Erklärtext von der Dropzone
+ * auf Schritt 2 in diese Gruppe zwei Schritte weiter. Der damalige Test blieb
+ * grün; die drei Kennungen wurden erst nachträglich durch ein Review gehoben.
+ *
+ * **Warum das ein Browser-Test ist.** Die umgebenden Texte stehen im Markup, und
+ * die einzige belastbare Lesart des Markups ist das, was der Browser daraus
+ * rendert. Die beiden Alternativen sind geprüft und verworfen: Das Schema-
+ * `.label()` mitzuhashen erfasst die Überschrift nicht, und die `.svelte`-Quelle
+ * per Regex abzugreifen schafft eine zweite, brüchige Quelle neben dem Markup.
+ *
+ * **Preis dieser Entscheidung:** Die Bindung an den Wortlaut ist damit aus
+ * `npm run test:quick` heraus — die läuft nur den Server-Teil. Sie greift in CI
+ * (`test:unit:client`, `.github/workflows/ci.yml`) und lokal über
+ * `npm run test:unit:client`. Wer an einem Einwilligungstext arbeitet, fährt den
+ * also zusätzlich, statt sich auf `test:quick` zu verlassen.
+ *
+ * **Wie die Fläche abgegrenzt wird.** Über `data-consent-surface` im Markup —
+ * die Auszeichnung steht dort mit Begründung neben dem Text, den sie umfasst.
+ * Flächen dürfen schachteln: `Step4Contact.svelte` markiert die gemeinsame Karte
+ * („Datenschutz und Einverständnis") **und** darin die beiden Gruppen. Gehasht
+ * wird pro Feld getrennt nach Ebene — äußere Fläche ohne die inneren, eigene
+ * Gruppe ohne die Felder, dann der eigene Ankreuztext. Damit bewegt eine
+ * Gruppen-Überschrift nur die Kennungen ihrer Gruppe, und der Wortlaut eines
+ * einzelnen Ankreuztextes nur die eigene — statt bei jeder Änderung alle vier.
+ *
+ * Der Ankreuztext ist damit mitgepinnt; der frühere `helpText`-Hash in
+ * `consentTextVersions.test.ts` ist deshalb entfallen. Zwei Hashes für eine
+ * Textänderung zu pflegen hätte nur die Gewohnheit gefördert, sie nachzutragen,
+ * statt die Kennung zu heben.
+ *
+ * **Geltungsbereich ist das Meldeformular**, nicht die Admin-Maske: Die Kennung
+ * bezeugt, was die meldende Person gelesen hat. Die Admin-Maske bindet weder
+ * `Step4Contact` noch `RequiredConsent` ein und schreibt die Nachweisspalten
+ * ohnehin nicht (`updateSighting`).
+ *
+ * **Schlägt der Test fehl, wurde eine Einwilligungsfläche geändert. Dann beides tun:**
+ *   1. die Fassungskennung in `consentVersions.ts` bzw. `mediaConsentVersion.ts`
+ *      auf das Datum der Änderung setzen,
+ *   2. den neuen Hash aus der Fehlermeldung hier eintragen.
+ *
+ * Wer nur (2) macht, hat den Nachweis entwertet: Alle Altbestände tragen dann
+ * eine Kennung, hinter der ein anderer Wortlaut steht.
+ */
+import { describe, expect, it } from 'vitest';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import { formStepsConfig } from '$lib/report/formConfig';
+import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
+import RequiredConsent from '$lib/report/components/form/RequiredConsent.svelte';
+import Step4Contact from '$lib/report/components/steps/Step4Contact.svelte';
+import type { UploadedFileInfo } from '$lib/types';
+import { MEDIA_CONSENT_VERSION } from './mediaConsentVersion';
+import {
+	NAME_CONSENT_VERSION,
+	PRIVACY_CONSENT_VERSION,
+	SHIP_NAME_CONSENT_VERSION
+} from './consentVersions';
+
+/**
+ * Attribute, die Text tragen, den jemand liest oder vorgelesen bekommt.
+ * `data-tip` ist die DaisyUI-Tooltip-Blase — dort steht der `meta.valueText`,
+ * und der ist Teil der Fläche, obwohl er nie im `textContent` auftaucht.
+ */
+const TEXT_ATTRIBUTES = ['data-tip', 'title', 'placeholder', 'alt', 'aria-label'] as const;
+
+/**
+ * Sammelt den lesbaren Text eines Teilbaums in Dokumentreihenfolge und
+ * normalisiert die Whitespace-Formatierung weg — sonst hinge der Hash daran, wie
+ * Prettier das Markup umbricht.
+ *
+ * `stopAt` schneidet Teilbäume ab, die zu einer eigenen Ebene gehören
+ * (geschachtelte Flächen, Feld-Wrapper). Der Knoten selbst wird dabei komplett
+ * übersprungen, nicht nur sein Inhalt.
+ */
+function readableText(root: Element, stopAt: (element: Element) => boolean): string {
+	const parts: string[] = [];
+
+	function walk(element: Element): void {
+		for (const attribute of TEXT_ATTRIBUTES) {
+			const value = element.getAttribute(attribute);
+			if (value) parts.push(value);
+		}
+		for (const node of element.childNodes) {
+			if (node.nodeType === Node.TEXT_NODE) {
+				parts.push(node.nodeValue ?? '');
+			} else if (node.nodeType === Node.ELEMENT_NODE) {
+				const child = node as Element;
+				if (!stopAt(child)) walk(child);
+			}
+		}
+	}
+
+	walk(root);
+	return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function fieldWrapper(field: string): Element {
+	const wrapper = document.querySelector(`[data-field="${field}"]`);
+	if (!wrapper) {
+		throw new Error(
+			`Feld ${field} wird in der gerenderten Komponente nicht angezeigt — ` +
+				`entweder ist es umgezogen (dann gehört es dort in eine ausgezeichnete ` +
+				`Fläche und die Kennung gehoben) oder der Render-Zustand unten blendet es aus.`
+		);
+	}
+	return wrapper;
+}
+
+/** Grenze zwischen zwei Ebenen: eine eigene Fläche oder ein anderes Feld. */
+function isOwnLevel(element: Element): boolean {
+	return element.hasAttribute('data-consent-surface') || element.hasAttribute('data-field');
+}
+
+/**
+ * Der Text, den die Fassungskennung eines Feldes bezeugt: jede umgebende
+ * ausgezeichnete Fläche von außen nach innen (jeweils ohne die tiefer liegenden
+ * Ebenen), zuletzt der eigene Ankreuztext samt Hilfetext und Tooltip.
+ */
+function consentSurfaceText(field: string): string {
+	const wrapper = fieldWrapper(field);
+
+	const surfaces: Element[] = [];
+	for (let element = wrapper.parentElement; element; element = element.parentElement) {
+		if (element.hasAttribute('data-consent-surface')) surfaces.unshift(element);
+	}
+	if (surfaces.length === 0) {
+		throw new Error(
+			`Feld ${field} steht in keiner mit \`data-consent-surface\` ausgezeichneten Fläche — ` +
+				`ohne sie ist nicht festgelegt, welchen Text seine Fassungskennung bezeugt.`
+		);
+	}
+
+	return [
+		...surfaces.map((surface) => readableText(surface, isOwnLevel)),
+		readableText(wrapper, () => false)
+	].join(' | ');
+}
+
+async function sha256(text: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+/**
+ * Ein abgeschlossen hochgeladenes File, wie es `$form.uploadedFiles` nach einem
+ * erfolgreichen Upload enthält — `mediaConsent` erscheint sonst gar nicht
+ * (`hasUploadedMedia`, Step4Contact.svelte).
+ */
+const UPLOADED_FILE = {
+	uid: 'uid-1',
+	filePath: 'ref-1/uid-1.jpg',
+	originalName: 'foto.jpg',
+	fileName: 'uid-1.jpg',
+	mimeType: 'image/jpeg',
+	size: 1234
+} as UploadedFileInfo;
+
+/**
+ * Kanonischer Render-Zustand für Schritt 4: von einem Boot gemeldet und mit
+ * vorliegender Aufnahme, damit `shipNameConsent` und `mediaConsent` sichtbar
+ * sind. Auf den Flächen-Text der Gruppen wirkt das nicht — die Feld-Wrapper
+ * werden aus den Flächen herausgerechnet.
+ */
+function mountStep4(): void {
+	renderWithFormContext(Step4Contact, {
+		overrides: { sightingFrom: SightingFromEnum.SAILBOAT, uploadedFiles: [UPLOADED_FILE] }
+	});
+}
+
+function mountRequiredConsent(): void {
+	renderWithFormContext(RequiredConsent, {
+		props: { currentStep: formStepsConfig.length - 1 }
+	});
+}
+
+const PINNED_CONSENT_SURFACES = [
+	{
+		field: 'nameConsent',
+		version: NAME_CONSENT_VERSION,
+		mount: mountStep4,
+		hash: 'ae40179764bc28f0893993379ef1638820386d06c3fe9520a1968b4b4716031e'
+	},
+	{
+		field: 'shipNameConsent',
+		version: SHIP_NAME_CONSENT_VERSION,
+		mount: mountStep4,
+		hash: '2f041f3d65c67637c75289eff37957b64b28c345f63dfe936eb4809c819773ff'
+	},
+	{
+		field: 'mediaConsent',
+		version: MEDIA_CONSENT_VERSION,
+		mount: mountStep4,
+		hash: 'f33cf518f1701359eb1922918414aeffda34799dff471561ae962d0b7870780f'
+	},
+	{
+		// Einzige Einwilligung ohne Fassungskennung: Sie erlaubt das Speichern der
+		// Kontaktdaten im Browser des Melders und wird nirgends serverseitig
+		// nachgewiesen — es gibt also keine Spalte, die eine Fassung tragen könnte
+		// (anders als bei den vier `…_am`/`…_version`-Paaren in `schema.ts`).
+		// Gepinnt ist der Text trotzdem: Eine Änderung daran soll eine bewusste
+		// Entscheidung sein und nicht beiläufig passieren.
+		field: 'persistentDataConsent',
+		version: null,
+		mount: mountStep4,
+		hash: '735a733833d1f00f388cd42c7826a4dcdb2d75316e53f2246603cc55be93bbea'
+	},
+	{
+		field: 'privacyConsent',
+		version: PRIVACY_CONSENT_VERSION,
+		mount: mountRequiredConsent,
+		hash: '2e281d78eac3a7af157d330092b2790674d29f96785bddaf2f3ba526795bc915'
+	}
+] as const;
+
+describe('Fassungskennungen der Einwilligungsflächen', () => {
+	it.each(PINNED_CONSENT_SURFACES)(
+		'$field entspricht dem gepinnten Hash der gelesenen Fläche',
+		async ({ field, version, mount, hash }) => {
+			mount();
+
+			const text = consentSurfaceText(field);
+			const actual = await sha256(text);
+
+			// Text und aktuelle Kennung stehen in der Meldung, weil ein Hash allein
+			// weder sagt, WAS sich geändert hat, noch woran Schritt (1) der
+			// Anleitung oben hängt — und die Entscheidung „Kennung heben oder
+			// nicht" genau daran hängt.
+			expect(
+				actual,
+				`Gelesene Fläche von ${field} (Kennung: ${version ?? 'keine, siehe Liste'}):\n${text}\n`
+			).toBe(hash);
+		}
+	);
+});
+
+/**
+ * Gegenprobe zur Vollständigkeit: Der Hash oben schützt nur Felder, die in der
+ * Liste stehen. Eine neue Einwilligung, die jemand in eine dieser beiden
+ * Komponenten stellt, wäre ohne diese Feststellung ungeschützt — und eine, die
+ * aus der ausgezeichneten Fläche herausrutscht, ebenfalls.
+ *
+ * **Zwei Grenzen, damit der Titel nicht mehr verspricht, als geprüft wird:**
+ * Gemountet werden nur `Step4Contact` und `RequiredConsent` — heute rendern alle
+ * fünf `*Consent`-Felder des Schemas dort und nur dort, eine künftige
+ * Einwilligung in einer anderen Komponente bliebe aber unsichtbar. Und die
+ * Erkennung hängt an der Namenskonvention `…Consent`. Beides fällt spätestens
+ * auf, wenn ein neues Feld ohne Nachweis in die DB geht; ein Wächter, der jede
+ * Komponente des Formulars mountet, wäre dafür zu teuer.
+ */
+describe('Die Einwilligungen dieser beiden Komponenten sind vollständig gepinnt', () => {
+	function renderedConsentFields(): string[] {
+		return Array.from(document.querySelectorAll('[data-field]'))
+			.map((element) => element.getAttribute('data-field') ?? '')
+			.filter((name) => name.endsWith('Consent'))
+			.sort();
+	}
+
+	const pinnedFields = PINNED_CONSENT_SURFACES.map(({ field }) => field);
+
+	it('Schritt 4 zeigt genau die gepinnten Einwilligungen', () => {
+		mountStep4();
+
+		expect(renderedConsentFields()).toEqual(
+			pinnedFields.filter((field) => field !== 'privacyConsent').sort()
+		);
+	});
+
+	it('die Pflicht-Einwilligung vor dem Absenden ist gepinnt', () => {
+		mountRequiredConsent();
+
+		expect(renderedConsentFields()).toEqual(['privacyConsent']);
+	});
+});

--- a/src/lib/form/consent/consentTextVersions.test.ts
+++ b/src/lib/form/consent/consentTextVersions.test.ts
@@ -1,42 +1,30 @@
 /**
- * Bindet die Fassungskennungen an die tatsächlichen Einwilligungstexte.
+ * Formregeln für die Fassungskennungen der Einwilligungstexte.
  *
  * Die Kennung ist der zweite Teil des Nachweises nach Art. 7 Abs. 1 DSGVO: Der
- * Zeitstempel sagt **wann**, die Kennung sagt **wozu** eingewilligt wurde. Sie
- * taugt dafür aber nur, solange sie sich mit dem Text ändert — eine Kennung, die
- * beim Umformulieren stehen bleibt, weist der Einwilligung rückwirkend einen
- * Text zu, den die Meldenden nie gesehen haben.
+ * Zeitstempel sagt **wann**, die Kennung sagt **wozu** eingewilligt wurde.
  *
- * Ein Kommentar allein trägt diese Zusicherung nicht. Deshalb pinnt dieser Test
- * den Hash jedes Textes — wie `notificationEmailDefault.test.ts` es für die
- * E-Mail-Vorlage tut.
+ * **Die Bindung an den Wortlaut steht nicht mehr hier, sondern in
+ * `consentSurfaces.svelte.test.ts`.** Dieser Test pinnte bis zum 2026-08-06 den
+ * Hash des `meta.helpText` aus `sightingSchema.ts` — und sagte in seinem eigenen
+ * Kopfkommentar, dass der Geltungsbereich einer Kennung die gelesene
+ * Einwilligungsfläche ist, also auch Überschrift und umgebender Text. Beides
+ * zusammen ging nicht auf: In PR #773 wechselte die Überschrift über
+ * `nameConsent`/`shipNameConsent`, und `mediaConsent` zog samt Erklärtext in
+ * einen anderen Kontext zwei Schritte weiter — der Test blieb grün, die
+ * Kennungen wurden erst nachträglich durch ein Review gehoben.
  *
- * **Geltungsbereich — bewusst enger, als es zunächst wirkt:** Gepinnt wird
- * ausschließlich `meta.helpText` aus `sightingSchema.ts`. **Nicht** erfasst sind
- * `.label()` und der gesamte umgebende Text in
- * `src/lib/report/components/form/RequiredConsent.svelte` — Überschrift,
- * Verarbeitungs-Kacheln, Widerrufshinweis, Verweis auf die
- * Datenschutzerklärung. Gerade bei `privacyConsent` ist das ein erheblicher Teil
- * dessen, was die meldende Person tatsächlich liest: Wer dort umformuliert,
- * lässt diesen Test grün.
+ * Der Wortlaut wird deshalb jetzt an der gerenderten Fläche gepinnt (Browser-
+ * Test, `npm run test:unit:client`); der Ankreuztext ist dort mitgehasht. Ein
+ * zweiter Hash über denselben Text hätte nur doppelte Buchführung erzeugt.
  *
- * Der Hash über die gerenderte Einwilligungsfläche zu ziehen wäre die
- * vollständige Lösung; sie braucht einen Browser-Test und ist hier bewusst
- * nicht gebaut. Bis dahin gilt: **Eine Änderung an `RequiredConsent.svelte`
- * erfordert die Fassungskennung genauso wie eine am `helpText`** — nur erinnert
- * daran kein Test.
- *
- * **Schlägt der Test fehl, wurde ein Einwilligungstext geändert. Dann beides tun:**
- *   1. die Fassungskennung in `consentVersions.ts` bzw. `mediaConsentVersion.ts`
- *      auf das Datum der Änderung setzen,
- *   2. den neuen Hash aus der Fehlermeldung hier eintragen.
- *
- * Wer nur (2) macht, hat den Nachweis entwertet: Alle Altbestände tragen dann
- * eine Kennung, hinter der ein anderer Wortlaut steht.
+ * Was hier bleibt, braucht keinen Browser und läuft damit in `npm run
+ * test:quick`: dass jede Kennung ein Datum im erwarteten Format trägt und keine
+ * in der Zukunft liegt. **Die Wortlaut-Prüfung ist damit aber nicht mehr Teil
+ * von `test:quick`** — wer an einem Einwilligungstext arbeitet, fährt zusätzlich
+ * `npm run test:unit:client`.
  */
-import { createHash } from 'crypto';
 import { describe, expect, it } from 'vitest';
-import { sightingSchema } from '$lib/form/validation/sightingSchema';
 import { MEDIA_CONSENT_VERSION } from './mediaConsentVersion';
 import {
 	NAME_CONSENT_VERSION,
@@ -44,52 +32,23 @@ import {
 	SHIP_NAME_CONSENT_VERSION
 } from './consentVersions';
 
-function helpTextOf(field: string): string {
-	const described = sightingSchema.describe().fields[field];
-	if (!described || !('meta' in described)) {
-		throw new Error(`Feld ${field} hat keine Beschreibung`);
-	}
-	const helpText = ((described.meta ?? {}) as { helpText?: string }).helpText;
-	if (!helpText) {
-		throw new Error(`Feld ${field} hat keinen Einwilligungstext`);
-	}
-	return helpText;
-}
-
-const PINNED_CONSENT_TEXTS = [
-	{
-		field: 'nameConsent',
-		version: NAME_CONSENT_VERSION,
-		hash: 'eb46f8a140808245a3f8de9a65917a69452ae212a80a738339405e091b0210d1'
-	},
-	{
-		field: 'shipNameConsent',
-		version: SHIP_NAME_CONSENT_VERSION,
-		hash: 'ad612652de32e9a21b272fd878dfc2509a5ae96308a1dd05365e484c5ff256b6'
-	},
-	{
-		field: 'privacyConsent',
-		version: PRIVACY_CONSENT_VERSION,
-		hash: '73445d9c1ac5e29d803efe505d830951dd296cbeff21ccc0042a223003527c01'
-	},
-	{
-		field: 'mediaConsent',
-		version: MEDIA_CONSENT_VERSION,
-		hash: '55294e0730f56023ef0e4eb3a3c907bf799996ddffecdaaa3af07e72ff4847f9'
-	}
+/**
+ * Die vier Einwilligungen mit Nachweisspalten (`…_am`/`…_version` in
+ * `schema.ts`). `persistentDataConsent` steht bewusst nicht dabei: Diese
+ * Zustimmung erlaubt das Speichern der Kontaktdaten im Browser des Melders und
+ * wird nirgends serverseitig nachgewiesen — es gibt also keine Spalte, die eine
+ * Fassung tragen könnte. Ihr Wortlaut ist trotzdem gepinnt
+ * (`consentSurfaces.svelte.test.ts`).
+ */
+const CONSENT_VERSIONS = [
+	{ field: 'nameConsent', version: NAME_CONSENT_VERSION },
+	{ field: 'shipNameConsent', version: SHIP_NAME_CONSENT_VERSION },
+	{ field: 'privacyConsent', version: PRIVACY_CONSENT_VERSION },
+	{ field: 'mediaConsent', version: MEDIA_CONSENT_VERSION }
 ] as const;
 
 describe('Fassungskennungen der Einwilligungstexte', () => {
-	it.each(PINNED_CONSENT_TEXTS)(
-		'$field entspricht dem gepinnten Hash der Fassung $version',
-		({ field, hash }) => {
-			const actual = createHash('sha256').update(helpTextOf(field), 'utf8').digest('hex');
-
-			expect(actual).toBe(hash);
-		}
-	);
-
-	it.each(PINNED_CONSENT_TEXTS)(
+	it.each(CONSENT_VERSIONS)(
 		'$field trägt eine Fassungskennung im Format JJJJ-MM-TT',
 		({ version }) => {
 			expect(version).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -109,7 +68,7 @@ describe('Fassungskennungen der Einwilligungstexte', () => {
 			month: '2-digit',
 			day: '2-digit'
 		}).format(new Date());
-		for (const { field, version } of PINNED_CONSENT_TEXTS) {
+		for (const { field, version } of CONSENT_VERSIONS) {
 			expect(version <= today, `${field}: ${version} liegt in der Zukunft`).toBe(true);
 		}
 	});

--- a/src/lib/form/consent/consentVersions.ts
+++ b/src/lib/form/consent/consentVersions.ts
@@ -9,11 +9,13 @@
  * Die Medien-Einwilligung führt denselben Nachweis seit dem 2026-07-28, hat aber
  * einen eigenen Lebenszyklus und bleibt deshalb in `mediaConsentVersion.ts`.
  *
- * **Regel:** Wird der Wortlaut einer Einwilligung in `sightingSchema.ts`
- * inhaltlich geändert, muss die zugehörige Kennung auf das Datum der Änderung
- * gesetzt werden. Altbestände behalten dadurch die Fassung, der sie tatsächlich
- * zugestimmt haben. `consentTextVersions.test.ts` erzwingt das über gepinnte
- * Hashes der Texte — ein Kommentar allein trägt diese Zusicherung nicht.
+ * **Regel:** Wird der Wortlaut einer Einwilligung inhaltlich geändert, muss die
+ * zugehörige Kennung auf das Datum der Änderung gesetzt werden. Altbestände
+ * behalten dadurch die Fassung, der sie tatsächlich zugestimmt haben. Gemeint
+ * ist die **gelesene Fläche** — Überschrift und umgebender Text im Markup
+ * genauso wie der Ankreuztext in `sightingSchema.ts`.
+ * `consentSurfaces.svelte.test.ts` erzwingt das über gepinnte Hashes der
+ * gerenderten Flächen — ein Kommentar allein trägt diese Zusicherung nicht.
  *
  * Die Datumswerte stammen aus der Historie des Wortlauts, nicht aus dem Tag der
  * Einführung dieser Spalten: `privacyConsent` wurde zuletzt mit der
@@ -31,8 +33,9 @@
  * (`Step4Contact.svelte`, „Optionale Veröffentlichung von Namen und
  * Aufnahmen" statt vorher „… Ihres Namens"). Der Geltungsbereich der Kennung
  * ist die gelesene Einwilligungsfläche, nicht die Zeichenkette im Schema —
- * wie bei `PRIVACY_CONSENT_VERSION` unten. `consentTextVersions.test.ts` sagt
- * das im Kopfkommentar ausdrücklich, kann es aber nicht prüfen.
+ * wie bei `PRIVACY_CONSENT_VERSION` unten. Seit dem 2026-08-06 ist genau das
+ * gepinnt (`consentSurfaces.svelte.test.ts`); zur Zeit dieser Änderung war es
+ * nur ein Kommentar, und die Kennung fiel deshalb erst einem Review auf.
  */
 export const NAME_CONSENT_VERSION = '2026-08-06';
 
@@ -54,10 +57,8 @@ export const SHIP_NAME_CONSENT_VERSION = '2026-08-06';
  * („um Ihre Meldung zu speichern", „Ohne diese Zustimmung kann Ihre Meldung
  * nicht gespeichert werden" — vorher jeweils „Sichtung", Änderungswunsch A5.3).
  * Der Geltungsbereich der Kennung ist die gelesene Einwilligungsfläche, nicht
- * die Zeichenkette im Schema; `consentTextVersions.test.ts` sagt das im
- * Kopfkommentar ausdrücklich, kann es aber nicht prüfen.
- *
- * Der gepinnte Hash in jenem Test bleibt deshalb korrekt und unverändert — er
- * deckt nur den `helpText` ab.
+ * die Zeichenkette im Schema. Seit dem 2026-08-06 deckt der gepinnte Hash in
+ * `consentSurfaces.svelte.test.ts` genau diese Fläche ab; der frühere Hash über
+ * den bloßen `helpText` hätte diese Änderung nicht bemerkt.
  */
 export const PRIVACY_CONSENT_VERSION = '2026-08-04';

--- a/src/lib/form/consent/mediaConsentVersion.ts
+++ b/src/lib/form/consent/mediaConsentVersion.ts
@@ -5,10 +5,12 @@
  * Ein gespeichertes „ja“ allein belegt nicht, **wozu** zugestimmt wurde —
  * deshalb wandert diese Kennung zusammen mit dem Zeitpunkt in die Sichtung.
  *
- * **Regel:** Wird der Wortlaut von `mediaConsent` in `sightingSchema.ts`
- * inhaltlich geändert, muss diese Kennung auf das Datum der Änderung gesetzt
- * werden. Altbestände behalten dadurch die Fassung, der sie tatsächlich
- * zugestimmt haben.
+ * **Regel:** Wird der Wortlaut von `mediaConsent` inhaltlich geändert, muss
+ * diese Kennung auf das Datum der Änderung gesetzt werden. Altbestände behalten
+ * dadurch die Fassung, der sie tatsächlich zugestimmt haben. Gemeint ist die
+ * **gelesene Fläche** — Überschrift und umgebender Text im Markup genauso wie
+ * der Ankreuztext in `sightingSchema.ts`; gepinnt in
+ * `consentSurfaces.svelte.test.ts`.
  *
  * Auf 2026-08-06 gehoben, obwohl der **Ankreuztext** (`meta.helpText`)
  * unverändert ist: `mediaConsent` ist seit dem 2026-08-05 von der Dropzone
@@ -19,8 +21,8 @@
  * `$form.uploadedFiles` tatsächlich eine abgeschlossene Aufnahme enthält
  * (`hasUploadedMedia`). Der Geltungsbereich der Kennung ist die gelesene
  * Einwilligungsfläche, nicht die Zeichenkette im Schema — wie bei
- * `PRIVACY_CONSENT_VERSION` in `consentVersions.ts`.
- * `consentTextVersions.test.ts` sagt das im Kopfkommentar ausdrücklich, kann
- * es aber nicht prüfen.
+ * `PRIVACY_CONSENT_VERSION` in `consentVersions.ts`. Seit dem 2026-08-06 ist
+ * genau das gepinnt (`consentSurfaces.svelte.test.ts`); zur Zeit dieses Umzugs
+ * war es nur ein Kommentar, und die Kennung fiel deshalb erst einem Review auf.
  */
 export const MEDIA_CONSENT_VERSION = '2026-08-06';

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -13,7 +13,15 @@
 
 {#if isLastStep}
 	<!-- Required Privacy Consent - Prominently displayed before submit -->
-	<div class="bg-primary/5 border-primary/20 mb-6 rounded-lg border-2 p-4">
+	<!-- `data-consent-surface` grenzt die Fläche ab, die
+	     `PRIVACY_CONSENT_VERSION` bezeugt: alles, was die meldende Person hier
+	     zur Einwilligung liest — Überschrift, Verarbeitungs-Kacheln,
+	     Widerrufshinweis, Verweis auf die Datenschutzerklärung —, nicht nur den
+	     Ankreuztext aus dem Schema. `consentSurfaces.svelte.test.ts` pinnt den
+	     Hash dieses Textes; wer hier umformuliert, muss die Fassungskennung
+	     heben. Text, der zur Einwilligung gehört, gehört deshalb INNERHALB
+	     dieses Elements. -->
+	<div class="bg-primary/5 border-primary/20 mb-6 rounded-lg border-2 p-4" data-consent-surface>
 		<div class="mb-4">
 			<h4 class="text-primary mb-2 flex items-center gap-2 text-lg font-bold">
 				<Icon icon="lucide:shield-alert" class="text-primary h-5 w-5" />
@@ -61,9 +69,11 @@
 				<!--
 					„Meldung", nicht „Sichtung" (A5.3): Über dieses Formular wird auch ein
 					Totfund gemeldet. Diese Fläche ist Rahmentext um die Einwilligung, nicht
-					der Ankreuztext selbst — sie hängt trotzdem an der Fassungskennung
-					(consentTextVersions.test.ts erklärt, warum kein Test das erzwingt).
-					PRIVACY_CONSENT_VERSION steht deshalb auf 2026-08-04.
+					der Ankreuztext selbst — sie hängt trotzdem an der Fassungskennung, und
+					seit dem 2026-08-06 erzwingt consentSurfaces.svelte.test.ts das auch
+					(gepinnter Hash über diese Fläche). PRIVACY_CONSENT_VERSION steht deshalb
+					auf 2026-08-04. Wer hier umformuliert, hebt die Kennung UND trägt den
+					neuen Hash nach — nur den Hash nachzutragen entwertet den Nachweis.
 				-->
 				<strong>Ohne diese Zustimmung kann Ihre Meldung nicht gespeichert werden.</strong>
 				Sie können diese Zustimmung jederzeit per E-Mail an datenschutz@meeresmuseum.de widerrufen.

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -163,7 +163,15 @@
 	</div>
 
 	<!-- Privacy and Consent Section -->
-	<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 md:p-4">
+	<!-- `data-consent-surface` grenzt die Fläche ab, die die Fassungskennungen
+	     bezeugen — hier die äußere, gemeinsame: Die Überschrift „Datenschutz und
+	     Einverständnis" rahmt alle vier Einwilligungen darunter. Die beiden
+	     Gruppen tragen je eine eigene, innere Fläche; `consentSurfaces.svelte.test.ts`
+	     hasht pro Feld die äußere Fläche, die eigene Gruppe und den eigenen
+	     Ankreuztext getrennt, sodass eine Gruppen-Überschrift nur die Kennungen
+	     ihrer eigenen Gruppe bewegt. Text, der zu einer Einwilligung gehört,
+	     gehört deshalb INNERHALB der passenden Fläche. -->
+	<div class="border-primary/20 bg-base-200/50 rounded-lg border p-3 md:p-4" data-consent-surface>
 		<h3 class="mb-3 flex gap-2 text-base font-semibold md:text-lg">
 			<Icon icon="lucide:lock" width="20" class="text-primary" />
 			Datenschutz und Einverständnis
@@ -173,7 +181,7 @@
 		     und Veröffentlichung von Aufnahmen. Die Überschrift muss alle drei
 		     Felder darunter tragen — `mediaConsent` ist keine Namensnennung, hier
 		     stand bis zum Review von Task 14 (2026-08-06) noch „…Ihres Namens". -->
-		<div class="mt-6 space-y-4">
+		<div class="mt-6 space-y-4" data-consent-surface>
 			<h4 class="flex items-center gap-2 text-base font-semibold">
 				<Icon icon="lucide:pen-line" width="16" class="text-primary" />
 				Optionale Veröffentlichung von Namen und Aufnahmen
@@ -219,7 +227,7 @@
 		</div>
 
 		<!-- Persistent Data Storage Consent -->
-		<div class="mt-6 space-y-4">
+		<div class="mt-6 space-y-4" data-consent-surface>
 			<h4 class="text-base font-semibold">
 				<Icon icon="lucide:save" width="16" class="inline" /> Dauerhafte Speicherung der Kontaktdaten
 			</h4>


### PR DESCRIPTION
## Problem

`consentTextVersions.test.ts` versprach in seinem Kopfkommentar, der Geltungsbereich einer Fassungskennung sei die **gelesene Einwilligungsfläche** — „Überschrift, … der gesamte umgebende Text" — und hashte dann nur `meta.helpText` aus `sightingSchema.ts`.

PR #773 zeigte die Lücke: Die Überschrift über `nameConsent`/`shipNameConsent` wechselte von „Optionale Veröffentlichung Ihres Namens" auf „… von Namen und Aufnahmen", und `mediaConsent` zog samt Erklärtext von der Dropzone auf Schritt 2 in einen anderen Kontext zwei Schritte weiter. Der Test blieb grün; die drei Kennungen wurden erst nachträglich durch ein Review gehoben (`5fe0bbbe`).

Eine Kennung, die beim Umformulieren stehen bleibt, weist der Einwilligung rückwirkend einen Text zu, den die Meldenden nie gesehen haben — der Nachweis nach Art. 7 Abs. 1 DSGVO ist damit entwertet.

## Lösung

Die umgebenden Texte stehen im Markup, und die einzige belastbare Lesart des Markups ist das, was der Browser daraus rendert. Der Wächter ist deshalb ein Komponententest (`consentSurfaces.svelte.test.ts`).

Geprüft und verworfen: das Schema-`.label()` mitzuhashen (deckt die Überschrift nicht ab) und die `.svelte`-Quelle per Regex abzugreifen (zweite, brüchige Quelle neben dem Markup).

- **`data-consent-surface`** grenzt die Flächen im Markup ab — mit Begründung neben dem Text, den sie umfassen.
- **Flächen schachteln.** `Step4Contact.svelte` markiert die gemeinsame Karte *und* darin die beiden Gruppen. Gehasht wird pro Feld ebenenweise: äußere Fläche ohne die inneren, eigene Gruppe ohne die Felder, dann der eigene Ankreuztext mit Hilfetext und Tooltip (`data-tip` trägt den `valueText` — im `textContent` steht er nie). Eine Gruppen-Überschrift bewegt damit nur die Kennungen ihrer Gruppe.
- **Zwei Gegenproben** prüfen, dass genau die gepinnten Einwilligungen gerendert werden — eine neue oder verschobene fällt auf, statt still ungeschützt zu bleiben.
- **Der alte `helpText`-Hash entfällt**, weil der Flächen-Hash ihn enthält. Zwei Hashes für eine Textänderung hätten nur die Gewohnheit gefördert, sie nachzutragen. In `consentTextVersions.test.ts` bleiben die Formregeln (Datumsformat, keine Zukunft), die weiterhin in `test:quick` laufen.

`persistentDataConsent` ist mitgepinnt, trägt aber bewusst keine Kennung: Die Zustimmung wird nirgends serverseitig nachgewiesen, es gibt keine Spalte, die eine Fassung tragen könnte.

## Diskriminierung — per Mutation belegt

| Mutation | Ergebnis |
| --- | --- |
| Überschrift zurück auf „Optionale Veröffentlichung Ihres Namens" (der Fall aus #773) | `nameConsent`, `shipNameConsent`, `mediaConsent` rot — `persistentDataConsent` und `privacyConsent` grün |
| Karten-Überschrift „Datenschutz und Einverständnis" geändert | alle vier Schritt-4-Einwilligungen rot, `privacyConsent` grün |
| beide zurückgenommen | 7/7 grün |

Die zweite Mutation belegt zugleich, dass die Ebenen-Trennung trägt und nicht alles an einem Hash hängt.

## Bekannte Grenzen (im Code dokumentiert)

- Die Wortlaut-Bindung ist aus `test:quick` heraus — sie läuft in CI (`test:unit:client`) und lokal über `npm run test:unit:client`.
- Der Vollständigkeits-Guard mountet `Step4Contact` und `RequiredConsent`; eine künftige Einwilligung in einer anderen Komponente wäre für ihn unsichtbar.
- Geltungsbereich ist das Meldeformular, nicht die Admin-Maske: Die Kennung bezeugt, was die meldende Person gelesen hat.

## Tests

`lint` 0 Fehler · `type-check` 0 · `svelte-check` 2126 Dateien / 0 · `test:unit` 3570 · `test:unit:client` 519. Einwilligungstexte selbst sind unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)