### PR TITLE
test(report): prove the weather auto-fetch survives the dead-finding branch

### DIFF
--- a/src/lib/report/components/steps/Step3Observations.svelte.test.ts
+++ b/src/lib/report/components/steps/Step3Observations.svelte.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { get } from 'svelte/store';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { StoredWeatherData } from '$lib/services/weatherService';
 import Step3Observations from './Step3Observations.svelte';
 
 /**
@@ -100,5 +103,174 @@ describe('Step3Observations — Verhaltens-Karte folgt dem Totfund-Zweig', () =>
 		renderWithFormContext(Step3Observations, { overrides: { isDead: true } });
 
 		expect(document.body.textContent).not.toContain('Verhaltensinformationen');
+	});
+});
+
+/**
+ * Antwort von `/api/weather/historical`, Form wie in dessen `+server.ts`. Das
+ * Datum liegt fest in der Vergangenheit — der Zweig `historical` im Test hängt
+ * damit nicht am Kalender des Laufs.
+ */
+const WEATHER_RESPONSE = {
+	success: true,
+	weather: {
+		time: '2026-07-01T12:00',
+		windSpeed: 18.5,
+		windDirection: 270,
+		windDirectionCardinal: 'W',
+		temperature: 17.4,
+		weatherCode: 3,
+		weatherDescription: 'Bedeckt',
+		visibility: 24000,
+		seaState: 3,
+		pressure: 1013
+	},
+	formFields: { windForce: '5', windDirection: 'W', seaState: '3', visibility: 4 },
+	metadata: {
+		source: 'Open-Meteo Historical Weather API',
+		dataType: 'historical',
+		cached: false,
+		latitude: 54.5,
+		longitude: 12.5
+	}
+};
+
+/** Position und Datum, wie sie aus Schritt 1 kommen — die Vorbedingung des Abrufs. */
+const POSITION_AND_DATE = {
+	latitude: 54.5,
+	longitude: 12.5,
+	sightingDate: '2026-07-01',
+	sightingTime: '12:00'
+};
+
+/** Überschrift des Vorschlagsblocks in `WeatherDataFetcher.svelte`. */
+const SUGGESTION_HEADING = 'Vorgeschlagene Wetterdaten für die angegebene Position';
+
+const WEATHER_ENDPOINT = '/api/weather/historical';
+
+function stubWeatherApi(): ReturnType<typeof vi.fn> {
+	const fetchSpy = vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => WEATHER_RESPONSE
+	});
+	vi.stubGlobal('fetch', fetchSpy);
+	return fetchSpy;
+}
+
+/**
+ * Nur die Wetter-Anfragen aus dem global gestubbten `fetch`. Gezählt wird
+ * gefiltert und nicht über `toHaveBeenCalledTimes`: Lädt eine Schwesterkarte
+ * dieses Schritts später etwas nach, wäre das sonst ein irreführender
+ * Fehlschlag in einem Test, der mit dem Wetter nichts zu tun hätte.
+ */
+function weatherRequests(fetchSpy: ReturnType<typeof vi.fn>): URL[] {
+	return fetchSpy.mock.calls
+		.map(([input]) => new URL(String(input), 'https://localhost:4000'))
+		.filter((url) => url.pathname === WEATHER_ENDPOINT);
+}
+
+/**
+ * Risiko 5 der Einstiegsseiten-Spezifikation
+ * (`docs/PLAN_EINSTIEGSSEITE_MELDEFORMULAR_2026-08-05.md`, Abschnitt 11) und
+ * Punkt 10 der Definition of Done: Die Karte „Umweltbedingungen" trägt einen
+ * **automatischen** Wetter-Abruf, der bei gesetzter Position und gesetztem
+ * Datum von selbst anspringt und über `handleFullWeatherData` einen
+ * vollständigen Datensatz ins Formular schreibt. Fassung 1 der Spezifikation
+ * wollte die Karte im Totfund-Zweig ausblenden — das hätte diese
+ * Forschungsdaten still verloren, und zwar Daten, die den Melder keinen
+ * einzigen Klick kosten.
+ *
+ * **Warum der Test hier steht und nicht in `Environment.svelte.test.ts`.**
+ * `Environment.svelte` kennt den Zweig gar nicht — es liest `latitude`,
+ * `longitude`, `sightingDate`, `sightingTime` und `adminMode`, aber nie
+ * `isDead`. Ein Test dort mit `overrides: { isDead: true }` verhielte sich
+ * identisch zu einem mit `isDead: false`: Er wäre in beiden Zweigen grün und
+ * könnte über den Totfund-Zweig deshalb nichts aussagen. Die Entscheidung, ob
+ * die Karte im Totfund-Zweig überhaupt gerendert wird, fällt eine Ebene höher
+ * — genau hier, wo `<Behavior>` hinter `isDeadFinding($form.isDead)` steht und
+ * `<Environment>` bewusst nicht. Wer Risiko 5 versehentlich eintreten lässt,
+ * tut das durch ein `{#if}` an dieser Aufrufstelle; davon wird dieser Test rot
+ * (vorgeführt am 2026-08-06: `<Environment>` hinter dieselbe Bedingung gesetzt
+ * → alle drei Tests rot; nur `autoFetch={false}` in `Environment.svelte` →
+ * die zwei positiven Tests rot, die Gegenprobe unten bleibt grün).
+ *
+ * **Warum kein E2E.** Der Abruf geht gegen `/api/weather/historical` und von
+ * dort gegen Open-Meteo. Ein E2E müsste diese Route ebenso abfangen wie dieser
+ * Test `fetch` — an echte Wetterdaten käme es also nicht näher, bräuchte aber
+ * eine eigene Spec-Datei samt Shard-Zuordnung. Den einen Teil, den es
+ * zusätzlich prüfte (`?meldung=totfund` kommt als `isDead` im Formular an),
+ * deckt `e2e/report-kind-choice.spec.ts` bereits ab.
+ *
+ * **Was der Test damit ausdrücklich nicht prüft:** die Server-Route und
+ * Open-Meteo selbst. Geprüft wird die Strecke, um die es in Risiko 5 geht —
+ * Totfund-Zweig → Karte wird gerendert → Abruf springt an → Antwort landet im
+ * Formular.
+ */
+describe('Step3Observations — der automatische Wetter-Abruf bleibt im Totfund-Zweig', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('fragt die Wetterdaten beim Totfund von selbst ab und zeigt sie an', async () => {
+		const fetchSpy = stubWeatherApi();
+
+		renderWithFormContext(Step3Observations, {
+			overrides: { isDead: true, ...POSITION_AND_DATE }
+		});
+
+		await expect.element(page.getByText(SUGGESTION_HEADING)).toBeVisible();
+		await expect.element(page.getByText('Bedeckt')).toBeVisible();
+
+		const requests = weatherRequests(fetchSpy);
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.searchParams.get('lat')).toBe('54.5');
+		expect(requests[0]?.searchParams.get('lng')).toBe('12.5');
+		expect(requests[0]?.searchParams.get('date')).toBe('2026-07-01');
+		expect(requests[0]?.searchParams.get('time')).toBe('12:00');
+	});
+
+	/**
+	 * Der eigentliche Wert des Abrufs ist nicht die Anzeige, sondern der
+	 * Datensatz, der ohne Zutun des Melders in `weatherData` landet und mit der
+	 * Sichtung gespeichert wird (`handleFullWeatherData` in
+	 * `Environment.svelte`). Die drei Felder darüber — Seegang, Sichtweite,
+	 * Windstärke — füllt erst „Daten übernehmen"; dieser Datensatz nicht.
+	 */
+	it('legt den vollständigen Datensatz beim Totfund ohne Zutun im Formular ab', async () => {
+		stubWeatherApi();
+
+		const context = renderWithFormContext(Step3Observations, {
+			overrides: { isDead: true, ...POSITION_AND_DATE }
+		});
+
+		await expect.element(page.getByText(SUGGESTION_HEADING)).toBeVisible();
+
+		const stored = get(context.form).weatherData as StoredWeatherData | undefined;
+		expect(stored).toBeDefined();
+		expect(stored?.provider).toBe('open-meteo');
+		// Vergangenes Datum → `historical`, nicht `forecast` (Datumslogik in Environment.svelte).
+		expect(stored?.data_type).toBe('historical');
+		expect(stored?.location).toMatchObject({ latitude: 54.5, longitude: 12.5 });
+		expect(stored?.processed.temperature).toBe(17.4);
+		expect(stored?.processed.windDirectionCardinal).toBe('W');
+	});
+
+	/**
+	 * Gegenprobe: Ohne die Vorbedingung darf nichts abgefragt werden. Ohne sie
+	 * belegte der Test oben nur, dass irgendwann irgendein `fetch` läuft — die
+	 * Aussage „springt an, **sobald** Position und Datum gesetzt sind" braucht
+	 * den Fall, in dem er es nicht tut.
+	 */
+	it('fragt beim Totfund nichts ab, solange die Position fehlt', async () => {
+		const fetchSpy = stubWeatherApi();
+
+		renderWithFormContext(Step3Observations, {
+			overrides: { isDead: true, sightingDate: '2026-07-01', sightingTime: '12:00' }
+		});
+
+		await expect.element(page.getByRole('heading', { name: 'Umweltbedingungen' })).toBeVisible();
+
+		expect(weatherRequests(fetchSpy)).toHaveLength(0);
+		expect(page.getByText(SUGGESTION_HEADING).elements()).toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## Warum

Risiko 5 der Einstiegsseiten-Spezifikation (`docs/PLAN_EINSTIEGSSEITE_MELDEFORMULAR_2026-08-05.md`, Abschnitt 11) verlangte ausdrücklich einen Test, der den **automatischen** Wetter-Abruf im Totfund-Zweig nachweist — die Karte „Umweltbedingungen" trägt einen Abruf, der bei gesetzter Position und gesetztem Datum von selbst anspringt und Forschungsdaten liefert, die den Melder keinen Klick kosten. Fassung 1 der Spezifikation wollte diese Karte im Totfund-Zweig ausblenden.

Der Test fehlte. Punkt 10 der Definition of Done (Abschnitt 12) war damit nur von Hand im Browser belegt.

## Was

Drei Tests in `Step3Observations.svelte.test.ts`:

1. Der Abruf springt beim Totfund von selbst an — Anfrage an `/api/weather/historical` mit `lat`/`lng`/`date`/`time`, die Karte zeigt die Werte.
2. Der vollständige Datensatz landet ohne Zutun in `weatherData` (`provider`, `data_type`, `location`, `processed`) — das ist der Forschungswert, um den Risiko 5 sich sorgt. Die drei Formularfelder darüber füllt weiterhin erst „Daten übernehmen".
3. Gegenprobe: ohne Position wird nichts abgefragt.

## Warum dort und nicht in `Environment.svelte.test.ts`

`Environment.svelte` kennt den Zweig gar nicht — es liest `latitude`, `longitude`, `sightingDate`, `sightingTime` und `adminMode`, aber nie `isDead`. Ein Test dort mit `overrides: { isDead: true }` verhielte sich identisch zu einem mit `isDead: false`: in beiden Zweigen grün, über den Totfund-Zweig ohne Aussage. Die Entscheidung, ob die Karte im Totfund-Zweig gerendert wird, fällt in `Step3Observations.svelte`, wo `<Behavior>` bereits hinter `isDeadFinding($form.isDead)` steht und `<Environment>` bewusst nicht.

## Warum kein E2E

Der Abruf geht über `/api/weather/historical` gegen Open-Meteo. Ein E2E müsste die Route ebenso abfangen wie dieser Test `fetch` — an echte Wetterdaten käme es also nicht näher, bräuchte aber eine eigene Spec-Datei samt Shard-Zuordnung in `ci.yml`. Den einen Teil, den es zusätzlich prüfte (`?meldung=totfund` kommt als `isDead` im Formular an), deckt `e2e/report-kind-choice.spec.ts` bereits ab. **`ci.yml` bleibt unberührt.**

Nicht geprüft werden damit die Server-Route und Open-Meteo selbst; das steht so im Testkopf.

## Diskriminierung — belegt, nicht behauptet

| Kurzzeitige Mutation | Ergebnis |
| --- | --- |
| `<Environment>` hinter `{#if !isDeadFinding($form.isDead)}` (= Risiko 5 wörtlich) | alle 3 Tests rot |
| `autoFetch={false}` in `Environment.svelte` (Karte bleibt, nur der Automatismus fehlt) | die 2 positiven rot, Gegenprobe bleibt grün |

Beide Mutationen zurückgenommen — an `src/` ist außer der Testdatei nichts geändert.

## Verifikation

- `npm run test:quick` grün (3574 Tests)
- Client-Vollsuite grün (48 Dateien, 515 Tests)
- `tsc --noEmit`, ESLint, Prettier sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)