### PR TITLE
fix(report): kein Bestätigungsmail-Versprechen auf der Erfolgsseite

### DIFF
--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -21,7 +21,7 @@
 		<div class="mb-8 space-y-6 text-center">
 			<div class="flex justify-center">
 				<div class="bg-success/20 flex h-20 w-20 items-center justify-center rounded-full">
-					<Icon icon="lucide:check" width="40" class="text-success-strong" />
+					<Icon icon="lucide:check" width="40" class="text-success-strong" aria-hidden="true" />
 				</div>
 			</div>
 
@@ -64,6 +64,7 @@
 							width="24"
 							height="24"
 							class="text-info-strong mt-1"
+							aria-hidden="true"
 						/>
 						<div>
 							<h3 class="font-semibold">Rückfragen zu Ihrer Meldung</h3>
@@ -78,7 +79,13 @@
 					</div>
 
 					<div class="flex items-start gap-3">
-						<Icon icon="lucide:activity" width="24" height="24" class="text-info-strong mt-1" />
+						<Icon
+							icon="lucide:activity"
+							width="24"
+							height="24"
+							class="text-info-strong mt-1"
+							aria-hidden="true"
+						/>
 						<div>
 							<h3 class="font-semibold">Wissenschaftliche Auswertung</h3>
 							<p class="text-base-content/70 text-sm">
@@ -88,7 +95,13 @@
 					</div>
 
 					<div class="flex items-start gap-3">
-						<Icon icon="lucide:camera" width="24" height="24" class="text-accent-strong mt-1" />
+						<Icon
+							icon="lucide:camera"
+							width="24"
+							height="24"
+							class="text-accent-strong mt-1"
+							aria-hidden="true"
+						/>
 						<div>
 							<h3 class="font-semibold">Fotos und Videos</h3>
 							<p class="text-base-content/70 text-sm">
@@ -109,6 +122,7 @@
 								width="24"
 								height="24"
 								class="text-warning-strong mt-1"
+								aria-hidden="true"
 							/>
 							<div>
 								<h3 class="font-semibold">Totfund gemeldet</h3>
@@ -120,7 +134,13 @@
 					{/if}
 
 					<div class="flex items-start gap-3">
-						<Icon icon="lucide:chart-pie" width="24" height="24" class="text-primary mt-1" />
+						<Icon
+							icon="lucide:chart-pie"
+							width="24"
+							height="24"
+							class="text-primary mt-1"
+							aria-hidden="true"
+						/>
 						<div>
 							<h3 class="font-semibold">Daten einsehen</h3>
 							<p class="text-base-content/70 text-sm">
@@ -191,7 +211,7 @@
 
 					<div class="grid grid-cols-1 gap-4 text-sm md:grid-cols-2">
 						<a href="/map" class="btn btn-outline btn-sm flex items-center gap-2">
-							<Icon icon="lucide:map" width="16" height="16" />
+							<Icon icon="lucide:map" width="16" height="16" aria-hidden="true" />
 							Alle Sichtungen auf der Karte
 						</a>
 						<a
@@ -200,7 +220,7 @@
 							rel="noopener"
 							class="btn btn-outline btn-sm flex items-center gap-2"
 						>
-							<Icon icon="lucide:shield-check" width="16" height="16" />
+							<Icon icon="lucide:shield-check" width="16" height="16" aria-hidden="true" />
 							Deutsches Meeresmuseum
 						</a>
 					</div>

--- a/src/lib/report/components/SubmissionSuccess.svelte
+++ b/src/lib/report/components/SubmissionSuccess.svelte
@@ -51,19 +51,28 @@
 				<h2 class="card-title text-success-strong mb-4">Was passiert als Nächstes?</h2>
 
 				<div class="space-y-4">
+					<!-- Kein automatischer Mailversand an die meldende Person — weder beim
+					     Absenden noch bei der Freigabe; `notification.email.*` steuert
+					     ausschließlich die interne Mail ans Museum. Zugesagt wird deshalb
+					     nur, dass die Kontaktdaten angekommen sind — nicht, dass etwas
+					     zurückkommt. Eine persönliche Rückmeldung des Museums bleibt damit
+					     möglich, ohne dass die Seite sie versprochen hätte, und der Kanal
+					     bleibt offen (Rückfragen laufen auch telefonisch). -->
 					<div class="flex items-start gap-3">
 						<Icon
