### PR TITLE
fix(report): stop hidden fields from silently blocking the submit

### DIFF
--- a/.claude/rules/forms.md
+++ b/.claude/rules/forms.md
@@ -106,6 +106,7 @@ Schema-Beschreibung, in der ein `when()` nicht sichtbar ist — siehe den
 
 - **`touched`** (`Record<string, boolean>`) wird von `handleChange`/`updateField` gesetzt und von `updateInitialValues` zurückgesetzt. Es steuert ausschließlich die Anzeige (grünes Häkchen nur an Feldern, die der Nutzer wirklich berührt hat) — nicht die Validierung.
 - **Kein `validateField`**: Validiert wird beim Submit (`abortEarly: false`, sammelt alle Fehler) sowie schrittweise über `validateStep` (`src/lib/form/validation/stepValidation.ts`, nutzt `sightingSchema.pick(...)`). `updateField` löscht den Fehler des geänderten Feldes.
+- **`validationSchema` darf eine Funktion sein** (`(values) => Schema`, Typ `ValidationSchemaOption`). Sie wird bei JEDEM Submit mit den aktuellen Werten aufgelöst — nötig, weil `createForm` nur einmal beim Mount läuft, das Formular Felder aber zur Laufzeit ausblendet. Das Meldeformular übergibt `reachableSchema` (= `sightingSchema.omit(hiddenFormFields(values))`), die Admin-Maske ein festes Schema.
 - **Fehler-Timing**: Fehler erscheinen erst nach einem gescheiterten „Weiter"-Versuch, nie beim Betreten eines Schritts (siehe `stepNavigationState.ts`).
 
 API — vollständig, das ist alles was `createForm` zurückgibt:
@@ -194,6 +195,31 @@ Beispiel für ein korrekt ausgeblendetes Feld: `mediaConsent` entfällt in
 Funktion steht als `{#if hasMedia}`-Bedingung in `Step4Contact.svelte` — beide Seiten rufen
 dieselbe Funktion auf demselben Wert auf, statt zwei getrennt gepflegte Bedingungen zu
 riskieren.
+
+### Ausgeblendet heißt: nicht Teil dieser Meldung
+
+Die beiden Hälften oben regeln Sichtbarkeit und Schritt-Validierung. Beim **Absenden**
+gilt dieselbe Aussage, und zwar für beides zugleich (entschieden am 2026-08-07):
+
+- **Validiert** wird `sightingSchema.omit(hiddenFormFields(values))` — in der Vorab-Prüfung
+  (`handleFinalSubmit`) UND in der maßgeblichen Prüfung (`createForm`, über den Resolver
+  oben). Zwei Ebenen mit verschiedenen Regeln ergaben eine stille Sackgasse: Die eine ließ
+  durch, was die andere aufhielt, und `handleSubmit` meldet einen Validierungs-Abbruch nicht
+  an seinen Aufrufer — kein Toast, kein Sprung, keine Markierung an einem Feld ohne DOM.
+- **Gesendet** wird ebenfalls ohne `hiddenFormFields(values)` (`onSubmit` in
+  `ModernReportForm`). Sonst ginge ein Wert raus, den Yups `omit` ungeprüft und ungecastet
+  hat durchlaufen lassen.
+
+Ein neu ausgeblendetes Feld braucht deshalb **keine** dritte Stelle mehr — es genügt der
+Eintrag in `hiddenFormFields`. Feldlisten am Absende-Rand (früher `OWN_VESSEL_FIELDS`,
+`MEDIA_CONSENT_FIELDS`) nicht wieder einführen.
+
+Was dabei **nicht** angetastet werden darf: `$form` selbst und das an `onSubmit` übergebene
+`values`. Aus Letzterem werden die dauerhaft gespeicherten Kontaktdaten gebaut, und
+`saveUserContactDataWithConsent` überschreibt ohne Merge — ein wiederkehrender Melder verlöre
+bei einer Land-Meldung sonst seine Bootsdaten. Dass `values` vollständig bleibt, hängt daran,
+dass Yups `omit` den Schlüssel im Ergebnis stehen lässt; ein `stripUnknown`/`noUnknown` an
+dieser Validierung bricht es.
 
 ---
 

--- a/e2e/form-from-land.spec.ts
+++ b/e2e/form-from-land.spec.ts
@@ -277,15 +277,20 @@ test.describe('Meldeformular — Beobachtung von Land', () => {
 		});
 
 		expect(capturedBody).toBeDefined();
-		// `OWN_VESSEL_FIELDS` — dieselbe Liste wie `HIDDEN_WHEN_FROM_LAND` in
-		// formConfig.ts, ohne `boatDrive` (eigener Reset-Mechanismus, siehe
-		// `boatDriveReset.ts` — es wird beim Wechsel weg vom Boot bereits im
-		// `$form`-Zustand geleert und ist deshalb hier nicht separat zu prüfen).
+		// Was der Beobachtungsort ausblendet, geht nicht mit — seit dem
+		// 2026-08-07 entscheidet das einheitlich `hiddenFormFields`
+		// (formConfig.ts) statt der früheren Teilliste `OWN_VESSEL_FIELDS`.
+		// `boatDrive` steht deshalb jetzt mit in der Prüfung: Vorher war es
+		// ausgenommen, weil `shouldResetBoatDrive` (`boatDriveReset.ts`) es
+		// beim Wechsel weg vom Boot ohnehin im `$form`-Zustand leert. Das
+		// bleibt richtig und ist der Grund, warum hier nichts anderes
+		// herauskommt als vorher — verlassen wird sich darauf aber nicht mehr.
 		expect(capturedBody?.boatType).toBeUndefined();
 		expect(capturedBody?.shipName).toBeUndefined();
 		expect(capturedBody?.homePort).toBeUndefined();
 		expect(capturedBody?.shipNameConsent).toBeUndefined();
 		expect(capturedBody?.reaction).toBeUndefined();
+		expect(capturedBody?.boatDrive).toBeUndefined();
 
 		// Der Beobachtungsort selbst geht weiterhin mit — nur die vom Boot
 		// abhängigen Felder entfallen.

--- a/src/lib/form/createForm.test.ts
+++ b/src/lib/form/createForm.test.ts
@@ -365,3 +365,102 @@ describe('createForm — field-level error clearing', () => {
 		expect(get(isValid)).toBe(true);
 	});
 });
