### PR TITLE
fix(report): let the error navigation follow the current branch

### DIFF
--- a/.claude/rules/forms.md
+++ b/.claude/rules/forms.md
@@ -164,9 +164,16 @@ Rohwert wie `$form.isDead` direkt:
 
 ### Die Zwei-Hälften-Regel — der teuerste Fehler in diesem Formular
 
-`getFormSteps` (`formConfig.ts`) steuert **ausschließlich die Validierung** — gelesen wird
-es nur von `stepValidation.ts`, gerendert wird daraus **nichts**. Ein Feld dort aus den
-`fields` eines Schritts zu entfernen macht es unvalidiert, aber nicht unsichtbar.
+`getFormSteps` (`formConfig.ts`) steuert **Validierung und Fehler-Navigation** — gerendert
+wird daraus **nichts**. Ein Feld dort aus den `fields` eines Schritts zu entfernen macht es
+unvalidiert, aber nicht unsichtbar.
+
+Gelesen wird es von `stepValidation.ts` (Schritt-Gate), von `StepNavigation.svelte`
+(Feldreihenfolge für `scrollToFirstError`), von `ModernReportForm.svelte`
+(`resolveServerFieldErrors`, `findStepForErrors`, Vorab-Prüfung über `hiddenFormFields`)
+und von `RequiredConsent.svelte` (letzter Schritt). Alle rechnen über Schritte, keiner
+rendert daraus — wer eine dieser Stellen auf `formStepsConfig` zurückdreht, führt zu einem
+Feld, das im aktuellen Zweig kein DOM-Element hat, und der Sprung fällt still aus.
 
 Jede Ausblendung eines Feldes braucht deshalb **beide Hälften**, über **dasselbe** benannte
 Prädikat:

--- a/src/lib/report/README.md
+++ b/src/lib/report/README.md
@@ -94,14 +94,26 @@ Titles, descriptions and the per-step validated fields live in `formStepsConfig`
 
 Three distinct layers — see `.claude/rules/forms.md` for the full table:
 
-| Layer          | Where                                  | Effect                                          |
-| -------------- | -------------------------------------- | ----------------------------------------------- |
-| **Per step**   | `../form/validation/stepValidation.ts` | Gates "Next"; blocks navigation                 |
-| **Pre-submit** | `ModernReportForm.handleFinalSubmit`   | Logging only — does **not** block               |
-| **Submit**     | `createForm.handleSubmit`              | Authoritative; sets `$errors`, calls `onSubmit` |
+| Layer          | Where                                  | Effect                                                 |
+| -------------- | -------------------------------------- | ------------------------------------------------------ |
+| **Per step**   | `../form/validation/stepValidation.ts` | Gates "Next"; blocks navigation                        |
+| **Pre-submit** | `ModernReportForm.handleFinalSubmit`   | Blocks; sets `$errors`, jumps to the earliest bad step |
+| **Submit**     | `createForm.handleSubmit`              | Authoritative; sets `$errors`, calls `onSubmit`        |
 
 `isStepValid(currentStep, formData)` and `validateStep(currentStep, formData)` take **two**
-arguments and validate `sightingSchema.pick(formStepsConfig[currentStep].fields)`.
+arguments and validate `sightingSchema.pick(getFormSteps(formData)[currentStep].fields)`.
+
+The pre-submit layer covers all steps at once (a field can go invalid after its step was
+left) and validates `sightingSchema.omit(hiddenFormFields(formValues))` — the full schema
+minus what the current branch hides. Without that subtraction, a leftover value in a hidden
+field blocks the submit behind an error nobody can see, and drags the jump target onto a
+step that shows nothing.
+
+**Known gap:** the authoritative layer below still validates the _full_ schema
+(`validationSchema` is handed to `createForm` once and cannot be branch-aware), so that same
+leftover value still stops the submit there — silently, without a toast or a jump. Closing it
+means deciding what a hidden field's leftover value should do on submit, which is a separate
+change.
 
 There is no debouncing. `createForm` exposes
 `{ form, errors, touched, isSubmitting, isValid, handleSubmit, handleChange, updateField, updateInitialValues }`

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -458,14 +458,21 @@
 		});
 
 		// Geprüft wird das volle Schema OHNE die Felder, die der aktuelle Zweig
