### PR TITLE
refactor(report): drop the no-op when() from deadSize

### DIFF
--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -530,7 +530,15 @@ export const sightingSchemaBase = yup.object().shape({
 
 	/**
 	 * Größe des toten Tieres in cm
-	 * Erforderlich, wenn isDead = true
+	 *
+	 * **Optional, in beiden Zweigen** — anders als `deadCondition` darüber. Eine
+	 * am Strand geschätzte Körperlänge ist eine Zusatzangabe, keine Bedingung
+	 * für die Meldung; die DB-Spalte `totfund_groesse` ist entsprechend nullable.
+	 * Bewusst **kein** `when('isDead')`: Am Zweig hängt hier nichts, und ein
+	 * `when()`, das in beiden Ästen dasselbe tut, behauptet optisch das Gegenteil
+	 * (Hergang und Nachweis in `sightingSchemaWhen.test.ts`, Gruppe „deadSize —
+	 * in KEINEM Zweig Pflichtfeld"). Die drei Zusagen darunter gelten unbedingt
+	 * und sind die einzige Validierung des Feldes.
 	 */
 	deadSize: yup
 		.number()
@@ -538,11 +546,6 @@ export const sightingSchemaBase = yup.object().shape({
 		.transform((value) => (isNaN(value) ? undefined : value))
 		.min(0, 'Die Größe muss positiv sein.')
 		.max(300, 'Die Größe darf 300 nicht überschreiten.')
-		.when('isDead', {
-			is: true,
-			then: (schema) => schema.notRequired(),
-			otherwise: (schema) => schema.notRequired()
-		})
 		.label('Körperlänge (cm)')
 		.meta({
 			placeholder: 'z.B. 150',

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -531,14 +531,24 @@ export const sightingSchemaBase = yup.object().shape({
 	/**
 	 * Größe des toten Tieres in cm
 	 *
-	 * **Optional, in beiden Zweigen** — anders als `deadCondition` darüber. Eine
-	 * am Strand geschätzte Körperlänge ist eine Zusatzangabe, keine Bedingung
-	 * für die Meldung; die DB-Spalte `totfund_groesse` ist entsprechend nullable.
-	 * Bewusst **kein** `when('isDead')`: Am Zweig hängt hier nichts, und ein
-	 * `when()`, das in beiden Ästen dasselbe tut, behauptet optisch das Gegenteil
-	 * (Hergang und Nachweis in `sightingSchemaWhen.test.ts`, Gruppe „deadSize —
-	 * in KEINEM Zweig Pflichtfeld"). Die drei Zusagen darunter gelten unbedingt
-	 * und sind die einzige Validierung des Feldes.
+	 * **Optional und nullable, in beiden Zweigen** — anders als `deadCondition`
+	 * darüber. Eine am Strand geschätzte Körperlänge ist eine Zusatzangabe, keine
+	 * Bedingung für die Meldung.
+	 *
+	 * Das `.nullable()` ist nicht kosmetisch: `totfund_groesse` ist in der DB
+	 * nullable und bei jeder Nicht-Totfund-Sichtung tatsächlich `NULL`. Die
+	 * Admin-Maske lädt diesen Wert in den Formular-Zustand; ohne `nullable()`
+	 * scheitert dort die Validierung mit „deadSize cannot be null", und ein
+	 * Bestandsdatensatz ließe sich nicht mehr speichern.
+	 *
+	 * Bis zum 2026-08-06 stand hier statt `.nullable()` ein `when('isDead')` mit
+	 * `notRequired()` in beiden Zweigen. Das sah wie ein No-op aus und war keines:
+	 * In yup 1.x hebt `notRequired()` auch die Null-Sperre auf, die Nullbarkeit
+	 * hing also unsichtbar an einer Verzweigung, die sonst nichts tat. Ersetzt
+	 * durch das explizite `.nullable()` — identisches Verhalten in allen
+	 * geprüften Fällen, aber dort lesbar, wo es gilt. Die Null-Fälle stehen
+	 * seitdem in `sightingSchemaWhen.test.ts`; sie fehlten vorher und genau
+	 * deshalb fiel die Änderung erst in den Admin-E2E-Tests auf.
 	 */
 	deadSize: yup
 		.number()
@@ -546,6 +556,7 @@ export const sightingSchemaBase = yup.object().shape({
 		.transform((value) => (isNaN(value) ? undefined : value))
 		.min(0, 'Die Größe muss positiv sein.')
 		.max(300, 'Die Größe darf 300 nicht überschreiten.')
+		.nullable()
 		.label('Körperlänge (cm)')
 		.meta({
 			placeholder: 'z.B. 150',

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -323,19 +323,26 @@ describe('sightingSchema - Sonstiges-Textfeld-Validierung', () => {
 		});
 	});
 
-	// ── deadSize — der Zweig entscheidet hier über gar nichts ─────────────────
+	// ── deadSize — optional UND nullable, in beiden Zweigen ───────────────────
 	//
-	// `deadSize` trug bis zum 2026-08-06 ein `.when('isDead', …)`, das in BEIDEN
-	// Zweigen `notRequired()` setzte — ein No-op. Es las sich wie das `when()`
-	// bei `deadCondition` direkt darüber und legte damit nahe, die Körperlänge
-	// sei beim Totfund Pflicht; der JSDoc über dem Feld behauptete das sogar.
-	// Beides stimmte nie.
+	// `deadSize` trug bis zum 2026-08-06 ein `.when('isDead', …)` mit
+	// `notRequired()` in BEIDEN Zweigen. Das sah wie ein No-op aus — war aber
+	// keines: In yup 1.x hebt `notRequired()` zusätzlich die Null-Sperre auf.
+	// Die Verzweigung trug also die Nullbarkeit des Feldes, ohne das irgendwo zu
+	// sagen. Sie ist jetzt durch ein explizites `.nullable()` ersetzt.
 	//
-	// Diese Gruppe hält den Ist-Zustand fest, damit das Entfernen des Blocks
-	// nachweislich nichts ändert: Sie ist vor UND nach der Änderung grün. Was
-	// unbedingt gilt — `integer()`, `min(0)`, `max(300)` — steht deshalb hier
-	// mit drin; genau diese Zusagen dürfen beim Aufräumen nicht mitverschwinden.
-	describe('deadSize — in KEINEM Zweig Pflichtfeld (No-op-when entfernt, 2026-08-06)', () => {
+	// Die Null-Fälle unten sind der eigentliche Grund für diese Gruppe. Sie
+	// fehlten beim ersten Anlauf, und weil `deadSize` bei jeder Nicht-Totfund-
+	// Sichtung als `NULL` aus der DB kommt, fiel der Unterschied erst in
+	// `e2e/admin-edit-preserves-record.spec.ts` auf — dort ließ sich ein
+	// Bestandsdatensatz nicht mehr speichern, weil die Validierung mit
+	// „deadSize cannot be null" abbrach und der Request nie rausging.
+	// Die Nachbarfelder oben tragen aus demselben Grund je einen
+	// „akzeptiert null (Legacy-DB-Wert)"-Fall.
+	//
+	// `integer()`, `min(0)` und `max(300)` stehen mit drin, weil sie unbedingt
+	// gelten und beim Umbau nicht mitverschwinden dürfen.
+	describe('deadSize — optional und nullable in beiden Zweigen (2026-08-06)', () => {
 		it('ist nicht required bei isDead=true', async () => {
 			expect(await fieldHasError('deadSize', { isDead: true })).toBe(false);
 		});
@@ -346,6 +353,18 @@ describe('sightingSchema - Sonstiges-Textfeld-Validierung', () => {
 
 		it('ist nicht required, wenn isDead gar nicht gesetzt ist', async () => {
 			expect(await fieldHasError('deadSize', {})).toBe(false);
+		});
+
+		// Der Regressionsfall: So kommt das Feld für JEDE Nicht-Totfund-Sichtung
+		// aus der DB in die Admin-Maske. Ohne `.nullable()` bricht hier die
+		// Validierung ab und der Speichern-Request geht nie raus.
+		it.each([
+			['isDead=true', true],
+			['isDead=false', false],
+			['isDead nicht gesetzt', undefined]
+		])('akzeptiert null (Legacy-DB-Wert) bei %s', async (_label, isDead) => {
+			const data = isDead === undefined ? { deadSize: null } : { isDead, deadSize: null };
+			expect(await fieldHasError('deadSize', data)).toBe(false);
 		});
 
 		it.each([true, false])(

--- a/src/lib/form/validation/sightingSchemaWhen.test.ts
+++ b/src/lib/form/validation/sightingSchemaWhen.test.ts
@@ -322,4 +322,52 @@ describe('sightingSchema - Sonstiges-Textfeld-Validierung', () => {
 			);
 		});
 	});
+
+	// ── deadSize — der Zweig entscheidet hier über gar nichts ─────────────────
+	//
+	// `deadSize` trug bis zum 2026-08-06 ein `.when('isDead', …)`, das in BEIDEN
+	// Zweigen `notRequired()` setzte — ein No-op. Es las sich wie das `when()`
+	// bei `deadCondition` direkt darüber und legte damit nahe, die Körperlänge
+	// sei beim Totfund Pflicht; der JSDoc über dem Feld behauptete das sogar.
+	// Beides stimmte nie.
+	//
+	// Diese Gruppe hält den Ist-Zustand fest, damit das Entfernen des Blocks
+	// nachweislich nichts ändert: Sie ist vor UND nach der Änderung grün. Was
+	// unbedingt gilt — `integer()`, `min(0)`, `max(300)` — steht deshalb hier
+	// mit drin; genau diese Zusagen dürfen beim Aufräumen nicht mitverschwinden.
+	describe('deadSize — in KEINEM Zweig Pflichtfeld (No-op-when entfernt, 2026-08-06)', () => {
+		it('ist nicht required bei isDead=true', async () => {
+			expect(await fieldHasError('deadSize', { isDead: true })).toBe(false);
+		});
+
+		it('ist nicht required bei isDead=false', async () => {
+			expect(await fieldHasError('deadSize', { isDead: false })).toBe(false);
+		});
+
+		it('ist nicht required, wenn isDead gar nicht gesetzt ist', async () => {
+			expect(await fieldHasError('deadSize', {})).toBe(false);
+		});
+
+		it.each([true, false])(
+			'akzeptiert einen gültigen Wert unverändert in beiden Zweigen (isDead=%s)',
+			async (isDead) => {
+				expect(await fieldHasError('deadSize', { isDead, deadSize: 150 })).toBe(false);
+			}
+		);
+
+		// Die drei unbedingten Zusagen — sie hängen NICHT am `when()` und müssen
+		// das Entfernen überleben. Jeweils in beiden Zweigen geprüft, weil ein
+		// versehentlich zu weit gefasstes Aufräumen sie nur in einem träfe.
+		it.each([true, false])('lehnt Nachkommastellen ab (isDead=%s)', async (isDead) => {
+			expect(await fieldHasError('deadSize', { isDead, deadSize: 150.5 })).toBe(true);
+		});
+
+		it.each([true, false])('lehnt negative Werte ab (isDead=%s)', async (isDead) => {
+			expect(await fieldHasError('deadSize', { isDead, deadSize: -1 })).toBe(true);
+		});
+
+		it.each([true, false])('lehnt Werte über 300 ab (isDead=%s)', async (isDead) => {
+			expect(await fieldHasError('deadSize', { isDead, deadSize: 301 })).toBe(true);
+		});
+	});
 });

--- a/src/lib/report/components/sections/DeadAnimal.svelte
+++ b/src/lib/report/components/sections/DeadAnimal.svelte
@@ -38,9 +38,10 @@
 		     sie nicht. Ohne den Override lief der Melder ohne Sternchen und ohne
 		     `aria-required` in „Bitte geben Sie den Zustand des toten Tieres an.".
 
-		     Die beiden Nachbarfelder bekommen ihn bewusst NICHT: `deadSize` hat zwar
-		     ein `when()`, setzt darin aber beide Zweige auf `notRequired()`, und
-		     `deadSex` hat das Museum am 2026-08-04 samt Pflicht abbestellt. -->
+		     Die beiden Nachbarfelder bekommen ihn bewusst NICHT: `deadSize` ist im
+		     Schema unbedingt optional (die Körperlänge ist eine Zusatzangabe, keine
+		     Bedingung für die Meldung), und `deadSex` hat das Museum am 2026-08-04
+		     samt Pflicht abbestellt. -->
 		<FormField name="deadCondition" required={true} />
 
 		<!-- Das Geschlecht beim Totfund ist seit 2026-08-04 nur noch in der

--- a/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
+++ b/src/lib/report/components/sections/DeadAnimal.svelte.test.ts
@@ -93,9 +93,9 @@ describe('sections/DeadAnimal — Zustand als konditionales Pflichtfeld', () => 
 
 	/**
 	 * Gegenprobe: Die beiden Nachbarfelder sind unter denselben Bedingungen
-	 * ausdrücklich optional (`deadSize` hat ein `when()`, das in beiden Zweigen
-	 * `notRequired()` setzt; `deadSex` hat das Museum am 2026-08-04 samt Pflicht
-	 * abbestellt). Ein pauschal auf die Section gesetzter Override fiele hier auf.
+	 * ausdrücklich optional (`deadSize` ist im Schema unbedingt optional;
+	 * `deadSex` hat das Museum am 2026-08-04 samt Pflicht abbestellt). Ein
+	 * pauschal auf die Section gesetzter Override fiele hier auf.
 	 */
 	it.each(['deadSize', 'deadSex'])('markiert %s weiterhin NICHT als Pflichtfeld', (name) => {
 		renderDeadAnimal({ adminMode: true });

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -257,12 +257,12 @@ const HIDDEN_WHEN_DEAD = ['behavior', 'behaviorText', 'reaction'] as const;
  * nichts, validiert trotzdem.
  *
  * Folgenlos war das nicht bloß theoretisch. `deadSize` trägt
- * `integer()`/`min(0)`/`max(300)` UNBEDINGT — sein `when('isDead')` ist ein
- * No-op (`notRequired()` in beiden Zweigen), am Zustand des Tieres hängt bei
- * diesem Feld also gar nichts. Ein zweigfremder Wert im Formular-Zustand (aus
- * dem localStorage einer früheren Sitzung) hätte damit „Weiter" auf Schritt 2
- * gesperrt, mit einem Fehler an einem Feld, das der Melder im Lebend-Zweig
- * weder sieht noch erreichen kann. Praktisch abgefangen hat das bisher
+ * `integer()`/`min(0)`/`max(300)` UNBEDINGT und ist in keinem Zweig Pflicht —
+ * am Zustand des Tieres hängt bei diesem Feld also gar nichts. Ein zweigfremder
+ * Wert im Formular-Zustand (aus dem localStorage einer früheren Sitzung) hätte
+ * damit „Weiter" auf Schritt 2 gesperrt, mit einem Fehler an einem Feld, das
+ * der Melder im Lebend-Zweig weder sieht noch erreichen kann. Praktisch
+ * abgefangen hat das bisher
  * `fieldsOutsideReportKind` (räumt dieselben Felder beim Start aus dem
  * Zustand) — aber als zweite, unabhängig gepflegte Absicherung, nicht als
  * Regel an der Stelle, an der die Validierung entsteht.


### PR DESCRIPTION
## Was

`deadSize` trug in `sightingSchema.ts` ein `.when('isDead', …)`, dessen `then` und `otherwise` beide `notRequired()` zurückgaben. Die Verzweigung ist ersetzt durch ein explizites `.nullable()`; `integer()`, `min(0)` und `max(300)` bleiben unverändert.

## Warum

Der Block stand direkt unter `deadCondition`, das bei `isDead === true` **tatsächlich** Pflicht ist, und las sich dadurch wie eine echte bedingte Pflicht. Der JSDoc darüber behauptete das sogar ausdrücklich („Erforderlich, wenn isDead = true") — das stimmte nie: `DeadAnimal.svelte` enthält dem Feld den `required`-Override bewusst vor, ein Komponententest prüft aktiv, dass es **nicht** als Pflichtfeld markiert wird, und `totfund_groesse` ist nullable.

## Der Fehlschlag zwischendurch — bitte mitlesen

Der erste Anlauf (Commit `2be3f33d`) hat den Block **ersatzlos** entfernt, mit der Begründung, er sei ein No-op. **Das war falsch.** In yup 1.7.1 hebt `notRequired()` zusätzlich die Null-Sperre auf:

```
{ isDead: true, deadSize: null }   mit when():  gültig
                                   ohne:        "deadSize cannot be null"
```

Die Verzweigung trug also unsichtbar die **Nullbarkeit** des Feldes. `totfund_groesse` ist bei jeder Nicht-Totfund-Sichtung `NULL`, die Admin-Maske lädt diesen Wert in den Formular-Zustand — nach dem Entfernen scheiterte dort die Validierung an einem Feld, das der Bearbeiter nicht einmal sieht, der Speichern-Request ging nie raus, und **kein Bestandsdatensatz ließ sich mehr bearbeiten**.

Aufgefallen ist das in `e2e/admin-edit-preserves-record.spec.ts` (drei Tests, alle Timeout in `page.waitForResponse`). Die lokale Unit-Suite hat es durchgelassen, weil kein Test `null` einspeiste — obwohl jedes Nachbarfeld in derselben Testdatei genau so einen „akzeptiert null (Legacy-DB-Wert)"-Fall hat. Commit `a712b9b7` behebt das.

## Für Reviewer

**`.nullable()` ist als exakter Ersatz geprüft, nicht angenommen:** identisches Verhalten der beiden Varianten über dreizehn Eingaben — `null` in allen drei `isDead`-Zuständen, `undefined`, leerer String, 0/150/300, 150.5, −1, 301.

**Warum nicht einfach das `when()` stehen lassen?** Es tat zwei Dinge, von denen nur eines beabsichtigt aussah: verzweigen (wirkungslos) und nullable machen (wesentlich). Genau diese Tarnung hat den ersten Anlauf verursacht. `.nullable()` sagt dasselbe an der Stelle, an der es gilt.

**Testabdeckung:** Die drei Null-Fälle in `sightingSchemaWhen.test.ts` sind ohne `.nullable()` rot und mit ihm grün — sie hätten den Fehlschlag oben gefangen. Zusätzlich abgedeckt sind `integer()`/`min(0)`/`max(300)` in beiden Zweigen, die vorher keine direkte Abdeckung hatten.

**Kommentar-Nachzug:** `formConfig.ts`, `DeadAnimal.svelte` und `DeadAnimal.svelte.test.ts` benannten den alten Block und wären sonst stale geworden.

## Verifikation

- `npm run test:quick` — 236 Dateien / 3592 Tests grün (lint, type-check, svelte-check in derselben Kette)
- Die 2 Lint-Warnungen in `src/tests/contract/helpers/createEvent.ts` sind vorbestehend und nicht Teil dieser Änderung

🤖 Generated with [Claude Code](https://claude.com/claude-code)