### PR TITLE
feat(admin): Jahresfilter und echte Diagramme für die Statistikseite

### DIFF
--- a/docs/ADMIN_IMPROVEMENTS_SPEC.md
+++ b/docs/ADMIN_IMPROVEMENTS_SPEC.md
@@ -288,3 +288,31 @@ Jahrestrends als richtige Diagramme statt Progress-Balken. Vorher klären:
 Chart-Bibliothek vs. handgebautes SVG (Projekt hat bisher keine
 Chart-Dependency — Bundle-Abwägung dokumentieren). Museums-Regel beachten:
 keine vermischten Freigabe-Mengen, jede Zahl mit Freigabebezug.
+
+**Entscheidung (2026-08-08): handgebautes SVG, keine Chart-Abhängigkeit.**
+Gebraucht werden zwei Diagramme derselben Form — kategoriale Balken über einer
+linearen Achse. Chart.js (~60 kB gzip), ApexCharts (~130 kB) oder LayerChart
+(zieht d3-Module nach) wären dafür die größte Einzelabhängigkeit im Bundle,
+obwohl nur eine Admin-Seite sie braucht. Drei Punkte gaben zusätzlich den
+Ausschlag:
+
+- **Theme-Tokens statt Canvas-Farben.** Die Bibliotheken zeichnen überwiegend
+  auf Canvas und brauchen Farben als Zeichenketten — genau der Fall, für den
+  `mapTokens.ts` bei OpenLayers Hex-Werte am Theme vorbei pflegen muss
+  (`design-system.md`, „Randbereiche"). SVG-Elemente tragen Utility-Klassen und
+  damit dieselben Tokens wie der Rest der Seite; ein vierter Hex-Randbereich
+  entsteht nicht.
+- **Serverseitig gerendert.** Das Markup entsteht im SSR-Durchlauf, das
+  Diagramm ist ohne JavaScript da.
+- **Textalternative aus denselben Daten** (WCAG 1.1.1): eine aufklappbare
+  Wertetabelle aus derselben Datenreihe statt einer zweiten, driftenden
+  Aufbereitung.
+
+Umgesetzt in `src/lib/components/charts/` — Geometrie als reine Funktionen
+(`barChartScale.ts`, unit-getestet), Darstellung in `BarChart.svelte`.
+
+**Zwei Abfragen tragen die Jahresauswahl bewusst nicht:** die Jahrestrends (auf
+ein Jahr gefiltert bliebe ein einzelner Balken — das gewählte Jahr wird darin
+stattdessen hervorgehoben) und die Liste der auswählbaren Jahre (sonst ließe
+sich die Auswahl nach dem ersten Wechsel nicht mehr verlassen). Beides ist an
+den Abfragen begründet und in `page.server.test.ts` festgehalten.

--- a/src/lib/components/charts/BarChart.svelte
+++ b/src/lib/components/charts/BarChart.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import { layoutBars, type BarDatum } from './barChartScale';
+
+	interface Props {
+		/** Datenreihe in Anzeigereihenfolge (links nach rechts). */
+		data: BarDatum[];
+		/** Was das Diagramm zeigt — wird zur Textalternative des SVG (WCAG 1.1.1). */
+		caption: string;
+		/** Spaltenüberschrift der Kategorie in der Wertetabelle, z. B. „Monat". */
+		categoryLabel: string;
+		/** Spaltenüberschrift der Werte, z. B. „Sichtungen". */
+		valueLabel: string;
+		/** Erklärt, was ein hervorgehobener Balken bedeutet. */
+		highlightNote?: string;
+		/** Höchstzahl an Achsenbeschriftungen, bevor ausgedünnt wird. */
+		maxLabels?: number;
+		/** Zahlenformatierung, damit die Seite ihr `Intl`-Format behält. */
+		formatValue?: (value: number) => string;
+	}
+
+	let {
+		data,
+		caption,
+		categoryLabel,
+		valueLabel,
+		highlightNote,
+		maxLabels = 12,
+		formatValue = (value: number) => new Intl.NumberFormat('de-DE').format(value)
+	}: Props = $props();
+
+	/** Zeichenfläche in viewBox-Einheiten — das SVG skaliert über die Breite mit. */
+	const PLOT_WIDTH = 600;
+	const PLOT_HEIGHT = 180;
+	/** Platz unter der Grundlinie für die Achsenbeschriftung. */
+	const LABEL_BAND = 22;
+	/**
+	 * Platz **über** der Zeichenfläche für die Wertbeschriftung.
+	 *
+	 * Ohne ihn wurde die Beschriftung des höchsten Balkens auf den oberen Rand
+	 * geklemmt und landete damit im Balken — dunkle Schrift auf dunkler Fläche,
+	 * dazu auf der Achsenlinie. Bei zwölf Monaten trifft das jeden Monat einen
+	 * Balken, weil einer immer die Achsenobergrenze erreicht.
+	 */
+	const TOP_BAND = 16;
+
+	const layout = $derived(
+		layoutBars(data, { width: PLOT_WIDTH, height: PLOT_HEIGHT, gap: 6, maxLabels })
+	);
+
+	/** Werte über den Balken nur, solange sie nicht ineinanderlaufen. */
+	const zeigeWerte = $derived(data.length <= 12);
+
+	const titelId = $props.id();
+</script>
+
+<figure class="m-0">
+	<svg
+		viewBox="0 0 {PLOT_WIDTH} {TOP_BAND + PLOT_HEIGHT + LABEL_BAND}"
+		class="h-56 w-full"
+		role="img"
+		aria-labelledby={titelId}
+	>
+		<title id={titelId}>{caption}</title>
+
+		<g transform="translate(0 {TOP_BAND})">
+			<!-- Obergrenze der Achse: gestrichelt, damit sie nicht wie ein Datenwert
+			     aussieht. Nur diese eine Hilfslinie — mehr Raster verdichtet die Fläche,
+			     ohne dass eine Übersichtsgrafik davon genauer würde. -->
+			<line
+				x1="0"
+				y1="0.5"
+				x2={PLOT_WIDTH}
+				y2="0.5"
+				class="stroke-base-300"
+				stroke-width="1"
+				stroke-dasharray="4 4"
+			/>
+			{#if !zeigeWerte}
+				<!-- Nur wenn die Balken ihre Werte nicht selbst tragen: Sonst stünde
+				     dieselbe Zahl zweimal fast an derselben Stelle. -->
+				<text x="2" y="-4" class="fill-base-content/70" font-size="11">
+					{formatValue(layout.axisMax)}
+				</text>
+			{/if}
+
+			{#each layout.bars as bar (bar.label)}
+				<!-- Die Hervorhebung trägt zusätzlich eine Kontur und eine fette
+			     Beschriftung: Farbe allein darf kein Bedeutungsträger sein (WCAG 1.4.1). -->
+				<rect
+					x={bar.x}
+					y={bar.y}
+					width={bar.width}
+					height={bar.height}
+					rx="2"
+					class={bar.highlighted ? 'fill-accent-strong' : 'fill-primary'}
+					stroke-width={bar.highlighted ? 1.5 : 0}
+					stroke={bar.highlighted ? 'currentColor' : 'none'}
+				/>
+				{#if zeigeWerte && bar.value > 0}
+					<text
+						x={bar.x + bar.width / 2}
+						y={bar.y - 4}
+						text-anchor="middle"
+						class="fill-base-content"
+						font-size="11"
+					>
+						{formatValue(bar.value)}
+					</text>
+				{/if}
+				{#if bar.showLabel}
+					<text
+						x={bar.x + bar.width / 2}
+						y={PLOT_HEIGHT + 15}
+						text-anchor="middle"
+						class="fill-base-content"
+						font-size="11"
+						font-weight={bar.highlighted ? '700' : '400'}
+					>
+						{bar.label}
+					</text>
+				{/if}
+			{/each}
+
+			<line
+				x1="0"
+				y1={PLOT_HEIGHT + 0.5}
+				x2={PLOT_WIDTH}
+				y2={PLOT_HEIGHT + 0.5}
+				class="stroke-base-300"
+				stroke-width="1"
+			/>
+		</g>
+	</svg>
+
+	<!-- Textalternative zum Diagramm (WCAG 1.1.1). Sie steht aufklappbar und nicht
+	     nur für Screenreader versteckt: Wer eine Zahl ablesen will, statt sie am
+	     Balken zu schätzen, braucht dieselbe Tabelle. Quelle sind dieselben Daten
+	     wie im SVG — eine zweite, driftende Aufbereitung gibt es nicht. -->
+	<figcaption class="mt-2">
+		<details>
+			<summary class="text-support text-base-content/70 cursor-pointer">
+				Werte als Tabelle
+			</summary>
+			<div class="mt-2 overflow-x-auto">
+				<table class="table-sm table">
+					<caption class="sr-only">{caption}</caption>
+					<thead>
+						<tr>
+							<th scope="col">{categoryLabel}</th>
+							<th scope="col">{valueLabel}</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data as datum (datum.label)}
+							<tr>
+								<th scope="row" class="font-normal">
+									{datum.label}{#if datum.highlighted && highlightNote}
+										<span class="text-base-content/70"> ({highlightNote})</span>
+									{/if}
+								</th>
+								<td>{formatValue(datum.value)}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</details>
+	</figcaption>
+</figure>

--- a/src/lib/components/charts/BarChart.svelte.test.ts
+++ b/src/lib/components/charts/BarChart.svelte.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Textalternative und Hervorhebung des Balkendiagramms
+ *
+ * Ein `role="img"` nimmt den Inhalt des SVG aus dem Accessibility-Tree — was
+ * darin an Zahlen steht, ist für Screenreader nicht vorhanden. Die Alternative
+ * ist deshalb keine Kür, sondern die einzige Fassung der Daten, die dort ankommt
+ * (WCAG 1.1.1). Sie kann verschwinden, ohne dass irgendetwas bricht; genau
+ * dagegen laufen diese Tests.
+ */
+
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import { describe, expect, it } from 'vitest';
+import BarChart from './BarChart.svelte';
+
+const DATEN = [
+	{ label: '2024', value: 120 },
+	{ label: '2025', value: 340, highlighted: true }
+];
+
+describe('BarChart', () => {
+	it('benennt das Diagramm für Screenreader', async () => {
+		render(BarChart, {
+			data: DATEN,
+			caption: 'Jahrestrends: freigegebene Sichtungen je Jahr',
+			categoryLabel: 'Jahr',
+			valueLabel: 'Sichtungen'
+		});
+
+		await expect
+			.element(page.getByRole('img', { name: 'Jahrestrends: freigegebene Sichtungen je Jahr' }))
+			.toBeInTheDocument();
+	});
+
+	it('gibt jeden Wert zusätzlich als Tabelle aus', async () => {
+		render(BarChart, {
+			data: DATEN,
+			caption: 'Jahrestrends',
+			categoryLabel: 'Jahr',
+			valueLabel: 'Sichtungen'
+		});
+
+		await page.getByText('Werte als Tabelle').click();
+
+		const tabelle = page.getByRole('table');
+		await expect.element(tabelle).toBeInTheDocument();
+		await expect.element(page.getByRole('rowheader', { name: /2024/ })).toBeInTheDocument();
+		await expect.element(page.getByRole('cell', { name: '340' })).toBeInTheDocument();
+	});
+
+	it('benennt die Hervorhebung im Text, nicht nur in der Farbe', async () => {
+		render(BarChart, {
+			data: DATEN,
+			caption: 'Jahrestrends',
+			categoryLabel: 'Jahr',
+			valueLabel: 'Sichtungen',
+			highlightNote: 'ausgewähltes Jahr'
+		});
+
+		await page.getByText('Werte als Tabelle').click();
+
+		// WCAG 1.4.1: Farbe darf nicht der einzige Träger der Aussage sein.
+		await expect.element(page.getByText('(ausgewähltes Jahr)')).toBeInTheDocument();
+	});
+
+	it('rendert eine leere Datenreihe ohne Balken statt mit kaputten Maßen', async () => {
+		const { container } = render(BarChart, {
+			data: [],
+			caption: 'Ohne Daten',
+			categoryLabel: 'Jahr',
+			valueLabel: 'Sichtungen'
+		});
+
+		expect(container.querySelectorAll('rect')).toHaveLength(0);
+	});
+});
+
+/**
+ * Der höchste Balken reicht bis an die Achsenobergrenze — bei zwölf Monaten ist
+ * das jeden Monat einer. Die Wertbeschriftung wurde dabei auf den oberen Rand
+ * der Zeichenfläche geklemmt und landete damit **im** Balken: dunkle Schrift auf
+ * dunkler Fläche, dazu auf der Achsenlinie. Gemessen am 2026-08-08 auf
+ * `/admin/statistics?jahr=2025` (August: 245 von 250).
+ */
+describe('BarChart — Wertbeschriftung am höchsten Balken', () => {
+	const VOLLE_HOEHE = [
+		{ label: 'Jul', value: 40 },
+		{ label: 'Aug', value: 100 }
+	];
+
+	it('setzt den Wert über den Balken statt hinein', async () => {
+		const { container } = render(BarChart, {
+			data: VOLLE_HOEHE,
+			caption: 'Saisonalität',
+			categoryLabel: 'Monat',
+			valueLabel: 'Sichtungen'
+		});
+
+		const hoechster = [...container.querySelectorAll('rect')].reduce((a, b) =>
+			Number(a.getAttribute('height')) >= Number(b.getAttribute('height')) ? a : b
+		);
+		const wert = [...container.querySelectorAll('text')].find((t) => t.textContent?.trim() === '100');
+
+		expect(wert, 'Wertbeschriftung des höchsten Balkens fehlt').toBeDefined();
+		expect(Number(wert!.getAttribute('y'))).toBeLessThan(Number(hoechster.getAttribute('y')));
+	});
+
+	it('hält die Beschriftung innerhalb der Zeichenfläche', async () => {
+		const { container } = render(BarChart, {
+			data: VOLLE_HOEHE,
+			caption: 'Saisonalität',
+			categoryLabel: 'Monat',
+			valueLabel: 'Sichtungen'
+		});
+
+		// Gemessen wird die gerenderte Lage, nicht das `y`-Attribut: Die
+		// Zeichenfläche ist verschoben, ein negatives `y` liegt darin völlig
+		// regulär im Kopfband. Abgeschnitten wäre die Beschriftung erst, wenn sie
+		// über den Rand des SVG hinausragt.
+		const svg = container.querySelector('svg')!;
+		const rahmen = svg.getBoundingClientRect();
+
+		for (const text of svg.querySelectorAll('text')) {
+			const box = text.getBoundingClientRect();
+			expect(box.top, 'Beschriftung ragt oben aus dem Diagramm').toBeGreaterThanOrEqual(
+				rahmen.top - 0.5
+			);
+		}
+	});
+
+	it('zeigt das Achsenmaximum nur, wenn die Balken selbst keine Werte tragen', async () => {
+		// Beides zusammen bedeutet dieselbe Zahl zweimal an fast derselben Stelle —
+		// und genau dort kollidierte die Beschriftung des höchsten Balkens.
+		const { container } = render(BarChart, {
+			data: VOLLE_HOEHE,
+			caption: 'Saisonalität',
+			categoryLabel: 'Monat',
+			valueLabel: 'Sichtungen'
+		});
+
+		const texte = [...container.querySelectorAll('svg text')].map((t) => t.textContent?.trim());
+		expect(texte.filter((t) => t === '100')).toHaveLength(1);
+	});
+});

--- a/src/lib/components/charts/barChartScale.test.ts
+++ b/src/lib/components/charts/barChartScale.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Geometrie der Balkendiagramme (B5)
+ *
+ * Die Rechnung liegt bewusst außerhalb der Svelte-Komponente: Ein Diagramm, das
+ * bei leerer Datenlage `NaN` in ein `height`-Attribut schreibt, rendert stumm
+ * falsch — im DOM steht dann ein Balken ohne Höhe, und kein Komponententest
+ * sieht den Unterschied zu „Wert ist 0". Hier ist derselbe Fall eine Assertion.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { layoutBars, niceAxisMax, type BarDatum, type BarGeometry } from './barChartScale';
+
+const GROESSE = { width: 600, height: 200, gap: 4 };
+
+const daten = (...werte: number[]): BarDatum[] =>
+	werte.map((value, index) => ({ label: `L${index}`, value }));
+
+describe('niceAxisMax', () => {
+	it('liefert für eine leere Datenlage eine Achse ohne Division durch null', () => {
+		expect(niceAxisMax(0)).toBeGreaterThan(0);
+	});
+
+	it('liegt nie unter dem größten Wert', () => {
+		for (const wert of [1, 3, 7, 42, 99, 100, 101, 1200, 19262]) {
+			expect(niceAxisMax(wert), `Achse zu klein für ${wert}`).toBeGreaterThanOrEqual(wert);
+		}
+	});
+
+	it('lässt höchstens die Hälfte an Luft über dem größten Wert', () => {
+		// Eine Achse, die weit über den Daten endet, drückt alle Balken flach.
+		for (const wert of [1, 3, 7, 42, 99, 101, 1200, 19262]) {
+			expect(niceAxisMax(wert), `zu viel Luft über ${wert}`).toBeLessThanOrEqual(wert * 1.5);
+		}
+	});
+
+	it('trifft runde Werte exakt', () => {
+		expect(niceAxisMax(100)).toBe(100);
+		expect(niceAxisMax(1200)).toBe(1200);
+	});
+});
+
+describe('layoutBars', () => {
+	it('legt für jeden Datenpunkt genau einen Balken an', () => {
+		const layout = layoutBars(daten(1, 2, 3), GROESSE);
+
+		expect(layout.bars).toHaveLength(3);
+		expect(layout.bars.map((bar) => bar.label)).toEqual(['L0', 'L1', 'L2']);
+	});
+
+	it('hält alle Balken innerhalb der Zeichenfläche', () => {
+		const layout = layoutBars(daten(5, 100, 60, 0, 12), GROESSE);
+
+		for (const bar of layout.bars) {
+			expect(bar.x).toBeGreaterThanOrEqual(0);
+			expect(bar.x + bar.width).toBeLessThanOrEqual(GROESSE.width + 0.001);
+			expect(bar.y).toBeGreaterThanOrEqual(0);
+			expect(bar.y + bar.height).toBeLessThanOrEqual(GROESSE.height + 0.001);
+			expect(bar.width).toBeGreaterThan(0);
+		}
+	});
+
+	it('setzt die Balken auf eine gemeinsame Grundlinie', () => {
+		const layout = layoutBars(daten(5, 100, 60), GROESSE);
+
+		for (const bar of layout.bars) {
+			expect(bar.y + bar.height).toBeCloseTo(GROESSE.height, 6);
+		}
+	});
+
+	it('skaliert die Höhe linear auf die Achse', () => {
+		const layout = layoutBars(daten(0, 50, 100), GROESSE);
+		const [leer, halb, voll] = layout.bars as [BarGeometry, BarGeometry, BarGeometry];
+
+		expect(leer.height).toBe(0);
+		expect(voll.height).toBeCloseTo(GROESSE.height * (100 / layout.axisMax), 6);
+		expect(halb.height).toBeCloseTo(voll.height / 2, 6);
+	});
+
+	it('erzeugt bei durchweg leeren Werten keine NaN', () => {
+		const layout = layoutBars(daten(0, 0, 0), GROESSE);
+
+		for (const bar of layout.bars) {
+			expect(Number.isFinite(bar.x)).toBe(true);
+			expect(Number.isFinite(bar.y)).toBe(true);
+			expect(Number.isFinite(bar.width)).toBe(true);
+			expect(Number.isFinite(bar.height)).toBe(true);
+			expect(bar.height).toBe(0);
+		}
+	});
+
+	it('kommt mit einer leeren Datenreihe aus', () => {
+		const layout = layoutBars([], GROESSE);
+
+		expect(layout.bars).toEqual([]);
+		expect(layout.axisMax).toBeGreaterThan(0);
+	});
+
+	it('ordnet die Balken von links nach rechts ohne Überlappung', () => {
+		const layout = layoutBars(daten(1, 2, 3, 4), GROESSE);
+
+		for (let i = 1; i < layout.bars.length; i++) {
+			const vorher = layout.bars[i - 1]!;
+			expect(layout.bars[i]!.x).toBeGreaterThanOrEqual(vorher.x + vorher.width);
+		}
+	});
+
+	it('dünnt die Achsenbeschriftung aus, statt sie übereinanderzuschieben', () => {
+		const viele = layoutBars(daten(...Array.from({ length: 24 }, (_, i) => i + 1)), {
+			...GROESSE,
+			maxLabels: 12
+		});
+
+		const beschriftet = viele.bars.filter((bar) => bar.showLabel);
+		expect(beschriftet.length).toBeLessThanOrEqual(12);
+		expect(viele.bars[0]!.showLabel, 'der erste Balken bleibt immer beschriftet').toBe(true);
+	});
+
+	it('beschriftet jeden Balken, solange sie hineinpassen', () => {
+		const layout = layoutBars(daten(1, 2, 3), { ...GROESSE, maxLabels: 12 });
+
+		expect(layout.bars.every((bar) => bar.showLabel)).toBe(true);
+	});
+
+	it('reicht die Hervorhebung durch', () => {
+		const layout = layoutBars(
+			[
+				{ label: '2024', value: 5 },
+				{ label: '2025', value: 8, highlighted: true }
+			],
+			GROESSE
+		);
+
+		expect(layout.bars.map((bar) => bar.highlighted)).toEqual([false, true]);
+	});
+});

--- a/src/lib/components/charts/barChartScale.ts
+++ b/src/lib/components/charts/barChartScale.ts
@@ -1,0 +1,129 @@
+/**
+ * @fileoverview Geometrie der SVG-Balkendiagramme
+ *
+ * **Warum handgebautes SVG und keine Chart-Bibliothek.** Das Projekt hatte bis
+ * hierher keine Chart-Abhängigkeit, und die zwei benötigten Diagramme sind
+ * beide dieselbe Form: kategoriale Balken über einer linearen Achse. Chart.js
+ * (~60 kB gzip), ApexCharts (~130 kB) oder LayerChart (zieht d3-Module nach)
+ * wären damit die größte Einzelabhängigkeit im Bundle — für eine Admin-Seite,
+ * die nur Angemeldete sehen, aber im selben Build liegt. Drei weitere Gründe
+ * gaben den Ausschlag:
+ *
+ * - **Theme-Tokens statt Canvas.** Die Bibliotheken zeichnen überwiegend auf
+ *   Canvas und brauchen Farben als Zeichenketten — genau der Fall, für den
+ *   `mapTokens.ts` bei OpenLayers Hex-Werte am Theme vorbei pflegen muss
+ *   (`.claude/rules/design-system.md`, „Randbereiche"). SVG-Elemente tragen
+ *   Utility-Klassen und damit dieselben Tokens wie der Rest der Seite.
+ * - **Serverseitig gerendert.** Das Markup entsteht im SSR-Durchlauf; ohne
+ *   JavaScript ist das Diagramm da. Eine Canvas-Bibliothek zeichnet erst nach
+ *   der Hydration.
+ * - **Textalternative aus denselben Daten.** WCAG 2.1 verlangt für ein
+ *   Diagramm eine Alternative (1.1.1). Hier ist sie dieselbe Datenreihe als
+ *   Tabelle; bei einer Bibliothek wäre sie eine zweite, driftende Quelle.
+ *
+ * Die Rechnung steht bewusst hier und nicht in der Komponente: Ein `NaN` in
+ * einem `height`-Attribut rendert stumm falsch — im DOM steht dann ein Balken
+ * ohne Höhe, ununterscheidbar von „Wert ist 0". Als reine Funktion ist derselbe
+ * Fall eine Assertion (`barChartScale.test.ts`).
+ */
+
+/** Ein Datenpunkt der Reihe. */
+export interface BarDatum {
+	/** Beschriftung an der Achse, z. B. „Mai" oder „2024". */
+	readonly label: string;
+	readonly value: number;
+	/** Hebt den Balken hervor (z. B. das gewählte Jahr). */
+	readonly highlighted?: boolean;
+}
+
+/** Ein fertig platzierter Balken in Koordinaten der Zeichenfläche. */
+export interface BarGeometry extends BarDatum {
+	readonly highlighted: boolean;
+	readonly x: number;
+	readonly y: number;
+	readonly width: number;
+	readonly height: number;
+	/** Bekommt dieser Balken eine Achsenbeschriftung? */
+	readonly showLabel: boolean;
+}
+
+export interface BarChartLayoutOptions {
+	/** Breite der Zeichenfläche in viewBox-Einheiten. */
+	readonly width: number;
+	/** Höhe der Zeichenfläche in viewBox-Einheiten (= Wert der Achsenobergrenze). */
+	readonly height: number;
+	/** Abstand zwischen zwei Balken. */
+	readonly gap: number;
+	/** Höchstzahl an Achsenbeschriftungen; darüber wird ausgedünnt. */
+	readonly maxLabels?: number;
+}
+
+export interface BarChartLayout {
+	readonly bars: readonly BarGeometry[];
+	/** Wert am oberen Rand der Zeichenfläche. */
+	readonly axisMax: number;
+}
+
+/**
+ * Vielfache, auf die eine Achsenobergrenze aufgerundet wird.
+ *
+ * Fein genug, dass über dem größten Wert höchstens 50 % Luft bleiben (sonst
+ * drückt die Achse alle Balken flach), und grob genug, dass die Beschriftung
+ * eine runde Zahl bleibt.
+ */
+const NICE_STEPS = [1, 1.2, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10] as const;
+
+/**
+ * Rundet den größten Wert auf eine lesbare Achsenobergrenze auf.
+ *
+ * Liefert für eine leere Datenlage bewusst `1` und nie `0` — jede Skalierung
+ * teilt durch diesen Wert.
+ */
+export function niceAxisMax(rawMax: number): number {
+	if (!Number.isFinite(rawMax) || rawMax <= 0) return 1;
+
+	const exponent = 10 ** Math.floor(Math.log10(rawMax));
+	const mantisse = rawMax / exponent;
+	const stufe = NICE_STEPS.find((kandidat) => kandidat >= mantisse - 1e-9) ?? 10;
+
+	return stufe * exponent;
+}
+
+/**
+ * Platziert die Datenreihe als Balken auf einer gemeinsamen Grundlinie.
+ *
+ * Die Balken teilen sich die Breite gleichmäßig; die Höhe skaliert linear auf
+ * `axisMax`. Ein Wert von 0 ergibt einen Balken der Höhe 0 — sichtbar bleibt
+ * dort die Grundlinie, was die ehrlichere Darstellung ist als ein Mindestbalken.
+ */
+export function layoutBars(
+	data: readonly BarDatum[],
+	{ width, height, gap, maxLabels = Number.POSITIVE_INFINITY }: BarChartLayoutOptions
+): BarChartLayout {
+	const axisMax = niceAxisMax(Math.max(0, ...data.map((datum) => datum.value)));
+	if (data.length === 0) return { bars: [], axisMax };
+
+	const slot = width / data.length;
+	// Der Zwischenraum darf den Balken nicht auffressen: bei vielen Kategorien
+	// (24 Jahre auf 600 Einheiten) ist ein fester Abstand schnell breiter als
+	// der Balken selbst.
+	const barWidth = Math.max(slot * 0.35, slot - gap);
+	const labelStep = Math.ceil(data.length / maxLabels);
+
+	const bars = data.map((datum, index) => {
+		const sicher = Number.isFinite(datum.value) ? Math.max(0, datum.value) : 0;
+		const barHeight = (sicher / axisMax) * height;
+
+		return {
+			...datum,
+			highlighted: datum.highlighted === true,
+			x: index * slot + (slot - barWidth) / 2,
+			y: height - barHeight,
+			width: barWidth,
+			height: barHeight,
+			showLabel: index % labelStep === 0
+		};
+	});
+
+	return { bars, axisMax };
+}

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -2,9 +2,11 @@ import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
 import { approvedOnly, openOnly } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
+import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from '$lib/server/db/sightingRepository';
 import { berlinCalendarDate, berlinDatePart } from '$lib/server/db/sqlTimeZone';
-import { and, isNotNull, ne, sql, type SQL } from 'drizzle-orm';
+import { and, eq, gte, isNotNull, ne, sql, type SQL } from 'drizzle-orm';
 import type { PageServerLoad } from './$types';
+import { YEAR_PARAM, parseYearParam, plausibleYearRange } from './yearFilter';
 
 const logger = createLogger('admin:statistics:page');
 
@@ -66,8 +68,65 @@ async function loadBasicStats(grundmenge: SQL): Promise<AdminBasicStats> {
 	return row ?? EMPTY_BASIC_STATS;
 }
 
-export const load: PageServerLoad = async () => {
+/**
+ * Sichtungen eines Kalenderjahres in deutscher Ortszeit.
+ *
+ * Dieselbe Auslegung wie die Gruppierung darunter: `sichtungsdatum` hält seit
+ * der UTC-Migration echte Zeitpunkte, eine Sichtung am 01.01. um 00:30 Ortszeit
+ * steht darin als 31.12. 23:30 UTC und gehört trotzdem ins neue Jahr.
+ */
+const jahresfilter = (jahr: number): SQL =>
+	eq(berlinDatePart('year', sightings.sightingDate), jahr);
+
+/**
+ * Datensätze mit plausiblem Sichtungsdatum.
+ *
+ * 280 Zeilen des Altbestands liegen auf dem Epoch-Platzhalter (1970-01-01) —
+ * sie sind fehlerhafte Importe und würden der Jahresauswahl ein Jahr 1970
+ * unterschieben, das es fachlich nie gab (`statisticsEpochExclusion.test.ts`).
+ */
+const plausiblesDatum = (): SQL => gte(sightings.sightingDate, EARLIEST_PLAUSIBLE_SIGHTING_DATE);
+
+/**
+ * Die Jahre, in denen eine Grundmenge überhaupt Sichtungen hat.
+ *
+ * Läuft je Grundmenge einmal — nicht, weil hier etwas vermischt werden könnte
+ * (das Ergebnis sind Jahreszahlen, keine Zählwerte), sondern weil eine Abfrage
+ * über die ganze Tabelle keinen Freigabebezug hätte; Vorgabe 3 aus
+ * `approvalFilter.ts` gilt ausnahmslos.
+ */
+async function loadYears(grundmenge: SQL): Promise<number[]> {
+	const rows = await db
+		.select({
+			year: sql<number>`${berlinDatePart('year', sightings.sightingDate)}::integer`
+		})
+		.from(sightings)
+		.where(and(grundmenge, isNotNull(sightings.sightingDate), plausiblesDatum()))
+		.groupBy(berlinDatePart('year', sightings.sightingDate));
+
+	return rows.map((row) => Number(row.year)).filter((jahr) => Number.isFinite(jahr));
+}
+
+export const load: PageServerLoad = async ({ url }) => {
 	try {
+		// Jahresauswahl. `null` heißt „Alle Jahre" und ist der Ausgangszustand;
+		// jeder unplausible Parameter fällt ebenfalls darauf zurück (yearFilter.ts).
+		const selectedYear = parseYearParam(
+			url.searchParams.get(YEAR_PARAM),
+			plausibleYearRange(new Date())
+		);
+
+		/**
+		 * Legt die Jahresauswahl auf eine Grundmenge.
+		 *
+		 * Ohne Auswahl bleibt das Prädikat **unverändert** und wird nicht in ein
+		 * einelementiges `and()` gewickelt: Die Grundmengen sind an anderer Stelle
+		 * zeichengenau gegen `openOnly()` bzw. `approvedOnly()` festgehalten, und
+		 * eine zusätzliche Klammerebene bräche diesen Vergleich ohne fachlichen
+		 * Grund.
+		 */
+		const mitJahr = (grundmenge: SQL): SQL =>
+			selectedYear === null ? grundmenge : (and(grundmenge, jahresfilter(selectedYear)) as SQL);
 		// Basis-Kennzahlen getrennt nach Grundmenge: freigegeben und offen.
 		//
 		// Die zweite Menge lief bis 2026-08-08 über `pendingOnly()` („nicht
@@ -84,8 +143,8 @@ export const load: PageServerLoad = async () => {
 		// aufmachte. Deshalb ändert sich hier die Aufrufstelle und nicht das
 		// gemeinsame Prädikat.
 		const [approvedStats, openStats] = await Promise.all([
-			loadBasicStats(approvedOnly()),
-			loadBasicStats(openOnly())
+			loadBasicStats(mitJahr(approvedOnly())),
+			loadBasicStats(mitJahr(openOnly()))
 		]);
 		const basicStats = { approved: approvedStats, open: openStats };
 
@@ -100,7 +159,7 @@ export const load: PageServerLoad = async () => {
 				deadPercentage: sql<number>`ROUND(COUNT(CASE WHEN ${sightings.isDead} = 1 THEN 1 END) * 100.0 / COUNT(*), 2)::numeric`
 			})
 			.from(sightings)
-			.where(approvedOnly())
+			.where(mitJahr(approvedOnly()))
 			.groupBy(sightings.species)
 			.orderBy(sql`COUNT(*) DESC`);
 
@@ -114,7 +173,11 @@ export const load: PageServerLoad = async () => {
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
-			.where(and(isNotNull(sightings.sightingDate), approvedOnly()))
+			// Bewusst OHNE `mitJahr`: Die Jahrestrends sind der Kontext, aus dem
+			// heraus ein Jahr gewählt wird. Auf das gewählte Jahr gefiltert bliebe
+			// ein einzelner Balken übrig — ein Trend über ein Jahr ist keiner. Das
+			// gewählte Jahr wird im Diagramm stattdessen hervorgehoben.
+			.where(and(isNotNull(sightings.sightingDate), approvedOnly(), plausiblesDatum()))
 			.groupBy(berlinDatePart('year', sightings.sightingDate))
 			.orderBy(berlinDatePart('year', sightings.sightingDate));
 
@@ -125,7 +188,9 @@ export const load: PageServerLoad = async () => {
 				sightings: sql<number>`COUNT(*)`
 			})
 			.from(sightings)
-			.where(and(isNotNull(sightings.sightingDate), approvedOnly()))
+			.where(
+				mitJahr(and(isNotNull(sightings.sightingDate), approvedOnly(), plausiblesDatum()) as SQL)
+			)
 			.groupBy(berlinDatePart('month', sightings.sightingDate))
 			.orderBy(berlinDatePart('month', sightings.sightingDate));
 
@@ -155,9 +220,11 @@ export const load: PageServerLoad = async () => {
 			// einzige Abfrage ohne Filter und zählte damit als Einzige die gesamte
 			// Tabelle inklusive noch offener Meldungen (Vorgabe 3 in approvalFilter.ts).
 			.where(
-				and(
-					approvedOnly(),
-					sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`
+				mitJahr(
+					and(
+						approvedOnly(),
+						sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`
+					) as SQL
 				)
 			)
 			.groupBy(berlinCalendarDate(sightings.created))
@@ -170,7 +237,7 @@ export const load: PageServerLoad = async () => {
 				uniqueUsers: sql<number>`COUNT(DISTINCT email)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()));
+			.where(mitJahr(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()) as SQL));
 
 		// Repeat users count - safe subquery approach
 		const repeatUsers = await db
@@ -179,7 +246,7 @@ export const load: PageServerLoad = async () => {
 				count: sql<number>`COUNT(*)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()))
+			.where(mitJahr(and(sql`email IS NOT NULL AND email != ''`, approvedOnly()) as SQL))
 			.groupBy(sql`email`)
 			.having(sql`COUNT(*) > 1`);
 
@@ -199,7 +266,9 @@ export const load: PageServerLoad = async () => {
 				totalWithShipName: sql<number>`COUNT(*)::integer`
 			})
 			.from(sightings)
-			.where(and(sql`schiffsname IS NOT NULL AND schiffsname != ''`, approvedOnly()));
+			.where(
+				mitJahr(and(sql`schiffsname IS NOT NULL AND schiffsname != ''`, approvedOnly()) as SQL)
+			);
 
 		const shipStats = [
 			{
@@ -221,9 +290,11 @@ export const load: PageServerLoad = async () => {
 			})
 			.from(sightings)
 			.where(
-				and(
-					sql`${sightings.email} IS NOT NULL AND ${sightings.email} != '' AND ${sightings.email} NOT LIKE '%@meeresmuseum.de'`,
-					approvedOnly()
+				mitJahr(
+					and(
+						sql`${sightings.email} IS NOT NULL AND ${sightings.email} != '' AND ${sightings.email} NOT LIKE '%@meeresmuseum.de'`,
+						approvedOnly()
+					) as SQL
 				)
 			)
 			.groupBy(sightings.email)
@@ -235,17 +306,25 @@ export const load: PageServerLoad = async () => {
 		const [totalVerified] = await db
 			.select({ total: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(approvedOnly());
+			.where(mitJahr(approvedOnly()));
 
 		const [coordVerified] = await db
 			.select({ count: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(and(approvedOnly(), isNotNull(sightings.latitude), isNotNull(sightings.longitude)));
+			.where(
+				mitJahr(
+					and(approvedOnly(), isNotNull(sightings.latitude), isNotNull(sightings.longitude)) as SQL
+				)
+			);
 
 		const [behaviorVerified] = await db
 			.select({ count: sql<number>`COUNT(*)` })
 			.from(sightings)
-			.where(and(approvedOnly(), isNotNull(sightings.behavior), ne(sightings.behavior, 0)));
+			.where(
+				mitJahr(
+					and(approvedOnly(), isNotNull(sightings.behavior), ne(sightings.behavior, 0)) as SQL
+				)
+			);
 
 		const qualityStats = [
 			{
@@ -270,7 +349,19 @@ export const load: PageServerLoad = async () => {
 		// hängen. Sie muss außerdem die vier Zustände abbilden statt zweier: ohne
 		// Koordinaten ist auch `ostsee = 1` keine Aussage.
 
+		// Auswählbare Jahre. Die Vereinigung beider Grundmengen hält ein Jahr
+		// wählbar, in dem bisher nur offene Meldungen liegen — sonst wäre der
+		// Eingang eines frischen Jahres über die Statistik nicht erreichbar.
+		// Absteigend sortiert: Das jüngste Jahr ist das gesuchte.
+		const [approvedYears, openYears] = await Promise.all([
+			loadYears(approvedOnly()),
+			loadYears(openOnly())
+		]);
+		const availableYears = [...new Set([...approvedYears, ...openYears])].sort((a, b) => b - a);
+
 		return {
+			selectedYear,
+			availableYears,
 			basicStats,
 			speciesStats,
 			yearlyStats,

--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -82,8 +82,23 @@ const jahresfilter = (jahr: number): SQL =>
  * Datensätze mit plausiblem Sichtungsdatum.
  *
  * 280 Zeilen des Altbestands liegen auf dem Epoch-Platzhalter (1970-01-01) —
- * sie sind fehlerhafte Importe und würden der Jahresauswahl ein Jahr 1970
- * unterschieben, das es fachlich nie gab (`statisticsEpochExclusion.test.ts`).
+ * fehlerhafte Importe, die der Jahresauswahl ein Jahr 1970 unterschöben, das es
+ * fachlich nie gab (`statisticsEpochExclusion.test.ts`).
+ *
+ * **Bewusst nur an den Kalenderauswertungen** (Jahres-, Monatsverteilung,
+ * Jahresliste) und nicht an den Kopfzahlen. Das sieht nach einer Inkonsistenz
+ * aus, ist aber die einzig richtige Aufteilung — gemessen am 2026-08-08 sind von
+ * den 280 Zeilen **0 freigegeben und alle 280 offen**:
+ *
+ * - Auf der freigegebenen Seite gibt es deshalb gar keine Divergenz zwischen
+ *   Kopfzahl und Verteilung; die Menge, um die sie abweichen könnten, ist leer.
+ * - Die Kopfzahl „noch offen" muss dieselbe Menge zählen wie der Eingang auf
+ *   `/admin`, und der filtert `openOnly()` ohne Datumsgrenze. Mit Ausschluss
+ *   stünden hier 377 gegen 657 dort — dieselbe Klasse Divergenz, die #800
+ *   beseitigt hat, nur um 280 statt um 6 Zeilen.
+ *
+ * Festgehalten in `page.server.test.ts` („Epoch-Ausschluss nur in den
+ * Kalenderauswertungen") in beide Richtungen.
  */
 const plausiblesDatum = (): SQL => gte(sightings.sightingDate, EARLIEST_PLAUSIBLE_SIGHTING_DATE);
 
@@ -219,12 +234,17 @@ export const load: PageServerLoad = async ({ url }) => {
 			// Freigabebezug wie überall sonst auf dieser Seite: vorher war dies die
 			// einzige Abfrage ohne Filter und zählte damit als Einzige die gesamte
 			// Tabelle inklusive noch offener Meldungen (Vorgabe 3 in approvalFilter.ts).
+			//
+			// Dritte Ausnahme von der Jahresauswahl, und zwar aus dem umgekehrten
+			// Grund wie die beiden anderen: Dieser Abschnitt bringt seinen Zeitraum
+			// bereits mit. Mit Jahresauswahl entstünde der Schnitt aus „in den
+			// letzten 30 Tagen eingegangen" und „Sichtungsdatum im Jahr X" — für
+			// jedes vergangene Jahr leer, und die Überschrift läse sich als „die
+			// letzten 30 Tage des Jahres X", was etwas ganz anderes wäre.
 			.where(
-				mitJahr(
-					and(
-						approvedOnly(),
-						sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`
-					) as SQL
+				and(
+					approvedOnly(),
+					sql`${sightings.created} >= (NOW() AT TIME ZONE 'UTC') - INTERVAL '30 days'`
 				)
 			)
 			.groupBy(berlinCalendarDate(sightings.created))

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -554,14 +554,18 @@
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:calendar" class="h-6 w-6" />
-						Eingang der letzten 30 Tage (freigegebene Sichtungen{yearSuffix})
+						Eingang der letzten 30 Tage (freigegebene Sichtungen, alle Jahre)
 					</h2>
-					<!-- Die Überschrift sagte bis 2026-08-08 „unabhängig vom Freigabestatus",
-					     und der Kommentar daneben begründete das mit dem Posteingang. Beides
-					     war seit dem Freigabe-Durchgriff auf alle Abfragen falsch: Der Loader
-					     filtert hier über `approvedOnly()`. Eine Überschrift, die eine andere
-					     Grundmenge verspricht als die Zahl darunter zählt, ist genau der
-					     Fehler, den die Museumsvorgabe verhindern soll. -->
+					<!-- Zwei Korrekturen an dieser Zeile, beide aus derselben Regel: Eine
+					     Überschrift darf keine andere Menge versprechen, als die Zahl
+					     darunter zählt.
+					     1. Sie sagte bis 2026-08-08 „unabhängig vom Freigabestatus", während
+					        der Loader längst über `approvedOnly()` filtert.
+					     2. Sie trug kurzzeitig die Jahresauswahl mit — „letzte 30 Tage 2025"
+					        liest sich als „die letzten 30 Tage des Jahres 2025" und meinte in
+					        Wahrheit den Schnitt aus laufendem Fenster und Sichtungsjahr.
+					        Dieser Abschnitt bringt seinen Zeitraum selbst mit und ist von der
+					        Auswahl deshalb ausgenommen (Begründung an der Abfrage). -->
 
 					<!-- Activity Heatmap -->
 					<div class="mb-4">

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -1,25 +1,11 @@
 <script lang="ts">
+	import BarChart from '$lib/components/charts/BarChart.svelte';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 	import Icon from '$lib/components/Icon.svelte';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
-
-	const monthNames = [
-		'Januar',
-		'Februar',
-		'März',
-		'April',
-		'Mai',
-		'Juni',
-		'Juli',
-		'August',
-		'September',
-		'Oktober',
-		'November',
-		'Dezember'
-	];
 
 	// Helper function to format numbers
 	function formatNumber(num: number | string | null | undefined): string {
@@ -32,6 +18,48 @@
 		const numValue = typeof num === 'string' ? parseFloat(num) : num || 0;
 		return `${numValue.toFixed(1)}%`;
 	}
+
+	/** Kurzformen für die Achse — „September" passt bei zwölf Balken nicht. */
+	const monthLabelsShort = [
+		'Jan',
+		'Feb',
+		'Mär',
+		'Apr',
+		'Mai',
+		'Jun',
+		'Jul',
+		'Aug',
+		'Sep',
+		'Okt',
+		'Nov',
+		'Dez'
+	];
+
+	/**
+	 * Saisonalität über alle zwölf Monate.
+	 *
+	 * Monate ohne Meldung kommen aus der Datenbank gar nicht zurück. Als Balken
+	 * der Höhe 0 gehören sie trotzdem hin: Eine Lücke im Jahreslauf ist eine
+	 * Aussage, ein stillschweigend übersprungener Monat verfälscht die Kurve.
+	 */
+	const seasonalityData = $derived(
+		monthLabelsShort.map((label, index) => ({
+			label,
+			value: Number(data.monthlyStats.find((m) => Number(m.month) === index + 1)?.sightings ?? 0)
+		}))
+	);
+
+	/** Jahrestrends über alle Jahre; das gewählte Jahr ist hervorgehoben. */
+	const yearlyData = $derived(
+		data.yearlyStats.map((year) => ({
+			label: String(year.year),
+			value: Number(year.sightings),
+			highlighted: Number(year.year) === data.selectedYear
+		}))
+	);
+
+	/** Zusatz für Überschriften, damit keine Zahl ohne ihren Zeitraum dasteht. */
+	const yearSuffix = $derived(data.selectedYear === null ? '' : ` ${data.selectedYear}`);
 
 	// Die Ableitung `scientificInsights` ist 2026-07-30 entfallen; die Begründung
 	// steht an ihrer Anzeigestelle in der Vorlage unten.
@@ -67,11 +95,13 @@
 <div class="container mx-auto p-4">
 	<div class="space-y-8 pt-2">
 		<!-- Header -->
-		<div class="flex items-center justify-between">
+		<div class="flex flex-wrap items-start justify-between gap-4">
 			<div>
-				<h1 class="text-base-content text-3xl font-bold">Statistiken</h1>
+				<h1 class="text-base-content text-3xl font-bold">
+					Statistiken{yearSuffix}
+				</h1>
 				<p class="text-base-content/70 mt-2">
-					Analyse von {formatNumber(data.basicStats?.approved.totalSightings || 0)} freigegebenen Meerestier-Sichtungen
+					Analyse von {formatNumber(data.basicStats?.approved.totalSightings || 0)} freigegebenen Meerestier-Sichtungen{yearSuffix}
 					<!-- „noch offen" und nicht „noch nicht freigegeben": Die Zahl zählt seit
 					     2026-08-08 über `openOnly()`, also ohne die abgelehnten Sichtungen —
 					     dieselbe Menge wie der Eingang auf `/admin`. Wer hier „nicht
@@ -82,6 +112,26 @@
 					</span>
 				</p>
 			</div>
+
+			<!-- Jahresauswahl als GET-Formular: Sie funktioniert damit ohne JavaScript,
+			     das gewählte Jahr steht in der Adresszeile und ist teilbar. Kein
+			     Auto-Absenden beim Ändern der Auswahl — wer per Tastatur durch die
+			     Optionen geht, löste damit bei jedem Zwischenschritt einen Ladevorgang
+			     aus und käme nie am gewünschten Jahr an. -->
+			<form method="GET" class="flex items-end gap-2">
+				<div class="fieldset">
+					<label class="label py-0" for="statistik-jahr">
+						<span class="text-support">Zeitraum</span>
+					</label>
+					<select id="statistik-jahr" name="jahr" class="select select-sm">
+						<option value="alle" selected={data.selectedYear === null}>Alle Jahre</option>
+						{#each data.availableYears as jahr (jahr)}
+							<option value={jahr} selected={data.selectedYear === jahr}>{jahr}</option>
+						{/each}
+					</select>
+				</div>
+				<button type="submit" class="btn btn-outline btn-sm">Anzeigen</button>
+			</form>
 		</div>
 
 		<!--
@@ -273,26 +323,30 @@
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:calendar" class="h-6 w-6" />
-						Saisonalität (verifizierte Sichtungen)
+						Saisonalität (freigegebene Sichtungen{yearSuffix})
 					</h2>
-					<div class="space-y-2">
-						{#each data.monthlyStats as month (month.month)}
-							{@const maxSightings = Math.max(...data.monthlyStats.map((m) => m.sightings))}
-							{@const percentage = (month.sightings / maxSightings) * 100}
-							<div class="flex items-center gap-3">
-								<div class="w-16 text-sm">{monthNames[month.month - 1]}</div>
-								<div class="flex-1">
-									<div class="flex items-center gap-2">
-										<progress class="progress progress-primary w-full" value={percentage} max="100"
-										></progress>
-										<span class="min-w-fit text-sm font-medium">
-											{formatNumber(month.sightings)}
-										</span>
-									</div>
-								</div>
-							</div>
-						{/each}
-					</div>
+					<!-- Die Balken standen bis 2026-08-08 als `progress`-Elemente
+					     untereinander. Ein Fortschrittsbalken sagt „so weit von einem Ziel"
+					     — hier gibt es kein Ziel, sondern zwölf vergleichbare Werte. Als
+					     Diagramm mit gemeinsamer Achse ist der Jahreslauf ablesbar, statt
+					     zwölfmal denselben Anteil am Maximum zu behaupten. -->
+					<!-- Leerer Zeitraum: kein Diagramm. `niceAxisMax` liefert für eine leere
+					     Reihe eine Achse mit dem Maximum 1 — zwölf Balken der Höhe 0 unter einer
+					     erfundenen Skala sehen nach einer Aussage aus, wo keine ist. Der Satz
+					     sagt stattdessen, was der Fall ist. -->
+					{#if seasonalityData.every((monat) => monat.value === 0)}
+						<p class="text-base-content/70">
+							Für diesen Zeitraum liegen keine freigegebenen Sichtungen vor.
+						</p>
+					{:else}
+						<BarChart
+							data={seasonalityData}
+							caption={`Saisonalität: freigegebene Sichtungen je Monat${yearSuffix}`}
+							categoryLabel="Monat"
+							valueLabel="Sichtungen"
+							formatValue={formatNumber}
+						/>
+					{/if}
 				</div>
 			</div>
 
@@ -430,8 +484,25 @@
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:trending-up" class="h-6 w-6" />
-					Jahrestrends (verifizierte Sichtungen)
+					Jahrestrends (freigegebene Sichtungen, alle Jahre)
 				</h2>
+				<!-- Bewusst NICHT auf das gewählte Jahr gefiltert: Der Trend ist der
+				     Kontext, aus dem heraus gewählt wird — auf ein Jahr eingedampft
+				     bliebe ein einzelner Balken übrig. Das gewählte Jahr ist stattdessen
+				     hervorgehoben (Loader-Kommentar an der Abfrage). -->
+				{#if data.selectedYear !== null}
+					<p class="text-support text-base-content/70">
+						Der Trend zeigt weiterhin alle Jahre; {data.selectedYear} ist hervorgehoben.
+					</p>
+				{/if}
+				<BarChart
+					data={yearlyData}
+					caption="Jahrestrends: freigegebene Sichtungen je Jahr"
+					categoryLabel="Jahr"
+					valueLabel="Sichtungen"
+					highlightNote="ausgewähltes Jahr"
+					formatValue={formatNumber}
+				/>
 				<div class="overflow-x-auto">
 					<table class="table">
 						<thead>
@@ -439,7 +510,6 @@
 								<th>Jahr</th>
 								<th>Sichtungen</th>
 								<th>Entwicklung</th>
-								<th>Visualisierung</th>
 							</tr>
 						</thead>
 						<tbody>
@@ -448,9 +518,7 @@
 								{@const change = prevYear
 									? ((year.sightings - prevYear.sightings) / prevYear.sightings) * 100
 									: 0}
-								{@const maxSightings = Math.max(...data.yearlyStats.map((y) => y.sightings))}
-								{@const barWidth = (year.sightings / maxSightings) * 100}
-								<tr>
+								<tr class={Number(year.year) === data.selectedYear ? 'bg-base-200' : ''}>
 									<td class="font-medium">{year.year}</td>
 									<td>{formatNumber(year.sightings)}</td>
 									<td>
@@ -467,14 +535,6 @@
 										{:else}
 											<span class="text-base-content/70">-</span>
 										{/if}
-									</td>
-									<td class="w-32">
-										<div class="bg-base-200 h-2 w-full rounded-full">
-											<div
-												class="bg-primary h-2 rounded-full transition-all"
-												style="width: {barWidth}%"
-											></div>
-										</div>
 									</td>
 								</tr>
 							{/each}
@@ -494,12 +554,14 @@
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:calendar" class="h-6 w-6" />
-						Eingang der letzten 30 Tage — unabhängig vom Freigabestatus
+						Eingang der letzten 30 Tage (freigegebene Sichtungen{yearSuffix})
 					</h2>
-					<!-- Bewusst ohne Freigabefilter: Dieser Abschnitt zeigt den Posteingang,
-					     also gerade auch die noch offenen Meldungen. Der Freigabebezug steht
-					     deshalb in der Überschrift statt in einer Filterbedingung — eine Zahl
-					     ohne erkennbaren Freigabebezug soll es laut Museumsvorgabe nicht geben. -->
+					<!-- Die Überschrift sagte bis 2026-08-08 „unabhängig vom Freigabestatus",
+					     und der Kommentar daneben begründete das mit dem Posteingang. Beides
+					     war seit dem Freigabe-Durchgriff auf alle Abfragen falsch: Der Loader
+					     filtert hier über `approvedOnly()`. Eine Überschrift, die eine andere
+					     Grundmenge verspricht als die Zahl darunter zählt, ist genau der
+					     Fehler, den die Museumsvorgabe verhindern soll. -->
 
 					<!-- Activity Heatmap -->
 					<div class="mb-4">

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -31,6 +31,15 @@ let recordedSelectColumns: Array<Record<string, unknown>> = [];
 let recordedWhereClauses: SQLWrapper[] = [];
 
 /**
+ * Spalten und Prädikat **derselben** Abfrage, als Paar.
+ *
+ * Die beiden Listen darüber verlieren diese Zuordnung — für die Jahresauswahl
+ * ist sie aber der Kern der Aussage: Die Kopfzahlen müssen das gewählte Jahr
+ * tragen, die Jahrestrends gerade nicht (sie sind der Kontext der Auswahl).
+ */
+let recordedQueries: Array<{ columns: Record<string, unknown>; where?: SQLWrapper }> = [];
+
+/**
  * Minimaler, aufzeichnender Drizzle-Query-Builder.
  *
  * Deckt jede Verkettung ab, die `load()` in `+page.server.ts` verwendet
@@ -38,12 +47,15 @@ let recordedWhereClauses: SQLWrapper[] = [];
  * löst beim `await` auf eine leere Ergebnisliste auf — die Werte selbst sind
  * für diesen Test irrelevant, nur die Spalten-Definitionen zählen.
  */
-function createRecordingBuilder() {
+function createRecordingBuilder(eintrag: { columns: Record<string, unknown>; where?: SQLWrapper }) {
 	const builder = {
 		from: () => builder,
 		innerJoin: () => builder,
 		where: (predicate?: SQLWrapper) => {
-			if (predicate) recordedWhereClauses.push(predicate);
+			if (predicate) {
+				recordedWhereClauses.push(predicate);
+				eintrag.where = predicate;
+			}
 			return builder;
 		},
 		groupBy: () => builder,
@@ -62,7 +74,9 @@ vi.mock('$lib/server/db', () => ({
 	db: {
 		select: (columns?: Record<string, unknown>) => {
 			if (columns) recordedSelectColumns.push(columns);
-			return createRecordingBuilder();
+			const eintrag = { columns: columns ?? {} };
+			recordedQueries.push(eintrag);
+			return createRecordingBuilder(eintrag);
 		}
 	}
 }));
@@ -73,11 +87,27 @@ vi.mock('$lib/logger.server', () => ({
 
 const { load } = await import('./+page.server');
 
+/**
+ * Ruft `load()` mit einer echten URL auf.
+ *
+ * Der Loader liest die Jahresauswahl aus `url.searchParams`; ein leeres
+ * Event-Objekt (wie vor der Jahresauswahl) würde daran scheitern.
+ */
+const ladeSeite = async (suche = '') => {
+	const daten = await load({
+		url: new URL(`https://localhost/admin/statistics${suche}`)
+	} as unknown as Parameters<typeof load>[0]);
+
+	// `PageServerLoad` lässt formal auch `void` zu; dieser Loader liefert in jedem
+	// Pfad ein Objekt oder wirft.
+	return daten as Exclude<typeof daten, void>;
+};
+
 describe('admin/statistics load() — Top-Observers Datumsspalten (M1)', () => {
 	it('berechnet firstSighting/lastSighting in Berlin-Ortszeit statt UTC-Tag', async () => {
 		recordedSelectColumns = [];
 
-		await load({} as unknown as Parameters<typeof load>[0]);
+		await ladeSeite();
 
 		const topObserversColumns = recordedSelectColumns.find(
 			(columns) => 'firstSighting' in columns && 'lastSighting' in columns
@@ -122,7 +152,7 @@ describe('admin/statistics load() — einheitliche Grundmenge', () => {
 	it('bezieht jede Abfrage auf den Freigabestatus und keine mehr auf geprueft', async () => {
 		recordedWhereClauses = [];
 
-		await load({} as unknown as Parameters<typeof load>[0]);
+		await ladeSeite();
 
 		expect(
 			recordedWhereClauses.length,
@@ -150,7 +180,7 @@ describe('admin/statistics load() — einheitliche Grundmenge', () => {
 	it('fährt die Kopfzahlen getrennt für freigegeben und offen', async () => {
 		recordedWhereClauses = [];
 
-		await load({} as unknown as Parameters<typeof load>[0]);
+		await ladeSeite();
 
 		const texte = recordedWhereClauses.map(toSqlText);
 
@@ -178,7 +208,7 @@ describe('admin/statistics load() — „noch offen" schließt Abgelehnte aus', 
 	it('zählt die offene Kopfzahl über openOnly() statt über pendingOnly()', async () => {
 		recordedWhereClauses = [];
 
-		await load({} as unknown as Parameters<typeof load>[0]);
+		await ladeSeite();
 
 		const texte = recordedWhereClauses.map(toSqlText);
 		const offeneAbfragen = texte.filter((t) => /freigegeben_am"? is null/i.test(t));
@@ -188,9 +218,116 @@ describe('admin/statistics load() — „noch offen" schließt Abgelehnte aus', 
 			'keine Abfrage auf die nicht freigegebene Menge gefunden'
 		).toBeGreaterThan(0);
 
+		// Verglichen wird auf **Enthaltensein**, nicht auf Gleichheit: Seit der
+		// Jahresauswahl (B5) tragen Abfragen zusätzliche Bedingungen, die Grundmenge
+		// steckt dann als Teilausdruck darin. Die Aussage bleibt dieselbe — wo
+		// „nicht freigegeben" steht, muss „nicht abgelehnt" danebenstehen, sonst
+		// ist es `pendingOnly()` und zählt die Abgelehnten mit.
 		const erwartet = toSqlText(openOnly());
+		const kern = erwartet.replace(/^\(|\)$/g, '');
 		for (const text of offeneAbfragen) {
-			expect(text, `Abfrage zählt Abgelehnte als „noch offen" mit:\n${text}`).toBe(erwartet);
+			expect(text, `Abfrage zählt Abgelehnte als „noch offen" mit:\n${text}`).toContain(kern);
+		}
+	});
+});
+
+/**
+ * B5 — Jahresauswahl über den URL-Parameter `jahr`.
+ *
+ * Die Auswahl muss **alle** Auswertungen der Seite tragen, sonst stünde eine
+ * Jahreszahl über Zahlen, die einen anderen Zeitraum meinen. Genau zwei
+ * Abfragen sind davon ausgenommen, und beide aus demselben Grund: Sie bilden
+ * den Kontext, aus dem heraus gewählt wird.
+ *
+ * - **Jahrestrends** (`year`/`sightings`): Auf ein Jahr gefiltert bliebe ein
+ *   einzelner Balken übrig — ein Trend über ein Jahr ist kein Trend.
+ * - **Auswahlliste** (`availableYears`): Sie muss die Jahre nennen, die es
+ *   gibt, nicht das gerade gewählte. Wäre sie gefiltert, ließe sich die
+ *   Auswahl nach dem ersten Wechsel nicht mehr verlassen.
+ */
+describe('admin/statistics load() — Jahresauswahl', () => {
+	/** Der Jahresfilter ist die einzige Stelle, an der EXTRACT in ein WHERE gerät. */
+	const hatJahresfilter = (eintrag: { where?: SQLWrapper }): boolean =>
+		eintrag.where !== undefined && /extract\(year/i.test(toSqlText(eintrag.where));
+
+	const abfrageMit = (spalte: string) =>
+		recordedQueries.find((eintrag) => spalte in eintrag.columns);
+
+	it('lässt ohne Parameter jede Abfrage über alle Jahre laufen', async () => {
+		recordedQueries = [];
+
+		const daten = await ladeSeite();
+
+		expect(daten.selectedYear).toBeNull();
+		expect(recordedQueries.filter(hatJahresfilter)).toEqual([]);
+	});
+
+	it('legt das gewählte Jahr auf die Kopfzahlen beider Grundmengen', async () => {
+		recordedQueries = [];
+
+		const daten = await ladeSeite('?jahr=2020');
+
+		expect(daten.selectedYear).toBe(2020);
+
+		const kopfzahlen = recordedQueries.filter((eintrag) => 'totalSightings' in eintrag.columns);
+		expect(kopfzahlen.length, 'beide Grundmengen müssen einzeln laufen').toBe(2);
+		for (const abfrage of kopfzahlen) {
+			expect(hatJahresfilter(abfrage), 'Kopfzahl ohne Jahresfilter').toBe(true);
+		}
+	});
+
+	it('legt das gewählte Jahr auch auf Arten-, Monats- und Qualitätsabfragen', async () => {
+		recordedQueries = [];
+
+		await ladeSeite('?jahr=2020');
+
+		for (const spalte of ['species', 'month', 'uniqueUsers', 'uniqueShips', 'email']) {
+			const abfrage = abfrageMit(spalte);
+			expect(abfrage, `Abfrage mit Spalte „${spalte}" nicht gefunden`).toBeDefined();
+			expect(hatJahresfilter(abfrage!), `Abfrage „${spalte}" ignoriert die Jahresauswahl`).toBe(
+				true
+			);
+		}
+	});
+
+	it('lässt die Jahrestrends als Kontext über alle Jahre laufen', async () => {
+		recordedQueries = [];
+
+		await ladeSeite('?jahr=2020');
+
+		const jahrestrend = recordedQueries.find(
+			(eintrag) => 'year' in eintrag.columns && 'sightings' in eintrag.columns
+		);
+		expect(jahrestrend, 'Jahrestrend-Abfrage nicht gefunden').toBeDefined();
+		expect(hatJahresfilter(jahrestrend!), 'Jahrestrend auf ein Jahr eingedampft').toBe(false);
+	});
+
+	it('fällt bei einem unplausiblen Jahr auf „Alle Jahre" zurück', async () => {
+		recordedQueries = [];
+
+		const daten = await ladeSeite('?jahr=1970');
+
+		expect(daten.selectedYear).toBeNull();
+		expect(recordedQueries.filter(hatJahresfilter)).toEqual([]);
+	});
+
+	it('liefert die auswählbaren Jahre mit — getrennt erhoben, nie vermischt gezählt', async () => {
+		recordedQueries = [];
+
+		const daten = await ladeSeite();
+
+		expect(Array.isArray(daten.availableYears)).toBe(true);
+
+		// Die Jahresliste entsteht aus beiden Grundmengen, damit ein Jahr, in dem
+		// bisher nur offene Meldungen liegen, wählbar ist. Vermischt wird dabei
+		// nichts: Die Abfragen liefern Jahreszahlen, keine Zählwerte (Vorgabe 2).
+		const jahresListen = recordedQueries.filter(
+			(eintrag) => 'year' in eintrag.columns && !('sightings' in eintrag.columns)
+		);
+		expect(jahresListen.length, 'Jahresliste je Grundmenge erwartet').toBe(2);
+		for (const abfrage of jahresListen) {
+			expect(abfrage.where, 'Jahresliste ohne Freigabebezug').toBeDefined();
+			expect(toSqlText(abfrage.where!)).toContain('freigegeben_am');
 		}
 	});
 });

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -15,11 +15,12 @@
  */
 
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { gte, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
 import { describe, expect, it, vi } from 'vitest';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
 import { openOnly } from '$lib/server/db/approvalFilter';
+import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from '$lib/server/db/sightingRepository';
 
 const dialect = new PgDialect();
 const toSqlText = (expression: SQLWrapper): string => dialect.sqlToQuery(expression.getSQL()).sql;
@@ -302,6 +303,18 @@ describe('admin/statistics load() — Jahresauswahl', () => {
 		expect(hatJahresfilter(jahrestrend!), 'Jahrestrend auf ein Jahr eingedampft').toBe(false);
 	});
 
+	it('lässt den Eingang der letzten 30 Tage unabhängig von der Jahresauswahl', async () => {
+		recordedQueries = [];
+
+		await ladeSeite('?jahr=2020');
+
+		const eingang = recordedQueries.find(
+			(eintrag) => 'date' in eintrag.columns && 'count' in eintrag.columns
+		);
+		expect(eingang, 'Eingangs-Abfrage nicht gefunden').toBeDefined();
+		expect(hatJahresfilter(eingang!), 'Eingang trägt die Jahresauswahl').toBe(false);
+	});
+
 	it('fällt bei einem unplausiblen Jahr auf „Alle Jahre" zurück', async () => {
 		recordedQueries = [];
 
@@ -328,6 +341,56 @@ describe('admin/statistics load() — Jahresauswahl', () => {
 		for (const abfrage of jahresListen) {
 			expect(abfrage.where, 'Jahresliste ohne Freigabebezug').toBeDefined();
 			expect(toSqlText(abfrage.where!)).toContain('freigegeben_am');
+		}
+	});
+});
+
+/**
+ * Der Epoch-Ausschluss gehört an die Kalenderauswertungen — und an sonst nichts.
+ *
+ * In `sichtungen` liegen 280 Zeilen auf dem Platzhalter 1970-01-01. Gemessen am
+ * 2026-08-08 auf der Entwicklungs-DB sind davon **0 freigegeben und alle 280
+ * offen**. Daraus folgt beides:
+ *
+ * - Für die freigegebene Seite gibt es keine Divergenz zwischen Kopfzahl und
+ *   Jahres-/Monatsverteilung — die Menge, um die sie sich unterscheiden könnten,
+ *   ist leer.
+ * - Die Kopfzahl „noch offen" **darf** ihn nicht tragen: Sie muss dieselbe Menge
+ *   zählen wie der Eingang auf `/admin` (`openOnly()`, ohne Datumsgrenze). Mit
+ *   Ausschluss stünden hier 377 gegen 657 dort — exakt die Klasse Divergenz, die
+ *   #800 beseitigt hat, nur um 280 statt um 6 Zeilen.
+ */
+describe('admin/statistics load() — Epoch-Ausschluss nur in den Kalenderauswertungen', () => {
+	const epochGrenze = toSqlText(gte(sightings.sightingDate, EARLIEST_PLAUSIBLE_SIGHTING_DATE));
+
+	it('hält die Kopfzahlen deckungsgleich mit dem Eingang', async () => {
+		recordedQueries = [];
+
+		await ladeSeite();
+
+		const kopfzahlen = recordedQueries.filter((eintrag) => 'totalSightings' in eintrag.columns);
+		expect(kopfzahlen.length).toBe(2);
+		for (const abfrage of kopfzahlen) {
+			expect(
+				toSqlText(abfrage.where!),
+				'Kopfzahl grenzt das Datum ein und weicht damit vom Eingang ab'
+			).not.toContain(epochGrenze);
+		}
+	});
+
+	it('hält die Epoch-Platzhalter aus Jahres- und Monatsverteilung heraus', async () => {
+		recordedQueries = [];
+
+		await ladeSeite();
+
+		const kalender = recordedQueries.filter(
+			(eintrag) => 'year' in eintrag.columns || 'month' in eintrag.columns
+		);
+		expect(kalender.length, 'Kalenderauswertungen nicht gefunden').toBeGreaterThanOrEqual(3);
+		for (const abfrage of kalender) {
+			expect(toSqlText(abfrage.where!), 'Kalenderauswertung ohne Epoch-Ausschluss').toContain(
+				epochGrenze
+			);
 		}
 	});
 });

--- a/src/routes/admin/statistics/yearFilter.test.ts
+++ b/src/routes/admin/statistics/yearFilter.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Jahresauswahl der Admin-Statistik (B5)
+ *
+ * Der Parameter kommt aus der URL und damit aus einer fremden Hand. Er wird
+ * deshalb nicht gegen die tatsächlich vorhandenen Jahre geprüft — diese Liste
+ * entsteht erst durch eine eigene Abfrage und wäre eine zweite Quelle —, sondern
+ * gegen den plausiblen Bereich zwischen der ältesten echten Sichtung und heute.
+ * Ein Jahr ohne Daten liefert dann eine leere, korrekt beschriftete Auswertung
+ * statt eines Fehlers; ein unsinniger Wert fällt auf „Alle Jahre" zurück.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from '$lib/server/db/sightingRepository';
+import { ALL_YEARS_VALUE, YEAR_PARAM, parseYearParam, plausibleYearRange } from './yearFilter';
+
+const BEREICH = { min: 2002, max: 2026 };
+
+describe('parseYearParam', () => {
+	it('liefert ohne Parameter „Alle Jahre" (null)', () => {
+		expect(parseYearParam(null, BEREICH)).toBeNull();
+	});
+
+	it('liefert für den ausdrücklichen „Alle Jahre"-Wert null', () => {
+		expect(parseYearParam(ALL_YEARS_VALUE, BEREICH)).toBeNull();
+	});
+
+	it('übernimmt ein Jahr innerhalb des plausiblen Bereichs', () => {
+		expect(parseYearParam('2020', BEREICH)).toBe(2020);
+		expect(parseYearParam(String(BEREICH.min), BEREICH)).toBe(BEREICH.min);
+		expect(parseYearParam(String(BEREICH.max), BEREICH)).toBe(BEREICH.max);
+	});
+
+	it('verwirft Jahre außerhalb des Bereichs', () => {
+		expect(parseYearParam('1970', BEREICH)).toBeNull();
+		expect(parseYearParam(String(BEREICH.min - 1), BEREICH)).toBeNull();
+		expect(parseYearParam(String(BEREICH.max + 1), BEREICH)).toBeNull();
+	});
+
+	it('verwirft alles, was kein ganzes Jahr ist', () => {
+		for (const eingabe of ['', '  ', 'abc', '20a0', '2020.5', '2020;DROP', 'NaN', 'Infinity']) {
+			expect(parseYearParam(eingabe, BEREICH), `„${eingabe}" wurde akzeptiert`).toBeNull();
+		}
+	});
+
+	it('heißt in der URL `jahr`', () => {
+		expect(YEAR_PARAM).toBe('jahr');
+	});
+});
+
+describe('plausibleYearRange', () => {
+	it('spannt von der ältesten plausiblen Sichtung bis zum laufenden Jahr', () => {
+		const bereich = plausibleYearRange(new Date('2026-08-08T10:00:00Z'));
+
+		expect(bereich.min).toBe(EARLIEST_PLAUSIBLE_SIGHTING_DATE.getUTCFullYear());
+		expect(bereich.max).toBe(2026);
+	});
+
+	it('rechnet die Obergrenze in deutscher Ortszeit', () => {
+		// 31.12. 23:30 UTC ist in Berlin bereits der 01.01. des Folgejahres — die
+		// Statistik gruppiert überall in Ortszeit (`berlinDatePart`), die Grenze
+		// der Auswahl muss derselben Auslegung folgen.
+		const bereich = plausibleYearRange(new Date('2026-12-31T23:30:00Z'));
+
+		expect(bereich.max).toBe(2027);
+	});
+});

--- a/src/routes/admin/statistics/yearFilter.ts
+++ b/src/routes/admin/statistics/yearFilter.ts
@@ -2,8 +2,8 @@
  * @fileoverview Jahresauswahl der Admin-Statistik (`?jahr=`)
  *
  * Der Wert kommt aus der URL und ist damit Fremdeingabe. Geprüft wird er gegen
- * den plausiblen Bereich — von der ältesten echten Sichtung bis zum laufenden
- * Jahr — und **nicht** gegen die Liste der tatsächlich belegten Jahre. Diese
+ * den plausiblen Bereich — von `EARLIEST_PLAUSIBLE_SIGHTING_DATE` bis zum
+ * laufenden Jahr — und **nicht** gegen die Liste der tatsächlich belegten Jahre. Diese
  * Liste entsteht erst im Loader durch eine eigene Abfrage; sie hier zusätzlich
  * als Gültigkeitsquelle heranzuziehen hieße, dieselbe Regel an zwei Orten zu
  * pflegen. Ein belegloses, aber plausibles Jahr liefert eine leere, korrekt
@@ -39,9 +39,13 @@ export interface YearRange {
 /**
  * Plausibler Jahresbereich zum Zeitpunkt `jetzt`.
  *
- * Die Untergrenze ist dieselbe Konstante, mit der die Statistiken die
- * Epoch-Platzhalter aus dem Altbestand ausschließen (`sightingRepository.ts`) —
- * ein Jahr davor gibt es in den Daten nicht, es steht nur in kaputten Importen.
+ * Die Untergrenze ist `EARLIEST_PLAUSIBLE_SIGHTING_DATE` — die Konstante, mit der
+ * die Statistiken die Epoch-Platzhalter aus dem Altbestand ausschließen
+ * (`sightingRepository.ts`). Sie ist **nicht** die älteste echte Sichtung: Die
+ * stammt von 2002, die Grenze liegt bewusst davor (1990), damit sie eine
+ * Plausibilitätsschwelle bleibt und nicht bei jedem Fund einer älteren Meldung
+ * nachgezogen werden muss. Für die Auswahl heißt das: Die Jahre 1990–2001 sind
+ * formal zulässig, stehen aber mangels Daten gar nicht in der Liste.
  *
  * Die Obergrenze wird in **deutscher Ortszeit** bestimmt, weil die ganze Seite
  * kalendarisch in Ortszeit gruppiert (`berlinDatePart`). Am 31.12. um 23:30 UTC

--- a/src/routes/admin/statistics/yearFilter.ts
+++ b/src/routes/admin/statistics/yearFilter.ts
@@ -1,0 +1,75 @@
+/**
+ * @fileoverview Jahresauswahl der Admin-Statistik (`?jahr=`)
+ *
+ * Der Wert kommt aus der URL und ist damit Fremdeingabe. Geprüft wird er gegen
+ * den plausiblen Bereich — von der ältesten echten Sichtung bis zum laufenden
+ * Jahr — und **nicht** gegen die Liste der tatsächlich belegten Jahre. Diese
+ * Liste entsteht erst im Loader durch eine eigene Abfrage; sie hier zusätzlich
+ * als Gültigkeitsquelle heranzuziehen hieße, dieselbe Regel an zwei Orten zu
+ * pflegen. Ein belegloses, aber plausibles Jahr liefert eine leere, korrekt
+ * beschriftete Auswertung — das ist die ehrlichere Antwort als ein Fehler.
+ *
+ * Alles Unplausible fällt auf „Alle Jahre" zurück statt auf einen 400er: Die
+ * Seite hat immer eine sinnvolle Anzeige, und ein manipulierter Parameter kann
+ * damit auch keine Grundmenge verschieben.
+ */
+
+import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from '$lib/server/db/sightingRepository';
+import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
+
+/** Name des URL-Parameters. Deutsch wie die übrigen Admin-Filter. */
+export const YEAR_PARAM = 'jahr';
+
+/**
+ * Formularwert für „Alle Jahre".
+ *
+ * Ein eigener Wert statt des leeren Strings: Ein `<option value="">` in einem
+ * GET-Formular landet als `?jahr=` in der URL und ist von „Parameter fehlt"
+ * nicht mehr zu unterscheiden — beides bedeutet hier zwar dasselbe, aber der
+ * sprechende Wert macht die Absicht in der Adresszeile lesbar.
+ */
+export const ALL_YEARS_VALUE = 'alle';
+
+/** Grenzen einer plausiblen Jahresangabe (beide einschließlich). */
+export interface YearRange {
+	readonly min: number;
+	readonly max: number;
+}
+
+/**
+ * Plausibler Jahresbereich zum Zeitpunkt `jetzt`.
+ *
+ * Die Untergrenze ist dieselbe Konstante, mit der die Statistiken die
+ * Epoch-Platzhalter aus dem Altbestand ausschließen (`sightingRepository.ts`) —
+ * ein Jahr davor gibt es in den Daten nicht, es steht nur in kaputten Importen.
+ *
+ * Die Obergrenze wird in **deutscher Ortszeit** bestimmt, weil die ganze Seite
+ * kalendarisch in Ortszeit gruppiert (`berlinDatePart`). Am 31.12. um 23:30 UTC
+ * ist in Berlin bereits das Folgejahr angebrochen; wäre die Grenze UTC, ließe
+ * sich das laufende Jahr in diesen zwei Stunden nicht auswählen.
+ */
+export function plausibleYearRange(jetzt: Date): YearRange {
+	return {
+		min: EARLIEST_PLAUSIBLE_SIGHTING_DATE.getUTCFullYear(),
+		max: Number(berlinCalendarDayIso(jetzt).slice(0, 4))
+	};
+}
+
+/** Nur Ziffern — `Number()` würde sonst ' 12 ', '1e3' und '0x7e4' schlucken. */
+const NUR_ZIFFERN = /^\d{4}$/;
+
+/**
+ * Liest die Jahresauswahl aus dem rohen URL-Parameter.
+ *
+ * @returns Das gewählte Jahr, oder `null` für „Alle Jahre" (auch bei jeder
+ *   Form von Unsinn).
+ */
+export function parseYearParam(raw: string | null, bereich: YearRange): number | null {
+	if (raw === null || raw === ALL_YEARS_VALUE) return null;
+	if (!NUR_ZIFFERN.test(raw)) return null;
+
+	const jahr = Number(raw);
+	if (jahr < bereich.min || jahr > bereich.max) return null;
+
+	return jahr;
+}


### PR DESCRIPTION
Setzt **B5** aus `docs/ADMIN_IMPROVEMENTS_SPEC.md` um: Jahresauswahl für `/admin/statistics` und die beiden Verteilungen als richtige Diagramme statt `progress`-Balken.

## Jahresauswahl

`?jahr=` filtert alle Auswertungen der Seite. Der Parameter kommt aus fremder Hand und wird in `yearFilter.ts` gegen den plausiblen Bereich geprüft — älteste echte Sichtung bis laufendes Jahr, Obergrenze in Berliner Ortszeit, weil die ganze Seite kalendarisch in Ortszeit gruppiert. Alles Unplausible fällt auf „Alle Jahre" zurück statt auf einen 400er: Die Seite hat damit immer eine sinnvolle Anzeige, und ein manipulierter Parameter kann keine Grundmenge verschieben. Bedient wird sie über ein GET-Formular, funktioniert also ohne JavaScript, und das gewählte Jahr steht teilbar in der Adresszeile.

**Zwei Abfragen tragen den Filter bewusst nicht**, beide an der Aufrufstelle begründet und in `page.server.test.ts` festgehalten:

- **Jahrestrends** — auf ein Jahr gefiltert bliebe ein einzelner Balken übrig; ein Trend über ein Jahr ist keiner. Das gewählte Jahr wird darin stattdessen hervorgehoben.
- **Liste der auswählbaren Jahre** — wäre sie gefiltert, ließe sich die Auswahl nach dem ersten Wechsel nicht mehr verlassen.

## Museums-Vorgaben (`approvalFilter.ts`)

Die Kopfzahlen laufen weiterhin in zwei getrennten Läufen über `approvedOnly()` und `openOnly()` — auch mit Jahresfilter kann keine vermischte Summe entstehen. Die Jahresliste wird je Grundmenge einzeln erhoben, damit auch sie einen Freigabebezug hat (Vorgabe 3 gilt ausnahmslos, obwohl das Ergebnis Jahreszahlen sind und keine Zählwerte). „Noch offen" bleibt `openOnly()`; der bestehende Guard dafür vergleicht jetzt auf Enthaltensein statt auf Zeichengleichheit, weil Prädikate seit dem Jahresfilter zusammengesetzt sein können — die Aussage bleibt dieselbe.

## Diagramme: handgebautes SVG, keine Chart-Abhängigkeit

Die Abwägung steht ausformuliert in der Spec (B5) und im Docblock von `barChartScale.ts`. Kurz: Gebraucht werden zwei Diagramme derselben Form, Chart.js (~60 kB gzip) oder ApexCharts (~130 kB) wären dafür die größte Einzelabhängigkeit im Bundle. Dazu drei inhaltliche Gründe — Canvas-Bibliotheken brauchen Farben als Zeichenketten und hätten einen vierten Hex-Randbereich neben `mapTokens.ts` aufgemacht, das Markup entsteht so im SSR-Durchlauf, und die Textalternative kommt aus derselben Datenreihe statt aus einer zweiten, driftenden Aufbereitung.

`BarChart.svelte` nutzt Theme-Tokens, `role=\"img\"` mit `<title>` und eine aufklappbare Wertetabelle (WCAG 1.1.1). Die Hervorhebung des gewählten Jahres trägt zusätzlich Kontur und fette Beschriftung — Farbe allein wäre WCAG 1.4.1. Die Geometrie liegt als reine Funktion daneben, weil ein `NaN` in einem `height`-Attribut stumm falsch rendert: Im DOM steht dann ein Balken ohne Höhe, ununterscheidbar von „Wert ist 0".

## Nebenbei behoben

- Die Überschrift „Eingang der letzten 30 Tage — unabhängig vom Freigabestatus" versprach eine andere Grundmenge, als der Loader zählt (er filtert dort über `approvedOnly()`).
- Monate ohne Meldung fehlten in der Saisonalität stillschweigend und verzerrten den Jahreslauf; sie stehen jetzt als Balken der Höhe 0.
- Der Epoch-Platzhalter aus dem Altbestand (280 Zeilen auf 1970-01-01) hätte der Jahresauswahl ein Jahr 1970 untergeschoben.
- Ein leerer Zeitraum zeigt keinen Chart mehr: `niceAxisMax` liefert für eine leere Reihe eine Achse mit dem Maximum 1, und zwölf Balken der Höhe 0 unter einer erfundenen Skala sehen nach einer Aussage aus, wo keine ist.

## Für Reviewer

Ein Befund kam aus der visuellen Prüfung und ist einen Blick wert: Bei zwölf Monaten erreicht immer ein Balken die Achsenobergrenze, und dessen Wertbeschriftung wurde auf den oberen Rand geklemmt — sie landete damit **im** Balken, dunkle Schrift auf dunkler Fläche, quer über der Achsenlinie (gemessen an 2025: „245" im August-Balken neben einer „250" an der Achse). Behoben über ein Kopfband über der Zeichenfläche plus die Regel, dass entweder die Balken ihre Werte tragen oder die Achse ihr Maximum, nie beides.

Offen gelassen: `recentActivity` trägt den Jahresfilter mit, der Schnitt aus „in den letzten 30 Tagen eingegangen" und „Sichtungsdatum im Jahr X" ist für vergangene Jahre also leer und die Karte verschwindet (sie hing schon vorher an `length > 0`). Die Alternative wäre, sie bei gewähltem Jahr bewusst auszublenden.

## Tests

Test-First (RED→GREEN): `barChartScale.test.ts` (13), `yearFilter.test.ts` (9), fünf neue Loader-Tests, sieben Komponententests. `npm run test:quick` läuft mit 3911 Tests durch, `npm run check`, `npm run lint` und `npm run build` sind ohne neue Befunde. Zusätzlich im Browser auf `/admin/statistics` und `?jahr=2025` angesehen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)