### PR TITLE
fix(report): vier UX-Befunde zur Einstiegsseite und zum Meldeformular

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -298,11 +298,31 @@ weiterhülfe. Bei den drei genannten Aufrufstellen ist das der Fall;
 `FormSteps.svelte` und `StepProgressCompact.svelte` sind zudem keine `.btn`
 und vom `pointer-events`-Befund gar nicht betroffen.
 
-**Offen (außerhalb des Scopes, an dem das auffiel):** `StepNavigation.svelte`
-sperrt „Absenden" bei fehlender Verbindung als `.btn` mit `aria-disabled` und
-`title` — per Maus unerreichbar, per Tastatur meldet der Wächter nur in den
-Logger. Wer dort das nächste Mal hinfasst, sollte es auf dasselbe Muster
-umstellen.
+**Der dritte Fall: Die Begründung steht schon da.** `StepNavigation.svelte`
+sperrt „Absenden" bei fehlender Verbindung — auflösen kann der Nutzer das nicht
+durch Eingabe, eine neue Meldung wäre also fehl am Platz. `SubmitStatus` trägt
+den Grund samt Datenzusage bereits dauerhaft **über** der Navigation. Trotzdem
+ist `aria-disabled` hier falsch, und zwar aus einem Grund, der leicht übersehen
+wird: Unterhalb `md` ist die Navigation ein ortsfester Balken am unteren Rand
+(`.form-step-nav`) — die Begründung kann weggescrollt sein, während der Knopf
+sichtbar bleibt. Wer dann drückt, bekam gar nichts.
+
+Das Muster dort ist deshalb:
+
+- **kein** `aria-disabled`/`btn-disabled`/`title` am Knopf — jede dieser
+  Auszeichnungen zieht das `pointer-events: none` nach sich,
+- `aria-describedby` auf die Begründungsfläche, damit der Grund am Knopf
+  anliegt, ohne dass er angeklickt werden muss (das ersetzt den `title`, der
+  ohnehin nur am Zeigegerät hing),
+- der Wächter im Handler **springt zur Begründung und fokussiert sie**, statt
+  still auszusteigen.
+
+Die `id` der Fläche wird dafür aus `SubmitStatus.svelte` exportiert und nicht
+auf beiden Seiten als Literal gepflegt — ein `aria-describedby` ins Leere meldet
+niemand.
+
+Hart über `disabled` gesperrt bleibt dort einzig der **laufende** Submit: sehr
+kurz, nichts zu erklären, und ein Doppelklick hätte echte Folgen.
 
 **Konsequenz für Tests — leicht zu übersehen:** Playwright wertet
 `aria-disabled="true"` selbst als „nicht bedienbar" und klickt gar nicht erst.

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -271,6 +271,39 @@ nicht erreichbare Schritte). Nebeneffekt, der das Muster zusätzlich trägt: der
 `title` mit der Begründung („Bitte füllen Sie zuerst die vorherigen Schritte
 aus") ist an einem `disabled`-Element per Tastatur nicht erreichbar.
 
+### Der Vorbehalt: an einem `.btn` sperrt `aria-disabled` härter als gedacht
+
+Die Regel gilt weiter — ihre Begründung trägt an einem DaisyUI-**Button** aber
+nur zur Hälfte. `daisyui/components/button.css` (5.7.4, nachgemessen am
+2026-08-06) legt an `.btn:is(:disabled, [disabled], .btn-disabled,
+[aria-disabled=true])` ein `pointer-events: none`. Daraus folgt:
+
+- **Der Wächter in der Handler-Funktion ist per Maus unerreichbar.** Der Klick
+  kommt nie am Element an — er kann also auch nichts melden.
+- **Der `title` mit der Begründung erscheint beim Hovern nie**, aus demselben
+  Grund. Das Argument oben gilt nur für den Tastaturweg.
+- Per Tastatur läuft Enter dagegen durch, landet im Wächter — und dort endete
+  es bis zum UX-Review still.
+
+`ReportKindChoice.svelte` (Einstiegsseite) hat deshalb **keine** gesperrte
+Schaltfläche mehr: Der Knopf ist immer frei, und die Sperre ist eine
+Fehlermeldung an der Radiogruppe (`aria-invalid` + `role="alert"`). Das ist
+die richtige Form überall dort, wo die Sperre eine **fehlende Eingabe** meint —
+sie hat dann etwas zu sagen, und eine unerreichbare Schaltfläche sagt es nicht.
+
+`aria-disabled` bleibt richtig, wo die Sperre einen **laufenden oder noch nicht
+erreichten Zustand** meint, den der Nutzer nicht durch Eingabe auflösen kann
+(Ortung läuft, Schritt noch nicht erreicht) — dort gibt es keine Meldung, die
+weiterhülfe. Bei den drei genannten Aufrufstellen ist das der Fall;
+`FormSteps.svelte` und `StepProgressCompact.svelte` sind zudem keine `.btn`
+und vom `pointer-events`-Befund gar nicht betroffen.
+
+**Offen (außerhalb des Scopes, an dem das auffiel):** `StepNavigation.svelte`
+sperrt „Absenden" bei fehlender Verbindung als `.btn` mit `aria-disabled` und
+`title` — per Maus unerreichbar, per Tastatur meldet der Wächter nur in den
+Logger. Wer dort das nächste Mal hinfasst, sollte es auf dasselbe Muster
+umstellen.
+
 **Konsequenz für Tests — leicht zu übersehen:** Playwright wertet
 `aria-disabled="true"` selbst als „nicht bedienbar" und klickt gar nicht erst.
 Ein Test, der die Sperre prüfen will, läuft ohne `force: true` in einen Timeout

--- a/e2e/form-from-land.spec.ts
+++ b/e2e/form-from-land.spec.ts
@@ -55,8 +55,9 @@ test.describe('Meldeformular — Beobachtung von Land', () => {
 		// Feld darin — sonst stünde eine leere Karte mit Titel und Einleitung im
 		// Formular.
 		await expect(page.getByText('Boot-/Schiffsinformationen')).toBeHidden();
-		// „Reaktion auf Ihr Boot" ist für einen Landbeobachter unbeantwortbar
-		// (Behavior.svelte); der Rest der Karte („Verhalten der Tiere") bleibt.
+		// „Reaktion auf Sie oder Ihr Fahrzeug" ist für einen Landbeobachter
+		// unbeantwortbar (Behavior.svelte); der Rest der Karte („Verhalten der
+		// Tiere") bleibt.
 		// Über die Rolle statt `getByText`: Der Kartentitel steht als `<h3>`,
 		// derselbe Text kommt aber zusätzlich als Feld-Hilfetext und -Begründung
 		// vor (`getByText` träfe dort auf drei Treffer statt einem).

--- a/e2e/form-submit.spec.ts
+++ b/e2e/form-submit.spec.ts
@@ -456,9 +456,15 @@ test.describe('Sichtung melden — Submit mit API-Mock', () => {
 		// `online`-Ereignis würde ihn nichts wieder aufheben. Eine harte Sperre
 		// hielte den Nutzer bis zum Neuladen fest. Gesperrt wird nur beim sicheren
 		// Nein des Browsers (siehe e2e/submit-offline.spec.ts).
+		//
+		// Geprüft wird das über `aria-describedby`: Seit die Sperre den Knopf nicht
+		// mehr als deaktiviert auszeichnet (design-system.md, „Der Vorbehalt"),
+		// wäre ein `aria-disabled`-Vergleich in BEIDEN Zuständen erfüllt und damit
+		// keine Aussage mehr. Der Verweis auf die Begründung hängt dagegen genau
+		// an der Sperre.
 		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
-			'aria-disabled',
-			'true'
+			'aria-describedby',
+			'submit-status-offline'
 		);
 		await expect(status.getByRole('button', { name: /Trotzdem versuchen/i })).toBeVisible();
 	});

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -16,9 +16,21 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
 
 		await expect(page.getByTestId('report-kind-submit')).not.toHaveAttribute('aria-disabled');
-		await page.getByTestId('report-kind-submit').click();
 
-		await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i);
+		// `toPass` statt eines einzelnen Klicks: `networkidle` sagt nur „keine
+		// Netzwerkaktivität mehr", nicht „Svelte hat hydratisiert". Trifft der
+		// Klick das Zeitfenster davor, schickt der Browser das Formular nativ ab
+		// und lädt die Seite ohne Auswahl neu (`/?`) — die Meldung entsteht dann
+		// nie, und der Test wäre flaky statt aussagekräftig. Der Klick ist
+		// idempotent, also darf er wiederholt werden; nach dem Reload ist
+		// hydratisiert.
+		await expect(async () => {
+			await page.getByTestId('report-kind-submit').click();
+			await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i, {
+				timeout: 2000
+			});
+		}).toPass();
+
 		await expect(page.getByRole('radiogroup')).toHaveAttribute('aria-invalid', 'true');
 		// Weitergegangen wird trotzdem nicht.
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -3,18 +3,35 @@ import { FormPage } from './pages/FormPage';
 import { fillStep1, fillStep4, waitForNextEnabled } from './helpers/form-helpers';
 
 test.describe('Einstiegsseite des Meldeformulars', () => {
+	/**
+	 * UX-Review (2026-08-06, Punkt 1): Der Knopf war gesperrt und sagte nicht,
+	 * warum — per Maus war er wegen DaisyUIs `pointer-events: none` an
+	 * `[aria-disabled=true]` gar nicht erreichbar, per Tastatur lief das Enter
+	 * still ins Leere. Die Sperre ist seither eine Meldung an der Radiogruppe;
+	 * geprüft wird deshalb nicht mehr das Attribut, sondern die Wirkung.
+	 */
 	test('Erstbesucher sieht die Auswahl und kommt ohne sie nicht weiter', async ({ page }) => {
 		await page.goto('/');
+		await page.waitForLoadState('networkidle');
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
-		await expect(page.getByTestId('report-kind-submit')).toHaveAttribute('aria-disabled', 'true');
+
+		await expect(page.getByTestId('report-kind-submit')).not.toHaveAttribute('aria-disabled');
+		await page.getByTestId('report-kind-submit').click();
+
+		await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i);
+		await expect(page.getByRole('radiogroup')).toHaveAttribute('aria-invalid', 'true');
+		// Weitergegangen wird trotzdem nicht.
+		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
 	});
 
 	test('nach der Auswahl erscheint Schritt 1', async ({ page }) => {
 		await page.goto('/');
 		// Wie FormPage.goto(): Playwrights Actionability-Check wartet nur auf
-		// Sichtbarkeit, nicht auf Hydration. Das radio's native `checked`
-		// springt sonst an, bevor Sveltes `onchange` überhaupt verdrahtet ist —
-		// die Auswahl bliebe dann unbemerkt und „Weiter" gesperrt.
+		// Sichtbarkeit, nicht auf Hydration. Ein Klick auf „Weiter" davor schickt
+		// das Formular nativ per GET ab (UX-Review 2026-08-06, Punkt 1: genau
+		// dafür heißen die Radios `meldung` und tragen `lebend`/`totfund`) — der
+		// Melder käme zwar richtig an, aber über eine Navigation statt über den
+		// Klick-Pfad, den dieser Test prüfen soll.
 		await page.waitForLoadState('networkidle');
 		await page.getByRole('radio', { name: /toten Tieres/i }).check();
 		await page.getByTestId('report-kind-submit').click();
@@ -187,14 +204,16 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 		// hydratisiert". Ein `toBeVisible()` allein bestünde deshalb auch dann, wenn
 		// `networkidle` noch VOR der Hydration aufläuft (langsamerer Runner,
 		// gecachte Module, andere Bundling-Strategie): Die statische SSR-Auswahlseite
-		// steht testidentisch im DOM, egal ob Svelte sie schon übernommen hat. Der
-		// folgende Schritt kann ohne Hydration nicht funktionieren — `aria-disabled`
-		// an `report-kind-submit` ist reaktiver Svelte-State (`selected`), der erst
-		// über das `onchange` eines hydratisierten Clients von `true` auf `false`
-		// kippt. Erst danach ist belegt, dass die Auswahlseite tatsächlich bedienbar
-		// (und nicht nur sichtbar) stehen geblieben ist.
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await expect(page.getByTestId('report-kind-submit')).toHaveAttribute('aria-disabled', 'false');
+		// steht testidentisch im DOM, egal ob Svelte sie schon übernommen hat.
+		//
+		// Der Beleg war früher der Wechsel von `aria-disabled` am „Weiter"-Knopf;
+		// den gibt es seit dem UX-Review (2026-08-06, Punkt 1) nicht mehr. An seine
+		// Stelle tritt die Fehlermeldung an der Radiogruppe: Sie entsteht
+		// ausschließlich aus Svelte-State. Ohne Hydration schickte derselbe Klick
+		// das Formular nativ ab und lüde die Seite neu, statt eine Meldung
+		// einzublenden — der Test wäre dann rot, nicht trivial grün.
+		await page.getByTestId('report-kind-submit').click();
+		await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i);
 
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
 	});

