### PR TITLE
feat(admin): spam rescore endpoint for deployed environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Erst der manuelle Workflow **Promote to Production** (mit Approval am Environmen
 | `docs/LEGACY_API_SPECIFICATION.md` | Legacy API (KRITISCH)                                                              |
 | `docs/OSTSEE_FLAGS.md`             | `ostsee` vs. `ostsee_geo` — Namen sind irreführend, `2` im Altbestand              |
 | `docs/IFRAME_EINBETTUNG.md`        | iframe auf meeresmuseum.de: warum `/bestimmungshilfe` eingebettet unerreichbar ist |
+| `docs/SPAM_DETECTION.md`           | Spam-Score: Signale, Persistenz, Backfill (deployt nur per Admin-Endpunkt)         |
 | `docs/RELEASE_PIPELINE.md`         | Release → Staging → Production, Image-Tags, Promotion, Rollback                    |
 | `docs/PRODUCTION_DEPLOYMENT.md`    | Production Deployment (Schnellanleitung)                                           |
 | `docs/DOCKER_DEPLOYMENT.md`        | Docker Setup (Vollständige Referenz)                                               |

--- a/docs/SPAM_DETECTION.md
+++ b/docs/SPAM_DETECTION.md
@@ -153,6 +153,7 @@ Antwort (`SpamRescoreReport`):
 	"lastId": 8123,
 	"remaining": 19396,
 	"done": false,
+	"stalled": false,
 	"distribution": { "0": 487, "2": 11, "10": 2 }
 }
 ```
@@ -166,6 +167,12 @@ while true; do
   echo "$r" | grep -q '"done":true' && break
 done
 ```
+
+`done` heißt „hör auf", nicht zwingend „alles bewertet". Es wird auch gesetzt,
+wenn ein **voller Batch gar nichts geschrieben hat** (`stalled: true`) — dann
+sind alle geladenen Zeilen an der Prüfung gescheitert, und weitere Aufrufe
+würden dieselben Zeilen laden. In dem Fall steht die Ursache im Server-Log; ein
+Blick auf `remaining` zeigt, wie viele Zeilen noch offen sind.
 
 Zugang wahlweise über eine angemeldete Admin-Session (dann ohne Header, z. B.
 aus dem Browser) oder das `CLEANUP_TOKEN` — dieselbe Regelung wie bei

