### PR TITLE
feat(admin): add dead-finding filter to the sightings table

### DIFF
--- a/.claude/rules/export.md
+++ b/.claude/rules/export.md
@@ -26,12 +26,16 @@ Regeln für CSV, JSON, KML und XML Export.
 
 **Auth:** Alle Endpoints erfordern `requireUserRole(url, locals.user, ['admin'])`
 
-**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`, `balticSea`
+**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`, `balticSea`, `deadFinding`
 
 `balticSea` nimmt einen der vier Werte aus `BalticSeaStatus` (`baltic`, `edge`,
 `outside`, `noPosition`) und übersetzt ihn über `$lib/server/db/balticSeaFilter`
 — dieselbe Fallunterscheidung, die die Admin-Liste anzeigt. Die Flag-Logik nicht
 hier nachbauen, sondern von dort importieren.
+
+`deadFinding` (`1`=Totfund, `0`=Lebendsichtung) läuft über
+`$lib/server/db/deadFindingFilter` — Totfund heißt dort `totfund <> 0`, dieselbe
+Boolean-Semantik wie das Badge (`isDeadFinding()`).
 
 ---
 

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -10,6 +10,7 @@
 		BALTIC_SEA_STATUS_PRESENTATION,
 		isBalticSeaStatus
 	} from '$lib/utils/geo/balticSeaStatus';
+	import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('ExportModal');
@@ -102,6 +103,13 @@
 			// Filter-Panel und Export-Zusammenfassung nie auseinanderlaufen.
 			const presentation = BALTIC_SEA_STATUS_PRESENTATION[currentFilters.balticSea];
 			filterDisplays.push(`Ostsee-Status: ${presentation.label}`);
+		}
+		if (currentFilters.deadFinding === '1') {
+			// Label aus DEAD_FINDING_PRESENTATION statt neu formuliert, damit
+			// Filter-Panel und Export-Zusammenfassung nie auseinanderlaufen.
+			filterDisplays.push(`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`);
+		} else if (currentFilters.deadFinding === '0') {
+			filterDisplays.push('Meldeart: Lebendsichtung');
 		}
 
 		return filterDisplays.length > 0 ? filterDisplays : ['Keine Filter aktiv'];

--- a/src/lib/server/db/deadFindingFilter.test.ts
+++ b/src/lib/server/db/deadFindingFilter.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Der Meldeart-Filter muss dieselbe Aussage treffen wie die Anzeige: Ein
+ * Totfund ist überall, wo `isDeadFinding()` (Boolean(isDead)) wahr ist — also
+ * `totfund <> 0`, nicht `totfund = 1`. Ein Altbestand mit einem anderen
+ * Nicht-Null-Wert würde sonst zwar das Badge tragen, aber aus dem Filter fallen.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQLWrapper } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { deadFindingCondition, DEAD_FINDING_FILTER_DEAD } from './deadFindingFilter';
+
+const dialect = new PgDialect();
+const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
+
+describe('deadFindingCondition', () => {
+	it('filtert Totfunde über totfund <> 0 (Boolean-Semantik wie isDeadFinding)', () => {
+		const condition = deadFindingCondition(DEAD_FINDING_FILTER_DEAD);
+
+		expect(condition).toBeDefined();
+		const sqlText = toSqlText(condition as unknown as SQLWrapper);
+		expect(sqlText).toContain('totfund');
+		expect(sqlText).toContain('<>');
+	});
+
+	it('filtert Lebendsichtungen über totfund = 0', () => {
+		const condition = deadFindingCondition('0');
+
+		expect(condition).toBeDefined();
+		const sqlText = toSqlText(condition as unknown as SQLWrapper);
+		expect(sqlText).toContain('totfund');
+		expect(sqlText).toContain('=');
+		expect(sqlText).not.toContain('<>');
+	});
+
+	it('löst für fehlende oder unbekannte Werte keinen Filter aus', () => {
+		expect(deadFindingCondition(null)).toBeUndefined();
+		expect(deadFindingCondition(undefined)).toBeUndefined();
+		expect(deadFindingCondition('')).toBeUndefined();
+		expect(deadFindingCondition('quatsch')).toBeUndefined();
+	});
+});

