### PR TITLE
fix(admin): wrap long reference ids in the mobile sighting card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,6 +514,12 @@ jobs:
             # nicht lokale Zahlen (Begründung im Warnblock bei `smoke`).
             e2e/admin-sighting-status.spec.ts
             e2e/admin-table-mobile-status-overflow.spec.ts
+            # Direkt beim Schwester-Spec darüber: dieselbe Route
+            # (/admin/sichtungen), dieselbe Mobilkarte, derselbe Messhelfer.
+            # Der Kaltkompilier-Aufschlag der Route fällt hier damit kein
+            # weiteres Mal an. Lokal 2 Tests, ~8 s — er legt sich seine
+            # Sichtung selbst an und räumt sie wieder weg.
+            e2e/admin-table-mobile-reference-overflow.spec.ts
             # Fährt /admin/[id]/edit statt der Tabelle — der einzige der drei
             # mit einer eigenen kalt zu kompilierenden Route.
             e2e/admin-edit-toggle-no-wrap-lock.spec.ts

--- a/e2e/admin-table-mobile-reference-overflow.spec.ts
+++ b/e2e/admin-table-mobile-reference-overflow.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+import { expectNoHorizontalOverflow } from './helpers/overflow';
+import { deleteSighting, seedSighting } from './helpers/seedSighting';
+
+/**
+ * admin-table-mobile-reference-overflow.spec.ts — die Referenz-ID in der
+ * Mobilkarte der Sichtungstabelle.
+ *
+ * **Der Befund:** In `src/routes/admin/sichtungen/+page.svelte` steht die
+ * Referenz-ID als `<a class="link link-primary link-hover font-mono">` in einer
+ * `flex flex-wrap items-center gap-2`-Zeile. `flex-wrap` bricht zwischen den
+ * Flex-Items um, nicht *innerhalb* eines Items — und eine Referenz-ID ist ein
+ * Wort ohne Umbruchgelegenheit. Der Link hielt damit rund 202px harte
+ * Mindestbreite und drückte sie bis zum Seiten-Wrapper durch. Gemessen mit
+ * `expectNoHorizontalOverflow` (`e2e/helpers/overflow.ts`) auf
+ * `/admin/sichtungen`, Verursacher jeweils `a.font-mono`:
+ *
+ * | Breite | Überlauf vorher |
+ * | ------ | --------------- |
+ * | 320px  | 97px            |
+ * | 375px  | 42px            |
+ *
+ * Der Fehler ist älter als der Status-Control-Fix aus
+ * `admin-table-mobile-status-overflow.spec.ts` (dort per `git stash`
+ * nachgestellt und als eigener Befund vermerkt).
+ *
+ * **Behoben mit `break-all`** und nicht mit `truncate`: Die Referenz-ID ist der
+ * Schlüssel, über den eine Meldung wiedergefunden wird — abgeschnitten wäre sie
+ * wertlos. Umbrochen belegt sie zwei Zeilen und bleibt vollständig lesbar.
+ *
+ * **Warum eine eigens angelegte Sichtung** statt des vorhandenen Bestands: Die
+ * Entwicklungs-DB ist über alle Worktrees geteilt (`docs/WORKTREES.md`), ihr
+ * Inhalt ist also keine Testvoraussetzung, auf die man sich stützen kann. Ohne
+ * eine garantiert lange Referenz-ID auf Seite 1 wäre der Test grün, ohne etwas
+ * geprüft zu haben. `?perPage=1` plus ein Sichtungsdatum in der Zukunft
+ * (Default-Sortierung: `sichtungsdatum` absteigend) stellt sicher, dass genau
+ * diese Zeile gerendert wird — der Überlauf-Befund kann damit auch keine fremde
+ * Ursache haben.
+ */
+
+/* 28 Zeichen, plus die dreistellige Viewport-Breite pro Testfall = 31: die App
+   vergibt Referenz-IDs als cuid2 (24–25 Zeichen, `@paralleldrive/cuid2`), die
+   Spalte lässt 64 zu. Ein Wert etwas über dem realen Bestand prüft den Fix mit
+   Reserve, ohne einen Fall zu konstruieren, den die Datenbank gar nicht
+   zuließe. */
+const LANGE_REFERENZ = 'e2erefa1b2c3d4e5f6g7h8i9j0k1';
+
+test.describe('Admin-Sichtungstabelle — lange Referenz-ID in der Mobilkarte', () => {
+	/* Nacheinander, weil `?perPage=1` genau eine Zeile rendert: Liefen beide
+	   Breiten parallel, ständen zwei Test-Sichtungen mit demselben Datum an der
+	   Spitze der Sortierung, und einer der beiden Läufe sähe die Zeile des
+	   anderen. Beobachtet als fehlgeschlagene Sichtbarkeitszusicherung bei 375px,
+	   während 320px grün war. */
+	test.describe.configure({ mode: 'serial' });
+
+	for (const width of [320, 375]) {
+		test(`kein horizontaler Überlauf bei ${width}px`, async ({ browser, baseURL }) => {
+			if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+			/* Eindeutig pro Testfall, obwohl die beiden Fälle seriell laufen: Bricht
+			   einer ab, bevor er aufräumt, kollidiert der andere sonst mit der
+			   liegengebliebenen Zeile statt sauber durchzulaufen. */
+			const referenceId = `${LANGE_REFERENZ}${width}`;
+			/* In der Zukunft, damit die Zeile bei `sichtungsdatum desc` ganz vorn steht. */
+			const sightingId = await seedSighting({
+				referenceId,
+				sightingDate: new Date('2099-01-01T12:00:00Z')
+			});
+
+			const context = await browser.newContext({ viewport: { width, height: 900 } });
+			await seedAdminSession(context, baseURL);
+			const page = await context.newPage();
+
+			try {
+				await page.goto('/admin/sichtungen?perPage=1');
+				await expect(page.getByRole('heading', { name: 'Sichtungen' })).toBeVisible();
+
+				// Ohne diese Zusicherung könnte der Test an einer Seite ohne die
+				// Test-Sichtung grün werden und würde nichts belegen.
+				await expect(
+					page.locator('.md\\:hidden').getByRole('link', { name: referenceId })
+				).toBeVisible();
+
+				await expectNoHorizontalOverflow(page, `/admin/sichtungen bei ${width}px (Mobilkarte)`);
+			} finally {
+				/* Eigenes try/finally, damit ein Fehler beim Schließen des Kontexts
+				   nicht die Zeile in der geteilten Entwicklungs-DB stehen lässt. */
+				try {
+					await context.close();
+				} finally {
+					await deleteSighting(sightingId);
+				}
+			}
+		});
+	}
+});

