### PR TITLE
test(test): consolidate admin e2e seeds onto the shared helper

### DIFF
--- a/e2e/admin-detail-actions.spec.ts
+++ b/e2e/admin-detail-actions.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { config as loadEnv } from 'dotenv';
-import postgres from 'postgres';
-import { DistanceEnum } from '../src/lib/report/formOptions/distance';
-import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
 import { seedAdminSession } from './helpers/adminSession';
+import { deleteSighting, seedSighting, sightingExists } from './helpers/seedSighting';
 
 /**
  * admin-detail-actions.spec.ts — die Detailansicht trägt dieselben Aktionen wie
@@ -20,84 +17,34 @@ import { seedAdminSession } from './helpers/adminSession';
  * verlassen, sonst steht der Admin vor einem 404. Ein Test, der nur die Existenz
  * des Buttons prüft, ginge an dem Teil vorbei, der schiefgehen kann.
  *
- * Eigene Testzeile mit `kommentar_intern = 'e2e-seed'`, Begründung wie in
+ * Eigene Testzeile über `e2e/helpers/seedSighting.ts`, Begründung wie in
  * `admin-edit-preserves-record.spec.ts`.
  */
 
-/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
-   e2e/helpers/adminSession.ts. */
-loadEnv();
-
-const SEED_MARKER = 'e2e-seed';
-
-function connect() {
-	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
-	if (!databaseUrl) {
-		throw new Error(
-			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
-				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
-		);
-	}
-	return postgres(databaseUrl, { max: 1 });
-}
-
-async function createSighting(referenceId: string): Promise<number> {
-	const sql = connect();
-	try {
-		const [row] = await sql<{ id: number }[]>`
-			INSERT INTO sichtungen (
-				sichtungsdatum, created, tierart, anzahl_gesamt,
-				vonwo, entfernung, referenz_id,
-				vorname, name, email,
-				datenschutz_einverstaendnis, kommentar_intern
-			) VALUES (
-				'2024-06-01T08:30:00.000Z', NOW(), 1, 2,
-				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${referenceId},
-				'Erika', 'Mustermann', 'erika.e2e@example.invalid',
-				1, ${SEED_MARKER}
-			)
-			RETURNING id
-		`;
-		return Number(row!.id);
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
-}
-
-async function countSighting(id: number): Promise<number> {
-	const sql = connect();
-	try {
-		const rows = await sql`SELECT id FROM sichtungen WHERE id = ${id}`;
-		return rows.length;
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
-}
-
-async function removeSighting(id: number): Promise<void> {
-	const sql = connect();
-	try {
-		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
-}
-
 /** Die Mail-Aktion — beschriftet nach Empfänger, nicht nach „Test" (#621). */
 const MAIL_ACTION = 'Benachrichtigung zu dieser Sichtung an das Team senden';
+
+/**
+ * Der Seed bleibt hier auf dem Pflichtteil: Geprüft werden Bedienelemente, und
+ * keines davon hängt an Art, Anzahl oder Melderdaten. Ein Datensatz, der nur
+ * Spaltendefaults trägt, ist für diese Tests sogar der schärfere Fall.
+ */
+function seedDetailSighting(referenceId: string): Promise<number> {
+	return seedSighting({ referenceId, sightingDate: new Date('2024-06-01T08:30:00.000Z') });
+}
 
 test.describe('Admin-Detailansicht — Aktionen', () => {
 	const createdIds: number[] = [];
 
 	test.afterEach(async () => {
 		while (createdIds.length > 0) {
-			await removeSighting(createdIds.pop()!);
+			await deleteSighting(createdIds.pop()!);
 		}
 	});
 
 	test('bietet dieselben Aktionen wie die Tabellenzeile', async ({ page, context, baseURL }) => {
 		await seedAdminSession(context, baseURL!, ['superadmin']);
-		const id = await createSighting('e2e-detail-aktionen');
+		const id = await seedDetailSighting('e2e-detail-aktionen');
 		createdIds.push(id);
 
 		await page.goto(`/admin/${id}`);
@@ -121,7 +68,7 @@ test.describe('Admin-Detailansicht — Aktionen', () => {
 		baseURL
 	}) => {
 		await seedAdminSession(context, baseURL!, ['admin']);
-		const id = await createSighting('e2e-detail-rolle');
+		const id = await seedDetailSighting('e2e-detail-rolle');
 		createdIds.push(id);
 
 		await page.goto(`/admin/${id}`);
@@ -132,7 +79,7 @@ test.describe('Admin-Detailansicht — Aktionen', () => {
 
 	test('löscht die Sichtung und verlässt die Seite', async ({ page, context, baseURL }) => {
 		await seedAdminSession(context, baseURL!, ['admin']);
-		const id = await createSighting('e2e-detail-loeschen');
+		const id = await seedDetailSighting('e2e-detail-loeschen');
 		createdIds.push(id);
 
 		await page.goto(`/admin/${id}`);
@@ -148,6 +95,6 @@ test.describe('Admin-Detailansicht — Aktionen', () => {
 		   Datensatz gehört in die Liste zurück, aus der man ihn geöffnet hat,
 		   nicht in die Task-Liste der offenen Meldungen. */
 		await expect(page).toHaveURL(/\/admin\/sichtungen$/);
-		expect(await countSighting(id)).toBe(0);
+		expect(await sightingExists(id)).toBe(false);
 	});
 });

--- a/e2e/admin-edit-preserves-record.spec.ts
+++ b/e2e/admin-edit-preserves-record.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { config as loadEnv } from 'dotenv';
-import postgres from 'postgres';
 import { DistanceEnum } from '../src/lib/report/formOptions/distance';
 import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
 import { seedAdminSession } from './helpers/adminSession';
+import { deleteSighting, openTestDatabase, seedSighting } from './helpers/seedSighting';
 
 /**
  * admin-edit-preserves-record.spec.ts — was eine Admin-Bearbeitung am Bestand
@@ -32,18 +31,12 @@ import { seedAdminSession } from './helpers/adminSession';
  *
  * **Eigene Datensätze statt Bestandsdaten.** Die lokale Datenbank ist laut
  * `docs/WORKTREES.md` über alle Worktrees geteilt; ein Test, der eine echte
- * Meldung speichert, änderte echte Daten. Jeder Testfall legt deshalb seine
- * eigene Zeile an und räumt sie wieder weg. Sie trägt denselben Marker wie
- * `scripts/seed-e2e.ts` (`kommentar_intern = 'e2e-seed'`), damit ein Abbruch
+ * Meldung speichert, änderte echte Daten. Jeder Testfall legt deshalb über
+ * `e2e/helpers/seedSighting.ts` seine eigene Zeile an und räumt sie wieder weg.
+ * Sie trägt denselben Marker wie `scripts/seed-e2e.ts`, damit ein Abbruch
  * mitten im Lauf nichts hinterlässt, was `npm run db:seed:e2e -- --purge` nicht
  * findet.
  */
-
-/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
-   e2e/helpers/adminSession.ts. */
-loadEnv();
-
-const SEED_MARKER = 'e2e-seed';
 
 /** Melderdaten, die keine der beiden Bearbeitungen anfassen darf. */
 const REPORTER = {
@@ -62,45 +55,30 @@ const REPORTER = {
 const POSITION = { latitude: '54.123456', longitude: '13.654321' };
 
 /**
- * Zeitpunkt der Sichtung, als ISO-UTC **mit `Z`** — im Formular erscheint er als
+ * Zeitpunkt der Sichtung, aus ISO-UTC **mit `Z`** — im Formular erscheint er als
  * 10:30 MESZ.
  *
- * Die Schreibweise ist nicht Geschmackssache: `postgres.js` serialisiert einen
- * String-Parameter über `new Date(x).toISOString()`. Ohne `Z` legt Node den Wert
- * als **Ortszeit** aus, und die Testzeile läge auf einem Rechner in Europe/Berlin
- * zwei Stunden neben der Absicht — der Test misst dann seine eigene Zeitzone
- * statt der Anwendung. Genau so ist der erste Anlauf dieses Tests gescheitert.
- * Drizzle schreibt aus demselben Grund `toISOString()`.
+ * Das `Z` ist nicht Geschmackssache: Ohne es legt Node den Wert als **Ortszeit**
+ * aus, und die Testzeile läge auf einem Rechner in Europe/Berlin zwei Stunden
+ * neben der Absicht — der Test misst dann seine eigene Zeitzone statt der
+ * Anwendung. Genau so ist der erste Anlauf dieses Tests gescheitert.
  */
-const SIGHTING_DATE_UTC = '2024-06-01T08:30:00.000Z';
+const SIGHTING_DATE_UTC = new Date('2024-06-01T08:30:00.000Z');
 
 /** Derselbe Zeitpunkt, wie ihn `to_char` aus der Spalte liest. */
 const SIGHTING_DATE_STORED = '2024-06-01 08:30:00';
 
-function connect() {
-	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
-	if (!databaseUrl) {
-		throw new Error(
-			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
-				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
-		);
-	}
-	return postgres(databaseUrl, { max: 1 });
-}
-
 /**
  * Legt eine Sichtung an und liefert ihre ID.
  *
- * `gps_breite`/`gps_laenge` kommen als Text herein und werden von Postgres
- * gecastet — so steht die erwartete Genauigkeit im Test als Literal und nicht
- * als Fließkommazahl, die schon beim Schreiben wackeln könnte.
- *
- * `referenz_id` ist gesetzt, weil `sightingSchema` sie verlangt; im Bestand
- * trägt sie jede Zeile. `vonwo` und `entfernung` sind überschreibbar — der
+ * `referenceId` ist gesetzt, weil `sightingSchema` sie verlangt; im Bestand
+ * trägt sie jede Zeile. `sightingFrom` und `distance` sind überschreibbar — der
  * dritte Testfall braucht dort genau die Werte, an denen das Speichern bis
- * 2026-08-02 scheiterte.
+ * 2026-08-02 scheiterte. Art, Anzahl und Einwilligung stehen mit, damit die
+ * Zeile eine vollständige Meldung ist: Geprüft wird hier eine Bearbeitung, die
+ * durch die Formularvalidierung muss.
  */
-async function createSighting(options: {
+function createSighting(options: {
 	latitude: string | null;
 	longitude: string | null;
 	waterway: string | null;
@@ -108,31 +86,19 @@ async function createSighting(options: {
 	sightingFrom?: number;
 	distance?: number;
 }): Promise<number> {
-	const sql = connect();
-	try {
-		const [row] = await sql<{ id: number }[]>`
-			INSERT INTO sichtungen (
-				sichtungsdatum, created, tierart, anzahl_gesamt,
-				vonwo, entfernung, referenz_id,
-				gps_breite, gps_laenge, fahrwasser,
-				vorname, name, email, strasse, plz, ort,
-				datenschutz_einverstaendnis, kommentar_intern
-			) VALUES (
-				${SIGHTING_DATE_UTC}, NOW(), 1, 2,
-				${options.sightingFrom ?? SightingFromEnum.LAND},
-				${options.distance ?? DistanceEnum.FROM_10_TO_50M},
-				${options.referenceId},
-				${options.latitude}, ${options.longitude}, ${options.waterway},
-				${REPORTER.firstName}, ${REPORTER.lastName}, ${REPORTER.email},
-				${REPORTER.street}, ${REPORTER.zipCode}, ${REPORTER.city},
-				1, ${SEED_MARKER}
-			)
-			RETURNING id
-		`;
-		return Number(row.id);
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
+	return seedSighting({
+		referenceId: options.referenceId,
+		sightingDate: SIGHTING_DATE_UTC,
+		species: 1,
+		totalCount: 2,
+		sightingFrom: options.sightingFrom ?? SightingFromEnum.LAND,
+		distance: options.distance ?? DistanceEnum.FROM_10_TO_50M,
+		latitude: options.latitude,
+		longitude: options.longitude,
+		waterway: options.waterway,
+		reporter: REPORTER,
+		privacyConsent: true
+	});
 }
 
 interface StoredSighting {
@@ -160,7 +126,7 @@ interface StoredSighting {
  * Treibers — und misst damit nicht dieselbe Annahme, die er prüfen soll.
  */
 async function readSighting(id: number): Promise<StoredSighting> {
-	const sql = connect();
+	const sql = openTestDatabase();
 	try {
 		const [row] = await sql<StoredSighting[]>`
 			SELECT
@@ -173,15 +139,6 @@ async function readSighting(id: number): Promise<StoredSighting> {
 			FROM sichtungen WHERE id = ${id}
 		`;
 		return row;
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
-}
-
-async function deleteSighting(id: number): Promise<void> {
-	const sql = connect();
-	try {
-		await sql`DELETE FROM sichtungen WHERE id = ${id}`;
 	} finally {
 		await sql.end({ timeout: 5 });
 	}
@@ -218,25 +175,26 @@ async function editAndSave(
 }
 
 test.describe('Admin-Bearbeitung erhält den Bestand', () => {
-	const createdIds: number[] = [];
+	/* Mit Referenz-ID, weil der dritte Testfall den Aufräum-Marker über die
+	   Oberfläche überschreibt — sie ist dann das einzige Merkmal, an dem
+	   `deleteSighting` die Zeile noch als eigene erkennt. */
+	const created: { id: number; referenceId: string }[] = [];
 
 	test.beforeEach(async ({ context, baseURL }) => {
 		await seedAdminSession(context, baseURL!);
 	});
 
 	test.afterEach(async () => {
-		while (createdIds.length > 0) {
-			await deleteSighting(createdIds.pop()!);
+		while (created.length > 0) {
+			const { id, referenceId } = created.pop()!;
+			await deleteSighting(id, { referenceId });
 		}
 	});
 
 	test('Adresse, Kontaktdaten und Koordinaten überstehen eine Bearbeitung', async ({ page }) => {
-		const id = await createSighting({
-			...POSITION,
-			waterway: null,
-			referenceId: 'e2e-mit-position'
-		});
-		createdIds.push(id);
+		const referenceId = 'e2e-mit-position';
+		const id = await createSighting({ ...POSITION, waterway: null, referenceId });
+		created.push({ id, referenceId });
 
 		await editAndSave(page, id, 'E2E: Nachtrag zur Beobachtung');
 
@@ -267,13 +225,14 @@ test.describe('Admin-Bearbeitung erhält den Bestand', () => {
 	});
 
 	test('Sichtung ohne Position bekommt keine erfundenen Koordinaten', async ({ page }) => {
+		const referenceId = 'e2e-ohne-position';
 		const id = await createSighting({
 			latitude: null,
 			longitude: null,
 			waterway: 'Strelasund',
-			referenceId: 'e2e-ohne-position'
+			referenceId
 		});
-		createdIds.push(id);
+		created.push({ id, referenceId });
 
 		await editAndSave(page, id, 'E2E: Bearbeitung ohne Position');
 
@@ -302,14 +261,15 @@ test.describe('Admin-Bearbeitung erhält den Bestand', () => {
 	 * `e2e-`-Referenz-ID.
 	 */
 	test('lässt eine Bestandssichtung mit unvollständigen Angaben speichern', async ({ page }) => {
+		const referenceId = 'e2e-bestand';
 		const id = await createSighting({
 			...POSITION,
 			waterway: null,
-			referenceId: 'e2e-bestand',
+			referenceId,
 			sightingFrom: SightingFromEnum.OTHER,
 			distance: 0
 		});
-		createdIds.push(id);
+		created.push({ id, referenceId });
 
 		await page.goto(`/admin/${id}/edit`);
 		const internalComment = page.locator('[data-testid="field-internalComment"]');

--- a/e2e/admin-table-dead-finding.spec.ts
+++ b/e2e/admin-table-dead-finding.spec.ts
@@ -1,9 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { config as loadEnv } from 'dotenv';
-import postgres from 'postgres';
-import { DistanceEnum } from '../src/lib/report/formOptions/distance';
-import { SightingFromEnum } from '../src/lib/report/formOptions/sightingFrom';
 import { seedAdminSession } from './helpers/adminSession';
+import { deleteSighting, FIRST_PAGE_DATE, seedSighting } from './helpers/seedSighting';
 
 /**
  * admin-table-dead-finding.spec.ts — der Totfund ist in der Tabelle erkennbar,
@@ -19,60 +16,22 @@ import { seedAdminSession } from './helpers/adminSession';
  * *keine* Spalte um — er verlässt sich darauf, dass es keinen Schalter gibt, und
  * die zweite Assertion belegt genau das.
  *
- * Eigene Testzeilen mit `kommentar_intern = 'e2e-seed'` und einem
+ * Eigene Testzeilen über `e2e/helpers/seedSighting.ts`, mit einem
  * Sichtungsdatum in der Zukunft: Die Tabelle sortiert per Vorgabe nach
  * `sichtungsdatum desc`, damit stehen beide Zeilen sicher auf Seite 1 — sonst
  * hinge der Test daran, wie viele Sichtungen die Datenbank sonst noch trägt.
  */
 
-/* Playwright lädt .env nicht von sich aus — dieselbe Begründung wie in
-   e2e/helpers/adminSession.ts. */
-loadEnv();
-
-const SEED_MARKER = 'e2e-seed';
-
-function connect() {
-	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
-	if (!databaseUrl) {
-		throw new Error(
-			'DATABASE_POSTGRES_URL fehlt — ohne Datenbank lässt sich keine Testsichtung anlegen. ' +
-				'Lokal steht sie in .env, in CI entsteht sie aus .env.example (ci.yml).'
-		);
-	}
-	return postgres(databaseUrl, { max: 1 });
-}
-
-async function createSighting(referenceId: string, dead: boolean): Promise<number> {
-	const sql = connect();
-	try {
-		const [row] = await sql<{ id: number }[]>`
-			INSERT INTO sichtungen (
-				sichtungsdatum, created, tierart, anzahl_gesamt,
-				vonwo, entfernung, referenz_id, totfund,
-				vorname, name, email,
-				datenschutz_einverstaendnis, kommentar_intern
-			) VALUES (
-				'2099-06-01T08:30:00.000Z', NOW(), 1, 2,
-				${SightingFromEnum.LAND}, ${DistanceEnum.FROM_10_TO_50M}, ${referenceId},
-				${dead ? 1 : 0},
-				'Erika', 'Mustermann', 'erika.e2e@example.invalid',
-				1, ${SEED_MARKER}
-			)
-			RETURNING id
-		`;
-		return Number(row!.id);
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
-}
-
-async function removeSighting(id: number): Promise<void> {
-	const sql = connect();
-	try {
-		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
-	} finally {
-		await sql.end({ timeout: 5 });
-	}
+/**
+ * Gesetzt wird nur `totfund` — der Marker soll allein daran hängen. Trüge der
+ * Seed zusätzlich Art und Melderdaten, bliebe offen, ob die Tabelle nicht
+ * daraus schließt.
+ *
+ * `FIRST_PAGE_DATE`, weil beiden Zeilen „auf Seite 1" genügt; die neueste Zeile
+ * ist reserviert (siehe `seedSighting.ts`).
+ */
+function seedDeadFinding(referenceId: string, isDead: boolean): Promise<number> {
+	return seedSighting({ referenceId, sightingDate: FIRST_PAGE_DATE, isDead });
 }
 
 test.describe('Admin-Sichtungstabelle — Totfund-Marker', () => {
@@ -80,7 +39,7 @@ test.describe('Admin-Sichtungstabelle — Totfund-Marker', () => {
 
 	test.afterEach(async () => {
 		while (createdIds.length > 0) {
-			await removeSighting(createdIds.pop()!);
+			await deleteSighting(createdIds.pop()!);
 		}
 	});
 
@@ -90,8 +49,8 @@ test.describe('Admin-Sichtungstabelle — Totfund-Marker', () => {
 		baseURL
 	}) => {
 		await seedAdminSession(context, baseURL!, ['admin']);
-		createdIds.push(await createSighting('e2e-tot', true));
-		createdIds.push(await createSighting('e2e-lebend', false));
+		createdIds.push(await seedDeadFinding('e2e-tot', true));
+		createdIds.push(await seedDeadFinding('e2e-lebend', false));
 
 		await page.setViewportSize({ width: 1280, height: 900 });
 		await page.goto('/admin/sichtungen');

--- a/e2e/admin-table-mobile-reference-overflow.spec.ts
+++ b/e2e/admin-table-mobile-reference-overflow.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type BrowserContext } from '@playwright/test';
 import { seedAdminSession } from './helpers/adminSession';
 import { expectNoHorizontalOverflow } from './helpers/overflow';
-import { deleteSighting, seedSighting } from './helpers/seedSighting';
+import { deleteSighting, NEWEST_ROW_DATE, seedSighting } from './helpers/seedSighting';
 
 /**
  * admin-table-mobile-reference-overflow.spec.ts — die Referenz-ID in der
@@ -62,10 +62,12 @@ test.describe('Admin-Sichtungstabelle — lange Referenz-ID in der Mobilkarte', 
 			   einer ab, bevor er aufräumt, kollidiert der andere sonst mit der
 			   liegengebliebenen Zeile statt sauber durchzulaufen. */
 			const referenceId = `${LANGE_REFERENZ}${width}`;
-			/* In der Zukunft, damit die Zeile bei `sichtungsdatum desc` ganz vorn steht. */
+			/* `NEWEST_ROW_DATE`: `?perPage=1` rendert genau die neueste Zeile, und
+			   dieser Wert ist dafür reserviert — kein anderer Seed liegt darüber
+			   (abgesichert in `helpers/seedSighting.test.ts`). */
 			const sightingId = await seedSighting({
 				referenceId,
-				sightingDate: new Date('2099-01-01T12:00:00Z')
+				sightingDate: NEWEST_ROW_DATE
 			});
 
 			/* Der `try` beginnt unmittelbar nach dem Seed und nicht erst nach dem

--- a/e2e/helpers/seedSighting.test.ts
+++ b/e2e/helpers/seedSighting.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { FIRST_PAGE_DATE, NEWEST_ROW_DATE } from './seedSighting';
+
+/**
+ * seedSighting.test.ts — hält die Reihenfolge der Seed-Datumswerte fest.
+ *
+ * Ohne diese Zusicherung ist die Regel bloß ein Kommentar. Sie kostet den
+ * nächsten Autor sonst einen Debug-Lauf: Wer für einen neuen Test wieder ein
+ * Datum oberhalb von `NEWEST_ROW_DATE` wählt, verdeckt damit die Zeile von
+ * `admin-table-mobile-reference-overflow.spec.ts` (`?perPage=1` rendert genau
+ * die neueste). Der Fehlschlag steht dann in einer *fremden* Datei und tritt
+ * nur auf, wenn beide Specs im selben Lauf parallel liegen — genau die
+ * Flakiness-Klasse, die schwer zu finden ist. Hier fällt sie sofort auf, und
+ * zwar an der Stelle, an der die Datumswerte gepflegt werden.
+ */
+describe('Seed-Datumswerte', () => {
+	it('hält die Seite-1-Zeilen unterhalb der neuesten Zeile', () => {
+		expect(FIRST_PAGE_DATE.getTime()).toBeLessThan(NEWEST_ROW_DATE.getTime());
+	});
+
+	it('liegt mit beiden Werten in der Zukunft', () => {
+		// Sonst greift die Default-Sortierung `sichtungsdatum desc` nicht mehr und
+		// die Zeile verschwindet zwischen 30.000 Bestandsmeldungen.
+		expect(FIRST_PAGE_DATE.getTime()).toBeGreaterThan(Date.now());
+	});
+
+	/**
+	 * `app-shell-height.spec.ts` filtert auf `2099-01-01..2099-01-02` und braucht
+	 * dort eine leere Trefferliste — die einzige kurze Admin-Seite, an der eine
+	 * zu groß geratene Mindesthöhe überhaupt auffällt.
+	 */
+	it('legt keine Zeile in das Filterfenster von app-shell-height', () => {
+		const fensterStart = new Date('2099-01-01T00:00:00.000Z').getTime();
+		const fensterEnde = new Date('2099-01-03T00:00:00.000Z').getTime();
+
+		for (const datum of [NEWEST_ROW_DATE, FIRST_PAGE_DATE]) {
+			const zeitpunkt = datum.getTime();
+			expect(zeitpunkt < fensterStart || zeitpunkt >= fensterEnde).toBe(true);
+		}
+	});
+});

--- a/e2e/helpers/seedSighting.test.ts
+++ b/e2e/helpers/seedSighting.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { FIRST_PAGE_DATE, NEWEST_ROW_DATE } from './seedSighting';
+import {
+	deleteSighting,
+	E2E_REFERENCE_PREFIX,
+	FIRST_PAGE_DATE,
+	NEWEST_ROW_DATE
+} from './seedSighting';
 
 /**
  * seedSighting.test.ts — hält die Reihenfolge der Seed-Datumswerte fest.
@@ -37,5 +42,33 @@ describe('Seed-Datumswerte', () => {
 			const zeitpunkt = datum.getTime();
 			expect(zeitpunkt < fensterStart || zeitpunkt >= fensterEnde).toBe(true);
 		}
+	});
+});
+
+/**
+ * `deleteSighting` erlaubt als zweites Erkennungsmerkmal eine Referenz-ID —
+ * für den einen Test, der den Aufräum-Marker über die Oberfläche überschreibt.
+ * Ohne Schranke wäre das ein Weg am Marker-Guard vorbei: Die Referenz-ID einer
+ * echten Meldung, versehentlich übergeben, löschte sie.
+ *
+ * Die Prüfung liegt vor dem Verbindungsaufbau — deshalb kommen diese Fälle
+ * ohne Datenbank aus.
+ */
+describe('deleteSighting — Schranke für die Referenz-ID', () => {
+	it('weist eine Referenz-ID ohne E2E-Präfix ab', async () => {
+		await expect(deleteSighting(157, { referenceId: 'clx8k2p9q000108l4h3v2b1c7' })).rejects.toThrow(
+			/Präfix/
+		);
+	});
+
+	it('nennt die abgelehnte Referenz-ID, damit der Fehler auffindbar ist', async () => {
+		await expect(deleteSighting(157, { referenceId: 'fremde-id' })).rejects.toThrow('fremde-id');
+	});
+
+	/* Die Gegenprobe — eine zugelassene Referenz-ID — braucht eine Datenbank und
+	   läuft in `admin-edit-preserves-record.spec.ts`: Dessen Zeilen tragen das
+	   Präfix und werden nach jedem Fall entfernt. */
+	it('kennt das Präfix, das die Specs verwenden', () => {
+		expect(E2E_REFERENCE_PREFIX).toBe('e2e-');
 	});
 });

--- a/e2e/helpers/seedSighting.ts
+++ b/e2e/helpers/seedSighting.ts
@@ -43,6 +43,14 @@ loadEnv();
 const SEED_MARKER = 'e2e-seed';
 
 /**
+ * Präfix, an dem `deleteSighting` eine Referenz-ID als selbst vergeben erkennt.
+ *
+ * Nur für den Löschpfad verbindlich, nicht für den Seed: Die App vergibt
+ * Referenz-IDs als cuid2, ein `e2e-` davor kommt im Bestand nicht vor.
+ */
+export const E2E_REFERENCE_PREFIX = 'e2e-';
+
+/**
  * Öffnet eine Verbindung zur Entwicklungs-Datenbank.
  *
  * Exportiert für Tests, die die geschriebene Zeile anschließend mit einer
@@ -201,13 +209,27 @@ export async function seedSighting(data: SeedSightingData): Promise<number> {
  * `referenceId` ist für den einen Fall gedacht, in dem der Test den Marker
  * selbst überschreibt: `admin-edit-preserves-record.spec.ts` bearbeitet den
  * internen Kommentar über die Oberfläche. Die Zeile bleibt danach über ihre
- * `e2e-`-Referenz-ID auffindbar — ein zweites Erkennungsmerkmal, statt die
- * Bedingung ersatzlos fallen zu lassen.
+ * Referenz-ID auffindbar — ein zweites Erkennungsmerkmal, statt die Bedingung
+ * ersatzlos fallen zu lassen.
+ *
+ * Damit dieser Ausweg den Marker-Guard nicht aushebelt, muss die Referenz-ID
+ * das Präfix `e2e-` tragen. Sonst genügte die Referenz-ID einer *echten*
+ * Meldung, um sie zu löschen — versehentlich übergeben, unbemerkt weg. Die
+ * Bedingung steht vor dem Verbindungsaufbau: Ein Aufruf, der so nicht gemeint
+ * sein kann, soll scheitern und nicht erst eine Verbindung öffnen.
  */
 export async function deleteSighting(
 	id: number,
 	options: { referenceId?: string } = {}
 ): Promise<void> {
+	if (options.referenceId !== undefined && !options.referenceId.startsWith(E2E_REFERENCE_PREFIX)) {
+		throw new Error(
+			`deleteSighting: referenz_id „${options.referenceId}" trägt nicht das Präfix ` +
+				`„${E2E_REFERENCE_PREFIX}" — als zweites Erkennungsmerkmal taugt nur eine ` +
+				'Referenz-ID, die dieser Helfer selbst vergeben haben kann.'
+		);
+	}
+
 	const sql = openTestDatabase();
 	try {
 		const byReference = options.referenceId ? sql`OR referenz_id = ${options.referenceId}` : sql``;

--- a/e2e/helpers/seedSighting.ts
+++ b/e2e/helpers/seedSighting.ts
@@ -8,9 +8,10 @@ import postgres from 'postgres';
  * **Warum überhaupt seeden:** Die Entwicklungs-Datenbank ist laut
  * `docs/WORKTREES.md` von allen Worktrees geteilt, und ihr Bestand ist
  * gewachsen statt gepflegt. Ein Test, der eine bestimmte Ausprägung braucht
- * (hier: eine lange Referenz-ID in der Mobilkarte), darf nicht darauf hoffen,
- * dass zufällig eine passende Zeile auf Seite 1 steht — sonst ist er entweder
- * grün ohne Aussage oder rot ohne Ursache im Code.
+ * (eine lange Referenz-ID, einen Totfund, eine Position mit voller Auflösung),
+ * darf nicht darauf hoffen, dass zufällig eine passende Zeile auf Seite 1
+ * steht — sonst ist er entweder grün ohne Aussage oder rot ohne Ursache im
+ * Code.
  *
  * **Warum ein eigener `postgres`-Client** statt `$lib/server/db`: dieselbe
  * Begründung wie in `adminSession.ts` — Playwright läuft als gewöhnliches
@@ -18,15 +19,19 @@ import postgres from 'postgres';
  * `$env/dynamic/private`.
  *
  * **Pflichtfelder:** In `sichtungen` sind nur `sichtungsdatum` und `created`
- * NOT NULL ohne Default (`src/lib/server/db/schema.ts`). Alles andere füllt die
- * Datenbank selbst — der Seed bleibt damit klein und altert nicht mit jedem
- * neuen Feld.
+ * NOT NULL ohne Default (`src/lib/server/db/schema.ts`). Alles Weitere ist
+ * optional und wird nur dann in das INSERT aufgenommen, wenn ein Test es
+ * angibt — ein ausgelassenes Feld bekommt damit den Spaltendefault und nicht
+ * etwa NULL. Der Unterschied ist keine Feinheit: `totfund`, `vonwo`,
+ * `entfernung`, `tierart`, `anzahl_gesamt` und
+ * `datenschutz_einverstaendnis` sind NOT NULL DEFAULT 0, ein ausgeschriebenes
+ * NULL ließe das INSERT scheitern.
  *
  * **Warum trotzdem `kommentar_intern`:** `scripts/seed-e2e.ts` räumt über genau
  * diesen Marker auf. Ohne ihn bleibt eine Zeile, deren `deleteSighting` nicht
  * mehr lief (abgebrochener Lauf, getöteter CI-Job), unauffindbar in der über
- * alle Worktrees geteilten Entwicklungs-DB liegen — und zwar mit einem
- * Sichtungsdatum in der Zukunft, also dauerhaft an der Spitze der
+ * alle Worktrees geteilten Entwicklungs-DB liegen — und zwar unter Umständen
+ * mit einem Sichtungsdatum in der Zukunft, also dauerhaft an der Spitze der
  * Default-Sortierung, wo sie den nächsten Test auf Seite 1 stört.
  */
 
@@ -37,7 +42,16 @@ loadEnv();
    löscht über `WHERE kommentar_intern = 'e2e-seed'`. */
 const SEED_MARKER = 'e2e-seed';
 
-function verbindung() {
+/**
+ * Öffnet eine Verbindung zur Entwicklungs-Datenbank.
+ *
+ * Exportiert für Tests, die die geschriebene Zeile anschließend mit einer
+ * eigenen Abfrage nachlesen (`admin-edit-preserves-record.spec.ts` liest
+ * Koordinaten und Zeitstempel bewusst als Text). Angelegt und entfernt wird
+ * ausschließlich über `seedSighting`/`deleteSighting` — sonst fehlt der Zeile
+ * der Aufräum-Marker.
+ */
+export function openTestDatabase(): postgres.Sql {
 	const databaseUrl = process.env.DATABASE_POSTGRES_URL;
 	if (!databaseUrl) {
 		throw new Error(
@@ -49,25 +63,126 @@ function verbindung() {
 }
 
 /**
- * Legt eine Sichtung an und liefert ihre `id` zurück.
+ * Sichtungsdatum für den Test, der die **einzige** neueste Zeile braucht —
+ * `admin-table-mobile-reference-overflow.spec.ts` ruft die Tabelle mit
+ * `?perPage=1` auf und sieht damit genau eine.
  *
- * `sightingDate` bewusst als Parameter: Die Admin-Tabelle sortiert per Default
- * nach `sichtungsdatum` absteigend. Ein Datum in der Zukunft stellt die Zeile
- * damit an den Anfang der ersten Seite — zusammen mit `?perPage=1` ist sie die
- * einzige, die der Test sieht.
+ * Nicht der 1. Januar: `app-shell-height.spec.ts` filtert auf
+ * `2099-01-01..2099-01-02` und erwartet dort eine leere Trefferliste.
  */
-export async function seedSighting(daten: {
+export const NEWEST_ROW_DATE = new Date('2099-06-01T12:00:00.000Z');
+
+/**
+ * Sichtungsdatum für Tests, denen „irgendwo auf Seite 1" genügt.
+ *
+ * Bewusst **unter** `NEWEST_ROW_DATE`: Läge es darüber, verdeckte diese Zeile
+ * die des `?perPage=1`-Tests, sobald beide Dateien parallel laufen — genau so
+ * beobachtet, als `admin-table-dead-finding.spec.ts` und
+ * `admin-table-mobile-reference-overflow.spec.ts` in einem Lauf lagen. Die
+ * Reihenfolge der beiden Konstanten ist deshalb in `seedSighting.test.ts`
+ * festgehalten und nicht bloß hier beschrieben.
+ */
+export const FIRST_PAGE_DATE = new Date('2098-06-01T08:30:00.000Z');
+
+/** Melderdaten. Vollständig optional — kein Feld davon ist NOT NULL. */
+export interface SeedReporter {
+	firstName?: string;
+	lastName?: string;
+	email?: string;
+	street?: string;
+	zipCode?: string;
+	city?: string;
+}
+
+/**
+ * Die seedbaren Felder.
+ *
+ * Bewusst nicht das ganze Schema: Aufgenommen ist, was ein bestehender Test
+ * belegt oder als Voraussetzung braucht. Wer ein weiteres Feld benötigt, nimmt
+ * es hier auf — eine Liste „auf Vorrat" wäre nur eine zweite, schlechtere
+ * Kopie von `schema.ts`.
+ */
+export interface SeedSightingData {
 	referenceId: string;
+	/**
+	 * Der Zeitpunkt der Sichtung, als absoluter Moment — gespeichert wird er als
+	 * UTC.
+	 *
+	 * Die Admin-Tabelle sortiert per Vorgabe nach `sichtungsdatum` absteigend.
+	 * Statt hier ein eigenes Datum zu erfinden, gehören Zeilen, die ein Test in
+	 * der Tabelle wiederfinden muss, auf `NEWEST_ROW_DATE` oder
+	 * `FIRST_PAGE_DATE` — die beiden Werte sind gegeneinander abgestimmt.
+	 */
 	sightingDate: Date;
-}): Promise<number> {
-	const sql = verbindung();
+	isDead?: boolean;
+	species?: number;
+	totalCount?: number;
+	sightingFrom?: number;
+	distance?: number;
+	/**
+	 * Koordinaten als Text, nicht als Zahl: So steht die erwartete Genauigkeit
+	 * im Test als Literal und wird von Postgres nach `numeric(8,6)` gecastet,
+	 * statt schon beim Schreiben durch eine Fließkommazahl zu wackeln.
+	 */
+	latitude?: string | null;
+	longitude?: string | null;
+	waterway?: string | null;
+	reporter?: SeedReporter;
+	privacyConsent?: boolean;
+}
+
+/** Postgres kennt kein Boolean an diesen Spalten — `smallint` mit 0/1. */
+function toFlag(value: boolean | undefined): number | undefined {
+	return value === undefined ? undefined : Number(value);
+}
+
+/** Baut die Spaltenzuordnung und lässt nicht angegebene Felder weg. */
+function toColumns(data: SeedSightingData): Record<string, unknown> {
+	const { reporter = {} } = data;
+	const all: Record<string, unknown> = {
+		/* `toISOString()` und nicht das `Date` selbst: `sichtungsdatum` ist
+		   `timestamp without time zone` und trägt UTC. Ein `Date`-Parameter kommt
+		   von `postgres.js` als **Ortszeit** formatiert an — die Zeile läge auf
+		   einem Rechner in Europe/Berlin zwei Stunden neben der Absicht, und der
+		   Test misst dann seine eigene Zeitzone statt der Anwendung. Drizzle
+		   schreibt aus demselben Grund `toISOString()`. */
+		sichtungsdatum: data.sightingDate.toISOString(),
+		created: new Date().toISOString(),
+		referenz_id: data.referenceId,
+		kommentar_intern: SEED_MARKER,
+		totfund: toFlag(data.isDead),
+		tierart: data.species,
+		anzahl_gesamt: data.totalCount,
+		vonwo: data.sightingFrom,
+		entfernung: data.distance,
+		gps_breite: data.latitude,
+		gps_laenge: data.longitude,
+		fahrwasser: data.waterway,
+		vorname: reporter.firstName,
+		name: reporter.lastName,
+		email: reporter.email,
+		strasse: reporter.street,
+		plz: reporter.zipCode,
+		ort: reporter.city,
+		datenschutz_einverstaendnis: toFlag(data.privacyConsent)
+	};
+
+	/* `null` bleibt drin und wird geschrieben — „ausdrücklich ohne Position" ist
+	   eine eigene Aussage. Nur `undefined` heißt „nicht angegeben". */
+	return Object.fromEntries(Object.entries(all).filter(([, value]) => value !== undefined));
+}
+
+/** Legt eine Sichtung an und liefert ihre `id` zurück. */
+export async function seedSighting(data: SeedSightingData): Promise<number> {
+	const sql = openTestDatabase();
 	try {
-		const [zeile] = await sql<{ id: number }[]>`
-			INSERT INTO sichtungen (sichtungsdatum, created, referenz_id, kommentar_intern)
-			VALUES (${daten.sightingDate}, NOW(), ${daten.referenceId}, ${SEED_MARKER})
+		/* `sql(objekt)` erzeugt Spaltenliste und VALUES aus den Schlüsseln und
+		   bindet die Werte als Parameter — kein zusammengesetztes SQL. */
+		const [row] = await sql<{ id: number }[]>`
+			INSERT INTO sichtungen ${sql(toColumns(data))}
 			RETURNING id
 		`;
-		return Number(zeile.id);
+		return Number(row.id);
 	} finally {
 		// Sonst hält der offene Pool den Playwright-Prozess am Leben.
 		await sql.end({ timeout: 5 });
@@ -81,14 +196,36 @@ export async function seedSighting(daten: {
  * alle Worktrees geteilt und enthält echte Meldungen. Eine falsch übergebene
  * `id` — vertauschte Variable, Wert aus einem früheren Lauf — löschte sonst
  * eine fremde Zeile, und zwar unbemerkt. Der Marker begrenzt den Schaden auf
- * das, was dieser Helfer selbst angelegt hat; dasselbe Muster fahren die
- * bestehenden Seeds in `admin-table-dead-finding.spec.ts` und
- * `admin-detail-actions.spec.ts`.
+ * das, was dieser Helfer selbst angelegt hat.
+ *
+ * `referenceId` ist für den einen Fall gedacht, in dem der Test den Marker
+ * selbst überschreibt: `admin-edit-preserves-record.spec.ts` bearbeitet den
+ * internen Kommentar über die Oberfläche. Die Zeile bleibt danach über ihre
+ * `e2e-`-Referenz-ID auffindbar — ein zweites Erkennungsmerkmal, statt die
+ * Bedingung ersatzlos fallen zu lassen.
  */
-export async function deleteSighting(id: number): Promise<void> {
-	const sql = verbindung();
+export async function deleteSighting(
+	id: number,
+	options: { referenceId?: string } = {}
+): Promise<void> {
+	const sql = openTestDatabase();
 	try {
-		await sql`DELETE FROM sichtungen WHERE id = ${id} AND kommentar_intern = ${SEED_MARKER}`;
+		const byReference = options.referenceId ? sql`OR referenz_id = ${options.referenceId}` : sql``;
+		await sql`
+			DELETE FROM sichtungen
+			WHERE id = ${id} AND (kommentar_intern = ${SEED_MARKER} ${byReference})
+		`;
+	} finally {
+		await sql.end({ timeout: 5 });
+	}
+}
+
+/** Ob die Zeile noch existiert — für Tests, die das Löschen selbst prüfen. */
+export async function sightingExists(id: number): Promise<boolean> {
+	const sql = openTestDatabase();
+	try {
+		const rows = await sql`SELECT id FROM sichtungen WHERE id = ${id}`;
+		return rows.length > 0;
 	} finally {
 		await sql.end({ timeout: 5 });
 	}


### PR DESCRIPTION
Führt das duplizierte DB-Setup der drei Admin-Specs auf `e2e/helpers/seedSighting.ts` zusammen (Helper aus #798).

## Warum

Jede der drei Dateien trug ihre eigene Kopie von `connect()`, `createSighting()` und `removeSighting()` — und ihr eigenes `SEED_MARKER`-Literal. Der Marker muss wörtlich mit `scripts/seed-e2e.ts` übereinstimmen, sonst findet `npm run db:seed:e2e -- --purge` liegengebliebene Zeilen nicht mehr. Vier Fundstellen sind drei zu viel, zumal die lokale DB über alle Worktrees geteilt ist.

## Was der Helper dazubekommt

- Ein optionales Feld-Bündel: `isDead`, `species`, `totalCount`, `sightingFrom`, `distance`, `latitude`/`longitude`/`waterway`, `reporter`, `privacyConsent`. Aufgenommen ist, was ein bestehender Test belegt oder als Voraussetzung braucht — keine Liste auf Vorrat.
- Das INSERT entsteht aus einem Objekt über `sql(objekt)` (parametrisiert). Nicht gesetzte Felder fallen heraus und bekommen den **Spaltendefault**, statt als NULL geschrieben zu werden: `totfund`, `vonwo`, `entfernung`, `tierart`, `anzahl_gesamt` und `datenschutz_einverstaendnis` sind `NOT NULL DEFAULT 0`. Ein ausdrückliches `null` bleibt erhalten — „ohne Position" ist eine eigene Aussage.
- `deleteSighting(id, { referenceId })`: Der Marker-Guard bleibt. Genau ein Test überschreibt den Marker über die Oberfläche; dessen Aufräumen lief bisher als `DELETE ... WHERE id = $1` ganz ohne Netz.
- `sightingExists()` und ein exportiertes `openTestDatabase()` für die spezifische Lese-Abfrage in `admin-edit-preserves-record`.

## Zwei Fehler, die dabei aufgefallen sind

Beide im Testlauf, nicht beim Lesen:

1. **Zeitzone.** Ein `Date`-Parameter kommt von `postgres.js` als *Ortszeit* formatiert an. `sichtungsdatum` ist `timestamp without time zone` und trägt UTC — die Zeile lag zwei Stunden neben der Absicht (`10:30` statt `08:30`), der Test maß seine eigene Zeitzone. Jetzt `toISOString()`, aus demselben Grund, aus dem Drizzle es tut.
2. **Kollidierende Seed-Datumswerte.** `admin-table-dead-finding` seedete `2099-06-01` und verdeckte damit die Zeile von `admin-table-mobile-reference-overflow`, das die Tabelle mit `?perPage=1` aufruft und die *einzige* neueste Zeile braucht. Bestand schon vorher, fällt aber nur auf, wenn beide Dateien parallel laufen. Die Datumswerte sind jetzt `NEWEST_ROW_DATE` und `FIRST_PAGE_DATE`; ihre Reihenfolge hält `e2e/helpers/seedSighting.test.ts` fest — als Kommentar wäre die Regel beim nächsten Seed wieder weg.

`NEWEST_ROW_DATE` liegt zusätzlich außerhalb des Filterfensters `2099-01-01..2099-01-02`, in dem `app-shell-height.spec.ts` eine leere Trefferliste braucht.

## Bewusste Verhaltensänderung

`admin-detail-actions` und `admin-table-dead-finding` seeden ohne Art, Anzahl und Melderdaten, laufen also gegen `tierart = 0` statt vormals `1`. Beide prüfen Bedienelemente bzw. den Totfund-Marker; ein Datensatz aus reinen Spaltendefaults ist dafür der schärfere Fall, und beim Totfund-Marker bleibt so belegt, dass er allein an `totfund` hängt.

## Verifikation

- `npx playwright test` über die drei Specs plus `admin-table-mobile-reference-overflow` und `app-shell-height`: **13 passed**
- `npx vitest run e2e/helpers/seedSighting.test.ts`: 3 passed
- `npm run type-check`, `npm run check` (2177 Dateien, 0 Fehler), `npx eslint e2e/`: sauber
- Danach keine Testzeile in der geteilten Dev-DB zurückgeblieben (die 55 `E2E-0xx`-Zeilen sind der gepflegte Datensatz aus `scripts/seed-e2e.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)