### PR TITLE
fix(report): UX-Review Runde 2 — Toast-Dedup, Totfund Schritt 2, Politur

### DIFF
--- a/e2e/form-autosave.spec.ts
+++ b/e2e/form-autosave.spec.ts
@@ -51,11 +51,23 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		const formPage = new FormPage(page);
 		await formPage.goto();
 
-		// Fill some data
+		// Eine ECHTE Eingabe, nicht nur das Datum: `sightingDate` steht per
+		// Schema-Default ohnehin auf heute — ein mit dem heutigen Datum
+		// „gefülltes" Formular unterscheidet sich nicht vom Initialzustand, und
+		// seit dem Gate `hasMeaningfulSavedData` (UX-Review 2026-08-07) meldet
+		// der Toast nur noch tatsächlich abweichende Daten.
 		await formPage.fillDate(today);
+		await formPage.fillWaterway('Kieler Bucht');
+		// Der Wert erreicht den Form-State erst mit dem `change`-Event — `fill()`
+		// blurt nicht. In den übrigen Specs übernimmt das der nächste Klick auf
+		// „Weiter"; hier gibt es keinen, also explizit.
+		await page.locator('[data-testid="field-waterway"]').blur();
 
 		// Wait for auto-save to persist to sessionStorage
-		await page.waitForFunction(() => !!sessionStorage.getItem('sichtungen_form_data'));
+		await page.waitForFunction(() => {
+			const raw = sessionStorage.getItem('sichtungen_form_data');
+			return !!raw && raw.includes('Kieler Bucht');
+		});
 
 		// Reload — should show restore toast
 		await page.reload();
@@ -64,6 +76,28 @@ test.describe('Formular — Auto-Save & Restore', () => {
 		await expect(page.getByText(/vorherigen Eingaben.*wiederhergestellt/i)).toBeVisible({
 			timeout: 5000
 		});
+	});
+
+	/**
+	 * Gegenprobe zum Gate `hasMeaningfulSavedData` (UX-Review 2026-08-07,
+	 * Befund 6): Das bloße Öffnen des Formulars schreibt `FORM_DATA` bereits in
+	 * den Storage — vor dem Gate meldete deshalb JEDES Reload „wiederhergestellt",
+	 * auch wenn nie etwas eingegeben wurde.
+	 */
+	test('Ohne echte Eingaben kein Restore-Toast', async ({ page }) => {
+		const formPage = new FormPage(page);
+		await formPage.goto();
+
+		// Der Mount-Effekt hat den (unveränderten) Zustand persistiert
+		await page.waitForFunction(() => !!sessionStorage.getItem('sichtungen_form_data'));
+
+		await page.reload();
+		await page.waitForLoadState('networkidle');
+
+		// Erst sicherstellen, dass das Formular wieder steht, DANN die Abwesenheit
+		// prüfen — sonst wäre ein zu früh ausgewerteter Nicht-Befund wertlos.
+		await expect(page.getByTestId('form-actions')).toBeVisible();
+		await expect(page.getByText(/vorherigen Eingaben.*wiederhergestellt/i)).not.toBeVisible();
 	});
 
 	/**

--- a/e2e/form-from-land.spec.ts
+++ b/e2e/form-from-land.spec.ts
@@ -20,11 +20,23 @@ import {
  * aus `$lib`): 0 Sonstiges, 1 Segelschiff, 2 Motorboot, 3 Land, 4 Fähre.
  */
 