-							icon="lucide:check-circle"
+							icon="lucide:message-circle"
 							width="24"
 							height="24"
-							class="text-success-strong mt-1"
+							class="text-info-strong mt-1"
 						/>
 						<div>
-							<h3 class="font-semibold">Bestätigung per E-Mail</h3>
+							<h3 class="font-semibold">Rückfragen zu Ihrer Meldung</h3>
 							<p class="text-base-content/70 text-sm">
-								Sie erhalten in Kürze eine Bestätigung an <strong
+								Eine automatische Bestätigungsmail versenden wir nicht. Falls zu Ihrer Meldung etwas
+								offen bleibt, melden wir uns bei Ihnen — per E-Mail an <strong
 									>{submittedData?.email ? maskEmail(submittedData.email) : '***@***.***'}</strong
-								>
+								>{#if submittedData?.phone}
+									oder telefonisch{/if}.
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
## Was geändert wurde

Der erste Block unter „Was passiert als Nächstes?" auf der Bestätigungsseite hieß **„Bestätigung per E-Mail"** und sagte zu:

> Sie erhalten in Kürze eine Bestätigung an j\*\*@tiira.de

Er heißt jetzt **„Rückfragen zu Ihrer Meldung"** (Icon `lucide:message-circle` statt Häkchen) und sagt:

> Eine automatische Bestätigungsmail versenden wir nicht. Falls zu Ihrer Meldung etwas offen bleibt, melden wir uns bei Ihnen — per E-Mail an **j\*\*@tiira.de** oder telefonisch.

## Warum

**Diese Mail gibt es nicht.** Weder beim Absenden noch bei der Freigabe geht etwas an die meldende Person raus:

- `notification.email.*` steuert ausschließlich die interne Benachrichtigung ans Museum (`emailService.ts`, `to: config.recipient`) — so auch schon in `configLabels.ts` dokumentiert: „Die meldende Person bekommt bis heute überhaupt keine Mail".
- `PATCH /api/sightings/[id]/verify` verschickt bei der Freigabe ebenfalls nichts.

Ein Melder-Versand ist als #621 vorgemerkt; bis dahin war die Zusage schlicht falsch.

## Was ein Reviewer wissen sollte

- **Der Kanal bleibt offen.** Erste Fassung lautete „Rückfragen per E-Mail" — das war genauso zu eng, weil das Museum auch anruft. Der Satz sagt jetzt „wir melden uns", nicht „Sie bekommen eine Mail".
- **„oder telefonisch" erscheint nur bei angegebener Nummer.** `phone` ist optional; ohne Nummer endet der Satz nach der Adresse. Die Nummer selbst wird nicht ausgegeben — dafür bräuchte es eine zweite Maskierungsfunktion neben `maskEmail`, und für die Zusage genügt der Hinweis.
- **Persönliche Bestätigungen bleiben möglich.** Verneint ist nur die *automatische* Mail. Schickt das Museum eine persönliche, hat die Seite nichts Falsches gesagt.
- **Die maskierte Adresse bleibt stehen** — sie ist die einzige Rückmeldung, dass die Kontaktdaten tippfehlerfrei angekommen sind.
- **`sightingSchema.ts` ist bewusst unverändert.** Der Hilfetext am E-Mail-Feld („Für Rückfragen und zur Bestätigung der Sichtung") war zwischenzeitlich mitgeändert und wurde auf Wunsch zurückgenommen: Die persönlichen Bestätigungen des Museums decken ihn.

## Tests

Kein neuer Test — reine Texterfassung ohne Logikänderung, und kein bestehender Test hing an der Formulierung (Ausnahme nach `.claude/rules/testing.md`, in der Commit-Message dokumentiert).

Geprüft: `npm run check` (0 Fehler, 2161 Dateien), `npm run lint` (nur zwei vorbestehende `any`-Warnungen in `src/tests/contract/helpers/createEvent.ts`), Schema- und Privacy-Unit-Tests 190/190 grün.

**Nicht visuell nachgestellt:** Die Seite ist erst nach einer vollständigen Meldung über alle vier Schritte erreichbar; geändert wurde statischer Text plus eine `{#if}`-Bedingung auf `phone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)