--- a/e2e/submit-offline.spec.ts
+++ b/e2e/submit-offline.spec.ts
@@ -38,18 +38,27 @@ test.describe('Absenden ohne Internetverbindung', () => {
 		await expect(status).toContainText('Keine Internetverbindung');
 		await expect(status).toContainText('Eingaben bleiben vollständig gespeichert');
 
-		// Der Button bleibt fokussierbar (`aria-disabled` statt `disabled`), damit
-		// die Tastaturposition erhalten bleibt — die Sperre sitzt im Handler.
+		// Der Knopf ist NICHT als deaktiviert ausgezeichnet: `aria-disabled` und
+		// `btn-disabled` ziehen an einem DaisyUI-`.btn` ein `pointer-events: none`
+		// nach sich, der Klick käme also gar nicht an und der Wächter könnte
+		// nichts melden (design-system.md, „Der Vorbehalt"). Er trägt den Grund
+		// stattdessen per `aria-describedby` und führt beim Klick dorthin.
 		const submit = page.getByRole('button', { name: /Formular absenden/i });
-		await expect(submit).toHaveAttribute('aria-disabled', 'true');
+		await expect(submit).not.toHaveAttribute('aria-disabled', 'true');
+		await expect(submit).toHaveAttribute('aria-describedby', 'submit-status-offline');
 
-		// Ohne `force` würde Playwright wegen `aria-disabled` gar nicht erst
-		// klicken und nur die eigene Actionability-Prüfung bestätigen.
-		await submit.click({ force: true });
+		// Kein `force` nötig — und das ist die eigentliche Aussage: Der Klick
+		// erreicht die Anwendung, statt an Playwrights Actionability-Prüfung zu
+		// enden.
+		await submit.click();
 
 		// Immer noch auf dem Kontaktschritt — es wurde nichts abgeschickt.
 		await expectCurrentStep(page, /Kontakt/i);
 		await expect(status).toBeVisible();
+		// Und der Klick blieb nicht folgenlos: Er führt zur Begründung. Unterhalb
+		// `md` ist die Navigation ein ortsfester Balken, die Begründung kann also
+		// weggescrollt sein, während der Knopf sichtbar bleibt.
+		await expect(status).toBeFocused();
 
 		// Zusage einlösen: Nach einem Neuladen sind die Eingaben noch da.
 		// Erst wieder online gehen — ein Reload ohne Netz lädt das Dokument nicht.
@@ -110,9 +119,12 @@ test.describe('Absenden ohne Internetverbindung', () => {
 		await context.setOffline(false);
 
 		await expect(page.locator('[data-testid="submit-status-offline"]')).toBeHidden();
+		// Der Knopf trägt den Verweis auf die Begründung nur, solange gesperrt ist —
+		// ein `aria-disabled`-Vergleich wäre hier seit dem Umbau in BEIDEN
+		// Zuständen erfüllt und damit keine Aussage mehr.
 		await expect(page.getByRole('button', { name: /Formular absenden/i })).not.toHaveAttribute(
-			'aria-disabled',
-			'true'
+			'aria-describedby',
+			'submit-status-offline'
 		);
 	});
 });

--- a/src/lib/form/consent/mediaConsentVersion.ts
+++ b/src/lib/form/consent/mediaConsentVersion.ts
@@ -22,5 +22,13 @@
  * `PRIVACY_CONSENT_VERSION` in `consentVersions.ts`.
  * `consentTextVersions.test.ts` sagt das im Kopfkommentar ausdrücklich, kann
  * es aber nicht prüfen.
