### PR TITLE
feat(admin): Totfunde optisch von Lebendsichtungen trennen

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -47,6 +47,23 @@ src/routes/admin/
 | `DataTableRow.svelte`          | Tabellen-Zeile                |
 | `BooleanStatus.svelte`         | Boolean-Status Anzeige        |
 | `ExportModal.svelte`           | Export-Dialog                 |
+| `deadFinding.ts`               | Totfund-Auszeichnung          |
+
+### Totfund vs. Lebendsichtung
+
+Wort und Icon der Totfund-Kennzeichnung kommen aus `deadFinding.ts` — für
+Tabelle, Mobilkarte und Detailansicht gemeinsam, nach dem Vorbild von
+`BALTIC_SEA_STATUS_PRESENTATION`. Die Farbklassen stehen bewusst an den
+Aufrufstellen (Begründung im Docblock des Moduls). Zwei Dinge dabei nicht
+zurückdrehen:
+
+- **Der Marker in der Tabelle steht in einer festen Spalte ganz links** und
+  gehört nicht in `availableColumns`. Als abschaltbare Spalte „Totfund
+  (Ja/Nein)" am rechten Rand war er genau dann unsichtbar, wenn viele Spalten
+  aktiv waren.
+- **Die Lebendsichtung bleibt neutral.** Kein Gegen-Badge — sie ist der
+  Normalfall, und ein zweites Badge in jeder Zeile ebnete den Kontrast wieder
+  ein, um den es geht.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,11 @@ jobs:
             # Der Aufschlag für die kalt kompilierte /admin-Route ist dabei
             # eingeplant (Begründung weiter unten bei `smoke`).
             e2e/admin-detail-actions.spec.ts
+            # Aus demselben Grund hier und nicht bei den Admin-Specs in `map`:
+            # `form` ist der kürzeste Shard, und die /admin-Route wird durch den
+            # Spec darüber ohnehin schon kalt kompiliert — der Aufschlag fällt
+            # hier also kein zweites Mal an. Lokal 13 s für zwei Tests.
+            e2e/admin-table-dead-finding.spec.ts
           )
 
           # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des