--- a/docs/SPAM_DETECTION.md
+++ b/docs/SPAM_DETECTION.md
@@ -1,0 +1,197 @@
+# Spam-Erkennung für Sichtungsmeldungen
+
+Die Spam-Erkennung ist eine **Triage-Hilfe, kein Türsteher**. Jede Meldung wird
+gespeichert; der Score priorisiert nur die Reihenfolge, in der Admins prüfen.
+Das ist bewusst so: Jede Sichtung wird ohnehin manuell freigegeben, bevor sie
+öffentlich wird — Spam erreicht die Öffentlichkeit also nie, er kostet nur
+Prüfzeit. Ein fälschlich abgewiesener Melder wäre dagegen ein echter
+Datenverlust, den niemand bemerkt.
+
+---
+
+## Was bewertet wird
+
+`detectSpamIndicators` (`src/lib/server/spam/spamDetector.ts`) liefert
+`score` (0–10), `isHighRisk` (ab `HIGH_RISK_THRESHOLD` = 5) und die Liste der
+ausgelösten Indikatoren.
+
+| Signal                                   | Punkte | Anmerkung                                             |
+| ---------------------------------------- | ------ | ----------------------------------------------------- |
+| URLs/Links im Text                       | 3      | inkl. Shortener ohne Schema und HTML-kodierter Formen |
+| Spam-Keywords (DE/EN)                    | 2 je   | **Wortgrenzen**, nicht Substring                      |
+| Übermäßige Satzzeichen/Großbuchstaben    | 2      |                                                       |
+| Wegwerf-E-Mail-Domain                    | 3      | gepflegte Liste, s. u.                                |
+| `noreply@`/`donotreply@`                 | 2      |                                                       |
+| ≥ 5 Ziffern vor dem `@`                  | 1      |                                                       |
+| E-Mail-Domain ohne MX-Record             | 3      | DNS-Lookup, fail-open                                 |
+| Position außerhalb des Kartenbereichs    | 2      | aus `ostsee_geo`, s. u.                               |
+| Unbekannte/fehlende Tierart              | 1      |                                                       |
+| Identischer Bemerkungstext (7 Tage)      | 2      | ab dem ersten Wiederauftreten                         |
+| ≥ 5 Meldungen derselben E-Mail (24 h)    | 2      | Schwelle bewusst hoch, s. u.                          |
+| Formular-Token fehlt/ungültig/zu schnell | 2      | nur an der Web-API                                    |
+
+### Entscheidungen, die man leicht zurückdreht
+
+- **Wortgrenzen statt Substring.** „win" matchte in „Wind", „free" in **jeder**
+  `freenet.de`-Adresse. Deshalb matcht die Keyword-Prüfung mit `\b` — und die
+  **E-Mail-Adresse ist aus dem Keyword-Text herausgenommen** (sie hat ihre
+  eigenen Prüfungen). Grenze des Ansatzes: `\b` ist ASCII, ein Keyword direkt
+  vor einem Umlaut matcht trotzdem.
+- **Die Geografie wird nicht neu gerechnet.** Der Positions-Indikator kommt aus
+  der DB-Spalte `ostsee_geo` (`> 0` = drin, inklusive Altbestandswert `2` —
+  siehe `docs/OSTSEE_FLAGS.md`), gefüllt von `mapFormToSighting`. Die
+  **Polygon-Spalte `ostsee` fließt bewusst nicht ein**: Ein Totfund am Strand
+  liegt legitim außerhalb des Wasser-Polygons, und das sind genau die
+  Meldungen, die man nicht bestrafen darf.
+- **Duplikat-Schwellen sind asymmetrisch.** Mehrere Meldungen derselben Person
+  an einem Tag sind bei Citizen Science normal (eine Bootstour, fünf
+  Schweinswale) — deshalb erst ab 5. Ein **identischer Bemerkungstext** ist
+  dagegen schon beim ersten Mal auffällig, ab 20 Zeichen Länge (kürzer wäre
+  „schön" jede zweite Meldung).
+- **MX-Lookup ist fail-open.** Nur ein eindeutiges „Domain existiert nicht" bzw.
+  „keine MX-Records" zählt. Timeouts und DNS-Serverfehler ergeben `unknown` und
+  erhöhen den Score nicht — sonst machte ein DNS-Ausfall jede Meldung
+  verdächtig. Ergebnisse werden 1 h gecacht (`unknown` nie), der Cache ist auf
+  5.000 Einträge begrenzt.
+- **Mailserver-_Reputation_ ist bewusst nicht implementiert.** DNSBLs bewerten
+  IPs, die Mail _versenden_ — der Melder sendet aber keine Mail, er tippt eine
+  Adresse in ein Formular. `gmail.com` hat exzellente Reputation und ist die
+  häufigste Absenderdomain in Formular-Spam.
+
+### Wegwerf-Domain-Liste
+
+`src/lib/server/spam/disposableEmailDomains.ts` ist **generiert** aus der
+Community-Liste
+[disposable-email-domains](https://github.com/disposable-email-domains/disposable-email-domains)
+(`disposable_email_blocklist.conf`, CC0). Zum Aktualisieren die Datei neu
+herunterladen und das Modul neu erzeugen; `tempmail.com` steht als Ergänzung
+oben in der Liste (war in der früheren Hartkodierung enthalten, fehlt in der
+Community-Liste).
+
+### Zeit-Token
+
+`src/routes/+page.server.ts` stellt beim Laden der Meldeseite ein signiertes
+`<timestampMs>.<hmac>` aus, das Formular schickt es als `_formToken` mit. Der
+Endpunkt entfernt es **vor** der Feld-Validierung (es ist kein Formularfeld)
+und wertet nur aus, wie lange das Formular offen war.
+
+`FORM_TOKEN_SECRET` ist optional (siehe `docs/ENVIRONMENT.md`). Ohne die
+Variable gilt ein Zufallswert pro Prozess — nach einem Neustart werden alte
+Tokens ungültig, was ausschließlich Score-Punkte kostet und nichts blockiert.
+
+---
+
+## Wo bewertet wird
+
+| Eingang                       | Bewertung                         | Token-Kontext                  |
+| ----------------------------- | --------------------------------- | ------------------------------ |
+| `POST /api/sightings` (Web)   | ja, beim Speichern                | ja                             |
+| `POST /rest_sichtungen` (App) | ja, beim Speichern (rein additiv) | **nein** — Vertrag kennt keins |
+| Admin-Modal „Spam prüfen"     | on demand, nicht gespeichert      | nein                           |
+| Benachrichtigungs-E-Mail      | zeigt den gespeicherten Score     | —                              |
+
+Der Legacy-Endpunkt bekommt bewusst **keinen** `submission`-Kontext: Ein
+„Token fehlt"-Malus würde jede App-Meldung pauschal bestrafen, obwohl der
+Legacy-Vertrag gar kein Token vorsieht.
+
+---
+
+## Persistenz
+
+Zwei Spalten in `sichtungen`:
+
+- `spam_score` (`smallint`) — `NULL` heißt **„nie bewertet"** (Altbestand). Das
+  ist nicht dasselbe wie `0` („geprüft, unauffällig"). Auch eine
+  **fehlgeschlagene** Prüfung wird nicht persistiert: Ihr Fail-Safe-Ergebnis
+  trägt `failed: true` und Score 0, und als 0 gespeichert läse es sich als das
+  Gegenteil dessen, was es aussagt.
+- `spam_indicators` (`jsonb`) — Array der ausgelösten Indikatortexte.
+
+In der Admin-Liste gibt es dafür eine sortierbare Spalte „Spam". Die Sortierung
+verwendet explizit `NULLS LAST` in **beiden** Richtungen: PostgreSQL sortiert
+`DESC` per Vorgabe `NULLS FIRST`, sonst stünde der unbewertete Altbestand über
+den Treffern.
+
+---
+
+## Backfill bestehender Daten
+
+Die Bewertungslogik steht einmal in `$lib/server/spam/rescoreSightings.ts` und
+wird von beiden Wegen benutzt. Sie lädt ausschließlich Zeilen mit
+`spam_score IS NULL` und ist damit idempotent — ein abgebrochener Lauf macht
+beim nächsten Aufruf dort weiter.
+
+> **Nachträgliche Scores sind systematisch milder** als die einer echten
+> Einreichung: Formular-Token und Duplikat-Fenster („letzte 24 h") existieren
+> nur zum Meldezeitpunkt. Das ist gewollt und kein Fehler.
+
+### Lokal (Entwicklungs-DB)
+
+```bash
+npm run spam:rescore            # bis fertig, Batches à 1000
+npm run spam:rescore -- --batch 100
+```
+
+### Deployte Umgebungen — nur über den Admin-Endpunkt
+
+Auf **hawking** (Preprod) und **dmm** (Produktion) ist die Datenbank von außen
+nicht erreichbar, und `src/tools/` liegt nicht im Runtime-Image. Ein
+SQL-Skript scheidet ebenfalls aus, weil die Heuristik MX-DNS-Lookups und
+TypeScript-Logik braucht. Deshalb:
+
+```bash
+curl -sS -X POST "https://<host>/api/admin/spam-rescore?limit=500" \
+  -H "Authorization: Bearer $CLEANUP_TOKEN"
+```
+
+Antwort (`SpamRescoreReport`):
+
+```json
+{
+	"scored": 500,
+	"skippedFailed": 0,
+	"lastId": 8123,
+	"remaining": 19396,
+	"done": false,
+	"distribution": { "0": 487, "2": 11, "10": 2 }
+}
+```
+
+**Bei `done: false` erneut aufrufen**, bis `done: true` kommt — z. B.:
+
+```bash
+while true; do
+  r=$(curl -sS -X POST "https://<host>/api/admin/spam-rescore?limit=500" -H "Authorization: Bearer $CLEANUP_TOKEN")
+  echo "$r"
+  echo "$r" | grep -q '"done":true' && break
+done
+```
+
+Zugang wahlweise über eine angemeldete Admin-Session (dann ohne Header, z. B.
+aus dem Browser) oder das `CLEANUP_TOKEN` — dieselbe Regelung wie bei
+`/api/admin/cleanup-orphans`. Jeder Lauf schreibt einen Audit-Eintrag
+(`sighting.spam_rescore`).
+
+**Warum keine Tunnel-Variante dokumentiert ist:** Auf dmm gibt das Compose des
+Servers für `db` keinen Port frei (die Repo-Datei
+`docker-compose.production.yml` tut das und führt hier in die Irre); auf
+hawking meldet `sshd -T` ein `allowtcpforwarding no`, wodurch jeder
+`LocalForward` zwar lokal bindet, die Verbindung aber serverseitig sofort
+geschlossen wird — das Fehlerbild sieht aus wie eine abstürzende Datenbank und
+ist keine.
+
+---
+
+## Grenzen und bewusst Nicht-Umgesetztes
+
+- **Kein Captcha, keine E-Mail-Bestätigung.** Beides kostet Conversion bei
+  einem Formular, bei dem jede echte Meldung zählt. Erst sinnvoll, wenn
+  nennenswert Spam mit Score < 5 durchrutscht — dann wären Friendly Captcha
+  (DSGVO-freundlich) oder Turnstile die Kandidaten.
+- **Keine Drittanbieter-Abfragen** (StopForumSpam o. ä.). Sie wären für
+  Formular-Spam zwar gebaut, würden aber personenbezogene Daten an Dritte
+  geben — eine DSGVO-Abwägung, die sich ohne akutes Problem nicht lohnt.
+- **Die Duplikat-Abfragen laufen ohne passenden Index** (`lower(email)`,
+  `trim(bemerkungen)`). Bei der aktuellen Datenmenge (~20.000 Zeilen)
+  unkritisch; bei deutlichem Wachstum wären Ausdrucksindizes der nächste
+  Schritt.

--- a/src/lib/server/audit/auditService.ts
+++ b/src/lib/server/audit/auditService.ts
@@ -9,6 +9,7 @@ export type AuditAction =
 	| 'sighting.delete'
 	| 'sighting.verify'
 	| 'sighting.weather.refresh'
+	| 'sighting.spam_rescore'
 	| 'file.delete'
 	| 'file.cleanup_orphans'
 	| 'config.update'

--- a/src/lib/server/spam/rescoreSightings.test.ts
+++ b/src/lib/server/spam/rescoreSightings.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn().mockReturnValue({
+		warn: vi.fn(),
+		debug: vi.fn(),
+		info: vi.fn(),
+		error: vi.fn()
+	})
+}));
+
+vi.mock('./spamDetector', () => ({
+	detectSpamIndicators: vi.fn().mockResolvedValue({ score: 0, isHighRisk: false, indicators: [] })
+}));
+
+// Drizzle-Chain-Mock: der erste select() liefert die Zeilen-Abfrage
+// (from→where→orderBy→limit), der zweite die Rest-Zählung (from→where→Promise).
+const selectMock = vi.fn();
+const updateSetCalls: Array<Record<string, unknown>> = [];
+vi.mock('$lib/server/db', () => ({
+	db: {
+		select: (...args: unknown[]) => selectMock(...args),
+		update: vi.fn().mockReturnValue({
+			set: vi.fn().mockImplementation((values: Record<string, unknown>) => {
+				updateSetCalls.push(values);
+				return { where: vi.fn().mockResolvedValue(undefined) };
+			})
+		})
+	}
+}));
+
+import { rescoreSightings } from './rescoreSightings';
+import { detectSpamIndicators } from './spamDetector';
+
+const mockDetect = vi.mocked(detectSpamIndicators);
+
+let capturedLimit: number | undefined;
+
+function primeDb(rows: Array<Record<string, unknown>>, remainingCount: number): void {
+	capturedLimit = undefined;
+	selectMock.mockReset();
+	// 1. Aufruf: Zeilen-Abfrage
+	selectMock.mockImplementationOnce(() => ({
+		from: () => ({
+			where: () => ({
+				orderBy: () => ({
+					limit: (n: number) => {
+						capturedLimit = n;
+						return Promise.resolve(rows);
+					}
+				})
+			})
+		})
+	}));
+	// 2. Aufruf: Rest-Zählung
+	selectMock.mockImplementationOnce(() => ({
+		from: () => ({
+			where: () => Promise.resolve([{ count: remainingCount }])
+		})
+	}));
+}
+
+function buildRow(id: number, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		id,
+		notes: null,
+		firstName: 'Max',
+		lastName: 'Muster',
+		email: 'max@example.com',
+		waterway: null,
+		seaMark: null,
+		species: 0,
+		latitude: '54.5',
+		longitude: '12.0',
+		inBalticSeaGeo: 1,
+		...overrides
+	};
+}
+
+describe('rescoreSightings', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		updateSetCalls.length = 0;
+		mockDetect.mockResolvedValue({ score: 0, isHighRisk: false, indicators: [] });
+	});
+
+	it('bewertet Zeilen, schreibt Score und Indikatoren und zählt die Verteilung', async () => {
+		primeDb([buildRow(1), buildRow(2)], 5);
+		mockDetect
+			.mockResolvedValueOnce({ score: 0, isHighRisk: false, indicators: [] })
+			.mockResolvedValueOnce({ score: 7, isHighRisk: true, indicators: ['Testindikator'] });
+
+		const report = await rescoreSightings({ limit: 10 });
+
+		expect(report.scored).toBe(2);
+		expect(report.lastId).toBe(2);
+		expect(report.remaining).toBe(5);
+		expect(report.distribution).toEqual({ '0': 1, '7': 1 });
+		expect(updateSetCalls).toEqual([
+			{ spamScore: 0, spamIndicators: [] },
+			{ spamScore: 7, spamIndicators: ['Testindikator'] }
+		]);
+	});
+
+	it('überspringt fehlgeschlagene Prüfungen ohne zu schreiben (NULL bleibt NULL)', async () => {
+		primeDb([buildRow(1)], 0);
+		mockDetect.mockResolvedValueOnce({
+			score: 0,
+			isHighRisk: true,
+			indicators: ['Spam-Prüfung fehlgeschlagen'],
+			failed: true
+		});
+
+		const report = await rescoreSightings({});
+
+		expect(report.scored).toBe(0);
+		expect(report.skippedFailed).toBe(1);
+		expect(updateSetCalls).toHaveLength(0);
+	});
+
+	it('meldet done=true, wenn weniger Zeilen kamen als das Limit', async () => {
+		primeDb([buildRow(1)], 0);
+		const report = await rescoreSightings({ limit: 10 });
+		expect(report.done).toBe(true);
+	});
+
+	it('meldet done=false bei voller Batch-Größe', async () => {
+		primeDb([buildRow(1), buildRow(2)], 3);
+		const report = await rescoreSightings({ limit: 2 });
+		expect(report.done).toBe(false);
+	});
+
+	it('klemmt das Limit auf höchstens 1000', async () => {
+		primeDb([], 0);
+		await rescoreSightings({ limit: 99999 });
+		expect(capturedLimit).toBe(1000);
+	});
+
+	it('übergibt dem Detektor die konvertierten Koordinaten und das ostsee_geo-Flag', async () => {
+		primeDb([buildRow(1, { latitude: '54.5', longitude: '12.0', inBalticSeaGeo: 2 })], 0);
+
+		await rescoreSightings({});
+
+		expect(mockDetect).toHaveBeenCalledWith(
+			expect.objectContaining({ latitude: 54.5, longitude: 12.0, inBalticSeaGeo: 2 })
+		);
+		// Kein Submission-Kontext beim Backfill — 'missing' wäre ein falscher Malus.
+		expect(mockDetect.mock.calls[0]?.[0]?.submission).toBeUndefined();
+	});
+});