-/** Minimal gültiger Schritt 2, mit frei wählbarem Beobachtungsort. */
-async function fillStep2From(formPage: FormPage, sightingFrom: number) {
+/**
+ * Minimal gültiger Schritt 2, mit frei wählbarem Beobachtungsort.
+ *
+ * `totfund: true` lässt die Entfernung aus: Sie entfällt seit dem UX-Review
+ * 2026-08-07 im Totfund-Zweig vollständig (`HIDDEN_WHEN_DEAD` in
+ * `formConfig.ts`) — ein `selectDistance` liefe dort in einen Timeout.
+ */
+async function fillStep2From(
+	formPage: FormPage,
+	sightingFrom: number,
+	options: { totfund?: boolean } = {}
+) {
 	await formPage.selectSpecies(0); // Schweinswal
 	await formPage.fillTotalCount(2);
-	await formPage.selectDistance(1);
+	if (!options.totfund) {
+		await formPage.selectDistance(1);
+	}
 	await formPage.selectSightingFrom(sightingFrom);
 }
 
@@ -143,7 +155,10 @@ test.describe('Meldeformular — Beobachtung von Land', () => {
 		await formPage.clickNext();
 		await expectCurrentStep(page, /Angaben zum Tier/i);
 
-		await fillStep2From(formPage, 3); // Land
+		await fillStep2From(formPage, 3, { totfund: true }); // Land
+		// Die Entfernung entfällt im Totfund-Zweig ganz — am Strand steht der
+		// Melder neben dem Tier (UX-Review 2026-08-07).
+		await expect(page.getByTestId('field-distance')).toHaveCount(0);
 		// Pflicht bei Totfund (Schema: deadCondition.when('isDead', …)); ohne
 		// diese Angabe bleibt „Weiter" gesperrt.
 		await formPage.selectDeadCondition(1); // Extrem frisch

--- a/e2e/horizontal-overflow.spec.ts
+++ b/e2e/horizontal-overflow.spec.ts
@@ -81,7 +81,9 @@ test.describe('Layout — horizontaler Überlauf', () => {
 			   Admin-Maske. */
 			await formPage.selectSpecies(0); // Schweinswal
 			await formPage.fillTotalCount(2);
-			await formPage.selectDistance(1);
+			/* Kein `selectDistance`: Die Entfernung entfällt im Totfund-Zweig
+			   vollständig (`HIDDEN_WHEN_DEAD` in `formConfig.ts`, UX-Review
+			   2026-08-07) — das Feld existiert hier gar nicht mehr im DOM. */
 			await formPage.selectSightingFrom(SightingFromEnum.MOTORBOAT);
 			await expect(page.locator('[data-testid="field-deadCondition"]')).toBeVisible();
 			await expect(page.locator('[data-testid="field-boatDrive-1"]')).toBeVisible();

--- a/e2e/report-kind-choice.spec.ts
+++ b/e2e/report-kind-choice.spec.ts
@@ -331,7 +331,8 @@ test.describe('Nach dem Absenden verlässt der Zweig den Speicher, und „Weiter
 
 		await formPage.selectSpecies(0);
 		await formPage.fillTotalCount(1);
-		await formPage.selectDistance(1);
+		// Kein `selectDistance`: Die Entfernung entfällt im Totfund-Zweig
+		// vollständig (`HIDDEN_WHEN_DEAD`, UX-Review 2026-08-07).
 		await formPage.selectSightingFrom(3); // Land
 		await formPage.selectDeadCondition(1);
 		await waitForNextEnabled(page);

--- a/src/lib/form/validation/sightingSchema.ts
+++ b/src/lib/form/validation/sightingSchema.ts
@@ -625,11 +625,37 @@ export const sightingSchemaBase = yup.object().shape({
 
 	/**
 	 * Entfernung zum gesichteten Tier
-	 * Pflichtfeld, muss einer gültigen Entfernungskategorie entsprechen
+	 * Pflichtfeld bei einer Sichtung, muss einer gültigen Entfernungskategorie
+	 * entsprechen.
+	 *
+	 * **Beim Totfund ist die Pflicht aufgehoben** (UX-Review 2026-08-07): Wer ein
+	 * totes Tier meldet, steht am Strand daneben — die Frage ist dort nicht
+	 * beantwortbar, und das Meldeformular zeigt sie im Totfund-Zweig seither gar
+	 * nicht mehr (`HIDDEN_WHEN_DEAD` in `formConfig.ts`). Die Lockerung ist dabei
+	 * keine Kür: Der Endpunkt validiert die Nutzlast gegen das **volle** Schema
+	 * (`routes/api/sightings/+server.ts`, Schritt 3), und der Client lässt
+	 * ausgeblendete Felder weg — ohne sie lehnte der Server jede Totfund-Meldung
+	 * mit einer Meldung an einem unsichtbaren Feld ab. Genau derselbe Zwang stand
+	 * am 2026-08-04 bei `deadSex` (Kommentar dort).
+	 *
+	 * `is: true` wie bei `deadCondition` oben: `isDead` kommt aus dem Zweig der
+	 * Einstiegsseite bzw. aus `field-mapping.ts` immer als echter Boolean. Ein
+	 * anderer Wahrheitswert ließe die Pflicht bestehen — die konservative
+	 * Richtung.
+	 *
+	 * Der Basis-Aufbau bleibt `.required()`, die Bedingung kommt erst danach:
+	 * `describe()` sieht ein `when()` nicht und beschreibt das Basis-Schema —
+	 * Pflicht-Sternchen und `aria-required` bleiben damit im Lebend-Zweig und in
+	 * der Admin-Maske unverändert stehen (`FieldRenderer`).
 	 */
 	distance: yup
 		.number()
 		.required('Bitte geben Sie eine Entfernung an.')
+		.when('isDead', {
+			is: true,
+			then: (schema) => schema.notRequired(),
+			otherwise: (schema) => schema
+		})
 		.test(
 			'is-valid-distance',
 			'Bitte wählen Sie eine gültige Entfernungskategorie.',

--- a/src/lib/report/components/ModernReportForm.svelte
+++ b/src/lib/report/components/ModernReportForm.svelte
@@ -17,6 +17,7 @@
 		reportKindClearedNotice
 	} from '$lib/report/fieldsOutsideReportKind';
 	import { findStepForErrors } from '$lib/report/findStepForErrors';
+	import { hasMeaningfulSavedData } from '$lib/report/hasMeaningfulSavedData';
 	import { resolveServerFieldErrors } from '$lib/report/serverFieldErrors';
 	import {
 		getFormSteps,
@@ -110,6 +111,19 @@
 		...initialFormData
 	});
 
+	// UX-Review (2026-08-07, Befund 6): Schnappschuss VOR der `initialIsDead`-
+	// Überschreibung und VOR dem Zweig-Aufräumen weiter unten — das ist der
+	// ehrlichste Vergleichszustand. `savedFormData` wird direkt im Anschluss
+	// mutiert (Zeile mit `savedFormData.isDead = …` und der `resetField`-
+	// Schleife); ein Vergleich NACH diesen Schritten sähe zweigfremde, aber
+	// echt vom Nutzer eingegebene Werte (z. B. `deadCondition` aus einer
+	// Totfund-Sitzung, wenn jetzt der Lebend-Zweig startet) nicht mehr — sie
+	// wurden zu diesem Zeitpunkt schon auf den Default zurückgesetzt. Der
+	// Wiederherstellungs-Hinweis soll aber genau das sagen: Es LAG etwas vor,
+	// unabhängig davon, ob es zum aktuellen Zweig passt (dafür gibt es
+	// `clearedNotice` weiter unten, als eigene, zusätzliche Meldung).
+	const savedFormDataAtLoad: SightingFormData = { ...savedFormData };
+
 	// `initialIsDead` überschreibt `isDead` aus dem Formular-State. Fehlten
 	// gespeicherte Formulardaten, steht dort ohnehin nur der Schema-Default —
 	// die Zuweisung ist dann gleichbedeutend mit „erstmalig setzen". Lagen
@@ -154,8 +168,16 @@
 		resetField(field);
 	}
 
-	// Zeige Feedback wenn vorherige Eingaben wiederhergestellt wurden
-	if (hadSavedFormData) {
+	// Zeige Feedback wenn vorherige Eingaben wiederhergestellt wurden.
+	//
+	// UX-Review (2026-08-07, Befund 6): `hadSavedFormData` allein sagt nur, DASS
+	// der Schlüssel `FORM_DATA` in `sessionStorage` stand — und den schreibt der
+	// `$effect` weiter unten schon beim bloßen Öffnen des Formulars, ohne dass
+	// der Nutzer etwas eingegeben hat. Auswahlseite → Formular → „Ändern" →
+	// Formular zeigte den Hinweis dadurch auch dann, wenn nichts wiederherzustellen
+	// war. `hasMeaningfulSavedData` prüft zusätzlich, ob sich die geladenen Daten
+	// TATSÄCHLICH vom Initialzustand unterscheiden (Ausnahmen und Begründung dort).
+	if (hadSavedFormData && hasMeaningfulSavedData(savedFormDataAtLoad, initialFormData)) {
 		// Defer toast to after Svelte hydration
 		queueMicrotask(() => {
 			toast.info('Ihre vorherigen Eingaben wurden wiederhergestellt.', { duration: 4000 });

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -438,7 +438,7 @@ describe('ModernReportForm — der Zweigwechsel meldet, was er geräumt hat (UX-
 
 		await vi.waitFor(() => {
 			expect(toastMessages()).toContain(
-				'Ihre Angaben zu Verhalten und Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
+				'Ihre Angaben zum Verhalten und zur Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
 			);
 		});
 	});

--- a/src/lib/report/components/ModernReportForm.svelte.test.ts
+++ b/src/lib/report/components/ModernReportForm.svelte.test.ts
@@ -438,7 +438,7 @@ describe('ModernReportForm — der Zweigwechsel meldet, was er geräumt hat (UX-
 
 		await vi.waitFor(() => {
 			expect(toastMessages()).toContain(
-				'Ihre Angaben zum Verhalten der Tiere wurden entfernt, alles Übrige bleibt erhalten.'
+				'Ihre Angaben zu Verhalten und Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
 			);
 		});
 	});

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import type { SightingFormValues } from '$lib/types/Form';
 	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
@@ -13,13 +12,6 @@
 		submittedData: SightingFormValues | null;
 		handleNewReport: () => void;
 	}>();
-
-	/**
-	 * Handle returning to main page
-	 */
-	function handleReturnHome() {
-		goto('/');
-	}
 </script>
 
 <!-- Success Page -->
@@ -54,7 +46,7 @@
 		</div>
 
 		<!-- Success Details -->
-		<div class="card bg-base-200 mb-8 shadow-xl">
+		<div class="card bg-base-200 shadow-raised mb-8">
 			<div class="card-body">
 				<h2 class="card-title text-success-strong mb-4">Was passiert als Nächstes?</h2>
 
@@ -134,7 +126,7 @@
 
 		<!-- Submission Summary -->
 		{#if submittedData}
-			<div class="card bg-base-100 mb-8 shadow-lg">
+			<div class="card bg-base-100 shadow-raised mb-8">
 				<div class="card-body">
 					<h2 class="card-title mb-4">Ihre Meldung</h2>
 					<div class="mb-4 grid grid-cols-1 gap-1 text-sm">
@@ -172,20 +164,19 @@
 		{/if}
 
 		<!-- Action Buttons -->
+		<!-- Nur noch ein Button: „Zur Startseite" landete wegen des gespeicherten
+		     Zweigs (ReportKind) faktisch im leeren Formular des alten Zweigs statt
+		     auf der Einstiegsseite — fast dieselbe Wirkung wie „Weitere Meldung
+		     abgeben", nur ohne den sauberen Zweig-Reset (UX-Review 2026-08-07). -->
 		<div class="flex flex-col justify-center gap-4 md:flex-row">
 			<button onclick={handleNewReport} class="btn btn-primary btn-lg">
 				Weitere Meldung abgeben
-			</button>
-
-			<button onclick={handleReturnHome} class="btn btn-outline btn-lg">
-				<Icon icon="lucide:arrow-left" width="20" />
-				Zur Startseite
 			</button>
 		</div>
 
 		<!-- Additional Resources -->
 		<div class="mt-12">
-			<div class="card bg-base-200 shadow-sm">
+			<div class="card bg-base-200">
 				<div class="card-body text-center">
 					<h3 class="mb-4 text-lg font-semibold">Interessiert an mehr?</h3>
 
@@ -220,15 +211,6 @@
 		max-width: 768px;
 	}
 
-	.card {
-		transition: all 0.2s ease;
-	}
-
-	.card:hover {
-		transform: translateY(-2px);
-		box-shadow: 0 12px 28px -8px var(--color-base-300);
-	}
-
 	/* Link styling */
 	.link {
 		text-decoration: underline;
@@ -237,15 +219,6 @@
 
 	.link:hover {
 		text-decoration-thickness: 2px;
-	}
-
-	/* Button animations */
-	.btn {
-		transition: all 0.2s ease;
-	}
-
-	.btn:hover {
-		transform: translateY(-1px);
 	}
 
 	/* Mobile-first responsive adjustments */

--- a/src/lib/report/components/form/FormActions.svelte
+++ b/src/lib/report/components/form/FormActions.svelte
@@ -57,7 +57,7 @@
 
 	<button
 		type="button"
-		class="btn btn-outline btn-error btn-sm min-h-11 w-full md:w-auto"
+		class="btn btn-outline btn-error btn-sm w-full md:w-auto"
 		onclick={handleReset}
 		disabled={$isSubmitting}
 	>

--- a/src/lib/report/components/form/StepNavigation.svelte
+++ b/src/lib/report/components/form/StepNavigation.svelte
@@ -21,6 +21,16 @@
 
 	const logger = createLogger('report:StepNavigation');
 
+	/**
+	 * Stabiler Toast-Key für den Validierungshinweis dieser Navigation. Ein
+	 * erneuter „Weiter"-Klick auf demselben Schritt ERSETZT den Toast statt sich
+	 * daneben zu stapeln (UX-Review: 4 identische Toasts bei viermal „Weiter"),
+	 * und der Schrittwechsel-Effect unten schließt ihn aktiv — sonst stünde die
+	 * Meldung des alten Schritts bis zu 5s auf dem neuen und widerspräche dem
+	 * sichtbaren Zustand.
+	 */
+	const VALIDATION_TOAST_KEY = 'step-validation';
+
 	let {
 		currentStep = $bindable(0),
 		totalSteps = $bindable(formStepsConfig.length),
@@ -76,6 +86,11 @@
 	$effect(() => {
 		if (attemptedStep !== null && attemptedStep !== currentStep) {
 			attemptedStep = null;
+			// Ein Validierungs-Toast kann nur entstehen, während `attemptedStep`
+			// gesetzt ist (siehe `showValidationError`) — hier ist deshalb genau
+			// der Moment, in dem ein noch aktiver Toast den VERLASSENEN Schritt
+			// beschreibt und nicht mehr zum sichtbaren (neuen) Schritt passt.
+			toast.removeByKey(VALIDATION_TOAST_KEY);
 		}
 	});
 
@@ -236,10 +251,13 @@
 			errorMessage = `Bitte beheben Sie die ${errorCount} Fehler in "${currentStepName}" bevor Sie fortfahren.`;
 		}
 
-		// Show toast notification
+		// Show toast notification — per key statt zu stapeln: ein erneuter
+		// „Weiter"-Klick auf demselben invaliden Schritt ersetzt den bestehenden
+		// Toast (inkl. neuer Anzeigedauer) statt einen weiteren daneben zu zeigen.
 		toast.error(errorMessage, {
 			title: 'Validierungsfehler',
-			duration: 5000
+			duration: 5000,
+			key: VALIDATION_TOAST_KEY
 		});
 
 		// Navigate to first error field

--- a/src/lib/report/components/form/StepNavigation.svelte.test.ts
+++ b/src/lib/report/components/form/StepNavigation.svelte.test.ts
@@ -1,0 +1,72 @@
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { key as formContextKey } from '$lib/report/formContext';
+import { createForm } from '$lib/form/createForm';
+import { initialFormState } from '$lib/report/formConfig';
+import { clearAllToasts, toasts } from '$lib/stores/toastState.svelte';
+import type { FormContext, SightingFormData } from '$lib/types';
+import StepNavigation from './StepNavigation.svelte';
+
+/**
+ * UX-Review-Nachgang (2026-08-07): Jeder „Weiter"-Klick auf einem invaliden
+ * Schritt erzeugte einen neuen `toast.error(...)` — vier Klicks, vier
+ * gleichzeitig sichtbare Toasts. Und wer den Fehler behebt und weiterklickt,
+ * sah den Toast des VERLASSENEN Schritts bis zu 5s auf dem neuen Schritt.
+ */
+
+function renderStepNavigation() {
+	const formContext: FormContext = {
+		...createForm<SightingFormData>({
+			// Step 0 („Position & Zeitpunkt") bleibt mit den Default-Werten
+			// invalide (keine Ortsbeschreibung, keine GPS-Position) — genau der
+			// Fall, der bisher den Toast auslöste.
+			initialValues: { ...initialFormState },
+			onSubmit: () => undefined
+		}),
+		mediaStore: { mediaFiles: [] }
+	};
+
+	const context = new Map([[formContextKey, formContext]]);
+	render(StepNavigation, { context });
+	return formContext;
+}
+
+function toastMessages(): string[] {
+	return toasts.map((entry) => entry.message);
+}
+
+describe('StepNavigation — Validierungs-Toast', () => {
+	beforeEach(() => {
+		clearAllToasts();
+	});
+
+	it('ersetzt den Toast statt sich zu stapeln, wenn mehrfach auf einem invaliden Schritt auf „Weiter" geklickt wird', async () => {
+		renderStepNavigation();
+
+		const next = page.getByRole('button', { name: /Nächster Schritt/i });
+		await next.click();
+		await next.click();
+		await next.click();
+		await next.click();
+
+		expect(toastMessages()).toHaveLength(1);
+	});
+
+	it('schließt einen aktiven Validierungs-Toast beim Wechsel auf den (nun validen) nächsten Schritt', async () => {
+		const formContext = renderStepNavigation();
+
+		const next = page.getByRole('button', { name: /Nächster Schritt/i });
+		await next.click();
+
+		expect(toastMessages()).toHaveLength(1);
+
+		// Fehler beheben (Ortsbeschreibung nachtragen) und erneut „Weiter" — der
+		// Schritt wechselt jetzt tatsächlich, und genau das muss den Toast des
+		// VERLASSENEN Schritts schließen, statt ihn bis zu 5s stehen zu lassen.
+		formContext.form.update((values) => ({ ...values, waterway: 'Kieler Bucht' }));
+		await next.click();
+
+		expect(toastMessages()).toHaveLength(0);
+	});
+});

--- a/src/lib/report/components/sections/SightingDetails.svelte
+++ b/src/lib/report/components/sections/SightingDetails.svelte
@@ -5,7 +5,8 @@
 	import { slide } from 'svelte/transition';
 	import FormField from '$lib/report/components/form/fields/FormField.svelte';
 	import SectionCard from './SectionCard.svelte';
-	import { detailsSectionTitle } from '$lib/report/wording';
+	import { detailsSectionTitle, sightingFromQuestion } from '$lib/report/wording';
+	import { isDeadFinding } from '$lib/report/formConfig';
 	import {
 		NOT_YET_TRACKED,
 		isBoatSightingFrom,
@@ -21,6 +22,17 @@
 	// Totfund). Gilt auch in der Admin-Maske — dort kommt `isDead` aus dem
 	// geladenen Datensatz, und ein Totfund heißt auch dort ein Fund.
 	const cardTitle = $derived(detailsSectionTitle($form.isDead));
+
+	// Die Frage über der Herkunftsauswahl folgt demselben Zweig wie der
+	// Kartentitel — „Funddetails" mit „Von wo aus wurde die SICHTUNG gemacht?"
+	// darunter war der auffälligste Rest der alten Ansprache (UX-Review
+	// 2026-08-07). In der Admin-Maske bleibt es beim Schema-Label: Dort wird ein
+	// Datensatz bearbeitet, und die Beschriftung ist dieselbe wie in Export und
+	// Detailansicht — `sightingFromQuestion(false)` IST dieses Label (in
+	// `wording.test.ts` gegen das Schema geprüft), deshalb ein unbedingter
+	// String statt eines `undefined`, das `exactOptionalPropertyTypes` an einem
+	// optionalen Prop ohnehin nicht zuließe.
+	const sightingFromLabel = $derived(sightingFromQuestion(adminMode ? false : $form.isDead));
 
 	/** Sichtung erfolgte von einem Boot mit Antrieb (Segelschiff/Motorboot) aus. */
 	const showsBoatDrive = $derived(isBoatSightingFrom($form.sightingFrom));
@@ -55,7 +67,7 @@
 <!-- Sighting Details Section -->
 <SectionCard title={cardTitle} icon="lucide:activity">
 	<div class="mt-2 grid grid-cols-1 gap-4 md:grid-cols-1">
-		<FormField name="sightingFrom" />
+		<FormField name="sightingFrom" label={sightingFromLabel} />
 		{#if String($form.sightingFrom) === String(SightingFromEnum.OTHER)}
 			<!-- `required` als Override, weil die Pflicht im Schema in einem
 			     `when('sightingFrom')` steckt und `describe()` das nicht sieht —
@@ -138,5 +150,13 @@
 		</div>
 	{/if}
 
-	<FormField name="distance" />
+	<!-- Markup-Hälfte zu `HIDDEN_WHEN_DEAD` (formConfig.ts): Beim Totfund steht
+	     der Melder neben dem Tier — „Entfernung zum Tier" ist dort nicht
+	     beantwortbar und war als Pflichtfeld eine Sperre ohne Ausweg. Die
+	     Admin-Maske behält das Feld: 282 Bestandszeilen tragen den Sentinel `0`
+	     („nicht angegeben"), und ein Totfund muss dort weiter nachbearbeitbar
+	     bleiben — dieselbe Struktur wie bei `deadSex` in `DeadAnimal.svelte`. -->
+	{#if adminMode || !isDeadFinding($form.isDead)}
+		<FormField name="distance" />
+	{/if}
 </SectionCard>

--- a/src/lib/report/components/sections/SightingDetails.svelte.test.ts
+++ b/src/lib/report/components/sections/SightingDetails.svelte.test.ts
@@ -177,3 +177,69 @@ describe('sections/SightingDetails — Kartentitel folgt dem Totfund-Schalter', 
 		expect(document.body.textContent).toContain('Funddetails');
 	});
 });
+
+/**
+ * UX-Review 2026-08-07, Befund A: Die Karte hieß beim Totfund bereits
+ * „Funddetails", das erste Feld darunter fragte aber weiter „Von wo aus wurde
+ * die Sichtung gemacht?" — das Schema-Label kennt nur den Lebend-Zweig. Die
+ * Zuordnung liegt wie alle Zweigtexte in `$lib/report/wording`.
+ */
+describe('sections/SightingDetails — die Herkunftsfrage folgt dem Zweig', () => {
+	it('fragt im Lebend-Zweig unverändert nach der Sichtung', () => {
+		renderSightingDetails({ isDead: false });
+
+		expect(document.body.textContent).toContain('Von wo aus wurde die Sichtung gemacht?');
+	});
+
+	it('fragt beim Totfund nach dem Fund', () => {
+		renderSightingDetails({ isDead: true });
+
+		const text = document.body.textContent ?? '';
+		expect(text).toContain('Von wo aus haben Sie das Tier gefunden?');
+		expect(text).not.toContain('Von wo aus wurde die Sichtung gemacht?');
+	});
+
+	/**
+	 * Anders als der Kartentitel bleibt die Feldbeschriftung in der Admin-Maske
+	 * am Schema-Label: Dort wird ein Datensatz bearbeitet, nicht gemeldet — die
+	 * Sachbearbeitung liest dieselbe Beschriftung wie im Export und in der
+	 * Detailansicht.
+	 */
+	it('behält in der Admin-Maske auch beim Totfund das Schema-Label', () => {
+		renderSightingDetails({ isDead: true }, { adminMode: true });
+
+		expect(document.body.textContent).toContain('Von wo aus wurde die Sichtung gemacht?');
+	});
+});
+
+/**
+ * UX-Review 2026-08-07, Befund B: „Entfernung zum Tier" war auch beim Totfund
+ * Pflichtfeld — wer am Strand neben dem Tier steht, kann die Frage nicht
+ * beantworten und kam ohne geratene Kategorie nicht weiter. Die Markup-Hälfte
+ * zur Aufnahme in `HIDDEN_WHEN_DEAD` (`formConfig.ts`); dieselbe Struktur wie
+ * bei `deadSex` in `DeadAnimal.svelte`.
+ */
+describe('sections/SightingDetails — Entfernung entfällt beim Totfund', () => {
+	it('zeigt die Entfernung im Lebend-Zweig', () => {
+		renderSightingDetails({ isDead: false });
+
+		expect(field('distance')).not.toBeNull();
+	});
+
+	it('zeigt die Entfernung beim Totfund gar nicht erst', () => {
+		renderSightingDetails({ isDead: true });
+
+		expect(document.querySelector('[data-field="distance"]')).toBeNull();
+	});
+
+	/**
+	 * Die Admin-Maske muss die Entfernung an Totfund-Altbeständen weiter
+	 * bearbeiten können — 282 Bestandszeilen tragen dort den Sentinel `0`
+	 * („nicht angegeben", siehe `adminSightingSchema`).
+	 */
+	it('behält die Entfernung in der Admin-Maske auch beim Totfund', () => {
+		renderSightingDetails({ isDead: true }, { adminMode: true });
+
+		expect(field('distance')).not.toBeNull();
+	});
+});

--- a/src/lib/report/components/steps/Step2SightingDetails.svelte
+++ b/src/lib/report/components/steps/Step2SightingDetails.svelte
@@ -31,8 +31,7 @@
 		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
 			<strong>{question}</strong> Bitte geben Sie
 			<strong>Tierart und Anzahl</strong>
-			an. Bei Unsicherheit wählen Sie „Unbekannte Walart" bzw. „Unbekannte Robbenart" — auch Schätzungen
-			sind wertvoll und unterstützen die Populationsforschung.
+			an.
 		</p>
 	</div>
 

--- a/src/lib/report/components/steps/Step4Contact.svelte
+++ b/src/lib/report/components/steps/Step4Contact.svelte
@@ -69,10 +69,6 @@
 			</div>
 		</div>
 		<h2 class="text-base-content text-xl font-bold md:text-2xl">Kontaktdaten</h2>
-		<p class="text-base-content/70 mx-auto max-w-2xl text-sm md:text-base">
-			Ihre <strong>E-Mail-Adresse</strong> ist erforderlich für die Bestätigung. Kontaktdaten ermöglichen
-			wichtige Rückfragen zur Datenqualität.
-		</p>
 		<!-- Der frühere Satz „Ihre persönlichen Daten werden nie öffentlich
 		     angezeigt!" war nachweislich falsch: Direkt darunter stehen die
 		     Einwilligungen zur Namensnennung, und `/api/map/sightings` liefert
@@ -134,7 +130,7 @@
 							>
 							<button
 								type="button"
-								class="btn btn-outline btn-error btn-sm min-h-11"
+								class="btn btn-outline btn-error btn-sm"
 								onclick={clearContactData}
 							>
 								<Icon icon="lucide:trash-2" width="14" />

--- a/src/lib/report/fieldsOutsideReportKind.test.ts
+++ b/src/lib/report/fieldsOutsideReportKind.test.ts
@@ -28,8 +28,24 @@ describe('fieldsOutsideReportKind', () => {
 		]);
 	});
 
-	it('nennt für den Zweig "dead" genau die drei Verhaltensfelder, die dort nicht hingehören', () => {
-		expect(fieldsOutsideReportKind('dead')).toEqual(['behavior', 'behaviorText', 'reaction']);
+	/**
+	 * Seit dem UX-Review 2026-08-07 steht `distance` mit in der Liste: Die
+	 * Entfernung zum Tier entfällt im Totfund-Zweig (`HIDDEN_WHEN_DEAD`), und
+	 * die Reihenfolge folgt der Schritt-Konfiguration — `distance` steht auf
+	 * Schritt 2 und damit vor den Verhaltensfeldern auf Schritt 3.
+	 *
+	 * Praktisch heißt das: Wer im Lebend-Zweig eine Entfernung gewählt hat und
+	 * danach im Totfund-Zweig startet, findet den Wert nicht mehr im
+	 * Formular-Zustand — er ginge sonst unvalidiert und unsichtbar mit ans
+	 * Backend.
+	 */
+	it('nennt für den Zweig "dead" die Entfernung und die drei Verhaltensfelder', () => {
+		expect(fieldsOutsideReportKind('dead')).toEqual([
+			'distance',
+			'behavior',
+			'behaviorText',
+			'reaction'
+		]);
 	});
 
 	/**
@@ -108,9 +124,11 @@ describe('reportKindClearedNotice', () => {
 		);
 	});
 
-	it('nennt im Totfund-Zweig die entfernten Verhaltensangaben', () => {
+	it('nennt im Totfund-Zweig die entfernten Verhaltens- und Entfernungsangaben', () => {
+		// Seit `distance` beim Totfund entfällt (UX-Review 2026-08-07), räumt der
+		// Start im Totfund-Zweig auch die Entfernung — der Text muss beides nennen.
 		expect(reportKindClearedNotice('dead', 1)).toBe(
-			'Ihre Angaben zum Verhalten der Tiere wurden entfernt, alles Übrige bleibt erhalten.'
+			'Ihre Angaben zu Verhalten und Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
 		);
 	});
 

--- a/src/lib/report/fieldsOutsideReportKind.test.ts
+++ b/src/lib/report/fieldsOutsideReportKind.test.ts
@@ -128,7 +128,7 @@ describe('reportKindClearedNotice', () => {
 		// Seit `distance` beim Totfund entfällt (UX-Review 2026-08-07), räumt der
 		// Start im Totfund-Zweig auch die Entfernung — der Text muss beides nennen.
 		expect(reportKindClearedNotice('dead', 1)).toBe(
-			'Ihre Angaben zu Verhalten und Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
+			'Ihre Angaben zum Verhalten und zur Entfernung wurden entfernt, alles Übrige bleibt erhalten.'
 		);
 	});
 

--- a/src/lib/report/fieldsOutsideReportKind.ts
+++ b/src/lib/report/fieldsOutsideReportKind.ts
@@ -81,6 +81,9 @@ export function reportKindClearedNotice(kind: ReportKind, clearedCount: number):
 		return null;
 	}
 
-	const removed = kind === 'alive' ? 'zum Totfund' : 'zum Verhalten der Tiere';
+	// „Verhalten und Entfernung": Seit dem UX-Review 2026-08-07 entfällt beim
+	// Totfund auch `distance` (HIDDEN_WHEN_DEAD) — der Text muss mitziehen,
+	// sonst verschweigt er einen Teil dessen, was gerade geräumt wurde.
+	const removed = kind === 'alive' ? 'zum Totfund' : 'zu Verhalten und Entfernung';
 	return `Ihre Angaben ${removed} wurden entfernt, alles Übrige bleibt erhalten.`;
 }

--- a/src/lib/report/fieldsOutsideReportKind.ts
+++ b/src/lib/report/fieldsOutsideReportKind.ts
@@ -84,6 +84,6 @@ export function reportKindClearedNotice(kind: ReportKind, clearedCount: number):
 	// „Verhalten und Entfernung": Seit dem UX-Review 2026-08-07 entfällt beim
 	// Totfund auch `distance` (HIDDEN_WHEN_DEAD) — der Text muss mitziehen,
 	// sonst verschweigt er einen Teil dessen, was gerade geräumt wurde.
-	const removed = kind === 'alive' ? 'zum Totfund' : 'zu Verhalten und Entfernung';
+	const removed = kind === 'alive' ? 'zum Totfund' : 'zum Verhalten und zur Entfernung';
 	return `Ihre Angaben ${removed} wurden entfernt, alles Übrige bleibt erhalten.`;
 }

--- a/src/lib/report/formConfig.test.ts
+++ b/src/lib/report/formConfig.test.ts
@@ -425,14 +425,26 @@ describe('getFormSteps', () => {
 		expect(fieldsOf(getFormSteps({ isDead: 0 }))).not.toContain('deadCondition');
 	});
 
-	it('lässt beim Totfund Wetter, Anzahl anderer Schiffe und Entfernung stehen', () => {
+	it('lässt beim Totfund Wetter und die Anzahl anderer Schiffe stehen', () => {
 		// Achse C der Spezifikation: Diese Felder hängen nicht am Zustand des
-		// Tieres. `shipCount` fragt nach ANDEREN Schiffen, `distance` ist auch
-		// vom Strand aus sinnvoll.
+		// Tieres. `shipCount` fragt nach ANDEREN Schiffen — Störungskontext, der
+		// auch am Fundort gilt.
 		const fields = fieldsOf(getFormSteps({ isDead: true }));
 		expect(fields).toEqual(
-			expect.arrayContaining(['seaState', 'visibility', 'windForce', 'shipCount', 'distance'])
+			expect.arrayContaining(['seaState', 'visibility', 'windForce', 'shipCount'])
 		);
+	});
+
+	/**
+	 * UX-Review 2026-08-07: „Entfernung zum Tier" war auch beim Totfund
+	 * Pflichtfeld — an einem Strandfund steht der Melder aber neben dem Tier.
+	 * Die Frage ist dort nicht bloß entbehrlich, sie ist unbeantwortbar, und
+	 * `distance` ist im Meldeformular Pflicht: Sie sperrte „Weiter", bis
+	 * irgendeine Kategorie geraten war.
+	 */
+	it('entfernt die Entfernung beim Totfund, behält sie im Lebend-Zweig', () => {
+		expect(fieldsOf(getFormSteps({ isDead: true }))).not.toContain('distance');
+		expect(fieldsOf(getFormSteps({ isDead: false }))).toContain('distance');
 	});
 
 	it('behält in beiden Zweigen vier Schritte — kein Schritt wird leer', () => {
@@ -616,6 +628,40 @@ describe('hiddenFormFields — der Server akzeptiert, was der Client weglässt',
 			deadSize: 150,
 			deadPhoneContact: true
 		});
+	});
+
+	/**
+	 * Der teuerste Teil des Entfernungs-Befunds: `distance` ist im vollen
+	 * `sightingSchema` `.required()`. Ein Feld aus dem Totfund-Zweig zu nehmen
+	 * heißt deshalb zwingend, seine Pflicht im Schema an denselben Zweig zu
+	 * binden — sonst lehnt der Endpunkt jede Totfund-Meldung mit „Bitte geben
+	 * Sie eine Entfernung an." ab, und zwar an einem Feld, das der Melder gar
+	 * nicht mehr sieht. Genau derselbe Zwang stand 2026-08-04 schon bei
+	 * `deadSex` (Kommentar im Schema).
+	 */
+	it('Totfund ohne jede Entfernungsangabe', async () => {
+		const { distance: _weggelassen, ...ohneEntfernung } = baseReport;
+		await expectServerAccepts({
+			...ohneEntfernung,
+			isDead: true,
+			deadCondition: 2,
+			sightingFrom: SightingFromEnum.LAND
+		});
+	});
+
+	/**
+	 * Die Gegenprobe dazu: Im Lebend-Zweig bleibt die Entfernung Pflicht — sonst
+	 * hätte die Lockerung oben das Feld für ALLE Meldungen entwertet, und der
+	 * Lebend-Weg darf sich nicht ändern.
+	 */
+	it('verlangt die Entfernung im Lebend-Zweig unverändert', async () => {
+		const { distance: _weggelassen, ...ohneEntfernung } = baseReport;
+		await expect(
+			sightingSchema.validate(
+				{ ...ohneEntfernung, isDead: false, sightingFrom: SightingFromEnum.LAND },
+				{ abortEarly: false }
+			)
+		).rejects.toThrow(/Entfernung/);
 	});
 
 	it('Totfund vom Segelboot — ohne die Verhaltensfelder', async () => {

--- a/src/lib/report/formConfig.ts
+++ b/src/lib/report/formConfig.ts
@@ -239,6 +239,16 @@ export function isDeadFinding(value: unknown): boolean {
  * Felder, die beim Totfund entfallen. Ein totes Tier zeigt kein Verhalten und
  * reagiert nicht — die Angaben wären für den Melder unbeantwortbar.
  *
+ * `distance` steht seit dem UX-Review 2026-08-07 mit in der Liste, aus
+ * derselben Begründung: Ein Totfund wird am Strand gefunden, der Melder steht
+ * neben dem Tier. „Entfernung zum Tier" ist dort keine Schätzung mehr, sondern
+ * eine Frage ohne sinnvolle Antwort — und im Meldeformular Pflicht, sie sperrte
+ * „Weiter", bis irgendeine Kategorie geraten war. Anders als bei den
+ * Verhaltensfeldern reicht der Eintrag hier nicht: `distance` ist im vollen
+ * `sightingSchema` unbedingt `.required()`, und der Endpunkt validiert dagegen
+ * — die Pflicht hängt dort jetzt über `when('isDead')` am selben Zweig
+ * (Begründung im Schema, gleiche Lage wie bei `deadSex` 2026-08-04).
+ *
  * WICHTIG: Diese Liste ist die halbe Miete, nicht die ganze. Sie steuert
  * ausschließlich die Validierung — gelesen wird sie nur von `stepValidation`,
  * gerendert wird aus ihr nichts. Wer ein Feld nur hier entfernt, bekommt ein
@@ -249,10 +259,11 @@ export function isDeadFinding(value: unknown): boolean {
  *
  * Beides gehört deshalb zusammen entschieden: Eintrag hier UND eine Bedingung
  * an der Aufrufstelle im Markup, beide über `isDeadFinding` — nie eine zweite,
- * eigene Regel daneben. Für diese drei Felder sitzt die Markup-Seite in
- * `steps/Step3Observations.svelte`.
+ * eigene Regel daneben. Für die drei Verhaltensfelder sitzt die Markup-Seite in
+ * `steps/Step3Observations.svelte`, für `distance` in
+ * `sections/SightingDetails.svelte`.
  */
-const HIDDEN_WHEN_DEAD = ['behavior', 'behaviorText', 'reaction'] as const;
+const HIDDEN_WHEN_DEAD = ['distance', 'behavior', 'behaviorText', 'reaction'] as const;
 
 /**
  * Die Gegenrichtung: Felder, die im Lebend-Zweig entfallen. Ein lebendes Tier

--- a/src/lib/report/hasMeaningfulSavedData.test.ts
+++ b/src/lib/report/hasMeaningfulSavedData.test.ts
@@ -1,0 +1,81 @@
+/**
+ * UX-Review (2026-08-07, Befund 6): Der Wiederherstellungs-Toast in
+ * `ModernReportForm.svelte` feuerte bislang schon dann, wenn `sessionStorage`
+ * den Schlüssel `FORM_DATA` überhaupt enthielt — und das Formular schreibt
+ * diesen Schlüssel schon beim bloßen Öffnen (`$effect`, `saveToStorage`).
+ * Auswahlseite → Formular → „Ändern" → Formular, ohne je etwas einzutippen,
+ * zeigte damit trotzdem „Ihre vorherigen Eingaben wurden wiederhergestellt.".
+ *
+ * `hasMeaningfulSavedData` ist die pure Vergleichsfunktion dahinter: Der Toast
+ * darf nur erscheinen, wenn sich die aus dem Storage geladenen Daten
+ * TATSÄCHLICH vom Initialzustand unterscheiden.
+ */
+import { describe, expect, it } from 'vitest';
+import { hasMeaningfulSavedData } from './hasMeaningfulSavedData';
+import { initialFormState } from './formConfig';
+import type { SightingFormData } from '$lib/types';
+
+describe('hasMeaningfulSavedData', () => {
+	it('meldet keine Änderung, wenn die gespeicherten Daten den Defaults entsprechen', () => {
+		const saved: SightingFormData = { ...initialFormState };
+		const initial: SightingFormData = { ...initialFormState };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(false);
+	});
+
+	it('ignoriert eine abweichende referenceId — jede Sitzung erzeugt eine neue', () => {
+		const saved: SightingFormData = { ...initialFormState, referenceId: 'alte-sitzung' };
+		const initial: SightingFormData = { ...initialFormState, referenceId: 'neue-sitzung' };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(false);
+	});
+
+	it('ignoriert eine abweichende isDead — der Zweig kommt von der Einstiegsseite, nicht vom Nutzer', () => {
+		const saved: SightingFormData = { ...initialFormState, isDead: true };
+		const initial: SightingFormData = { ...initialFormState, isDead: false };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(false);
+	});
+
+	it('meldet keine Änderung, wenn die Kontaktdaten mit den persistierten übereinstimmen', () => {
+		// `initialFormData` in ModernReportForm.svelte trägt bereits
+		// `savedUserContactData` — dieselben Werte stehen deshalb auch in
+		// `savedFormData` (aus einer früheren Sitzung mit demselben
+		// wiederkehrenden Melder). Kein Unterschied, also kein Toast.
+		const initial: SightingFormData = {
+			...initialFormState,
+			firstName: 'Max',
+			lastName: 'Mustermann',
+			email: 'max@example.com',
+			phone: '0170123456'
+		};
+		const saved: SightingFormData = { ...initial, referenceId: 'andere-referenz' };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(false);
+	});
+
+	it('meldet eine Änderung, wenn ein Fahrwasser eingetippt wurde', () => {
+		const saved: SightingFormData = { ...initialFormState, waterway: 'Kieler Förde' };
+		const initial: SightingFormData = { ...initialFormState };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(true);
+	});
+
+	it('meldet eine Änderung, wenn bereits Dateien hochgeladen wurden', () => {
+		const saved: SightingFormData = {
+			...initialFormState,
+			uploadedFiles: [
+				{
+					uid: 'abc',
+					filePath: '/uploads/abc.jpg',
+					originalName: 'abc.jpg',
+					mimeType: 'image/jpeg',
+					size: 1234
+				}
+			]
+		};
+		const initial: SightingFormData = { ...initialFormState };
+
+		expect(hasMeaningfulSavedData(saved, initial)).toBe(true);
+	});
+});

--- a/src/lib/report/hasMeaningfulSavedData.ts
+++ b/src/lib/report/hasMeaningfulSavedData.ts
@@ -1,0 +1,61 @@
+import type { SightingFormData } from '$lib/types';
+
+/**
+ * Felder, die beim Vergleich nicht zählen — sie tragen keine Nutzereingabe und
+ * dürfen den Wiederherstellungs-Toast deshalb nicht auslösen:
+ *
+ * - `referenceId`: pro Formular-Mount neu erzeugt (`createId()` in
+ *   `ModernReportForm.svelte`). `savedFormData` trägt immer die Referenz der
+ *   VORHERIGEN Sitzung — ein Vergleich ohne diese Ausnahme wäre also immer
+ *   „verschieden".
+ * - `isDead`: kommt aus `initialIsDead` von der Einstiegsseite
+ *   (`ReportKindChoice`), nicht vom Nutzer im Formular getippt.
+ * - `entryChannel`: fester Schema-Default (`.default(0)`), im Meldeformular
+ *   kein Bedienelement — nur die Admin-Maske zeigt/ändert es.
+ * - `weatherData`: `type: 'hidden'` im Schema, wird automatisch von der
+ *   Wetter-API befüllt (`Environment.svelte`), nicht vom Nutzer eingegeben.
+ */
+const IGNORED_FIELDS: ReadonlySet<keyof SightingFormData> = new Set([
+	'referenceId',
+	'isDead',
+	'entryChannel',
+	'weatherData'
+]);
+
+/**
+ * Ob die aus dem Storage geladenen Formulardaten sich tatsächlich vom
+ * Initialzustand unterscheiden — also ob eine frühere Sitzung wirklich etwas
+ * hinterlassen hat, das den Wiederherstellungs-Toast in `ModernReportForm.svelte`
+ * rechtfertigt.
+ *
+ * Feld für Feld verglichen, nicht per `JSON.stringify` über das ganze Objekt:
+ * Reihenfolge-Unterschiede in verschachtelten Strukturen dürften sonst falsch
+ * positiv auslösen, und die Ausnahmen in `IGNORED_FIELDS` ließen sich über
+ * einen Gesamtvergleich nicht sauber herausrechnen.
+ *
+ * `uploadedFiles` ist die eine Ausnahme vom Feld-für-Feld-Vergleich: Es ist ein
+ * Array, ein `!==` auf die Referenz wäre immer wahr. Die Länge genügt hier —
+ * bereits eine hochgeladene Datei ist ein Unterschied, der es wert ist, gemeldet
+ * zu werden; ein inhaltlicher Abgleich (Dateiname, Größe, …) bringt keinen
+ * zusätzlichen Erkenntnisgewinn, den der Nutzer über den Toast bewerten könnte.
+ */
+export function hasMeaningfulSavedData(
+	saved: SightingFormData,
+	initial: SightingFormData
+): boolean {
+	if ((saved.uploadedFiles?.length ?? 0) !== (initial.uploadedFiles?.length ?? 0)) {
+		return true;
+	}
+
+	const keys = new Set<keyof SightingFormData>([
+		...(Object.keys(saved) as (keyof SightingFormData)[]),
+		...(Object.keys(initial) as (keyof SightingFormData)[])
+	]);
+
+	for (const key of keys) {
+		if (key === 'uploadedFiles' || IGNORED_FIELDS.has(key)) continue;
+		if (saved[key] !== initial[key]) return true;
+	}
+
+	return false;
+}

--- a/src/lib/report/wording.test.ts
+++ b/src/lib/report/wording.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import * as yup from 'yup';
+import { sightingSchema } from '$lib/form/validation/sightingSchema';
 import {
 	dateSectionIntro,
 	dateSectionTitle,
@@ -8,6 +10,7 @@ import {
 	outsideBalticNotice,
 	outsideBalticSeverity,
 	positionQuestion,
+	sightingFromQuestion,
 	speciesQuestion,
 	step3ObservationsIntro
 } from './wording';
@@ -64,6 +67,36 @@ describe('wording — Totfund-Ansprache auf Schritt 2', () => {
 
 		it('nennt die Karte beim Totfund „Funddetails"', () => {
 			expect(detailsSectionTitle(true)).toBe('Funddetails');
+		});
+	});
+
+	/**
+	 * Die Karte heißt beim Totfund „Funddetails" (`detailsSectionTitle`), das
+	 * erste Feld darunter fragte aber weiter „Von wo aus wurde die Sichtung
+	 * gemacht?" — das Schema-Label, das nur den Lebend-Zweig kennt.
+	 */
+	describe('sightingFromQuestion', () => {
+		/**
+		 * Verbindliche Entscheidung des Auftraggebers (siehe Kopf von
+		 * `dateSectionTitle`): Der Lebend-Weg darf sich nicht sichtbar ändern.
+		 * Verglichen wird deshalb gegen das Schema-Label selbst und nicht gegen
+		 * ein Literal — ein Textwechsel im Schema würde sonst still auseinander
+		 * laufen, und die Admin-Maske zeigt weiterhin genau diesen Text.
+		 */
+		it('behält im Lebend-Zweig wörtlich das Schema-Label', () => {
+			// `fields` ist bei Yup als `ISchema | Reference` typisiert; das Label
+			// steht nur an der Schema-Variante.
+			const schemaLabel = (sightingSchema.fields.sightingFrom as yup.NumberSchema).spec.label;
+			expect(sightingFromQuestion(false)).toBe(schemaLabel);
+			expect(sightingFromQuestion(false)).toBe('Von wo aus wurde die Sichtung gemacht?');
+		});
+
+		it('fragt beim Totfund nach dem Fund statt nach der Sichtung', () => {
+			expect(sightingFromQuestion(true)).toBe('Von wo aus haben Sie das Tier gefunden?');
+		});
+
+		it('behandelt den String "1" (DB-Wert) wie einen Totfund', () => {
+			expect(sightingFromQuestion('1')).toBe('Von wo aus haben Sie das Tier gefunden?');
 		});
 	});
 

--- a/src/lib/report/wording.ts
+++ b/src/lib/report/wording.ts
@@ -38,6 +38,26 @@ export function observationQuestion(isDead: unknown): string {
 	return isDeadFinding(isDead) ? 'Was haben Sie gefunden?' : 'Was haben Sie beobachtet?';
 }
 
+/**
+ * Beschriftung des Herkunftsfeldes (`sightingFrom`) auf Schritt 2.
+ *
+ * Die Karte darüber heißt beim Totfund „Funddetails" (`detailsSectionTitle`),
+ * das erste Feld darin fragte trotzdem weiter nach der Sichtung — das
+ * Schema-Label kennt nur den Lebend-Zweig.
+ *
+ * Der Lebend-Zweig gibt wörtlich das Schema-Label zurück (verbindliche
+ * Auftraggeber-Regel, siehe `dateSectionTitle`): Die Aufrufstelle kann die
+ * Beschriftung deshalb unbedingt überschreiben, ohne im Lebend-Zweig etwas zu
+ * verändern — nötig, weil `exactOptionalPropertyTypes` kein `undefined` an ein
+ * optionales Prop erlaubt. Dass beide Texte übereinstimmen, prüft
+ * `wording.test.ts` gegen das Schema selbst.
+ */
+export function sightingFromQuestion(isDead: unknown): string {
+	return isDeadFinding(isDead)
+		? 'Von wo aus haben Sie das Tier gefunden?'
+		: 'Von wo aus wurde die Sichtung gemacht?';
+}
+
 /** Titel der Karte unter den Tierangaben auf Schritt 2. */
 export function detailsSectionTitle(isDead: unknown): string {
 	return isDeadFinding(isDead) ? 'Funddetails' : 'Sichtungsdetails';

--- a/src/lib/stores/toastState.svelte.ts
+++ b/src/lib/stores/toastState.svelte.ts
@@ -9,6 +9,15 @@ export interface ToastMessage {
 	message: string;
 	duration?: number;
 	dismissible?: boolean;
+	/**
+	 * Stabiler Schlüssel für Toasts, die sich gegenseitig ersetzen statt sich zu
+	 * stapeln (z. B. wiederholte Validierungsfehler auf demselben Schritt).
+	 * `addToast` entfernt einen bestehenden Toast mit demselben `key`, bevor es
+	 * den neuen einfügt — der neue trägt eine neue `id`, wodurch `ToastContainer`
+	 * (`{#each … (toast.id)}`) die `Toast`-Komponente neu mountet und ihr
+	 * `$effect`-Timeout neu startet. Ohne `key` verhalten sich Aufrufer wie bisher.
+	 */
+	key?: string;
 }
 
 export const toasts = $state<ToastMessage[]>([]);
@@ -18,6 +27,9 @@ export function getToasts(): ToastMessage[] {
 }
 
 export function addToast(toast: Omit<ToastMessage, 'id'>): string {
+	if (toast.key) {
+		removeToastByKey(toast.key);
+	}
 	const id = crypto.randomUUID();
 	toasts.push({ id, duration: 5000, dismissible: true, ...toast });
 	return id;
@@ -25,6 +37,12 @@ export function addToast(toast: Omit<ToastMessage, 'id'>): string {
 
 export function removeToast(id: string): void {
 	const idx = toasts.findIndex((t) => t.id === id);
+	if (idx !== -1) toasts.splice(idx, 1);
+}
+
+/** Entfernt einen aktiven Toast anhand seines `key` — No-Op, wenn keiner existiert. */
+export function removeToastByKey(key: string): void {
+	const idx = toasts.findIndex((t) => t.key === key);
 	if (idx !== -1) toasts.splice(idx, 1);
 }
 
@@ -74,6 +92,7 @@ export const toast = {
 	},
 	add: addToast,
 	remove: removeToast,
+	removeByKey: removeToastByKey,
 	clear: clearAllToasts,
 	success: successToast,
 	error: errorToast,

--- a/src/lib/stores/toastState.test.ts
+++ b/src/lib/stores/toastState.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
 	addToast,
 	removeToast,
+	removeToastByKey,
 	clearAllToasts,
 	getToasts,
 	successToast,
@@ -195,6 +196,76 @@ describe('Toast State Management (Svelte 5 Runes)', () => {
 
 			toast.clear();
 			expect(toast.current).toHaveLength(0);
+		});
+	});
+
+	describe('Ersetzen per key (Validierungs-Toast stapelt nicht)', () => {
+		it('ersetzt einen bestehenden Toast mit demselben key statt ihn zu stapeln', () => {
+			addToast({ type: 'error', message: 'Erster Versuch', key: 'step-validation' });
+			addToast({ type: 'error', message: 'Zweiter Versuch', key: 'step-validation' });
+			addToast({ type: 'error', message: 'Dritter Versuch', key: 'step-validation' });
+			addToast({ type: 'error', message: 'Vierter Versuch', key: 'step-validation' });
+
+			const toasts = getToasts();
+			expect(toasts).toHaveLength(1);
+			expect(toasts[0]!.message).toBe('Vierter Versuch');
+		});
+
+		it('vergibt beim Ersetzen eine neue id, damit die Anzeigedauer neu startet', () => {
+			const id1 = addToast({ type: 'error', message: 'Erster Versuch', key: 'step-validation' });
+			const id2 = addToast({ type: 'error', message: 'Zweiter Versuch', key: 'step-validation' });
+
+			expect(id2).not.toBe(id1);
+		});
+
+		it('lässt Toasts ohne key unangetastet, auch wenn ein neuer Toast denselben key trägt wie keiner von ihnen', () => {
+			addToast({ type: 'info', message: 'Unabhängiger Toast' });
+			addToast({ type: 'error', message: 'Validierungsfehler', key: 'step-validation' });
+
+			expect(getToasts()).toHaveLength(2);
+		});
+
+		it('stapelt Toasts mit unterschiedlichem key weiterhin normal', () => {
+			addToast({ type: 'error', message: 'Fehler A', key: 'step-validation' });
+			addToast({ type: 'error', message: 'Fehler B', key: 'other-key' });
+
+			expect(getToasts()).toHaveLength(2);
+		});
+
+		it('bestehende Aufrufer ohne key verhalten sich unverändert (mehrere Toasts stapeln)', () => {
+			addToast({ type: 'error', message: 'Ohne key 1' });
+			addToast({ type: 'error', message: 'Ohne key 2' });
+
+			expect(getToasts()).toHaveLength(2);
+		});
+	});
+
+	describe('removeToastByKey', () => {
+		it('entfernt den Toast mit dem angegebenen key', () => {
+			addToast({ type: 'error', message: 'Validierungsfehler', key: 'step-validation' });
+
+			removeToastByKey('step-validation');
+
+			expect(getToasts()).toHaveLength(0);
+		});
+
+		it('lässt Toasts mit anderem oder ohne key unberührt', () => {
+			addToast({ type: 'error', message: 'Validierungsfehler', key: 'step-validation' });
+			addToast({ type: 'info', message: 'Unabhängig' });
+
+			removeToastByKey('step-validation');
+
+			const toasts = getToasts();
+			expect(toasts).toHaveLength(1);
+			expect(toasts[0]!.message).toBe('Unabhängig');
+		});
+
+		it('ist ein No-Op, wenn kein Toast mit diesem key existiert', () => {
+			addToast({ type: 'info', message: 'Unabhängig' });
+
+			removeToastByKey('nicht-vorhanden');
+
+			expect(getToasts()).toHaveLength(1);
 		});
 	});
 


### PR DESCRIPTION
## Zusammenfassung

Umsetzung aller 8 Befunde aus dem UX-Review des Meldeformulars vom 2026-08-07 (alle Steps, beide Zweige, Desktop + Mobil live durchgespielt).

### Toast-Verhalten (Befund 1)
- Validierungs-Toasts tragen einen stabilen `key` und **ersetzen** sich statt zu stapeln (vorher: 4 identische Toasts nach 4× „Weiter")
- Beim Verlassen eines Schritts wird dessen Validierungs-Toast geschlossen — kein veralteter „Fehler in Position & Zeitpunkt"-Toast mehr auf Schritt 2
- API rückwärtskompatibel: Toasts ohne `key` verhalten sich unverändert

### Totfund Schritt 2 (Befund 2)
- Label: „Von wo aus **haben Sie das Tier gefunden**?" statt „…wurde die Sichtung gemacht?" (`sightingFromQuestion` in `wording.ts`; Lebend-Zweig und Admin-Maske wörtlich unverändert)
- „Entfernung zum Tier" entfällt beim Totfund komplett (bei einem Strandfund unbeantwortbar): `HIDDEN_WHEN_DEAD` + Markup-Bedingung + Schema-`when('isDead')`. Die Schema-Lockerung ist zwingend — `POST /api/sightings` validiert gegen das volle Schema, ohne sie bekäme **jede** Totfund-Meldung eine 400 an einem unsichtbaren Feld
- `reportKindClearedNotice` nennt jetzt auch die entfernte Entfernung
- Admin-Maske zeigt `distance` an Totfund-Altbeständen weiterhin; Legacy-API unberührt

### Wiederherstellungs-Toast (Befund 6)
- „Ihre vorherigen Eingaben wurden wiederhergestellt" nur noch, wenn die geladenen Daten tatsächlich vom Initialzustand abweichen (`hasMeaningfulSavedData.ts`; `referenceId`/`isDead`/`entryChannel`/`weatherData` zählen nicht)

### UI/Text-Politur (Befunde 3, 4, 5, 7, 8)
- Erfolgsseite: Token-Schatten (`shadow-raised`) statt `shadow-xl/lg/sm`, Hover-Transforms entfernt, redundanter „Zur Startseite"-Button entfernt
- Schritt-2-Kopf dupliziert den Artfeld-Hilfetext nicht mehr; Schritt-4-Kopf gestrafft (Consent-Flächen byte-identisch, gepinnte Hashes grün)
- Redundante `min-h-11` entfernt (44px kommen zentral aus `app.css`)

### E2E
- Totfund-Flows füllen `distance` nicht mehr; neue Assertion, dass das Feld im Totfund fehlt
- Autosave-Restore-Test macht jetzt eine echte Eingabe **mit Blur** (`fill()` allein erreicht den Form-State nie — Commit erst beim `change`-Event) plus Gegenprobe „kein Toast ohne Eingabe"

## Abnahme

- `npm run test:quick`: Lint 0 Fehler, tsc, svelte-check 0 Fehler, **3722 Unit-Tests grün**
- Browser-Komponenten-Tests: **562/562**
- E2E chromium (alle Formular-Specs): **130/130**
- Projekt-Review-Skill (`/review`): 0 Anti-Pattern, 0 Befunde

🤖 Generated with [Claude Code](https://claude.com/claude-code)