--- a/e2e/admin-table-dead-finding.spec.ts
+++ b/e2e/admin-table-dead-finding.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from '@playwright/test';
+import { config as loadEnv } from 'dotenv';
+import postgres from 'postgres';
+import { DistanceEnum } from '../src/lib/report/formOptions/distance';
+import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * admin-table-dead-finding.spec.ts — der Totfund ist in der Tabelle erkennbar,
+ * ohne dass eine Spalte dafür eingeschaltet sein muss.
+ *
+ * **Der Befund:** Die einzige Unterscheidung war eine Spalte „Totfund" mit
+ * „Ja"/„Nein". Sie war über die Spaltenauswahl abschaltbar — war sie aus, sah
+ * ein Totfund exakt aus wie eine Lebendsichtung —, und sie stand ganz rechts im
+ * horizontal scrollbaren Bereich, also bei vielen aktiven Spalten außer Sicht.
+ *
+ * **Was hier geprüft wird:** Der Marker sitzt in einer festen Spalte ganz links,
+ * die nicht in der Spaltenauswahl steht. Der Test schaltet deshalb bewusst
+ * *keine* Spalte um — er verlässt sich darauf, dass es keinen Schalter gibt, und
+ * die zweite Assertion belegt genau das.
+ *
+ * Eigene Testzeilen mit `kommentar_intern = 'e2e-seed'` und einem
+ * Sichtungsdatum in der Zukunft: Die Tabelle sortiert per Vorgabe nach
+ * `sichtungsdatum desc`, damit stehen beide Zeilen sicher auf Seite 1 — sonst
+ * hinge der Test daran, wie viele Sichtungen die Datenbank sonst noch trägt.
+ */
+
+/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
+   e2e/helpers/adminSession.ts. */
+loadEnv();
+
+const SEED_MARKER = 'e2e-seed';
+
+function connect() {
+	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
+	if (!databaseUrl) {
+		throw new Error(
+			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
+				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
+		);
+	}
+	return postgres(databaseUrl, { max: 1 });
+}
+
+async function createSighting(referenceId: string, dead: boolean): Promise<number> {
+	const sql = connect();
+	try {
+		const [row] = await sql<{ id: number }[]>`
+			INSERT INTO sichtungen (
+				sichtungsdatum, created, tierart, anzahl_gesamt,
+				vonwo, entfernung, referenz_id, totfund,
+				vorname, name, email,
+				datenschutz_einverstaendnis, kommentar_intern
+			) VALUES (
+				'2099-06-01T08:30:00.000Z', NOW(), 1, 2,
+				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${referenceId},
+				${dead ? 1 : 0},
+				'Erika', 'Mustermann', 'erika.e2e@example.invalid',
+				1, ${SEED_MARKER}
+			)
+			RETURNING id
+		`;
+		return Number(row!.id);
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+async function removeSighting(id: number): Promise<void> {
+	const sql = connect();
+	try {
+		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+test.describe('Admin-Sichtungstabelle — Totfund-Marker', () => {
+	const createdIds: number[] = [];
+
+	test.afterEach(async () => {
+		while (createdIds.length > 0) {
+			await removeSighting(createdIds.pop()!);
+		}
+	});
+
+	test('markiert den Totfund und lässt die Lebendsichtung unmarkiert', async ({
+		page,
+		context,
+		baseURL
+	}) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+		createdIds.push(await createSighting('e2e-tot', true));
+		createdIds.push(await createSighting('e2e-lebend', false));
+
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/admin');
+
+		const totfundZeile = page.getByRole('row').filter({ hasText: 'e2e-tot' });
+		const lebendZeile = page.getByRole('row').filter({ hasText: 'e2e-lebend' });
+
+		// Über den Text und nicht über eine Test-ID: Was der Marker einem
+		// Screenreader mitteilt, ist hier die eigentliche Zusage — ein rein
+		// farbiges Zeichen wäre kein Merkmal (WCAG 1.4.1).
+		//
+		// `toHaveCount` und nicht `toBeVisible`: Träger des Textes ist der
+		// `sr-only`-Span der Markerzelle. Der ist heute „sichtbar" im Sinne von
+		// Playwright, weil Tailwinds `sr-only` eine 1×1-px-Box stehen lässt — ein
+		// Implementierungsdetail, an das dieser Test sich nicht binden soll.
+		await expect(totfundZeile.getByText('Totfund')).toHaveCount(1);
+		await expect(lebendZeile.getByText('Totfund')).toHaveCount(0);
+	});
+
+	/**
+	 * Gegenprobe zur Fix-Richtung: Die alte Spalte „Totfund" war abschaltbar, und
+	 * genau daran hing der Befund. Stünde der Marker wieder in der Spaltenauswahl,
+	 * wäre er wieder ausschaltbar — dieser Test wird dann rot, auch wenn die
+	 * Assertion oben weiter grün ist.
+	 */
+	test('bietet keinen Schalter an, der die Kennzeichnung ausblenden könnte', async ({
+		page,
+		context,
+		baseURL
+	}) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await page.goto('/admin');
+
+		await expect(page.getByRole('columnheader', { name: 'Tierart' })).toBeVisible();
+		await expect(page.getByLabel('Totfund', { exact: true })).toHaveCount(0);
+	});
+});

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -31,6 +31,7 @@
 		PHOTO_ANNOUNCEMENT_TITLE
 	} from '$lib/utils/media/photoAnnouncement';
 	import Icon from '$lib/components/Icon.svelte';
+	import { DEAD_FINDING_PRESENTATION, isDeadFinding } from './deadFinding';
 	import { untrack } from 'svelte';
 
 	// Definiere die Struktur einer Datenzeile
@@ -215,27 +216,30 @@
 		].filter((row): row is DataRowType => row !== undefined)
 	);
 