--- a/src/lib/server/spam/rescoreSightings.test.ts
+++ b/src/lib/server/spam/rescoreSightings.test.ts
@@ -130,6 +130,52 @@ describe('rescoreSightings', () => {
 		expect(report.done).toBe(false);
 	});
 
+	it('bricht ab, wenn ein voller Batch gar nichts schreibt (sonst Endlosschleife)', async () => {
+		// Scheitert die Prüfung für JEDE Zeile eines vollen Batches, bleibt
+		// spam_score NULL — derselbe Batch käme beim nächsten Lauf erneut, und
+		// `done` aus der Batch-Größe bliebe für immer false.
+		primeDb([buildRow(1), buildRow(2)], 2);
+		mockDetect.mockResolvedValue({
+			score: 0,
+			isHighRisk: true,
+			indicators: ['Spam-Prüfung fehlgeschlagen'],
+			failed: true
+		});
+
+		const report = await rescoreSightings({ limit: 2 });
+
+		expect(report.scored).toBe(0);
+		expect(report.skippedFailed).toBe(2);
+		expect(report.stalled).toBe(true);
+		expect(report.done).toBe(true);
+	});
+
+	it('läuft weiter, solange ein voller Batch wenigstens eine Zeile schreibt', async () => {
+		primeDb([buildRow(1), buildRow(2)], 5);
+		mockDetect
+			.mockResolvedValueOnce({
+				score: 0,
+				isHighRisk: true,
+				indicators: ['Spam-Prüfung fehlgeschlagen'],
+				failed: true
+			})
+			.mockResolvedValueOnce({ score: 3, isHighRisk: false, indicators: [] });
+
+		const report = await rescoreSightings({ limit: 2 });
+
+		expect(report.stalled).toBe(false);
+		expect(report.done).toBe(false);
+	});
+
+	it('meldet auf leerer Menge kein stalled', async () => {
+		primeDb([], 0);
+
+		const report = await rescoreSightings({ limit: 10 });
+
+		expect(report.stalled).toBe(false);
+		expect(report.done).toBe(true);
+	});
+
 	it('klemmt das Limit auf höchstens 1000', async () => {
 		primeDb([], 0);
 		await rescoreSightings({ limit: 99999 });

--- a/src/lib/server/spam/rescoreSightings.ts
+++ b/src/lib/server/spam/rescoreSightings.ts
@@ -34,8 +34,14 @@ export interface RescoreReport {
 	lastId: number | null;
 	/** Noch unbewertete Zeilen NACH diesem Lauf. */
 	remaining: number;
-	/** true, wenn dieser Lauf die Menge geleert hat (weniger Zeilen als Limit). */
+	/** true, wenn der Aufrufer aufhören soll — Menge geleert ODER kein Fortschritt. */
 	done: boolean;
+	/**
+	 * true, wenn ein voller Batch gar nichts geschrieben hat. Dann bleibt
+	 * `remaining` unverändert stehen und weitere Aufrufe würden dieselben
+	 * Zeilen laden — der Aufrufer muss aufhören und ins Log schauen.
+	 */
+	stalled: boolean;
 	/** Score → Anzahl, für einen schnellen Blick auf die Verteilung. */
 	distribution: Record<string, number>;
 }
@@ -120,15 +126,28 @@ export async function rescoreSightings(options: RescoreOptions): Promise<Rescore
 		.where(isNull(sightings.spamScore));
 	const remaining = Number(remainingRow?.count ?? 0);
 
-	// `done` aus der Batch-Größe, nicht aus `remaining === 0`: Zeilen mit
-	// fehlgeschlagener Prüfung bleiben NULL und würden `remaining` sonst nie
-	// auf 0 fallen lassen — der Aufrufer liefe endlos weiter.
-	const done = rows.length < limit;
+	// Zwei Abbruchgründe, und beide werden gebraucht:
+	//
+	// 1. Weniger Zeilen als das Limit — die Menge ist leer. `remaining === 0`
+	//    taugt dafür nicht: Zeilen mit fehlgeschlagener Prüfung bleiben NULL
+	//    und würden `remaining` nie auf 0 fallen lassen.
+	// 2. Ein voller Batch, der nichts geschrieben hat. Dann sind genau die
+	//    geladenen Zeilen alle gescheitert, der nächste Aufruf lädt dieselben
+	//    wieder, und (1) allein liefe endlos weiter.
+	const stalled = rows.length > 0 && scored === 0;
+	const done = rows.length < limit || stalled;
+
+	if (stalled) {
+		logger.error(
+			{ skippedFailed, lastId, remaining },
+			'Spam-Rescore kommt nicht voran — ganzer Batch fehlgeschlagen, Lauf beendet'
+		);
+	}
 
 	logger.info(
-		{ scored, skippedFailed, lastId, remaining, done },
+		{ scored, skippedFailed, lastId, remaining, done, stalled },
 		'Spam-Rescore-Batch abgeschlossen'
 	);
 
-	return { scored, skippedFailed, lastId, remaining, done, distribution };
+	return { scored, skippedFailed, lastId, remaining, done, stalled, distribution };
 }

--- a/src/lib/server/spam/rescoreSightings.ts
+++ b/src/lib/server/spam/rescoreSightings.ts
@@ -1,0 +1,134 @@
+/**
+ * Nachträgliche Spam-Bewertung bestehender Sichtungen (Backfill).
+ *
+ * Die Logik liegt hier und nicht im Endpunkt, damit sie testbar bleibt und
+ * `src/tools/rescore-spam.ts` (lokal/Dev) dieselbe Rechnung benutzt wie der
+ * Admin-Endpunkt (deployte Umgebungen, wo kein Zugang zur DB von außen
+ * besteht: dmm gibt den DB-Port nicht frei, hawking hat
+ * `allowtcpforwarding no`).
+ *
+ * Was der Backfill NICHT kann: Signale, die nur zum Meldezeitpunkt existieren
+ * — Formular-Token und Duplikat-Fenster („letzte 24 h"). Nachträgliche Scores
+ * fallen deshalb systematisch milder aus als die einer echten Einreichung.
+ * Das ist gewollt: ein `submission: { tokenStatus: 'missing' }` wäre für
+ * Altbestand ein erfundener Malus.
+ */
+import { createLogger } from '$lib/logger.server';
+import { db } from '$lib/server/db';
+import { sightings } from '$lib/server/db/schema';
+import { count, eq, isNull } from 'drizzle-orm';
+import { detectSpamIndicators } from './spamDetector';
+
+const logger = createLogger('spam:rescore');
+
+/** Obergrenze je Lauf. Hält die Antwortzeit im Rahmen (MX-Lookups!). */
+export const MAX_RESCORE_BATCH = 1000;
+const DEFAULT_RESCORE_BATCH = 200;
+
+export interface RescoreReport {
+	/** Zeilen, die in diesem Lauf einen Score bekommen haben. */
+	scored: number;
+	/** Zeilen mit fehlgeschlagener Prüfung — bleiben NULL, siehe saveSighting. */
+	skippedFailed: number;
+	/** Höchste bearbeitete ID (für Fortschritts-Anzeige im Log). */
+	lastId: number | null;
+	/** Noch unbewertete Zeilen NACH diesem Lauf. */
+	remaining: number;
+	/** true, wenn dieser Lauf die Menge geleert hat (weniger Zeilen als Limit). */
+	done: boolean;
+	/** Score → Anzahl, für einen schnellen Blick auf die Verteilung. */
+	distribution: Record<string, number>;
+}
+
+export interface RescoreOptions {
+	/** Zeilen je Lauf, geklemmt auf MAX_RESCORE_BATCH. */
+	limit?: number | undefined;
+}
+
+/**
+ * Bewertet einen Batch bislang unbewerteter Sichtungen und schreibt
+ * `spam_score`/`spam_indicators`.
+ *
+ * Idempotent: Es werden ausschließlich Zeilen mit `spam_score IS NULL`
+ * geladen — ein abgebrochener Lauf macht beim nächsten Aufruf dort weiter.
+ */
+export async function rescoreSightings(options: RescoreOptions): Promise<RescoreReport> {
+	const requested = options.limit ?? DEFAULT_RESCORE_BATCH;
+	const limit = Math.min(
+		Math.max(Math.floor(requested) || DEFAULT_RESCORE_BATCH, 1),
+		MAX_RESCORE_BATCH
+	);
+
+	const rows = await db
+		.select({
+			id: sightings.id,
+			notes: sightings.notes,
+			firstName: sightings.firstName,
+			lastName: sightings.lastName,
+			email: sightings.email,
+			waterway: sightings.waterway,
+			seaMark: sightings.seaMark,
+			species: sightings.species,
+			latitude: sightings.latitude,
+			longitude: sightings.longitude,
+			inBalticSeaGeo: sightings.inBalticSeaGeo
+		})
+		.from(sightings)
+		.where(isNull(sightings.spamScore))
+		.orderBy(sightings.id)
+		.limit(limit);
+
+	let scored = 0;
+	let skippedFailed = 0;
+	let lastId: number | null = null;
+	const distribution: Record<string, number> = {};
+
+	for (const row of rows) {
+		lastId = row.id;
+
+		const result = await detectSpamIndicators({
+			notes: row.notes,
+			firstName: row.firstName,
+			lastName: row.lastName,
+			email: row.email,
+			waterway: row.waterway,
+			seaMark: row.seaMark,
+			species: row.species,
+			latitude: row.latitude != null ? Number(row.latitude) : null,
+			longitude: row.longitude != null ? Number(row.longitude) : null,
+			inBalticSeaGeo: row.inBalticSeaGeo
+		});
+
+		if (result.failed) {
+			skippedFailed++;
+			continue;
+		}
+
+		await db
+			.update(sightings)
+			.set({ spamScore: result.score, spamIndicators: result.indicators })
+			.where(eq(sightings.id, row.id));
+
+		scored++;
+		const key = String(result.score);
+		distribution[key] = (distribution[key] ?? 0) + 1;
+	}
+
+	const [remainingRow] = await db
+		.select({ count: count() })
+		.from(sightings)
+		.where(isNull(sightings.spamScore));
+	const remaining = Number(remainingRow?.count ?? 0);
+
+	// `done` aus der Batch-Größe, nicht aus `remaining === 0`: Zeilen mit
+	// fehlgeschlagener Prüfung bleiben NULL und würden `remaining` sonst nie
+	// auf 0 fallen lassen — der Aufrufer liefe endlos weiter.
+	const done = rows.length < limit;
+
+	logger.info(
+		{ scored, skippedFailed, lastId, remaining, done },
+		'Spam-Rescore-Batch abgeschlossen'
+	);
+
+	return { scored, skippedFailed, lastId, remaining, done, distribution };
+}

--- a/src/routes/api/admin/spam-rescore/+server.ts
+++ b/src/routes/api/admin/spam-rescore/+server.ts
@@ -1,0 +1,93 @@
+/**
+ * Stößt die nachträgliche Spam-Bewertung bestehender Sichtungen an.
+ *
+ * Warum es diesen Endpunkt gibt: Auf den deployten Hosts ist die Datenbank von
+ * außen nicht erreichbar — auf dmm gibt das Compose für `db` keinen Port frei,
+ * auf hawking hat sshd `allowtcpforwarding no`. Ein Werkzeug vom Arbeitsplatz
+ * aus (`npm run spam:rescore`) erreicht dort also nichts, und im Runtime-Image
+ * liegt `src/tools/` gar nicht erst. Der Backfill muss deshalb dort laufen, wo
+ * die Anwendung läuft. Ein reines SQL-Skript scheidet aus: Die Heuristik
+ * braucht MX-DNS-Lookups und die TypeScript-Logik.
+ *
+ * Zugang und Aufbau folgen `/api/admin/cleanup-orphans` — angemeldete
+ * Admin-Session ODER `Authorization: Bearer` mit `CLEANUP_TOKEN`. Bewusst
+ * `isAdminUser` statt `requireUserRole`: Letzteres wirft `redirect(302)` auf
+ * die Anmeldeseite, ein Skript würde die Weiterleitung als Erfolg werten.
+ *
+ * Der Lauf arbeitet in Batches (`limit`, Vorgabe 200, Maximum 1000) — bei
+ * ~20.000 Zeilen und je einem MX-Lookup wäre ein Durchlauf in einer einzigen
+ * Antwort weder zumutbar noch sinnvoll. `done: false` heißt: nochmal aufrufen.
+ * Idempotent, weil nur Zeilen mit `spam_score IS NULL` geladen werden.
+ */
+import { env } from '$env/dynamic/private';
+import { createLogger } from '$lib/logger.server';
+import { logAuditEvent } from '$lib/server/audit/auditService';
+import { isAdminUser } from '$lib/server/auth/auth';
+import { isValidCleanupToken, MIN_TOKEN_LENGTH } from '$lib/server/media/cleanupAuth';
+import {
+	buildRateLimitHeaders,
+	createRateLimitIdentifier,
+	enforceRateLimit,
+	RATE_LIMITS
+} from '$lib/server/middleware/rateLimit';
+import { rescoreSightings } from '$lib/server/spam/rescoreSightings';
+import { getClientIp } from '$lib/server/utils/getClientIp';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+const logger = createLogger('api:admin:spam-rescore');
+
+export const POST: RequestHandler = async ({ request, url, locals, getClientAddress }) => {
+	const bySession = isAdminUser(locals.user);
+	const byToken = isValidCleanupToken(request.headers.get('authorization'), env.CLEANUP_TOKEN);
+
+	if (!bySession && !byToken) {
+		// Ein gesetztes, aber zu kurzes Token verhält sich wie keins — das ist
+		// leicht zu übersehen und muss deshalb sichtbar sein.
+		if (env.CLEANUP_TOKEN && env.CLEANUP_TOKEN.length < MIN_TOKEN_LENGTH) {
+			logger.warn(
+				{ action: 'rescore_token_too_short', required: MIN_TOKEN_LENGTH },
+				'CLEANUP_TOKEN ist zu kurz und wird ignoriert'
+			);
+		}
+		// Bewusst ohne Unterscheidung, welcher Weg fehlschlug.
+		logger.warn({ action: 'rescore_unauthorized' }, 'Spam-Rescore ohne gültigen Ausweis');
+		return json({ error: 'Unauthorized' }, { status: 401 });
+	}
+
+	const clientIp = getClientIp(getClientAddress, request) ?? 'unknown';
+	// Außerhalb des try: enforceRateLimit wirft error(429), das darf nicht als
+	// 500 enden.
+	const rateLimit = enforceRateLimit(
+		createRateLimitIdentifier(locals.user?.sub, clientIp, bySession),
+		RATE_LIMITS.ADMIN_CLEANUP,
+		'admin_spam_rescore'
+	);
+	const headers = buildRateLimitHeaders(RATE_LIMITS.ADMIN_CLEANUP, rateLimit);
+
+	// Ein unbrauchbares `limit` wird weggelassen statt geraten — die Vorgabe
+	// steht in rescoreSightings und existiert damit genau einmal.
+	const rawLimit = Number(url.searchParams.get('limit'));
+	const options = Number.isFinite(rawLimit) && rawLimit > 0 ? { limit: rawLimit } : {};
+
+	try {
+		const report = await rescoreSightings(options);
+
+		await logAuditEvent({
+			action: 'sighting.spam_rescore',
+			resourceType: 'sighting',
+			// exactOptionalPropertyTypes: das Feld weglassen statt undefined
+			// setzen. Beim Token-Weg gibt es keinen Nutzer — `trigger` in den
+			// Details hält fest, wer ausgelöst hat.
+			...(locals.user?.email ? { userEmail: locals.user.email } : {}),
+			ipAddress: clientIp,
+			details: { ...report, trigger: bySession ? 'session' : 'token' },
+			status: 'success'
+		});
+
+		return json(report, { headers });
+	} catch (error) {
+		logger.error({ error }, 'Spam-Rescore fehlgeschlagen');
+		return json({ error: 'Spam-Rescore fehlgeschlagen' }, { status: 500, headers });
+	}
+};

--- a/src/routes/api/admin/spam-rescore/endpoint.test.ts
+++ b/src/routes/api/admin/spam-rescore/endpoint.test.ts
@@ -51,6 +51,7 @@ describe('POST /api/admin/spam-rescore', () => {
 			lastId: 42,
 			remaining: 0,
 			done: true,
+			stalled: false,
 			distribution: { '0': 2 }
 		});
 	});

