### PR TITLE
feat(report): Dropdown-Optionen nach Wahrscheinlichkeit sortieren, redundantes "Keine Angabe" entfernen

### DIFF
--- a/src/lib/report/formOptions/animalCondition.ts
+++ b/src/lib/report/formOptions/animalCondition.ts
@@ -26,12 +26,33 @@ export const animalConditionLabels: Record<AnimalConditionEnum, string> = {
 export type AnimalCondition = AnimalConditionEnum;
 
 /**
+ * Zustände, die im Formular auswählbar sind — "Unbekannt" am Ende.
+ *
+ * Anders als bei `seaState`, `visibility` und `sex` bleibt die Nicht-Antwort
+ * hier **wählbar**: `deadCondition` ist im Totfund-Zweig ein Pflichtfeld
+ * (`when('isDead')` im Schema). Ohne "Unbekannt" gäbe es keinen Ausweg für
+ * jemanden, der den Verwesungsgrad am Strand nicht einschätzen kann — der
+ * Platzhalter von `BaseSelect` taugt dafür nicht, weil er die Pflicht nicht
+ * erfüllt. Sie steht nur nicht mehr an erster Stelle, wohin ihr Enum-Wert `0`
+ * sie sortiert hatte.
+ *
+ * Abgeleitet statt aufgezählt: Die übrigen Stufen sind ordinal
+ * (extrem frisch → starke Verwesung).
+ */
+const SELECTABLE_ANIMAL_CONDITIONS: readonly AnimalConditionEnum[] = [
+	...Object.values(AnimalConditionEnum).filter(
+		(value): value is AnimalConditionEnum =>
+			typeof value === 'number' && value !== AnimalConditionEnum.UNKNOWN
+	),
+	AnimalConditionEnum.UNKNOWN
+];
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const animalConditionOptions: Array<{ value: number; label: string }> = Object.entries(
-	animalConditionLabels
-).map(([value, label]) => ({ value: Number(value), label }));
+const animalConditionOptions: Array<{ value: number; label: string }> =
+	SELECTABLE_ANIMAL_CONDITIONS.map((value) => ({ value, label: animalConditionLabels[value] }));
 export const getAnimalConditionOptions = (): Array<{ value: number; label: string }> =>
 	animalConditionOptions;
 

--- a/src/lib/report/formOptions/boatDrive.test.ts
+++ b/src/lib/report/formOptions/boatDrive.test.ts
@@ -45,13 +45,15 @@ describe('BoatDriveEnum.NONE', () => {
 		// serverseitig beim Speichern einer Land-Sichtung.
 		const values = getBoatDriveOptions().map((option) => option.value);
 		expect(values).not.toContain(BoatDriveEnum.NONE);
+		// `OTHER` steht am Ende, obwohl sein Enum-Wert `0` ist — Auffangkategorie
+		// hinter die konkreten Antworten (siehe `SELECTABLE_BOAT_DRIVES`).
 		expect(values).toEqual([
-			BoatDriveEnum.OTHER,
 			BoatDriveEnum.MOTOR,
 			BoatDriveEnum.SAIL,
 			BoatDriveEnum.DRIFTING,
 			BoatDriveEnum.ANCHORED,
-			BoatDriveEnum.MOTOR_OFF
+			BoatDriveEnum.MOTOR_OFF,
+			BoatDriveEnum.OTHER
 		]);
 	});
 });

--- a/src/lib/report/formOptions/boatDrive.ts
+++ b/src/lib/report/formOptions/boatDrive.ts
@@ -56,10 +56,19 @@ export type BoatDrive = BoatDriveEnum;
  *
  * Abgeleitet statt aufgezählt: Ein später ergänzter echter Wert erscheint
  * dadurch automatisch im Formular, statt still zu fehlen.
+ *
+ * `OTHER` wandert dabei ans Ende — Auffangkategorie hinter die konkreten
+ * Antworten, statt durch seinen Enum-Wert `0` davor. Der gespeicherte Wert
+ * bleibt `0`. Diese Liste versorgt nur noch die Admin-Maske; das
+ * Meldeformular nutzt `PUBLIC_BOAT_DRIVE_OPTIONS` (siehe unten).
  */