-	// Totfund
+	const isDead = $derived(isDeadFinding(currentSighting.isDead));
+
+	// Totfund — die Zeilen der Karte, ohne eine eigene Zeile „Totfund: Ja".
+	// Die trüge nichts bei: Gezeigt wird die Karte ausschließlich bei einem
+	// Totfund, und ihre Überschrift sagt es bereits. Vorher stand die Zeile
+	// hier unbedingt und zog damit die ganze Karte auch über jede
+	// Lebendsichtung — mit dem Inhalt „Totfund: Nein".
 	const deadAnimalRows = $derived(
-		[
-			BooleanDataRow('Totfund', currentSighting.isDead),
-			...(currentSighting.isDead
-				? [
-						DataRow(
-							'Zustand',
-							getAnimalConditionLabel(currentSighting.deadCondition),
-							hasValue(currentSighting.deadCondition)
-						),
-						DataRow(
-							'Geschlecht',
-							getSexLabel(currentSighting.deadSex),
-							hasValue(currentSighting.deadSex)
-						),
-						DataRow('Größe', `${currentSighting.deadSize} cm`, hasValue(currentSighting.deadSize)),
-						BooleanDataRow('Telefonischer Kontakt', currentSighting.deadPhoneContact)
-					]
-				: [])
-		].filter((row): row is DataRowType => row !== undefined)
+		isDead
+			? [
+					DataRow(
+						'Zustand',
+						getAnimalConditionLabel(currentSighting.deadCondition),
+						hasValue(currentSighting.deadCondition)
+					),
+					DataRow(
+						'Geschlecht',
+						getSexLabel(currentSighting.deadSex),
+						hasValue(currentSighting.deadSex)
+					),
+					DataRow('Größe', `${currentSighting.deadSize} cm`, hasValue(currentSighting.deadSize)),
+					BooleanDataRow('Telefonischer Kontakt', currentSighting.deadPhoneContact)
+				].filter((row): row is DataRowType => row !== undefined)
+			: []
 	);
 
 	// Sichtungsdetails
@@ -447,6 +451,18 @@
 		</div>
 	</div>
 {:else}
+	{#if isDead}
+		<!-- Steht über allen Angaben und nicht zwischen den Karten: Die Art der
+		     Meldung entscheidet, wie der Datensatz gelesen wird, und muss deshalb
+		     vor dem ersten Detail feststehen. `role="note"` statt `role="alert"` —
+		     es ist eine dauerhafte Einordnung des Datensatzes, kein Ereignis, das
+		     einen Screenreader unterbrechen sollte. -->
+		<div class="alert alert-warning mb-4" role="note">
+			<Icon icon={DEAD_FINDING_PRESENTATION.icon} class="shrink-0" aria-hidden="true" />
+			<span>{DEAD_FINDING_PRESENTATION.description}</span>
+		</div>
+	{/if}
+
 	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 		<div class="space-y-4">
 			<!-- Datum & Zeit -->
@@ -488,12 +504,21 @@
 			</div>
 
 			<!-- Totfund-Details -->
-			{#if deadAnimalRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+			{#if isDead}
+				<!-- Linke Kante und Icon in der Fehlerfarbe: Alle anderen Karten
+				     tragen `text-primary` am Icon, diese hob sich damit in nichts
+				     ab. Die Kante trägt die Farbe, das Icon zusätzlich die Form —
+				     Farbe allein wäre kein Merkmal (WCAG 1.4.1). -->
+				<div class="card bg-base-200 border-error border-l-4 shadow-sm">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
-							<Icon icon="lucide:triangle-alert" width="20" class="text-primary" />
-							Totfund
+							<Icon
+								icon={DEAD_FINDING_PRESENTATION.icon}
+								width="20"
+								class="text-error"
+								aria-hidden="true"
+							/>
+							{DEAD_FINDING_PRESENTATION.label}
 						</h3>
 						<div class="overflow-x-auto">
 							<table class="table-zebra table-sm table w-full">

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import AdminSightingView from './AdminSightingView.svelte';
+import { DEAD_FINDING_PRESENTATION } from './deadFinding';
 import type { FrontendSighting } from '$lib/types';
 import {
 	PHOTO_ANNOUNCEMENT_LABEL,
@@ -54,8 +55,8 @@ describe('AdminSightingView — Foto-Ankündigung', () => {
 			sighting: baseSighting({ mediaUpload: 0, uploadedFiles: [] })
 		});
 
-		// Mehrere Zeilen zeigen „Nein" (Totfund, Namensnennung, …) — deshalb
-		// gezielt die Upload-Zeile über ihre Beschriftung greifen.
+		// Mehrere Zeilen zeigen „Nein" (Namensnennung, Schiffsnennung, …) —
+		// deshalb gezielt die Upload-Zeile über ihre Beschriftung greifen.
 		await expect.element(page.getByRole('row', { name: 'Upload Nein' })).toBeVisible();
 		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
 	});
@@ -95,5 +96,50 @@ describe('AdminSightingView — Foto-Ankündigung', () => {
 
 		await expect.element(page.getByRole('row', { name: 'Upload Ja' })).toBeVisible();
 		expect(document.body.textContent).not.toContain(PHOTO_ANNOUNCEMENT_LABEL);
+	});
+});
+
+/**
+ * Totfund vs. Lebendsichtung.
+ *
+ * **Der Befund:** Die Karte „Totfund" wurde bei *jeder* Sichtung gerendert —
+ * `deadAnimalRows` enthielt immer mindestens die Zeile „Totfund: Nein". Eine
+ * Lebendsichtung behauptete damit optisch einen Totfund-Abschnitt, und beim
+ * Überfliegen sahen beide Arten gleich aus.
+ */
+describe('AdminSightingView — Totfund-Auszeichnung', () => {
+	it('zeichnet einen Totfund über allen Angaben aus und zeigt die Totfund-Karte', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({ isDead: 1, deadCondition: 1, deadSize: 142 })
+		});
+
+		await expect.element(page.getByText(DEAD_FINDING_PRESENTATION.description)).toBeVisible();
+		await expect.element(page.getByRole('heading', { name: 'Totfund' })).toBeVisible();
+		await expect.element(page.getByRole('row', { name: 'Größe 142 cm' })).toBeVisible();
+	});
+
+	// Die Überschrift der Karte sagt es bereits — die Zeile darunter wiederholte
+	// sie nur und kostete eine Zeile in einer ohnehin dichten Ansicht.
+	it('wiederholt „Totfund" nicht als eigene Ja-Zeile in der Karte', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({ isDead: 1, deadCondition: 1 })
+		});
+
+		await expect.element(page.getByRole('heading', { name: 'Totfund' })).toBeVisible();
+		expect(page.getByRole('row', { name: 'Totfund Ja' }).elements()).toHaveLength(0);
+	});
+
+	it('zeigt bei einer Lebendsichtung weder Kennzeichen noch Totfund-Karte', async () => {
+		render(AdminSightingView, {
+			sighting: baseSighting({ isDead: 0 })
+		});
+
+		// Erst auf etwas warten, das sicher gerendert ist — sonst prüfte die
+		// Abwesenheit unter Umständen einen noch leeren Baum und wäre grün,
+		// ohne etwas zu belegen.
+		await expect.element(page.getByRole('heading', { name: 'Tierinformationen' })).toBeVisible();
+		expect(document.body.textContent).not.toContain(DEAD_FINDING_PRESENTATION.description);
+		expect(page.getByRole('heading', { name: 'Totfund' }).elements()).toHaveLength(0);
+		expect(page.getByRole('row', { name: 'Totfund Nein' }).elements()).toHaveLength(0);
 	});
 });