--- a/src/routes/api/admin/spam-rescore/endpoint.test.ts
+++ b/src/routes/api/admin/spam-rescore/endpoint.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Der Rescore-Endpunkt schreibt in `sichtungen` — die Zugangsregeln sind hier
+ * festgeschrieben. Er ist der einzige Weg, den Backfill auf deployten Hosts
+ * anzustoßen: dmm gibt den DB-Port nicht frei, hawking hat
+ * `allowtcpforwarding no`.
+ */
+import { MIN_TOKEN_LENGTH } from '$lib/server/media/cleanupAuth';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const TOKEN = 'z'.repeat(MIN_TOKEN_LENGTH);
+
+const { rescoreSightings, logAuditEvent, mockEnv } = vi.hoisted(() => ({
+	rescoreSightings: vi.fn(),
+	logAuditEvent: vi.fn(),
+	// Literal statt MIN_TOKEN_LENGTH: vi.hoisted läuft vor den Importen.
+	mockEnv: { CLEANUP_TOKEN: 'z'.repeat(32) }
+}));
+
+vi.mock('$lib/server/spam/rescoreSightings', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/spam/rescoreSightings')>(
+		'$lib/server/spam/rescoreSightings'
+	);
+	return { ...actual, rescoreSightings };
+});
+vi.mock('$lib/server/audit/auditService', () => ({ logAuditEvent }));
+vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+
+import { POST } from './+server';
+
+const ADMIN = { sub: 'u1', email: 'a@b.de', roles: ['admin'] };
+
+function event(init: { token?: string; query?: string; user?: unknown } = {}) {
+	return {
+		request: new Request('https://x/api/admin/spam-rescore', {
+			method: 'POST',
+			headers: init.token ? { Authorization: `Bearer ${init.token}` } : {}
+		}),
+		url: new URL(`https://x/api/admin/spam-rescore?${init.query ?? ''}`),
+		locals: { user: init.user },
+		getClientAddress: () => '127.0.0.1'
+	} as never;
+}
+
+describe('POST /api/admin/spam-rescore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockEnv.CLEANUP_TOKEN = TOKEN;
+		rescoreSightings.mockResolvedValue({
+			scored: 2,
+			skippedFailed: 0,
+			lastId: 42,
+			remaining: 0,
+			done: true,
+			distribution: { '0': 2 }
+		});
+	});
+
+	it('weist Aufrufe ohne Ausweis mit 401 ab', async () => {
+		const response = await POST(event());
+
+		expect(response.status).toBe(401);
+		expect(rescoreSightings).not.toHaveBeenCalled();
+	});
+
+	it('weist einen Nutzer ohne Admin-Rolle mit 401 ab', async () => {
+		const response = await POST(event({ user: { sub: 'u2', roles: ['user'] } }));
+
+		expect(response.status).toBe(401);
+		expect(rescoreSightings).not.toHaveBeenCalled();
+	});
+
+	it('lässt eine Admin-Session durch und gibt den Bericht zurück', async () => {
+		const response = await POST(event({ user: ADMIN }));
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body).toMatchObject({ scored: 2, remaining: 0, done: true });
+	});
+
+	it('lässt den Token-Weg durch (Cron ohne Session)', async () => {
+		const response = await POST(event({ token: TOKEN }));
+
+		expect(response.status).toBe(200);
+		expect(rescoreSightings).toHaveBeenCalledOnce();
+	});
+
+	it('weist ein falsches Token mit 401 ab', async () => {
+		const response = await POST(event({ token: 'x'.repeat(MIN_TOKEN_LENGTH) }));
+
+		expect(response.status).toBe(401);
+	});
+
+	it('reicht das Limit aus der Query durch', async () => {
+		await POST(event({ user: ADMIN, query: 'limit=50' }));
+
+		expect(rescoreSightings).toHaveBeenCalledWith({ limit: 50 });
+	});
+
+	it('ignoriert ein unbrauchbares Limit statt zu raten', async () => {
+		await POST(event({ user: ADMIN, query: 'limit=abc' }));
+
+		expect(rescoreSightings).toHaveBeenCalledWith({});
+	});
+
+	it('schreibt einen Audit-Eintrag mit dem Ergebnis', async () => {
+		await POST(event({ user: ADMIN }));
+
+		expect(logAuditEvent).toHaveBeenCalledWith(
+			expect.objectContaining({
+				action: 'sighting.spam_rescore',
+				userEmail: ADMIN.email,
+				status: 'success'
+			})
+		);
+	});
+
+	it('meldet einen Fehler im Rescore als 500, ohne den Prozess zu reißen', async () => {
+		rescoreSightings.mockRejectedValueOnce(new Error('DB weg'));
+
+		const response = await POST(event({ user: ADMIN }));
+
+		expect(response.status).toBe(500);
+	});
+});