-		// ausblendet. Ein ausgeblendetes Feld behält seinen Wert (`$form` wird
-		// bewusst nicht geleert — Begründung samt verworfenem Ansatz bei
-		// `HIDDEN_WHEN_FROM_LAND` in formConfig.ts), und ein ungültiger Restwert
-		// darin brächte hier beides zum Stillstand: Der Sprung landete auf einem
-		// Schritt, auf dem nichts markiert ist, und das Absenden bliebe mit einer
-		// Meldung an einem Feld hängen, das niemand sieht und niemand korrigieren
-		// kann. Real erreichbar z. B. so: „Motorboot" wählen, Antrieb setzen,
-		// auf „Land" wechseln.
+		// ausblendet. Ein ungültiger Restwert darin brächte hier beides zum
+		// Stillstand: Der Sprung landete auf einem Schritt, auf dem nichts
+		// markiert ist, und das Absenden bliebe mit einer Meldung an einem Feld
+		// hängen, das niemand sieht und niemand korrigieren kann.
+		//
+		// Erreichbar ist das über den Beobachtungsort, nicht über den Zweig:
+		// `HIDDEN_WHEN_FROM_LAND` lässt `$form` bewusst stehen (Begründung samt
+		// verworfenem Ansatz dort), also überlebt ein zu langer `reaction`- oder
+		// `shipName`-Text den Wechsel auf „Land" — kein `maxlength` im
+		// Feld-Renderer hält ihn vorher auf. Über den Zweig entsteht kein
+		// Restwert: `boatDrive` räumt `shouldResetBoatDrive` beim Übergang
+		// Boot→Land ab (`sections/boatDriveReset.ts`), und die drei
+		// `HIDDEN_WHEN_DEAD`-Felder leert der Mount-Aufräumer oben über
+		// `fieldsOutsideReportKind` — ein Zweigwechsel geht immer über die
+		// Einstiegsseite und mountet dieses Formular neu (`+page.svelte`).
 		//
 		// `omit` statt einer aus den Schritt-Feldern gebauten Positivliste
 		// (`pick`): Das Schema führt auch Felder, die in keinem Schritt stehen
@@ -475,8 +482,7 @@
 		// in `when()`-Beziehungen ausschließlich die abhängige Seite; die
 		// Bedingungsfelder (`hasPosition`, `isDead`, `sightingFrom`) bleiben
 		// sämtlich im Schema.