--- a/src/lib/components/admin/deadFinding.ts
+++ b/src/lib/components/admin/deadFinding.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Auszeichnung eines Totfunds im Admin-Bereich.
+ *
+ * Eine Quelle für Wort und Icon der drei Anzeigestellen — Sichtungstabelle,
+ * Mobilkarte und Detailansicht —, nach dem Vorbild von
+ * `BALTIC_SEA_STATUS_PRESENTATION` (`$lib/utils/geo/balticSeaStatus.ts`). Ohne
+ * sie liefen Beschriftung und Icon an drei Stellen auseinander, sobald eine
+ * davon angefasst wird.
+ *
+ * Wort und Icon sind bewusst identisch zur Einstiegsseite des Meldeformulars
+ * (`OPTIONS` in `$lib/report/components/ReportKindChoice.svelte`): Melder und
+ * Admin sollen dieselbe Sache gleich benennen.
+ *
+ * **Nur der Totfund wird ausgezeichnet.** Für die Lebendsichtung gibt es hier
+ * bewusst kein Gegenstück — sie ist der Normalfall und bleibt neutral. Ein
+ * zweites Badge in jeder Zeile hätte den Kontrast wieder eingeebnet, um den es
+ * hier geht.
+ *
+ * **Was hier bewusst NICHT steht: die Farben der übrigen Anzeigestellen.**
+ * `text-error` am Tabellen-Marker, `border-error` an dessen Zelle und an der
+ * Detailkarte sowie das `alert-warning` des Einordnungsbanners stehen an ihrer
+ * jeweiligen Aufrufstelle. Jede dieser Klassen hat genau eine Verwendung; sie
+ * hier zu spiegeln, ergäbe vier Konstanten mit je einem Leser — Indirektion
+ * ohne den Nutzen, den `label` und `icon` haben (die stehen an drei bzw. vier
+ * Stellen). Dass das Banner `warning` trägt und die Auszeichnungen `error`,
+ * ist ebenfalls Absicht: Das Banner ordnet den Datensatz ein, die
+ * Auszeichnungen heben ihn hervor.
+ */
+export const DEAD_FINDING_PRESENTATION = {
+	label: 'Totfund',
+	icon: 'lucide:triangle-alert',
+	/** Flächenfarbe — deshalb ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
+	badgeClass: 'badge-error',
+	/**
+	 * Der Satz, der in der Detailansicht über allen Angaben steht. Er
+	 * wiederholt nicht nur das Wort „Totfund", sondern sagt, was es bedeutet —
+	 * dieselbe Formulierung wie in der Einstiegsseite des Meldeformulars.
+	 */
+	description: 'Totfund — Fund eines toten Tieres'
+} as const;
+
+/**
+ * Ob eine Sichtung ein Totfund ist.
+ *
+ * `isDead` kommt als `0`/`1` aus der Datenbank (Spalte `totfund`); die
+ * Umwandlung in einen Wahrheitswert gehört deshalb an eine Stelle und nicht in
+ * jede Aufrufstelle.
+ */
+export function isDeadFinding(isDead: number | boolean | null | undefined): boolean {
+	return Boolean(isDead);
+}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
 	import ExportModal from '$lib/components/admin/ExportModal.svelte';
