### PR TITLE
fix(admin): vier Bugs aus dem Admin-Review (Filterverlust, Zähler, Datumsfilter, Statistik)

### DIFF
--- a/docs/ADMIN_IMPROVEMENTS_SPEC.md
+++ b/docs/ADMIN_IMPROVEMENTS_SPEC.md
@@ -1,0 +1,290 @@
+# Spec: Admin-Bereich — Verbesserungen aus dem Review vom 2026-08-08
+
+Grundlage ist das Admin-Review vom 2026-08-08 (Usability, UX, Function-Check).
+Die vier Function-Bugs daraus (Filterverlust Zurück-Link, „1 Fotos ausstehend",
+Datumsfilter nur mit beiden Grenzen, Statistik zählt Abgelehnte als offen) sind
+bereits separat in Arbeit und **nicht** Teil dieser Spec.
+
+Jeder Punkt nennt seinen Umsetzungsweg:
+
+- **Agent (sonnet)** — klar umrissen, wenig Entscheidungsspielraum.
+- **Agent (opus)** — Schema-/API-Änderungen, A11y-Muster oder heikles CSS.
+- **Follow-Up-Chip** — größerer Wurf, eigene Session mit eigenem Review.
+
+Für alle Agent-Punkte gilt das Projekt-Reglement: Test-First (RED→GREEN),
+Svelte 5 Runes, Design-System-Regeln (`.claude/rules/design-system.md`),
+deutsche Warum-Kommentare, kein Commit durch den Agenten.
+
+**Reihenfolge/Konflikte:** U2, U5 und X1 ändern alle
+`src/routes/admin/sichtungen/+page.svelte` — sie dürfen nicht parallel laufen.
+Empfohlene Wellen: zuerst U1, U4, X2, X3, X4 (disjunkte Dateien, parallel),
+danach sequenziell X1 → U2 → U5.
+
+---
+
+## Usability
+
+### U1 — `freigegeben_von` einführen (Agent: opus)
+
+**Befund:** Ablehnungen speichern `abgelehnt_von` und zeigen „Abgelehnt am …
+durch X"; Freigaben speichern nur `freigegeben_am`. Im Team ist nicht
+nachvollziehbar, wer freigegeben hat.
+
+**Umsetzung:**
+
+1. Schema (`src/lib/server/db/schema.ts`): neue nullable Spalte
+   `freigegeben_von` (`text`), symmetrisch zu `abgelehnt_von`. Migration mit
+   `npm run db:generate` erzeugen und **committen** (CLAUDE.md-Pflicht).
+   Altbestand bleibt `NULL` — das Altsystem liegt auf derselben DB, eine
+   nullable Zusatzspalte ist rückwärtskompatibel.
+2. `PATCH /api/sightings/[id]/verify`: beim Verdict `approve` zusätzlich
+   `freigegeben_von` mit derselben Identität stempeln, die heute
+   `abgelehnt_von` bekommt; `reset` löscht beide `_von`-Spalten mit.
+   **Nur** dieser Endpunkt schreibt die Spalte (Zwei-Spalten-ein-Vorgang-Regel
+   aus CLAUDE.md gilt sinngemäß weiter).
+3. Anzeige: Detailansicht (`AdminSightingView.svelte`, Status-Leiste) und
+   Edit-Kopf (`AdminSightingEditForm.svelte`) zeigen „Freigegeben am … durch X"
+   analog zum Abgelehnt-Fall; `FrontendSighting`-Typ und API-Mapping ergänzen.
+
+**Akzeptanz:** Approve stempelt Zeit + Person; Reset räumt beides; Altbestand
+ohne Person zeigt weiterhin nur das Datum (kein „durch null").
+**Tests:** Endpunkt-Tests am verify-Endpoint (approve/reset), Anzeige-Test in
+`AdminSightingView.svelte.test.ts`. `verifiedReadScan.test.ts` muss grün
+bleiben.
+
+### U2 — Spaltenauswahl merken (Agent: sonnet, nach X1)
+
+**Befund:** `columnVisibility` in `src/routes/admin/sichtungen/+page.svelte`
+ist reiner Komponenten-State — jeder Reload setzt auf den Default zurück.
+
+**Umsetzung:** Persistenz in `localStorage` (Schlüssel z. B.
+`admin.sichtungen.columns`, versioniert: `{ v: 1, columns: {...} }`).
+Beim Laden mergen mit dem Default (neue Spalten erscheinen mit ihrem
+Default-Wert, entfernte Schlüssel werden ignoriert) — sonst versteckt ein
+alter Eintrag künftige Spalten für immer. SSR-sicher: Zugriff nur im Browser
+(`$effect` bzw. `typeof window`-Guard, Regel aus `architecture.md`).
+
+**Akzeptanz:** Auswahl übersteht Reload; ungültiges/altes JSON fällt still auf
+den Default zurück; SSR rendert ohne Fehler.
+**Tests:** Extraktion der Merge-/Parse-Logik in ein TS-Modul
+(`columnPreferences.ts`) mit Unit-Tests (kaputtes JSON, unbekannte Schlüssel,
+neue Spalte).
+
+### U3 — Suche über Sichtungen (**Follow-Up-Chip**)
+
+**Befund:** Es gibt keinen Weg, eine Sichtung per E-Mail, Name, Referenz-ID
+oder Ortstext zu finden. Der Ref-Lookup (`/admin/ref/[refId]`) existiert, hat
+aber kein Eingabefeld in der UI.
+
+**Umsetzung (Skizze für die eigene Session):**
+
+- Ein Suchfeld im Kopf von `/admin/sichtungen`, URL-Parameter `q`, serverseitig
+  `ILIKE`-Suche über `referenz_id`, `email`, `vorname`/`nachname`,
+  `fahrwasser` (parametrisiert via Drizzle, kein SQL-String).
+- `q` muss in **drei** bestehende Parameterlisten: Export
+  (`exportFilterParams.ts`), Rückweg (`tableReturnUrl.ts` — dessen
+  Abgleich-Test wird sonst rot, das ist gewollt) und Filteranzeige im
+  Export-Modal.
+- Trefferanzeige: normale Tabelle mit aktivem `q`; Referenz-ID-Exakt-Treffer
+  darf direkt auf die Detailseite weiterleiten (Verhalten wie Ref-Lookup).
+- Performance: `ILIKE '%…%'` auf 20k Zeilen ist vertretbar; Index-Frage
+  (`pg_trgm`) in der Session prüfen, nicht vorab entscheiden.
+
+### U4 — Eingang: Standardsortierung neueste zuerst (Agent: sonnet)
+
+**Befund:** Der Eingang sortiert per Default älteste zuerst (FIFO). Mit
+~650 offenen Meldungen inkl. Altbestand ab 2013 sieht ein Bearbeiter zuerst
+13 Jahre alte Meldungen; Aktuelles ist nur über den Toggle erreichbar.
+
+**Entscheidung (Jan, 2026-08-08):** Default wird `desc` (neueste zuerst); der
+Toggle bleibt.
+
+**Umsetzung:** In `src/routes/admin/+page.server.ts` den Default von `asc` auf
+`desc` drehen (`?order=asc` bleibt als bewusste Wahl erhalten) und den
+FIFO-Begründungskommentar ersetzen (neue Begründung: Backlog macht FIFO
+unbrauchbar, Entscheidung dokumentieren). Toggle-Beschriftung in
+`src/routes/admin/+page.svelte` prüfen — sie zeigt die **aktive** Richtung an
+und muss mit dem neuen Default weiterhin stimmen.
+
+**Akzeptanz:** `/admin` ohne Parameter zeigt neueste zuerst; `?order=asc`
+zeigt älteste zuerst; Toggle wechselt korrekt.
+**Tests:** `inboxPage.server.test.ts` erweitern (Default-Richtung, explizites
+`asc`).
+
+### U5 — Bulk-Aktionen in der Tabelle (Agent: opus, nach U2)
+
+**Befund:** Offensichtliche Spam-Wellen oder Altbestand lassen sich nur
+zeilenweise abarbeiten.
+
+**Umsetzung:**
+
+- Checkbox-Spalte links (fester Platz wie der Totfund-Marker, **nicht** in
+  `availableColumns`), „Alle auf dieser Seite"-Checkbox im Kopf
+  (indeterminate-Zustand bei Teilauswahl).
+- Aktionsleiste erscheint bei Auswahl > 0 (über der Tabelle): „N ausgewählt —
+  Freigeben / Ablehnen / Auswahl aufheben".
+- Ausführung client-seitig sequenziell über den bestehenden
+  `submitVerdict(id, verdict)` (kein neuer Bulk-Endpunkt — der
+  verify-Endpunkt bleibt der einzige Schreibweg). Fortschrittsanzeige,
+  Fehler je Zeile einsammeln und am Ende als Toast zusammenfassen.
+- Undo: ein Toast „N Sichtungen freigegeben — Rückgängig" mit
+  `SIGHTING_STATUS_UNDO_MS`, Rückgängig schickt `reset` für alle erfolgreichen
+  IDs (gleiches Muster wie Einzel-Undo).
+- Auswahl wird bei Seitenwechsel/Filterwechsel geleert (kein
+  Cross-Page-Gedächtnis — bewusst, sonst löst „Freigeben" Unsichtbares aus).
+
+**Akzeptanz:** Teilfehler blockieren die übrigen nicht; Undo stellt alle
+erfolgreich geänderten zurück; Mobile-Kartenansicht bleibt unverändert
+(Bulk nur Desktop-Tabelle).
+**Tests:** Auswahl-State-Logik als Modul testen (selectAll/teilweise/leeren
+bei Datenwechsel); Verdict-Schleife mit gemocktem `submitVerdict`
+(Teilfehler-Fall).
+
+---
+
+## UX
+
+### X1 — Status- und Aktionsspalte erreichbar machen (Agent: opus, vor U2/U5)
+
+**Befund:** Bei Standard-Spaltenauswahl laufen Status-Control und Aktionen auf
+1456 px aus dem Viewport — genau die Spalten, wegen derer man die Tabelle
+öffnet, erfordern horizontales Scrollen.
+
+**Umsetzung, zwei Teile:**
+
+1. **Default-Spaltenauswahl bereinigen:** `email`, `distance` und
+   `distribution` per Default auf `false` (bleiben über „Spalten" zuschaltbar).
+   Referenz-ID, Datum×2, Tierart, Anzahl, Jung, Aufnahme, Spam, Ostsee,
+   Status, Aktionen bleiben an.
+2. **Fixieren prüfen:** Status + Aktionen als sticky-rechts
+   (`position: sticky; right: 0`) im Scroll-Container. Achtung Zebra/Hover:
+   sticky-Zellen brauchen einen opaken Hintergrund, der Zeilen-Hover und
+   Zebra mitmacht — mit Theme-Tokens lösen (`bg-base-100`/`bg-base-200`),
+   keine Hex-Werte. Wenn das mit `table-zebra` nicht sauber hinzubekommen ist
+   (Kanten, Schatten), ist Teil 1 allein akzeptabel — dann den Verzicht im
+   Code begründen.
+   Zusätzlich: `hover:bg-base-300` von den **nicht** sortierbaren `<th>`
+   entfernen (suggeriert Klickbarkeit).
+
+**Akzeptanz:** Auf 1440 px mit Default-Spalten sind Status + Aktionen ohne
+horizontales Scrollen sicht- und bedienbar.
+**Tests:** bestehende Tabellen-Tests grün; visuelle Verifikation im Browser
+(Screenshot) gehört zur Abnahme.
+
+### X2 — Einstellungen: „Zurücksetzen" entschärfen (Agent: sonnet)
+
+**Befund:** Der Reset-Button ist als voller Warn-Button oben rechts das
+prominenteste Element der Seite — für eine destruktive Aktion die falsche
+Hierarchie (`design-system.md`: destruktiv = `btn btn-outline btn-error`,
+immer mit Bestätigung).
+
+**Umsetzung:** In `src/routes/admin/settings/+page.svelte`: Variante auf
+`btn btn-outline btn-error btn-sm` ändern und aus der Kopfzeile ans Ende der
+Seite (unter die Kategorien) verschieben; Bestätigungsdialog davor — prüfen,
+ob bereits einer existiert (`confirm()` o. ä.): falls nur `confirm()`, auf den
+projektüblichen Dialog (`DeleteDialog.svelte`-Muster) umstellen; der Dialog
+benennt konkret, was passiert („Alle Einstellungen auf die Vorbelegung
+zurücksetzen — gespeicherte Werte gehen verloren").
+
+**Akzeptanz:** Kein Reset ohne expliziten Dialog; Button folgt der
+Destruktiv-Konvention; Primärplatz oben rechts gehört wieder dem Toggle.
+**Tests:** bestehende Settings-Tests grün; Dialog-Flow als Component-Test,
+falls ohne großen Aufwand möglich (sonst begründen).
+
+### X3 — Edit-Seite aufräumen (Agent: opus)
+
+**Befund:** Überschrift sagt „Sichtung Details" statt „bearbeiten";
+„Abbrechen" und der Layout-Button „Zurück zur Tabelle" verwerfen Änderungen
+kommentarlos; der Speichern-Button nutzt `disabled` entgegen dem
+`aria-disabled`-Muster aus `design-system.md`.
+
+**Umsetzung** (`src/routes/admin/[id]/edit/+page.svelte`,
+`AdminSightingEditForm.svelte`):
+
+1. Überschrift und `<title>` auf „Sichtung bearbeiten".
+2. Unsaved-Changes-Guard: Dirty-Zustand aus dem Form-Context ableiten
+   (`createForm` prüfen — gibt es `isDirty`? Sonst Werte-Vergleich gegen
+   `initialValues`). Bei Navigation mit ungespeicherten Änderungen
+   (`beforeNavigate` aus `$app/navigation`) Bestätigung verlangen; erfolgreiches
+   Speichern und „Abbrechen"-Bestätigung setzen den Guard außer Kraft.
+3. Speichern-Button: `disabled={$isSubmitting || !$isValid}` ersetzen nach dem
+   Muster aus `design-system.md` („Gesperrte Schaltflächen"): Wächter in der
+   Handler-Funktion, `aria-disabled` nur für den Laufend-Zustand ist hier
+   **falsch** (fehlende Eingabe → Fehlermeldung zeigen/fokussieren statt
+   sperren; nur der laufende Submit bleibt hart `disabled`). Die Regel-Datei
+   dazu vollständig lesen und das dortige `StepNavigation`-Muster übernehmen.
+
+**Akzeptanz:** Wegnavigieren mit Änderungen fragt nach; Speichern mit
+Validierungsfehlern springt zur Fehlerliste statt still gesperrt zu sein;
+Tastatur-Fokus geht bei laufendem Submit nicht verloren.
+**Tests:** Dirty-Ableitung als Unit-Test; Guard-Verhalten als Component-Test
+soweit machbar, sonst dokumentierte manuelle Verifikation.
+
+### X4 — Statistik-Seite: Beschriftung und Zahlenformat (Agent: sonnet)
+
+**Befund:** (a) Spaltenlabel „Mortalität" behauptet eine Kennzahl, deren
+Nicht-Herleitbarkeit im Kommentar derselben Datei begründet ist (nur Anteil
+der Totfund-_Meldungen_). (b) `formatPercentage` liefert `9.2%` mit
+Dezimalpunkt, direkt neben deutsch formatierten Zahlen (`19.284`).
+
+**Umsetzung** (`src/routes/admin/statistics/+page.svelte`):
+
+1. Spaltenkopf „Mortalität" → „Totfund-Anteil"; die Zellen-Schwellwerte
+   (30 %/15 %) bleiben.
+2. `formatPercentage` auf `Intl.NumberFormat('de-DE', { style: 'percent', maximumFractionDigits: 1 })`
+   bzw. äquivalent mit Komma umstellen (Achtung: `style: 'percent'`
+   multipliziert mit 100 — Eingabewerte entsprechend teilen oder
+   `minimumFractionDigits` mit manueller Division nutzen; Tests entscheiden).
+3. Kurz prüfen, ob weitere „Mortalität"-Wörter auf der Seite stehen (Tabelle
+   Artenverteilung) und mitziehen.
+
+**Akzeptanz:** Alle Prozentwerte der Seite mit Komma; kein „Mortalität" mehr.
+**Tests:** `formatPercentage` als reine Funktion extrahieren + Unit-Tests
+(0, 9.2, 100, String-Input).
+
+---
+
+## Brainstorming (alle als **Follow-Up-Chip**)
+
+Diese fünf sind bewusst keine Agent-Aufgaben: Sie brauchen Produkt- und
+Design-Entscheidungen, teils Schema-Erweiterungen, und verdienen eigene
+Sessions mit eigenem Review.
+
+### B1 — Tastatur-Triage im Eingang
+
+J/K = nächste/vorherige Karte (Fokus-Ring sichtbar), A = Freigeben,
+R = Ablehnen, U = Rückgängig der letzten Aktion, ? = Hilfe-Overlay.
+Nur wenn kein Eingabefeld fokussiert ist. A11y: Fokus-Management beim
+Verschwinden einer Karte (Fokus auf die nächste), Shortcuts im UI entdeckbar
+machen. Undo-Fenster-Logik des Eingangs wiederverwenden.
+
+### B2 — Duplikat-Hinweis
+
+Heuristik: gleiche E-Mail ± gleiche Kalenderstunde, oder Position < 1 km +
+Sichtungszeit < 2 h Abstand. Anzeige als Badge auf der Inbox-Karte
+(„2 ähnliche Meldungen") mit Aufklapper/Link zu den Kandidaten. Serverseitig
+als Zusatz-Query im Inbox-Loader (nur für die 50 gelisteten). Kein
+Auto-Merge — nur Hinweis.
+
+### B3 — Status-Historie pro Sichtung
+
+Neue Tabelle `sichtung_status_log` (sichtung_id, verdict, wer, wann),
+geschrieben ausschließlich vom verify-Endpunkt. Anzeige als Zeitleiste in der
+Detailansicht. Ersetzt perspektivisch die Einzelfelder nicht (Legacy-DB!),
+ergänzt sie. Aufbewahrung/Datenschutz klären (Bearbeiter-Identität).
+
+### B4 — Gespeicherte Filteransichten
+
+Benannte Filter-Presets als Chips über der Tabelle. Persistenz zunächst
+`localStorage` (pro Bearbeiter, kein Schema nötig); Inhalt ist die
+Query-String-Teilmenge aus `tableReturnUrl.ts`-Parameterliste. Verwaltung:
+anlegen aus aktuellem Zustand, umbenennen, löschen. Später optional
+serverseitig teilbar.
+
+### B5 — Statistik: Jahresfilter + echte Charts
+
+Jahres-Auswahl (URL-Parameter) für alle Abschnitte; Saisonalität und
+Jahrestrends als richtige Diagramme statt Progress-Balken. Vorher klären:
+Chart-Bibliothek vs. handgebautes SVG (Projekt hat bisher keine
+Chart-Dependency — Bundle-Abwägung dokumentieren). Museums-Regel beachten:
+keine vermischten Freigabe-Mengen, jede Zahl mit Freigabebezug.

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -88,11 +88,15 @@ export const load: PageServerLoad = async ({ url }) => {
 		});
 	}
 
+	// `count(*)` ist bigint und kommt je nach PG-Treiber als String zurück. Der
+	// Loader-Vertrag sagt `number`, also wird hier normalisiert und nicht in
+	// jeder Aufrufstelle einzeln: `>` verglich sonst lexikografisch ("9" > "50")
+	// und `=== 1` traf nie.
 	return {
 		open,
-		openTotal: openCountResult[0]?.count || 0,
+		openTotal: Number(openCountResult[0]?.count ?? 0),
 		order,
 		imagesBySighting,
-		pendingPhotoAnnouncements: pendingPhotoResult[0]?.count || 0
+		pendingPhotoAnnouncements: Number(pendingPhotoResult[0]?.count ?? 0)
 	};
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -29,10 +29,6 @@
 	   `data.open`. Erst nach dem Reload ist der Server die Wahrheit. */
 	const abgelaufen = new SvelteSet<number>();
 
-	/* Der Zähler kommt je nach Treiber als String aus `count(*)` — ohne Number()
-	   vergleicht `>` lexikografisch ("9" > "50"). */
-	const openTotal = $derived(Number(data.openTotal));
-
 	onDestroy(() => {
 		// Ohne dieses Aufräumen feuert ein laufender Undo-Timer nach dem Verlassen
 		// der Seite noch invalidateAll() und lädt fremde Routen neu.
@@ -99,7 +95,7 @@
 	<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
 		<h1 class="text-2xl font-bold">
 			Eingang
-			<span class="badge badge-outline align-middle">{openTotal} offen</span>
+			<span class="badge badge-outline align-middle">{data.openTotal} offen</span>
 		</h1>
 		<button type="button" class="btn btn-ghost btn-sm" onclick={sortierungUmschalten}>
 			{#if data.order === 'asc'}
@@ -162,9 +158,9 @@
 				{/if}
 			{/each}
 		</ul>
-		{#if openTotal > data.open.length}
+		{#if data.openTotal > data.open.length}
 			<p class="text-base-content/70 mt-4 text-center text-sm">
-				{data.open.length} von {openTotal} offenen Sichtungen angezeigt — die Liste füllt sich beim Abarbeiten
+				{data.open.length} von {data.openTotal} offenen Sichtungen angezeigt — die Liste füllt sich beim Abarbeiten
 				nach.
 			</p>
 		{/if}

--- a/src/routes/admin/[id]/+layout.svelte
+++ b/src/routes/admin/[id]/+layout.svelte
@@ -2,36 +2,12 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import Icon from '$lib/components/Icon.svelte';
+	import { tableReturnUrl } from './tableReturnUrl';
 
 	let { children, data } = $props();
 
 	function handleClose() {
-		// Preserve only the filter-related search parameters
-		const searchParams = page.url.searchParams;
-		const adminUrl = new URL('/admin/sichtungen', page.url.origin);
-
-		// List of filter parameters to preserve
-		const filterParams = [
-			'fromDate',
-			'toDate',
-			'verified',
-			'entryChannel',
-			'mediaUpload',
-			'sort',
-			'order',
-			'page',
-			'perPage'
-		];
-
-		// Copy only filter-related parameters to maintain filters
-		for (const param of filterParams) {
-			const value = searchParams.get(param);
-			if (value) {
-				adminUrl.searchParams.set(param, value);
-			}
-		}
-
-		goto(adminUrl.toString());
+		goto(tableReturnUrl(page.url));
 	}
 </script>
 

--- a/src/routes/admin/[id]/tableReturnUrl.test.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { TABELLEN_PARAMETER, tableReturnUrl } from './tableReturnUrl';
+
+describe('tableReturnUrl — Rückweg aus der Detailansicht', () => {
+	it('behält den Ostsee-Filter (balticSea)', () => {
+		const ziel = tableReturnUrl(new URL('https://x/admin/29518?balticSea=baltic'));
+		expect(new URL(ziel).searchParams.get('balticSea')).toBe('baltic');
+	});
+
+	it('behält den Meldeart-Filter (deadFinding)', () => {
+		const ziel = tableReturnUrl(new URL('https://x/admin/29518?deadFinding=1'));
+		expect(new URL(ziel).searchParams.get('deadFinding')).toBe('1');
+	});
+
+	it('behält Status, Ostsee-Status und Meldeart gemeinsam', () => {
+		const ziel = new URL(
+			tableReturnUrl(new URL('https://x/admin/29518?verified=open&balticSea=baltic&deadFinding=1'))
+		);
+		expect(ziel.pathname).toBe('/admin/sichtungen');
+		expect(ziel.searchParams.get('verified')).toBe('open');
+		expect(ziel.searchParams.get('balticSea')).toBe('baltic');
+		expect(ziel.searchParams.get('deadFinding')).toBe('1');
+	});
+
+	it('übernimmt fremde Parameter nicht', () => {
+		const ziel = new URL(tableReturnUrl(new URL('https://x/admin/29518?tab=media&from=inbox')));
+		expect(ziel.searchParams.has('tab')).toBe(false);
+		expect(ziel.searchParams.has('from')).toBe(false);
+	});
+
+	it('führt ohne Parameter auf die nackte Tabellen-URL', () => {
+		expect(tableReturnUrl(new URL('https://x/admin/29518'))).toBe('https://x/admin/sichtungen');
+	});
+
+	it('deckt alle Filter-Parameter ab, die die Tabelle tatsächlich liest', () => {
+		// Abgleich gegen die Quelle statt gegen eine zweite Liste: Wer der Tabelle
+		// einen Filter hinzufügt, ohne ihn hier nachzuziehen, bekommt genau den
+		// Bug, um den es geht — der Rückweg verlöre ihn still.
+		const quellen = ['+page.server.ts', '+page.svelte'].map((datei) =>
+			readFileSync(new URL(`../sichtungen/${datei}`, import.meta.url), 'utf-8')
+		);
+		const gelesen = new Set<string>();
+		for (const quelle of quellen) {
+			for (const treffer of quelle.matchAll(/searchParams\.get\('([^']+)'\)/g)) {
+				if (treffer[1]) gelesen.add(treffer[1]);
+			}
+		}
+
+		expect(gelesen.size).toBeGreaterThan(0);
+		expect([...gelesen].sort()).toEqual([...TABELLEN_PARAMETER].sort());
+	});
+});

--- a/src/routes/admin/[id]/tableReturnUrl.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.ts
@@ -1,0 +1,39 @@
+/**
+ * Baut den Rückweg aus der Detailansicht zurück auf `/admin/sichtungen`.
+ *
+ * Die Detailansicht wird mit **allen** Parametern der Tabelle aufgerufen
+ * (`viewSightingDetails` kopiert sie unbesehen); zurück gehen darf nur, was die
+ * Tabelle auch liest. Diese Liste lag bis 2026-08 inline im `+layout.svelte` —
+ * und hat `balticSea` und `deadFinding` nie nachgezogen, als die beiden Filter
+ * dazukamen: Wer nach Ostsee-Status oder Meldeart filterte, eine Sichtung
+ * öffnete und zurückging, stand wieder vor der ungefilterten Tabelle. Deshalb
+ * eigenes Modul statt Inline-Liste — `tableReturnUrl.test.ts` gleicht sie gegen
+ * die tatsächlich in `sichtungen/` gelesenen Parameter ab und meldet die nächste
+ * solche Lücke, statt sie still entstehen zu lassen.
+ */
+export const TABELLEN_PARAMETER = [
+	'fromDate',
+	'toDate',
+	'verified',
+	'entryChannel',
+	'mediaUpload',
+	'balticSea',
+	'deadFinding',
+	'sort',
+	'order',
+	'page',
+	'perPage'
+] as const;
+
+export function tableReturnUrl(currentUrl: URL): string {
+	const zielUrl = new URL('/admin/sichtungen', currentUrl.origin);
+
+	for (const param of TABELLEN_PARAMETER) {
+		const wert = currentUrl.searchParams.get(param);
+		if (wert) {
+			zielUrl.searchParams.set(param, wert);
+		}
+	}
+
+	return zielUrl.toString();
+}

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -203,4 +203,21 @@ describe('Eingangs-Load', () => {
 		expect(recordedSelects[0]?.limit).toBeGreaterThan(0);
 		expect(recordedSelects[1]?.limit).toBeUndefined();
 	});
+
+	/**
+	 * `count(*)` ist bigint und kommt je nach Treiber als **String** zurück. Die
+	 * Seite verglich damit lexikografisch (`"9" > "50"`) bzw. auf Identität
+	 * (`"1" === 1` ist falsch → „1 Fotos ausstehend"). Der Loader-Vertrag sagt
+	 * `number`, also normalisiert der Loader — nicht jede Aufrufstelle einzeln.
+	 */
+	it('liefert beide Zähler als Zahl, auch wenn der Treiber Strings liefert', async () => {
+		resolvedRows = [[{ id: 1 }, { id: 2 }], [{ count: '50' }], [{ count: '1' }], []];
+
+		const result = await runLoad(makeUrl());
+
+		expect(result.openTotal).toBe(50);
+		expect(typeof result.openTotal).toBe('number');
+		expect(result.pendingPhotoAnnouncements).toBe(1);
+		expect(typeof result.pendingPhotoAnnouncements).toBe('number');
+	});
 });

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -36,15 +36,23 @@ export const load: PageServerLoad = async ({ url }) => {
 	// Bedingungen für die SQL-Abfrage sammeln
 	const conditions: SQL[] = [];
 
-	// Datums-Filter (nur mit validiertem YYYY-MM-DD Format)
+	// Datums-Filter (nur mit validiertem YYYY-MM-DD Format). Beide Grenzen sind
+	// unabhängig voneinander optional: „alles ab dem 01.06." ist der erwartete
+	// Fall, nicht die Ausnahme. Vorher griff der Filter nur, wenn beide Felder
+	// gesetzt waren — wer eines ausfüllte, bekam kommentarlos die ungefilterte
+	// Liste und hielt sie für gefiltert.
+	//
+	// Kalendertag in deutscher Ortszeit: `fromDate`/`toDate` kommen als lokales
+	// "YYYY-MM-DD" aus der Admin-UI, `sichtungsdatum` hält seit der UTC-Migration
+	// echte Zeitpunkte. Ohne Umrechnung fiele eine Sichtung vom 15.07. um 00:30
+	// Ortszeit (= 14.07. 22:30 UTC) aus dem Filter.
+	const sightingCalendarDate = berlinCalendarDate(sightings.sightingDate);
 	if (isValidDateParam(fromDate) && isValidDateParam(toDate)) {
-		// Kalendertag in deutscher Ortszeit: `fromDate`/`toDate` kommen als lokales
-		// "YYYY-MM-DD" aus der Admin-UI, `sichtungsdatum` hält seit der UTC-Migration
-		// echte Zeitpunkte. Ohne Umrechnung fiele eine Sichtung vom 15.07. um 00:30
-		// Ortszeit (= 14.07. 22:30 UTC) aus dem Filter.
-		conditions.push(
-			sql`${berlinCalendarDate(sightings.sightingDate)} BETWEEN ${fromDate} AND ${toDate}`
-		);
+		conditions.push(sql`${sightingCalendarDate} BETWEEN ${fromDate} AND ${toDate}`);
+	} else if (isValidDateParam(fromDate)) {
+		conditions.push(sql`${sightingCalendarDate} >= ${fromDate}`);
+	} else if (isValidDateParam(toDate)) {
+		conditions.push(sql`${sightingCalendarDate} <= ${toDate}`);
 	}
 
 	// Statusfilter über dieselben Prädikate wie die öffentlichen Flächen —
@@ -144,8 +152,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		countQuery,
 		pendingPhotoQuery
 	]);
-	const count = countResult[0]?.count || 0;
-	const pendingPhotoAnnouncements = pendingPhotoResult[0]?.count || 0;
+	// `count(*)` ist bigint und kommt je nach PG-Treiber als String zurück. Der
+	// Loader-Vertrag sagt `number`, also wird hier normalisiert und nicht in
+	// jeder Aufrufstelle einzeln: `"1" === 1` ist falsch und ergab in der
+	// Kopfzeile „1 Fotos ausstehend".
+	const count = Number(countResult[0]?.count ?? 0);
+	const pendingPhotoAnnouncements = Number(pendingPhotoResult[0]?.count ?? 0);
 
 	return {
 		sightings: data,

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -17,7 +17,7 @@
  * kompiliert.
  */
 import { PgDialect } from 'drizzle-orm/pg-core';
-import type { SQL, SQLWrapper } from 'drizzle-orm';
+import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
@@ -26,6 +26,8 @@ import {
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { rejectedOnly } from '$lib/server/db/approvalFilter';
+import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
+import { sightings } from '$lib/server/db/schema';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
@@ -210,5 +212,105 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		const expected = toSqlText(rejectedOnly());
 		expect(recordedSelects[0]?.whereSql).toBe(expected);
 		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+});
+
+/**
+ * Der Datumsfilter der Tabelle hat zwei unabhängige Felder — „Von" und „Bis".
+ * Bis 2026-08 griff er nur, wenn **beide** gültig gesetzt waren: Wer nur eine
+ * Grenze eintrug, bekam kommentarlos die ungefilterte Liste zurück und hielt
+ * das Ergebnis für gefiltert. Offene Grenzen sind der erwartete Fall („alles
+ * ab dem 01.06."), nicht die Ausnahme.
+ */
+describe('admin/sichtungen/+page.server load() — Datumsfilter mit offenen Grenzen', () => {
+	/** Kalendertag-Ausdruck der Abfrage — derselbe wie in `load()`. */
+	const kalendertag = berlinCalendarDate(sightings.sightingDate);
+
+	beforeEach(() => {
+		recordedSelects = [];
+		resolvedRows = [[{ id: 1 }], [{ count: 5 }], [{ count: 2 }]];
+	});
+
+	it('filtert mit beiden Grenzen weiterhin über BETWEEN', async () => {
+		await load({
+			url: makeUrl({ fromDate: '2024-06-01', toDate: '2024-06-30' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(
+			sql`${kalendertag} BETWEEN ${'2024-06-01'} AND ${'2024-06-30'}` as unknown as SQLWrapper
+		);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+
+	it('filtert mit nur „Von" ab diesem Kalendertag', async () => {
+		await load({
+			url: makeUrl({ fromDate: '2024-06-01' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(sql`${kalendertag} >= ${'2024-06-01'}` as unknown as SQLWrapper);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+
+	it('filtert mit nur „Bis" bis zu diesem Kalendertag', async () => {
+		await load({
+			url: makeUrl({ toDate: '2024-06-30' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(sql`${kalendertag} <= ${'2024-06-30'}` as unknown as SQLWrapper);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+
+	it('ignoriert eine ungültige Grenze, statt sie in die Abfrage zu tragen', async () => {
+		await load({
+			url: makeUrl({ fromDate: 'quatsch', toDate: '2024-06-30' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(sql`${kalendertag} <= ${'2024-06-30'}` as unknown as SQLWrapper);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+	});
+
+	it('filtert ohne gültige Grenze gar nicht', async () => {
+		await load({
+			url: makeUrl({ fromDate: 'quatsch', toDate: '2024-13-99' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(recordedSelects[0]?.whereSql).toBeUndefined();
+	});
+});
+
+/**
+ * `count(*)` kommt je nach PG-Treiber als **String** zurück (bigint). Die Seite
+ * verglich `pendingPhotoAnnouncements === 1` und zeigte deshalb „1 Fotos
+ * ausstehend". Die Normalisierung gehört in den Loader, nicht in jede
+ * Aufrufstelle: Ein Loader-Vertrag mit `number` gilt für alle.
+ */
+describe('admin/sichtungen/+page.server load() — Zähler sind Zahlen, keine Strings', () => {
+	beforeEach(() => {
+		recordedSelects = [];
+		resolvedRows = [[{ id: 1 }], [{ count: '42' }], [{ count: '1' }]];
+	});
+
+	it('liefert pendingPhotoAnnouncements als Zahl, auch wenn der Treiber einen String liefert', async () => {
+		const result = (await load({
+			url: makeUrl()
+		} as unknown as Parameters<typeof load>[0])) as { pendingPhotoAnnouncements: number };
+
+		expect(result.pendingPhotoAnnouncements).toBe(1);
+		expect(typeof result.pendingPhotoAnnouncements).toBe('number');
+	});
+
+	it('liefert pagination.total als Zahl und rechnet totalPages daraus', async () => {
+		const result = (await load({
+			url: makeUrl({ perPage: '20' })
+		} as unknown as Parameters<typeof load>[0])) as {
+			pagination: { total: number; totalPages: number };
+		};
+
+		expect(result.pagination.total).toBe(42);
+		expect(typeof result.pagination.total).toBe('number');
+		expect(result.pagination.totalPages).toBe(3);
 	});
 });

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -1,13 +1,9 @@
 import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
-import {
-	approvalFilter,
-	approvedOnly,
-	type ResolvedSightingScope
-} from '$lib/server/db/approvalFilter';
+import { approvedOnly, openOnly } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate, berlinDatePart } from '$lib/server/db/sqlTimeZone';
-import { and, isNotNull, ne, sql } from 'drizzle-orm';
+import { and, isNotNull, ne, sql, type SQL } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
 
 const logger = createLogger('admin:statistics:page');
@@ -43,14 +39,19 @@ const EMPTY_BASIC_STATS: AdminBasicStats = {
 };
 
 /**
- * Basis-Kennzahlen für **einen** Freigabestatus
+ * Basis-Kennzahlen für **eine** Grundmenge
  *
  * Vorgabe des Meeresmuseums: Nicht freigegebene Sichtungen dürfen in der
  * Admin-Statistik vorkommen, aber niemals mit freigegebenen zu einer Zahl
  * verschmelzen. Zwei getrennte Läufe statt einer Abfrage über die ganze
  * Tabelle machen eine vermischte Summe strukturell unmöglich.
+ *
+ * Die Grundmenge kommt als fertiges Prädikat herein statt als Scope-Name: Diese
+ * Seite fährt seit 2026-08-08 `approvedOnly()` gegen `openOnly()` und damit
+ * keine der beiden Hälften von `approvalFilter()` (Begründung an der
+ * Aufrufstelle in `load()`).
  */
-async function loadBasicStats(scope: ResolvedSightingScope): Promise<AdminBasicStats> {
+async function loadBasicStats(grundmenge: SQL): Promise<AdminBasicStats> {
 	const [row] = await db
 		.select({
 			totalSightings: sql<number>`COUNT(*)::integer`,
@@ -60,19 +61,33 @@ async function loadBasicStats(scope: ResolvedSightingScope): Promise<AdminBasicS
 			withMedia: sql<number>`COUNT(CASE WHEN ${sightings.mediaUpload} != 0 THEN 1 END)::integer`
 		})
 		.from(sightings)
-		.where(approvalFilter(scope));
+		.where(grundmenge);
 
 	return row ?? EMPTY_BASIC_STATS;
 }
 
 export const load: PageServerLoad = async () => {
 	try {
-		// Basis-Kennzahlen getrennt nach Freigabestatus
-		const [approvedStats, pendingStats] = await Promise.all([
-			loadBasicStats('approved'),
-			loadBasicStats('pending')
+		// Basis-Kennzahlen getrennt nach Grundmenge: freigegeben und offen.
+		//
+		// Die zweite Menge lief bis 2026-08-08 über `pendingOnly()` („nicht
+		// freigegeben") und zählte damit die abgelehnten Sichtungen mit, obwohl die
+		// Anzeige sie an jeder Stelle „noch offen" nennt. Der Eingang (`/admin`)
+		// zählt seit der Rejection-Triage über `openOnly()` — beide Seiten wichen
+		// dadurch sichtbar voneinander ab (gemessen 663 hier gegen 657 dort, die
+		// Differenz waren die 6 Abgelehnten). Abgelehnt ist erledigt, nicht offen.
+		//
+		// `approvalFilter()` bleibt davon unberührt: Sein `'pending'` meint weiter
+		// „nicht freigegeben" und ist die Gegenmenge der öffentlichen Statistik
+		// (`getSightingStatistics`) — dort wäre der Ausschluss der Abgelehnten
+		// falsch, weil er eine dritte Menge neben freigegeben/nicht freigegeben
+		// aufmachte. Deshalb ändert sich hier die Aufrufstelle und nicht das
+		// gemeinsame Prädikat.
+		const [approvedStats, openStats] = await Promise.all([
+			loadBasicStats(approvedOnly()),
+			loadBasicStats(openOnly())
 		]);
-		const basicStats = { approved: approvedStats, pending: pendingStats };
+		const basicStats = { approved: approvedStats, open: openStats };
 
 		// Species distribution
 		const speciesStats = await db

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -72,8 +72,13 @@
 				<h1 class="text-base-content text-3xl font-bold">Statistiken</h1>
 				<p class="text-base-content/70 mt-2">
 					Analyse von {formatNumber(data.basicStats?.approved.totalSightings || 0)} freigegebenen Meerestier-Sichtungen
+					<!-- „noch offen" und nicht „noch nicht freigegeben": Die Zahl zählt seit
+					     2026-08-08 über `openOnly()`, also ohne die abgelehnten Sichtungen —
+					     dieselbe Menge wie der Eingang auf `/admin`. Wer hier „nicht
+					     freigegeben" schreibt, verspricht die Gegenmenge der Freigabe und
+					     weicht damit wieder um die Abgelehnten vom Eingang ab. -->
 					<span class="text-base-content/70">
-						· {formatNumber(data.basicStats?.pending.totalSightings || 0)} noch nicht freigegeben
+						· {formatNumber(data.basicStats?.open.totalSightings || 0)} noch offen
 					</span>
 				</p>
 			</div>
@@ -132,7 +137,7 @@
 					</div>
 					<div class="stat-desc">
 						<span class="text-warning-strong"
-							>{formatNumber(data.basicStats?.pending.totalSightings || 0)} noch offen</span
+							>{formatNumber(data.basicStats?.open.totalSightings || 0)} noch offen</span
 						>
 					</div>
 				</div>
@@ -172,7 +177,7 @@
 						)} der freigegebenen
 						<br />
 						<span class="text-warning-strong"
-							>{formatNumber(data.basicStats?.pending.deadAnimals || 0)} noch offen</span
+							>{formatNumber(data.basicStats?.open.deadAnimals || 0)} noch offen</span
 						>
 					</div>
 				</div>

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -19,6 +19,7 @@ import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { describe, expect, it, vi } from 'vitest';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
+import { openOnly } from '$lib/server/db/approvalFilter';
 
 const dialect = new PgDialect();
 const toSqlText = (expression: SQLWrapper): string => dialect.sqlToQuery(expression.getSQL()).sql;
@@ -153,9 +154,43 @@ describe('admin/statistics load() — einheitliche Grundmenge', () => {
 
 		const texte = recordedWhereClauses.map(toSqlText);
 
-		// `loadBasicStats` läuft zweimal — einmal je Freigabestatus. Eine vermischte
+		// `loadBasicStats` läuft zweimal — einmal je Grundmenge. Eine vermischte
 		// Summe über beide soll strukturell unmöglich bleiben (Vorgabe 2).
 		expect(texte.some((t) => /freigegeben_am"? is not null/i.test(t))).toBe(true);
 		expect(texte.some((t) => /freigegeben_am"? is null/i.test(t))).toBe(true);
+	});
+});
+
+/**
+ * „Noch offen" muss auf dieser Seite dasselbe heißen wie im Eingang (`/admin`).
+ *
+ * Bug: Die zweite Kopfzahl lief über `pendingOnly()` (`freigegeben_am IS NULL`)
+ * und zählte damit die **abgelehnten** Sichtungen mit, während die Beschriftung
+ * an drei Stellen „noch offen" bzw. „noch nicht freigegeben" sagte. Der Eingang
+ * zählt seit der Rejection-Triage (#793/#794/#797) über `openOnly()` — gemessen
+ * am Produktionsstand ergab das 663 hier gegen 657 dort, die Differenz waren
+ * genau die 6 Abgelehnten. Abgelehnt ist erledigt, nicht offen.
+ *
+ * Der Test vergleicht gegen `openOnly()` selbst statt gegen abgetipptes SQL:
+ * Eine nachgebaute Zeichenkette wäre eine zweite Quelle neben dem Prädikat.
+ */
+describe('admin/statistics load() — „noch offen" schließt Abgelehnte aus', () => {
+	it('zählt die offene Kopfzahl über openOnly() statt über pendingOnly()', async () => {
+		recordedWhereClauses = [];
+
+		await load({} as unknown as Parameters<typeof load>[0]);
+
+		const texte = recordedWhereClauses.map(toSqlText);
+		const offeneAbfragen = texte.filter((t) => /freigegeben_am"? is null/i.test(t));
+
+		expect(
+			offeneAbfragen.length,
+			'keine Abfrage auf die nicht freigegebene Menge gefunden'
+		).toBeGreaterThan(0);
+
+		const erwartet = toSqlText(openOnly());
+		for (const text of offeneAbfragen) {
+			expect(text, `Abfrage zählt Abgelehnte als „noch offen" mit:\n${text}`).toBe(erwartet);
+		}
 	});
 });

--- a/src/routes/api/sightings/export/exportFilterParams.test.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.test.ts
@@ -127,9 +127,47 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 		expect(includes(range, '2024-12-31T23:30:00.000Z')).toBe(false);
 	});
 
-	it('lässt den Datumsfilter weg, wenn nur eine Grenze gesetzt ist', () => {
+	/**
+	 * Offene Grenzen wie in der Tabelle (`/admin/sichtungen`): Der Export erbt
+	 * die Filter der Ansicht, aus der er ausgelöst wird. Ließe er eine einzeln
+	 * gesetzte Grenze weg, enthielte die Datei mehr Zeilen, als der Nutzer
+	 * gerade gesehen hat — genau die Falle, die bei `mediaUpload` und
+	 * `balticSea` schon einmal vermieden wurde.
+	 */
+	it('filtert mit nur „Von" ab Berliner Mitternacht dieses Tages, ohne Obergrenze', () => {
 		const conditions = buildExportConditions({
 			fromDate: '2024-06-01',
+			toDate: '',
+			verified: null,
+			entryChannel: null,
+			mediaUpload: null,
+			deadFinding: null,
+			balticSea: null
+		}) as unknown as Condition[];
+
+		expect(conditions.map((condition) => condition.op)).toEqual(['gte']);
+		expect((conditions[0]!.value as Date).toISOString()).toBe('2024-05-31T22:00:00.000Z');
+	});
+
+	it('filtert mit nur „Bis" bis vor Berliner Mitternacht des Folgetags, ohne Untergrenze', () => {
+		const conditions = buildExportConditions({
+			fromDate: '',
+			toDate: '2024-06-30',
+			verified: null,
+			entryChannel: null,
+			mediaUpload: null,
+			deadFinding: null,
+			balticSea: null
+		}) as unknown as Condition[];
+
+		expect(conditions.map((condition) => condition.op)).toEqual(['lt']);
+		// Der letzte Tag gehört vollständig dazu: 30.06. 23:30 Berlin = 21:30Z.
+		expect((conditions[0]!.value as Date).toISOString()).toBe('2024-06-30T22:00:00.000Z');
+	});
+
+	it('lässt den Datumsfilter weg, wenn keine Grenze gesetzt ist', () => {
+		const conditions = buildExportConditions({
+			fromDate: '',
 			toDate: '',
 			verified: null,
 			entryChannel: null,

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -59,13 +59,20 @@ export function buildExportConditions(params: ExportFilterParams) {
 	const { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea } = params;
 	const conditions = [];
 
-	if (isValidDateParam(fromDate) && isValidDateParam(toDate)) {
-		// fromDate/toDate meinen Berliner Kalendertage, die Spalte hält UTC.
-		// Halboffenes Intervall statt BETWEEN, damit der letzte Tag vollständig
-		// enthalten ist; beide Grenzen treffen den Index auf der rohen Spalte.
-		const { start, endExclusive } = berlinDayRangeUtc(fromDate, toDate);
-		conditions.push(gte(sightingsTable.sightingDate, start));
-		conditions.push(lt(sightingsTable.sightingDate, endExclusive));
+	// fromDate/toDate meinen Berliner Kalendertage, die Spalte hält UTC.
+	// Halboffenes Intervall statt BETWEEN, damit der letzte Tag vollständig
+	// enthalten ist; beide Grenzen treffen den Index auf der rohen Spalte.
+	//
+	// Jede Grenze gilt für sich: Der Export erbt die Filter der Tabelle
+	// (`/admin/sichtungen`), die seit 2026-08 ebenfalls offene Grenzen kennt —
+	// sonst enthielte die Datei mehr Zeilen, als der Nutzer gesehen hat.
+	if (isValidDateParam(fromDate)) {
+		conditions.push(gte(sightingsTable.sightingDate, berlinDayRangeUtc(fromDate, fromDate).start));
+	}
+	if (isValidDateParam(toDate)) {
+		conditions.push(
+			lt(sightingsTable.sightingDate, berlinDayRangeUtc(toDate, toDate).endExclusive)
+		);
 	}
 	// Dieselbe Logik wie die Tabelle — sonst enthält die CSV eine andere Menge,
 	// als der Nutzer im Filter gesehen hat.


### PR DESCRIPTION
## Zusammenfassung

Vier im Admin-Review vom 2026-08-08 gefundene und im Browser verifizierte Bugs, jeweils test-first behoben:

1. **Filterverlust am „Zurück zur Tabelle"-Link** — die Parameter-Whitelist im Detail-Layout kannte `balticSea` und `deadFinding` nicht. Die Liste lebt jetzt in `tableReturnUrl.ts`; ein Abgleich-Test liest die von der Tabelle tatsächlich gelesenen Parameter aus dem Quelltext und wird rot, wenn ein künftiger Filter nicht nachgezogen wird.
2. **„1 Fotos ausstehend"** — `count(*)` kommt je nach Treiber als String, der strikte Plural-Vergleich schlug fehl. Die Loader normalisieren Counts jetzt per `Number()`; der alte Client-Workaround im Eingang ist entfernt.
3. **Datumsfilter nur mit beiden Grenzen** — nur „Von" oder nur „Bis" wurde kommentarlos ignoriert. Tabelle und Export unterstützen jetzt offene Grenzen; der Export behält bewusst sein indexfreundliches UTC-Intervall-Modell (im Code begründet).
4. **Statistik zählte Abgelehnte als „noch offen"** (663 vs. 657 im Eingang) — die Kopfzahlen laufen jetzt über `openOnly()`, konsistent mit dem Eingang. Das gemeinsame `pendingOnly()` bleibt unverändert, weil die öffentliche Statistik die alte Semantik braucht.

Außerdem: `docs/ADMIN_IMPROVEMENTS_SPEC.md` — Spec für die weiteren Review-Punkte (Usability/UX/Brainstorming) mit Umsetzungs-Routing.

## Test plan

- [x] `npm run test:quick` grün (253 Dateien, 3877 Tests, inkl. `approvalPredicateScan`, `verifiedReadScan`, `statisticsApprovalScope`)
- [x] Neue Regressionstests je Bug (tableReturnUrl 6 Tests, Loader-Counts, Datumsfilter Tabelle+Export, Statistik openOnly)
- [ ] E2E-Suite in CI beobachten — Bug 3 ändert die Ergebnismenge der Tabelle bei einseitigem Datumsfilter

🤖 Generated with [Claude Code](https://claude.com/claude-code)