--- a/src/lib/server/db/deadFindingFilter.ts
+++ b/src/lib/server/db/deadFindingFilter.ts
@@ -1,0 +1,35 @@
+/**
+ * Gemeinsames Meldeart-Filterprädikat (Totfund/Lebendsichtung) für die
+ * Admin-Übersicht (`routes/admin/+page.server.ts`) und den Export
+ * (`routes/api/sightings/export/exportFilterParams.ts`) — dieselbe Trennung
+ * wie `mediaUploadFilter.ts`: reine, DB-lose Funktion, die ein Drizzle-Prädikat
+ * baut und es dem Aufrufer für dessen `and(...)`-Liste überlässt.
+ *
+ * Totfund heißt `totfund <> 0`, nicht `= 1` — dieselbe Boolean-Semantik wie
+ * `isDeadFinding()` in `$lib/components/admin/deadFinding.ts`, die das Badge
+ * setzt. Ein Altbestandswert wie die `2` in `ostsee_geo` (docs/OSTSEE_FLAGS.md)
+ * würde sonst das Badge tragen, aber aus dem Filter fallen.
+ */
+import { eq, ne, type SQL } from 'drizzle-orm';
+import { sightings } from '$lib/server/db/schema';
+
+/** Query-Parameter-Wert für „nur Totfunde". */
+export const DEAD_FINDING_FILTER_DEAD = '1';
+/** Query-Parameter-Wert für „nur Lebendsichtungen". */
+export const DEAD_FINDING_FILTER_ALIVE = '0';
+
+/**
+ * @param deadFinding Der rohe Query-Parameter (`'1'`, `'0'` oder alles
+ *   andere/fehlend für „kein Filter").
+ * @returns Ein Prädikat für `and(...)`, oder `undefined`, wenn der Wert keinen
+ *   Filter auslöst.
+ */
+export function deadFindingCondition(deadFinding: string | null | undefined): SQL | undefined {
+	if (deadFinding === DEAD_FINDING_FILTER_DEAD) {
+		return ne(sightings.isDead, 0);
+	}
+	if (deadFinding === DEAD_FINDING_FILTER_ALIVE) {
+		return eq(sightings.isDead, 0);
+	}
+	return undefined;
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	mediaUploadCondition
 } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
+import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { and, asc, desc, eq, sql } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
@@ -29,6 +30,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const entryChannel = url.searchParams.get('entryChannel');
 	const mediaUpload = url.searchParams.get('mediaUpload');
 	const balticSea = url.searchParams.get('balticSea');
+	const deadFinding = url.searchParams.get('deadFinding');
 
 	// Bedingungen für die SQL-Abfrage sammeln
 	const conditions = [];
@@ -71,6 +73,13 @@ export const load: PageServerLoad = async ({ url }) => {
 	const balticSeaFilterCondition = balticSeaCondition(balticSea);
 	if (balticSeaFilterCondition) {
 		conditions.push(balticSeaFilterCondition);
+	}
+
+	// Meldeart-Filter (Totfund/Lebendsichtung) — dieselbe Boolean-Semantik wie
+	// das Badge in der Tabelle, siehe deadFindingFilter.ts.
+	const deadFindingFilterCondition = deadFindingCondition(deadFinding);
+	if (deadFindingFilterCondition) {
+		conditions.push(deadFindingFilterCondition);
 	}
 
 	// Kombinierte WHERE-Bedingung erstellen

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -42,6 +42,7 @@
 	let selectedChannel = $state(page.url.searchParams.get('entryChannel') || 'all');
 	let mediaUpload = $state(page.url.searchParams.get('mediaUpload') || '');
 	let balticSea = $state(page.url.searchParams.get('balticSea') || '');
+	let deadFinding = $state(page.url.searchParams.get('deadFinding') || '');
 	let showDeleteDialog = $state(false);
 	let sightingToDelete = $state<FrontendSighting | null>(null);
 	let isFilterPanelOpen = $state(false);
@@ -102,7 +103,8 @@
 			verified ||
 			(selectedChannel && selectedChannel !== 'all') ||
 			mediaUpload ||
-			balticSea
+			balticSea ||
+			deadFinding
 		)
 	);
 
@@ -113,7 +115,8 @@
 		verified: verified || '',
 		entryChannel: selectedChannel !== 'all' ? selectedChannel : '',
 		mediaUpload: mediaUpload || '',