--- a/src/tools/rescore-spam.ts
+++ b/src/tools/rescore-spam.ts
@@ -59,6 +59,15 @@ for (;;) {
 
 	console.log(`  ${scored} bewertet, ${report.remaining} offen …`);
 
+	if (report.stalled) {
+		// Ganzer Batch gescheitert — weitere Läufe würden dieselben Zeilen laden.
+		console.error(
+			`\nAbbruch: Der letzte Batch hat nichts geschrieben (${report.skippedFailed} Prüfungen ` +
+				`fehlgeschlagen, ${report.remaining} Zeilen weiterhin ohne Bewertung). Ursache im Log suchen.`
+		);
+		process.exit(1);
+	}
+
 	if (report.done) break;
 }
 

--- a/src/tools/rescore-spam.ts
+++ b/src/tools/rescore-spam.ts
@@ -2,16 +2,17 @@
  * Bewertet bestehende Sichtungen nachträglich mit der Spam-Heuristik und
  * schreibt `spam_score`/`spam_indicators`.
  *
- * Aufruf: npm run spam:rescore [-- --all] [-- --limit <n>]
+ * Aufruf: npm run spam:rescore [-- --batch <n>]
  *
- *   (ohne Flags)  nur Zeilen ohne Bewertung (spam_score IS NULL)
- *   --all         auch bereits bewertete Zeilen neu bewerten
- *   --limit <n>   höchstens n Zeilen (zum Ausprobieren)
+ * **Nur für Datenbanken, die von hier aus erreichbar sind** — also die lokale
+ * Entwicklungs-DB. Auf den deployten Hosts geht das nicht: dmm gibt den
+ * DB-Port nicht frei, hawking hat `allowtcpforwarding no`, und `src/tools/`
+ * liegt gar nicht erst im Runtime-Image. Dort führt der Weg über
+ * `POST /api/admin/spam-rescore` (siehe docs/SPAM_DETECTION.md).
  *
