### PR TITLE
refactor(report): Rückmeldung „Sie melden" wandert in die Aktionszeile

### DIFF
--- a/e2e/form-ux.spec.ts
+++ b/e2e/form-ux.spec.ts
@@ -158,8 +158,10 @@ test.describe('SightingDetails — Motorfrage bei Motorboot', () => {
  * Der Totfund-Schalter auf Schritt 2 ist seit Commit d7767383 entfallen: Die
  * Frage „lebendes Tier oder Totfund?" beantwortet seither die Einstiegsseite
  * (`/?meldung=lebend|totfund`, s. `AnimalInfo.svelte`), bevor das Formular
- * überhaupt erscheint — Schritt 2 zeigt stattdessen nur noch die Rückmeldung
- * „Sie melden: … · [Ändern]". `isDead` kommt dadurch bereits über den
+ * überhaupt erscheint. Die Rückmeldung „Sie melden: … · [Ändern]", die an
+ * seine Stelle getreten war, steht seit dem Umzug in der Aktionszeile unter
+ * dem Formular (`form/FormActions.svelte`) und gilt dort für alle vier
+ * Schritte. `isDead` kommt dadurch bereits über den
  * Einstiegs-Zweig fest ins Formular, es gibt keinen Weg mehr, es innerhalb des
  * Bürgerformulars umzuschalten — jeder Test wählt den Zweig deshalb über
  * `FormPage.goto()`, nicht mehr über `[data-testid="field-isDead"]` (das

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -110,11 +110,11 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	});
 
 	/**
-	 * Review-Befund 2 (Task 7): Der vierte Hop der Durchreich-Kette
-	 * (`+page.svelte` → `ModernReportForm` → `Step2SightingDetails` →
-	 * `AnimalInfo`) hatte keinen Test, der rot wird, wenn `onchangekind` an
-	 * irgendeiner Stelle nicht mehr durchgereicht wird. Dieser Test fährt die
-	 * volle Strecke bis zum Klick.
+	 * Review-Befund 2 (Task 7): Die Durchreich-Kette von `onchangekind` hatte
+	 * keinen Test, der rot wird, wenn das Callback an irgendeiner Stelle nicht
+	 * mehr weitergereicht wird. Dieser Test fährt die volle Strecke bis zum
+	 * Klick — seit dem Umzug der Rückmeldung in die Aktionszeile ist die Kette
+	 * `+page.svelte` → `ModernReportForm` → `FormActions`.
 	 */
 	test('„Ändern" auf Schritt 2 führt zurück auf die Auswahlseite', async ({ page }) => {
 		await page.goto('/');
@@ -138,8 +138,9 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	 * zurück zur Auswahl — „Zurück" ist dort hart gesperrt, und die einzige
 	 * Korrektur lag einen Schritt weiter, unterhalb der Upload-Karte. Genau auf
 	 * Schritt 1 merkt ein Melder aber am ehesten, dass er falsch abgebogen ist
-	 * („Funddatum" statt „Datum und Uhrzeit"). Die Rückmeldung steht seither
-	 * auch am Kopf von Schritt 1.
+	 * („Funddatum" statt „Datum und Uhrzeit"). Die Rückmeldung stand seither am
+	 * Kopf von Schritt 1 und sitzt inzwischen in der Aktionszeile unter dem
+	 * Formular — sie gilt damit für alle vier Schritte, dieser eingeschlossen.
 	 */
 	test('„Ändern" auf Schritt 1 führt zurück auf die Auswahlseite (B6)', async ({ page }) => {
 		await page.goto('/');

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -62,7 +62,7 @@
 		onCancel = () => {},
 		initialIsDead,
 		// Default-Noop wie `onCancel` oben: `exactOptionalPropertyTypes` verbietet sonst das
-		// Weiterreichen als `{onchangekind}` an `Step2SightingDetails`.
+		// Weiterreichen als `{onchangekind}` an `FormActions`.
 		onchangekind = () => {},
 		// Default-Noop aus demselben Grund wie `onchangekind` — hier gibt es
 		// aber keine weitere Aufrufstelle, an die durchgereicht werden müsste.
@@ -79,9 +79,9 @@
 		/**
 		 * Reicht den „Ändern"-Knopf aus `ReportKindFeedback` bis zur Aufrufstelle
 		 * durch — nur `+page.svelte` kennt die Einstiegsseite, zu der er
-		 * zurückführt. Seit B6 (Abschlussreview) steht die Rückmeldung an ZWEI
-		 * Stellen: Schritt 1 (`Step1LocationTime`) und Schritt 2 (`AnimalInfo`,
-		 * über `Step2SightingDetails`).
+		 * zurückführt. Empfänger ist seit dem Umzug in die Aktionszeile nur noch
+		 * `FormActions`; die Rückmeldung stand vorher doppelt am Kopf von
+		 * Schritt 1 und Schritt 2.
 		 */
 		onchangekind?: () => void;
 		/**
@@ -666,9 +666,9 @@
 			<!-- Step Content -->
 			<div class="min-h-[400px]">
 				{#if currentStep === 0}
-					<Step1LocationTime {onchangekind} />
+					<Step1LocationTime />
 				{:else if currentStep === 1}
-					<Step2SightingDetails {onchangekind} />
+					<Step2SightingDetails />
 				{:else if currentStep === 2}
 					<Step3Observations bind:currentStep />
 				{:else if currentStep === 3}
@@ -697,7 +697,7 @@
 		</div>
 	</div>
 
-	<FormActions {onCancel} {onReset}></FormActions>
+	<FormActions {onCancel} {onReset} {onchangekind}></FormActions>
 
 	<FormHelp />
 </Form>

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -218,15 +218,18 @@ describe('ModernReportForm — der Zweig verlässt den Speicher mit den Formular
 });
 
 /**
- * Zweiter Hop der Task-7-Kette (`+page.svelte` → `ModernReportForm` →
- * `Step2SightingDetails` → `AnimalInfo`): `ModernReportForm` muss ein
- * mitgegebenes `onchangekind` bis zum „Ändern"-Knopf auf Schritt 2
- * durchreichen. Ohne diesen Test bliebe ein versehentlich entfernter
- * Prop-Hop unbemerkt — der Knopf sähe im DOM unverändert aus, wäre aber
- * wirkungslos (die Lücke, an der Task 6 schon einmal scheiterte).
+ * Letzter Hop der Kette (`+page.svelte` → `ModernReportForm` → `FormActions`):
+ * `ModernReportForm` muss ein mitgegebenes `onchangekind` bis zum
+ * „Ändern"-Knopf durchreichen. Ohne diesen Test bliebe ein versehentlich
+ * entfernter Prop-Hop unbemerkt — der Knopf sähe im DOM unverändert aus, wäre
+ * aber wirkungslos (die Lücke, an der Task 6 schon einmal scheiterte).
+ *
+ * Geprüft auf Schritt 2 und Schritt 1, weil die Aktionszeile seit dem Umzug
+ * für alle Schritte gilt: Der Knopf muss auf jedem erreichbar sein, nicht nur
+ * auf dem, auf dem er früher stand.
  */
 describe('ModernReportForm — „Ändern" auf Schritt 2 erreicht die Kette', () => {
-	it('reicht onchangekind bis zu AnimalInfo durch', async () => {
+	it('reicht onchangekind bis zur Aktionszeile durch', async () => {
 		sessionStorage.setItem(STORAGE_KEYS.CURRENT_STEP, JSON.stringify(1));
 		const onchangekind = vi.fn();
 		render(ModernReportForm, { onchangekind });
@@ -238,16 +241,13 @@ describe('ModernReportForm — „Ändern" auf Schritt 2 erreicht die Kette', ()
 });
 
 /**
- * B6 (Abschlussreview): Auf Schritt 1 fehlte bislang jeder Weg zurück zur
- * Einstiegsseite — „Zurück" ist dort hart gesperrt, die einzige Korrektur lag
- * einen Schritt weiter unter der Upload-Karte. Die Rückmeldung aus
- * `AnimalInfo.svelte` steht jetzt auch am Kopf von Schritt 1
- * (`ReportKindFeedback.svelte`, über `Step1LocationTime`). Derselbe Hop-Test
- * wie oben für Schritt 2, nur ohne den `CURRENT_STEP`-Sprung — Schritt 1 ist
- * der Startzustand.
+ * B6 (Abschlussreview): Auf Schritt 1 fehlte einmal jeder Weg zurück zur
+ * Einstiegsseite — „Zurück" ist dort hart gesperrt. Derselbe Hop-Test wie oben
+ * für Schritt 2, nur ohne den `CURRENT_STEP`-Sprung; Schritt 1 ist der
+ * Startzustand.
  */
 describe('ModernReportForm — „Ändern" auf Schritt 1 erreicht die Kette (B6)', () => {
-	it('reicht onchangekind bis zur Rückmeldung auf Schritt 1 durch', async () => {
+	it('reicht onchangekind auch auf Schritt 1 durch', async () => {
 		sessionStorage.setItem(STORAGE_KEYS.CURRENT_STEP, JSON.stringify(0));
 		const onchangekind = vi.fn();
 		render(ModernReportForm, { onchangekind });

--- a/src/lib/report/components/ReportKindFeedback.svelte
+++ b/src/lib/report/components/ReportKindFeedback.svelte
@@ -12,21 +12,22 @@
 </script>
 
 <!--
-  Abschlussreview B6: Diese Rückmeldung stand bis dahin ausschließlich in
-  `sections/AnimalInfo.svelte` (Schritt 2) — auf Schritt 1 gab es damit keinen
-  Korrekturweg zurück zur Einstiegsseite, obwohl der Melder genau dort am
-  ehesten merkt, falsch abgebogen zu sein („Funddatum" statt „Datum und
-  Uhrzeit"). Ausgelagert hierher, damit dieselbe Zeile an zwei Stellen
-  (`AnimalInfo.svelte`, `steps/Step1LocationTime.svelte`) stehen kann, ohne
-  dass die Regel zweimal gepflegt wird und beide Antworten auseinanderlaufen
-  können.
+  Einzige Aufrufstelle ist `form/FormActions.svelte` — die Aktionszeile unter
+  dem Formular, neben „Formular zurücksetzen". Vorher stand die Zeile doppelt
+  und jeweils oben: am Kopf von Schritt 1 und in der Karte „Tierinformationen"
+  auf Schritt 2. Dort kostete sie den knappsten Platz des Telefons, obwohl sie
+  weder Eingabe noch Schritt-Kontext ist, sondern eine Korrektur an der Meldung
+  als Ganzes — wie das Zurücksetzen daneben. Aus der Aktionszeile heraus gilt
+  sie für alle vier Schritte statt nur für zwei; der Korrekturweg zurück zur
+  Einstiegsseite (Abschlussreview B6) ist damit an mehr Stellen erreichbar als
+  vorher, nicht an weniger.
 
   isDeadFinding statt eines rohen Booleans: `isDead` kommt beim Wiederaufsetzen
   aus dem Storage als String und in der Admin-Maske als Zahl aus der DB. Ein
   roher Ternär (`$form.isDead ? … : …`) träfe bei einem falsy-wirkenden, aber
   nicht-leeren String wie '0' die falsche Antwort.
 -->
-<p class="text-base-content/70 text-support mb-4">
+<p class="text-base-content/70 text-support">
 	Sie melden:
 	<strong class="text-base-content">
 		{isDeadFinding($form.isDead) ? 'Fund eines toten Tieres' : 'Beobachtung eines lebenden Tieres'}
@@ -40,6 +41,7 @@
 		class="btn btn-outline btn-sm"
 		onclick={onchangekind}
 		aria-label="Art der Meldung ändern"
+		data-testid="report-kind-change"
 	>
 		Ändern
 	</button>

--- a/src/lib/report/components/ReportKindFeedback.svelte.test.ts
+++ b/src/lib/report/components/ReportKindFeedback.svelte.test.ts
@@ -5,12 +5,11 @@ import type { SightingFormData } from '$lib/types';
 import ReportKindFeedback from './ReportKindFeedback.svelte';
 
 /**
- * B6 (Abschlussreview): Auf Schritt 1 fehlte ein Korrekturweg zurück zur
- * Einstiegsseite — die Rückmeldung „Sie melden: … · [Ändern]" stand nur auf
- * Schritt 2 (`sections/AnimalInfo.svelte`). Damit sie an zwei Stellen stehen
- * kann, ohne dass die Regel zweimal existiert, ist sie hierher ausgelagert.
- * Dieser Test deckt die Komponente isoliert ab; `AnimalInfo.svelte.test.ts`
- * und `Step1LocationTime.svelte.test.ts` prüfen die jeweilige Einbindung.
+ * Die Rückmeldung „Sie melden: … · [Ändern]" stand doppelt und jeweils oben —
+ * am Kopf von Schritt 1 und in der Karte „Tierinformationen" auf Schritt 2.
+ * Sie sitzt jetzt einmal in der Aktionszeile unter dem Formular, neben
+ * „Formular zurücksetzen". Dieser Test deckt die Komponente isoliert ab;
+ * `form/FormActions.svelte.test.ts` prüft die Einbindung.
  */
 function renderFeedback(
 	overrides: Partial<SightingFormData> = {},
@@ -33,8 +32,22 @@ describe('ReportKindFeedback — Wortlaut normalisiert isDead', () => {
 		await expect.element(page.getByText(/Beobachtung eines lebenden Tieres/i)).toBeInTheDocument();
 	});
 
-	// Derselbe Beleg wie in AnimalInfo.svelte.test.ts: '0' ist im JS truthy, ein
-	// roher Ternär träfe hier die falsche Antwort. isDeadFinding normalisiert.
+	// `isDead` kommt beim Wiederaufsetzen aus dem Storage als String und in der
+	// Admin-Maske als Zahl aus der DB. 1 und '1' sind in JS bereits truthy — ein
+	// roher Ternär träfe für sie zufällig dieselbe Antwort und beweist den
+	// Fehler deshalb NICHT; sie stehen hier als der wörtlich verlangte Beleg.
+	it.each([1, '1'] as const)(
+		'zeigt „Fund eines toten Tieres", wenn isDead als %s ankommt',
+		async (value) => {
+			renderFeedback({ isDead: value as unknown as boolean });
+
+			await expect.element(page.getByText(/Fund eines toten Tieres/i)).toBeInTheDocument();
+		}
+	);
+
+	// '0' zeigt den Unterschied dagegen zuverlässig: JS wertet den nicht-leeren
+	// String als truthy, `isDeadFinding('0')` liefert korrekt `false`. Dieser
+	// Test wird bei einer Rückkehr zum rohen Ternär tatsächlich rot.
 	it('behandelt den truthy String "0" korrekt als Sichtung', async () => {
 		renderFeedback({ isDead: '0' as unknown as boolean });
 

--- a/src/lib/report/components/form/FormActions.svelte
+++ b/src/lib/report/components/form/FormActions.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getFormContext } from '$lib/report/formContext';
+	import ReportKindFeedback from '$lib/report/components/ReportKindFeedback.svelte';
 
 	// `onCancel` bleibt Teil der Props für Abwärtskompatibilität mit
 	// ModernReportForm.svelte, das den Wert weiterreicht. Der bisherige
@@ -12,10 +13,19 @@
 	// hier wieder ein Button ergänzt werden.
 	let {
 		onReset = () => {},
-		onCancel: _onCancel = () => {}
+		onCancel: _onCancel = () => {},
+		// Default-Noop wie an den übrigen `onchangekind`-Aufrufstellen:
+		// `exactOptionalPropertyTypes` verbietet sonst das Weiterreichen als
+		// `{onchangekind}` an `ReportKindFeedback`, dessen eigener Default
+		// (`= () => {}`) den externen Proptyp auf `() => void` ohne `undefined`
+		// verengt.
+		onchangekind = () => {}
 	}: {
 		onReset?: () => void;
 		onCancel?: () => void;
+		/** Reicht den „Ändern"-Knopf aus `ReportKindFeedback` weiter — nur
+		 *  `+page.svelte` kennt die Einstiegsseite, zu der er zurückführt. */
+		onchangekind?: () => void;
 	} = $props();
 
 	const { isSubmitting } = getFormContext();
@@ -32,7 +42,19 @@
 </script>
 
 <!-- Form Actions -->
-<div class="mx-auto mt-8 flex justify-center md:justify-start">
+<div
+	class="mx-auto mt-8 flex flex-col items-center gap-2 md:flex-row md:justify-between md:gap-4"
+	data-testid="form-actions"
+>
+	<!-- „Sie melden: … · [Ändern]" stand bis hierher am Kopf von Schritt 1 und
+	     ein zweites Mal in der Karte „Tierinformationen" auf Schritt 2. Oben
+	     verbrauchte die Zeile genau den Platz, der auf dem Telefon am knappsten
+	     ist — vor dem ersten Feld stehen dort schon Seitentitel, Schritt-Anzeige
+	     und Schritt-Überschrift. Hier unten steht sie neben „Zurücksetzen", wo
+	     die übrigen Korrekturen an der Meldung als Ganzes sitzen, und gilt für
+	     alle vier Schritte statt nur für zwei. -->
+	<ReportKindFeedback {onchangekind} />
+
 	<button
 		type="button"
 		class="btn btn-outline btn-error btn-sm min-h-11 w-full md:w-auto"

--- a/src/lib/report/components/form/FormActions.svelte.test.ts
+++ b/src/lib/report/components/form/FormActions.svelte.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
+import type { SightingFormData } from '$lib/types';
+import FormActions from './FormActions.svelte';
+
+/**
+ * Die Rückmeldung „Sie melden: … · [Ändern]" stand am Kopf von Schritt 1 und
+ * ein zweites Mal in der Karte „Tierinformationen" auf Schritt 2. Oben kostete
+ * sie genau den Platz, an dem er am knappsten ist — auf dem Telefon steht
+ * dort bereits Titel, Schritt-Anzeige und Schritt-Überschrift, bevor das erste
+ * Feld erscheint. Sie steht deshalb jetzt einmal in der Aktionszeile unten,
+ * neben „Formular zurücksetzen": Beides sind Korrekturen an der Meldung als
+ * Ganzes, keine Eingabe — und die Zeile gilt für alle vier Schritte, der
+ * Korrekturweg ist damit sogar an zwei Stellen mehr erreichbar als vorher.
+ */
+function renderActions(
+	overrides: Partial<SightingFormData> = {},
+	onchangekind = vi.fn()
+): ReturnType<typeof vi.fn> {
+	renderWithFormContext(FormActions, { overrides, props: { onchangekind } });
+	return onchangekind;
+}
+
+describe('FormActions — Rückmeldung steht neben „Zurücksetzen"', () => {
+	it('zeigt die Rückmeldung zum gewählten Zweig in der Aktionszeile', async () => {
+		renderActions({ isDead: false });
+
+		await expect.element(page.getByText(/Sie melden/i)).toBeInTheDocument();
+		await expect.element(page.getByText(/Beobachtung eines lebenden Tieres/i)).toBeInTheDocument();
+	});
+
+	it('behält den Zurücksetzen-Knopf', async () => {
+		renderActions({ isDead: false });
+
+		await expect.element(page.getByRole('button', { name: /zurücksetzen/i })).toBeInTheDocument();
+	});
+
+	// Beide Knöpfe stehen im selben Container — das ist die eigentliche
+	// Aussage der Änderung. Ein Test, der nur „beide sind im DOM" prüft,
+	// bliebe grün, wenn die Rückmeldung wieder nach oben wanderte.
+	it('stellt beide Knöpfe in dieselbe Aktionszeile', () => {
+		renderActions({ isDead: false });
+
+		const zeile = document.querySelector('[data-testid="form-actions"]');
+		expect(zeile).not.toBeNull();
+		expect(zeile?.textContent).toContain('Sie melden');
+		expect(zeile?.querySelector('button[data-testid="report-kind-change"]')).not.toBeNull();
+		expect(zeile?.textContent).toContain('Formular zurücksetzen');
+	});
+
+	it('ruft onchangekind auf, wenn „Ändern" geklickt wird', async () => {
+		const onchangekind = renderActions({ isDead: true });
+
+		await page.getByRole('button', { name: /ändern/i }).click();
+
+		expect(onchangekind).toHaveBeenCalledOnce();
+	});
+});

--- a/src/lib/report/components/sections/AnimalInfo.svelte
+++ b/src/lib/report/components/sections/AnimalInfo.svelte
@@ -3,20 +3,11 @@
 
 	import { getFormContext } from '$lib/report/formContext';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
-	import ReportKindFeedback from '$lib/report/components/ReportKindFeedback.svelte';
 	import SectionCard from './SectionCard.svelte';
 	import { isDeadFinding } from '$lib/report/formConfig';
 	import { speciesQuestion } from '$lib/report/wording';
 
-	let {
-		adminMode = false,
-		// Default-Noop wie an den übrigen `onchangekind`-Aufrufstellen:
-		// `exactOptionalPropertyTypes` verbietet sonst das Weiterreichen als
-		// `{onchangekind}` an `ReportKindFeedback`, dessen eigener Default
-		// (`= () => {}`) den externen Proptyp auf `() => void` ohne `undefined`
-		// verengt.
-		onchangekind = () => {}
-	}: { adminMode?: boolean; onchangekind?: () => void } = $props();
+	let { adminMode = false }: { adminMode?: boolean } = $props();
 
 	const { form } = getFormContext();
 
@@ -47,30 +38,27 @@
 		     Nur in der Admin-Maske: Hier korrigiert eine Bearbeiterin einen
 		     bestehenden Datensatz, es gibt keine vorgeschaltete Einstiegsseite. Im
 		     Meldeformular beantwortet die Einstiegsseite „Was möchten Sie melden?"
-		     dieselbe Frage bereits — der Schalter entfällt dort zugunsten der
-		     Rückmeldung im else-Zweig, damit die beiden Antworten nicht
-		     auseinanderlaufen können. -->
+		     dieselbe Frage bereits — der Schalter entfällt dort ersatzlos, damit
+		     die beiden Antworten nicht auseinanderlaufen können. Die Rückmeldung
+		     „Sie melden: … · [Ändern]", die hier als else-Zweig stand, sitzt seit
+		     dem Umzug einmal in der Aktionszeile unter dem Formular
+		     (`form/FormActions.svelte`) und gilt von dort für alle vier
+		     Schritte. -->
 		<div
 			class="bg-base-100 border-base-300 rounded-lg border p-4"
 			style="box-shadow: var(--shadow-raised)"
 		>
 			<FormField name="isDead" />
 		</div>
-	{:else}
-		<!-- Ausgelagert nach `ReportKindFeedback.svelte` (Abschlussreview B6):
-		     dieselbe Rückmeldung steht seither auch am Kopf von Schritt 1
-		     (`steps/Step1LocationTime.svelte`), damit ein Melder auch dort ohne
-		     Umweg zurück zur Einstiegsseite kommt. -->
-		<ReportKindFeedback {onchangekind} />
 	{/if}
 
 	<!-- Dead Animal Additional Fields — unmittelbar unter dem Schalter, nicht
 	     mehr am Kartenende. isDeadFinding statt eines rohen Booleans, aus
-	     demselben Grund wie an der Rückmeldung drei Zeilen darüber: `isDead`
-	     kommt hier über dieselben drei Quellen an (Storage-String, DB-Zahl,
-	     echter Boolean) — ein roher Ternär (`$form.isDead`) zeigte den Block
-	     bei einem falsy-wirkenden String wie '0' trotzdem, während die
-	     Rückmeldung darüber schon korrekt „lebend" auswies. -->
+	     demselben Grund wie in `ReportKindFeedback.svelte`: `isDead` kommt hier
+	     über dieselben drei Quellen an (Storage-String, DB-Zahl, echter
+	     Boolean) — ein roher Ternär (`$form.isDead`) zeigte den Block bei einem
+	     falsy-wirkenden String wie '0' trotzdem, während die Rückmeldung in der
+	     Aktionszeile schon korrekt „lebend" auswies. -->
 	{#if isDeadFinding($form.isDead)}
 		<DeadAnimal {adminMode} />
 	{/if}

--- a/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
+++ b/src/lib/report/components/sections/AnimalInfo.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import type { SightingFormData } from '$lib/types';
@@ -152,15 +152,18 @@ describe('sections/AnimalInfo — adminMode wird an DeadAnimal durchgereicht', (
  * Die Einstiegsseite („Was möchten Sie melden?") beantwortet Sichtung/Totfund
  * bereits vor dem Formular. Der Totfund-Schalter auf Schritt 2 würde dieselbe
  * Frage ein zweites Mal stellen — mit dem Risiko, dass beide Antworten
- * auseinanderlaufen. Im Meldeformular (adminMode=false) tritt deshalb eine
- * reine Rückmeldung an seine Stelle. In der Admin-Maske (adminMode=true) gibt
- * es keine Einstiegsseite — der Schalter bleibt dort das einzige Bedienelement,
- * mit dem eine Bearbeiterin den Status korrigieren kann.
+ * auseinanderlaufen. Im Meldeformular (adminMode=false) entfällt er deshalb.
+ * Die Rückmeldung „Sie melden: … · [Ändern]", die hier an seine Stelle getreten
+ * war, steht seit dem Umzug in die Aktionszeile unter dem Formular
+ * (`form/FormActions.svelte`, dort getestet) — oben kostete sie Platz, obwohl
+ * sie keine Eingabe ist. In der Admin-Maske (adminMode=true) gibt es keine
+ * Einstiegsseite — der Schalter bleibt dort das einzige Bedienelement, mit dem
+ * eine Bearbeiterin den Status korrigieren kann.
  */
 describe('AnimalInfo — Totfund-Schalter', () => {
-	it('zeigt im Meldeformular keinen Schalter mehr, sondern die Rückmeldung', async () => {
+	it('zeigt im Meldeformular weder Schalter noch Rückmeldung', async () => {
 		renderWithAdminMode(false);
-		await expect.element(page.getByText(/Sie melden/i)).toBeInTheDocument();
+		expect(document.body.textContent).not.toContain('Sie melden');
 		await expect.element(page.getByTestId('field-isDead')).not.toBeInTheDocument();
 	});
 
@@ -169,38 +172,6 @@ describe('AnimalInfo — Totfund-Schalter', () => {
 		// ohne Schalter könnten Admins den Status nicht mehr korrigieren.
 		renderWithAdminMode(true);
 		await expect.element(page.getByTestId('field-isDead')).toBeInTheDocument();
-	});
-});
-
-/**
- * Korrektur 1 (Task 7): Ein roher Ternär (`$form.isDead ? … : …`) genügt
- * hier nicht — `isDead` kommt beim Wiederaufsetzen aus dem Storage als String
- * und in der Admin-Maske als Zahl aus der DB. `isDeadFinding` (`formConfig.ts`)
- * ist die einzige gültige Normalisierung dafür.
- *
- * Die Werte 1 und '1' sind in JS bereits truthy — ein roher Ternär trifft für
- * sie zufällig dieselbe Antwort wie `isDeadFinding` und beweist den Fehler
- * deshalb NICHT. Der String '0' zeigt den Unterschied dagegen zuverlässig:
- * JS wertet ihn als truthy (nicht-leerer String) und ein roher Ternär zeigte
- * fälschlich „Fund eines toten Tieres", während `isDeadFinding('0')` korrekt
- * `false` liefert. Alle drei Werte stehen hier trotzdem — 1 und '1' als der
- * im Auftrag wörtlich verlangte Beleg, '0' als der Test, der bei einer
- * Rückkehr zum rohen Ternär tatsächlich rot wird.
- */
-describe('AnimalInfo — Rückmeldung normalisiert isDead (Task 7, Korrektur 1)', () => {
-	it.each([1, '1'] as const)(
-		'zeigt „Fund eines toten Tieres", wenn isDead als %s ankommt',
-		async (value) => {
-			renderAnimalInfo({ isDead: value as unknown as boolean }, false);
-
-			await expect.element(page.getByText(/Fund eines toten Tieres/i)).toBeInTheDocument();
-		}
-	);
-
-	it('zeigt „Beobachtung eines lebenden Tieres", wenn isDead der String "0" ist', async () => {
-		renderAnimalInfo({ isDead: '0' as unknown as boolean }, false);
-
-		await expect.element(page.getByText(/Beobachtung eines lebenden Tieres/i)).toBeInTheDocument();
 	});
 });
 
@@ -220,28 +191,6 @@ describe('AnimalInfo — Totfund-Detailblock folgt derselben Normalisierung (Rev
 });
 
 /**
- * Korrektur 2 (Task 7): Ein Button ohne Wirkung gehört laut Design-Regel
- * entfernt, nicht dekorativ stehen gelassen — deshalb muss „Ändern" das
- * Callback tatsächlich auslösen. Dies ist der letzte Hop der Durchreich-Kette
- * (`+page.svelte` → `ModernReportForm` → `Step2SightingDetails` →
- * `AnimalInfo`); die beiden vorgelagerten Hops stehen in den Component-Tests
- * von `ModernReportForm` und `Step2SightingDetails`.
- */
-describe('AnimalInfo — „Ändern" ruft das Callback auf', () => {
-	it('ruft onchangekind auf, wenn im Meldeformular auf „Ändern" geklickt wird', async () => {
-		const onchangekind = vi.fn();
-		renderWithFormContext(AnimalInfo, {
-			overrides: { isDead: true },
-			props: { adminMode: false, onchangekind }
-		});
-
-		await page.getByRole('button', { name: /ändern/i }).click();
-
-		expect(onchangekind).toHaveBeenCalledOnce();
-	});
-});
-
-/**
  * Review-Befund 5 (Task 7): Der Wrapper `renderAnimalInfo` rendert per Default
  * mit `adminMode={true}`, seit der Totfund-Schalter dort das echte
  * Bedienelement bleibt (siehe Kommentar an `renderAnimalInfo` oben). Die
@@ -253,8 +202,7 @@ describe('AnimalInfo — „Ändern" ruft das Callback auf', () => {
  *
  * Im Meldeformular gibt es keinen `isDead`-Schalter mehr, an dem sich „davor"/
  * „danach" festmachen ließe — der Detailblock ist dort schlicht das erste
- * Feld der Karte, wenn er erscheint (unmittelbar unter der textlichen
- * Rückmeldung, die kein `data-field` trägt).
+ * Feld der Karte, wenn er erscheint.
  */
 describe('sections/AnimalInfo — Feldreihenfolge und progressive Anzeige im Meldeformular (Review-Befund 5)', () => {
 	it('rendert den Totfund-Detailblock bei einem Totfund als erstes Feld', () => {

--- a/src/lib/report/components/steps/Step1LocationTime.svelte
+++ b/src/lib/report/components/steps/Step1LocationTime.svelte
@@ -1,18 +1,6 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import PositionAndTime from '$lib/report/components/sections/PositionAndTime.svelte';
-	import ReportKindFeedback from '$lib/report/components/ReportKindFeedback.svelte';
-
-	let {
-		// Default-Noop wie an den übrigen `onchangekind`-Aufrufstellen
-		// (`Step2SightingDetails.svelte`): `exactOptionalPropertyTypes` verbietet
-		// sonst das Weiterreichen eines undefaulteten optionalen Props.
-		onchangekind = () => {}
-	}: {
-		/** Reicht den „Ändern"-Knopf aus `ReportKindFeedback` unverändert weiter —
-		 *  nur `+page.svelte` kennt die Einstiegsseite, zu der er zurückführt. */
-		onchangekind?: () => void;
-	} = $props();
 </script>
 
 <div class="space-y-6 md:space-y-8">
@@ -32,13 +20,10 @@
 		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
 			<strong>Wo und wann fand die Sichtung statt?</strong> Je genauer, desto wertvoller für die Forschung.
 		</p>
-		<!-- Abschlussreview B6: Genau hier merkt ein Melder am ehesten, dass er
-		     falsch abgebogen ist („Funddatum" statt „Datum und Uhrzeit" weiter
-		     unten) — bislang stand der einzige Korrekturweg erst auf Schritt 2,
-		     unterhalb der Upload-Karte. Dieselbe Rückmeldung wie dort
-		     (`sections/AnimalInfo.svelte`), ausgelagert nach
-		     `ReportKindFeedback.svelte`, damit die Regel nicht zweimal existiert. -->
-		<ReportKindFeedback {onchangekind} />
+		<!-- Die Rückmeldung „Sie melden: … · [Ändern]" stand hier und kostete
+		     oben den knappsten Platz. Sie steht jetzt einmal in der Aktionszeile
+		     unter dem Formular (`form/FormActions.svelte`) und gilt von dort für
+		     alle vier Schritte. -->
 	</div>
 
 	<!-- Step Content -->

--- a/src/lib/report/components/steps/Step1LocationTime.svelte.test.ts
+++ b/src/lib/report/components/steps/Step1LocationTime.svelte.test.ts
@@ -1,50 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import type { SightingFormData } from '$lib/types';
 import Step1LocationTime from './Step1LocationTime.svelte';
 
 /**
- * B6 (Abschlussreview, wichtig): Auf Schritt 1 gab es keinen Weg zurück zur
- * Einstiegsseite — genau dort merkt der Melder am ehesten, dass er falsch
- * abgebogen ist („Funddatum" statt „Datum und Uhrzeit"). Der einzige
- * Korrekturweg lag auf Schritt 2, unterhalb der Upload-Karte. Die Rückmeldung
- * „Sie melden: … · [Ändern]" (bisher nur in `sections/AnimalInfo.svelte`)
- * steht jetzt zusätzlich am Kopf von Schritt 1 — dieselbe Komponente
- * (`ReportKindFeedback.svelte`), damit die Regel nicht zweimal existiert.
+ * B6 (Abschlussreview) hatte die Rückmeldung „Sie melden: … · [Ändern]" an den
+ * Kopf von Schritt 1 gestellt, damit es dort überhaupt einen Korrekturweg
+ * zurück zur Einstiegsseite gibt. Der Weg bleibt — die Zeile steht nur nicht
+ * mehr hier oben, wo sie vor dem ersten Feld Platz kostet, sondern einmal in
+ * der Aktionszeile unter dem Formular (`form/FormActions.svelte`) und gilt von
+ * dort für alle vier Schritte.
+ *
+ * Der Test prüft die Abwesenheit, weil das die eigentliche Aussage ist: Ein
+ * Test über die neue Stelle allein (`FormActions.svelte.test.ts`) bliebe grün,
+ * wenn die Zeile zusätzlich wieder nach oben wanderte.
  */
-function renderStep1(
-	overrides: Partial<SightingFormData> = {},
-	onchangekind = vi.fn()
-): ReturnType<typeof vi.fn> {
-	renderWithFormContext(Step1LocationTime, { overrides, props: { onchangekind } });
-	return onchangekind;
+function renderStep1(overrides: Partial<SightingFormData> = {}): void {
+	renderWithFormContext(Step1LocationTime, { overrides });
 }
 
-describe('Step1LocationTime — Rückmeldung zum gewählten Zweig (B6)', () => {
-	it('zeigt die Rückmeldung „Sie melden" bereits auf Schritt 1', async () => {
+describe('Step1LocationTime — Rückmeldung steht nicht mehr im Schritt-Kopf', () => {
+	it('rendert die Zeile „Sie melden" nicht', () => {
 		renderStep1({ isDead: false });
 
-		await expect.element(page.getByText(/Sie melden/i)).toBeInTheDocument();
+		expect(document.body.textContent).not.toContain('Sie melden');
 	});
 
-	it('nennt den Totfund-Zweig korrekt', async () => {
+	it('rendert keinen „Ändern"-Knopf im Schritt', () => {
 		renderStep1({ isDead: true });
 
-		await expect.element(page.getByText(/Fund eines toten Tieres/i)).toBeInTheDocument();
-	});
-
-	it('nennt den Lebend-Zweig korrekt', async () => {
-		renderStep1({ isDead: false });
-
-		await expect.element(page.getByText(/Beobachtung eines lebenden Tieres/i)).toBeInTheDocument();
-	});
-
-	it('ruft onchangekind auf, wenn „Ändern" auf Schritt 1 geklickt wird', async () => {
-		const onchangekind = renderStep1({ isDead: false });
-
-		await page.getByRole('button', { name: /ändern/i }).click();
-
-		expect(onchangekind).toHaveBeenCalledOnce();
+		expect(document.querySelector('[data-testid="report-kind-change"]')).toBeNull();
 	});
 });

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte
@@ -6,17 +6,6 @@
 	import { getFormContext } from '$lib/report/formContext';
 	import { observationQuestion } from '$lib/report/wording';
 
-	let {
-		// Default-Noop wie `onCancel` in `ModernReportForm.svelte`: `exactOptionalPropertyTypes`
-		// verbietet sonst das Weiterreichen als `{onchangekind}` an `AnimalInfo`, weil ein
-		// undefaulteter optionaler Prop dort explizit `undefined` zuwiese.
-		onchangekind = () => {}
-	}: {
-		/** Reicht den „Ändern"-Knopf aus `AnimalInfo` unverändert weiter — nur
-		 *  `+page.svelte` kennt die Einstiegsseite, zu der er zurückführt. */
-		onchangekind?: () => void;
-	} = $props();
-
 	const { form } = getFormContext();
 
 	const question = $derived(observationQuestion($form.isDead));
@@ -54,6 +43,6 @@
 	     „Schritt überspringen"-Knopf und war damit für jeden unsichtbar, der ihn
 	     benutzte. -->
 	<Media />
-	<AnimalInfo {onchangekind} />
+	<AnimalInfo />
 	<SightingDetails />
 </div>

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
 import { renderWithFormContext } from '$lib/report/components/testing/renderWithFormContext.testutil';
 import type { SightingFormData } from '$lib/types';
 import Step2SightingDetails from './Step2SightingDetails.svelte';
@@ -84,23 +83,17 @@ describe('Step2SightingDetails — Ansprache bei Sichtung und Totfund', () => {
 });
 
 /**
- * Task 7 ersetzt den Totfund-Schalter im Meldeformular durch eine Rückmeldung
- * mit „Ändern"-Knopf (`AnimalInfo.svelte`). Der Knopf braucht dafür ein
- * Callback bis zur Einstiegsseite (`+page.svelte`) hoch — dieser Schritt prüft
- * den mittleren Hop der Kette: `Step2SightingDetails` reicht `onchangekind`
- * unverändert an `AnimalInfo` weiter, statt es fallen zu lassen. Ohne diesen
- * Test würde ein versehentlich entfernter Prop-Hop nicht auffallen, obwohl der
- * Knopf danach wirkungslos wäre (genau der Fehler, den Task 6 schon einmal
- * unbemerkt ließ, weil nur die Textfunktion, nicht das Rendering getestet
- * war).
+ * Der „Ändern"-Knopf stand bis zum Umzug in `AnimalInfo` und wurde über diesen
+ * Schritt durchgereicht. Er sitzt jetzt in der Aktionszeile unter dem Formular
+ * (`form/FormActions.svelte`, dort getestet) — die Durchreich-Kette endet damit
+ * bei `ModernReportForm`, und `Step2SightingDetails` kennt `onchangekind` nicht
+ * mehr.
  */
-describe('Step2SightingDetails — „Ändern" erreicht AnimalInfo', () => {
-	it('reicht onchangekind unverändert an AnimalInfo weiter', async () => {
-		const onchangekind = vi.fn();
-		renderWithFormContext(Step2SightingDetails, { props: { onchangekind } });
+describe('Step2SightingDetails — kein „Ändern"-Knopf mehr im Schritt', () => {
+	it('rendert die Rückmeldung nicht', () => {
+		renderStep2({ isDead: true });
 
-		await page.getByRole('button', { name: /ändern/i }).click();
-
-		expect(onchangekind).toHaveBeenCalledOnce();
+		expect(document.body.textContent).not.toContain('Sie melden');
+		expect(document.querySelector('[data-testid="report-kind-change"]')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Was

„Sie melden: … · [Ändern]" stand doppelt und jeweils oben — im Kopf von Schritt 1 und in der Karte „Tierinformationen" auf Schritt 2. Die Zeile sitzt jetzt einmal in der Aktionszeile unter dem Formular, links neben „Formular zurücksetzen".

## Warum

Oben kostete sie den knappsten Platz des Telefons: vor dem ersten Feld stehen dort schon Seitentitel, Schritt-Anzeige und Schritt-Überschrift. Sie ist weder Eingabe noch Schritt-Kontext, sondern eine Korrektur an der Meldung als Ganzes — dieselbe Art von Aktion wie das Zurücksetzen daneben.

**Nebeneffekt:** Die Aktionszeile gilt für alle vier Schritte. Der Korrekturweg zurück zur Einstiegsseite ist damit auf **allen** Schritten erreichbar statt nur auf zweien, und die `onchangekind`-Kette schrumpft von vier auf zwei Hops (`+page.svelte` → `ModernReportForm` → `FormActions`, statt zusätzlich über `Step1LocationTime` bzw. `Step2SightingDetails` → `AnimalInfo`).

Bewusster Trade: Die Zeile liegt jetzt unterhalb des Sticky-Navigationsbalkens und ist erst nach Scrollen ans Seitenende sichtbar. Dafür ist der Weg oben frei.

## Tests

Die Tests, die die alte Platzierung festschrieben, prüfen jetzt deren **Abwesenheit** — ein Test nur über die neue Stelle bliebe grün, wenn die Zeile zusätzlich wieder nach oben wanderte. Neu: `form/FormActions.svelte.test.ts`. Die `isDeadFinding`-Normalisierungsfälle (`1`, `'1'`, `'0'`) wandern von `AnimalInfo.svelte.test.ts` nach `ReportKindFeedback.svelte.test.ts`, damit die Abdeckung nicht verloren geht.

- `npm run lint` / `type-check` / `check`: 0 Fehler
- Betroffene Browser-Tests: 6 Dateien, 60 Tests grün
- Visuell geprüft bei 390 px und 1280 px; „Ändern" misst 69×44 px und hält das Touch-Target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