+
+/**
+ * Das Sichtungsformular blendet Felder je nach Zweig und Beobachtungsort aus,
+ * und zwar zur LAUFZEIT — `validationSchema` geht dagegen genau einmal beim
+ * Mount an `createForm` (über `Form.svelte`). Ein ungültiger Restwert in einem
+ * inzwischen ausgeblendeten Feld blockierte damit das Absenden, ohne dass
+ * irgendjemand ihn korrigieren könnte: Das Feld hat kein DOM-Element mehr.
+ *
+ * Ein Schema-Resolver löst genau das — er wird bei JEDEM Submit mit den
+ * aktuellen Werten aufgerufen und darf daraus ein anderes Schema bauen. Die
+ * Admin-Maske übergibt weiterhin ein Schema-Objekt und läuft unverändert durch
+ * denselben Zweig; die Fassung mit Objekt ist deshalb hier mitgetestet.
+ */
+describe('createForm — validationSchema als Resolver', () => {
+	const branchSchema = yup.object({
+		name: yup.string().required('Name ist erforderlich'),
+		hint: yup.string().max(3, 'Höchstens 3 Zeichen')
+	});
+
+	it('ruft den Resolver mit den AKTUELLEN Werten auf, nicht mit den initialen', async () => {
+		// Parameter explizit typisiert: Ohne ihn leitet `vi.fn` eine leere
+		// Argumentliste ab, und `mock.calls[0][0]` wäre schon zur Übersetzungszeit
+		// ein Tupel-Zugriff ins Leere.
+		const resolver = vi.fn((_values: { name: string; hint: string }) => branchSchema);
+		const { handleSubmit, updateField } = createForm({
+			initialValues: { name: 'Max', hint: 'ok' },
+			validationSchema: resolver,
+			onSubmit: vi.fn().mockResolvedValue(undefined)
+		});
+
+		updateField('name', 'Elke');
+		await handleSubmit(new Event('submit'));
+
+		expect(resolver).toHaveBeenCalledOnce();
+		expect(resolver.mock.calls[0]?.[0]).toMatchObject({ name: 'Elke' });
+	});
+
+	it('sendet ab, wenn der Resolver das ungültige Feld aus dem Schema nimmt', async () => {
+		const onSubmit = vi.fn().mockResolvedValue(undefined);
+		const { handleSubmit, errors } = createForm({
+			initialValues: { name: 'Max', hint: 'viel zu lang' },
+			validationSchema: () => branchSchema.omit(['hint']),
+			onSubmit
+		});
+
+		await handleSubmit(new Event('submit'));
+
+		expect(onSubmit).toHaveBeenCalledOnce();
+		expect(get(errors)).toEqual({});
+	});
+
+	it('lässt den Wert des ausgenommenen Feldes trotzdem an onSubmit durch', async () => {
+		// Yups `omit` entfernt den Schlüssel NICHT aus dem Ergebnis — er läuft
+		// nur ungeprüft und ungecastet durch. Darauf beruht, dass das
+		// Meldeformular seine dauerhaft gespeicherten Kontaktdaten
+		// (`shipName`, `homePort`, …) weiterhin aus dem Submit-Objekt bauen
+		// kann, obwohl eine Land-Meldung genau diese Felder ausblendet. Wer
+		// hier auf `stripUnknown`/`noUnknown` umstellt, nimmt einem
+		// wiederkehrenden Melder seine gespeicherten Bootsdaten.
+		const onSubmit = vi.fn().mockResolvedValue(undefined);
+		const { handleSubmit } = createForm({
+			initialValues: { name: 'Max', hint: 'viel zu lang' },
+			validationSchema: () => branchSchema.omit(['hint']),
+			onSubmit
+		});
+
+		await handleSubmit(new Event('submit'));
+
+		expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({ hint: 'viel zu lang' });
+	});
+
+	it('blockiert weiterhin, wenn ein im Schema VERBLIEBENES Feld ungültig ist', async () => {
+		const onSubmit = vi.fn();
+		const { handleSubmit, errors } = createForm({
+			initialValues: { name: '', hint: 'ok' },
+			validationSchema: () => branchSchema.omit(['hint']),
+			onSubmit
+		});
+
+		await handleSubmit(new Event('submit'));
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(get(errors)['name']).toBe('Name ist erforderlich');
+	});
+
+	it('behandelt ein übergebenes Schema-Objekt unverändert (Admin-Maske)', async () => {
+		const onSubmit = vi.fn();
+		const { handleSubmit, errors } = createForm({
+			initialValues: { name: 'Max', hint: 'viel zu lang' },
+			validationSchema: branchSchema,
+			onSubmit
+		});
+
+		await handleSubmit(new Event('submit'));
+
+		expect(onSubmit).not.toHaveBeenCalled();
+		expect(get(errors)['hint']).toBe('Höchstens 3 Zeichen');
+	});
+});

--- a/src/lib/form/createForm.ts
+++ b/src/lib/form/createForm.ts
@@ -2,11 +2,30 @@ import { derived, get, writable } from 'svelte/store';
 import { ValidationError } from 'yup';
 import type { AnyObjectSchema } from 'yup';
 
+/**
+ * Das Schema, gegen das beim Absenden geprüft wird — entweder fest oder pro
+ * Submit aus den aktuellen Werten abgeleitet.
+ *
+ * Die Funktions-Fassung gibt es, weil das Sichtungsformular Felder zur
+ * LAUFZEIT ausblendet (Zweig, Beobachtungsort, vorhandene Aufnahme), während
+ * `createForm` genau einmal beim Mount aufgerufen wird. Ein fest übergebenes
+ * Schema prüft deshalb weiter Felder, die der Melder längst nicht mehr sieht —
+ * und ein ungültiger Restwert darin hielt das Absenden auf, ohne dass ihn
+ * jemand korrigieren konnte (das Feld hat kein DOM-Element mehr). Der Resolver
+ * wird bei jedem Submit mit `get(form)` aufgerufen und darf daraus ein anderes
+ * Schema bauen.
+ *
+ * Die Admin-Maske übergibt weiterhin ein Schema-Objekt und läuft unverändert
+ * durch denselben Zweig.
+ */
+export type ValidationSchemaOption<T extends Record<string, unknown>> =
+	AnyObjectSchema | ((values: T) => AnyObjectSchema);
+
 export interface FormProps<T extends Record<string, unknown> = Record<string, unknown>> {
 	initialValues: T;
 	// Return type is unknown — callers may return values (e.g. admin form returns FrontendSighting)
 	onSubmit: (values: T) => unknown;
-	validationSchema?: AnyObjectSchema | null;
+	validationSchema?: ValidationSchemaOption<T> | null;
 	validate?: ((values: T) => Record<string, string> | Promise<Record<string, string>>) | null;
 }
 
