### PR TITLE
fix(admin): let multi-line badge values grow instead of overflowing the pill

### DIFF
--- a/src/lib/components/admin/DataTableRow.svelte
+++ b/src/lib/components/admin/DataTableRow.svelte
@@ -35,7 +35,11 @@
 		{#if isBoolean}
 			<BooleanStatus value={booleanValue} />
 		{:else if badgeClass}
-			<span class="badge {badgeClass}" {title}>{value}</span>
+			<!-- h-auto/min-h-6/py-1: DaisyUI gibt .badge eine feste Höhe (height: var(--size)).
+			     Bricht ein langer Wert in der schmalen Spalte um, läuft der Text sonst über
+			     die Pille hinaus. min-h-6 entspricht dem --size-Default, einzeilige Badges
+			     sehen also unverändert aus. -->
+			<span class="badge {badgeClass} h-auto min-h-6 py-1" {title}>{value}</span>
 		{:else}
 			{value}
 		{/if}


### PR DESCRIPTION
## Problem

In der Admin-Detailansicht lief der Badge-Text „Foto angekündigt, folgt per E-Mail" über die Pille hinaus: DaisyUI gibt `.badge` eine feste Höhe (`height: var(--size)` = 24px). Bricht ein langer Wert in der schmalen Wertespalte um, bleibt die Pille 24px hoch und die zweite Zeile läuft unten heraus.

## Fix

`DataTableRow.svelte`: Das Badge bekommt zusätzlich `h-auto min-h-6 py-1` — die Pille wächst bei mehrzeiligem Text mit. `min-h-6` (24px) entspricht exakt dem DaisyUI-Default, einzeilige Badges (z. B. der Ostsee-Status) rendern unverändert.

## Verifikation

Playwright gegen den Worktree-Dev-Server, Badge in 260px-Spalte:

| | clientHeight | scrollHeight | Überlauf |
|---|---|---|---|
| vorher | 22px | 33px | ❌ ja |
| nachher | 51px | 51px | ✅ nein |

Kein Test: reine CSS-Styling-Änderung (Ausnahme laut `testing.md`, im Commit dokumentiert). Prettier/ESLint/type-check sauber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)