### PR TITLE
feat(report): Einstiegsseite mit zwei klickbaren Karten statt Radio + „Weiter"

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -285,11 +285,19 @@ nur zur Hälfte. `daisyui/components/button.css` (5.7.4, nachgemessen am
 - Per Tastatur läuft Enter dagegen durch, landet im Wächter — und dort endete
   es bis zum UX-Review still.
 
-`ReportKindChoice.svelte` (Einstiegsseite) hat deshalb **keine** gesperrte
-Schaltfläche mehr: Der Knopf ist immer frei, und die Sperre ist eine
-Fehlermeldung an der Radiogruppe (`aria-invalid` + `role="alert"`). Das ist
-die richtige Form überall dort, wo die Sperre eine **fehlende Eingabe** meint —
-sie hat dann etwas zu sagen, und eine unerreichbare Schaltfläche sagt es nicht.
+Wo die Sperre eine **fehlende Eingabe** meint, ist eine Fehlermeldung die
+richtige Form — sie hat dann etwas zu sagen, und eine unerreichbare
+Schaltfläche sagt es nicht.
+
+**Der beste Fall ist allerdings, dass es nichts zu sperren gibt.**
+`ReportKindChoice.svelte` (Einstiegsseite) war die Aufrufstelle, an der dieser
+Befund entstand: erst ein `aria-disabled`-Knopf, dann ein freier Knopf mit
+Fehlermeldung an der Radiogruppe. Seit dem UX-Review 2026-08-07 hat sie
+**gar keine Schaltfläche mehr** — die Frage ist eine Weiche mit zwei Zielen,
+also zwei Links, und der Zustand „bestätigt, ohne etwas gewählt zu haben" ist
+strukturell nicht mehr herstellbar. Wer vor einem gesperrten Knopf steht,
+sollte deshalb zuerst prüfen, ob die Auswahl davor überhaupt eine Auswahl ist
+oder in Wahrheit eine Navigation (Begründung im Markup dort).
 
 `aria-disabled` bleibt richtig, wo die Sperre einen **laufenden oder noch nicht
 erreichten Zustand** meint, den der Nutzer nicht durch Eingabe auflösen kann

--- a/docs/PLAN_EINSTIEGSSEITE_MELDEFORMULAR_2026-08-05.md
+++ b/docs/PLAN_EINSTIEGSSEITE_MELDEFORMULAR_2026-08-05.md
@@ -1,5 +1,14 @@
 # Einstiegsseite des Meldeformulars — Konzept und Spezifikation
 
+> **Überholt am 2026-08-07 (Auswahlmechanik):** Die Einstiegsseite ist keine
+> Radiogruppe mit „Weiter" mehr, sondern zwei Link-Karten — jede Antwort ist
+> eine Navigation mit eigener URL, keine Auswahl, die noch bestätigt werden
+> müsste. Alles zur Radiogruppe, zum „Weiter"-Knopf und zum Fehlerzustand
+> „nichts gewählt" in diesem Dokument beschreibt den damaligen, nicht den
+> heutigen Stand. Zweig-Semantik, Query-Parameter-Vertrag und Fokus-Verhalten
+> gelten unverändert. Begründung: `ReportKindChoice.svelte` und der
+> `aria-disabled`-Abschnitt in `.claude/rules/design-system.md`.
+
 **Stand:** 2026-08-05 · **Fassung 2** (nach Review, siehe Abschnitt 14)
 **Vorlage:** `Sichtungs-Webseite_SL.docx` des Deutschen Meeresmuseums, Punkt C1
 **Status:** Umgesetzt (Branch `claude/bold-dhawan-5373e7`, 15 Tasks + Task 8b, Abschlussreview

--- a/docs/PLAN_EINSTIEGSSEITE_UMSETZUNG_2026-08-05.md
+++ b/docs/PLAN_EINSTIEGSSEITE_UMSETZUNG_2026-08-05.md
@@ -1,5 +1,14 @@
 # Einstiegsseite Meldeformular — Implementierungsplan
 
+> **Überholt am 2026-08-07 (Auswahlmechanik):** Die Einstiegsseite ist keine
+> Radiogruppe mit „Weiter" mehr, sondern zwei Link-Karten — jede Antwort ist
+> eine Navigation mit eigener URL, keine Auswahl, die noch bestätigt werden
+> müsste. Alles zur Radiogruppe, zum „Weiter"-Knopf und zum Fehlerzustand
+> „nichts gewählt" in diesem Dokument beschreibt den damaligen, nicht den
+> heutigen Stand. Zweig-Semantik, Query-Parameter-Vertrag und Fokus-Verhalten
+> gelten unverändert. Begründung: `ReportKindChoice.svelte` und der
+> `aria-disabled`-Abschnitt in `.claude/rules/design-system.md`.
+
 > **Für agentische Ausführung:** ERFORDERLICHE SUB-SKILL:
 > `superpowers:subagent-driven-development` (empfohlen) oder
 > `superpowers:executing-plans`. Schritte nutzen Checkbox-Syntax (`- [ ]`).

--- a/e2e/bestimmungshilfe.spec.ts
+++ b/e2e/bestimmungshilfe.spec.ts
@@ -100,8 +100,7 @@ test.describe('Bestimmungshilfe', () => {
 		   auch tatsächlich im Formular ankommt — ein Abbruch an der Auswahl wäre
 		   sonst nicht von einem echten Rückweg zu unterscheiden. */
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await expect(page.getByRole('heading', { name: 'Position & Zeitpunkt' })).toBeVisible();
 	});
 

--- a/e2e/form-autosave.spec.ts
+++ b/e2e/form-autosave.spec.ts
@@ -124,8 +124,7 @@ test.describe('Formular — Auto-Save & Restore', () => {
 
 		// Erneute Wahl darf nicht die vor dem Reset eingegebenen Werte zurückholen —
 		// sonst wäre "alle gespeicherten Daten" nur für den Zweig eingelöst.
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await expectCurrentStep(page, /Position & Zeitpunkt/i);
 		await expect(page.locator('[data-testid="field-waterway"]')).toHaveValue('');
 	});

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -4,49 +4,61 @@ import { fillStep1, fillStep4, waitForNextEnabled } from './helpers/form-helpers
 
 test.describe('Einstiegsseite des Meldeformulars', () => {
 	/**
-	 * UX-Review (2026-08-06, Punkt 1): Der Knopf war gesperrt und sagte nicht,
-	 * warum — per Maus war er wegen DaisyUIs `pointer-events: none` an
-	 * `[aria-disabled=true]` gar nicht erreichbar, per Tastatur lief das Enter
-	 * still ins Leere. Die Sperre ist seither eine Meldung an der Radiogruppe;
-	 * geprüft wird deshalb nicht mehr das Attribut, sondern die Wirkung.
+	 * UX-Review (2026-08-07): Die Seite ist keine Radiogruppe mit „Weiter" mehr,
+	 * sondern zwei Links. Der Zustand „bestätigt, ohne etwas gewählt zu haben" —
+	 * und mit ihm der ganze Fehler-Apparat, den der vorherige Test hier prüfte —
+	 * ist damit strukturell nicht mehr herstellbar.
+	 *
+	 * Was stattdessen zu sichern ist: Der Weg VOR der Hydration darf nicht ins
+	 * Leere laufen. Er hängt jetzt allein am `href` — und zwar am serverseitig
+	 * ausgelieferten, weshalb dieser Test bewusst NICHT auf `networkidle`
+	 * wartet: Die Aussage gilt für das rohe SSR-Markup.
 	 */
-	test('Erstbesucher sieht die Auswahl und kommt ohne sie nicht weiter', async ({ page }) => {
+	test('Erstbesucher sieht die Auswahl, beide Karten tragen ihr Ziel im href', async ({ page }) => {
 		await page.goto('/');
-		await page.waitForLoadState('networkidle');
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
 
-		await expect(page.getByTestId('report-kind-submit')).not.toHaveAttribute('aria-disabled');
+		await expect(page.getByTestId('report-kind-option-lebend')).toHaveAttribute(
+			'href',
+			/[?&]meldung=lebend/
+		);
+		await expect(page.getByTestId('report-kind-option-totfund')).toHaveAttribute(
+			'href',
+			/[?&]meldung=totfund/
+		);
+	});
 
-		// `toPass` statt eines einzelnen Klicks: `networkidle` sagt nur „keine
-		// Netzwerkaktivität mehr", nicht „Svelte hat hydratisiert". Trifft der
-		// Klick das Zeitfenster davor, schickt der Browser das Formular nativ ab
-		// und lädt die Seite ohne Auswahl neu (`/?`) — die Meldung entsteht dann
-		// nie, und der Test wäre flaky statt aussagekräftig. Der Klick ist
-		// idempotent, also darf er wiederholt werden; nach dem Reload ist
-		// hydratisiert.
-		await expect(async () => {
-			await page.getByTestId('report-kind-submit').click();
-			await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i, {
-				timeout: 2000
-			});
-		}).toPass();
+	/**
+	 * Die Gegenprobe zum Test oben: Der `href` allein belegt nur, dass das Ziel
+	 * dasteht — nicht, dass ein Melder ohne JS dort auch ankommt. Hier wird die
+	 * Navigation tatsächlich gefahren, mit abgeschaltetem JavaScript.
+	 */
+	test('ohne JavaScript führt die Karte per Navigation in den richtigen Zweig', async ({
+		browser
+	}) => {
+		const context = await browser.newContext({ javaScriptEnabled: false });
+		const page = await context.newPage();
+		await page.goto('/');
 
-		await expect(page.getByRole('radiogroup')).toHaveAttribute('aria-invalid', 'true');
-		// Weitergegangen wird trotzdem nicht.
-		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
+		await page.getByTestId('report-kind-option-totfund').click();
+
+		await expect(page).toHaveURL(/meldung=totfund/);
+		// Ohne JS bleibt das Formular statisch, die serverseitig aufgelöste
+		// Verzweigung ist aber sichtbar — Schritt 1 trägt im Totfund-Zweig
+		// „Funddatum" statt „Datum und Uhrzeit".
+		await expect(page.getByRole('heading', { name: 'Funddatum' })).toBeVisible();
+
+		await context.close();
 	});
 
 	test('nach der Auswahl erscheint Schritt 1', async ({ page }) => {
 		await page.goto('/');
 		// Wie FormPage.goto(): Playwrights Actionability-Check wartet nur auf
-		// Sichtbarkeit, nicht auf Hydration. Ein Klick auf „Weiter" davor schickt
-		// das Formular nativ per GET ab (UX-Review 2026-08-06, Punkt 1: genau
-		// dafür heißen die Radios `meldung` und tragen `lebend`/`totfund`) — der
-		// Melder käme zwar richtig an, aber über eine Navigation statt über den
-		// Klick-Pfad, den dieser Test prüfen soll.
+		// Sichtbarkeit, nicht auf Hydration. Ein Klick davor navigiert nativ über
+		// den `href` — der Melder käme zwar richtig an, aber über eine
+		// Seitennavigation statt über den Klick-Pfad, den dieser Test prüfen soll.
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /toten Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-totfund').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 		// toBeHidden() allein wäre auch für ein gar nicht existentes Element
 		// erfüllt — erst diese Zeile belegt, dass tatsächlich Schritt 1 da ist.
@@ -65,8 +77,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 		// irgendeine Seite hinter der Auswahl anzeigen.
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /toten Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-totfund').click();
 
 		// Schritt 1: ohne GPS-Position ist die Ortsbeschreibung Pflicht.
 		await page.getByTestId('field-waterway').fill('Kieler Bucht');
@@ -84,8 +95,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 		// navigiert das die Museumsseite weg.
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 
 		await page.goBack();
@@ -102,8 +112,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	test('Wiederkehrer mit gespeichertem Stand wird nicht erneut gefragt', async ({ page }) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await page.reload();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 		await expect(page.getByRole('heading', { name: 'Position & Zeitpunkt' })).toBeVisible();
@@ -119,8 +128,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	test('„Ändern" auf Schritt 2 führt zurück auf die Auswahlseite', async ({ page }) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 
 		// Schritt 1 → Schritt 2, wie im Test „Totfund-Wahl kommt als isDead an".
@@ -145,8 +153,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	test('„Ändern" auf Schritt 1 führt zurück auf die Auswahlseite (B6)', async ({ page }) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /toten Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-totfund').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 
 		// Schon auf Schritt 1 sichtbar, ohne dass ein Feld ausgefüllt werden muss.
@@ -168,13 +175,12 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	test('„Ändern" setzt den Fokus auf die Auswahlfrage (B7)', async ({ page }) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /lebenden Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-lebend').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 
 		await page.getByRole('button', { name: /ändern/i }).click();
 
-		const legend = page.locator('#report-kind-legend');
+		const legend = page.locator('#report-kind-question');
 		await expect(legend).toBeVisible();
 		await expect(legend).toBeFocused();
 	});
@@ -194,8 +200,7 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	}) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /toten Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-totfund').click();
 		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
 
 		await page.getByTestId('field-waterway').fill('Kieler Bucht');
@@ -213,22 +218,41 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 		// durch diesen kurzen SSR-Flash, unabhängig vom eigentlichen Fehler.
 		await page.waitForLoadState('networkidle');
 
-		// `networkidle` sagt nur „keine Netzwerkaktivität mehr" — nicht „Svelte hat
-		// hydratisiert". Ein `toBeVisible()` allein bestünde deshalb auch dann, wenn
-		// `networkidle` noch VOR der Hydration aufläuft (langsamerer Runner,
-		// gecachte Module, andere Bundling-Strategie): Die statische SSR-Auswahlseite
-		// steht testidentisch im DOM, egal ob Svelte sie schon übernommen hat.
-		//
-		// Der Beleg war früher der Wechsel von `aria-disabled` am „Weiter"-Knopf;
-		// den gibt es seit dem UX-Review (2026-08-06, Punkt 1) nicht mehr. An seine
-		// Stelle tritt die Fehlermeldung an der Radiogruppe: Sie entsteht
-		// ausschließlich aus Svelte-State. Ohne Hydration schickte derselbe Klick
-		// das Formular nativ ab und lüde die Seite neu, statt eine Meldung
-		// einzublenden — der Test wäre dann rot, nicht trivial grün.
-		await page.getByTestId('report-kind-submit').click();
-		await expect(page.getByRole('alert')).toContainText(/Bitte wählen Sie aus/i);
-
 		await expect(page.getByTestId('report-kind-choice')).toBeVisible();
+
+		// `networkidle` sagt nur „keine Netzwerkaktivität mehr" — nicht „Svelte hat
+		// hydratisiert". Die Zeile darüber bestünde deshalb auch dann, wenn
+		// `networkidle` noch VOR der Hydration aufläuft (langsamerer Runner,
+		// gecachte Module, andere Bundling-Strategie): Die statische
+		// SSR-Auswahlseite steht testidentisch im DOM, egal ob Svelte sie schon
+		// übernommen hat.
+		//
+		// Der Beleg war früher der Wechsel von `aria-disabled` am „Weiter"-Knopf,
+		// danach die Fehlermeldung an der Radiogruppe — beides gibt es seit dem
+		// Umbau auf Links (UX-Review 2026-08-07) nicht mehr. An ihre Stelle tritt
+		// das Shallow Routing: Ein hydratisierter Klick fängt den Link ab und
+		// wechselt per `pushState` in den Zweig, OHNE das Dokument neu zu laden —
+		// die Markierung am `window` überlebt das. Ohne Hydration navigierte
+		// derselbe Klick nativ über den `href`, und sie wäre weg.
+		//
+		// Dass diese Karte überhaupt noch klickbar ist, ist zugleich der
+		// eigentliche Befund: Wäre der verlassene Zweig über `resolveReportKind`s
+		// dritte Quelle zurückgekehrt, stünde hier längst das Formular.
+		await page.evaluate(() => {
+			(window as unknown as Record<string, unknown>).__vorDemKlick = true;
+		});
+		await page.getByTestId('report-kind-option-lebend').click();
+		// Nicht auf Schritt 1 prüfen: `currentStep` kommt aus dem Storage, und
+		// dieser Test war vor dem „Ändern" bereits auf Schritt 2 — das Formular
+		// kehrt dorthin zurück. Die Aussage hier ist „die Auswahl ist durch", nicht
+		// „ein bestimmter Schritt steht".
+		await expect(page.getByTestId('report-kind-choice')).toBeHidden();
+		await expect(page.getByRole('navigation', { name: 'Formular-Schritte' })).toBeVisible();
+
+		const dokumentUeberlebte = await page.evaluate(
+			() => (window as unknown as Record<string, unknown>).__vorDemKlick === true
+		);
+		expect(dokumentUeberlebte).toBe(true);
 	});
 });
 
@@ -349,8 +373,7 @@ test.describe('Der aus dem Storage aufgelöste Zweig wird in die URL nachgetrage
 	}) => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
-		await page.getByRole('radio', { name: /toten Tieres/i }).check();
-		await page.getByTestId('report-kind-submit').click();
+		await page.getByTestId('report-kind-option-totfund').click();
 		await expect(page).toHaveURL(/meldung=totfund/);
 
 		// Simuliert einen Wiederkehrer in derselben Sitzung, dessen URL den

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -169,8 +169,12 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 	 * B7 (Abschlussreview, wichtig): „Ändern" tauschte den ganzen Formularbaum
 	 * gegen die Auswahlseite aus, ohne den Fokus mitzunehmen — er fiel auf
 	 * `<body>`, angesagt wurde nichts. `ReportKindChoice` fokussiert seither
-	 * beim Rücksprung ihre Legend, dieselbe Mechanik wie beim Schrittwechsel im
-	 * Formular (`scrollAndFocusStep`).
+	 * beim Rücksprung ihre Auswahlfrage, dieselbe Mechanik wie beim
+	 * Schrittwechsel im Formular (`scrollAndFocusStep`).
+	 *
+	 * Bis zum Umbau auf Links war diese Frage eine `<legend>`; seither ist sie
+	 * die `<h2>` über den beiden Karten. Die Rolle im Fokus-Muster ist
+	 * unverändert.
 	 */
 	test('„Ändern" setzt den Fokus auf die Auswahlfrage (B7)', async ({ page }) => {
 		await page.goto('/');
@@ -180,9 +184,9 @@ test.describe('Einstiegsseite des Meldeformulars', () => {
 
 		await page.getByRole('button', { name: /ändern/i }).click();
 
-		const legend = page.locator('#report-kind-question');
-		await expect(legend).toBeVisible();
-		await expect(legend).toBeFocused();
+		const auswahlfrage = page.locator('#report-kind-question');
+		await expect(auswahlfrage).toBeVisible();
+		await expect(auswahlfrage).toBeFocused();
 	});
 
 	/**

--- a/src/lib/report/components/ReportKindChoice.svelte
+++ b/src/lib/report/components/ReportKindChoice.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
-	import {
-		REPORT_KIND_PARAM,
-		reportKindToParam,
-		resolveReportKind,
-		type ReportKind
-	} from '$lib/report/reportKind';
+	import { REPORT_KIND_PARAM, reportKindToParam, type ReportKind } from '$lib/report/reportKind';
 	import { isNotIFrame } from '$lib/utils/client/isNotIFrame';
 	import { scrollToElement } from '$lib/utils/fieldNavigation';
 
@@ -17,41 +12,24 @@
 		// ersten Tab-Stopp hinter die Navigation, ohne Nutzen. `+page.svelte`
 		// setzt das Prop gezielt nur für den Rücksprung aus dem Formular (Ändern,
 		// Reset, Browser-Zurück).
-		autofocusHeading = false
-	}: { onchoose: (kind: ReportKind) => void; autofocusHeading?: boolean } = $props();
+		autofocusHeading = false,
+		/*
+		 * Das Ziel der beiden Links — der JS-lose Pfad, siehe Kommentar am Markup.
+		 * Der Default reicht für die Startseite ohne weitere Query-Parameter;
+		 * `+page.svelte` überschreibt ihn, um bestehende Parameter (Kampagnen-
+		 * Marker aus einem Museums-Link) zu erhalten. Die Komponente baut den
+		 * Wert bewusst nicht selbst aus `$app/state`: Sie bliebe damit ohne
+		 * SvelteKit-Umgebung nicht mehr renderbar, und die Stelle, die die URL
+		 * ohnehin schon hält, ist `+page.svelte`.
+		 */
+		buildHref = (kind: ReportKind) => `?${REPORT_KIND_PARAM}=${reportKindToParam(kind)}`
+	}: {
+		onchoose: (kind: ReportKind) => void;
+		autofocusHeading?: boolean;
+		buildHref?: (kind: ReportKind) => string;
+	} = $props();
 
-	/**
-	 * UX-Review (2026-08-06, Punkt 1): Steht auf `true`, sobald einmal ohne
-	 * Auswahl bestätigt wurde. Ersetzt die frühere `aria-disabled`-Sperre am
-	 * „Weiter"-Knopf, die zwei Wege still ins Leere laufen ließ — Begründung an
-	 * der Aufrufstelle des Knopfes unten.
-	 */
-	let selectionMissing = $state(false);
-	let legendEl: HTMLElement | undefined = $state();
-
-	/*
-	 * Die Radios heißen wie der Query-Parameter der Seite (`REPORT_KIND_PARAM`)
-	 * und tragen dessen deutsche Werte (`reportKindToParam`). Warum das ein
-	 * Vertrag und keine Kosmetik ist, steht an der Konstante in `reportKind.ts`.
-	 *
-	 * Zwei Dinge, die dieser Weg NICHT leistet:
-	 *
-	 * 1. **Bestehende Query-Parameter überleben ihn nicht** — ein GET-Submit
-	 *    ersetzt die gesamte Query. `choose()` in `+page.svelte` hält sie im
-	 *    JS-Pfad erhalten (Kampagnen-Marker aus einem Museums-Link); ohne JS
-	 *    bräuchte es dafür je ein verstecktes Feld, dessen Wert nur
-	 *    `$app/state` kennt.
-	 * 2. **Ohne Auswahl bleibt er stumm.** Vor der Hydration führt „Weiter"
-	 *    ohne angekreuzte Option zu `/?` — einem vollständigen Reload ohne
-	 *    Erklärung statt der Meldung unten. Ein `required` an den Radios löste
-	 *    das nativ, verdrängte aber im JS-Pfad die eigene Meldung durch die
-	 *    Browser-Blase, die nicht barrierefrei ist und nicht stehen bleibt. Der
-	 *    Zielkonflikt ist zugunsten des JS-Pfads entschieden: Er ist der
-	 *    Regelfall, der andere ein Zeitfenster von Sekunden.
-	 *
-	 * Beides ist bewusst in Kauf genommen — auf diesem Weg passierte vorher
-	 * überhaupt nichts (der Knopf war per `pointer-events: none` unerreichbar).
-	 */
+	let questionEl: HTMLElement | undefined = $state();
 
 	/**
 	 * B7: „Ändern" tauschte bislang den gesamten Formularbaum gegen diese Seite
@@ -59,48 +37,37 @@
 	 * nichts. Dieselbe Mechanik wie beim Schrittwechsel (`scrollAndFocusStep` in
 	 * `form/StepNavigation.svelte`): Kopf des neuen Inhalts fokussieren.
 	 *
-	 * Fokussiert wird die `<legend>`, nicht die `<h1>` darüber — die
-	 * Überschrift ist im iframe bewusst ausgeblendet (siehe unten), die Legend
-	 * dagegen immer vorhanden. Anders als bei den Formular-Schritten braucht es
-	 * kein `requestAnimationFrame`: Diese Komponente ist beim ersten Lauf des
-	 * Effekts bereits vollständig gerendert, es gibt keinen „alten Inhalt", der
-	 * noch im Weg stehen könnte.
+	 * Fokussiert wird die Frage, nicht die `<h1>` darüber — die Seitenüberschrift
+	 * ist im iframe bewusst ausgeblendet (siehe unten), die Frage dagegen immer
+	 * vorhanden. Anders als bei den Formular-Schritten braucht es kein
+	 * `requestAnimationFrame`: Diese Komponente ist beim ersten Lauf des Effekts
+	 * bereits vollständig gerendert, es gibt keinen „alten Inhalt", der noch im
+	 * Weg stehen könnte.
 	 */
 	$effect(() => {
-		if (!autofocusHeading || !legendEl) return;
-		scrollToElement(legendEl);
-		legendEl.setAttribute('tabindex', '-1');
-		legendEl.focus({ preventScroll: true });
+		if (!autofocusHeading || !questionEl) return;
+		scrollToElement(questionEl);
+		questionEl.setAttribute('tabindex', '-1');
+		questionEl.focus({ preventScroll: true });
 	});
 
 	/**
-	 * Die Auswahl wird aus dem abgeschickten Formular gelesen, nicht aus einem
-	 * eigenen `$state`. Der Grund ist derselbe wie beim Feldnamen oben: Wer vor
-	 * der Hydration eine Option ankreuzt, tut das im DOM — ein `$state` wüsste
-	 * davon nichts und meldete danach „nichts gewählt", obwohl sichtbar etwas
-	 * angekreuzt ist.
+	 * Der Regelweg: Klick abfangen, Zweig melden, statt die Seite neu zu laden.
+	 * `+page.svelte` setzt daraufhin selbst die URL (inklusive History-Eintrag,
+	 * damit „Zurück" auf die Auswahl führt statt aus der App).
 	 *
-	 * `resolveReportKind(param, null, null)` ist hier die Parameter-Zuordnung
-	 * ohne Storage-Quellen — dieselbe Aufrufform wie im `popstate`-Handler in
-	 * `+page.svelte`.
+	 * Modifizierte Klicks bleiben dem Browser überlassen — Strg/Cmd öffnet einen
+	 * neuen Tab, Shift ein neues Fenster. Würde der Handler auch sie abfangen,
+	 * bliebe der Nutzer im alten Tab zurück, während der neue leer bleibt.
+	 * `button !== 0` deckt Klicks ab, die manche Browser als `click` melden,
+	 * ohne dass die primäre Taste gedrückt war.
 	 */
-	function submit(event: SubmitEvent & { currentTarget: HTMLFormElement }): void {
-		event.preventDefault();
-
-		const submitted = new FormData(event.currentTarget).get(REPORT_KIND_PARAM);
-		const chosen = resolveReportKind(typeof submitted === 'string' ? submitted : null, null, null);
-
-		if (!chosen) {
-			selectionMissing = true;
-			// Fokus zur Gruppe, zu der die Meldung gehört — er stünde sonst auf dem
-			// Knopf, und ein Screenreader-Nutzer müsste rückwärts suchen, was
-			// beanstandet wird. Das Fokussieren eines Radios wählt es nicht aus.
-			event.currentTarget.querySelector<HTMLInputElement>('input[type="radio"]')?.focus();
+	function select(event: MouseEvent, kind: ReportKind): void {
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) {
 			return;
 		}
-
-		selectionMissing = false;
-		onchoose(chosen);
+		event.preventDefault();
+		onchoose(kind);
 	}
 
 	const OPTIONS: Array<{ value: ReportKind; label: string; hint: string; icon: string }> = [
@@ -119,7 +86,7 @@
 	];
 </script>
 
-<form class="mx-auto max-w-2xl px-4 py-8" onsubmit={submit} data-testid="report-kind-choice">
+<div class="mx-auto max-w-2xl px-4 py-8" data-testid="report-kind-choice">
 	{#if isNotIFrame}
 		<!-- Nur außerhalb des meeresmuseum.de-iframe: Die Museumsseite trägt dort
 		     ihre eigene Überschrift „Meerestier melden" — dieselbe Bedingung wie
@@ -130,76 +97,67 @@
 		<h1 class="text-display mb-2">Meerestier melden</h1>
 	{/if}
 	<!-- Beantwortet die naheliegende Frage „warum werde ich das gefragt?" genau
-	     dort, wo sie anfällt — das ist die Begründung für den zusätzlichen Klick. -->
+	     dort, wo sie anfällt. -->
 	<p class="text-base-content/70 mb-6">Damit wir Ihnen die passenden Fragen stellen können.</p>
 
-	<!-- role="radiogroup" überschreibt die implizite Rolle `group` des fieldset:
-	     nur so sagt ein Screenreader „1 von 2" an und verknüpft die Legend mit
-	     den Optionen. Gleiche Mechanik wie in FieldRenderer.svelte. -->
-	<!-- aria-invalid und aria-describedby tragen die Gruppe, nicht die einzelnen
-	     Radios — aber aus zwei verschiedenen Gründen, die sich leicht
-	     verwechseln lassen:
+	<h2 id="report-kind-question" class="text-section mb-3" bind:this={questionEl}>
+		Was möchten Sie melden?
+	</h2>
 
-	     `aria-invalid` MUSS hierher: ARIA 1.2 hat es (wie `aria-required`) aus
-	     den globalen Zuständen entfernt, `role="radio"` unterstützt es seither
-	     nicht (design-system.md, A11y-Minima). `aria-describedby` ist dagegen
-	     weiterhin global und stünde an einem Radio nicht falsch — es steht
-	     hier, weil die Meldung die GRUPPE beanstandet und nicht eine der beiden
-	     Optionen. Dasselbe Muster wie in FieldRenderer.svelte. -->
-	<fieldset
-		role="radiogroup"
-		aria-labelledby="report-kind-legend"
-		aria-required="true"
-		aria-invalid={selectionMissing ? 'true' : undefined}
-		aria-describedby={selectionMissing ? 'report-kind-error' : undefined}
-	>
-		<legend id="report-kind-legend" class="text-section mb-3" bind:this={legendEl}
-			>Was möchten Sie melden?</legend
-		>
+	<!-- Zwei Links, keine Radiogruppe mit „Weiter": Jede Antwort führt sofort
+	     woanders hin und hat eine eigene URL — das ist eine Navigation, keine
+	     Auswahl, die noch bestätigt werden müsste. Eine Radio-Karte, die beim
+	     Ankreuzen selbst weiterschickt, wäre kein Ersatz, sondern ein
+	     Anti-Pattern: Wer per Pfeiltaste durch eine Radiogruppe geht, wählt
+	     zwangsläufig die erste Option aus (WCAG 3.2.2).
 
-		<div class="flex flex-col gap-3">
+	     Der `href` trägt das Ziel und macht den Weg ohne JS trivial: Ein Klick
+	     vor der Hydration navigiert nativ auf `/?meldung=totfund`, wo
+	     `resolveReportKind` den Zweig schon serverseitig auflöst. Der frühere
+	     GET-Submit konnte das nur unter zwei Vorbehalten — er ersetzte die
+	     gesamte Query (Kampagnen-Marker gingen verloren) und lud ohne Auswahl
+	     stumm `/?` nach. Beides entfällt hier, ebenso der ganze Fehlerzustand
+	     „nichts gewählt": Er ist strukturell nicht mehr herstellbar.
+
+	     `<nav>` mit `aria-labelledby` statt einer Liste loser Links: So findet
+	     ein Screenreader-Nutzer die beiden Ziele als benannte Gruppe („Was
+	     möchten Sie melden?") wieder, ohne dass es eine Auswahl-Semantik
+	     vortäuscht. -->
+	<nav aria-labelledby="report-kind-question">
+		<ul class="flex list-none flex-col gap-3 p-0">
 			{#each OPTIONS as option (option.value)}
-				<label
-					class="border-base-300 hover:bg-base-200 rounded-box flex cursor-pointer items-start gap-3 border p-4"
-				>
-					<input
-						type="radio"
-						name={REPORT_KIND_PARAM}
-						class="radio radio-primary mt-1"
-						value={reportKindToParam(option.value)}
-						onchange={() => (selectionMissing = false)}
-					/>
-					<span class="flex flex-col gap-1">
-						<span class="flex items-center gap-2 font-medium">
-							<Icon icon={option.icon} width="20" aria-hidden="true" />
-							{option.label}
+				<li>
+					<!-- Label UND Hinweis stehen INNERHALB des Links: Der Hinweis ist die
+					     eigentliche Unterscheidungshilfe; außerhalb gelassen hörte ein
+					     Screenreader-Nutzer beim Durchgehen der Links nur die beiden
+					     ähnlich klingenden Überschriften. -->
+					<a
+						href={buildHref(option.value)}
+						onclick={(event) => select(event, option.value)}
+						data-testid="report-kind-option-{reportKindToParam(option.value)}"
+						class="border-base-300 hover:bg-base-200 hover:border-primary rounded-box flex w-full items-center gap-3 border p-4 no-underline transition-colors"
+					>
+						<Icon
+							icon={option.icon}
+							width="24"
+							class="text-primary flex-shrink-0"
+							aria-hidden="true"
+						/>
+						<span class="flex flex-1 flex-col gap-1">
+							<span class="text-base-content font-medium">{option.label}</span>
+							<span class="text-base-content/70 text-support">{option.hint}</span>
 						</span>
-						<span class="text-base-content/70 text-support">{option.hint}</span>
-					</span>
-				</label>
+						<!-- Macht die Karte auf den ersten Blick als „führt weiter" lesbar —
+						     die Aufgabe, die vorher der „Weiter"-Knopf übernahm. -->
+						<Icon
+							icon="lucide:chevron-right"
+							width="20"
+							class="text-base-content/70 flex-shrink-0"
+							aria-hidden="true"
+						/>
+					</a>
+				</li>
 			{/each}
-		</div>
-
-		<!-- Gleiche Fehler-Optik wie an jedem Formularfeld (FieldRenderer.svelte),
-		     damit die Meldung hier nicht wie ein Fremdkörper aussieht. -->
-		{#if selectionMissing}
-			<div id="report-kind-error" class="mt-3 text-left" role="alert" aria-live="polite">
-				<span class="text-error text-support flex items-center gap-1 font-medium">
-					<Icon icon="lucide:triangle-alert" width="14" class="text-error flex-shrink-0" />
-					Bitte wählen Sie aus, was Sie melden möchten.
-				</span>
-			</div>
-		{/if}
-	</fieldset>
-
-	<!-- Kein `aria-disabled` (und erst recht kein `disabled`): Eine gesperrte
-	     Schaltfläche sagte nicht, was fehlt. DaisyUI legt an
-	     `.btn[aria-disabled=true]` ein `pointer-events: none` — vor der Hydration
-	     erreichte ein Klick das Element damit gar nicht, und per Tastatur lief das
-	     Enter durch, ohne dass der stille Wächter in `submit` etwas meldete
-	     (UX-Review 2026-08-06, Punkt 1). Die Sperre ist jetzt die Meldung an der
-	     Radiogruppe oben. -->
-	<button type="submit" class="btn btn-primary mt-6 w-full" data-testid="report-kind-submit">
-		Weiter
-	</button>
-</form>
+		</ul>
+	</nav>
+</div>

--- a/src/lib/report/components/ReportKindChoice.svelte.test.ts
+++ b/src/lib/report/components/ReportKindChoice.svelte.test.ts
@@ -113,20 +113,67 @@ describe('ReportKindChoice — der Link trägt den Zweig ohne JS', () => {
  * neue zeigt nichts — der klassische Fehler beim „Aufwerten" eines Links per JS.
  */
 describe('ReportKindChoice — modifizierte Klicks bleiben Browser-Sache', () => {
+	/**
+	 * Genau das Verhalten, das hier geprüft wird, macht den Test gefährlich: Ein
+	 * Klick, den die Komponente absichtlich NICHT abfängt, aktiviert den Link —
+	 * und Vitests Browser-Mode rendert jede Testdatei in einem eigenen iframe.
+	 * Der navigiert dann weg, und der Lauf bricht mit „Cannot connect to the
+	 * iframe" ab, ohne dass eine einzige Assertion fehlschlägt (in CI so
+	 * passiert, lokal nicht — es ist ein Rennen gegen die Navigation).
+	 *
+	 * Der Helfer hängt deshalb einen eigenen Listener ans `document`. Er läuft in
+	 * der Bubbling-Phase, also NACH dem Handler am Link: Er liest zuerst ab, ob
+	 * die Komponente den Klick abgefangen hat, und unterbindet danach die
+	 * Navigation. Ein `preventDefault` in der Capture-Phase wäre kein Ersatz — es
+	 * verdeckte genau die Frage, um die es geht.
+	 */
+	function klickenOhneNavigation(
+		link: Element,
+		modifier: MouseEventInit
+	): { vonKomponenteAbgefangen: boolean } {
+		let vonKomponenteAbgefangen = false;
+		const wächter = (event: Event) => {
+			vonKomponenteAbgefangen = event.defaultPrevented;
+			event.preventDefault();
+		};
+		document.addEventListener('click', wächter);
+		try {
+			link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, ...modifier }));
+		} finally {
+			document.removeEventListener('click', wächter);
+		}
+		return { vonKomponenteAbgefangen };
+	}
+
 	it.each([
 		['Strg', { ctrlKey: true }],
 		['Cmd', { metaKey: true }],
-		['Shift', { shiftKey: true }]
+		['Shift', { shiftKey: true }],
+		['Alt', { altKey: true }]
 	])('%s-Klick wird nicht abgefangen', (_name, modifier) => {
 		const onchoose = vi.fn();
 		render(ReportKindChoice, { onchoose });
 
 		const link = document.querySelector('a[data-testid="report-kind-option-totfund"]');
-		const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...modifier });
-		link?.dispatchEvent(event);
+		expect(link).not.toBeNull();
+		const { vonKomponenteAbgefangen } = klickenOhneNavigation(link as Element, modifier);
 
 		expect(onchoose).not.toHaveBeenCalled();
-		expect(event.defaultPrevented).toBe(false);
+		expect(vonKomponenteAbgefangen).toBe(false);
+	});
+
+	it('fängt den gewöhnlichen Klick dagegen ab — die Gegenprobe zum Helfer', () => {
+		// Ohne sie belegte das Grün oben nur, dass `vonKomponenteAbgefangen`
+		// irgendwie `false` wird: Ein Helfer, der die Flanke gar nicht misst, wäre
+		// für alle vier Modifier genauso grün.
+		const onchoose = vi.fn();
+		render(ReportKindChoice, { onchoose });
+
+		const link = document.querySelector('a[data-testid="report-kind-option-totfund"]');
+		const { vonKomponenteAbgefangen } = klickenOhneNavigation(link as Element, {});
+
+		expect(onchoose).toHaveBeenCalledWith('dead');
+		expect(vonKomponenteAbgefangen).toBe(true);
 	});
 });
 

--- a/src/lib/report/components/ReportKindChoice.svelte.test.ts
+++ b/src/lib/report/components/ReportKindChoice.svelte.test.ts
@@ -1,147 +1,132 @@
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
+import type { ReportKind } from '$lib/report/reportKind';
 import ReportKindChoice from './ReportKindChoice.svelte';
 
+/**
+ * Die Einstiegsseite fragt eine Weiche ab, kein Formularfeld: Jede der beiden
+ * Antworten führt sofort woanders hin und hat eine eigene URL (`?meldung=…`).
+ * Sie ist deshalb seit dem UX-Review (2026-08-07) keine Radiogruppe mit
+ * „Weiter" mehr, sondern zwei Links — genau eine Aktion pro Karte.
+ *
+ * Warum das die richtige Form ist und die alte nicht:
+ *
+ * - **Radios dürfen nicht selbst auslösen** (WCAG 3.2.2, „On Input"): Wer per
+ *   Pfeiltaste durch eine Radiogruppe geht, wählt zwangsläufig die erste Option
+ *   aus. Eine anklickbare Radio-Karte mit Auto-Submit wäre also kein
+ *   Fortschritt, sondern ein Anti-Pattern — die Auswahl-Semantik musste ganz
+ *   weichen, nicht nur der Knopf.
+ * - **Der Zustand „nichts gewählt" verschwindet strukturell.** Der frühere
+ *   Fehler-Apparat (`selectionMissing`, `aria-invalid` an der Gruppe, Fokus-
+ *   Sprung zum ersten Radio) existierte nur, weil „Weiter" ohne Auswahl
+ *   drückbar war. Zwei direkte Links machen diesen Zustand unmöglich.
+ * - **Der JS-lose Pfad wird trivial.** Er hängt nicht mehr an einem nativen
+ *   GET-Submit, der die übrigen Query-Parameter ersetzt hätte (der bewusst in
+ *   Kauf genommene Verlust von Kampagnen-Markern aus einem Museums-Link), und
+ *   auch nicht mehr an einem stummen Reload auf `/?`, wenn nichts gewählt war.
+ *   Der `href` trägt das Ziel; ohne JS navigiert der Browser einfach dorthin.
+ */
 describe('ReportKindChoice', () => {
-	it('stellt die Frage als Radiogruppe, nicht als zwei lose Buttons', async () => {
+	it('bietet beide Zweige als Links an, lebendes Tier zuerst', async () => {
 		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
-		await expect.element(gruppe).toBeInTheDocument();
-	});
 
-	it('bietet beide Zweige an, lebendes Tier zuerst', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+		const testids = Array.from(
+			document.querySelectorAll<HTMLAnchorElement>('a[data-testid^="report-kind-option-"]')
+		).map((link) => link.getAttribute('data-testid'));
+		expect(testids).toEqual(['report-kind-option-lebend', 'report-kind-option-totfund']);
+
 		await expect
-			.element(screen.getByRole('radio', { name: /lebenden Tieres/i }))
+			.element(screen.getByRole('link', { name: /lebenden Tieres/i }))
 			.toBeInTheDocument();
-		await expect.element(screen.getByRole('radio', { name: /toten Tieres/i })).toBeInTheDocument();
+		await expect.element(screen.getByRole('link', { name: /toten Tieres/i })).toBeInTheDocument();
 	});
 
-	it('meldet erst beim Bestätigen, nicht schon beim Auswählen', async () => {
-		// Kein Auto-Advance: Wer per Pfeiltaste durch eine Radiogruppe geht,
-		// wählt zwangsläufig die erste Option aus und würde sonst ungewollt
-		// weitergeschickt (WCAG 3.2.2).
+	it('trägt den Hinweistext im Namen des Links, nicht nur daneben', async () => {
+		// Der Hinweis ist die eigentliche Unterscheidungshilfe („Sie haben ein
+		// totes Tier gefunden, meist an einem Strand"). Stünde er außerhalb des
+		// Links, hörte ein Screenreader-Nutzer beim Durchgehen der Links nur die
+		// beiden ähnlich klingenden Überschriften.
+		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
+
+		await expect
+			.element(screen.getByRole('link', { name: /totes Tier gefunden/i }))
+			.toBeInTheDocument();
+	});
+
+	it('meldet den Zweig beim Klick und lässt den Browser nicht navigieren', async () => {
 		const onchoose = vi.fn();
-		const screen = render(ReportKindChoice, { onchoose });
+		render(ReportKindChoice, { onchoose });
 
-		await screen.getByRole('radio', { name: /toten Tieres/i }).click();
-		expect(onchoose).not.toHaveBeenCalled();
-
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-		expect(onchoose).toHaveBeenCalledWith('dead');
-	});
-
-	it('lässt sich nicht ohne Auswahl bestätigen', async () => {
-		const onchoose = vi.fn();
-		const screen = render(ReportKindChoice, { onchoose });
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-		expect(onchoose).not.toHaveBeenCalled();
-	});
-});
-
-/**
- * UX-Review (2026-08-06, Punkt 1): Der Knopf trug `aria-disabled`, solange nichts
- * gewählt war — und sagte nicht, warum. Zwei Wege liefen damit ins Leere:
- *
- * - **Maus, vor der Hydration.** DaisyUI setzt an `.btn[aria-disabled=true]`
- *   ein `pointer-events: none` (verifiziert in `node_modules/daisyui/components/
- *   button.css`, 5.7.4). Der Klick erreichte das Element also gar nicht. Auf einer
- *   schlechten Mobilverbindung am Strand sind das Sekunden, in denen die Seite
- *   kaputt wirkt.
- * - **Tastatur, nach der Hydration.** `pointer-events` bremst keine
- *   Enter-Taste — der Submit lief, der Wächter in `submit()` stieg still aus,
- *   angesagt wurde nichts.
- *
- * Der Knopf ist deshalb immer freigegeben; die Sperre ist eine Fehlermeldung an
- * der Gruppe. `aria-invalid` und `aria-describedby` gehören dabei ans
- * `fieldset` mit `role="radiogroup"`, nicht an die einzelnen Radios — ARIA 1.2
- * kennt beide an `role="radio"` nicht (`design-system.md`, A11y-Minima).
- */
-describe('ReportKindChoice — Sperre ohne Auswahl ist eine Meldung, kein toter Knopf', () => {
-	it('gibt den Weiter-Knopf frei, auch ohne Auswahl', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		const weiter = screen.getByRole('button', { name: /Weiter/i });
-		await expect.element(weiter).not.toHaveAttribute('aria-disabled', 'true');
-		await expect.element(weiter).not.toBeDisabled();
-	});
-
-	it('meldet die fehlende Auswahl beim Bestätigen', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-
-		await expect.element(screen.getByRole('alert')).toHaveTextContent(/Bitte wählen Sie aus/i);
-	});
-
-	it('markiert die Radiogruppe als fehlerhaft und verweist auf die Meldung', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-
-		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
-		await expect.element(gruppe).toHaveAttribute('aria-invalid', 'true');
-
-		const beschreibung = (await gruppe.element()).getAttribute('aria-describedby');
-		expect(beschreibung).not.toBeNull();
-		expect(document.getElementById(beschreibung as string)?.textContent).toMatch(
-			/Bitte wählen Sie aus/i
+		const link = document.querySelector<HTMLAnchorElement>(
+			'a[data-testid="report-kind-option-totfund"]'
 		);
-	});
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		link?.dispatchEvent(event);
 
-	it('trägt die Fehlermarkierung nicht schon vor dem ersten Versuch', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
-		await expect.element(gruppe).not.toHaveAttribute('aria-invalid');
-		expect(document.querySelector('[role="alert"]')).toBeNull();
-	});
-
-	it('nimmt die Meldung zurück, sobald etwas gewählt wird', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-		await screen.getByRole('radio', { name: /toten Tieres/i }).click();
-
-		const gruppe = screen.getByRole('radiogroup', { name: /Was möchten Sie melden/i });
-		await expect.element(gruppe).not.toHaveAttribute('aria-invalid');
-		expect(document.querySelector('[role="alert"]')).toBeNull();
-	});
-
-	it('führt den Fokus zur Gruppe, statt ihn beim Knopf zu lassen', async () => {
-		const screen = render(ReportKindChoice, { onchoose: vi.fn() });
-
-		await screen.getByRole('button', { name: /Weiter/i }).click();
-
-		const ersteOption = document.querySelector('input[type="radio"]');
-		expect(document.activeElement).toBe(ersteOption);
+		expect(onchoose).toHaveBeenCalledWith('dead');
+		expect(event.defaultPrevented).toBe(true);
 	});
 });
 
 /**
- * UX-Review (2026-08-06, Punkt 1), zweite Hälfte: Ein freigegebener Submit-Knopf
- * heißt, dass ein Klick VOR der Hydration den Browser das Formular nativ
- * abschicken lässt — der `onsubmit`-Wächter hängt zu diesem Zeitpunkt noch nicht
- * am DOM. Genau dieser Weg soll etwas Sinnvolles tun statt eines
- * Leerlauf-Reloads: Die Radios heißen deshalb `meldung` und tragen die
- * deutschen Parameterwerte aus `reportKindToParam` — ein nativer GET-Submit
- * landet damit auf `/?meldung=totfund`, und `resolveReportKind` löst das schon
- * serverseitig in den richtigen Zweig auf (`+page.svelte`).
+ * Der `href` ist der JS-lose Pfad und muss ihn allein tragen: Ein Klick vor der
+ * Hydration — auf einer schlechten Mobilverbindung am Strand sind das Sekunden —
+ * navigiert nativ dorthin, und `resolveReportKind` löst `?meldung=totfund`
+ * bereits serverseitig in den richtigen Zweig auf (`+page.svelte`).
  *
- * Nicht abgedeckt bleibt dabei, dass ein nativer GET-Submit die übrigen
- * Query-Parameter (Kampagnen-Marker aus einem Museums-Link) ersetzt — der
- * JS-Pfad hält sie in `choose()` erhalten, der JS-lose kann es ohne versteckte
- * Felder nicht. Bewusst in Kauf genommen: bisher passierte auf diesem Weg
- * überhaupt nichts.
+ * Die Parameterwerte sind bewusst deutsch (`lebend`/`totfund`) und kommen aus
+ * `reportKindToParam` — warum das ein Vertrag und keine Kosmetik ist, steht an
+ * `REPORT_KIND_PARAM` in `reportKind.ts`.
  */
-describe('ReportKindChoice — der Submit trägt ohne JS bereits den Zweig', () => {
-	it('benennt die Radios nach dem Query-Parameter der Seite', () => {
+describe('ReportKindChoice — der Link trägt den Zweig ohne JS', () => {
+	it('zeigt per Default auf den Query-Parameter der Seite', () => {
 		render(ReportKindChoice, { onchoose: vi.fn() });
 
-		const radios = Array.from(document.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
-		expect(radios.map((radio) => radio.name)).toEqual(['meldung', 'meldung']);
-		expect(radios.map((radio) => radio.value)).toEqual(['lebend', 'totfund']);
+		const hrefs = Array.from(
+			document.querySelectorAll<HTMLAnchorElement>('a[data-testid^="report-kind-option-"]')
+		).map((link) => link.getAttribute('href'));
+
+		expect(hrefs).toEqual(['?meldung=lebend', '?meldung=totfund']);
+	});
+
+	it('überlässt das Ziel dem Aufrufer, damit fremde Query-Parameter überleben', () => {
+		// `+page.svelte` baut den `href` aus `page.url` und hält damit
+		// Kampagnen-Marker aus einem Museums-Link erhalten. Die alte Lösung
+		// konnte das auf dem JS-losen Weg nicht: Ein nativer GET-Submit ersetzt
+		// die gesamte Query.
+		render(ReportKindChoice, {
+			onchoose: vi.fn(),
+			buildHref: (kind: ReportKind) =>
+				`/?kampagne=museumsnacht&meldung=${kind === 'dead' ? 'totfund' : 'lebend'}`
+		});
+
+		const link = document.querySelector('a[data-testid="report-kind-option-totfund"]');
+		expect(link?.getAttribute('href')).toBe('/?kampagne=museumsnacht&meldung=totfund');
+	});
+});
+
+/**
+ * Ein Link, der auf eine eigene URL zeigt, muss sich auch wie einer benehmen:
+ * Strg-/Cmd-Klick öffnet einen neuen Tab, Shift einen neuen Fenster. Fängt der
+ * Handler diese Klicks mit ab, bleibt der Nutzer im alten Tab zurück und der
+ * neue zeigt nichts — der klassische Fehler beim „Aufwerten" eines Links per JS.
+ */
+describe('ReportKindChoice — modifizierte Klicks bleiben Browser-Sache', () => {
+	it.each([
+		['Strg', { ctrlKey: true }],
+		['Cmd', { metaKey: true }],
+		['Shift', { shiftKey: true }]
+	])('%s-Klick wird nicht abgefangen', (_name, modifier) => {
+		const onchoose = vi.fn();
+		render(ReportKindChoice, { onchoose });
+
+		const link = document.querySelector('a[data-testid="report-kind-option-totfund"]');
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true, ...modifier });
+		link?.dispatchEvent(event);
+
+		expect(onchoose).not.toHaveBeenCalled();
+		expect(event.defaultPrevented).toBe(false);
 	});
 });
 
@@ -150,33 +135,33 @@ describe('ReportKindChoice — der Submit trägt ohne JS bereits den Zweig', () 
  * durch die Einstiegsseite — der auslösende Knopf verschwand, der Fokus fiel
  * auf `<body>`, angesagt wurde nichts. Das Formular macht es an jedem
  * Schrittwechsel bereits richtig (`scrollAndFocusStep` in
- * `form/StepNavigation.svelte`): Kopf des neuen Inhalts fokussieren, damit ein
- * Screenreader ihn ansagt.
+ * `form/StepNavigation.svelte`): Kopf des neuen Inhalts fokussieren.
  *
- * Fokussiert wird die `<legend>` „Was möchten Sie melden?", nicht die `<h1>`:
- * Die Überschrift ist im iframe bewusst ausgeblendet (Abschlussreview,
- * Politur — dieselbe Bedingung wie in `ModernReportForm.svelte`), die Legend
- * dagegen immer vorhanden. Ein Fokus auf ein bedingt fehlendes Element wäre im
- * iframe wirkungslos — genau der Fall, den dieser Test über `document.getElementById`
- * statt über die (im iframe unsichtbare) Rolle „heading" prüft.
+ * Fokussiert wird die Frage „Was möchten Sie melden?", nicht die `<h1>`: Die
+ * Seitenüberschrift ist im iframe bewusst ausgeblendet (dieselbe Bedingung wie
+ * in `ModernReportForm.svelte`), die Frage dagegen immer vorhanden. Ein Fokus
+ * auf ein bedingt fehlendes Element wäre im iframe wirkungslos — genau der
+ * Fall, den dieser Test über `document.getElementById` statt über die (im
+ * iframe unsichtbare) Rolle „heading" prüft.
+ *
+ * Bis zum Umbau auf Links war das eine `<legend>`; die Rolle im Fokus-Muster
+ * ist unverändert.
  *
  * `autofocusHeading` ist bewusst `false` per Default: Beim allerersten
- * Seitenaufruf (keine vorherige Formularansicht) ist die Auswahlseite kein
- * „Wechsel" — ein Fokus-Sprung dorthin verschöbe für Tastaturnutzer nur den
- * ersten Tab-Stopp hinter die Navigation, ohne Nutzen. Der Fokus-Sprung gilt
- * ausschließlich dem Rücksprung aus dem Formular (Ändern, Reset, Browser-
- * Zurück) — `+page.svelte` setzt das Prop dafür gezielt.
+ * Seitenaufruf ist die Auswahlseite kein „Wechsel" — ein Fokus-Sprung dorthin
+ * verschöbe für Tastaturnutzer nur den ersten Tab-Stopp hinter die Navigation,
+ * ohne Nutzen.
  */
 describe('ReportKindChoice — Fokus beim Rücksprung aus dem Formular (B7)', () => {
-	it('fokussiert die Legend, wenn autofocusHeading gesetzt ist', async () => {
+	it('fokussiert die Frage, wenn autofocusHeading gesetzt ist', async () => {
 		vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
 
 		render(ReportKindChoice, { onchoose: vi.fn(), autofocusHeading: true });
 		await tick();
 
-		const legend = document.getElementById('report-kind-legend');
-		expect(legend).not.toBeNull();
-		expect(document.activeElement).toBe(legend);
+		const frage = document.getElementById('report-kind-question');
+		expect(frage).not.toBeNull();
+		expect(document.activeElement).toBe(frage);
 	});
 
 	it('lässt den Fokus beim allerersten Aufruf unangetastet (kein Prop)', async () => {
@@ -185,8 +170,8 @@ describe('ReportKindChoice — Fokus beim Rücksprung aus dem Formular (B7)', ()
 		render(ReportKindChoice, { onchoose: vi.fn() });
 		await tick();
 
-		const legend = document.getElementById('report-kind-legend');
-		expect(document.activeElement).not.toBe(legend);
+		const frage = document.getElementById('report-kind-question');
+		expect(document.activeElement).not.toBe(frage);
 	});
 });
 
@@ -194,7 +179,7 @@ describe('ReportKindChoice — Fokus beim Rücksprung aus dem Formular (B7)', ()
  * Politur (Abschlussreview, nicht blockierend): `ModernReportForm.svelte`
  * unterdrückt seine `<h1>` bewusst im iframe (die Museumsseite trägt ihre
  * eigene Überschrift) — die Einstiegsseite tat das bisher nicht. Der
- * eingebettete Besucher sah „Meerestier melden" doppelt, und nach „Weiter"
+ * eingebettete Besucher sah „Meerestier melden" doppelt, und nach der Auswahl
  * verschwand der Titel wieder, was den Höhensprung im iframe vergrößerte.
  *
  * `window.top !== window` in dieser Testumgebung (Vitest Browser Mode rendert

--- a/src/lib/report/reportKind.ts
+++ b/src/lib/report/reportKind.ts
@@ -10,16 +10,19 @@ import {
 export type ReportKind = 'alive' | 'dead';
 
 /**
- * Name des Query-Parameters — und, seit dem UX-Review (2026-08-06, Punkt 1),
- * zugleich der `name` der Radios auf der Einstiegsseite.
+ * Name des Query-Parameters — und zugleich der Bestandteil des `href`, den die
+ * beiden Karten auf der Einstiegsseite tragen.
  *
- * Das ist kein Zufall, sondern ein tragender Vertrag: Ein Klick auf „Weiter"
- * VOR der Hydration schickt das Formular nativ per GET ab. Nur weil die Radios
- * `meldung` heißen und `lebend`/`totfund` tragen, landet der Melder dabei auf
- * `/?meldung=totfund`, wo `resolveReportKind` den Zweig schon serverseitig
- * auflöst. Stünde der Name auf beiden Seiten als Literal, machte eine
- * einseitige Umbenennung den JS-losen Pfad still wieder zum Leerlauf-Reload —
- * ohne dass ein Test rot würde.
+ * Das ist kein Zufall, sondern ein tragender Vertrag: Ein Klick VOR der
+ * Hydration navigiert nativ über den `href`. Nur weil dieser `meldung` heißt
+ * und `lebend`/`totfund` trägt, landet der Melder dabei auf `/?meldung=totfund`,
+ * wo `resolveReportKind` den Zweig schon serverseitig auflöst. Stünde der Name
+ * auf beiden Seiten als Literal, machte eine einseitige Umbenennung den JS-losen
+ * Pfad still wieder wirkungslos — ohne dass ein Test rot würde.
+ *
+ * Bis zum UX-Review 2026-08-07 hing derselbe Vertrag am `name` zweier Radios
+ * und einem nativen GET-Submit; der Weg trug den Zweig zwar auch, ersetzte
+ * dabei aber die gesamte Query. Der `href` erhält sie (`+page.svelte`).
  */
 export const REPORT_KIND_PARAM = 'meldung';
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 
 	/**
 	 * B7 (Abschlussreview): Steuert, ob `ReportKindChoice` beim nächsten Mount
-	 * ihre Legend fokussiert. `false` bleibt es genau einmal — für den
+	 * ihre Auswahlfrage fokussiert. `false` bleibt es genau einmal — für den
 	 * allerersten Aufruf dieser Seite, an dem die Auswahlseite kein „Wechsel"
 	 * ist, sondern der normale Seiteneinstieg. Sobald einmal eine
 	 * Formularansicht sichtbar war und der Melder über „Ändern", „Formular
@@ -76,14 +76,35 @@
 		reportKind = kind;
 		writeReportKind(kind);
 		// History-Eintrag, damit „Zurück" auf die Auswahl führt statt aus der App.
-		// Bestehende Query-Parameter (z. B. Kampagnen-Marker aus einem
-		// Museums-Link) bleiben erhalten — nur `meldung` wird gesetzt/ersetzt.
+		//
+		// Dasselbe Ziel wie im `href` der Karte, aus derselben Funktion: Der
+		// JS-Pfad und der JS-lose Pfad müssen an derselben Stelle landen. Zwei
+		// getrennte Aufbauten drifteten still auseinander — die Zusage „bestehende
+		// Query-Parameter bleiben erhalten" (Kampagnen-Marker aus einem
+		// Museums-Link) gälte dann nur noch auf einem der beiden Wege, ohne dass
+		// ein Test rot würde.
+		pushState(reportKindHref(kind), {});
+	}
+
+	/**
+	 * Ziel der beiden Links auf der Einstiegsseite — der Weg, den ein Klick VOR
+	 * der Hydration nimmt, und zugleich das Ziel, das `choose()` oben nach der
+	 * Hydration per `pushState` setzt. Bestehende Query-Parameter (Kampagnen-
+	 * Marker aus einem Museums-Link) bleiben dabei erhalten; nur `meldung` wird
+	 * gesetzt. Das ist die Zusage, die der frühere native GET-Submit nicht
+	 * einlösen konnte — er ersetzte die gesamte Query.
+	 *
+	 * `page.url` statt `window.location`: Diese Funktion läuft auch im SSR, wo es
+	 * kein `window` gibt. Der ausgelieferte `href` ist damit von Anfang an
+	 * richtig und nicht erst nach der Hydration.
+	 */
+	function reportKindHref(kind: ReportKind): string {
 		// Wirft weg, keine Komponenten-Reaktivität nötig — dasselbe Muster wie in
 		// ExportModal.svelte.
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity
-		const params = new URLSearchParams(window.location.search);
+		const params = new URLSearchParams(page.url.searchParams);
 		params.set(REPORT_KIND_PARAM, reportKindToParam(kind));
-		pushState(`/?${params.toString()}`, {});
+		return `/?${params.toString()}`;
 	}
 
 	/**
@@ -118,7 +139,7 @@
 		// B7: Dieser Rücksprung ist immer ein „Wechsel" — ausgelöst durch
 		// „Ändern" (`changeKind()`) oder „Formular zurücksetzen"
 		// (`resetReportKind()`), nie der allererste Seitenaufruf. `ReportKindChoice`
-		// fokussiert deshalb bei ihrem nächsten Mount ihre Legend.
+		// fokussiert deshalb bei ihrem nächsten Mount ihre Auswahlfrage.
 		returnedToSelection = true;
 		reportKind = null;
 		clearReportKind();
@@ -298,7 +319,11 @@
 	<div class="mb-8">
 		<!-- Form Content -->
 		{#if reportKind === null}
-			<ReportKindChoice onchoose={choose} autofocusHeading={returnedToSelection} />
+			<ReportKindChoice
+				onchoose={choose}
+				autofocusHeading={returnedToSelection}
+				buildHref={reportKindHref}
+			/>
 		{:else if submissionSuccess && submittedData}
 			<SubmissionSuccess {submittedData} {handleNewReport} />
 		{:else}


### PR DESCRIPTION
## Worum es geht

Die Einstiegsseite („Was möchten Sie melden?") war eine Radiogruppe mit einem
„Weiter"-Knopf. Sie fragt aber eine **Weiche** ab, kein Formularfeld: Jede der
beiden Antworten führt sofort woanders hin und hat eine eigene URL
(`?meldung=lebend` / `?meldung=totfund`). Das ist eine Navigation, keine Auswahl,
die noch bestätigt werden müsste — und wird jetzt als zwei Link-Karten gerendert.


## Warum nicht einfach anklickbare Radio-Karten

Die naheliegende Zwischenlösung scheidet aus: Wer per Pfeiltaste durch eine
Radiogruppe geht, wählt zwangsläufig die erste Option aus und würde bei
Auto-Submit ungewollt weitergeschickt (WCAG 3.2.2 „On Input"). Die
Auswahl-Semantik musste deshalb ganz weichen, nicht nur der Knopf. Für die
Semantik der Karten gilt die übliche Regel: Navigiert die Aktion zu einer eigenen
URL, gehört ein Link hin — kein Button.

## Was dadurch entfällt

- **Der Zustand „nichts gewählt".** Der ganze Fehler-Apparat (`selectionMissing`,
  `aria-invalid` an der Gruppe, `role="alert"`, Fokus-Sprung zum ersten Radio) war
  nur nötig, weil „Weiter" ohne Auswahl drückbar war. Mit zwei direkten Links ist
  der Zustand strukturell nicht mehr herstellbar. Ein Fehler, der nicht auftreten
  kann, schlägt jede Fehlermeldung.
- **Zwei dokumentierte Kompromisse am JS-losen Pfad.** Er hing an einem nativen
  GET-Submit, der die gesamte Query ersetzte (Kampagnen-Marker aus einem
  Museums-Link gingen verloren) und ohne Auswahl stumm `/?` nachlud. Jetzt trägt
  der `href` das Ziel; `+page.svelte` baut ihn aus `page.url` und erhält bestehende
  Parameter. `choose()` nutzt dieselbe Funktion für sein `pushState` — der JS-Pfad
  und der JS-lose Pfad können nicht auseinanderdriften.
- **Ein Klick und ein Tab-Stopp weniger** auf dem Weg ins Formular.

## Details

Modifizierte Klicks (Strg/Cmd/Shift/Alt) bleiben dem Browser überlassen, sonst
bliebe der Nutzer im alten Tab zurück, während der neue nichts zeigt. Label und
Hinweistext stehen **innerhalb** des Links, damit ein Screenreader beim Durchgehen
der Links die eigentliche Unterscheidungshilfe mithört statt zweier ähnlich
klingender Überschriften. Die Gruppe ist ein `<nav aria-labelledby>` auf die
Frage — benannt, ohne Auswahl-Semantik vorzutäuschen.

Beide Karten bleiben bewusst gleich eingefärbt. Ein Warnton am Totfund wäre die
falsche Aussage: Totfunde sind **9,2 % aller 19.946 Meldungen, seit 2020 sogar
14,9 %** — ein regulärer zweiter Weg, kein Sonderfall, und für den Melder weder
riskant noch falsch. Unterschieden wird über Icon, Titel und Hinweistext.

Unverändert: Zweig-Semantik, der Vertrag um `REPORT_KIND_PARAM`, das
Fokus-Verhalten beim Rücksprung (B7 — zielt jetzt auf die `<h2>` statt auf die
`<legend>`) und `ReportKindFeedback` als Ort der Verzweigungs-Rückmeldung im
Formular.

## Tests

- `ReportKindChoice.svelte.test.ts` neu geschnitten: beide Links, Hinweis im
  Link-Namen, abgefangener Klick, Default- und überschriebener `href`, die drei
  modifizierten Klicks, Fokus-Verhalten — 11 grün.
- **Neu:** ein E2E-Test mit `javaScriptEnabled: false`, der die Navigation
  tatsächlich fährt und belegt, dass der Zweig danach serverseitig aufgelöst ist.
- Der Reload-Test benutzte bisher den Submit-Klick als Hydrations-Beleg; er prüft
  jetzt Shallow Routing — eine Markierung am `window` überlebt den Klick nur, wenn
  Svelte den Link abgefangen hat.
- Grün: `test:quick` (3684 Tests), `lint`, `type-check`, `check`, sowie 153 E2E aus
  `report-kind-choice`, `form-autosave`, `bestimmungshilfe`, `form-ux`,
  `form-a11y`, `design-tokens`, `horizontal-overflow`, `modal-overflow`.
- Visuell verifiziert auf Desktop und 390px, inkl. Hover- und Tastatur-Fokus.

## Doku

Der `aria-disabled`-Abschnitt in `.claude/rules/design-system.md` beschrieb diese
Komponente noch als „freier Knopf mit Fehlermeldung an der Radiogruppe" — er hält
jetzt fest, dass der beste Fall ist, gar nichts sperren zu müssen. Der
Vertrags-Kommentar an `REPORT_KIND_PARAM` hing am `name` der Radios und hängt
jetzt am `href`. Die beiden Planungsdokumente von 2026-08-05 haben einen
Kopfhinweis bekommen, dass ihre Auswahlmechanik überholt ist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