+	import { DEAD_FINDING_PRESENTATION, isDeadFinding } from '$lib/components/admin/deadFinding';
 	import {
 		deleteSighting,
 		sendTestEmail,
@@ -63,7 +64,6 @@
 		wind: false,
 		visibility: false,
 		mediaUpload: true,
-		isDead: true,
 		balticSea: true,
 		verified: true,
 		actions: true
@@ -84,8 +84,11 @@
 		{ key: 'seaState', label: 'Seegang', sortKey: 'seaState' },
 		{ key: 'wind', label: 'Wind', sortKey: 'wind' },
 		{ key: 'visibility', label: 'Sichtweite', sortKey: 'visibility' },
+		// Kein Eintrag für den Totfund: Seine Kennzeichnung steht in einer festen
+		// Spalte ganz links und ist bewusst nicht abschaltbar — als „Totfund
+		// (Ja/Nein)"-Spalte am rechten Rand war sie genau dann weg, wenn man
+		// viele Spalten eingeschaltet hatte und am wenigsten hinsah.
 		{ key: 'mediaUpload', label: 'Aufnahme', sortKey: null },
-		{ key: 'isDead', label: 'Totfund', sortKey: null },
 		{ key: 'balticSea', label: 'Ostsee', sortKey: null },
 		{ key: 'verified', label: 'Geprüft', sortKey: null },
 		{ key: 'actions', label: 'Aktionen', sortKey: null }
@@ -617,16 +620,35 @@
 			<div class="bg-base-100 border-base-300 rounded-lg border p-4 shadow-sm">
 				<div class="mb-3 flex items-start justify-between">
 					<div class="flex-1">
-						{#if sighting.referenceId}
-							<a
-								href="/admin/ref/{sighting.referenceId}"
-								class="link link-primary link-hover font-mono text-sm"
-							>
-								{sighting.referenceId}
-							</a>
-						{:else}
-							<span class="text-base-content/70 text-sm">Keine Referenz</span>
-						{/if}
+						<!-- Referenz und Kennzeichen als eigene Flex-Zeile: Nebeneinander,
+						     solange der Platz reicht, und darunter, wenn nicht — ein
+						     Inline-Badge mit `ml-2` stand nach dem Umbruch eingerückt da. -->
+						<div class="flex flex-wrap items-center gap-2">
+							{#if sighting.referenceId}
+								<a
+									href="/admin/ref/{sighting.referenceId}"
+									class="link link-primary link-hover font-mono text-sm"
+								>
+									{sighting.referenceId}
+								</a>
+							{:else}
+								<span class="text-base-content/70 text-sm">Keine Referenz</span>
+							{/if}
+							<!-- In der Kopfzeile und nicht unten in der Badge-Reihe: Dort stand
+							     der Totfund gleichrangig neben „Mit Aufnahme" und dem
+							     Ostsee-Status und ging zwischen ihnen unter. Die Art der Meldung
+							     ist keine Eigenschaft unter anderen. -->
+							{#if isDeadFinding(sighting.isDead)}
+								<span class="badge badge-sm {DEAD_FINDING_PRESENTATION.badgeClass} gap-1">
+									<Icon
+										icon={DEAD_FINDING_PRESENTATION.icon}
+										class="h-3.5 w-3.5"
+										aria-hidden="true"
+									/>
+									{DEAD_FINDING_PRESENTATION.label}
+								</span>
+							{/if}
+						</div>
 						<h3 class="mt-1 text-base font-semibold">{getSpeciesLabel(sighting.species)}</h3>
 					</div>
 					<div class="ml-2 flex gap-1">
@@ -694,10 +716,7 @@
 					{#if sighting.mediaUpload}
 						<span class="badge badge-success badge-sm">Mit Aufnahme</span>
 					{/if}
-					{#if sighting.isDead}
-						<span class="badge badge-error badge-sm">Totfund</span>
-					{/if}
-					<!-- Anders als Aufnahme/Totfund immer sichtbar: „außerhalb" und „ohne
+					<!-- Anders als die Aufnahme immer sichtbar: „außerhalb" und „ohne
 					     Position" sind für die Triage genauso relevant wie „Ostsee", ein
 					     fehlendes Badge wäre hier also keine Aussage. -->
 					<span
@@ -749,6 +768,10 @@
 			<table class="table-zebra table w-full">
 				<thead class="bg-base-200 text-base-content">
 					<tr>
+						<!-- Feste Markerspalte, nicht in der Spaltenauswahl: Sie steht vor
+						     allen konfigurierbaren Spalten und überlebt damit sowohl jede
+						     Spaltenwahl als auch das horizontale Scrollen der Tabelle. -->
+						<th class="w-px p-0"><span class="sr-only">Art der Meldung</span></th>
 						{#if columnVisibility.referenceId}
 							<th class="hover:bg-base-300">Referenz-ID</th>
 						{/if}
@@ -791,9 +814,6 @@
 						{#if columnVisibility.mediaUpload}
 							<th class="hover:bg-base-300">Aufnahme</th>
 						{/if}
-						{#if columnVisibility.isDead}
-							<th class="hover:bg-base-300">Totfund</th>
-						{/if}
 						{#if columnVisibility.balticSea}
 							<th class="hover:bg-base-300">Ostsee</th>
 						{/if}
@@ -808,6 +828,27 @@
 				<tbody>
 					{#each sightings as sighting (sighting.id)}
 						<tr class="hover:bg-base-200">
+							<!-- Kante und Icon zusammen: Die Kante wirkt beim Überfliegen, das
+							     Icon trägt zusätzlich eine Form — Farbe allein wäre kein
+							     Merkmal (WCAG 1.4.1). Der `sr-only`-Text benennt beides, sonst
+							     bliebe die Zelle für Screenreader leer.
+							     Die Kante steht an der Zelle und nicht am `<tr>`: unter
+							     `border-collapse` entscheidet dort sonst die Konfliktauflösung
+							     der Nachbarkanten, ob sie überhaupt gezeichnet wird. -->
+							<td
+								class="w-px p-0 {isDeadFinding(sighting.isDead) ? 'border-error border-l-4' : ''}"
+							>
+								{#if isDeadFinding(sighting.isDead)}
+									<span class="flex items-center justify-center px-2">
+										<Icon
+											icon={DEAD_FINDING_PRESENTATION.icon}
+											class="text-error h-4 w-4"
+											aria-hidden="true"
+										/>
+										<span class="sr-only">{DEAD_FINDING_PRESENTATION.label}</span>
+									</span>
+								{/if}
+							</td>
 							{#if columnVisibility.referenceId}
 								<td>
 									{#if sighting.referenceId}
@@ -873,15 +914,6 @@
 								<td class="text-center">
 									{#if sighting.mediaUpload}
 										<span class="badge badge-success badge-sm">Ja</span>
-									{:else}
-										<span class="badge badge-ghost badge-sm">Nein</span>
-									{/if}
-								</td>
-							{/if}
-							{#if columnVisibility.isDead}
-								<td class="text-center">
-									{#if sighting.isDead}
-										<span class="badge badge-error badge-sm">Ja</span>
 									{:else}
 										<span class="badge badge-ghost badge-sm">Nein</span>
 									{/if}


### PR DESCRIPTION
## Warum

Im Admin-Bereich waren Totfund und Lebendsichtung schlecht auseinanderzuhalten — und zwar in beiden Ansichten aus je einem eigenen Grund:

- **Tabelle:** Die einzige Unterscheidung war die Spalte „Totfund" mit `badge-error` „Ja" / `badge-ghost` „Nein". Sie war über `columnVisibility` abschaltbar — war sie aus, sah ein Totfund exakt aus wie eine Lebendsichtung — und stand ganz rechts im horizontal scrollbaren Bereich, also bei vielen aktiven Spalten außer Sicht.
- **Einzelansicht:** `deadAnimalRows` enthielt **immer** mindestens die Boolean-Zeile. Die Karte „Totfund" wurde damit bei *jeder* Sichtung gerendert, bei Lebendsichtungen mit dem Inhalt „Totfund: Nein". Jeder Datensatz sah auf den ersten Blick nach Totfund aus.

Ausgezeichnet wird nur der Totfund; die Lebendsichtung ist der Normalfall und bleibt neutral. Ein Gegen-Badge in jeder Zeile hätte den Kontrast wieder eingeebnet, um den es geht.

## Was sich ändert

| Ansicht | Vorher | Nachher |
| --- | --- | --- |
| Tabelle | abschaltbare Spalte „Totfund" (Ja/Nein), rechts außen | feste Markerspalte ganz links: `border-error`-Kante + Warndreieck + `sr-only`-Text; die alte Spalte entfällt samt `columnVisibility`-Eintrag |
| Mobilkarte | `badge-error` „Totfund" gleichrangig zwischen „Mit Aufnahme" und Ostsee-Status | Kennzeichen in der Kopfzeile neben der Referenz-ID |
| Einzelansicht | „Totfund"-Karte bei jeder Sichtung, Icon in `text-primary` | Einordnung über allen Karten (`alert alert-warning`, `role="note"`), Karte nur noch beim Totfund, Zeile „Totfund: Ja" gestrichen, Icon `text-error` + linke Kante |

Wort und Icon kommen aus dem neuen `deadFinding.ts` und sind identisch zur Einstiegsseite des Meldeformulars (`ReportKindChoice.svelte`) — Melder und Admin benennen dieselbe Sache gleich. Die Farbklassen stehen bewusst an den Aufrufstellen (je genau ein Leser); begründet im Docblock.

## Barrierefreiheit

Kante **und** Icon zusammen, dazu der `sr-only`-Text: Farbe ist nirgends das einzige Merkmal (WCAG 1.4.1). `text-error`/`border-error` sitzen auf `base-100`/`base-200` (6,04:1), dekorative Icons durchgehend `aria-hidden`.

## Tests

- `AdminSightingView.svelte.test.ts` — drei neue Fälle: Totfund zeigt Kennzeichen und Karte, „Totfund" wird nicht als Ja-Zeile wiederholt, Lebendsichtung zeigt weder das eine noch das andere (mit vorgeschaltetem Positiv-Anker, damit die Abwesenheits-Assertion nicht am leeren Baum grün wird).
- `e2e/admin-table-dead-finding.spec.ts` *(neu)* — markierte vs. unmarkierte Zeile, plus eine Gegenprobe, dass es keinen Schalter gibt, der die Kennzeichnung wieder ausblenden könnte. Dem Shard `form` zugeordnet (kürzester Shard, `/admin` wird dort durch `admin-detail-actions.spec.ts` ohnehin schon kalt kompiliert).

Grün: `test:quick` 3596 · Client-Suite 549 · Playwright `admin-table-dead-finding`, `design-tokens`, `admin-table-verified-column`.

Visuell geprüft per Playwright-Screenshot in allen vier Zuständen (Tabelle, Mobilkarte, Detailansicht Totfund und Lebendsichtung).

🤖 Generated with [Claude Code](https://claude.com/claude-code)