- * Was der Backfill NICHT kann: Die Signale, die nur zum Meldezeitpunkt
- * existieren — Formular-Token und Duplikat-Fenster („letzte 24 h") — fehlen
- * hier. Nachträglich vergebene Scores fallen deshalb systematisch milder aus
- * als die einer echten Einreichung; das ist gewollt und kein Fehler.
+ * Die Bewertung selbst steht in `$lib/server/spam/rescoreSightings` — beide
+ * Wege rechnen damit identisch, und die Logik ist dort getestet. Dieses
+ * Werkzeug ist nur die Schleife drumherum plus Fortschrittsausgabe.
  *
  * Der npm-Eintrag setzt `TEST=true` vor den vite-node-Aufruf — dasselbe
  * Ventil wie bei generate-antworten-json.js, damit der Server-Import-Guard
@@ -24,92 +25,45 @@
  * importiertes Modul liest die Verbindungszeichenfolge schon beim Laden.
  */
 import 'dotenv/config';
-import { isNull, eq } from 'drizzle-orm';
-import { db } from '$lib/server/db';
-import { sightings } from '$lib/server/db/schema';
-import { detectSpamIndicators } from '$lib/server/spam/spamDetector';
-import { resolveConnectionString, maskConnection } from './dbConnection';
+import { MAX_RESCORE_BATCH, rescoreSightings } from '$lib/server/spam/rescoreSightings';
+import { maskConnection, resolveConnectionString } from './dbConnection';
 
-function parseArgs(argv: string[]): { all: boolean; limit: number | null } {
-	const all = argv.includes('--all');
-	const limitIndex = argv.indexOf('--limit');
-	const limit = limitIndex >= 0 ? Number(argv[limitIndex + 1]) : null;
-	if (limit !== null && (!Number.isInteger(limit) || limit <= 0)) {
-		throw new Error('--limit erwartet eine positive ganze Zahl');
+function parseBatch(argv: string[]): number {
+	const index = argv.indexOf('--batch');
+	if (index < 0) return MAX_RESCORE_BATCH;
+	const value = Number(argv[index + 1]);
+	if (!Number.isInteger(value) || value <= 0) {
+		throw new Error('--batch erwartet eine positive ganze Zahl');
 	}
-	return { all, limit };
+	return Math.min(value, MAX_RESCORE_BATCH);
 }
 
-const { all, limit } = parseArgs(process.argv.slice(2));
+const batch = parseBatch(process.argv.slice(2));
 
 console.log(`Datenbank: ${maskConnection(resolveConnectionString(process.env))}`);
-console.log(`Modus: ${all ? 'ALLE Zeilen neu bewerten' : 'nur unbewertete Zeilen'}`);
 
-const baseQuery = db
-	.select({
-		id: sightings.id,
-		notes: sightings.notes,
-		firstName: sightings.firstName,
-		lastName: sightings.lastName,
-		email: sightings.email,
-		waterway: sightings.waterway,
-		seaMark: sightings.seaMark,
-		species: sightings.species,
-		latitude: sightings.latitude,
-		longitude: sightings.longitude,
-		inBalticSeaGeo: sightings.inBalticSeaGeo
-	})
-	.from(sightings)
-	.orderBy(sightings.id);
-
-const filtered = all ? baseQuery : baseQuery.where(isNull(sightings.spamScore));
-const rows = await (limit ? filtered.limit(limit) : filtered);
-
-console.log(`${rows.length} Sichtungen zu bewerten …`);
-
-let written = 0;
+let scored = 0;
 let skippedFailed = 0;
 const distribution = new Map<number, number>();
-const startedAt = Date.now();
 
-for (const row of rows) {
-	const result = await detectSpamIndicators({
-		notes: row.notes,
-		firstName: row.firstName,
-		lastName: row.lastName,
-		email: row.email,
-		waterway: row.waterway,
-		seaMark: row.seaMark,
-		species: row.species,
-		latitude: row.latitude != null ? Number(row.latitude) : null,
-		longitude: row.longitude != null ? Number(row.longitude) : null,
-		inBalticSeaGeo: row.inBalticSeaGeo
-	});
+// Batch-weise bis `done` — dieselbe Schleife, die ein Aufrufer auch gegen den
+// Admin-Endpunkt fahren würde.
+for (;;) {
+	const report = await rescoreSightings({ limit: batch });
 
-	if (result.failed) {
-		// Fail-Safe-Ergebnisse nicht persistieren — NULL heißt „nicht bewertet",
-		// dieselbe Regel wie in saveSighting.
-		skippedFailed++;
-		continue;
+	scored += report.scored;
+	skippedFailed += report.skippedFailed;
+	for (const [score, count] of Object.entries(report.distribution)) {
+		distribution.set(Number(score), (distribution.get(Number(score)) ?? 0) + count);
 	}
 
-	await db
-		.update(sightings)
-		.set({ spamScore: result.score, spamIndicators: result.indicators })
-		.where(eq(sightings.id, row.id));
+	console.log(`  ${scored} bewertet, ${report.remaining} offen …`);
 
-	written++;
-	distribution.set(result.score, (distribution.get(result.score) ?? 0) + 1);
-
-	if (written % 500 === 0) {
-		const perRow = (Date.now() - startedAt) / written;
-		const remaining = Math.round(((rows.length - written) * perRow) / 1000);
-		console.log(`  ${written}/${rows.length} … (Rest ~${remaining}s)`);
-	}
+	if (report.done) break;
 }
 
 console.log(
-	`\nFertig: ${written} bewertet, ${skippedFailed} übersprungen (Prüfung fehlgeschlagen).`
+	`\nFertig: ${scored} bewertet, ${skippedFailed} übersprungen (Prüfung fehlgeschlagen).`
 );
 console.log('Score-Verteilung:');
 for (const [score, count] of [...distribution.entries()].sort(([a], [b]) => a - b)) {

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1078,7 +1078,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/SpamRescoreReport'
         '401':
-          description: Kein oder falsches Token
+          description: >-
+            Nicht autorisiert — erforderlich ist eine angemeldete Admin-Session
+            oder ein gültiges `CLEANUP_TOKEN`. Eine Session ohne Admin-Rolle
+            wird ebenso abgewiesen wie ein fehlendes oder falsches Token.
         '429':
           description: Rate Limit überschritten
         '500':
@@ -2379,7 +2382,7 @@ components:
   schemas:
     SpamRescoreReport:
       type: object
-      required: [scored, skippedFailed, lastId, remaining, done, distribution]
+      required: [scored, skippedFailed, lastId, remaining, done, stalled, distribution]
       properties:
         scored:
           type: integer
@@ -2399,9 +2402,16 @@ components:
         done:
           type: boolean
           description: >-
-            true, wenn dieser Lauf die Menge geleert hat. Aus der Batch-Größe
-            abgeleitet, nicht aus remaining — übersprungene Zeilen bleiben NULL
-            und würden remaining sonst nie auf 0 fallen lassen.
+            true, wenn der Aufrufer aufhören soll: Menge geleert (weniger
+            Zeilen als das Limit) ODER stalled. Nicht aus remaining abgeleitet
+            — übersprungene Zeilen bleiben NULL und würden remaining nie auf 0
+            fallen lassen.
+        stalled:
+          type: boolean
+          description: >-
+            true, wenn ein voller Batch gar nichts geschrieben hat (alle
+            Prüfungen fehlgeschlagen). Weitere Aufrufe würden dieselben Zeilen
+            laden; done ist dann ebenfalls true. Ursache im Server-Log suchen.
         distribution:
           type: object
           additionalProperties:

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1037,6 +1037,53 @@ paths:
         '500':
           description: Unerwarteter Fehler
 
+  /api/admin/spam-rescore:
+    post:
+      tags:
+        - Admin
+      summary: Bestehende Sichtungen nachträglich auf Spam bewerten
+      description: >
+        Bewertet Sichtungen ohne gespeicherten Spam-Score (`spam_score IS NULL`)
+        und schreibt `spam_score`/`spam_indicators`. Idempotent und
+        wiederholbar: Ein abgebrochener Lauf macht beim nächsten Aufruf dort
+        weiter. Arbeitet in Batches — bei `done: false` erneut aufrufen.
+
+
+        Der Endpunkt existiert, weil die Datenbank auf den deployten Hosts von
+        außen nicht erreichbar ist und die Bewertung MX-DNS-Lookups braucht,
+        also nicht als SQL-Skript läuft.
+
+
+        Nachträgliche Scores sind systematisch milder als die einer echten
+        Einreichung: Formular-Token und Duplikat-Fenster existieren nur zum
+        Meldezeitpunkt. Zugang über Admin-Session oder Bearer-Token
+        (`CLEANUP_TOKEN`).
+      security:
+        - adminAuth: []
+        - cleanupToken: []
+      parameters:
+        - name: limit
+          in: query
+          description: Zeilen pro Aufruf. Unlesbare Werte fallen auf die Vorgabe zurück.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 200
+      responses:
+        '200':
+          description: Batch bewertet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpamRescoreReport'
+        '401':
+          description: Kein oder falsches Token
+        '429':
+          description: Rate Limit überschritten
+        '500':
+          description: Unerwarteter Fehler
+
   /api/admin/test-email:
     post:
       tags:
@@ -2330,6 +2377,38 @@ components:
         example: "1"
 
   schemas:
+    SpamRescoreReport:
+      type: object
+      required: [scored, skippedFailed, lastId, remaining, done, distribution]
+      properties:
+        scored:
+          type: integer
+          description: Zeilen, die in diesem Lauf einen Score bekommen haben.
+        skippedFailed:
+          type: integer
+          description: >-
+            Zeilen mit fehlgeschlagener Prüfung. Sie bleiben NULL — ein Score 0
+            läse sich als "geprüft, sauber" und wäre die falsche Aussage.
+        lastId:
+          type: integer
+          nullable: true
+          description: Höchste in diesem Lauf bearbeitete Sichtungs-ID.
+        remaining:
+          type: integer
+          description: Noch unbewertete Zeilen nach diesem Lauf.
+        done:
+          type: boolean
+          description: >-
+            true, wenn dieser Lauf die Menge geleert hat. Aus der Batch-Größe
+            abgeleitet, nicht aus remaining — übersprungene Zeilen bleiben NULL
+            und würden remaining sonst nie auf 0 fallen lassen.
+        distribution:
+          type: object
+          additionalProperties:
+            type: integer
+          description: Score → Anzahl in diesem Lauf.
+          example: { '0': 187, '2': 11, '10': 2 }
+
     CleanupReport:
       type: object
       description: Ergebnis eines Aufräum-Laufs für verwaiste Uploads.


### PR DESCRIPTION
Folge-PR zu #787. Der dort ergänzte Spam-Score wird beim Speichern gesetzt — der **Backfill des Altbestands** war damit auf den deployten Hosts aber nicht durchführbar.

## Warum ein Endpunkt und kein Skript

Auf beiden Servern kommt man von außen nicht an die Datenbank (am 2026-08-07 verifiziert):

- **dmm (Produktion):** Das Compose auf dem Server gibt für `db` keinen Port frei — die DB hängt nur im internen Netz. Die Repo-Datei `docker-compose.production.yml` veröffentlicht zwar `127.0.0.1:5432` und führt hier in die Irre.
- **hawking (Preprod):** `sshd -T` meldet `allowtcpforwarding no` (Plesk-Härtung). Ein `LocalForward` bindet lokal, die Verbindung wird serverseitig sofort geschlossen — das Fehlerbild sieht aus wie eine abstürzende Postgres und ist keine.
- Zusätzlich liegt **`src/tools/` nicht im Runtime-Image**, und ein reines SQL-Skript scheidet aus: Die Heuristik braucht MX-DNS-Lookups und die TypeScript-Logik.

Der Backfill muss also dort laufen, wo die Anwendung läuft.

## Änderungen

- **`$lib/server/spam/rescoreSightings.ts`** — die Bewertungsschleife als getestetes Modul, benutzt von CLI **und** Endpunkt. Idempotent über `spam_score IS NULL`; Zeilen mit fehlgeschlagener Prüfung bleiben `NULL` (ein Score 0 läse sich als „geprüft, sauber"). `done` kommt aus der Batch-Größe, **nicht** aus `remaining` — sonst liefe ein Aufrufer wegen der übersprungenen Zeilen endlos.
- **`POST /api/admin/spam-rescore`** — Zugang und Aufbau wie `/api/admin/cleanup-orphans` (Admin-Session **oder** `CLEANUP_TOKEN`, `isAdminUser` statt `requireUserRole`, damit ein Skript keine 302 als Erfolg wertet). Batches à 200 (max. 1000), Audit-Eintrag `sighting.spam_rescore` je Lauf.
- **`src/tools/rescore-spam.ts`** auf das gemeinsame Modul umgebaut: schleift jetzt bis `done`, statt alles auf einmal zu laden.
- **`docs/SPAM_DETECTION.md`** (neu) — Signale samt Punkten, die Entscheidungen, die man leicht zurückdreht (Wortgrenzen, `ostsee_geo` statt Polygon, asymmetrische Duplikat-Schwellen, fail-open MX, warum Mailserver-Reputation *nicht* passt), Persistenz-Semantik und beide Backfill-Wege inkl. Loop-Snippet. Verlinkt aus `CLAUDE.md`.
- OpenAPI um Endpunkt und `SpamRescoreReport` ergänzt.

## Test-Nachweis

Test-First (RED→GREEN): 6 Tests fürs Modul (Verteilung, Fail-Safe wird nicht geschrieben, `done`-Semantik in beide Richtungen, Limit-Klemmung, Koordinaten/`ostsee_geo`-Durchreichung) und 9 für den Endpunkt (401 ohne Ausweis / ohne Admin-Rolle / mit falschem Token, beide Zugangswege, Limit-Durchreichung, unbrauchbares Limit, Audit-Eintrag, 500 bei Fehler). Volle Suite grün: Lint, `tsc`, svelte-check, **3.699 Unit-Tests**.

Zusätzlich gegen die lokale DB verifiziert: 30 Zeilen zurückgesetzt, Tool mit `--batch 20` gefahren → zwei Batches, 30 bewertet, Verteilung plausibel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)