-		balticSea: balticSea || ''
+		balticSea: balticSea || '',
+		deadFinding: deadFinding || ''
 	}));
 
 	function updateSort(column: string): void {
@@ -157,6 +160,10 @@
 		if (balticSea) url.searchParams.set('balticSea', balticSea);
 		else url.searchParams.delete('balticSea');
 
+		// Meldeart-Filter (Totfund/Lebendsichtung)
+		if (deadFinding) url.searchParams.set('deadFinding', deadFinding);
+		else url.searchParams.delete('deadFinding');
+
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -180,6 +187,7 @@
 		selectedChannel = 'all';
 		mediaUpload = '';
 		balticSea = '';
+		deadFinding = '';
 
 		const url = new URL(page.url);
 		url.searchParams.delete('fromDate');
@@ -188,6 +196,7 @@
 		url.searchParams.delete('entryChannel');
 		url.searchParams.delete('mediaUpload');
 		url.searchParams.delete('balticSea');
+		url.searchParams.delete('deadFinding');
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -554,6 +563,21 @@
 						<option value="">Alle</option>
 						<option value="1">Geprüft</option>
 						<option value="0">Ungeprüft</option>
+					</select>
+				</div>
+				<div class="fieldset w-full">
+					<label for="deadFinding" class="label py-0">
+						<span class="text-xs">Meldeart</span>
+					</label>
+					<select
+						id="deadFinding"
+						name="deadFinding"
+						class="select select-sm w-full text-sm"
+						bind:value={deadFinding}
+					>
+						<option value="">Alle</option>
+						<option value="1">{DEAD_FINDING_PRESENTATION.label}</option>
+						<option value="0">Lebendsichtung</option>
 					</select>
 				</div>
 				<div class="fieldset w-full">

--- a/src/routes/admin/page.server.test.ts
+++ b/src/routes/admin/page.server.test.ts
@@ -24,6 +24,7 @@ import {
 	mediaUploadCondition
 } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
+import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
@@ -138,6 +139,29 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 			expect(recordedSelects[1]?.whereSql).toBe(expected);
 		}
 	);