+ *
+ * **Am selben Tag ein zweites Mal geändert** (UX-Review, Punkt 2): Über dem
+ * Ankreuzfeld stehen seither die hochgeladenen Aufnahmen namentlich („Ihre 2
+ * hochgeladenen Aufnahmen: …", `Step4Contact.svelte`) — bis dahin musste der
+ * Melder zwei Schritte nach dem Upload aus dem Gedächtnis wissen, worüber er
+ * entscheidet. Die Kennung bleibt `2026-08-06`, weil beide Änderungen an
+ * dieselbe Fassung gehen; wäre die vorherige an einem früheren Tag gewesen,
+ * müsste hier gehoben werden.
  */
 export const MEDIA_CONSENT_VERSION = '2026-08-06';

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -717,7 +717,12 @@ export const sightingSchemaBase = yup.object().shape({
 	reaction: yup
 		.string()
 		.max(1000, 'Die Reaktion darf nicht länger als 1000 Zeichen sein.')
-		.label('Reaktion auf Ihr Boot')
+		// UX-Review (2026-08-06, Punkt 4): „Ihr Boot" setzt ein Boot voraus, das
+		// `isFromLand` bewusst nicht verlangt — `sightingFrom = 0` heißt
+		// gleichzeitig „Sonstiges" (Kajak, SUP, Seebrücke) und „noch nicht
+		// beantwortet", das Feld steht für diese Melder also zu Recht da. Die
+		// Frage bleibt sinnvoll, nur die Beschriftung war zu eng.
+		.label('Reaktion auf Sie oder Ihr Fahrzeug')
 		.meta({
 			placeholder: 'z.B. neugierig genähert, geflohen, ignoriert...',
 			helpText: 'Wie haben die Tiere auf Ihre Anwesenheit reagiert?',

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -717,12 +717,14 @@ export const sightingSchemaBase = yup.object().shape({
 	reaction: yup
 		.string()
 		.max(1000, 'Die Reaktion darf nicht länger als 1000 Zeichen sein.')
-		// UX-Review (2026-08-06, Punkt 4): „Ihr Boot" setzt ein Boot voraus, das
-		// `isFromLand` bewusst nicht verlangt — `sightingFrom = 0` heißt
-		// gleichzeitig „Sonstiges" (Kajak, SUP, Seebrücke) und „noch nicht
-		// beantwortet", das Feld steht für diese Melder also zu Recht da. Die
-		// Frage bleibt sinnvoll, nur die Beschriftung war zu eng.
-		.label('Reaktion auf Sie oder Ihr Fahrzeug')
+		// Das Schema-Label ist die Beschriftung der ADMIN-Maske. Das Meldeformular
+		// fragt seit dem UX-Review (2026-08-06, Punkt 4) allgemeiner — „Reaktion
+		// auf Sie oder Ihr Fahrzeug" —, weil `isFromLand` nur ein ausdrückliches
+		// „Land" ausblendet und Kajak, SUP und Seebrücke unter „Sonstiges" hier
+		// stehen bleiben. Gesetzt wird das als `label`-Override an der
+		// Aufrufstelle in `sections/Behavior.svelte`; die Sachbearbeitung behält
+		// ihren gewohnten Wortlaut.
+		.label('Reaktion auf Ihr Boot')
 		.meta({
 			placeholder: 'z.B. neugierig genähert, geflohen, ignoriert...',
 			helpText: 'Wie haben die Tiere auf Ihre Anwesenheit reagiert?',

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -11,7 +11,10 @@
 	import { describeSubmitFailure, submitSightingForm } from '$lib/form/submitSightingForm';
 	import { sightingSchema } from '$lib/form/validation/sightingSchema';
 	import { createLogger } from '$lib/logger';
-	import { fieldsOutsideReportKind } from '$lib/report/fieldsOutsideReportKind';
+	import {
+		fieldsOutsideReportKind,
+		reportKindClearedNotice
+	} from '$lib/report/fieldsOutsideReportKind';
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
 	import { resolveServerFieldErrors } from '$lib/report/serverFieldErrors';
 	import {
@@ -137,9 +140,16 @@
 	function resetField<K extends keyof SightingFormData>(key: K): void {
 		savedFormData[key] = initialFormState[key];
 	}
-	for (const field of fieldsOutsideReportKind(
-		isDeadFinding(savedFormData.isDead) ? 'dead' : 'alive'
-	)) {
+	const reportKindAtMount = isDeadFinding(savedFormData.isDead) ? 'dead' : 'alive';
+	const fieldsToClear = fieldsOutsideReportKind(reportKindAtMount);
+	// UX-Review (2026-08-06, Punkt 3): Nur die Felder zählen, die WIRKLICH einen
+	// Wert trugen. Die Schleife darunter läuft unverändert über alle — sie ist
+	// idempotent, und ein Reset auf den bereits geltenden Default kostet nichts.
+	// Gezählt wird VOR dem Reset, sonst wäre die Antwort immer null.
+	const clearedCount = fieldsToClear.filter(
+		(field) => savedFormData[field] !== initialFormState[field]
+	).length;
+	for (const field of fieldsToClear) {
 		resetField(field);
 	}
 
@@ -148,6 +158,24 @@
 		// Defer toast to after Svelte hydration
 		queueMicrotask(() => {
 			toast.info('Ihre vorherigen Eingaben wurden wiederhergestellt.', { duration: 4000 });
+		});
+	}
+
+	/**
+	 * UX-Review (2026-08-06, Punkt 3): Der Zweigwechsel über „Ändern" nahm die
+	 * Felder des verlassenen Zweigs oben kommentarlos mit. Steht direkt hinter
+	 * dem Wiederherstellungs-Hinweis, weil beide Meldungen dasselbe Ereignis
+	 * betreffen und in dieser Reihenfolge zusammen gelesen werden: „Ihre
+	 * vorherigen Eingaben wurden wiederhergestellt." — „Ihre Angaben zum Totfund
+	 * wurden entfernt, alles Übrige bleibt erhalten."
+	 *
+	 * Dasselbe `queueMicrotask` wie oben: ein Toast, der während des Aufbaus der
+	 * Komponente in den `$state`-Store schreibt, käme vor der Hydration.
+	 */
+	const clearedNotice = reportKindClearedNotice(reportKindAtMount, clearedCount);
+	if (clearedNotice) {
+		queueMicrotask(() => {
+			toast.info(clearedNotice, { duration: 6000 });
 		});
 	}
 

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -44,6 +44,7 @@ vi.mock('$lib/form/submitSightingForm', () => ({
 import { initialFormState } from '$lib/report/formConfig';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 import { loadFromStorage, saveToStorage, STORAGE_KEYS } from '$lib/storage/localStorage';
+import { clearAllToasts, toasts } from '$lib/stores/toastState.svelte';
 import type { UploadedFileInfo } from '$lib/types';
 import ModernReportForm from './ModernReportForm.svelte';
 
@@ -379,6 +380,93 @@ describe('ModernReportForm — zweigfremde Felder werden beim Start geleert', ()
 		const data = persistedFormData();
 		expect(data.mediaConsent).toBe(true);
 		expect(data.uploadedFiles).toEqual([UPLOAD]);
+	});
+});
+
+/**
+ * UX-Review (2026-08-06, Punkt 3): Der Aufräum-Block oben räumte still. Wer
+ * über „Ändern" den Zweig wechselt, sieht seine Totfund- bzw. Verhaltensangaben
+ * Schritte später kommentarlos fehlen — und kann nicht wissen, ob Position,
+ * Datum und Fotos ebenfalls betroffen sind. Der Wortlaut selbst steht in
+ * `reportKindClearedNotice` (`fieldsOutsideReportKind.ts`) und ist dort in Node
+ * getestet; hier geht es um die Strecke: Räumt der Block wirklich etwas, kommt
+ * die Meldung — und schweigt sie sonst.
+ */
+describe('ModernReportForm — der Zweigwechsel meldet, was er geräumt hat (UX-Review Punkt 3)', () => {
+	beforeEach(() => {
+		clearAllToasts();
+	});
+
+	function toastMessages(): string[] {
+		return toasts.map((entry) => entry.message);
+	}
+
+	it('meldet die entfernten Totfund-Angaben nach dem Wechsel in den Lebend-Zweig', async () => {
+		sessionStorage.setItem(
+			STORAGE_KEYS.FORM_DATA,
+			JSON.stringify({
+				...initialFormState,
+				referenceId: 'ref-wechsel-lebend',
+				deadCondition: 2,
+				deadSize: 150,
+				species: 7
+			})
+		);
+
+		render(ModernReportForm, { initialIsDead: false });
+
+		await vi.waitFor(() => {
+			expect(toastMessages()).toContain(
+				'Ihre Angaben zum Totfund wurden entfernt, alles Übrige bleibt erhalten.'
+			);
+		});
+	});
+
+	it('meldet die entfernten Verhaltensangaben nach dem Wechsel in den Totfund-Zweig', async () => {
+		sessionStorage.setItem(
+			STORAGE_KEYS.FORM_DATA,
+			JSON.stringify({
+				...initialFormState,
+				referenceId: 'ref-wechsel-totfund',
+				behavior: 3,
+				reaction: 'neugierig genähert',
+				species: 7
+			})
+		);
+
+		render(ModernReportForm, { initialIsDead: true });
+
+		await vi.waitFor(() => {
+			expect(toastMessages()).toContain(
+				'Ihre Angaben zum Verhalten der Tiere wurden entfernt, alles Übrige bleibt erhalten.'
+			);
+		});
+	});
+
+	/**
+	 * Der häufigste Fall — und der, an dem eine unbedingte Meldung peinlich
+	 * würde: Wer auf „Ändern" tippt und denselben Zweig erneut wählt, hat nichts
+	 * verloren und darf das auch nicht erzählt bekommen.
+	 */
+	it('schweigt, wenn im verlassenen Zweig gar nichts ausgefüllt war', async () => {
+		sessionStorage.setItem(
+			STORAGE_KEYS.FORM_DATA,
+			JSON.stringify({
+				...initialFormState,
+				referenceId: 'ref-wechsel-leer',
+				species: 7
+			})
+		);
+
+		render(ModernReportForm, { initialIsDead: false });
+
+		// Auf den Wiederherstellungs-Hinweis warten: Er läuft über dasselbe
+		// `queueMicrotask` und ist damit der Beleg, dass die Meldung, auf die es
+		// hier ankommt, ebenfalls schon gefallen WÄRE.
+		await vi.waitFor(() => {
+			expect(toastMessages()).toContain('Ihre vorherigen Eingaben wurden wiederhergestellt.');
+		});
+		expect(toastMessages().some((message) => message.includes('wurden entfernt'))).toBe(false);
 	});
 });
 

--- a/src/lib/report/components/ReportKindChoice.svelte
+++ b/src/lib/report/components/ReportKindChoice.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
-	import type { ReportKind } from '$lib/report/reportKind';
+	import { resolveReportKind, reportKindToParam, type ReportKind } from '$lib/report/reportKind';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 	import { scrollToElement } from '$lib/utils/fieldNavigation';
 
@@ -15,8 +15,30 @@
 		autofocusHeading = false
 	}: { onchoose: (kind: ReportKind) => void; autofocusHeading?: boolean } = $props();
 
-	let selected = $state<ReportKind | null>(null);
+	/**
+	 * UX-Review (2026-08-06, Punkt 1): Steht auf `true`, sobald einmal ohne
+	 * Auswahl bestätigt wurde. Ersetzt die frühere `aria-disabled`-Sperre am
+	 * „Weiter"-Knopf, die zwei Wege still ins Leere laufen ließ — Begründung an
+	 * der Aufrufstelle des Knopfes unten.
+	 */
+	let selectionMissing = $state(false);
 	let legendEl: HTMLElement | undefined = $state();
+
+	/**
+	 * Der Feldname ist zugleich der Query-Parameter der Seite, die Optionswerte
+	 * sind dessen deutsche Werte (`reportKindToParam`). Das ist keine Kosmetik:
+	 * Ein Klick auf „Weiter" VOR der Hydration schickt das Formular nativ per GET
+	 * ab — `onsubmit` hängt dann noch nicht am DOM. Mit diesen Namen landet der
+	 * Melder auf `/?meldung=totfund`, und `+page.svelte` löst den Zweig über
+	 * `resolveReportKind` bereits serverseitig auf, statt nur neu zu laden.
+	 *
+	 * Was dieser Weg NICHT kann: bestehende Query-Parameter erhalten (ein
+	 * GET-Submit ersetzt die gesamte Query). `choose()` in `+page.svelte` tut das
+	 * für den JS-Pfad; ohne JS wäre dafür je ein verstecktes Feld nötig, dessen
+	 * Wert nur `$app/state` kennt. Bewusst nicht gebaut — auf diesem Weg passierte
+	 * bisher überhaupt nichts.
+	 */
+	const KIND_FIELD_NAME = 'meldung';
 
 	/**
 	 * B7: „Ändern" tauschte bislang den gesamten Formularbaum gegen diese Seite
@@ -38,10 +60,34 @@
 		legendEl.focus({ preventScroll: true });
 	});
 
-	function submit(event: SubmitEvent): void {
+	/**
+	 * Die Auswahl wird aus dem abgeschickten Formular gelesen, nicht aus einem
+	 * eigenen `$state`. Der Grund ist derselbe wie beim Feldnamen oben: Wer vor
+	 * der Hydration eine Option ankreuzt, tut das im DOM — ein `$state` wüsste
+	 * davon nichts und meldete danach „nichts gewählt", obwohl sichtbar etwas
+	 * angekreuzt ist.
+	 *
+	 * `resolveReportKind(param, null, null)` ist hier die Parameter-Zuordnung
+	 * ohne Storage-Quellen — dieselbe Aufrufform wie im `popstate`-Handler in
+	 * `+page.svelte`.
+	 */
+	function submit(event: SubmitEvent & { currentTarget: HTMLFormElement }): void {
 		event.preventDefault();
-		if (!selected) return;
-		onchoose(selected);
+
+		const submitted = new FormData(event.currentTarget).get(KIND_FIELD_NAME);
+		const chosen = resolveReportKind(typeof submitted === 'string' ? submitted : null, null, null);
+
+		if (!chosen) {
+			selectionMissing = true;
+			// Fokus zur Gruppe, zu der die Meldung gehört — er stünde sonst auf dem
+			// Knopf, und ein Screenreader-Nutzer müsste rückwärts suchen, was
+			// beanstandet wird. Das Fokussieren eines Radios wählt es nicht aus.
+			event.currentTarget.querySelector<HTMLInputElement>('input[type="radio"]')?.focus();
+			return;
+		}
+
+		selectionMissing = false;
+		onchoose(chosen);
 	}
 
 	const OPTIONS: Array<{ value: ReportKind; label: string; hint: string; icon: string }> = [
@@ -77,7 +123,17 @@
 	<!-- role="radiogroup" überschreibt die implizite Rolle `group` des fieldset:
 	     nur so sagt ein Screenreader „1 von 2" an und verknüpft die Legend mit
 	     den Optionen. Gleiche Mechanik wie in FieldRenderer.svelte. -->
-	<fieldset role="radiogroup" aria-labelledby="report-kind-legend" aria-required="true">
+	<!-- aria-invalid und aria-describedby tragen die Gruppe, nicht die einzelnen
+	     Radios: ARIA 1.2 hat beide aus den globalen Zuständen entfernt, und
+	     `role="radio"` unterstützt sie nicht (design-system.md, A11y-Minima).
+	     Dasselbe Muster wie in FieldRenderer.svelte. -->
+	<fieldset
+		role="radiogroup"
+		aria-labelledby="report-kind-legend"
+		aria-required="true"
+		aria-invalid={selectionMissing ? 'true' : undefined}
+		aria-describedby={selectionMissing ? 'report-kind-error' : undefined}
+	>
 		<legend id="report-kind-legend" class="text-section mb-3" bind:this={legendEl}
 			>Was möchten Sie melden?</legend
 		>
@@ -89,11 +145,10 @@
 				>
 					<input
 						type="radio"
-						name="reportKind"
+						name={KIND_FIELD_NAME}
 						class="radio radio-primary mt-1"
-						value={option.value}
-						checked={selected === option.value}
-						onchange={() => (selected = option.value)}
+						value={reportKindToParam(option.value)}
+						onchange={() => (selectionMissing = false)}
 					/>
 					<span class="flex flex-col gap-1">
 						<span class="flex items-center gap-2 font-medium">
@@ -105,17 +160,27 @@
 				</label>
 			{/each}
 		</div>
+
+		<!-- Gleiche Fehler-Optik wie an jedem Formularfeld (FieldRenderer.svelte),
+		     damit die Meldung hier nicht wie ein Fremdkörper aussieht. -->
+		{#if selectionMissing}
+			<div id="report-kind-error" class="mt-3 text-left" role="alert" aria-live="polite">
+				<span class="text-error text-support flex items-center gap-1 font-medium">
+					<Icon icon="lucide:triangle-alert" width="14" class="text-error flex-shrink-0" />
+					Bitte wählen Sie aus, was Sie melden möchten.
+				</span>
+			</div>
+		{/if}
 	</fieldset>
 
-	<!-- aria-disabled statt disabled: Die Schaltfläche bleibt fokussierbar, der
-	     Tastaturfokus geht beim Sperren nicht verloren. Die Sperre trägt der
-	     Wächter in `submit`. -->
-	<button
-		type="submit"
-		class="btn btn-primary mt-6 w-full"
-		aria-disabled={selected === null}
-		data-testid="report-kind-submit"
-	>
+	<!-- Kein `aria-disabled` (und erst recht kein `disabled`): Eine gesperrte
+	     Schaltfläche sagte nicht, was fehlt. DaisyUI legt an
+	     `.btn[aria-disabled=true]` ein `pointer-events: none` — vor der Hydration
+	     erreichte ein Klick das Element damit gar nicht, und per Tastatur lief das
+	     Enter durch, ohne dass der stille Wächter in `submit` etwas meldete
+	     (UX-Review 2026-08-06, Punkt 1). Die Sperre ist jetzt die Meldung an der
+	     Radiogruppe oben. -->
+	<button type="submit" class="btn btn-primary mt-6 w-full" data-testid="report-kind-submit">
 		Weiter
 	</button>
 </form>

--- a/src/lib/report/components/ReportKindChoice.svelte
+++ b/src/lib/report/components/ReportKindChoice.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
-	import { resolveReportKind, reportKindToParam, type ReportKind } from '$lib/report/reportKind';
+	import {
+		REPORT_KIND_PARAM,
+		reportKindToParam,
+		resolveReportKind,
+		type ReportKind
+	} from '$lib/report/reportKind';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 	import { scrollToElement } from '$lib/utils/fieldNavigation';
 
@@ -24,21 +29,29 @@
 	let selectionMissing = $state(false);
 	let legendEl: HTMLElement | undefined = $state();
 
-	/**
-	 * Der Feldname ist zugleich der Query-Parameter der Seite, die Optionswerte
-	 * sind dessen deutsche Werte (`reportKindToParam`). Das ist keine Kosmetik:
-	 * Ein Klick auf „Weiter" VOR der Hydration schickt das Formular nativ per GET
-	 * ab — `onsubmit` hängt dann noch nicht am DOM. Mit diesen Namen landet der
-	 * Melder auf `/?meldung=totfund`, und `+page.svelte` löst den Zweig über
-	 * `resolveReportKind` bereits serverseitig auf, statt nur neu zu laden.
+	/*
+	 * Die Radios heißen wie der Query-Parameter der Seite (`REPORT_KIND_PARAM`)
+	 * und tragen dessen deutsche Werte (`reportKindToParam`). Warum das ein
+	 * Vertrag und keine Kosmetik ist, steht an der Konstante in `reportKind.ts`.
 	 *
-	 * Was dieser Weg NICHT kann: bestehende Query-Parameter erhalten (ein
-	 * GET-Submit ersetzt die gesamte Query). `choose()` in `+page.svelte` tut das
-	 * für den JS-Pfad; ohne JS wäre dafür je ein verstecktes Feld nötig, dessen
-	 * Wert nur `$app/state` kennt. Bewusst nicht gebaut — auf diesem Weg passierte
-	 * bisher überhaupt nichts.
+	 * Zwei Dinge, die dieser Weg NICHT leistet:
+	 *
+	 * 1. **Bestehende Query-Parameter überleben ihn nicht** — ein GET-Submit
+	 *    ersetzt die gesamte Query. `choose()` in `+page.svelte` hält sie im
+	 *    JS-Pfad erhalten (Kampagnen-Marker aus einem Museums-Link); ohne JS
+	 *    bräuchte es dafür je ein verstecktes Feld, dessen Wert nur
+	 *    `$app/state` kennt.
+	 * 2. **Ohne Auswahl bleibt er stumm.** Vor der Hydration führt „Weiter"
+	 *    ohne angekreuzte Option zu `/?` — einem vollständigen Reload ohne
+	 *    Erklärung statt der Meldung unten. Ein `required` an den Radios löste
+	 *    das nativ, verdrängte aber im JS-Pfad die eigene Meldung durch die
+	 *    Browser-Blase, die nicht barrierefrei ist und nicht stehen bleibt. Der
+	 *    Zielkonflikt ist zugunsten des JS-Pfads entschieden: Er ist der
+	 *    Regelfall, der andere ein Zeitfenster von Sekunden.
+	 *
+	 * Beides ist bewusst in Kauf genommen — auf diesem Weg passierte vorher
+	 * überhaupt nichts (der Knopf war per `pointer-events: none` unerreichbar).
 	 */
-	const KIND_FIELD_NAME = 'meldung';
 
 	/**
 	 * B7: „Ändern" tauschte bislang den gesamten Formularbaum gegen diese Seite
@@ -74,7 +87,7 @@
 	function submit(event: SubmitEvent & { currentTarget: HTMLFormElement }): void {
 		event.preventDefault();
 
-		const submitted = new FormData(event.currentTarget).get(KIND_FIELD_NAME);
+		const submitted = new FormData(event.currentTarget).get(REPORT_KIND_PARAM);
 		const chosen = resolveReportKind(typeof submitted === 'string' ? submitted : null, null, null);
 
 		if (!chosen) {
@@ -124,9 +137,15 @@
 	     nur so sagt ein Screenreader „1 von 2" an und verknüpft die Legend mit
 	     den Optionen. Gleiche Mechanik wie in FieldRenderer.svelte. -->
 	<!-- aria-invalid und aria-describedby tragen die Gruppe, nicht die einzelnen
-	     Radios: ARIA 1.2 hat beide aus den globalen Zuständen entfernt, und
-	     `role="radio"` unterstützt sie nicht (design-system.md, A11y-Minima).
-	     Dasselbe Muster wie in FieldRenderer.svelte. -->
+	     Radios — aber aus zwei verschiedenen Gründen, die sich leicht
+	     verwechseln lassen:
+
+	     `aria-invalid` MUSS hierher: ARIA 1.2 hat es (wie `aria-required`) aus
+	     den globalen Zuständen entfernt, `role="radio"` unterstützt es seither
+	     nicht (design-system.md, A11y-Minima). `aria-describedby` ist dagegen
+	     weiterhin global und stünde an einem Radio nicht falsch — es steht
+	     hier, weil die Meldung die GRUPPE beanstandet und nicht eine der beiden
+	     Optionen. Dasselbe Muster wie in FieldRenderer.svelte. -->
 	<fieldset
 		role="radiogroup"
 		aria-labelledby="report-kind-legend"
@@ -145,7 +164,7 @@
 				>
 					<input
 						type="radio"
-						name={KIND_FIELD_NAME}
+						name={REPORT_KIND_PARAM}
 						class="radio radio-primary mt-1"
 						value={reportKindToParam(option.value)}
 						onchange={() => (selectionMissing = false)}

--- a/src/lib/report/components/ReportKindChoice.svelte.test.ts
+++ b/src/lib/report/components/ReportKindChoice.svelte.test.ts
@@ -35,8 +35,113 @@ describe('ReportKindChoice', () => {
 	it('lässt sich nicht ohne Auswahl bestätigen', async () => {
 		const onchoose = vi.fn();
 		const screen = render(ReportKindChoice, { onchoose });
-		await screen.getByRole('button', { name: /Weiter/i }).click({ force: true });
+		await screen.getByRole('button', { name: /Weiter/i }).click();
 		expect(onchoose).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * UX-Review (2026-08-06, Punkt 1): Der Knopf trug `aria-disabled`, solange nichts
+ * gewählt war — und sagte nicht, warum. Zwei Wege liefen damit ins Leere:
+ *
+ * - **Maus, vor der Hydration.** DaisyUI setzt an `.btn[aria-disabled=true]`
+ *   ein `pointer-events: none` (verifiziert in `node_modules/daisyui/components/
+ *   button.css`, 5.7.4). Der Klick erreichte das Element also gar nicht. Auf einer
+ *   schlechten Mobilverbindung am Strand sind das Sekunden, in denen die Seite
+ *   kaputt wirkt.
+ * - **Tastatur, nach der Hydration.** `pointer-events` bremst keine
+ *   Enter-Taste — der Submit lief, der Wächter in `submit()` stieg still aus,
+ *   angesagt wurde nichts.
+ *
+ * Der Knopf ist deshalb immer freigegeben; die Sperre ist eine Fehlermeldung an
+ * der Gruppe. `aria-invalid` und `aria-describedby` gehören dabei ans
+ * `fieldset` mit `role="radiogroup"`, nicht an die einzelnen Radios — ARIA 1.2
+ * kennt beide an `role="radio"` nicht (`design-system.md`, A11y-Minima).
+ */
+describe('ReportKindChoice — Sperre ohne Auswahl ist eine Meldung, kein toter Knopf', () => {
+	it('gibt den Weiter-Knopf frei, auch ohne Auswahl', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		const weiter = screen.getByRole('button', { name: /Weiter/i });
+		await expect.element(weiter).not.toHaveAttribute('aria-disabled', 'true');
+		await expect.element(weiter).not.toBeDisabled();
+	});
+
+	it('meldet die fehlende Auswahl beim Bestätigen', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		await screen.getByRole('button', { name: /Weiter/i }).click();
+
+		await expect.element(screen.getByRole('alert')).toHaveTextContent(/Bitte wählen Sie aus/i);
+	});
+
+	it('markiert die Radiogruppe als fehlerhaft und verweist auf die Meldung', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		await screen.getByRole('button', { name: /Weiter/i }).click();
+
+		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
+		await expect.element(gruppe).toHaveAttribute('aria-invalid', 'true');
+
+		const beschreibung = (await gruppe.element()).getAttribute('aria-describedby');
+		expect(beschreibung).not.toBeNull();
+		expect(document.getElementById(beschreibung as string)?.textContent).toMatch(
+			/Bitte wählen Sie aus/i
+		);
+	});
+
+	it('trägt die Fehlermarkierung nicht schon vor dem ersten Versuch', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
+		await expect.element(gruppe).not.toHaveAttribute('aria-invalid');
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+	});
+
+	it('nimmt die Meldung zurück, sobald etwas gewählt wird', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		await screen.getByRole('button', { name: /Weiter/i }).click();
+		await screen.getByRole('radio', { name: /toten Tieres/i }).click();
+
+		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
+		await expect.element(gruppe).not.toHaveAttribute('aria-invalid');
+		expect(document.querySelector('[role="alert"]')).toBeNull();
+	});
+
+	it('führt den Fokus zur Gruppe, statt ihn beim Knopf zu lassen', async () => {
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		await screen.getByRole('button', { name: /Weiter/i }).click();
+
+		const ersteOption = document.querySelector('input[type="radio"]');
+		expect(document.activeElement).toBe(ersteOption);
+	});
+});
+
+/**
+ * UX-Review (2026-08-06, Punkt 1), zweite Hälfte: Ein freigegebener Submit-Knopf
+ * heißt, dass ein Klick VOR der Hydration den Browser das Formular nativ
+ * abschicken lässt — der `onsubmit`-Wächter hängt zu diesem Zeitpunkt noch nicht
+ * am DOM. Genau dieser Weg soll etwas Sinnvolles tun statt eines
+ * Leerlauf-Reloads: Die Radios heißen deshalb `meldung` und tragen die
+ * deutschen Parameterwerte aus `reportKindToParam` — ein nativer GET-Submit
+ * landet damit auf `/?meldung=totfund`, und `resolveReportKind` löst das schon
+ * serverseitig in den richtigen Zweig auf (`+page.svelte`).
+ *
+ * Nicht abgedeckt bleibt dabei, dass ein nativer GET-Submit die übrigen
+ * Query-Parameter (Kampagnen-Marker aus einem Museums-Link) ersetzt — der
+ * JS-Pfad hält sie in `choose()` erhalten, der JS-lose kann es ohne versteckte
+ * Felder nicht. Bewusst in Kauf genommen: bisher passierte auf diesem Weg
+ * überhaupt nichts.
+ */
+describe('ReportKindChoice — der Submit trägt ohne JS bereits den Zweig', () => {
+	it('benennt die Radios nach dem Query-Parameter der Seite', () => {
+		render(ReportKindChoice, { onchoose: vi.fn() });
+
+		const radios = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+		expect(radios.map((radio) => radio.name)).toEqual(['meldung', 'meldung']);
+		expect(radios.map((radio) => radio.value)).toEqual(['lebend', 'totfund']);
 	});
 });
 

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import StepProgressCompact from './StepProgressCompact.svelte';
+	import { SUBMIT_STATUS_OFFLINE_ID } from './submitStatusIds';
 	import { validateStep } from '$lib/form/validation/stepValidation';
 	import { createLogger } from '$lib/logger';
 	import { getFormContext } from '$lib/report/formContext';
 	import { toast } from '$lib/stores/toastState.svelte';
 	import {
 		getErrorCount,
+		scrollToElement,
 		scrollToFirstError,
 		scrollToStepHeader
 	} from '$lib/utils/fieldNavigation';
@@ -108,12 +110,38 @@
 	/** Absenden ist gesperrt — nur auf dem letzten Schritt relevant. */
 	const isSubmitBlocked = $derived(isLastStep && submitBlocked);
 
+	/**
+	 * Führt zur bereits stehenden Begründung über der Navigation.
+	 *
+	 * UX-Review-Nachgang (2026-08-06): Der Knopf trug für diese Sperre
+	 * `aria-disabled` + `btn-disabled`, und DaisyUI legt darauf ein
+	 * `pointer-events: none` (design-system.md, „Der Vorbehalt"). Ein Klick kam
+	 * damit nie an, per Tastatur endete er in einem `logger.info` — beides ohne
+	 * jede Rückmeldung. Der `title` mit dem Grund erschien aus demselben Grund
+	 * beim Hovern nie.
+	 *
+	 * Erklärt werden muss hier nichts Neues: `SubmitStatus` steht mit dem vollen
+	 * Grund und der Datenzusage direkt über dieser Navigation. Nur ist die
+	 * Navigation unterhalb `md` ein ortsfester Balken am unteren Rand — die
+	 * Begründung kann also weggescrollt sein, während der Knopf sichtbar bleibt.
+	 * Genau dorthin führt dieser Sprung, und der Fokus sorgt für die Ansage.
+	 */
+	function revealSubmitBlockedReason(): void {
+		const reason = document.getElementById(SUBMIT_STATUS_OFFLINE_ID);
+		if (!reason) return;
+		scrollToElement(reason);
+		reason.setAttribute('tabindex', '-1');
+		reason.focus({ preventScroll: true });
+	}
+
 	async function nextStep(): Promise<void> {
 		try {
-			// Wächter zur `aria-disabled`-Sperre am Button: Das Element bleibt
-			// fokussierbar (siehe design-system.md), die eigentliche Sperre sitzt hier.
+			// Der Knopf ist NICHT als deaktiviert ausgezeichnet (Begründung an
+			// `revealSubmitBlockedReason`) — die Sperre sitzt allein hier, und sie
+			// antwortet, statt still auszusteigen.
 			if (isSubmitBlocked) {
 				logger.info('Absenden gesperrt — keine Verbindung');
+				revealSubmitBlockedReason();
 				return;
 			}
 
@@ -295,21 +323,29 @@
 		{/if}
 
 		<!--
-			`aria-disabled` statt `disabled` für die Verbindungssperre: Das Element
-			bleibt fokussierbar, damit die Tastaturposition erhalten bleibt und der
-			Grund erreichbar ist (design-system.md). Der laufende Submit sperrt
-			weiterhin hart über `disabled` — dort ist der Zustand von sehr kurzer
-			Dauer und ein Doppelklick hätte echte Folgen.
+			Die Verbindungssperre zeichnet den Knopf NICHT mehr als deaktiviert aus
+			(kein `aria-disabled`, kein `btn-disabled`, kein `title`): DaisyUI legt
+			auf jede dieser Auszeichnungen ein `pointer-events: none`, wodurch der
+			Klick nie ankam, der Wächter nichts melden konnte und der `title` beim
+			Hovern nie erschien (design-system.md, „Der Vorbehalt"). Stattdessen
+			führt ein Klick zur Begründung, die ohnehin über der Navigation steht —
+			`revealSubmitBlockedReason`.
+
+			`aria-describedby` auf dieselbe Fläche: So trägt der Knopf den Grund
+			auch für Screenreader, ohne dass er dafür angeklickt werden muss. Das
+			ersetzt den `title`, der ohnehin nur am Zeigegerät hing.
+
+			Der laufende Submit sperrt weiterhin hart über `disabled` — dort ist der
+			Zustand von sehr kurzer Dauer, es gibt nichts zu erklären, und ein
+			Doppelklick hätte echte Folgen.
 		-->
 		<button
 			type="button"
 			onclick={nextStep}
 			disabled={$isSubmitting}
-			aria-disabled={isSubmitBlocked}
 			class="btn btn-primary"
-			class:btn-disabled={isSubmitBlocked}
 			aria-label={isLastStep ? 'Formular absenden' : 'Nächster Schritt'}
-			title={isSubmitBlocked ? 'Ohne Internetverbindung kann nicht abgesendet werden' : undefined}
+			aria-describedby={isSubmitBlocked ? SUBMIT_STATUS_OFFLINE_ID : undefined}
 		>
 			{#if $isSubmitting}
 				<span class="loading loading-spinner loading-sm"></span>

--- a/src/lib/report/components/form/SubmitStatus.svelte
+++ b/src/lib/report/components/form/SubmitStatus.svelte
@@ -27,6 +27,7 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { ORPHAN_RETENTION_HOURS } from '$lib/constants/uploadRetention';
+	import { SUBMIT_STATUS_OFFLINE_ID } from './submitStatusIds';
 
 	let {
 		state = 'idle',
@@ -115,6 +116,7 @@
 		Satz unterbrechen, ohne dass etwas passiert wäre.
 	-->
 	<div
+		id={SUBMIT_STATUS_OFFLINE_ID}
 		class="alert alert-warning mb-2 items-start"
 		role="status"
 		aria-live="polite"

--- a/src/lib/report/components/form/SubmitStatus.svelte.test.ts
+++ b/src/lib/report/components/form/SubmitStatus.svelte.test.ts
@@ -3,6 +3,7 @@ import { tick } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import SubmitStatus from './SubmitStatus.svelte';
+import { SUBMIT_STATUS_OFFLINE_ID } from './submitStatusIds';
 
 /** Findet den Statusblock im gerenderten Dokument. */
 function block(testid: string): HTMLElement | null {
@@ -38,6 +39,19 @@ describe('SubmitStatus', () => {
 
 			expect(block('submit-status-offline')?.getAttribute('role')).toBe('status');
 			expect(document.querySelector('[role="alert"]')).toBeNull();
+		});
+
+		/**
+		 * Die Fläche wird seit dem UX-Review-Nachgang (2026-08-06) von außen
+		 * referenziert: `StepNavigation.svelte` hängt sie bei gesperrtem Absenden
+		 * als `aria-describedby` an den Absenden-Knopf und springt bei einem Klick
+		 * darauf hierher. Verschwände die `id`, zeigte das `aria-describedby` ins
+		 * Leere und der Sprung fände nichts — beides meldet niemand von selbst.
+		 */
+		it('trägt die exportierte id, auf die StepNavigation verweist', () => {
+			render(SubmitStatus, { state: 'offline' });
+
+			expect(block('submit-status-offline')?.id).toBe(SUBMIT_STATUS_OFFLINE_ID);
 		});
 	});
 

--- a/src/lib/report/components/form/fields/FieldRenderer.svelte
+++ b/src/lib/report/components/form/fields/FieldRenderer.svelte
@@ -28,7 +28,8 @@
 		label: labelOverride = undefined,
 		type: typeOverride = undefined,
 		options: optionsOverride = undefined,
-		helpText: helpTextOverride = undefined
+		helpText: helpTextOverride = undefined,
+		describedBy = undefined
 	}: {
 		fieldConfig: yup.SchemaDescription;
 		name?: string;
@@ -76,6 +77,21 @@
 		 * `aria-describedby`), `undefined` = Ableitung aus dem Schema (Default).
 		 */
 		helpText?: string | null | undefined;
+		/**
+		 * `id` eines Elements, das der Aufrufer selbst neben das Feld gestellt
+		 * hat und das mitvorgelesen werden soll — zusätzlich zu Hilfetext,
+		 * Beschreibung und Fehler, die diese Pipeline ohnehin verknüpft.
+		 *
+		 * Gebraucht, wenn der Kontext einer Frage nicht im Schema stehen kann,
+		 * weil er aus dem Formularzustand kommt: `mediaConsent` auf Schritt 4
+		 * nennt die hochgeladenen Aufnahmen namentlich (`Step4Contact.svelte`,
+		 * UX-Review 2026-08-06, Punkt 2). Ohne diese Verknüpfung sieht ein
+		 * Sehender die Dateinamen, wer direkt aufs Ankreuzfeld tabbt aber nicht.
+		 *
+		 * Bewusst nur die `id` und kein Text: Der Inhalt steht im Markup des
+		 * Aufrufers, nicht in dieser Pipeline — sonst gäbe es ihn zweimal.
+		 */
+		describedBy?: string | undefined;
 	} = $props();
 
 	// Bindable values for different component types
@@ -220,6 +236,9 @@
 	// ARIA attributes
 	let ariaDescribedBy = $derived.by(() => {
 		const ids = [];
+		// Zuerst: Was der Aufrufer neben das Feld gestellt hat, steht dort auch
+		// optisch VOR ihm — die Vorlesereihenfolge soll der gesehenen folgen.
+		if (describedBy) ids.push(describedBy);
 		if (metaValues.helpText) ids.push(helpId);
 		if (metaValues.description && metaValues.description !== metaValues.helpText)
 			ids.push(descriptionId);

--- a/src/lib/report/components/form/fields/FormField.svelte
+++ b/src/lib/report/components/form/fields/FormField.svelte
@@ -23,7 +23,8 @@
 		label = undefined,
 		type = undefined,
 		options = undefined,
-		helpText = undefined
+		helpText = undefined,
+		describedBy = undefined
 	}: {
 		name: keyof Omit<SightingFormData, 'uploadedFiles'>;
 		disabled?: boolean;
@@ -58,6 +59,13 @@
 		 * gilt weiterhin `meta.helpText`.
 		 */
 		helpText?: string | null | undefined;
+		/**
+		 * `id` eines Elements, das der Aufrufer selbst neben das Feld gestellt
+		 * hat und das mitvorgelesen werden soll. Für Kontext, der nicht im Schema
+		 * stehen kann, weil er aus dem Formularzustand kommt — Beispiel und volle
+		 * Begründung an derselben Prop in `FieldRenderer.svelte`.
+		 */
+		describedBy?: string | undefined;
 	} = $props();
 
 	const context = getFormContext();
@@ -117,6 +125,7 @@
 		{type}
 		{options}
 		{helpText}
+		{describedBy}
 		onchange={handleChange}
 	/>
 </div>

--- a/src/lib/report/components/form/submitStatusIds.ts
+++ b/src/lib/report/components/form/submitStatusIds.ts
@@ -1,0 +1,20 @@
+/**
+ * `id` der Offline-Fläche aus `SubmitStatus.svelte`.
+ *
+ * Sie wird seit dem UX-Review-Nachgang (2026-08-06) von außen referenziert:
+ * `StepNavigation.svelte` hängt sie bei gesperrtem Absenden als
+ * `aria-describedby` an den Absenden-Knopf und springt bei einem Klick darauf
+ * dorthin. Ein Literal auf beiden Seiten wäre ein stiller Bruch — ein
+ * `aria-describedby` ins Leere meldet niemand.
+ *
+ * **Warum eine eigene Datei und nicht der `<script module>`-Block von
+ * `SubmitStatus.svelte`:** Dort stünde sie fachlich am richtigen Ort (der Typ
+ * `SubmitState` liegt genau da), aber `npm run type-check` fährt `tsc --noEmit`,
+ * und für `tsc` ist jede `.svelte`-Datei die Ambient-Deklaration `*.svelte` mit
+ * ausschließlich einem Default-Export. Eine `.ts`-Datei — hier
+ * `SubmitStatus.svelte.test.ts` — kann von dort deshalb keinen benannten Export
+ * beziehen (TS2614), auch wenn `svelte-check` es klaglos auflöst. Der
+ * `SubmitState`-Import in `ModernReportForm.svelte` fällt nicht darunter: Das
+ * ist selbst eine `.svelte`-Datei und wird nur von `svelte-check` geprüft.
+ */
+export const SUBMIT_STATUS_OFFLINE_ID = 'submit-status-offline';

--- a/src/lib/report/components/sections/Behavior.svelte
+++ b/src/lib/report/components/sections/Behavior.svelte
@@ -17,6 +17,25 @@
 	 * Admin genommen, denn beide benutzen diese Sektion.
 	 */
 	let { adminMode = false }: { adminMode?: boolean } = $props();
+
+	/**
+	 * Beschriftung von `reaction` im Meldeformular — allgemeiner als das
+	 * Schema-Label „Reaktion auf Ihr Boot", das die Admin-Maske behält.
+	 *
+	 * UX-Review (2026-08-06, Punkt 4): `isFromLand` blendet das Feld bewusst nur
+	 * bei einem ausdrücklichen „Land" aus, weil `sightingFrom = 0` gleichzeitig
+	 * „Sonstiges" und „noch nicht beantwortet" bedeutet (Begründung an
+	 * `isFromLand` in `formConfig.ts`). Das ist richtig — heißt aber, dass die
+	 * Frage auch dem Kajakfahrer, dem SUP-Paddler und dem Besucher auf der
+	 * Seebrücke gestellt wird, und für die drei gibt es kein „Ihr Boot".
+	 *
+	 * Der `label`-Override ist dafür der vorgesehene Weg und keine Ausnahme von
+	 * der Regel „Beschriftungen kommen aus dem Schema": `FormField` führt ihn
+	 * ausdrücklich für den Fall, dass dieselbe Schema-Spalte im Meldeformular
+	 * und in der Admin-Maske unterschiedlich gefragt wird. Präzedenz mit
+	 * derselben Mechanik: `species` in `sections/AnimalInfo.svelte`.
+	 */
+	const REPORT_REACTION_LABEL = 'Reaktion auf Sie oder Ihr Fahrzeug';
 </script>
 
 <!-- Animal Behavior Section -->
@@ -36,20 +55,24 @@
 		</div>
 	{/if}
 
-	<!-- „Reaktion auf Sie oder Ihr Fahrzeug" ist für einen Landbeobachter
-	     unbeantwortbar — er steht am Ufer, die Tiere reagieren nicht auf ihn.
-	     Das Label ist seit dem UX-Review (2026-08-06, Punkt 4) verallgemeinert,
-	     weil `isFromLand` bewusst nur ein ausdrückliches „Land" ausblendet und
-	     Kajak, SUP und Seebrücke unter „Sonstiges" hier stehen bleiben.
-	     `getFormSteps`
+	<!-- Die Reaktionsfrage ist für einen Landbeobachter unbeantwortbar — er steht
+	     am Ufer, die Tiere reagieren nicht auf ihn. `getFormSteps`
 	     (formConfig.ts) nimmt `reaction` bereits bei einer Land-Meldung aus der
 	     Validierung; dieselbe Bedingung (`isFromLand`) hier, sonst bliebe das
 	     Feld sichtbar, aber unvalidiert ausgefüllt.
 
-	     Nur außerhalb von `adminMode`: Die Admin-Maske muss `reaction` auch an
-	     Altbestands-Datensätzen mit `vonwo = Land` korrigieren können. -->
-	{#if adminMode || !isFromLand($form.sightingFrom)}
+	     Die zwei Zweige sind nicht nur die Ausnahme für den Admin-Modus (die
+	     Admin-Maske muss `reaction` auch an Altbestands-Datensätzen mit
+	     `vonwo = Land` korrigieren können), sondern tragen seit dem UX-Review
+	     (2026-08-06, Punkt 4) auch die zwei Beschriftungen: Die Sachbearbeitung
+	     behält das Schema-Label, das Meldeformular fragt allgemeiner
+	     (`REPORT_REACTION_LABEL`, Begründung im script-Block). Getrennte Zweige
+	     statt eines Ternärs am `label`-Prop, weil `exactOptionalPropertyTypes`
+	     ein explizites `undefined` an einem optionalen Prop nicht zulässt. -->
+	{#if adminMode}
 		<FormField name="reaction" />
+	{:else if !isFromLand($form.sightingFrom)}
+		<FormField name="reaction" label={REPORT_REACTION_LABEL} />
 	{/if}
 
 	<!-- `otherObservations` ist aus dem Meldeformular genommen (Überschneidung

--- a/src/lib/report/components/sections/Behavior.svelte
+++ b/src/lib/report/components/sections/Behavior.svelte
@@ -36,8 +36,12 @@
 		</div>
 	{/if}
 
-	<!-- „Reaktion auf Ihr Boot" ist für einen Landbeobachter unbeantwortbar — er
-	     hat kein Boot, auf das die Tiere reagieren könnten. `getFormSteps`
+	<!-- „Reaktion auf Sie oder Ihr Fahrzeug" ist für einen Landbeobachter
+	     unbeantwortbar — er steht am Ufer, die Tiere reagieren nicht auf ihn.
+	     Das Label ist seit dem UX-Review (2026-08-06, Punkt 4) verallgemeinert,
+	     weil `isFromLand` bewusst nur ein ausdrückliches „Land" ausblendet und
+	     Kajak, SUP und Seebrücke unter „Sonstiges" hier stehen bleiben.
+	     `getFormSteps`
 	     (formConfig.ts) nimmt `reaction` bereits bei einer Land-Meldung aus der
 	     Validierung; dieselbe Bedingung (`isFromLand`) hier, sonst bliebe das
 	     Feld sichtbar, aber unvalidiert ausgefüllt.

--- a/src/lib/report/components/sections/Behavior.svelte.test.ts
+++ b/src/lib/report/components/sections/Behavior.svelte.test.ts
@@ -70,10 +70,16 @@ describe('sections/Behavior — Reaktion aufs Boot entfällt bei Land', () => {
  * wird. „Ihr Boot" ist für die drei schlicht falsch; die Frage selbst bleibt
  * sinnvoll.
  *
- * Verallgemeinert wird deshalb das Label — und zwar im Yup-Schema, der einzigen
- * Quelle für Feldbeschriftungen (`design-system.md`, Formularfeld-Muster). Die
- * Admin-Maske liest dasselbe Label; das ist gewollt, sie editiert dieselbe
- * Spalte `reaktion` und hatte den Boot-Bezug genauso wenig verdient.
+ * Verallgemeinert wird das Label ausschließlich im Meldeformular, über den
+ * `label`-Override von `FormField` — den es genau für diesen Fall gibt
+ * („dieselbe Schema-Spalte in zwei Kontexten unterschiedlich gefragt",
+ * Präzedenz: `species` in `AnimalInfo.svelte`). Die Admin-Maske behält das
+ * Schema-Label „Reaktion auf Ihr Boot"; sie ist ausdrücklich unverändert zu
+ * lassen.
+ *
+ * Beide Richtungen gehören deshalb geprüft: Ein Override, der versehentlich
+ * auch im Admin-Zweig gesetzt wird, fiele sonst nicht auf — und ein
+ * versehentlich entfernter Override im Meldeformular genauso wenig.
  */
 describe('sections/Behavior — die Reaktionsfrage setzt kein Boot voraus (UX-Review Punkt 4)', () => {
 	/**
@@ -86,16 +92,18 @@ describe('sections/Behavior — die Reaktionsfrage setzt kein Boot voraus (UX-Re
 		return field('reaction')?.closest('.fieldset')?.querySelector('label')?.textContent ?? '';
 	}
 
-	it('spricht von „Sie oder Ihr Fahrzeug", nicht von „Ihr Boot"', () => {
+	it('spricht im Meldeformular von „Sie oder Ihr Fahrzeug", nicht von „Ihr Boot"', () => {
 		renderBehavior({ sightingFrom: SightingFromEnum.OTHER });
 
 		expect(reactionLabel()).toMatch(/Reaktion auf Sie oder Ihr Fahrzeug/i);
 		expect(reactionLabel()).not.toMatch(/Ihr Boot/i);
 	});
 
-	it('trägt dasselbe Label in der Admin-Maske — ein Feld, eine Beschriftung', () => {
+	// Gegenprobe: Die Admin-Maske bleibt beim Schema-Label. Ohne diese
+	// Feststellung könnte der Override unbemerkt in beide Zweige rutschen.
+	it('lässt die Admin-Maske beim Schema-Label „Reaktion auf Ihr Boot"', () => {
 		renderBehavior({ sightingFrom: SightingFromEnum.LAND }, { adminMode: true });
 
-		expect(reactionLabel()).toMatch(/Reaktion auf Sie oder Ihr Fahrzeug/i);
+		expect(reactionLabel()).toMatch(/Reaktion auf Ihr Boot/i);
 	});
 });

--- a/src/lib/report/components/sections/Behavior.svelte.test.ts
+++ b/src/lib/report/components/sections/Behavior.svelte.test.ts
@@ -60,3 +60,42 @@ describe('sections/Behavior — Reaktion aufs Boot entfällt bei Land', () => {
 		expect(field('reaction')).not.toBeNull();
 	});
 });
+
+/**
+ * UX-Review (2026-08-06, Punkt 4): `isFromLand` greift bewusst nur bei einem
+ * ausdrücklichen „Land", weil `sightingFrom = 0` gleichzeitig „Sonstiges" und
+ * „noch nicht beantwortet" bedeutet (Begründung an `isFromLand` in
+ * `formConfig.ts`). Das ist richtig — bedeutet aber, dass die Frage auch dem
+ * Kajakfahrer, dem SUP-Paddler und dem Besucher auf der Seebrücke gestellt
+ * wird. „Ihr Boot" ist für die drei schlicht falsch; die Frage selbst bleibt
+ * sinnvoll.
+ *
+ * Verallgemeinert wird deshalb das Label — und zwar im Yup-Schema, der einzigen
+ * Quelle für Feldbeschriftungen (`design-system.md`, Formularfeld-Muster). Die
+ * Admin-Maske liest dasselbe Label; das ist gewollt, sie editiert dieselbe
+ * Spalte `reaktion` und hatte den Boot-Bezug genauso wenig verdient.
+ */
+describe('sections/Behavior — die Reaktionsfrage setzt kein Boot voraus (UX-Review Punkt 4)', () => {
+	/**
+	 * `.fieldset` ist hier die DaisyUI-KLASSE am Wrapper-`div`, das
+	 * `FieldRenderer` um jedes Feld legt — nicht das Element `<fieldset>`. Das
+	 * gibt es nur bei Radiogruppen; `reaction` ist ein Textfeld und trägt sein
+	 * `<label for>` als Geschwister des Controls.
+	 */
+	function reactionLabel(): string {
+		return field('reaction')?.closest('.fieldset')?.querySelector('label')?.textContent ?? '';
+	}
+
+	it('spricht von „Sie oder Ihr Fahrzeug", nicht von „Ihr Boot"', () => {
+		renderBehavior({ sightingFrom: SightingFromEnum.OTHER });
+
+		expect(reactionLabel()).toMatch(/Reaktion auf Sie oder Ihr Fahrzeug/i);
+		expect(reactionLabel()).not.toMatch(/Ihr Boot/i);
+	});
+
+	it('trägt dasselbe Label in der Admin-Maske — ein Feld, eine Beschriftung', () => {
+		renderBehavior({ sightingFrom: SightingFromEnum.LAND }, { adminMode: true });
+
+		expect(reactionLabel()).toMatch(/Reaktion auf Sie oder Ihr Fahrzeug/i);
+	});
+});

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -33,6 +33,8 @@
 	 * Benannt wird `originalName` (der Name, unter dem der Melder die Datei
 	 * kennt), nicht der interne `fileName`.
 	 */
+	const UPLOADED_MEDIA_SUMMARY_ID = 'uploaded-media-summary';
+
 	let uploadedMedia = $derived($form.uploadedFiles ?? []);
 	let uploadedMediaCaption = $derived(
 		uploadedMedia.length === 1
@@ -233,7 +235,16 @@
 					     (`space-y-3` außen). Die Aufzählung steht bewusst VOR dem
 					     Feld: Sie ist die Frage, das Feld die Antwort. -->
 					<div class="space-y-1">
-						<div class="text-base-content/70 text-support" data-testid="uploaded-media-summary">
+						<!-- `id` + `describedBy` am Feld: Optisch steht die Aufzählung über
+						     dem Ankreuzfeld, für einen Screenreader wäre sie ohne die
+						     Verknüpfung aber nicht Teil der Frage — wer direkt aufs Feld
+						     tabbt, hörte den Einwilligungstext ohne die Dateinamen, also
+						     genau das Problem, das die Aufzählung beheben soll. -->
+						<div
+							id={UPLOADED_MEDIA_SUMMARY_ID}
+							class="text-base-content/70 text-support"
+							data-testid="uploaded-media-summary"
+						>
 							<p class="font-medium">{uploadedMediaCaption}</p>
 							<ul class="list-inside list-disc">
 								{#each uploadedMedia as file (file.uid)}
@@ -241,7 +252,7 @@
 								{/each}
 							</ul>
 						</div>
-						<FormField name="mediaConsent" />
+						<FormField name="mediaConsent" describedBy={UPLOADED_MEDIA_SUMMARY_ID} />
 					</div>
 				{/if}
 			</div>

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -25,6 +25,21 @@
 	// Schritt sonst fälschlich leer.
 	let hasMedia = $derived(hasUploadedMedia($form.uploadedFiles));
 
+	/**
+	 * UX-Review (2026-08-06, Punkt 2): Worüber der Melder hier entscheidet, liegt
+	 * zwei Schritte zurück — die Dateien selbst stehen auf Schritt 2. Ohne diese
+	 * Aufzählung müsste er aus dem Gedächtnis wissen, was er freigibt.
+	 *
+	 * Benannt wird `originalName` (der Name, unter dem der Melder die Datei
+	 * kennt), nicht der interne `fileName`.
+	 */
+	let uploadedMedia = $derived($form.uploadedFiles ?? []);
+	let uploadedMediaCaption = $derived(
+		uploadedMedia.length === 1
+			? 'Ihre hochgeladene Aufnahme:'
+			: `Ihre ${uploadedMedia.length} hochgeladenen Aufnahmen:`
+	);
+
 	// Check if user has saved contact data
 	let hasSavedContactData = $state(false);
 
@@ -213,7 +228,21 @@
 				     sichtbar, aber unvalidiert ausgefüllt (die „halbe Miete" aus der
 				     Doku dort). -->
 				{#if hasMedia}
-					<FormField name="mediaConsent" />
+					<!-- Aufzählung und Ankreuzfeld bilden eine Einheit und stehen
+					     deshalb enger beieinander als die Geschwister der Gruppe
+					     (`space-y-3` außen). Die Aufzählung steht bewusst VOR dem
+					     Feld: Sie ist die Frage, das Feld die Antwort. -->
+					<div class="space-y-1">
+						<div class="text-base-content/70 text-support" data-testid="uploaded-media-summary">
+							<p class="font-medium">{uploadedMediaCaption}</p>
+							<ul class="list-inside list-disc">
+								{#each uploadedMedia as file (file.uid)}
+									<li class="break-all">{file.originalName}</li>
+								{/each}
+							</ul>
+						</div>
+						<FormField name="mediaConsent" />
+					</div>
 				{/if}
 			</div>
 		</div>

--- a/src/lib/report/components/steps/Step4Contact.svelte.test.ts
+++ b/src/lib/report/components/steps/Step4Contact.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 import type { SightingFormData, UploadedFileInfo } from '$lib/types';
@@ -29,6 +30,14 @@ const UPLOADED_FILE: UploadedFileInfo = {
 	fileName: 'uid-1.jpg',
 	mimeType: 'image/jpeg',
 	size: 1234
+} as UploadedFileInfo;
+
+const SECOND_UPLOADED_FILE: UploadedFileInfo = {
+	...UPLOADED_FILE,
+	uid: 'uid-2',
+	filePath: 'ref-1/uid-2.jpg',
+	originalName: 'robbe-am-strand.jpg',
+	fileName: 'uid-2.jpg'
 } as UploadedFileInfo;
 
 function field(name: string): HTMLElement | null {
@@ -162,6 +171,52 @@ describe('Step4Contact — Gruppen-Überschrift deckt alle Einwilligungen ab (Re
  * irgendwo sonst im Schritt (z. B. bei „Zusätzliche Informationen" oder bei
  * der „Dauerhafte Speicherung"-Gruppe, die ebenfalls `.space-y-4` trägt).
  */
+/**
+ * UX-Review (2026-08-06, Punkt 2): `mediaConsent` steht zwei Schritte nach dem
+ * Upload. Wer hier zustimmt, musste bis dahin aus dem Gedächtnis wissen,
+ * worüber er entscheidet — die Dateien selbst liegen auf Schritt 2.
+ *
+ * Benannt wird `originalName` aus `$form.uploadedFiles`, also der Dateiname, den
+ * der Melder selbst kennt — nicht der interne `fileName`.
+ */
+describe('Step4Contact — die Medien-Einwilligung benennt die Aufnahmen (UX-Review Punkt 2)', () => {
+	it('nennt die einzelne Aufnahme im Singular und mit ihrem Namen', async () => {
+		renderStep4({ uploadedFiles: [UPLOADED_FILE] });
+
+		await expect.element(page.getByText(/Ihre hochgeladene Aufnahme/i)).toBeInTheDocument();
+		await expect.element(page.getByText('foto.jpg')).toBeInTheDocument();
+	});
+
+	it('zählt mehrere Aufnahmen und benennt jede einzeln', async () => {
+		renderStep4({ uploadedFiles: [UPLOADED_FILE, SECOND_UPLOADED_FILE] });
+
+		await expect.element(page.getByText(/Ihre 2 hochgeladenen Aufnahmen/i)).toBeInTheDocument();
+		await expect.element(page.getByText('foto.jpg')).toBeInTheDocument();
+		await expect.element(page.getByText('robbe-am-strand.jpg')).toBeInTheDocument();
+	});
+
+	it('stellt die Aufzählung VOR das Ankreuzfeld, nicht dahinter', () => {
+		renderStep4({ uploadedFiles: [UPLOADED_FILE] });
+
+		const liste = document.querySelector('[data-testid="uploaded-media-summary"]');
+		const feld = field('mediaConsent');
+		expect(liste).not.toBeNull();
+		expect(feld).not.toBeNull();
+		// DOCUMENT_POSITION_FOLLOWING: das Feld steht im Dokument NACH der Liste.
+		expect(
+			(liste as Element).compareDocumentPosition(feld as Node) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	});
+
+	// Gegenprobe: Ohne Aufnahme gibt es weder Einwilligung noch Aufzählung —
+	// sonst stünde eine leere Überschrift „Ihre 0 hochgeladenen Aufnahmen" da.
+	it('zeigt ohne Aufnahme auch keine Aufzählung', () => {
+		renderStep4();
+
+		expect(document.querySelector('[data-testid="uploaded-media-summary"]')).toBeNull();
+	});
+});
+
 describe('Step4Contact — mediaConsent steht in der Einwilligungsgruppe, nicht irgendwo im Schritt (Review-Befund 4)', () => {
 	it('teilt sich mit nameConsent dieselbe Einwilligungsgruppe unter der Überschrift', () => {
 		// Braucht eine vorliegende Aufnahme (Task 15) — sonst rendert

--- a/src/lib/report/components/steps/Step4Contact.svelte.test.ts
+++ b/src/lib/report/components/steps/Step4Contact.svelte.test.ts
@@ -215,6 +215,23 @@ describe('Step4Contact — die Medien-Einwilligung benennt die Aufnahmen (UX-Rev
 
 		expect(document.querySelector('[data-testid="uploaded-media-summary"]')).toBeNull();
 	});
+
+	/**
+	 * Review-Befund: Optisch stand die Aufzählung über dem Feld, programmatisch
+	 * war sie nicht damit verknüpft — wer direkt auf das Ankreuzfeld tabbt,
+	 * hörte den Einwilligungstext ohne die Dateinamen und damit genau das
+	 * Problem, das die Aufzählung beheben soll. `FormField`/`FieldRenderer`
+	 * reichen dafür seither ein `describedBy` durch.
+	 */
+	it('verknüpft die Aufzählung als Beschreibung mit dem Ankreuzfeld', () => {
+		renderStep4({ uploadedFiles: [UPLOADED_FILE] });
+
+		const beschreibung = field('mediaConsent')?.getAttribute('aria-describedby') ?? '';
+		expect(beschreibung.split(/\s+/)).toContain('uploaded-media-summary');
+		// Der Hilfetext des Feldes darf dabei nicht verloren gehen — die
+		// Verknüpfung ergänzt die Pipeline, sie ersetzt sie nicht.
+		expect(beschreibung.split(/\s+/).length).toBeGreaterThan(1);
+	});
 });
 
 describe('Step4Contact — mediaConsent steht in der Einwilligungsgruppe, nicht irgendwo im Schritt (Review-Befund 4)', () => {

--- a/src/lib/report/fieldsOutsideReportKind.test.ts
+++ b/src/lib/report/fieldsOutsideReportKind.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { formStepsConfig } from './formConfig';
-import { fieldsOutsideReportKind } from './fieldsOutsideReportKind';
+import { fieldsOutsideReportKind, reportKindClearedNotice } from './fieldsOutsideReportKind';
 
 /**
  * Task 8, korrigierte Fassung: Es gibt keinen „vorherigen Zweig" mehr, gegen
@@ -78,5 +78,43 @@ describe('fieldsOutsideReportKind', () => {
 
 	it('ist rein — zweimaliger Aufruf mit demselben Zweig liefert dieselbe Liste', () => {
 		expect(fieldsOutsideReportKind('alive')).toEqual(fieldsOutsideReportKind('alive'));
+	});
+});
+
+/**
+ * UX-Review (2026-08-06, Punkt 3): Der Zweigwechsel über „Ändern" räumt die
+ * Felder des verlassenen Zweigs aus dem Formular-Zustand — bis dahin still.
+ * Wer auf Schritt 2 „Zustand des Tieres" und „Größe" ausgefüllt hatte und
+ * zurück auf „lebendes Tier" wechselt, findet sie danach kommentarlos nicht
+ * mehr vor und kann nicht wissen, ob auch Position, Datum und Fotos betroffen
+ * sind. Genau diese Sorge beantwortet der zweite Halbsatz.
+ *
+ * Die Meldung hängt an dem Zweig, in dem das Formular JETZT steht — sie sagt,
+ * was WEG ist, nicht was bleibt: Im Lebend-Zweig sind das die Totfund-Angaben,
+ * im Totfund-Zweig die Verhaltensangaben. Dieselbe Blickrichtung wie
+ * `fieldsOutsideReportKind` oben.
+ */
+describe('reportKindClearedNotice', () => {
+	it('nennt im Lebend-Zweig die entfernten Totfund-Angaben', () => {
+		expect(reportKindClearedNotice('alive', 2)).toBe(
+			'Ihre Angaben zum Totfund wurden entfernt, alles Übrige bleibt erhalten.'
+		);
+	});
+
+	it('nennt im Totfund-Zweig die entfernten Verhaltensangaben', () => {
+		expect(reportKindClearedNotice('dead', 1)).toBe(
+			'Ihre Angaben zum Verhalten der Tiere wurden entfernt, alles Übrige bleibt erhalten.'
+		);
+	});
+
+	/**
+	 * Der wichtigste Fall: Ohne diese Bedingung meldete JEDER Start des
+	 * Formulars eine Entfernung — auch der allererste, bei dem es nichts zu
+	 * entfernen gab, und der Wechsel zurück in denselben Zweig. Eine Meldung
+	 * über eine Änderung, die nicht stattgefunden hat, ist schlimmer als keine.
+	 */
+	it('schweigt, wenn tatsächlich nichts entfernt wurde', () => {
+		expect(reportKindClearedNotice('alive', 0)).toBeNull();
+		expect(reportKindClearedNotice('dead', 0)).toBeNull();
 	});
 });

--- a/src/lib/report/fieldsOutsideReportKind.ts
+++ b/src/lib/report/fieldsOutsideReportKind.ts
@@ -65,3 +65,30 @@ export function fieldsOutsideReportKind(kind: ReportKind): (keyof SightingFormDa
 	const keptWhenDead = new Set(getFormSteps({ isDead: true }).flatMap((step) => step.fields));
 	return keptWhenAlive.filter((field) => !keptWhenDead.has(field)) as (keyof SightingFormData)[];
 }
+
+/**
+ * Was der Melder darüber erfahren soll, dass `fieldsOutsideReportKind`
+ * tatsächlich etwas geräumt hat — oder `null`, wenn nichts zu melden ist.
+ *
+ * UX-Review (2026-08-06, Punkt 3): Der Wechsel über „Ändern" nahm die Felder
+ * des verlassenen Zweigs kommentarlos mit. Sichtbar wird das erst Schritte
+ * später, und ohne Erklärung liegt die Vermutung nahe, dass auch Position,
+ * Datum und Fotos betroffen sind — genau die teuersten Eingaben. Der zweite
+ * Halbsatz beantwortet das mit.
+ *
+ * `clearedCount` statt der Feldliste: Welche Felder es einzeln waren, ist für
+ * den Melder ohne Belang — er hat sie unter „Angaben zum Totfund" bzw.
+ * „Verhalten" ausgefüllt, nicht unter `deadPhoneContact`. Gebraucht wird nur
+ * die Unterscheidung „es wurde etwas geräumt" von „es war nichts da": Eine
+ * Meldung über eine Änderung, die nicht stattgefunden hat, ist schlimmer als
+ * keine — und dieser Fall ist der häufigere (jeder gewöhnliche Formularstart,
+ * und der Wechsel zurück in denselben Zweig).
+ */
+export function reportKindClearedNotice(kind: ReportKind, clearedCount: number): string | null {
+	if (clearedCount === 0) {
+		return null;
+	}
+
+	const removed = kind === 'alive' ? 'zum Totfund' : 'zum Verhalten der Tiere';
+	return `Ihre Angaben ${removed} wurden entfernt, alles Übrige bleibt erhalten.`;
+}

--- a/src/lib/report/reportKind.ts
+++ b/src/lib/report/reportKind.ts
@@ -10,6 +10,20 @@ import {
 export type ReportKind = 'alive' | 'dead';
 
 /**
+ * Name des Query-Parameters — und, seit dem UX-Review (2026-08-06, Punkt 1),
+ * zugleich der `name` der Radios auf der Einstiegsseite.
+ *
+ * Das ist kein Zufall, sondern ein tragender Vertrag: Ein Klick auf „Weiter"
+ * VOR der Hydration schickt das Formular nativ per GET ab. Nur weil die Radios
+ * `meldung` heißen und `lebend`/`totfund` tragen, landet der Melder dabei auf
+ * `/?meldung=totfund`, wo `resolveReportKind` den Zweig schon serverseitig
+ * auflöst. Stünde der Name auf beiden Seiten als Literal, machte eine
+ * einseitige Umbenennung den JS-losen Pfad still wieder zum Leerlauf-Reload —
+ * ohne dass ein Test rot würde.
+ */
+export const REPORT_KIND_PARAM = 'meldung';
+
+/**
  * Der Query-Parameter ist bewusst deutsch: Er steht in Links, die das Museum
  * selbst setzt und liest.
  *

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	import {
 		clearReportKind,
 		readReportKind,
+		REPORT_KIND_PARAM,
 		reportKindToIsDead,
 		reportKindToParam,
 		resolveReportKind,
@@ -51,7 +52,7 @@
 	// NÄCHSTE Reload serverseitig sofort richtig auflöst.
 	let reportKind = $state<ReportKind | null>(
 		resolveReportKind(
-			page.url.searchParams.get('meldung'),
+			page.url.searchParams.get(REPORT_KIND_PARAM),
 			browser ? readReportKind() : null,
 			browser
 				? (loadFromStorage(STORAGE_KEYS.FORM_DATA, null) as { isDead?: unknown } | null)?.isDead
@@ -81,7 +82,7 @@
 		// ExportModal.svelte.
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const params = new URLSearchParams(window.location.search);
-		params.set('meldung', reportKindToParam(kind));
+		params.set(REPORT_KIND_PARAM, reportKindToParam(kind));
 		pushState(`/?${params.toString()}`, {});
 	}
 
@@ -135,7 +136,7 @@
 		// Gleiches Muster wie in `choose()`.
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const params = new URLSearchParams(window.location.search);
-		params.delete('meldung');
+		params.delete(REPORT_KIND_PARAM);
 		pushState(`/?${params.toString()}`, {});
 	}
 
@@ -182,7 +183,7 @@
 
 		function onPopState() {
 			const params = new URLSearchParams(window.location.search);
-			const nextReportKind = resolveReportKind(params.get('meldung'), null, null);
+			const nextReportKind = resolveReportKind(params.get(REPORT_KIND_PARAM), null, null);
 			// B7: Browser-Zurück auf die Auswahl ist derselbe „Wechsel" wie
 			// „Ändern" — nur ausgelöst über die History statt über einen Klick.
 			// Die Bedingung `reportKind !== null` grenzt das gegen den Fall ab, in
@@ -228,9 +229,9 @@
 		const target = reportKindToParam(reportKind);
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
 		const params = new URLSearchParams(window.location.search);
-		if (params.get('meldung') === target) return;
+		if (params.get(REPORT_KIND_PARAM) === target) return;
 		tick().then(() => {
-			params.set('meldung', target);
+			params.set(REPORT_KIND_PARAM, target);
 			replaceState(`/?${params.toString()}`, {});
 		});
 	});


### PR DESCRIPTION
Vier unabhängige Befunde aus dem UX-Review zu #773. Keiner blockiert, alle betreffen das Erleben des Melders am Strand oder an Deck.

## 1 — „Weiter" auf der Einstiegsseite ist nicht mehr stumm gesperrt

Der Knopf trug `aria-disabled`, solange nichts gewählt war, und sagte nicht warum. Beide Wege liefen ins Leere, und das ist nachgemessen statt vermutet:

- **Maus, vor der Hydration:** DaisyUI 5.7.4 setzt an `.btn[aria-disabled=true]` ein `pointer-events: none` (`node_modules/daisyui/components/button.css`). Der Klick erreichte das Element gar nicht.
- **Tastatur, nach der Hydration:** `pointer-events` bremst kein Enter — der Submit lief, der Wächter stieg still aus.

Der Knopf ist jetzt immer frei; die Sperre ist eine Fehlermeldung an der Radiogruppe (`aria-invalid` + `role="alert"` + `aria-describedby` am `fieldset`, nicht an den Radios — ARIA 1.2 kennt `aria-invalid` an `role="radio"` nicht).

**Folge, die mitgelöst werden musste:** Ein freigegebener Submit-Knopf heißt, dass ein Klick vor der Hydration nativ per GET abschickt. Ohne Gegenmaßnahme wäre das ein Leerlauf-Reload — schlechter als vorher. Die Radios heißen deshalb `meldung` und tragen `lebend`/`totfund`; der native Submit landet auf `/?meldung=totfund`, was `resolveReportKind` schon serverseitig auflöst. Die Auswahl wird passend dazu aus der abgeschickten `FormData` gelesen statt aus Komponenten-State, damit ein vor der Hydration angekreuztes Radio zählt.

Bewusst nicht gelöst, im Code begründet: Der JS-lose Submit ersetzt bestehende Query-Parameter (Kampagnen-Marker), und ohne Auswahl lädt er kommentarlos neu. `required` an den Radios löste Letzteres nativ, verdrängte im JS-Pfad aber die eigene Meldung durch die nicht barrierefreie Browser-Blase.

## 2 — Die Einwilligung für Aufnahmen nennt die Aufnahmen

`mediaConsent` steht seit #773 auf Schritt 4, zwei Schritte nach dem Upload. Darüber stehen jetzt die hochgeladenen Dateien namentlich („Ihre 2 hochgeladenen Aufnahmen: …", aus `originalName`), und sie sind über ein neues `describedBy` an `FormField`/`FieldRenderer` mit dem Ankreuzfeld verknüpft — wer direkt darauf tabbt, hörte sonst den Einwilligungstext ohne die Dateinamen.

`MEDIA_CONSENT_VERSION` bleibt `2026-08-06`: Die gelesene Einwilligungsfläche hat sich am selben Tag schon einmal geändert, beide Änderungen gehören derselben Fassung. Der Kommentar dort hält die zweite fest.

## 3 — „Ändern" sagt, was es gekostet hat

Der Zweigwechsel räumte die Felder des verlassenen Zweigs still weg. Sichtbar wird das erst Schritte später, und ohne Erklärung liegt die Vermutung nahe, dass auch Position, Datum und Fotos betroffen sind — die teuersten Eingaben.

`ModernReportForm` zählt jetzt vor dem Räumen, welche Felder wirklich einen Wert trugen, und meldet nur dann: „Ihre Angaben zum Totfund wurden entfernt, alles Übrige bleibt erhalten." Wer zurück in denselben Zweig geht, verliert nichts und bekommt auch nichts erzählt.

## 4 — „Reaktion auf Ihr Boot" verallgemeinert — nur im Meldeformular

`isFromLand` blendet das Feld bewusst nur bei einem ausdrücklichen „Land" aus, weil `sightingFrom = 0` gleichzeitig „Sonstiges" und „noch nicht beantwortet" heißt. Das bleibt so — für den Kajakfahrer, den SUP-Paddler und den Besucher auf der Seebrücke war die Frage trotzdem schief beschriftet.

Das Meldeformular fragt jetzt „Reaktion auf Sie oder Ihr Fahrzeug", über den `label`-Override von `FormField`, den es genau für diesen Fall gibt („dieselbe Schema-Spalte in zwei Kontexten unterschiedlich gefragt"; Präzedenz: `species` in `AnimalInfo.svelte`). **Die Admin-Maske bleibt unverändert** beim Schema-Label; der Test prüft beide Richtungen.

## Dokumentation

`.claude/rules/design-system.md` verlangte weiterhin genau das `aria-disabled`-Muster, das dieser Branch für die Einstiegsseite entfernt — und zwei seiner Begründungen sind durch den DaisyUI-Befund für `.btn` widerlegt. Die Regel gilt weiter für Sperren, die der Nutzer nicht durch Eingabe auflösen kann (Ortung läuft, Schritt noch nicht erreicht); für fehlende Eingaben ist die Meldung die richtige Form. `StepNavigation.svelte` trägt dasselbe Muster für die Offline-Sperre und ist dort als offener Punkt vermerkt — außerhalb des Scopes dieses Branches.

## Prüfungen

- `npm run test:quick`: 3577 Tests, `npm run test:unit:client`: 529 Tests, `svelte-check` 0 Fehler / 0 Warnungen. Die zwei verbleibenden ESLint-Warnungen stehen in `src/tests/contract/helpers/createEvent.ts` und sind unverändert aus `main`.
- E2E: `report-kind-choice`, `form-from-land`, `form-autosave`, `bestimmungshilfe` grün. Zwei Feststellungen hingen am entfernten `aria-disabled`; die eine nutzte es als Hydrations-Beleg, den jetzt die Fehlermeldung trägt.
- `svelte-autofixer` auf allen geänderten Komponenten ohne Befund.
- Fehlermeldung der Einstiegsseite im Browser gegengeprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)