-		const hidden = hiddenFormFields(formValues) as Array<keyof SightingFormData>;
-		const reachableSchema = hidden.length > 0 ? sightingSchema.omit(hidden) : sightingSchema;
+		const reachableSchema = sightingSchema.omit(hiddenFormFields(formValues));
 
 		try {
 			await reachableSchema.validate(formValues, { abortEarly: false });

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -16,7 +16,9 @@
 	import { resolveServerFieldErrors } from '$lib/report/serverFieldErrors';
 	import {
 		HIDDEN_WHEN_FROM_LAND,
+		getFormSteps,
 		hasUploadedMedia,
+		hiddenFormFields,
 		initialFormState,
 		isDeadFinding,
 		isFromLand
@@ -394,15 +396,27 @@
 	 * in `StepNavigation.handleFormSubmission` der Catch-Zweig mit
 	 * `showValidationError()`, das einen ZWEITEN `scrollToFirstError` samt
 	 * eigenem Fokus-Timeout auslöst. Zwei konkurrierende Sprünge entstehen daraus
-	 * heute nicht, weil `handleFinalSubmit` gegen das volle Schema vorvalidiert:
-	 * Der Server wird nur mit client-seitig gültigen Daten erreicht, `validateStep`
-	 * findet dort nichts und `showValidationError` steigt sofort wieder aus. Wer
-	 * dieses Vorab-Gate lockert, muss die beiden Sprünge gegeneinander absichern.
+	 * heute nicht, weil `handleFinalSubmit` vorvalidiert: Der Server wird nur mit
+	 * client-seitig gültigen Daten erreicht, `validateStep` findet dort nichts und
+	 * `showValidationError` steigt sofort wieder aus. Dass die Vorab-Prüfung die
+	 * im Zweig ausgeblendeten Felder auslässt, ändert daran nichts — `validateStep`
+	 * lässt über `getFormSteps` genau dieselben aus. Wer das Vorab-Gate weiter
+	 * lockert, muss die beiden Sprünge gegeneinander absichern.
 	 */
 	function applyServerFieldErrors(serverFields: Record<string, string>): void {
+		// `getFormSteps($form)`, nicht `formStepsConfig`: Die statische Liste führt
+		// auch Felder, die im aktuellen Zweig nicht gerendert werden. Benennt der
+		// Server eines davon, hätte es hier zwei Wirkungen, die beide falsch sind
+		// — es käme als unbehebbarer Fehler in den Store (`updateField` löscht nur
+		// den Fehler des GEÄNDERTEN Feldes, und dieses Feld hat kein
+		// Bedienelement), und es stünde in der Feldreihenfolge vor dem sichtbaren
+		// Feld, sodass `scrollToFirstError` kein Element fände und der Sprung ganz
+		// ausfiele. Die Zweig-Fassung filtert es an derselben Stelle weg, an der
+		// `resolveServerFieldErrors` schon die schrittlosen Felder (`allgemein`,
+		// `referenceId`, …) aussortiert — dieselbe Begründung, dieselbe Naht.
 		const { fields, targetStep, fieldOrder } = resolveServerFieldErrors(
 			serverFields,
-			formStepsConfig,
+			getFormSteps($form),
 			currentStep
 		);
 
@@ -427,7 +441,7 @@
 	async function handleFinalSubmit(e: Event): Promise<void> {
 		logger.info('Final submission:');
 
-		// Pre-submit: validate against the FULL Schema. A step's own
+		// Pre-submit: validate across ALL steps at once. A step's own
 		// validation only covers ITS OWN fields — a field can become invalid
 		// after its step was already left (e.g. a value depends on another
 		// step). Submitting despite that must never look like "nothing
@@ -438,13 +452,34 @@
 		// 3. abort BEFORE calling formContext.handleSubmit — and rethrow so
 		//    StepNavigation's existing submit-catch (toast + showValidationError)
 		//    takes over, exactly like it already does for real submit errors.
-		const formValues = await new Promise<unknown>((resolve) => {
+		const formValues = await new Promise<SightingFormData>((resolve) => {
 			const unsub = formContext.form.subscribe((v) => resolve(v));
 			unsub();
 		});
 
+		// Geprüft wird das volle Schema OHNE die Felder, die der aktuelle Zweig
+		// ausblendet. Ein ausgeblendetes Feld behält seinen Wert (`$form` wird
+		// bewusst nicht geleert — Begründung samt verworfenem Ansatz bei
+		// `HIDDEN_WHEN_FROM_LAND` in formConfig.ts), und ein ungültiger Restwert
+		// darin brächte hier beides zum Stillstand: Der Sprung landete auf einem
+		// Schritt, auf dem nichts markiert ist, und das Absenden bliebe mit einer
+		// Meldung an einem Feld hängen, das niemand sieht und niemand korrigieren
+		// kann. Real erreichbar z. B. so: „Motorboot" wählen, Antrieb setzen,
+		// auf „Land" wechseln.
+		//
+		// `omit` statt einer aus den Schritt-Feldern gebauten Positivliste
+		// (`pick`): Das Schema führt auch Felder, die in keinem Schritt stehen
+		// (`referenceId`, `entryChannel`, `weatherData.*`) — die sollen weiter
+		// geprüft werden. Warum das Komplement die richtige Größe ist, steht bei
+		// `hiddenFormFields`. Unkritisch für Yup: Alle ausgeblendeten Felder sind
+		// in `when()`-Beziehungen ausschließlich die abhängige Seite; die
+		// Bedingungsfelder (`hasPosition`, `isDead`, `sightingFrom`) bleiben
+		// sämtlich im Schema.
+		const hidden = hiddenFormFields(formValues) as Array<keyof SightingFormData>;
+		const reachableSchema = hidden.length > 0 ? sightingSchema.omit(hidden) : sightingSchema;
+
 		try {
-			await sightingSchema.validate(formValues, { abortEarly: false });
+			await reachableSchema.validate(formValues, { abortEarly: false });
 			logger.info('Pre-submit validation: all fields OK');
 		} catch (yupError) {
 			if (!(yupError instanceof ValidationError)) {
@@ -465,9 +500,13 @@
 
 			// Jump to the earliest step that actually contains an error —
 			// no-op if the errors are already visible on the current step
+			// Zweig-Fassung, aus demselben Grund wie in `applyServerFieldErrors`:
+			// `findStepForErrors` liefert den frühesten Schritt, der eines der
+			// Felder führt — aus der statischen Liste könnte das ein Schritt sein,
+			// auf dem das Feld gar nicht gerendert wird.
 			const targetStep = findStepForErrors(
 				Object.keys(validationErrors),
-				formStepsConfig,
+				getFormSteps(formValues),
 				currentStep
 			);
 			if (targetStep !== null) {

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -819,9 +819,16 @@ describe('ModernReportForm — die Fehler-Navigation kennt den Zweig', () => {
 	 *
 	 * `boatDrive` (Schritt 2, Index 1) ist bei einer Land-Meldung ausgeblendet —
 	 * `sections/SightingDetails.svelte` zeigt es nur bei Segelschiff/Motorboot.
-	 * Ein Restwert entsteht real: Wer erst „Motorboot" wählt, den Antrieb setzt
-	 * und dann auf „Land" wechselt, lässt ihn im Formular-Zustand stehen (der
-	 * Zustand wird bewusst nicht geleert, siehe `HIDDEN_WHEN_FROM_LAND`).
+	 * Es steht hier als gesetzter Wert im Zustand, weil es das ausgeblendete
+	 * Feld im FRÜHESTEN Schritt ist und die Verwechslung damit am Sprungziel
+	 * sichtbar macht. Der Weg dorthin ist gestellt: Beim Übergang Boot→Land
+	 * räumt `shouldResetBoatDrive` (`sections/boatDriveReset.ts`) es real ab.
+	 * Ungestellt erreichbar ist dieselbe Lage über die Felder, die
+	 * `HIDDEN_WHEN_FROM_LAND` bewusst stehen lässt (`reaction`, `shipName`,
+	 * `homePort`) — die liegen nur alle auf Schritt 3 und trügen den Fehler
+	 * damit auf demselben Schritt wie `shipCount`, was den Sprung nicht
+	 * unterscheidbar machte.
+	 *
 	 * `shipCount` (Schritt 3, Index 2) ist dagegen sichtbar und trägt hier den
 	 * einzigen Fehler, den der Melder auch beheben kann.
 	 */

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -723,3 +723,125 @@ describe('ModernReportForm — mediaConsent ohne fertigen Upload erreicht den Se
 		expect(sent.mediaConsent).toBe(true);
 	});
 });
+
+/**
+ * Die Fehler-Navigation lief bis hierher gegen `formStepsConfig` — die
+ * STATISCHE Feldliste ohne Zweigfilter. `scrollToFirstError` und
+ * `findStepForErrors` laufen diese Liste ab, um zum ersten fehlerhaften Feld
+ * bzw. zum frühesten betroffenen Schritt zu führen; ein im aktuellen Zweig
+ * ausgeblendetes Feld steht dort aber weiterhin drin. Beide landeten damit an
+ * einem Feld, das gar nicht gerendert ist — der Melder sieht einen Sprung ohne
+ * erkennbaren Anlass und findet nichts zu korrigieren. Genau die Sackgasse, vor
+ * der die Zwei-Hälften-Regel in `.claude/rules/forms.md` warnt, nur eine Ebene
+ * weiter: nicht das Feld selbst, sondern der WEG dorthin kannte den Zweig nicht.
+ *
+ * Beide Tests fahren die Land-Meldung (`sightingFrom = LAND`), weil dort mit
+ * `reaction` und `boatDrive` ausgeblendete Felder in ZWEI verschiedenen
+ * Schritten liegen — die Verwechslung wird dadurch am Sprungziel sichtbar und
+ * nicht nur an der Feldreihenfolge.
+ */
+describe('ModernReportForm — die Fehler-Navigation kennt den Zweig', () => {
+	const today = new Date().toISOString().split('T')[0];
+
+	/** Vollständig gültige Land-Meldung auf Schritt 4 (Index 3). */
+	function seedValidLandReport(overrides: Record<string, unknown> = {}): void {
+		sessionStorage.setItem(STORAGE_KEYS.CURRENT_STEP, JSON.stringify(3));
+		sessionStorage.setItem(
+			STORAGE_KEYS.FORM_DATA,
+			JSON.stringify({
+				...initialFormState,
+				referenceId: 'ref-fehler-navigation',
+				entryChannel: 0,
+				species: 0,
+				totalCount: 1,
+				distance: 1,
+				shipCount: 2,
+				sightingFrom: SightingFromEnum.LAND,
+				hasPosition: true,
+				latitude: 54.5,
+				longitude: 13.5,
+				sightingDate: today,
+				firstName: 'Max',
+				lastName: 'Mustermann',
+				email: 'max@example.com',
+				privacyConsent: true,
+				...overrides
+			})
+		);
+	}
+
+	beforeEach(() => {
+		submitSightingFormMock.mockClear();
+		submitSightingFormMock.mockResolvedValue({ status: 'ok', id: 1 });
+	});
+
+	/**
+	 * Server-Ablehnung: `resolveServerFieldErrors` bekommt die Feldreihenfolge
+	 * des Zielschritts. Steht darin ein ausgeblendetes Feld VOR dem sichtbaren,
+	 * wählt `scrollToFirstError` das ausgeblendete, findet dafür kein Element
+	 * und springt gar nicht — der Melder bleibt ohne Fokus und ohne Hinweis
+	 * zurück, während die Meldung „Validierungsfehler bei der Eingabe" über der
+	 * Navigation steht.
+	 *
+	 * `reaction` steht in `formStepsConfig` auf Schritt 3 (Index 2) vor
+	 * `shipCount`, ist bei einer Land-Meldung aber ausgeblendet
+	 * (`sections/Behavior.svelte`).
+	 */
+	it('springt bei einer Server-Ablehnung zum ersten SICHTBAREN Feld des Zielschritts', async () => {
+		seedValidLandReport();
+		submitSightingFormMock.mockResolvedValue({
+			status: 'rejected',
+			message: 'Validierungsfehler bei der Eingabe',
+			fields: {
+				reaction: 'Die Reaktion darf nicht länger als 1000 Zeichen sein.',
+				shipCount: 'Die Anzahl der Schiffe darf 15 nicht überschreiten.'
+			}
+		} as never);
+
+		render(ModernReportForm);
+
+		await page.getByRole('button', { name: 'Formular absenden' }).click();
+
+		// `scrollToFirstError` fokussiert verzögert (500 ms in `fieldNavigation.ts`),
+		// davor läuft noch ein `requestAnimationFrame` — großzügig warten.
+		await vi.waitFor(() => expect(document.activeElement?.getAttribute('name')).toBe('shipCount'), {
+			timeout: 4000
+		});
+	});
+
+	/**
+	 * Vorab-Prüfung beim Absenden: `handleFinalSubmit` validiert gegen das
+	 * Schema und lässt `findStepForErrors` den frühesten betroffenen Schritt
+	 * bestimmen. Ein ausgeblendetes Feld mit ungültigem Restwert zieht dieses
+	 * Sprungziel nach vorne — der Melder landet auf einem Schritt, auf dem gar
+	 * nichts markiert ist, und das eigentliche Problem liegt einen Schritt
+	 * weiter hinten.
+	 *
+	 * `boatDrive` (Schritt 2, Index 1) ist bei einer Land-Meldung ausgeblendet —
+	 * `sections/SightingDetails.svelte` zeigt es nur bei Segelschiff/Motorboot.
+	 * Ein Restwert entsteht real: Wer erst „Motorboot" wählt, den Antrieb setzt
+	 * und dann auf „Land" wechselt, lässt ihn im Formular-Zustand stehen (der
+	 * Zustand wird bewusst nicht geleert, siehe `HIDDEN_WHEN_FROM_LAND`).
+	 * `shipCount` (Schritt 3, Index 2) ist dagegen sichtbar und trägt hier den
+	 * einzigen Fehler, den der Melder auch beheben kann.
+	 */
+	it('bestimmt das Sprungziel nur aus Feldern, die im aktuellen Zweig bedienbar sind', async () => {
+		seedValidLandReport({ boatDrive: 99, shipCount: 99 });
+
+		render(ModernReportForm);
+
+		await page.getByRole('button', { name: 'Formular absenden' }).click();
+
+		// Gelandet wird auf „Weitere Informationen" (Index 2) — nicht auf
+		// „Angaben zum Tier" (Index 1), wo `boatDrive` steht, aber niemandem
+		// angezeigt wird.
+		await vi.waitFor(() =>
+			expect(
+				document.querySelector('[data-testid="field-shipCount"]')?.getAttribute('aria-invalid')
+			).toBe('true')
+		);
+		await expect
+			.element(page.getByRole('heading', { name: 'Weitere Informationen' }))
+			.toBeVisible();
+	});
+});

--- a/src/lib/report/components/form/RequiredConsent.svelte
+++ b/src/lib/report/components/form/RequiredConsent.svelte
@@ -1,14 +1,26 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import FormField from './fields/FormField.svelte';
-	import { formStepsConfig } from '$lib/report/formConfig';
+	import { getFormSteps } from '$lib/report/formConfig';
+	import { getFormContext } from '$lib/report/formContext';
 
 	let { currentStep } = $props<{
 		currentStep: number;
 	}>();
 
+	// Die Komponente steht ohnehin nur unterhalb von `<Form>` — `FormField`
+	// unten wirft ohne Context.
+	const { form } = getFormContext();
+
 	// Only show on the last step (0-indexed)
-	const isLastStep = $derived(currentStep === formStepsConfig.length - 1);
+	//
+	// Gezählt wird die Schritt-Konfiguration des aktuellen Zweigs, nicht die
+	// statische `formStepsConfig`: eine Quelle für alle Stellen, die über
+	// Schritte rechnen. Heute liefern beide dieselbe Zahl — `getFormSteps`
+	// filtert Felder, nie ganze Schritte —, und genau deshalb ist das hier
+	// kein Verhaltenswechsel, sondern nur der Verzicht auf eine zweite Liste,
+	// deren Gleichlauf niemand erzwingt.
+	const isLastStep = $derived(currentStep === getFormSteps($form).length - 1);
 </script>
 
 {#if isLastStep}

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -10,7 +10,7 @@
 		scrollToFirstError,
 		scrollToStepHeader
 	} from '$lib/utils/fieldNavigation';
-	import { formStepsConfig } from '$lib/report/formConfig';
+	import { formStepsConfig, getFormSteps } from '$lib/report/formConfig';
 	import {
 		getStepAlertMessages,
 		shouldShowStepAlert,
@@ -39,8 +39,23 @@
 	const formContext = getFormContext();
 	const { isSubmitting, form, errors } = formContext;
 
+	/**
+	 * Schritt-Konfiguration des AKTUELLEN Zweigs — dieselbe Quelle, aus der
+	 * `validateStep` unten seine Felder nimmt. `formStepsConfig` (statisch)
+	 * führt auch Felder, die im aktuellen Zweig gar nicht gerendert werden.
+	 *
+	 * Für die Feldreihenfolge unten ist das heute folgenlos: `scrollToFirstError`
+	 * sucht in ihr das erste Feld, das in den Fehlern vorkommt — und die Fehler
+	 * stammen ausschließlich aus `validateStep`, das ausgeblendete Felder gar
+	 * nicht erst prüft. Trotzdem dieselbe Quelle, statt zwei Listen, deren
+	 * Gleichlauf niemand erzwingt: Sobald hier eine zweite Fehlerquelle
+	 * dazukäme (Server-Felder etwa, wie in `ModernReportForm`), zeigte die
+	 * statische Liste auf ein Feld ohne DOM-Element und der Sprung fiele aus.
+	 */
+	const formSteps = $derived(getFormSteps($form));
+
 	// Get field orders from form configuration
-	const stepFieldOrders = formStepsConfig.map((step) => step.fields);
+	const stepFieldOrders = $derived(formSteps.map((step) => step.fields));
 
 	// Single validation pass — used for both canGoNext and stepErrorMessages
 	const stepValidation = $derived.by(() => validateStep(currentStep, $form));
@@ -174,7 +189,7 @@
 		// Use the validation function that collects errors
 		const { errors: stepErrors } = validateStep(currentStep, $form);
 		const errorCount = getErrorCount(stepErrors);
-		const currentStepName = formStepsConfig[currentStep]?.title || `Schritt ${currentStep + 1}`;
+		const currentStepName = formSteps[currentStep]?.title || `Schritt ${currentStep + 1}`;
 
 		if (errorCount === 0) {
 			return;

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -372,6 +372,36 @@ export function hasUploadedMedia(
  * serverseitig ein Gegenstück, für das ein Nachweis Sinn ergäbe.
  */
 export function getFormSteps(data: FormStepsInput): FormStep[] {
+	const hidden = new Set(hiddenFormFields(data));
+
+	if (hidden.size === 0) {
+		return formStepsConfig;
+	}
+
+	return formStepsConfig.map((step) => ({
+		...step,
+		fields: step.fields.filter((field) => !hidden.has(field))
+	}));
+}
+
+/**
+ * Die Felder, die im übergebenen Zustand nicht bedienbar sind — die drei Achsen
+ * aus `getFormSteps` an einer Stelle, damit niemand sie ein zweites Mal
+ * ausschreibt.
+ *
+ * `getFormSteps` beantwortet „welche Felder validiert dieser Schritt", und das
+ * ist für die Schritt-Navigation genau richtig. Für die Vorab-Prüfung beim
+ * Absenden (`ModernReportForm.handleFinalSubmit`) reicht es nicht: Die prüft
+ * gegen das ganze Schema, also auch gegen Felder, die in KEINEM Schritt stehen
+ * (`referenceId`, `entryChannel`, `weatherData.*`). Aus den Schritt-Feldern
+ * eine Positivliste zu bauen, würde die stillschweigend mit ausschließen; das
+ * Komplement ist deshalb die richtige Größe — es nimmt genau das weg, was der
+ * Melder im aktuellen Zweig nicht sieht, und lässt alles andere in Kraft.
+ *
+ * Ohne Duplikate: `reaction` steht in `HIDDEN_WHEN_DEAD` UND in
+ * `HIDDEN_WHEN_FROM_LAND` — ein Totfund von Land trifft beide Bedingungen.
+ */
+export function hiddenFormFields(data: FormStepsInput): string[] {
 	const hidden = new Set<string>();
 	if (isDeadFinding(data.isDead)) {
 		HIDDEN_WHEN_DEAD.forEach((field) => hidden.add(field));
@@ -382,13 +412,5 @@ export function getFormSteps(data: FormStepsInput): FormStep[] {
 	if (!hasUploadedMedia(data.uploadedFiles)) {
 		hidden.add('mediaConsent');
 	}
-
-	if (hidden.size === 0) {
-		return formStepsConfig;
-	}
-
-	return formStepsConfig.map((step) => ({
-		...step,
-		fields: step.fields.filter((field) => !hidden.has(field))
-	}));
+	return [...hidden];
 }

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -372,7 +372,7 @@ export function hasUploadedMedia(
  * serverseitig ein Gegenstück, für das ein Nachweis Sinn ergäbe.
  */
 export function getFormSteps(data: FormStepsInput): FormStep[] {
-	const hidden = new Set(hiddenFormFields(data));
+	const hidden = new Set<string>(hiddenFormFields(data));
 
 	if (hidden.size === 0) {
 		return formStepsConfig;
@@ -401,8 +401,8 @@ export function getFormSteps(data: FormStepsInput): FormStep[] {
  * Ohne Duplikate: `reaction` steht in `HIDDEN_WHEN_DEAD` UND in
  * `HIDDEN_WHEN_FROM_LAND` — ein Totfund von Land trifft beide Bedingungen.
  */
-export function hiddenFormFields(data: FormStepsInput): string[] {
-	const hidden = new Set<string>();
+export function hiddenFormFields(data: FormStepsInput): Array<keyof SightingFormData> {
+	const hidden = new Set<keyof SightingFormData>();
 	if (isDeadFinding(data.isDead)) {
 		HIDDEN_WHEN_DEAD.forEach((field) => hidden.add(field));
 	}


### PR DESCRIPTION
## Problem

`scrollToFirstError` and `findStepForErrors` walked `formStepsConfig` — the **static** field list, without the branch filter. A field hidden in the current branch still stands there, so both could aim at an element that is not rendered:

- **Server rejection:** the field order of the target step led with a hidden field, `scrollToFirstError` found no element, and the jump silently fell through. The named field also landed in `$errors`, where nothing could ever clear it — `updateField` only drops the error of the *changed* field, and this one has no control.
- **Pre-submit check:** an invalid leftover in a hidden field dragged the jump target onto an earlier step, where nothing is marked. The reporter lands somewhere with no visible error while the real problem sits a step further back.

Only `stepValidation.ts` had been converted to `getFormSteps` so far. Four call sites still read the static list.

## Change

| Call site | now |
| --- | --- |
| `ModernReportForm` → `resolveServerFieldErrors` | `getFormSteps($form)` |
| `ModernReportForm` → `findStepForErrors` | `getFormSteps(formValues)` |
| `StepNavigation` → `stepFieldOrders`, step title | `$derived(getFormSteps($form))` |
| `RequiredConsent` → `isLastStep` | `getFormSteps($form).length` |

`formStepsConfig` stays at the pure display sites (`FormSteps`, `StepProgressCompact`, the `totalSteps` default) — there the number of steps is meant, which `getFormSteps` never changes.

The pre-submit check validates `sightingSchema.omit(hiddenFormFields(formValues))` instead of the full schema. Deliberately `omit` rather than a `pick` over the step fields: the schema also carries fields that live in no step at all (`referenceId`, `entryChannel`, `weatherData.*`), and those should stay checked.

`hiddenFormFields` is extracted from `getFormSteps` so the three axes (dead find, reporting location, media upload) are written down once.

## Tests

Test-first, both red before the change:

- **Server rejection jumps to the first *visible* field** — with `sightingFrom = Land`, `reaction` precedes `shipCount` in the static list but is not rendered. Before: no focus at all. After: focus lands on `shipCount`.
- **The jump target comes only from operable fields** — an invalid `boatDrive` (hidden on a land report, step 2) no longer pulls the jump ahead of the visible `shipCount` error on step 3.

Green: `test:quick` (3574), `test:unit:client` (514), targeted E2E (70) — `form-ux`, `form-from-land`, `form-a11y`, `form-stepper`, `media-consent-placement`, `form-submit`.

## Known gap — please read before merging

`createForm.handleSubmit` validates the **full** schema again after the pre-submit check passes. An invalid leftover in a hidden field therefore still stops the submit there — and now completely silently: the `ValidationError` is caught, `$errors` is written, nothing throws, so `StepNavigation` shows no toast and no jump, and the field has no DOM element to mark. Before this PR the same state at least produced a toast plus a (mis-targeted) jump.

Verified with a throwaway browser test, not inferred: a land report with `boatDrive: 99` never reaches `submitSightingForm`.

Not fixed here because the obvious route (`yup.lazy` + `omit` as the `validationSchema`) trims the validated object that `onSubmit` builds the persisted contact data from — exactly the data-loss regression from Task 11. The alternative (relaxing the fields instead of removing them) loses the yup casts for `boatDrive` and `behavior`. The real question behind it is a product one: what should a hidden field's leftover value do on submit? Today six of them are stripped at the submit boundary, `boatDrive` and `behavior` are sent.

Documented as "Known gap" in `src/lib/report/README.md`.

## Reachability, corrected during review

The second commit fixes a wrong claim in the first one's comments. `boatDrive` is *not* a real leftover path — `shouldResetBoatDrive` clears it on the Boot→Land transition. The `HIDDEN_WHEN_DEAD` fields are covered too: a branch switch always goes through the entry page, which remounts the form and runs the `fieldsOutsideReportKind` cleanup. What is genuinely reachable runs over the reporting location, where `HIDDEN_WHEN_FROM_LAND` deliberately leaves values in `$form` and no `maxlength` stops an over-long `reaction` or `shipName` first.

`.claude/rules/forms.md` was updated along the way — "read only by `stepValidation.ts`" no longer held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)