+
+	// Wie beim Ostsee-Status: Die Bedingung selbst ist in `deadFindingFilter.test.ts`
+	// abgesichert, hier zählt nur die Verdrahtung von `?deadFinding=…` in die WHERE-Klausel.
+	it.each(['1', '0'] as const)(
+		'?deadFinding=%s filtert die Hauptliste mit derselben Bedingung',
+		async (value) => {
+			await load({
+				url: makeUrl({ deadFinding: value })
+			} as unknown as Parameters<typeof load>[0]);
+
+			const expected = toSqlText(deadFindingCondition(value) as unknown as SQLWrapper);
+			expect(recordedSelects[0]?.whereSql).toBe(expected);
+			expect(recordedSelects[1]?.whereSql).toBe(expected);
+		}
+	);
+
+	it('ein unbekannter deadFinding-Wert filtert die Hauptliste gar nicht', async () => {
+		await load({
+			url: makeUrl({ deadFinding: 'quatsch' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(recordedSelects[0]?.whereSql).toBeUndefined();
+	});
 
 	it('ein unbekannter balticSea-Wert filtert die Hauptliste gar nicht', async () => {
 		await load({

--- a/src/routes/api/sightings/export/exportFilterParams.test.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.test.ts
@@ -13,6 +13,7 @@ vi.mock('drizzle-orm', () => ({
 	lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
 	lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
 	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+	ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
 	isNull: vi.fn((column) => ({ op: 'isNull', column })),
 	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column }))
 }));
@@ -23,6 +24,7 @@ vi.mock('$lib/server/db/schema', () => ({
 		verified: 'verified',
 		entryChannel: 'entryChannel',
 		mediaUpload: 'mediaUpload',
+		isDead: 'isDead',
 		inBalticSea: 'inBalticSea',
 		inBalticSeaGeo: 'inBalticSeaGeo',
 		latitude: 'latitude',
@@ -41,6 +43,7 @@ function dateRange(fromDate: string, toDate: string): { start: Date; endExclusiv
 		verified: null,
 		entryChannel: null,
 		mediaUpload: null,
+		deadFinding: null,
 		balticSea: null
 	}) as unknown as Condition[];
 
@@ -67,6 +70,7 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			verified: null,
 			entryChannel: null,
 			mediaUpload: null,
+			deadFinding: null,
 			balticSea: null
 		});
 
@@ -127,6 +131,7 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			verified: null,
 			entryChannel: null,
 			mediaUpload: null,
+			deadFinding: null,
 			balticSea: null
 		}) as unknown as Condition[];
 
@@ -147,7 +152,8 @@ describe('Export-Filter — Ostsee-Status', () => {
 		toDate: '',
 		verified: null,
 		entryChannel: null,
-		mediaUpload: null
+		mediaUpload: null,
+		deadFinding: null
 	};
 
 	it('parseExportFilterParams liest balticSea aus der URL', () => {
@@ -188,6 +194,56 @@ describe('Export-Filter — Ostsee-Status', () => {
 			...noFilters,
 			verified: '1',
 			balticSea: 'baltic'
+		});
+
+		expect(conditions).toHaveLength(2);
+	});
+});
+
+/**
+ * Wie beim Ostsee-Status: Die Bedingung selbst ist in
+ * `$lib/server/db/deadFindingFilter.test.ts` abgesichert, hier zählt nur die
+ * Verdrahtung — sonst zeigte die Admin-Liste gefiltert Totfunde, der Export
+ * lieferte aber still alles.
+ */
+describe('Export-Filter — Meldeart (Totfund)', () => {
+	const noFilters = {
+		fromDate: '',
+		toDate: '',
+		verified: null,
+		entryChannel: null,
+		mediaUpload: null,
+		balticSea: null
+	};
+
+	it('parseExportFilterParams liest deadFinding aus der URL', () => {
+		const result = parseExportFilterParams(
+			new URL('https://example.com/api/sightings/export?format=json&deadFinding=1')
+		);
+
+		expect(result).toHaveProperty('params');
+		expect((result as { params: { deadFinding: string | null } }).params.deadFinding).toBe('1');
+	});
+
+	it.each(['1', '0'])(
+		'buildExportConditions hängt für deadFinding=%s eine Bedingung an',
+		(value) => {
+			const conditions = buildExportConditions({ ...noFilters, deadFinding: value });
+
+			expect(conditions).toHaveLength(1);
+		}
+	);
+
+	it('hängt ohne Meldeart-Filter keine Bedingung an', () => {
+		expect(buildExportConditions({ ...noFilters, deadFinding: null })).toHaveLength(0);
+		expect(buildExportConditions({ ...noFilters, deadFinding: 'quatsch' })).toHaveLength(0);
+	});
+
+	it('kombiniert den Meldeart-Filter mit anderen Filtern, statt sie zu ersetzen', () => {
+		const conditions = buildExportConditions({
+			...noFilters,
+			verified: '1',
+			deadFinding: '1'
 		});
 
 		expect(conditions).toHaveLength(2);

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -4,6 +4,7 @@ import { berlinDayRangeUtc } from '$lib/server/datetime/berlinDayRange';
 import { sightings as sightingsTable } from '$lib/server/db/schema';
 import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
+import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 
 export function xmlEscape(str: string | null | undefined): string {
 	if (!str) return '';
@@ -21,6 +22,7 @@ export type ExportFilterParams = {
 	verified: string | null;
 	entryChannel: string | null;
 	mediaUpload: string | null;
+	deadFinding: string | null;
 	balticSea: string | null;
 };
 
@@ -33,6 +35,7 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 	const verified = url.searchParams.get('verified');
 	const entryChannel = url.searchParams.get('entryChannel');
 	const mediaUpload = url.searchParams.get('mediaUpload');
+	const deadFinding = url.searchParams.get('deadFinding');
 	const balticSea = url.searchParams.get('balticSea');
 
 	if (fromDate && !isValidDateParam(fromDate)) {
@@ -46,11 +49,13 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 		};
 	}
 
-	return { params: { fromDate, toDate, verified, entryChannel, mediaUpload, balticSea } };
+	return {
+		params: { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea }
+	};
 }
 
 export function buildExportConditions(params: ExportFilterParams) {
-	const { fromDate, toDate, verified, entryChannel, mediaUpload, balticSea } = params;
+	const { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea } = params;
 	const conditions = [];
 
 	if (isValidDateParam(fromDate) && isValidDateParam(toDate)) {
@@ -77,6 +82,12 @@ export function buildExportConditions(params: ExportFilterParams) {
 	const mediaCondition = mediaUploadCondition(mediaUpload);
 	if (mediaCondition) {
 		conditions.push(mediaCondition);
+	}
+	// Dieselbe Meldeart-Bedingung (Totfund/Lebendsichtung) wie die Admin-Liste,
+	// siehe deadFindingFilter.ts.
+	const deadFindingFilterCondition = deadFindingCondition(deadFinding);
+	if (deadFindingFilterCondition) {
+		conditions.push(deadFindingFilterCondition);
 	}
 	// Dieselbe Ostsee-Status-Bedingung wie die Admin-Liste, siehe balticSeaFilter.ts.
 	const balticSeaFilterCondition = balticSeaCondition(balticSea);

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -433,6 +433,7 @@ paths:
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
+        - $ref: '#/components/parameters/ExportDeadFinding'
       responses:
         '200':
           description: Exportdatei
@@ -473,6 +474,7 @@ paths:
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
+        - $ref: '#/components/parameters/ExportDeadFinding'
       responses:
         '200':
           description: JSON-Datei mit Sichtungen
@@ -543,6 +545,7 @@ paths:
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
+        - $ref: '#/components/parameters/ExportDeadFinding'
       responses:
         '200':
           description: CSV-Datei mit Sichtungen
@@ -576,6 +579,7 @@ paths:
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
+        - $ref: '#/components/parameters/ExportDeadFinding'
       responses:
         '200':
           description: XML-Datei mit Sichtungen
@@ -609,6 +613,7 @@ paths:
         - $ref: '#/components/parameters/ExportEntryChannel'
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
+        - $ref: '#/components/parameters/ExportDeadFinding'
       responses:
         '200':
           description: KML-Datei mit Sichtungen
@@ -2311,6 +2316,18 @@ components:
         type: string
         enum: ["baltic", "edge", "outside", "noPosition"]
         example: "baltic"
+
+    ExportDeadFinding:
+      name: deadFinding
+      in: query
+      description: >-
+        Meldeart filtern (1=Totfund, 0=Lebendsichtung; leer = kein Filter).
+        Totfund heißt totfund <> 0 — dieselbe Boolean-Semantik wie die
+        Kennzeichnung in der Admin-Tabelle (deadFindingFilter.ts).
+      schema:
+        type: string
+        enum: ["0", "1"]
+        example: "1"
 
   schemas:
     CleanupReport:


### PR DESCRIPTION
## Zusammenfassung

Seit #784 kennzeichnet die Admin-Tabelle Totfunde — filtern ließ sich danach aber nicht. Dieser PR ergänzt im Filter-Panel ein **Meldeart**-Select (Alle / Totfund / Lebendsichtung), das über `?deadFinding=1|0` die Liste **und** alle Export-Formate filtert.

- **`src/lib/server/db/deadFindingFilter.ts`** — gemeinsames Filterprädikat nach dem Vorbild von `balticSeaFilter`/`mediaUploadFilter`, damit Admin-Liste und Export dieselbe Bedingung nutzen. Totfund heißt bewusst `totfund <> 0` statt `= 1` — dieselbe Boolean-Semantik wie das Badge (`isDeadFinding()`), damit ein Nicht-Null-Altbestandswert nicht das Badge trägt, aber aus dem Filter fällt (vgl. die `2` in `ostsee_geo`, `docs/OSTSEE_FLAGS.md`).
- **Admin-Liste** (`+page.server.ts`) und **Export** (`exportFilterParams.ts`) verdrahten den Parameter in ihre Bedingungslisten.
- **UI** (`+page.svelte`, `ExportModal.svelte`): Select im Filter-Panel neben „Status", Anwenden/Zurücksetzen/aktive-Filter-Anzeige, Export-Zusammenfassung. Das Totfund-Label kommt aus `DEAD_FINDING_PRESENTATION` — Filter und Badge benennen dieselbe Sache gleich.
- **Doku:** `deadFinding`-Parameter in `static/openapi.yml` (alle fünf Export-Routen, YAML validiert) und `.claude/rules/export.md`.

## Tests (Test-First)

- Neu: `deadFindingFilter.test.ts` (Bedingungssemantik `<> 0` / `= 0` / kein Filter)
- Verdrahtung: `page.server.test.ts` (`?deadFinding=…` → WHERE der Hauptliste und des Counts) und `exportFilterParams.test.ts` (Parse + Bedingung + Kombination mit anderen Filtern)
- `npm run test:quick` grün: 237 Dateien, 3617 Tests

## Nicht abgedeckt

Kein Browser-Screenshot: `/admin` hängt hinter dem Auth0-Login. Das Markup spiegelt 1:1 die bestehenden Filter-Selects; die Server-Verdrahtung ist durch Unit-Tests abgedeckt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)