--- a/e2e/admin-table-mobile-reference-overflow.spec.ts
+++ b/e2e/admin-table-mobile-reference-overflow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type BrowserContext } from '@playwright/test';
 import { seedAdminSession } from './helpers/adminSession';
 import { expectNoHorizontalOverflow } from './helpers/overflow';
 import { deleteSighting, seedSighting } from './helpers/seedSighting';
@@ -68,11 +68,18 @@ test.describe('Admin-Sichtungstabelle — lange Referenz-ID in der Mobilkarte', 
 				sightingDate: new Date('2099-01-01T12:00:00Z')
 			});
 
-			const context = await browser.newContext({ viewport: { width, height: 900 } });
-			await seedAdminSession(context, baseURL);
-			const page = await context.newPage();
+			/* Der `try` beginnt unmittelbar nach dem Seed und nicht erst nach dem
+			   Seitenaufbau: Wirft `seedAdminSession` oder `newContext` — fehlende
+			   DATABASE_POSTGRES_URL, ausgelasteter Browser —, bliebe die Zeile sonst
+			   in der geteilten Entwicklungs-DB liegen. `context` ist deshalb `let`
+			   und im `finally` optional. */
+			let context: BrowserContext | undefined;
 
 			try {
+				context = await browser.newContext({ viewport: { width, height: 900 } });
+				await seedAdminSession(context, baseURL);
+				const page = await context.newPage();
+
 				await page.goto('/admin/sichtungen?perPage=1');
 				await expect(page.getByRole('heading', { name: 'Sichtungen' })).toBeVisible();
 
@@ -87,7 +94,7 @@ test.describe('Admin-Sichtungstabelle — lange Referenz-ID in der Mobilkarte', 
 				/* Eigenes try/finally, damit ein Fehler beim Schließen des Kontexts
 				   nicht die Zeile in der geteilten Entwicklungs-DB stehen lässt. */
 				try {
-					await context.close();
+					await context?.close();
 				} finally {
 					await deleteSighting(sightingId);
 				}

--- a/e2e/helpers/seedSighting.ts
+++ b/e2e/helpers/seedSighting.ts
@@ -74,11 +74,21 @@ export async function seedSighting(daten: {
 	}
 }
 
-/** Entfernt eine mit `seedSighting` angelegte Zeile wieder. */
+/**
+ * Entfernt eine mit `seedSighting` angelegte Zeile wieder.
+ *
+ * Die `id` allein reicht als Bedingung **nicht**: Die Entwicklungs-DB ist über
+ * alle Worktrees geteilt und enthält echte Meldungen. Eine falsch übergebene
+ * `id` — vertauschte Variable, Wert aus einem früheren Lauf — löschte sonst
+ * eine fremde Zeile, und zwar unbemerkt. Der Marker begrenzt den Schaden auf
+ * das, was dieser Helfer selbst angelegt hat; dasselbe Muster fahren die
+ * bestehenden Seeds in `admin-table-dead-finding.spec.ts` und
+ * `admin-detail-actions.spec.ts`.
+ */
 export async function deleteSighting(id: number): Promise<void> {
 	const sql = verbindung();
 	try {
-		await sql`DELETE FROM sichtungen WHERE id = ${id}`;
+		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
 	} finally {
 		await sql.end({ timeout: 5 });
 	}

--- a/e2e/helpers/seedSighting.ts
+++ b/e2e/helpers/seedSighting.ts
@@ -1,0 +1,85 @@
+import { config as loadEnv } from 'dotenv';
+import postgres from 'postgres';
+
+/**
+ * seedSighting.ts — eine einzelne Sichtung für E2E-Tests anlegen und wieder
+ * entfernen.
+ *
+ * **Warum überhaupt seeden:** Die Entwicklungs-Datenbank ist laut
+ * `docs/WORKTREES.md` von allen Worktrees geteilt, und ihr Bestand ist
+ * gewachsen statt gepflegt. Ein Test, der eine bestimmte Ausprägung braucht
+ * (hier: eine lange Referenz-ID in der Mobilkarte), darf nicht darauf hoffen,
+ * dass zufällig eine passende Zeile auf Seite 1 steht — sonst ist er entweder
+ * grün ohne Aussage oder rot ohne Ursache im Code.
+ *
+ * **Warum ein eigener `postgres`-Client** statt `$lib/server/db`: dieselbe
+ * Begründung wie in `adminSession.ts` — Playwright läuft als gewöhnliches
+ * Node-Programm ohne SvelteKit-Bundler, also ohne `$lib`-Alias und ohne
+ * `$env/dynamic/private`.
+ *
+ * **Pflichtfelder:** In `sichtungen` sind nur `sichtungsdatum` und `created`
+ * NOT NULL ohne Default (`src/lib/server/db/schema.ts`). Alles andere füllt die
+ * Datenbank selbst — der Seed bleibt damit klein und altert nicht mit jedem
+ * neuen Feld.
+ *
+ * **Warum trotzdem `kommentar_intern`:** `scripts/seed-e2e.ts` räumt über genau
+ * diesen Marker auf. Ohne ihn bleibt eine Zeile, deren `deleteSighting` nicht
+ * mehr lief (abgebrochener Lauf, getöteter CI-Job), unauffindbar in der über
+ * alle Worktrees geteilten Entwicklungs-DB liegen — und zwar mit einem
+ * Sichtungsdatum in der Zukunft, also dauerhaft an der Spitze der
+ * Default-Sortierung, wo sie den nächsten Test auf Seite 1 stört.
+ */
+
+/* Playwright lädt .env nicht von sich aus — siehe adminSession.ts. */
+loadEnv();
+
+/* Muss wörtlich mit `scripts/seed-e2e.ts` übereinstimmen — dessen Aufräumlauf
+   löscht über `WHERE kommentar_intern = 'e2e-seed'`. */
+const SEED_MARKER = 'e2e-seed';
+
+function verbindung() {
+	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
+	if (!databaseUrl) {
+		throw new Error(
+			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank kann keine Test-Sichtung angelegt werden. ' +
+				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
+		);
+	}
+	return postgres(databaseUrl, { max: 1 });
+}
+
+/**
+ * Legt eine Sichtung an und liefert ihre `id` zurück.
+ *
+ * `sightingDate` bewusst als Parameter: Die Admin-Tabelle sortiert per Default
+ * nach `sichtungsdatum` absteigend. Ein Datum in der Zukunft stellt die Zeile
+ * damit an den Anfang der ersten Seite — zusammen mit `?perPage=1` ist sie die
+ * einzige, die der Test sieht.
+ */
+export async function seedSighting(daten: {
+	referenceId: string;
+	sightingDate: Date;
+}): Promise<number> {
+	const sql = verbindung();
+	try {
+		const [zeile] = await sql<{ id: number }[]>`
+			INSERT INTO sichtungen (sichtungsdatum, created, referenz_id, kommentar_intern)
+			VALUES (${daten.sightingDate}, NOW(), ${daten.referenceId}, ${SEED_MARKER})
+			RETURNING id
+		`;
+		return Number(zeile.id);
+	} finally {
+		// Sonst hält der offene Pool den Playwright-Prozess am Leben.
+		await sql.end({ timeout: 5 });
+	}
+}
+
+/** Entfernt eine mit `seedSighting` angelegte Zeile wieder. */
+export async function deleteSighting(id: number): Promise<void> {
+	const sql = verbindung();
+	try {
+		await sql`DELETE FROM sichtungen WHERE id = ${id}`;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -689,9 +689,15 @@
 						     Inline-Badge mit `ml-2` stand nach dem Umbruch eingerückt da. -->
 						<div class="flex flex-wrap items-center gap-2">
 							{#if sighting.referenceId}
+								<!-- `break-all`, weil `flex-wrap` nur zwischen Flex-Items umbricht und
+								     eine Referenz-ID ein Wort ohne Umbruchgelegenheit ist: der Link hielt
+								     ~202px Mindestbreite und schob die ganze Seite über den Viewport
+								     (320px/375px, siehe admin-table-mobile-reference-overflow.spec.ts).
+								     Nicht `truncate` — die Referenz-ID ist der Schlüssel zum Wiederfinden
+								     einer Meldung und wäre abgeschnitten wertlos. -->
 								<a
 									href="/admin/ref/{sighting.referenceId}"
-									class="link link-primary link-hover font-mono text-sm"
+									class="link link-primary link-hover font-mono text-sm break-all"
 								>
 									{sighting.referenceId}
 								</a>


### PR DESCRIPTION
## Befund

In der Mobilkarte von `/admin/sichtungen` steht die Referenz-ID als `font-mono`-Link in einer `flex flex-wrap items-center gap-2`-Zeile. `flex-wrap` bricht nur **zwischen** Flex-Items um, nicht innerhalb eines Items — und eine Referenz-ID ist ein Wort ohne Umbruchgelegenheit. Der Link hielt damit rund 202px harte Mindestbreite und schob die ganze Seite über den Viewport.

Gemessen mit `findHorizontalOverflow` (`e2e/helpers/overflow.ts`), Verursacher jeweils `a.font-mono`:

| Breite | Überlauf vorher |
| ------ | --------------- |
| 320px  | 97px            |
| 375px  | 42px            |

Der Fehler ist älter als der Status-Control-Fix aus #797 (dort per `git stash` nachgestellt und als eigener Befund vermerkt).

## Behebung

`break-all` am Link — nicht `truncate`: Die Referenz-ID ist der Schlüssel, über den eine Meldung wiedergefunden wird, und wäre abgeschnitten wertlos. Umbrochen belegt sie zwei Zeilen und bleibt vollständig lesbar. Begründung steht als Markup-Kommentar an der Aufrufstelle.

## Test

Neu: `e2e/admin-table-mobile-reference-overflow.spec.ts` mit dem Helfer `e2e/helpers/seedSighting.ts`.

Der Spec legt sich seine eigene Sichtung mit langer Referenz-ID an, statt sich auf den Bestand zu stützen — die Entwicklungs-DB ist über alle Worktrees geteilt (`docs/WORKTREES.md`), ihr Inhalt ist keine Testvoraussetzung. `?perPage=1` plus ein Sichtungsdatum in der Zukunft (Default-Sortierung `sichtungsdatum desc`) stellt sicher, dass genau diese Zeile gerendert wird; eine Sichtbarkeitszusicherung davor verhindert ein grünes Ergebnis ohne Aussage. Aufgeräumt wird in einem eigenen `finally`, und die Zeile trägt zusätzlich `kommentar_intern = 'e2e-seed'`, damit `scripts/seed-e2e.ts` sie nach einem abgebrochenen Lauf noch findet. Beide Breiten laufen `serial`, weil `?perPage=1` sonst zwei Test-Sichtungen um dieselbe Zeile konkurrieren ließe.

## Verifikation

- **RED vor dem Fix:** 97px Überlauf bei 320px, 101px bei 375px, Verursacher `a.link.link-primary.link-hover.font-mono` (261px breit).
- **GREEN nach dem Fix:** 2/2 grün; `admin-table-mobile-status-overflow.spec.ts` weiterhin 4/4 grün.
- `npm run type-check` und `npm run check` fehlerfrei (0 Errors, 0 Warnings), ESLint ohne neue Befunde.
- DB-Nachkontrolle: keine übrig gebliebenen Seed-Zeilen.

## Offener Hinweis (nicht Teil dieser Änderung)

`admin-detail-actions.spec.ts`, `admin-table-dead-finding.spec.ts` und `admin-edit-preserves-record.spec.ts` tragen je eigene `connect()`/`createSighting()`-Kopien samt eigenem Seed-Marker-Literal. Der neue Helfer wäre der natürliche Ort für eine Konsolidierung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)