@@ -69,8 +88,13 @@ export function createForm<T extends Record<string, unknown>>(options: FormProps
 			}
 
 			if (validationSchema) {
+				// Ein Resolver wird pro Submit aufgelöst — siehe `ValidationSchemaOption`.
+				// Yup-Schemas sind Objekte, `typeof === 'function'` unterscheidet die
+				// beiden Fassungen also zuverlässig.
+				const schema =
+					typeof validationSchema === 'function' ? validationSchema(values) : validationSchema;
 				// validate() with abortEarly: false returns all errors + applies .transform()
-				const validated = await validationSchema.validate(values, { abortEarly: false });
+				const validated = await schema.validate(values, { abortEarly: false });
 				await onSubmit(validated as T);
 			} else {
 				await onSubmit(values);

--- a/src/lib/report/README.md
+++ b/src/lib/report/README.md
@@ -103,17 +103,29 @@ Three distinct layers — see `.claude/rules/forms.md` for the full table:
 `isStepValid(currentStep, formData)` and `validateStep(currentStep, formData)` take **two**
 arguments and validate `sightingSchema.pick(getFormSteps(formData)[currentStep].fields)`.
 
-The pre-submit layer covers all steps at once (a field can go invalid after its step was
-left) and validates `sightingSchema.omit(hiddenFormFields(formValues))` — the full schema
-minus what the current branch hides. Without that subtraction, a leftover value in a hidden
-field blocks the submit behind an error nobody can see, and drags the jump target onto a
-step that shows nothing.
+**Both submit layers validate the same thing:** `reachableSchema(values)` in
+`ModernReportForm` — `sightingSchema.omit(hiddenFormFields(values))`, the full schema minus
+what the current branch hides. The pre-submit layer additionally covers all steps at once (a
+field can go invalid after its step was left) and jumps to the earliest affected step.
 
-**Known gap:** the authoritative layer below still validates the _full_ schema
-(`validationSchema` is handed to `createForm` once and cannot be branch-aware), so that same
-leftover value still stops the submit there — silently, without a toast or a jump. Closing it
-means deciding what a hidden field's leftover value should do on submit, which is a separate
-change.
+The authoritative layer gets there via a **schema resolver**: `validationSchema` accepts
+`(values) => AnyObjectSchema` as well as a schema (`ValidationSchemaOption` in
+`createForm.ts`), resolved on every submit. It has to be a function — `createForm` runs once
+at mount, while the reporting location changes at runtime. Until 2026-08-07 it validated the
+full schema, so a leftover value in a hidden field stopped the submit **silently**:
+`handleSubmit` catches the `ValidationError`, writes it to `$errors` and returns, so
+`StepNavigation` sees no failure and logs "Form submitted successfully" — no toast, no jump,
+no marking, because the field has no DOM element. Reproducible by typing more than 1000
+characters into `reaction` on a boat report and then switching `sightingFrom` to land.
+
+**Hidden means: not part of this report** — for validation and for what goes out. The
+submit edge drops `hiddenFormFields(values)` from the submitted object (`onSubmit` in
+`ModernReportForm`), so nothing that slipped past the schema unvalidated ever reaches the
+server. Yup's `omit` does **not** strip the key from its result — hidden fields pass through
+uncast, which is what keeps `values` complete enough to build the persisted contact data
+(`shipName`, `homePort`, …) on a land report. Switching that validate call to
+`stripUnknown`/`noUnknown` would wipe a returning reporter's saved boat details; pinned by
+`createForm.test.ts` → "lässt den Wert des ausgenommenen Feldes trotzdem an onSubmit durch".
 
 There is no debouncing. `createForm` exposes
 `{ form, errors, touched, isSubmitting, isValid, handleSubmit, handleChange, updateField, updateInitialValues }`

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -18,13 +18,11 @@
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
 	import { resolveServerFieldErrors } from '$lib/report/serverFieldErrors';
 	import {
-		HIDDEN_WHEN_FROM_LAND,
 		getFormSteps,
 		hasUploadedMedia,
 		hiddenFormFields,
 		initialFormState,
-		isDeadFinding,
-		isFromLand
+		isDeadFinding
 	} from '$lib/report/formConfig';
 	import { toast } from '$lib/stores/toastState.svelte';
 	import {
@@ -241,65 +239,90 @@
 	}
 
 	/**
-	 * Dieselbe Feldliste wie `HIDDEN_WHEN_FROM_LAND` (formConfig.ts, dort die
-	 * volle Begründung), ohne `boatDrive` — das hat mit `shouldResetBoatDrive`
-	 * (`boatDriveReset.ts`) einen eigenen, gezielteren Mechanismus.
+	 * Das Schema dieses Absende-Versuchs: das volle, minus der Felder, die der
+	 * aktuelle Zweig ausblendet.
+	 *
+	 * Als **Resolver** übergeben und nicht als fertiges Schema, weil sich der
+	 * Beobachtungsort zur Laufzeit ändert, `createForm` aber nur einmal beim
+	 * Mount läuft (`ValidationSchemaOption` in `createForm.ts`). Vorher prüfte
+	 * die maßgebliche Validierung deshalb weiter gegen das volle Schema: Ein zu
+	 * langer `reaction`-Text, der den Wechsel auf „Land" überlebt hat, hielt das
+	 * Absenden auf — und zwar STILL. `handleSubmit` fängt den `ValidationError`
+	 * und kehrt zurück, `StepNavigation` sieht keinen Fehler und loggt „Form
+	 * submitted successfully". Kein Toast, kein Sprung, keine Markierung; das
+	 * Feld ist nicht gerendert. Der Melder drückte „Absenden" und nichts geschah.
+	 *
+	 * Dieselbe Zeile steht in `handleFinalSubmit` als Vorab-Prüfung — beide
+	 * Ebenen rechnen jetzt mit derselben Regel, statt dass die eine durchlässt,
+	 * was die andere aufhält.
+	 *
+	 * **Was der Resolver NICHT tut:** Er entfernt die Felder nicht aus dem
+	 * Ergebnis. Yups `omit` lässt unbekannte Schlüssel durchlaufen (nur
+	 * ungeprüft und ungecastet) — `values` in `onSubmit` unten trägt deshalb
+	 * weiterhin `shipName`/`homePort`/`boatType`/`shipNameConsent`, aus denen
+	 * die dauerhaft gespeicherten Kontaktdaten gebaut werden. Genau daran hing
+	 * die Regression aus Task 11 (zweite Runde): `saveUserContactDataWithConsent`
+	 * überschreibt ohne Merge, ein wiederkehrender Melder verlöre bei einer
+	 * Land-Meldung seine Bootsdaten. Abgesichert in `createForm.test.ts`
+	 * („lässt den Wert des ausgenommenen Feldes trotzdem an onSubmit durch") —
+	 * wer dort auf `stripUnknown`/`noUnknown` umstellt, bricht das hier.
 	 */
-	const OWN_VESSEL_FIELDS = HIDDEN_WHEN_FROM_LAND.filter(
-		(field) => field !== 'boatDrive'
-	) as Exclude<(typeof HIDDEN_WHEN_FROM_LAND)[number], 'boatDrive'>[];
-
-	/**
-	 * Task 15 (Review-Befund 3): benannte Konstante statt eines Inline-Literals
-	 * an der Aufrufstelle unten — demselben Muster wie `OWN_VESSEL_FIELDS`
-	 * folgend, statt eines Stilbruchs im selben Block.
-	 */
-	const MEDIA_CONSENT_FIELDS = ['mediaConsent'] as const;
+	function reachableSchema(values: SightingFormData) {
+		return sightingSchema.omit(hiddenFormFields(values));
+	}
 
 	// Formular initialisieren
 	const formProps = {
 		initialValues: { ...savedFormData },
-		validationSchema: sightingSchema,
+		validationSchema: reachableSchema,
 		onSubmit: async (values: SightingFormData) => {
 			try {
 				// Remove admin only attributes and uploaded files (already uploaded)
 				const { verified, internalComment, uploadedFiles, ...submitValuesTemp } = values;
 				let submitValues: SightingFormValues = submitValuesTemp as SightingFormValues;
 
-				// Ausgeblendete Bootsangaben nicht absenden — entfernt am
-				// Absende-Rand, statt `$form` vorher zu leeren. Begründung samt
-				// verworfenem ersten Ansatz: `HIDDEN_WHEN_FROM_LAND` in
-				// formConfig.ts. `values` bleibt unangetastet — die
-				// Kontaktdaten unten werden bewusst daraus gebaut, nicht aus
-				// `submitValues`.
-				if (isFromLand(values.sightingFrom)) {
-					submitValues = omitFields(submitValues, OWN_VESSEL_FIELDS) as SightingFormValues;
-				}
+				// Was der aktuelle Zweig ausblendet, geht auch nicht raus —
+				// ausgeblendet heißt: nicht Teil dieser Meldung. Dieselbe Größe,
+				// gegen die oben validiert wird (`reachableSchema`), sodass nie
+				// etwas gesendet wird, das ungeprüft und ungecastet durch Yups
+				// `omit` gelaufen ist.
+				//
+				// Entfernt wird am Absende-Rand, NICHT vorher aus `$form`.
+				// Begründung samt verworfenem ersten Ansatz (ein `$effect`, der
+				// `$form` leerte, und die Kontaktdaten-Regression daraus):
+				// `HIDDEN_WHEN_FROM_LAND` in formConfig.ts. `values` bleibt
+				// unangetastet — die Kontaktdaten unten werden bewusst daraus
+				// gebaut, nicht aus `submitValues`.
+				//
+				// Bis hierher standen an dieser Stelle ZWEI Sonderfälle
+				// (`OWN_VESSEL_FIELDS` und `mediaConsent`), während `boatDrive`
+				// bei einer Land-Meldung und `behavior`/`behaviorText` beim
+				// Totfund mitgingen — teils gewollt, teils nur historisch. Kein
+				// Feld verliert dabei Aussage: `mapFormToSighting` bildet alle
+				// sechs neu entfallenden auf denselben Wert ab wie ihren Default
+				// (`deadCondition`→0, `deadSize`→null, `deadPhoneContact`→0,
+				// `behavior`→`UNKNOWN`, `reaction`/`behaviorText` durchgereicht).
+				// Bei `boatDrive` ist das Weglassen sogar die korrektere Angabe:
+				// `resolveBoatDrive` schreibt ohne Angabe `NONE`, während der
+				// Default `0` „Sonstiger Antrieb" bedeutet — die Kategorie, die
+				// durch dieselbe Verwechslung schon einmal 5.858 Zeilen falsch
+				// gefüllt hat.
+				submitValues = omitFields(
+					submitValues,
+					hiddenFormFields(values) as (keyof SightingFormValues)[]
+				) as SightingFormValues;
+
 				// Datum und Uhrzeit gehen als Strings (deutsche Wanduhrzeit) raus — den
 				// Zeitpunkt bildet ausschließlich der Server, sonst ginge die Zeitzone
 				// des Browsers in den gespeicherten Instant ein.
 				// set mediaUpload indicator
-				const hasCompletedUpload = hasUploadedMedia(uploadedFiles);
-				submitValues.mediaUpload = hasCompletedUpload;
-
-				// Task 15: Keine Einwilligung ohne Gegenstand. `mediaConsent` fragt
-				// nach der Freigabe von Aufnahmen — ohne eine zum Absende-Zeitpunkt
-				// tatsächlich abgeschlossene Übertragung ist das eine Frage ohne
-				// Bezugsgegenstand, dieselbe Fehlerklasse wie `shipNameConsent` bei
-				// einer Land-Meldung oben. `hasUploadedMedia` (formConfig.ts) ist
-				// dieselbe Funktion, die auch `getFormSteps` und `Step4Contact.svelte`
-				// aufrufen — absichtlich gegen `uploadedFiles` geprüft, nicht gegen
-				// den Medien-Store: Nur eine hier abgeschlossene Übertragung hat
-				// serverseitig ein Gegenstück, für das `mapFormToSighting` einen
-				// Nachweis (`…_am`/`…_version`) stempeln könnte. Das ist der Riegel,
-				// der auch dann greift, wenn der Reset-Effekt weiter unten aus
-				// irgendeinem Grund übersehen wurde — `mapFormToSighting` liest ein
-				// fehlendes Feld ohnehin als falsy (`formData.mediaConsent ? 1 : 0`),
-				// Weglassen statt `false` setzen spart deshalb keinen Fall, hält sich
-				// aber an dasselbe Muster wie `OWN_VESSEL_FIELDS` oben.
-				if (!hasCompletedUpload) {
-					submitValues = omitFields(submitValues, MEDIA_CONSENT_FIELDS) as SightingFormValues;
-				}
+				// `mediaConsent` ist dabei schon durch die Zeile oben entfallen, falls
+				// keine Aufnahme vorliegt: `hiddenFormFields` prüft es über dieselbe
+				// `hasUploadedMedia`-Funktion (Task 15 — keine Einwilligung ohne
+				// Gegenstand; ohne abgeschlossene Übertragung gibt es serverseitig
+				// nichts, wofür `mapFormToSighting` einen Nachweis `…_am`/`…_version`
+				// stempeln könnte).
+				submitValues.mediaUpload = hasUploadedMedia(uploadedFiles);
 
 				submitAttempt += 1;
 				submitState = 'submitting';
@@ -486,10 +509,12 @@
 		});
 
 		// Geprüft wird das volle Schema OHNE die Felder, die der aktuelle Zweig
-		// ausblendet. Ein ungültiger Restwert darin brächte hier beides zum
-		// Stillstand: Der Sprung landete auf einem Schritt, auf dem nichts
-		// markiert ist, und das Absenden bliebe mit einer Meldung an einem Feld
-		// hängen, das niemand sieht und niemand korrigieren kann.
+		// ausblendet — `reachableSchema` oben, dieselbe Funktion, mit der auch
+		// `createForm` gleich darunter prüft. Ein ungültiger Restwert darin
+		// brächte hier beides zum Stillstand: Der Sprung landete auf einem
+		// Schritt, auf dem nichts markiert ist, und das Absenden bliebe mit
+		// einer Meldung an einem Feld hängen, das niemand sieht und niemand
+		// korrigieren kann.
 		//
 		// Erreichbar ist das über den Beobachtungsort, nicht über den Zweig:
 		// `HIDDEN_WHEN_FROM_LAND` lässt `$form` bewusst stehen (Begründung samt
@@ -502,18 +527,12 @@
 		// `fieldsOutsideReportKind` — ein Zweigwechsel geht immer über die
 		// Einstiegsseite und mountet dieses Formular neu (`+page.svelte`).
 		//
-		// `omit` statt einer aus den Schritt-Feldern gebauten Positivliste
-		// (`pick`): Das Schema führt auch Felder, die in keinem Schritt stehen
-		// (`referenceId`, `entryChannel`, `weatherData.*`) — die sollen weiter
-		// geprüft werden. Warum das Komplement die richtige Größe ist, steht bei
-		// `hiddenFormFields`. Unkritisch für Yup: Alle ausgeblendeten Felder sind
-		// in `when()`-Beziehungen ausschließlich die abhängige Seite; die
-		// Bedingungsfelder (`hasPosition`, `isDead`, `sightingFrom`) bleiben
-		// sämtlich im Schema.
-		const reachableSchema = sightingSchema.omit(hiddenFormFields(formValues));
-
+		// Diese Prüfung ist damit keine Absicherung mehr gegen die Ebene
+		// darunter, sondern nur noch das, wozu sie da ist: Sie prüft ALLE
+		// Schritte auf einmal (ein Feld kann ungültig werden, nachdem sein
+		// Schritt verlassen wurde) und führt zum frühesten betroffenen Schritt.
 		try {
-			await reachableSchema.validate(formValues, { abortEarly: false });
+			await reachableSchema(formValues).validate(formValues, { abortEarly: false });
 			logger.info('Pre-submit validation: all fields OK');
 		} catch (yupError) {
 			if (!(yupError instanceof ValidationError)) {

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -940,3 +940,181 @@ describe('ModernReportForm — die Fehler-Navigation kennt den Zweig', () => {
 			.toBeVisible();
 	});
 });
+
+/**
+ * Ausgeblendet heißt: nicht Teil dieser Meldung — für die Validierung UND für
+ * das, was rausgeht.
+ *
+ * Bis hierher galt das nur halb. Die Vorab-Prüfung in `handleFinalSubmit`
+ * ließ die ausgeblendeten Felder korrekt aus, die maßgebliche Prüfung in
+ * `createForm.handleSubmit` danach aber nicht: `validationSchema` geht einmal
+ * beim Mount an `createForm` und kannte den Zweig nicht. Ein ungültiger
+ * Restwert in einem ausgeblendeten Feld hielt das Absenden damit auf — und
+ * zwar STILL. `handleSubmit` fängt den `ValidationError`, schreibt ihn in den
+ * `errors`-Store und kehrt zurück; `StepNavigation.handleFormSubmission` sieht
+ * keinen Fehler und loggt „Form submitted successfully". Kein Toast, kein
+ * Sprung, keine Markierung — das Feld ist ja nicht gerendert. Der Melder
+ * klickte „Absenden" und nichts geschah.
+ *
+ * Der Weg dorthin führt über den BEOBACHTUNGSORT, nicht über den Zweig:
+ * `HIDDEN_WHEN_FROM_LAND` lässt die Felder bewusst im `$form` stehen
+ * (Begründung dort), und die Feld-Pipeline setzt kein `maxlength`. Auf einer
+ * Boots-Meldung mehr als 1000 Zeichen in `reaction` tippen, dann auf „Land"
+ * stellen — fertig. Über den Zweig entsteht kein Restwert (`boatDrive` räumt
+ * `shouldResetBoatDrive` ab, die Totfund-Felder der Mount-Aufräumer).
+ */
+describe('ModernReportForm — ausgeblendete Felder halten das Absenden nicht auf', () => {
+	const today = new Date().toISOString().split('T')[0];
+
+	function seedReport(overrides: Record<string, unknown> = {}): void {
+		sessionStorage.setItem(STORAGE_KEYS.CURRENT_STEP, JSON.stringify(3));
+		sessionStorage.setItem(
+			STORAGE_KEYS.FORM_DATA,
+			JSON.stringify({
+				...initialFormState,
+				referenceId: 'ref-ausgeblendet',
+				entryChannel: 0,
+				species: 0,
+				totalCount: 1,
+				distance: 1,
+				shipCount: 2,
+				sightingFrom: SightingFromEnum.LAND,
+				hasPosition: true,
+				latitude: 54.5,
+				longitude: 13.5,
+				sightingDate: today,
+				firstName: 'Max',
+				lastName: 'Mustermann',
+				email: 'max@example.com',
+				privacyConsent: true,
+				...overrides
+			})
+		);
+	}
+
+	async function submit(): Promise<Record<string, unknown>> {
+		await page.getByRole('button', { name: 'Formular absenden' }).click();
+		await vi.waitFor(() => expect(submitSightingFormMock).toHaveBeenCalled(), { timeout: 4000 });
+		return submitSightingFormMock.mock.calls[0]?.[0] as Record<string, unknown>;
+	}
+
+	beforeEach(() => {
+		submitSightingFormMock.mockClear();
+		submitSightingFormMock.mockResolvedValue({ status: 'ok', id: 1 });
+	});
+
+	/**
+	 * Der reproduzierte Befund selbst. `reaction` ist bei einer Land-Meldung
+	 * ausgeblendet und wird beim Absenden ohnehin verworfen — der Restwert
+	 * blockierte also eine Übermittlung, aus der er gar nicht mit hinausging.
+	 */
+	it('sendet trotz eines zu langen Restwerts in `reaction` ab', async () => {
+		seedReport({ reaction: 'x'.repeat(1001) });
+
+		render(ModernReportForm);
+
+		const sent = await submit();
+
+		expect('reaction' in sent).toBe(false);
+		expect(sent.shipCount).toBe(2);
+	});
+
+	/**
+	 * Dieselbe Lage an einem Feld mit anderer Grenze — damit der Test nicht an
+	 * einer einzelnen Schema-Regel hängt. `shipName` erlaubt 64 Zeichen.
+	 */
+	it('sendet trotz eines zu langen Restwerts in `shipName` ab', async () => {
+		seedReport({ shipName: 'M'.repeat(65) });
+
+		render(ModernReportForm);
+
+		const sent = await submit();
+
+		expect('shipName' in sent).toBe(false);
+	});
+
+	/**
+	 * Die Gegenprobe. Ein SICHTBARES Feld mit ungültigem Wert muss weiterhin
+	 * aufhalten — sonst belegte das Grün oben nur, dass die Prüfung insgesamt
+	 * ausgefallen ist. `shipCount` steht auf Schritt 3 und ist auch von Land
+	 * aus bedienbar (Störungskontext).
+	 */
+	it('hält weiterhin auf, wenn ein SICHTBARES Feld ungültig ist', async () => {
+		seedReport({ shipCount: 99 });
+
+		render(ModernReportForm);
+
+		await page.getByRole('button', { name: 'Formular absenden' }).click();
+
+		await vi.waitFor(() =>
+			expect(
+				document.querySelector('[data-testid="field-shipCount"]')?.getAttribute('aria-invalid')
+			).toBe('true')
+		);
+		expect(submitSightingFormMock).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Die zweite Hälfte der Entscheidung: Was ausgeblendet ist, geht auch nicht
+	 * raus. Vorher entschieden das zwei Sonderfälle am Absende-Rand
+	 * (`OWN_VESSEL_FIELDS`, `MEDIA_CONSENT_FIELDS`), während `boatDrive` (Land)
+	 * und die Zweig-Felder mitgingen — teils gewollt, teils nur historisch.
+	 * Jetzt entscheidet `hiddenFormFields` beides.
+	 *
+	 * Für `boatDrive` ist das Weglassen sogar die korrektere Angabe:
+	 * `resolveBoatDrive` (`mapFormToSighting.ts`) schreibt ohne Angabe `NONE`,
+	 * während der Default `0` „Sonstiger Antrieb" bedeutet — genau die
+	 * Kategorie, die durch dieselbe Verwechslung schon einmal 5.858 Zeilen
+	 * falsch gefüllt hat.
+	 */
+	it('sendet `boatDrive` bei einer Land-Meldung nicht mit', async () => {
+		seedReport({ boatDrive: 1 });
+
+		render(ModernReportForm);
+
+		const sent = await submit();
+
+		expect('boatDrive' in sent).toBe(false);
+	});
+
+	it('sendet die Totfund-Felder bei einer Lebend-Meldung nicht mit', async () => {
+		seedReport({ isDead: false, deadCondition: 2, deadSize: 150, deadPhoneContact: true });
+
+		render(ModernReportForm, { initialIsDead: false });
+
+		const sent = await submit();
+
+		expect('deadCondition' in sent).toBe(false);
+		expect('deadSize' in sent).toBe(false);
+		expect('deadPhoneContact' in sent).toBe(false);
+	});
+
+	/**
+	 * Die Gegenrichtung. Gesetzt wird der Zweig über `initialIsDead`; der
+	 * Mount-Aufräumer (`fieldsOutsideReportKind`) leert `behavior`/
+	 * `behaviorText`/`reaction` dabei ohnehin schon aus dem Zustand — hier
+	 * geht es darum, dass sie auch dann nicht im Absende-Objekt stehen, wenn
+	 * sie es täten. Der Zustand wird deshalb nach dem Mount nicht erneut
+	 * gesetzt, sondern nur das Ergebnis geprüft.
+	 */
+	it('sendet die Verhaltensfelder bei einer Totfund-Meldung nicht mit', async () => {
+		seedReport({
+			isDead: true,
+			deadCondition: 1,
+			behavior: 3,
+			behaviorText: 'ruhiges Schwimmen',
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: 1
+		});
+
+		render(ModernReportForm, { initialIsDead: true });
+
+		const sent = await submit();
+
+		expect('behavior' in sent).toBe(false);
+		expect('behaviorText' in sent).toBe(false);
+		expect('reaction' in sent).toBe(false);
+		// Der Beobachtungsort ist hier ein Boot — die Bootsangaben bleiben.
+		expect(sent.boatDrive).toBe(1);
+	});
+});

--- a/src/lib/report/components/form/Form.svelte
+++ b/src/lib/report/components/form/Form.svelte
@@ -6,6 +6,7 @@
 
 	import { createForm, type FormProps } from '$lib/form/createForm';
 	import type { HTMLFormAttributes } from 'svelte/elements';
+	import type { AnyObjectSchema } from 'yup';
 
 	const onSubmitDefault = () => {
 		throw new Error('onSubmit is a required property in <Form /> when using the fallback context');
@@ -16,7 +17,7 @@
 		context = $bindable({} as FormContext),
 		...formAndRestProps
 	} = $props<
-		Omit<FormProps, 'onSubmit'> &
+		Omit<FormProps, 'onSubmit' | 'validationSchema'> &
 			HTMLFormAttributes & {
 				children: Snippet;
 				context?: FormContext;
@@ -25,6 +26,13 @@
 				// but at runtime createForm always calls onSubmit with the correctly-typed values.
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				onSubmit?: (...args: any[]) => unknown;
+				// Same reason, one step further: since `validationSchema` may be a resolver
+				// (`(values) => schema`, see `ValidationSchemaOption` in createForm.ts), it
+				// carries the same T in its PARAMETER — and a parameter is contravariant, so
+				// a `(values: SightingFormData) => …` resolver is not assignable to the
+				// `Record<string, unknown>` fallback that this non-generic component pins T to.
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				validationSchema?: AnyObjectSchema | ((...args: any[]) => AnyObjectSchema) | null;
 			}
 	>();
 

--- a/src/lib/report/components/form/Form.svelte
+++ b/src/lib/report/components/form/Form.svelte
@@ -31,8 +31,13 @@
 				// carries the same T in its PARAMETER — and a parameter is contravariant, so
 				// a `(values: SightingFormData) => …` resolver is not assignable to the
 				// `Record<string, unknown>` fallback that this non-generic component pins T to.
+				//
+				// Widened at the parameter TYPE, not at the parameter LIST: `createForm`
+				// calls the resolver with exactly one argument. A `(...args: any[])` here
+				// would type-check a resolver that reads a second one, which is `undefined`
+				// at runtime. A single `any` escapes the variance check just as well.
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				validationSchema?: AnyObjectSchema | ((...args: any[]) => AnyObjectSchema) | null;
+				validationSchema?: AnyObjectSchema | ((values: any) => AnyObjectSchema) | null;
 			}
 	>();
 

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import type * as yup from 'yup';
 import { SightingFromEnum } from './formOptions/sightingFrom';
-import { formStepsConfig, getFormSteps, sightingSchemaFields } from './formConfig';
+import {
+	formStepsConfig,
+	getFormSteps,
+	hiddenFormFields,
+	sightingSchemaFields,
+	type FormStepsInput
+} from './formConfig';
+import { sightingSchema } from '$lib/form/validation/sightingSchema';
+import type { SightingFormData } from './types';
 import type { UploadedFileInfo } from '$lib/types';
 
 /**
@@ -542,5 +550,130 @@ describe('formStepsConfig — Umweltfelder in Render-Reihenfolge', () => {
 		const umwelt = ['seaState', 'visibility', 'windForce', 'shipCount'];
 
 		expect(fields.filter((name) => umwelt.includes(name))).toEqual(umwelt);
+	});
+});
+
+/**
+ * Der Vertrag zwischen dem Absende-Rand und dem Server.
+ *
+ * `ModernReportForm.onSubmit` entfernt `hiddenFormFields(values)` aus dem
+ * Objekt, das an `POST /api/sightings` geht — ausgeblendet heißt: nicht Teil
+ * dieser Meldung. Der Endpunkt validiert die Nutzlast danach gegen das
+ * **volle** `sightingSchema` (`src/routes/api/sightings/+server.ts`, Schritt 3).
+ * Ein Feld, das der Client weglässt und der Server verlangt, wäre damit eine
+ * Ablehnung, die kein Melder auflösen kann — sein Formular ist ja vollständig.
+ *
+ * Die Unit-Tests am Formular sehen das nicht: Sie mocken `submitSightingForm`.
+ * Die E2E-Tests ebenfalls nicht: `form-from-land.spec.ts` und
+ * `form-submit.spec.ts` fangen die Route mit `page.route` ab, um die Nutzlast
+ * zu lesen. Die Naht wird deshalb hier geprüft — dort, wo die Auslassung
+ * entsteht.
+ *
+ * Geprüft wird jede Achse einzeln, damit ein Fehlschlag benennt, welche
+ * Auslassung der Server nicht verträgt.
+ */
+describe('hiddenFormFields — der Server akzeptiert, was der Client weglässt', () => {
+	/** Vollständige, in jedem Zweig gültige Meldung. */
+	const baseReport = {
+		referenceId: 'ref-vertrag',
+		entryChannel: 0,
+		firstName: 'Max',
+		lastName: 'Mustermann',
+		email: 'max@example.com',
+		species: 0,
+		totalCount: 1,
+		distance: 1,
+		shipCount: 2,
+		hasPosition: true,
+		latitude: 54.5,
+		longitude: 13.5,
+		sightingDate: '2024-01-15',
+		privacyConsent: true
+	};
+
+	async function expectServerAccepts(report: Record<string, unknown>): Promise<void> {
+		const hidden = hiddenFormFields(report as FormStepsInput);
+		const sent = Object.fromEntries(
+			Object.entries(report).filter(([key]) => !hidden.includes(key as keyof SightingFormData))
+		);
+
+		// Dieselbe Prüfung wie im Endpunkt: volles Schema, alle Fehler sammeln.
+		await expect(sightingSchema.validate(sent, { abortEarly: false })).resolves.toBeDefined();
+	}
+
+	it('Lebend-Meldung von Land — ohne Bootsangaben, `reaction` und die Totfund-Felder', async () => {
+		await expectServerAccepts({
+			...baseReport,
+			isDead: false,
+			sightingFrom: SightingFromEnum.LAND,
+			boatDrive: 1,
+			shipName: 'MS Seelöwe',
+			homePort: 'Kiel',
+			boatType: 'Segelboot',
+			shipNameConsent: true,
+			reaction: 'neugierig genähert',
+			deadCondition: 2,
+			deadSize: 150,
+			deadPhoneContact: true
+		});
+	});
+
+	it('Totfund vom Segelboot — ohne die Verhaltensfelder', async () => {
+		await expectServerAccepts({
+			...baseReport,
+			isDead: true,
+			deadCondition: 2,
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: 1,
+			behavior: 3,
+			behaviorText: 'ruhiges Schwimmen',
+			reaction: 'neugierig genähert'
+		});
+	});
+
+	it('Lebend-Meldung vom Segelboot — ohne die Totfund-Felder, Bootsangaben bleiben', async () => {
+		await expectServerAccepts({
+			...baseReport,
+			isDead: false,
+			sightingFrom: SightingFromEnum.SAILBOAT,
+			boatDrive: 1,
+			shipName: 'MS Seelöwe',
+			deadCondition: 2,
+			deadSize: 150,
+			deadPhoneContact: true
+		});
+	});
+
+	/**
+	 * Ohne Aufnahme entfällt `mediaConsent` — die einzige Achse, die weder am
+	 * Zweig noch am Beobachtungsort hängt.
+	 */
+	it('Meldung ohne Aufnahme — ohne `mediaConsent`', async () => {
+		await expectServerAccepts({
+			...baseReport,
+			isDead: false,
+			sightingFrom: SightingFromEnum.LAND,
+			mediaConsent: true
+		});
+	});
+
+	/**
+	 * Gegenprobe. Ohne sie belegten die vier Tests oben nur, dass
+	 * `sightingSchema.validate` irgendetwas durchlässt — nicht, dass es die
+	 * Auslassungen des Clients verträgt. Geprüft wird an einem Feld, das die
+	 * Auslassungsregel NIE anfasst: `privacyConsent` steht in keiner der
+	 * `HIDDEN_*`-Listen und ist unbedingt Pflicht.
+	 */
+	it('lehnt dagegen ab, wenn ein wirklich verlangtes Feld fehlt', async () => {
+		const { privacyConsent, ...ohneEinwilligung } = {
+			...baseReport,
+			isDead: false,
+			sightingFrom: SightingFromEnum.LAND
+		};
+		void privacyConsent;
+
+		await expect(
+			sightingSchema.validate(ohneEinwilligung, { abortEarly: false })
+		).rejects.toThrow();
 	});
 });

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -288,10 +288,10 @@ const HIDDEN_WHEN_DEAD = ['behavior', 'behaviorText', 'reaction'] as const;
  * ohnehin nicht mehr stehen (Begründungen dort) — ein Eintrag hier wäre
  * wirkungslos.
  *
- * **Nicht exportiert**, anders als `HIDDEN_WHEN_FROM_LAND`: Der zweite
- * Interessent, `fieldsOutsideReportKind.ts`, leitet seit dieser Änderung BEIDE
- * Zweige aus `getFormSteps` ab (Differenz der beiden Aufrufe) statt aus den
- * Listen selbst. Ein Export wäre eine zweite Quelle für dieselbe Aussage.
+ * **Nicht exportiert:** Der zweite Interessent, `fieldsOutsideReportKind.ts`,
+ * leitet seit dieser Änderung BEIDE Zweige aus `getFormSteps` ab (Differenz
+ * der beiden Aufrufe) statt aus den Listen selbst. Ein Export wäre eine
+ * zweite Quelle für dieselbe Aussage.
  */
 const HIDDEN_WHEN_ALIVE = ['deadCondition', 'deadSize', 'deadPhoneContact'] as const;
 
@@ -316,10 +316,9 @@ const HIDDEN_WHEN_ALIVE = ['deadCondition', 'deadSize', 'deadPhoneContact'] as c
  * `sections/SightingDetails.svelte` zeigt es ohnehin nur bei Segelschiff/
  * Motorboot (`isBoatSightingFrom`), eine Teilmenge von „nicht Land".
  *
- * **Exportiert**, weil `ModernReportForm.svelte` dieselbe Liste noch für eine
- * DRITTE Sache braucht (Review-Befund, Task 11, zweite Runde): Ausblenden
- * allein reicht nicht — ein ausgeblendetes Feld bleibt sonst unsichtbar, aber
- * weiter im `$form`-Zustand stehen und ginge beim Absenden mit ans Backend.
+ * Ausblenden allein reicht nicht (Review-Befund, Task 11, zweite Runde) — ein
+ * ausgeblendetes Feld bleibt sonst unsichtbar, aber weiter im `$form`-Zustand
+ * stehen und ginge beim Absenden mit ans Backend.
  *
  * Ein erster Versuch räumte dafür `$form` per `$effect` leer, sobald „Land"
  * galt — das löste GENAU DAS aus, was es verhindern sollte: `onSubmit`
@@ -331,15 +330,22 @@ const HIDDEN_WHEN_ALIVE = ['deadCondition', 'deadSize', 'deadPhoneContact'] as c
  * Bootsdaten gespeichert waren, verlor sie beim nächsten Land-Bericht.
  *
  * Der Fix sitzt deshalb NICHT im Formular-Zustand, sondern am Absende-Rand:
- * `ModernReportForm.svelte`s `onSubmit` entfernt dieselbe Liste (ohne
- * `boatDrive`, das einen eigenen, gezielteren Reset-Mechanismus hat —
- * Begründung dort) nur aus dem Objekt, das tatsächlich an den Server geht.
- * `$form` selbst bleibt unangetastet: Die persistierten Kontaktdaten werden
- * aus `values` (dem UNGEKÜRZTEN Submit-Objekt) gebaut und bleiben deshalb
- * unverändert stehen, und ein Melder, der versehentlich auf „Land" stellt und
- * zurückwechselt, findet seinen getippten Schiffsnamen noch vor.
+ * `ModernReportForm.svelte`s `onSubmit` entfernt nur aus dem Objekt, das
+ * tatsächlich an den Server geht. `$form` selbst bleibt unangetastet: Die
+ * persistierten Kontaktdaten werden aus `values` (dem UNGEKÜRZTEN
+ * Submit-Objekt) gebaut und bleiben deshalb unverändert stehen, und ein
+ * Melder, der versehentlich auf „Land" stellt und zurückwechselt, findet
+ * seinen getippten Schiffsnamen noch vor.
+ *
+ * **Nicht mehr exportiert** (2026-08-07): `ModernReportForm` führte davon
+ * lange eine eigene Fassung (`OWN_VESSEL_FIELDS`, dieselbe Liste ohne
+ * `boatDrive`) für genau diese Entfernung. Seit dort einheitlich
+ * `hiddenFormFields` entscheidet — was ausgeblendet ist, geht auch nicht raus
+ * —, gibt es keinen zweiten Interessenten mehr, und die Liste bleibt eine
+ * reine Zutat von `hiddenFormFields`. Dasselbe gilt für `HIDDEN_WHEN_ALIVE`
+ * und `HIDDEN_WHEN_DEAD` darüber.
  */
-export const HIDDEN_WHEN_FROM_LAND = [
+const HIDDEN_WHEN_FROM_LAND = [
 	'boatDrive',
 	'boatType',
 	'shipName',

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -418,15 +418,16 @@ export function hasUploadedMedia(
  * `stepValidation.ts` nie übergab, `mediaConsent` blieb dadurch validiert,
  * obwohl das Markup es längst ausblendete).
  *
- * **Dritte Stelle, wie bei `HIDDEN_WHEN_FROM_LAND`:** Ausblenden allein
- * reicht nicht — ein `mediaConsent: true`, das der Nutzer setzt und dessen
- * Aufnahme danach wieder entfernt wird, bliebe sonst im `$form`-Zustand
- * stehen und ginge beim Absenden mit ans Backend, wo `mapFormToSighting`
- * daraus einen datierten, versionierten Nachweis ohne Bezugsgegenstand
- * stempelt. Der Riegel dafür sitzt in `ModernReportForm.svelte`s `onSubmit`,
- * ebenfalls über `hasUploadedMedia` gegen dasselbe `uploadedFiles` geprüft —
- * nur eine zum Absende-Zeitpunkt tatsächlich abgeschlossene Übertragung hat
- * serverseitig ein Gegenstück, für das ein Nachweis Sinn ergäbe.
+ * **Dritte Stelle:** Ausblenden allein reicht nicht — ein `mediaConsent: true`,
+ * das der Nutzer setzt und dessen Aufnahme danach wieder entfernt wird, bliebe
+ * sonst im `$form`-Zustand stehen und ginge beim Absenden mit ans Backend, wo
+ * `mapFormToSighting` daraus einen datierten, versionierten Nachweis ohne
+ * Bezugsgegenstand stempelt. Der Riegel dafür sitzt in
+ * `ModernReportForm.svelte`s `onSubmit` — seit dem 2026-08-07 nicht mehr als
+ * eigene `hasUploadedMedia`-Abfrage, sondern über `hiddenFormFields` unten,
+ * das dieselbe Funktion auf demselben `uploadedFiles` auswertet. Nur eine zum
+ * Absende-Zeitpunkt tatsächlich abgeschlossene Übertragung hat serverseitig
+ * ein Gegenstück, für das ein Nachweis Sinn ergäbe.
  */
 export function getFormSteps(data: FormStepsInput): FormStep[] {
 	const hidden = new Set<string>(hiddenFormFields(data));


### PR DESCRIPTION
Schließt den Rest, den PR #773 offen gelassen hat — die letzte Hälfte einer Sackgasse im Meldeformular.

## Der Befund

Ein ungültiger Restwert in einem Feld, das der aktuelle Zweig ausblendet, hielt das Absenden auf — **ohne jede Rückmeldung**.

`handleFinalSubmit` prüfte seit defec8c8 zweig-bewusst und ließ durch. Danach validierte `createForm.handleSubmit` erneut, gegen das volle Schema, und scheiterte: Es fängt den `ValidationError`, schreibt ihn in `$errors` und kehrt zurück — `StepNavigation.handleFormSubmission` sieht keinen Fehler und loggt „Form submitted successfully". Kein Toast, kein Sprung, keine Markierung; das Feld ist nicht gerendert. Der Melder drückte „Absenden" und nichts geschah.

Vor #773 gab derselbe Zustand wenigstens einen Toast plus einen (falsch gezielten) Sprung. Der PR hat den Sprung korrigiert und damit die letzte Rückmeldung entfernt.

### Reproduziert vor der Änderung

Land-Meldung, `reaction` mit 1001 Zeichen:

| Beobachtung | Wert |
| --- | --- |
| Vorab-Prüfung | loggt „Pre-submit validation: all fields OK" |
| `StepNavigation` | loggt „Form submitted successfully" |
| `submitSightingForm` | **0 Aufrufe** |
| Toasts | nur „Ihre vorherigen Eingaben wurden wiederhergestellt." |
| Felder mit `aria-invalid` | keine |
| sichtbarer Schritt | unverändert „Kontaktdaten" |

Erreichbar über den **Beobachtungsort**, nicht über den Zweig: `HIDDEN_WHEN_FROM_LAND` lässt die Werte bewusst im `$form` stehen (sonst verlöre ein wiederkehrender Melder seine gespeicherten Bootsdaten), und die Feld-Pipeline setzt kein `maxlength`. Auf einer Boots-Meldung mehr als 1000 Zeichen in `reaction` tippen, dann auf „Land" stellen.

## Die Entscheidung

Die eigentliche Frage war fachlich, nicht technisch: *Was soll mit dem Restwert eines ausgeblendeten Feldes beim Absenden passieren?* Bisher war das teils gewollt, teils historisch — `boatDrive` (Land) und `behavior`/`behaviorText` (Totfund) gingen mit, `reaction`/`shipName`/`homePort`/`boatType`/`shipNameConsent`/`mediaConsent` wurden über zwei Sonderfälle entfernt.

Entschieden: **Ausgeblendet heißt: nicht Teil dieser Meldung** — für die Validierung *und* für das, was rausgeht. `hiddenFormFields(values)` entscheidet ab jetzt beides.

## Umsetzung

- **`createForm`**: `validationSchema` nimmt zusätzlich einen Resolver `(values) => Schema` an (`ValidationSchemaOption`), aufgelöst bei jedem Submit. Nötig, weil `createForm` einmal beim Mount läuft, der Beobachtungsort sich aber zur Laufzeit ändert. **Additiv** — die Admin-Maske übergibt weiterhin ein Schema-Objekt und läuft durch denselben Zweig.
- **`ModernReportForm`**: übergibt `reachableSchema` = `sightingSchema.omit(hiddenFormFields(values))` — dieselbe Funktion, mit der auch die Vorab-Prüfung arbeitet. Beide Ebenen rechnen jetzt mit derselben Regel, statt dass die eine durchlässt, was die andere aufhält.
- **Absende-Rand**: die zwei Sonderfälle (`OWN_VESSEL_FIELDS`, `MEDIA_CONSENT_FIELDS`) werden zu einem `omitFields(submitValues, hiddenFormFields(values))`. Damit geht nie etwas raus, das ungeprüft und ungecastet durch Yups `omit` gelaufen ist.
- `HIDDEN_WHEN_FROM_LAND` ist nicht mehr exportiert — der Grund für den Export ist entfallen.

### Die drei Fallen

- **Nicht reaktiv** → gelöst durch den Resolver.
- **Kontaktdaten-Regression (Task 11, zweite Runde)** → fällt weg statt umschifft: Yups `omit` entfernt den Schlüssel **nicht** aus dem Ergebnis, unbekannte Felder laufen ungecastet durch. `values` in `onSubmit` trägt deshalb weiterhin `shipName`/`homePort`/`boatType`/`shipNameConsent`, und `saveUserContactDataWithConsent` bleibt unberührt. Empirisch belegt und als Test gepinnt (`createForm.test.ts` → „lässt den Wert des ausgenommenen Feldes trotzdem an onSubmit durch") — wer dort auf `stripUnknown`/`noUnknown` umstellt, bricht es.
- **Verlorene Casts** → fällt ebenfalls weg: Was ungecastet durchkommt, wird am Absende-Rand entfernt und erreicht den Server nie.

## Änderung an der Nutzlast

`boatDrive` (Land) sowie `behavior`/`behaviorText` (Totfund) und `deadCondition`/`deadSize`/`deadPhoneContact` (lebend) gehen nicht mehr mit. An `mapFormToSighting` nachgesehen — kein Feld verliert Aussage:

| Feld | fehlt → | Default → |
| --- | --- | --- |
| `deadCondition` | 0 | 0 |
| `deadSize` | null | null |
| `deadPhoneContact` | 0 | 0 |
| `behavior` | `UNKNOWN` | `UNKNOWN` |
| `behaviorText` / `reaction` | durchgereicht | durchgereicht |
| `boatDrive` | **`NONE`** | `0` = „Sonstiger Antrieb" |

Bei `boatDrive` ist das Weglassen sogar die korrektere Angabe — „Sonstiger Antrieb" ist die Kategorie, die durch dieselbe Verwechslung schon einmal 5.858 Zeilen falsch gefüllt hat.

## Tests

Test-First, alle neuen Tests waren vor der Implementierung rot (4 an `createForm`, 4 an `ModernReportForm`).

- **`createForm.test.ts`** (+5): Resolver bekommt die aktuellen Werte; ein ausgenommenes ungültiges Feld blockiert nicht mehr; sein Wert kommt trotzdem bei `onSubmit` an; ein **verbliebenes** ungültiges Feld blockiert weiterhin; ein Schema-**Objekt** verhält sich unverändert (Admin-Maske).
- **`ModernReportForm.svelte.test.ts`** (+6): die reproduzierte Sackgasse an `reaction` und an `shipName`; Gegenprobe, dass ein **sichtbares** ungültiges Feld weiterhin aufhält; `boatDrive`, die Totfund- und die Verhaltensfelder gehen nicht mehr mit.
- **`formConfig.test.ts`** (+5): der Vertrag zum Server. Der Endpunkt validiert gegen das **volle** Schema — nichts garantierte bisher, dass er die reduzierte Nutzlast akzeptiert. Die Komponententests mocken `submitSightingForm`, die E2E-Tests fangen die Route ab; die Naht war ungedeckt. Jetzt pro Achse geprüft, mit einer Gegenprobe an `privacyConsent`, damit die Gruppe nicht trivial grün ist.
- **`e2e/form-from-land.spec.ts`**: `boatDrive` steht jetzt mit in der Nutzlast-Prüfung.

| Lauf | Ergebnis |
| --- | --- |
| `npm run test:quick` | 3606 Tests, lint 0 Fehler, type-check + svelte-check sauber |
| `npm run test:unit:client` | 552/552 |
| E2E (`form-from-land`, `form-submit`, `admin-edit-preserves-record`) | 24 passed |

## Dokumentation

`src/lib/report/README.md` — der Absatz „Known gap" ist durch die tatsächliche Regel ersetzt. `.claude/rules/forms.md` — neuer Abschnitt „Ausgeblendet heißt: nicht Teil dieser Meldung", inklusive der Warnung, die Feldlisten am Absende-Rand nicht wieder einzuführen.

## Bewusst nicht enthalten

`createForm.handleSubmit` unterscheidet weiterhin nicht zwischen „Validierung hat etwas gefunden" und „abgesendet". Dieser Fall ist damit nicht mehr erreichbar (beide Ebenen prüfen dasselbe), die strukturelle Lautlosigkeit bleibt aber bestehen, falls die Ebenen je wieder auseinanderlaufen. Das war die abgewogene Alternative und wurde bewusst zugunsten der Ursachenbehebung zurückgestellt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)