### PR TITLE
test(report): cover the boat-drive path from click to schema

### DIFF
--- a/src/lib/report/components/sections/SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/SightingDetails.svelte.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { get } from 'svelte/store';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import { sightingSchema } from '$lib/form/validation/sightingSchema';
+import { PUBLIC_BOAT_DRIVE_OPTIONS } from '$lib/report/formOptions/boatDrive';
 import { SightingFromEnum } from '$lib/report/formOptions/sightingFrom';
 import type { SightingFormData } from '$lib/types';
 import SightingDetails from './SightingDetails.svelte';
@@ -101,6 +105,45 @@ describe('sections/SightingDetails — boatDrive im Meldeformular', () => {
 
 		expect(document.querySelector('[data-field="boatDrive"]')).toBeNull();
 	});
+});
+
+/**
+ * Gemeldet am 2026-08-06: „Motor lief" wählen und „Weiter" klicken habe die rohe
+ * Yup-Meldung „Bootsantrieb must be a `number` type, but the final value was:
+ * `NaN` (cast from the value `\"undefined\"`)" gezeigt. Nachstellen ließ sich das
+ * am Bestand nicht — die Strecke war aber ungetestet, und zwar genau die, auf
+ * der ein solcher Fehler entsteht.
+ *
+ * **Was hier anders geprüft wird als in `BaseRadio.svelte.test.ts`:** Dort steht
+ * der Auswahl-Zustand (`checked`) bei vorgegebenem Wert. Der Weg in die
+ * Gegenrichtung — Klick → `handleChange` → Formular-Store → Yup — kommt darin
+ * nicht vor: Kein Test der Feld-Pipeline klickt. Ein `onchange`, das
+ * `FieldRenderer` für Radiogruppen nicht mehr durchreicht, bliebe damit
+ * unbemerkt, obwohl der Melder danach vor einem gesperrten „Weiter" säße.
+ *
+ * Der Umweg über den String ist dabei kein Testartefakt, sondern der
+ * Produktivpfad: `createForm.handleChange` liest `target.value`, legt also einen
+ * String in den Store, und erst Yup castet ihn zurück zur Zahl.
+ */
+describe('sections/SightingDetails — der gewählte Antrieb übersteht den Weg zur Validierung', () => {
+	// Nur die beiden Felder, um die es geht: `boatDrive` hängt über
+	// `when('sightingFrom')` an der Herkunft, alles Weitere des Schritts wäre
+	// hier Beiwerk.
+	const antriebsSchema = sightingSchema.pick(['sightingFrom', 'boatDrive']);
+
+	it.each(PUBLIC_BOAT_DRIVE_OPTIONS.map((option) => [option.label, option.value] as const))(
+		'„%s" landet als validierbare Zahl im Formular-Store',
+		async (label, erwartet) => {
+			const { form } = renderWithFormContext(SightingDetails, {
+				overrides: { sightingFrom: SightingFromEnum.MOTORBOAT }
+			});
+
+			await page.getByRole('radio', { name: label, exact: true }).click();
+
+			const geprueft = await antriebsSchema.validate(get(form));
+			expect(geprueft.boatDrive).toBe(erwartet);
+		}
+	);
 });
 
 /**

--- a/src/lib/report/formOptions/boatDrive.test.ts
+++ b/src/lib/report/formOptions/boatDrive.test.ts
@@ -113,6 +113,49 @@ describe('PUBLIC_BOAT_DRIVE_OPTIONS (Meldeformular)', () => {
 	});
 });
 
+/**
+ * Gemeldet am 2026-08-06: Im Meldeformular sei die Option „Motor lief" mit
+ * `value="undefined"` im DOM gelandet, und „Weiter" habe die rohe Yup-Meldung
+ * „Bootsantrieb must be a `number` type, but the final value was: `NaN` (cast
+ * from the value `"undefined"`)" gezeigt. Am Bestand ließ sich das nicht
+ * nachstellen (Browser-Prüfung gegen den Dev-Server, beide Radios trugen
+ * `value="1"` bzw. `value="6"`).
+ *
+ * Warum trotzdem ein Test: `PUBLIC_BOAT_DRIVE_OPTIONS` ist zwar per `toEqual`
+ * oben festgenagelt, die aus `Object.values(BoatDriveEnum)` **abgeleitete**
+ * Admin-Liste aber nur auf Vollständigkeit geprüft, nie auf die Beschaffenheit
+ * ihrer Werte. Der Optionswert macht auf dem Weg zur Validierung eine DOM-Runde
+ * (`value`-Attribut → `handleChange` liest `target.value` als String → Yup
+ * castet zurück); ein nicht-numerischer Eintrag überlebt `toBeDefined()`
+ * problemlos und wird erst dort zu NaN. Geprüft wird deshalb der String-Zustand,
+ * nicht der Startwert.
+ */
+describe('Optionswerte überstehen die DOM-Runde (value-Attribut → Yup-Cast)', () => {
+	const optionsListen = [
+		['PUBLIC_BOAT_DRIVE_OPTIONS (Meldeformular)', PUBLIC_BOAT_DRIVE_OPTIONS],
+		['getBoatDriveOptions() (Admin-Maske)', getBoatDriveOptions()]
+	] as const;
+
+	it.each(optionsListen)('%s trägt in jedem Eintrag eine endliche Zahl', (_name, options) => {
+		expect(options.length).toBeGreaterThan(0);
+
+		for (const option of options) {
+			expect(typeof option.value, `Option "${option.label}"`).toBe('number');
+			expect(Number.isFinite(option.value), `Option "${option.label}"`).toBe(true);
+		}
+	});
+
+	// Der Test mit Aussagekraft: `isValidBoatDrive` prüft die Enum-Zugehörigkeit,
+	// und zwar am String — also an dem, was aus dem DOM zurückkommt. Ein
+	// `Number(String(n)) === n` daneben wäre tautologisch (gilt für jede endliche
+	// Zahl) und ist deshalb bewusst nicht da.
+	it.each(optionsListen)('%s gilt auch als String noch als gültiger Antrieb', (_name, options) => {
+		for (const option of options) {
+			expect(isValidBoatDrive(String(option.value)), `Option "${option.label}"`).toBe(true);
+		}
+	});
+});
+
 describe('getBoatDriveLabel — bestehende Werte bleiben unverändert', () => {
 	it('löst alle Alt-Werte weiterhin auf', () => {
 		expect(getBoatDriveLabel(0)).toBe('Sonstiger Bootsantrieb');


### PR DESCRIPTION
## Ausgangslage: der gemeldete Fehler ist nicht reproduzierbar

Gemeldet am 2026-08-06: „Motor lief" in Schritt 2 wählen und „Weiter" klicken zeige die rohe Yup-Meldung

> Bootsantrieb must be a `number` type, but the final value was: `NaN` (cast from the value `"undefined"`)

und das erste Radio trage im DOM `value="undefined"`.

**Er tritt nicht auf.** Im Browser gegen den Dev-Server auf diesem Branch nachgestellt (Repro exakt wie beschrieben, echter Mausklick):

| | „Motor lief" | „Motor lief nicht" |
|---|---|---|
| `value`-Attribut | `"1"` | `"6"` |
| `input.__value` | `1` | `6` |

Nach dem Klick steht `boatDrive: "1"` im Store, „Weiter" springt fehlerfrei auf Schritt 3 — auch über den Zweig Segelschiff und über den Reset-Zyklus Boot → Land → Boot.

**Die vermutete Ursache scheidet strukturell aus.** Gegenprobe mit eingebautem Defekt (`value` am ersten Options-Eintrag entfernt): Svelte rendert dann **gar kein** `value`-Attribut (`null`), nie den String `"undefined"`. Ein fehlender Options-`value` kann die gemeldete Meldung also nicht erzeugen. Deshalb **keine Änderung an Produktionscode**.

Wahrscheinlichste Erklärung des Befunds: Port 4000 wird von allen Worktrees geteilt — dieselbe Falle wie seinerzeit bei den E2E-Läufen (`e2e-port-4001-fremder-worktree`).

## Was tatsächlich fehlte

Nicht der Options-Wert, sondern die Abdeckung der Gegenrichtung. Alle bestehenden Radio-Tests geben einen Wert vor und prüfen `checked`; **kein** Test klickt und verfolgt den Wert weiter. Belegt per Mutation: Ein `FieldRenderer`, der `onchange` für Radiogruppen nicht mehr durchreicht, besteht **alle 87 Tests** in `BaseRadio.svelte.test.ts` und `FieldRenderer.svelte.test.ts` — und lässt den Melder vor einem gesperrten „Weiter" sitzen.

## Änderungen (nur Tests, +86 Zeilen)

- **`SightingDetails.svelte.test.ts`** — klickt jede Option und validiert den entstandenen Store gegen `sightingSchema`. Deckt die Strecke Klick → `handleChange` → Store → Yup ab. Verifiziert: fällt unter genau der obigen Mutation, während der Rest der Suite grün bleibt.
- **`boatDrive.test.ts`** — jeder Optionswert übersteht die DOM-Runde als gültiger Antrieb. Zielt auf die **Admin-Liste**, die aus `Object.values(BoatDriveEnum)` abgeleitet ist und bisher nur auf Vollständigkeit geprüft wurde, nie auf die Beschaffenheit ihrer Werte.

## Verworfen im Review

Ein erster Entwurf prüfte zusätzlich das gerenderte `value`-Attribut in `BaseRadio` und `FieldRenderer`. Die Mutationsprüfung zeigte, dass diese Tests **keine eigenständige Nachweiskraft** haben: Bei `value={String(option.value)}` — also genau der Zahl-vs-String-Unterscheidung, um die es geht — schlägt der bestehende `checked`-Test an, die neuen nicht. `bind:group` hängt am selben Ausdruck. Ebenfalls entfernt: eine tautologische Assertion (`Number(String(n)) === n` gilt für jede endliche Zahl).

## Test-Status

`npm run test:quick`: 236 Dateien, 3582 Tests grün. Browser-Tests der drei betroffenen Dateien: 89/89 grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)