-const SELECTABLE_BOAT_DRIVES: readonly BoatDriveEnum[] = Object.values(BoatDriveEnum).filter(
-	(value): value is BoatDriveEnum => typeof value === 'number' && value !== BoatDriveEnum.NONE
-);
+const SELECTABLE_BOAT_DRIVES: readonly BoatDriveEnum[] = [
+	...Object.values(BoatDriveEnum).filter(
+		(value): value is BoatDriveEnum =>
+			typeof value === 'number' && value !== BoatDriveEnum.NONE && value !== BoatDriveEnum.OTHER
+	),
+	BoatDriveEnum.OTHER
+];
 
 /**
  * Generiert eine Array-Struktur für Select-Komponenten

--- a/src/lib/report/formOptions/boatType.ts
+++ b/src/lib/report/formOptions/boatType.ts
@@ -36,11 +36,25 @@ export const boatTypeLabels: Record<BoatTypeEnum, string> = {
 export type BoatType = BoatTypeEnum;
 
 /**
+ * Bootstypen, die im Formular auswählbar sind — "Sonstiger Bootstyp" am Ende.
+ *
+ * `OTHER` ist die Auffangkategorie und gehört hinter die konkreten Antworten;
+ * sein Enum-Wert `0` hatte es davor sortiert. Der gespeicherte Wert bleibt
+ * `0`, nur die Reihenfolge der Optionen ändert sich.
+ */
+const SELECTABLE_BOAT_TYPES: readonly BoatTypeEnum[] = [
+	...Object.values(BoatTypeEnum).filter(
+		(value): value is BoatTypeEnum => typeof value === 'number' && value !== BoatTypeEnum.OTHER
+	),
+	BoatTypeEnum.OTHER
+];
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const boatTypeOptions: Array<{ value: number; label: string }> = Object.entries(boatTypeLabels).map(
-	([value, label]) => ({ value: Number(value), label })
+const boatTypeOptions: Array<{ value: number; label: string }> = SELECTABLE_BOAT_TYPES.map(
+	(value) => ({ value, label: boatTypeLabels[value] })
 );
 export const getBoatTypeOptions = (): Array<{ value: number; label: string }> => boatTypeOptions;
 

--- a/src/lib/report/formOptions/distribution.ts
+++ b/src/lib/report/formOptions/distribution.ts
@@ -35,15 +35,21 @@ export const distributionLabels: Record<DistributionEnum, string> = {
 };
 
 /**
- * Verteilungen, die im Formular auswählbar sind.
+ * Verteilungen, die im Formular auswählbar sind — in dieser Reihenfolge.
  * `UNKNOWN` ist bewusst ausgenommen (siehe Enum-Kommentar).
  *
- * Abgeleitet statt aufgezählt: Ein später ergänzter echter Wert erscheint
- * dadurch automatisch im Formular, statt still zu fehlen.
+ * Aufgezählt statt abgeleitet, aus zwei Gründen: `OTHER` ist die
+ * Auffangkategorie und gehört ans Ende (sein Enum-Wert `0` hätte es nach vorn
+ * sortiert), und die konkreten Antworten stehen nach gemessener Häufigkeit
+ * (2026-08-07): Einzeln 3.066, Deutliche Schulen 1.096, Mutter mit Jungtier
+ * 644. Der gespeicherte Wert bleibt jeweils unverändert.
  */
-const SELECTABLE_DISTRIBUTIONS: readonly DistributionEnum[] = Object.values(DistributionEnum).filter(
-	(value): value is DistributionEnum => typeof value === 'number' && value !== DistributionEnum.UNKNOWN
-);
+const SELECTABLE_DISTRIBUTIONS: readonly DistributionEnum[] = [
+	DistributionEnum.SINGLE,
+	DistributionEnum.SCHOOLS,
+	DistributionEnum.MOTHER_WITH_YOUNG,
+	DistributionEnum.OTHER
+];
 
 export type Distribution = DistributionEnum;
 

--- a/src/lib/report/formOptions/mediaType.ts
+++ b/src/lib/report/formOptions/mediaType.ts
@@ -30,12 +30,24 @@ export const mediaTypeLabels: Record<MediaTypeEnum, string> = {
 export type MediaType = MediaTypeEnum;
 
 /**
+ * Medienformate, die im Formular auswählbar sind — "Sonstiges Medienformat"
+ * am Ende. Auffangkategorie hinter die konkreten Antworten; der gespeicherte
+ * Wert bleibt `0`.
+ */
+const SELECTABLE_MEDIA_TYPES: readonly MediaTypeEnum[] = [
+	...Object.values(MediaTypeEnum).filter(
+		(value): value is MediaTypeEnum => typeof value === 'number' && value !== MediaTypeEnum.OTHER
+	),
+	MediaTypeEnum.OTHER
+];
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const mediaTypeOptions: Array<{ value: number; label: string }> = Object.entries(
-	mediaTypeLabels
-).map(([value, label]) => ({ value: Number(value), label }));
+const mediaTypeOptions: Array<{ value: number; label: string }> = SELECTABLE_MEDIA_TYPES.map(
+	(value) => ({ value, label: mediaTypeLabels[value] })
+);
 export const getMediaTypeOptions = (): Array<{ value: number; label: string }> => mediaTypeOptions;
 
 /**

--- a/src/lib/report/formOptions/optionOrdering.test.ts
+++ b/src/lib/report/formOptions/optionOrdering.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { AnimalConditionEnum, getAnimalConditionOptions } from './animalCondition';
+import { BoatDriveEnum, getBoatDriveOptions } from './boatDrive';
+import { BoatTypeEnum, getBoatTypeOptions } from './boatType';
+import { MediaTypeEnum, getMediaTypeOptions } from './mediaType';
+import { SeaStateEnum, getSeaStateOptions } from './seaState';
+import { SexEnum, getSexOptions } from './sex';
+import { VisibilityEnum, getVisibilityOptions } from './visibility';
+import { WindDirectionEnum, getWindDirectionOptions } from './windDirection';
+
+/**
+ * Reihenfolge der Auswahllisten — unabhängig vom gespeicherten Wert.
+ *
+ * Hintergrund: Die meisten Listen entstanden aus `Object.entries(labels)`, und
+ * JavaScript sortiert ganzzahlige Objekt-Schlüssel **immer** numerisch
+ * aufsteigend — die Reihenfolge im Quelltext ist dabei wirkungslos. Da die
+ * Auffangkategorie ("Sonstiges") historisch die `0` trägt, stand sie damit
+ * überall an erster Stelle: vor allen konkreten Antworten.
+ *
+ * Zwei Regeln, beide auf Wunsch des Deutschen Meeresmuseums (2026-08-07),
+ * beide rein kosmetisch — der gespeicherte Wert ändert sich nirgends:
+ *
+ *  1. Die Auffangkategorie steht am **Ende**.
+ *  2. "Keine Angabe"/"Unbekannt" steht in einer Liste eines **optionalen**
+ *     Feldes gar nicht mehr: `BaseSelect` rendert ohnehin einen
+ *     Platzhalter ("Bitte wählen…"), solange nichts gewählt ist. Eine zweite
+ *     Formulierung derselben Aussage stiftet nur Verwirrung.
+ *
+ * Ausgenommen von Regel 2 ist `deadCondition` (siehe `animalCondition`-Block
+ * unten): Das Feld ist im Totfund-Zweig Pflicht, dort braucht "Unbekannt"
+ * einen Platz — nur eben den letzten.
+ *
+ * Bereits vor dieser Runde umgesetzt und deshalb hier nicht wiederholt:
+ * `animalBehavior` und `sightingFrom`/`distribution` (siehe
+ * `unspecifiedDefaults.test.ts` und `sightingFrom.test.ts`).
+ */
+describe('Auffangkategorie steht am Ende', () => {
+	it('animalCondition: "Unbekannt" zuletzt — das Feld ist Pflicht, der Ausweg bleibt', () => {
+		const values = getAnimalConditionOptions().map((option) => option.value);
+		expect(values).toEqual([
+			AnimalConditionEnum.EXTREMELY_FRESH,
+			AnimalConditionEnum.FRESH_BEGINNING_DECOMPOSITION,
+			AnimalConditionEnum.MEDIUM_DECOMPOSITION,
+			AnimalConditionEnum.ADVANCED_DECOMPOSITION,
+			AnimalConditionEnum.SEVERE_DECOMPOSITION,
+			AnimalConditionEnum.UNKNOWN
+		]);
+	});
+
+	it('boatType: "Sonstiger Bootstyp" zuletzt', () => {
+		const values = getBoatTypeOptions().map((option) => option.value);
+		expect(values.at(-1)).toBe(BoatTypeEnum.OTHER);
+		expect(values.at(0)).toBe(BoatTypeEnum.SAILBOAT);
+		expect(values).toHaveLength(Object.keys(BoatTypeEnum).length / 2);
+	});
+
+	it('mediaType: "Sonstiges Medienformat" zuletzt', () => {
+		const values = getMediaTypeOptions().map((option) => option.value);
+		expect(values.at(-1)).toBe(MediaTypeEnum.OTHER);
+		expect(values.at(0)).toBe(MediaTypeEnum.PHOTO);
+	});
+
+	it('boatDrive: "Sonstiger Bootsantrieb" zuletzt (Admin-Maske)', () => {
+		const values = getBoatDriveOptions().map((option) => option.value);
+		expect(values.at(-1)).toBe(BoatDriveEnum.OTHER);
+		expect(values).not.toContain(BoatDriveEnum.NONE);
+	});
+});
+
+describe('"Keine Angabe" steht in optionalen Feldern nicht mehr zur Wahl', () => {
+	it('seaState: nur die fünf echten Kategorien', () => {
+		const values = getSeaStateOptions().map((option) => option.value);
+		expect(values).not.toContain(SeaStateEnum.NONE);
+		expect(values).toEqual([
+			SeaStateEnum.SMOOTH,
+			SeaStateEnum.CALM,
+			SeaStateEnum.SLIGHT,
+			SeaStateEnum.ROUGH,
+			SeaStateEnum.HIGH
+		]);
+	});
+
+	it('visibility: nur die vier echten Kategorien', () => {
+		const values = getVisibilityOptions().map((option) => option.value);
+		expect(values).not.toContain(VisibilityEnum.NONE);
+		expect(values).toEqual([
+			VisibilityEnum.EXCEPTIONAL,
+			VisibilityEnum.CLEAR,
+			VisibilityEnum.HAZY,
+			VisibilityEnum.FOGGY
+		]);
+	});
+
+	it('windDirection: nur die acht Himmelsrichtungen, in Kompass-Reihenfolge', () => {
+		const values = getWindDirectionOptions().map((option) => option.value);
+		expect(values).not.toContain(WindDirectionEnum.NONE);
+		expect(values).toEqual(['N', 'NO', 'O', 'SO', 'S', 'SW', 'W', 'NW']);
+	});
+
+	it('sex: nur weiblich/männlich', () => {
+		const values = getSexOptions().map((option) => option.value);
+		expect(values).not.toContain(SexEnum.UNKNOWN);
+		expect(values).toEqual([SexEnum.FEMALE, SexEnum.MALE]);
+	});
+});
+
+/**
+ * Die Labels bleiben vollständig — sie lösen weiterhin Bestandsdaten auf.
+ * Eine Option aus der Auswahl zu nehmen darf die Anzeige eines bereits
+ * gespeicherten Wertes nicht kaputt machen; `seegang`, `sichtweite` und
+ * `totfund_geschlecht` sind `not null default 0`, im Bestand steht diese `0`
+ * also millionenfach.
+ */
+describe('entfernte Optionen bleiben anzeigbar', () => {
+	it('löst die Alt-Werte weiterhin auf', async () => {
+		const { getSeaStateLabel } = await import('./seaState');
+		const { getVisibilityLabel } = await import('./visibility');
+		const { getSexLabel } = await import('./sex');
+		const { getWindDirectionLabel } = await import('./windDirection');
+
+		expect(getSeaStateLabel(0)).toBe('Keine Angabe');
+		expect(getVisibilityLabel(0)).toBe('Keine Angabe');
+		expect(getSexLabel(0)).toBe('Unbekannt');
+		expect(getWindDirectionLabel('')).toBe('Keine Angabe');
+	});
+});

--- a/src/lib/report/formOptions/optionOrdering.test.ts
+++ b/src/lib/report/formOptions/optionOrdering.test.ts
@@ -30,9 +30,14 @@ import { WindDirectionEnum, getWindDirectionOptions } from './windDirection';
  * unten): Das Feld ist im Totfund-Zweig Pflicht, dort braucht "Unbekannt"
  * einen Platz — nur eben den letzten.
  *
- * Bereits vor dieser Runde umgesetzt und deshalb hier nicht wiederholt:
- * `animalBehavior` und `sightingFrom`/`distribution` (siehe
- * `unspecifiedDefaults.test.ts` und `sightingFrom.test.ts`).
+ * **Diese Datei deckt nicht alle betroffenen Listen ab.** Drei Felder haben
+ * bereits einen eigenen Test, der ihre Reihenfolge festnagelt — sie hier ein
+ * zweites Mal zu prüfen ergäbe zwei Quellen für dieselbe Erwartung:
+ *
+ *  - `sightingFrom` → `sightingFrom.test.ts` (in dieser Runde mit geändert)
+ *  - `distribution` → `unspecifiedDefaults.test.ts` (dito)
+ *  - `animalBehavior` → `unspecifiedDefaults.test.ts` (schon vorher umgestellt,
+ *    2026-07; von dieser Runde unberührt und hier nur als Vorbild genannt)
  */
 describe('Auffangkategorie steht am Ende', () => {
 	it('animalCondition: "Unbekannt" zuletzt — das Feld ist Pflicht, der Ausweg bleibt', () => {

--- a/src/lib/report/formOptions/seaState.ts
+++ b/src/lib/report/formOptions/seaState.ts
@@ -26,11 +26,31 @@ export const seaStateLabels: Record<SeaStateEnum, string> = {
 export type SeaState = SeaStateEnum;
 
 /**
+ * Seegang-Stufen, die im Formular auswählbar sind.
+ *
+ * `NONE` ("Keine Angabe") ist bewusst ausgenommen: Das Feld ist optional, und
+ * `BaseSelect` rendert ohnehin einen Platzhalter ("Bitte wählen…"), solange
+ * nichts gewählt ist. Eine zweite Formulierung derselben Aussage stiftet nur
+ * Verwirrung — und sie stand durch den Enum-Wert `0` auch noch an erster
+ * Stelle, vor allen echten Kategorien.
+ *
+ * Der Wert selbst bleibt gültig: `seegang` ist `not null default 0`, im
+ * Bestand steht diese `0` also millionenfach und wird von `getSeaStateLabel`
+ * weiterhin aufgelöst.
+ *
+ * Abgeleitet statt aufgezählt: Die Stufen sind ordinal (glatt → hohe See), die
+ * Enum-Reihenfolge ist damit die fachlich richtige.
+ */
+const SELECTABLE_SEA_STATES: readonly SeaStateEnum[] = Object.values(SeaStateEnum).filter(
+	(value): value is SeaStateEnum => typeof value === 'number' && value !== SeaStateEnum.NONE
+);
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const seaStateOptions: Array<{ value: number; label: string }> = Object.entries(seaStateLabels).map(
-	([value, label]) => ({ value: Number(value), label })
+const seaStateOptions: Array<{ value: number; label: string }> = SELECTABLE_SEA_STATES.map(
+	(value) => ({ value, label: seaStateLabels[value] })
 );
 export const getSeaStateOptions = (): Array<{ value: number; label: string }> => seaStateOptions;
 

--- a/src/lib/report/formOptions/sex.ts
+++ b/src/lib/report/formOptions/sex.ts
@@ -20,12 +20,27 @@ export const sexLabels: Record<SexEnum, string> = {
 export type Sex = SexEnum;
 
 /**
+ * Geschlechter, die im Formular auswählbar sind.
+ *
+ * `UNKNOWN` ("Unbekannt") ist bewusst ausgenommen: `deadSex` ist optional
+ * (das Museum hat das Feld am 2026-08-04 aus dem Meldeformular abbestellt, es
+ * steht nur noch in der Admin-Maske), und der Platzhalter von `BaseSelect`
+ * sagt "nicht angegeben" bereits. Der Enum-Wert `0` hätte "Unbekannt"
+ * außerdem vor die beiden echten Antworten sortiert.
+ *
+ * `totfund_geschlecht` ist `not null default 0`; der Wert bleibt für
+ * Bestandsdaten gültig und wird von `getSexLabel` weiterhin aufgelöst.
+ */
+const SELECTABLE_SEXES: readonly SexEnum[] = [SexEnum.FEMALE, SexEnum.MALE];
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const sexOptions: Array<{ value: number; label: string }> = Object.entries(sexLabels).map(
-	([value, label]) => ({ value: Number(value), label })
-);
+const sexOptions: Array<{ value: number; label: string }> = SELECTABLE_SEXES.map((value) => ({
+	value,
+	label: sexLabels[value]
+}));
 export const getSexOptions = (): Array<{ value: number; label: string }> => sexOptions;
 
 /**

--- a/src/lib/report/formOptions/sightingFrom.test.ts
+++ b/src/lib/report/formOptions/sightingFrom.test.ts
@@ -46,17 +46,19 @@ describe('SightingFromEnum.UNKNOWN', () => {
 		expect(isValidSightingFrom('5')).toBe(true);
 	});
 
+	// Reihenfolge nach gemessener Häufigkeit, "Sonstiges" ans Ende — Begründung
+	// und Messwerte stehen an `SELECTABLE_SIGHTING_FROM` in `sightingFrom.ts`.
 	it('erscheint NICHT in den auswählbaren Optionen', () => {
 		// "Keine Angabe" ist keine Wahl, die ein Melder trifft — der Wert
 		// entsteht ausschließlich serverseitig in `mapFormToSighting`.
 		const values = getSightingFromOptions().map((option) => option.value);
 		expect(values).not.toContain(SightingFromEnum.UNKNOWN);
 		expect(values).toEqual([
-			SightingFromEnum.OTHER,
 			SightingFromEnum.SAILBOAT,
-			SightingFromEnum.MOTORBOAT,
 			SightingFromEnum.LAND,
-			SightingFromEnum.FERRY
+			SightingFromEnum.MOTORBOAT,
+			SightingFromEnum.FERRY,
+			SightingFromEnum.OTHER
 		]);
 	});
 });

--- a/src/lib/report/formOptions/sightingFrom.ts
+++ b/src/lib/report/formOptions/sightingFrom.ts
@@ -40,15 +40,27 @@ export const sightingFromLabels: Record<SightingFromEnum, string> = {
 export type SightingFrom = SightingFromEnum;
 
 /**
- * Beobachtungsorte, die im Formular auswählbar sind.
+ * Beobachtungsorte, die im Formular auswählbar sind — in dieser Reihenfolge.
  * `UNKNOWN` ist bewusst ausgenommen (siehe Enum-Kommentar).
  *
- * Abgeleitet statt aufgezählt: Ein später ergänzter echter Wert erscheint
- * dadurch automatisch im Formular, statt still zu fehlen.
+ * **Die Reihenfolge ist aufgezählt und nicht abgeleitet**, anders als bei den
+ * übrigen Listen. Sie folgt der gemessenen Häufigkeit im Bestand
+ * (2026-08-07, 19.947 Zeilen): Segelschiff 10.362, Land 5.937, Motorboot 1.479,
+ * Fähre 281. `OTHER` steht trotz seiner 1.888 Zeilen am Ende — es ist die
+ * Auffangkategorie und gehört hinter die konkreten Antworten.
+ *
+ * Ein neu ergänzter Wert erscheint dadurch NICHT automatisch; er muss hier
+ * einsortiert werden. Das ist der Preis dafür, dass die Reihenfolge eine
+ * Aussage trifft — `Object.values()` hätte sie nach Enum-Wert sortiert, also
+ * nach einer Zahl ohne fachliche Bedeutung.
  */
-const SELECTABLE_SIGHTING_FROM: readonly SightingFromEnum[] = Object.values(SightingFromEnum).filter(
-	(value): value is SightingFromEnum => typeof value === 'number' && value !== SightingFromEnum.UNKNOWN
-);
+const SELECTABLE_SIGHTING_FROM: readonly SightingFromEnum[] = [
+	SightingFromEnum.SAILBOAT,
+	SightingFromEnum.LAND,
+	SightingFromEnum.MOTORBOAT,
+	SightingFromEnum.FERRY,
+	SightingFromEnum.OTHER
+];
 
 /**
  * Generiert eine Array-Struktur für Select-Komponenten

--- a/src/lib/report/formOptions/unspecifiedDefaults.test.ts
+++ b/src/lib/report/formOptions/unspecifiedDefaults.test.ts
@@ -48,14 +48,17 @@ describe('DistributionEnum.UNKNOWN', () => {
 		expect(isValidDistribution('4')).toBe(true);
 	});
 
-	it('erscheint NICHT in den auswählbaren Optionen', () => {
+	// Wie bei `animalBehavior` unten steht `OTHER` am ENDE, obwohl sein
+	// Enum-Wert `0` ist. Die konkreten Antworten stehen nach gemessener
+	// Häufigkeit — Begründung an `SELECTABLE_DISTRIBUTIONS` in `distribution.ts`.
+	it('erscheint NICHT in den auswählbaren Optionen, "Sonstige" steht am Ende', () => {
 		const values = getDistributionOptions().map((option) => option.value);
 		expect(values).not.toContain(DistributionEnum.UNKNOWN);
 		expect(values).toEqual([
-			DistributionEnum.OTHER,
 			DistributionEnum.SINGLE,
+			DistributionEnum.SCHOOLS,
 			DistributionEnum.MOTHER_WITH_YOUNG,
-			DistributionEnum.SCHOOLS
+			DistributionEnum.OTHER
 		]);
 	});
 

--- a/src/lib/report/formOptions/visibility.ts
+++ b/src/lib/report/formOptions/visibility.ts
@@ -24,12 +24,27 @@ export const visibilityLabels: Record<VisibilityEnum, string> = {
 export type Visibility = VisibilityEnum;
 
 /**
+ * Sichtweiten-Kategorien, die im Formular auswählbar sind.
+ *
+ * `NONE` ("Keine Angabe") ist bewusst ausgenommen — dieselbe Begründung wie
+ * beim Seegang (`seaState.ts`): optionales Feld, der Platzhalter von
+ * `BaseSelect` sagt es bereits, und der Enum-Wert `0` hätte die Nicht-Antwort
+ * an die erste Stelle sortiert. `sichtweite` ist `not null default 0`, der
+ * Wert bleibt für Bestandsdaten gültig und anzeigbar.
+ *
+ * Abgeleitet statt aufgezählt: Die Kategorien sind ordinal (klar → Nebel).
+ */
+const SELECTABLE_VISIBILITIES: readonly VisibilityEnum[] = Object.values(VisibilityEnum).filter(
+	(value): value is VisibilityEnum => typeof value === 'number' && value !== VisibilityEnum.NONE
+);
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const visibilityOptions: Array<{ value: number; label: string }> = Object.entries(
-	visibilityLabels
-).map(([value, label]) => ({ value: Number(value), label }));
+const visibilityOptions: Array<{ value: number; label: string }> = SELECTABLE_VISIBILITIES.map(
+	(value) => ({ value, label: visibilityLabels[value] })
+);
 export const getVisibilityOptions = (): Array<{ value: number; label: string }> =>
 	visibilityOptions;
 

--- a/src/lib/report/formOptions/windDirection.ts
+++ b/src/lib/report/formOptions/windDirection.ts
@@ -32,12 +32,29 @@ export const windDirectionLabels: Record<WindDirectionEnum, string> = {
 export type WindDirection = WindDirectionEnum;
 
 /**
+ * Himmelsrichtungen, die im Formular auswählbar sind.
+ *
+ * `NONE` (Leerstring, "Keine Angabe") ist bewusst ausgenommen — dieselbe
+ * Begründung wie beim Seegang (`seaState.ts`). Hier kommt ein zweiter Grund
+ * dazu: `BaseSelect` gibt seinem Platzhalter ebenfalls `value=""`, die
+ * Option war also ein exaktes Duplikat des Platzhalters.
+ *
+ * Der Leerstring bleibt im Yup-Schema (`oneOf`) gültig und wird von
+ * `getWindDirectionLabel` weiterhin aufgelöst.
+ *
+ * Abgeleitet statt aufgezählt: Die Enum-Reihenfolge ist die Kompass-Folge
+ * (N → NW) und damit die fachlich richtige.
+ */
+const SELECTABLE_WIND_DIRECTIONS: readonly WindDirectionEnum[] = Object.values(
+	WindDirectionEnum
+).filter((value) => value !== WindDirectionEnum.NONE);
+
+/**
  * Generiert eine Array-Struktur für Select-Komponenten
  * @returns Array von Objekten mit value und label
  */
-const windDirectionOptions: Array<{ value: string; label: string }> = Object.entries(
-	windDirectionLabels
-).map(([value, label]) => ({ value, label }));
+const windDirectionOptions: Array<{ value: string; label: string }> =
+	SELECTABLE_WIND_DIRECTIONS.map((value) => ({ value, label: windDirectionLabels[value] }));
 export const getWindDirectionOptions = (): Array<{ value: string; label: string }> =>
 	windDirectionOptions;
 


### PR DESCRIPTION
## Worum es geht

Die Auswahllisten im Meldeformular zeigten „Sonstiges" ganz **oben** — vor allen konkreten Antworten. Ursache ist kein Versehen an einer einzelnen Stelle, sondern ein JS-Detail: Die Listen entstanden aus `Object.entries(labels)`, und JavaScript sortiert ganzzahlige Objekt-Schlüssel **immer** numerisch aufsteigend. Die Reihenfolge im Quelltext war damit wirkungslos, und da die Auffangkategorie historisch die `0` trägt, landete sie überall an erster Stelle.

Zwei Regeln, beide rein kosmetisch — **kein gespeicherter Wert ändert sich, keine Migration**:

### 1. Auffangkategorie ans Ende

| Feld | Neue Reihenfolge |
| --- | --- |
| `sightingFrom` | Segelschiff, Land, Motorboot, Fähre, *Sonstiges* |
| `distribution` | Einzeln, Deutliche Schulen, Mutter mit Jungtier, *Sonstige* |
| `animalCondition` | Extrem frisch → Starke Verwesung, *Unbekannt* |
| `boatDrive` (Admin) | Motor, Segel, Treibend, Anker, Motor aus, *Sonstiger* |
| `boatType`, `mediaType` | *Sonstiges* jeweils ans Ende |

Bei `sightingFrom` und `distribution` stehen die konkreten Antworten zusätzlich nach **gemessener Häufigkeit im Bestand** statt nach Enum-Wert. `vonwo` (19.947 Zeilen): Segelschiff 10.362, Land 5.937, Motorboot 1.479, Fähre 281 — Land liegt also 4× vor Motorboot.

`animalBehavior` hatte diese Umstellung bereits (PR-Historie 2026-07), sie ist hier nur auf die übrigen Listen übertragen.

### 2. „Keine Angabe" ganz raus, wo das Feld optional ist

Betrifft `seaState`, `visibility`, `windDirection` und `deadSex`. `BaseSelect` rendert ohnehin einen Platzhalter („Bitte wählen…"), solange nichts gewählt ist — eine zweite Formulierung derselben Aussage stiftet nur Verwirrung. Bei `windDirection` war die Option mit ihrem `value=""` sogar ein **exaktes Duplikat des Platzhalters**.

**Ausgenommen: `deadCondition`.** Das Feld ist im Totfund-Zweig ein Pflichtfeld (`when('isDead')`). Ohne „Unbekannt" gäbe es keinen Ausweg für jemanden, der den Verwesungsgrad am Strand nicht einschätzen kann — der Platzhalter erfüllt die Pflicht nicht. Die Option bleibt wählbar und wandert nur ans Ende.

## Worauf beim Review zu achten ist

- **Die `*Labels`-Maps bleiben vollständig.** `seegang`, `sichtweite` und `totfund_geschlecht` sind `not null default 0`; der Altbestand muss weiterhin als „Keine Angabe" anzeigbar sein. Ein eigener Test-Block nagelt das fest.
- **Legacy-API unberührt.** Die Endpunkte bauen ihre Optionslisten direkt aus den Labels, nicht aus `get*Options()` — im Testlauf sichtbar an unverändertem `vonwo: 6` / `totfund_geschlecht: 3`.
- **`sightingFrom` und `distribution` zählen ihre Werte jetzt auf statt sie abzuleiten.** Ein neu ergänzter Enum-Wert erscheint dort **nicht** automatisch, er muss einsortiert werden. Das ist der bewusste Preis dafür, dass die Reihenfolge eine fachliche Aussage trifft; die Begründung steht jeweils am `SELECTABLE_*`-Array.
- **`windDirection` und `distribution` werden im öffentlichen Formular gar nicht gerendert** — sie stehen nur im Schema und in der Admin-Maske. Das war schon vorher so; ihre neue Reihenfolge greift also nur im Admin-Bereich. Falls das ein eigener Bug ist, gehört er in ein separates Issue.

## Verifikation

- Test-first: `src/lib/report/formOptions/optionOrdering.test.ts` neu (zuerst rot, 8 Fehlschläge), drei bestehende Erwartungen nachgezogen
- 3.784 Server-Unit-Tests grün, ESLint 0 Fehler, `tsc --noEmit` sauber, `svelte-check` 2.162 Dateien / 0 Fehler
- Im Browser gegengeprüft (Dev-Server, Schritt 2 und 3): `sightingFrom` liefert Segelschiff → Sonstiges, Seegang und Sichtbedingungen zeigen „Bitte wählen…" statt der alten vorausgewählten „Keine Angabe"

🤖 Generated with [Claude Code](https://claude.com/claude-code)