### PR TITLE
feat(admin): usability- und UX-verbesserungen aus dem admin-review

### DIFF
--- a/drizzle/0006_tense_redwing.sql
+++ b/drizzle/0006_tense_redwing.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "sichtungen" ADD COLUMN "freigegeben_von" varchar(255);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1143 @@
+{
+  "id": "9d32c1e7-8b43-4740-bf60-b2e7f2023623",
+  "prevId": "7a6b5325-92f8-4f77-9d56-ca306d69ddaa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_app_config_key": {
+          "name": "idx_app_config_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_category": {
+          "name": "idx_app_config_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_config_key_unique": {
+          "name": "app_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_timestamp": {
+          "name": "idx_audit_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action_timestamp": {
+          "name": "idx_audit_logs_action_timestamp",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_email_timestamp": {
+          "name": "idx_audit_logs_user_email_timestamp",
+          "columns": [
+            {
+              "expression": "user_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "user_claims": {
+          "name": "user_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_expires_at": {
+          "name": "absolute_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_sub": {
+          "name": "idx_sessions_sub",
+          "columns": [
+            {
+              "expression": "sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtungen_dateien": {
+      "name": "sichtungen_dateien",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sichtung_id": {
+          "name": "sichtung_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_name": {
+          "name": "datei_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_pfad": {
+          "name": "datei_pfad",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_typ": {
+          "name": "mime_typ",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hochgeladen_am": {
+          "name": "hochgeladen_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exif_daten": {
+          "name": "exif_daten",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erstellt_am": {
+          "name": "erstellt_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sichtungen_dateien_sichtung_id": {
+          "name": "idx_sichtungen_dateien_sichtung_id",
+          "columns": [
+            {
+              "expression": "sichtung_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_referenz_id": {
+          "name": "idx_sichtungen_dateien_referenz_id",
+          "columns": [
+            {
+              "expression": "referenz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_uid": {
+          "name": "idx_sichtungen_dateien_uid",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sichtungen_dateien_sichtung_id_sichtungen_id_fk": {
+          "name": "sichtungen_dateien_sichtung_id_sichtungen_id_fk",
+          "tableFrom": "sichtungen_dateien",
+          "tableTo": "sichtungen",
+          "columnsFrom": [
+            "sichtung_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtungen": {
+      "name": "sichtungen",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('sichtungen_seq'::regclass)"
+        },
+        "gps_breite": {
+          "name": "gps_breite",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gps_laenge": {
+          "name": "gps_laenge",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fahrwasser": {
+          "name": "fahrwasser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seezeichen": {
+          "name": "seezeichen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtungsdatum": {
+          "name": "sichtungsdatum",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vonwo": {
+          "name": "vonwo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vonwo_text": {
+          "name": "vonwo_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entfernung": {
+          "name": "entfernung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_schiffe": {
+          "name": "anzahl_schiffe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anzahl_gesamt": {
+          "name": "anzahl_gesamt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_jung": {
+          "name": "anzahl_jung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung": {
+          "name": "verteilung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung_text": {
+          "name": "verteilung_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahme": {
+          "name": "aufnahme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahmeHochladen": {
+          "name": "aufnahmeHochladen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten": {
+          "name": "verhalten",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten_text": {
+          "name": "verhalten_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaktion": {
+          "name": "reaktion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sonstige_auffaelligkeiten": {
+          "name": "sonstige_auffaelligkeiten",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seegang": {
+          "name": "seegang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windrichtung": {
+          "name": "windrichtung",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "windstaerke": {
+          "name": "windstaerke",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtweite": {
+          "name": "sichtweite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffsname": {
+          "name": "schiffsname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heimathafen": {
+          "name": "heimathafen",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstyp": {
+          "name": "bootstyp",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootsantrieb": {
+          "name": "bootsantrieb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bootsantrieb_text": {
+          "name": "bootsantrieb_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vorname": {
+          "name": "vorname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strasse": {
+          "name": "strasse",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plz": {
+          "name": "plz",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ort": {
+          "name": "ort",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telefon": {
+          "name": "telefon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung": {
+          "name": "namensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "namensnennung_am": {
+          "name": "namensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung_version": {
+          "name": "namensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung": {
+          "name": "schiffnamensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffnamensnennung_am": {
+          "name": "schiffnamensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung_version": {
+          "name": "schiffnamensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bemerkungen": {
+          "name": "bemerkungen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eingangskanal": {
+          "name": "eingangskanal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freigegeben_am": {
+          "name": "freigegeben_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geprueft": {
+          "name": "geprueft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ostsee": {
+          "name": "ostsee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "kommentar_intern": {
+          "name": "kommentar_intern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ostsee_geo": {
+          "name": "ostsee_geo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund": {
+          "name": "totfund",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_groesse": {
+          "name": "totfund_groesse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totfund_zustand": {
+          "name": "totfund_zustand",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_geschlecht": {
+          "name": "totfund_geschlecht",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_telefon": {
+          "name": "totfund_telefon",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tierart": {
+          "name": "tierart",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis": {
+          "name": "datenschutz_einverstaendnis",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis_am": {
+          "name": "datenschutz_einverstaendnis_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datenschutz_einverstaendnis_version": {
+          "name": "datenschutz_einverstaendnis_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung": {
+          "name": "medien_einwilligung",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "medien_einwilligung_am": {
+          "name": "medien_einwilligung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung_version": {
+          "name": "medien_einwilligung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data": {
+          "name": "weather_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_fetched_at": {
+          "name": "weather_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_provider": {
+          "name": "weather_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open-meteo'"
+        },
+        "weather_api_version": {
+          "name": "weather_api_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data_type": {
+          "name": "weather_data_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'historical'"
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spam_indicators": {
+          "name": "spam_indicators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abgelehnt_am": {
+          "name": "abgelehnt_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abgelehnt_von": {
+          "name": "abgelehnt_von",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freigegeben_von": {
+          "name": "freigegeben_von",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "geom_sichtungen": {
+          "name": "geom_sichtungen",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_geometry_ops_2d"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_sichtungsdatum": {
+          "name": "idx_sichtungsdatum",
+          "columns": [
+            {
+              "expression": "sichtungsdatum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungsdatum_berlin_tag": {
+          "name": "idx_sichtungsdatum_berlin_tag",
+          "columns": [
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_year_sichtungen": {
+          "name": "idx_year_sichtungen",
+          "columns": [
+            {
+              "expression": "EXTRACT(year FROM \"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_data_gin": {
+          "name": "idx_weather_data_gin",
+          "columns": [
+            {
+              "expression": "weather_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_weather_fetched": {
+          "name": "idx_weather_fetched",
+          "columns": [
+            {
+              "expression": "weather_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_provider": {
+          "name": "idx_weather_provider",
+          "columns": [
+            {
+              "expression": "weather_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_position_date_weather": {
+          "name": "idx_position_date_weather",
+          "columns": [
+            {
+              "expression": "ROUND(\"gps_breite\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ROUND(\"gps_laenge\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sichtungen\".\"weather_data\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.sichtungen_seq": {
+      "name": "sichtungen_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1840",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1786102688381,
       "tag": "0005_stale_grey_gargoyle",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1786175923049,
+      "tag": "0006_tense_redwing",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/admin/AdminSightingEditForm.svelte
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { beforeNavigate } from '$app/navigation';
+	import { isFormDirty } from '$lib/form/isFormDirty';
 	import { adminSightingSchema } from '$lib/form/validation/sightingSchema';
 	import Form from '$lib/report/components/form/Form.svelte';
 	import Administrative from '$lib/report/components/sections/Administrative.svelte';
@@ -15,6 +17,7 @@
 	import type { FrontendSighting } from '$lib/types';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import { untrack } from 'svelte';
+	import { get } from 'svelte/store';
 
 	import { buildAdminEditInitialValues } from './adminEditInitialValues';
 	import { getSightingStatus, SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
@@ -50,7 +53,20 @@
 			}
 
 			const updatedSighting = await response.json();
+			// Vor `onSave`, weil der Aufrufer dort navigiert: Der Guard darf nicht
+			// nach Änderungen fragen, die soeben in der Datenbank gelandet sind.
+			guardEntschaerft = true;
 			await onSave(updatedSighting);
+			/* Navigiert der Aufrufer nicht (eine künftige Aufrufstelle ohne
+			   Navigation) und wird hier weiterbearbeitet, ist der Guard wieder
+			   scharf — mit dem aktuellen Formular-Store als neuer Basis, sonst
+			   fragte er nach den bereits gespeicherten Änderungen. Bewusst der
+			   Store und nicht der `values`-Parameter oder die Server-Antwort:
+			   `isFormDirty` vergleicht gegen den Store, und sowohl der
+			   Schema-Cast im Submit als auch das Datensatz-Format der Antwort
+			   weichen von ihm ab — beide meldeten eine saubere Maske als dirty. */
+			initProps.initialValues = { ...get(formContext.form) };
+			guardEntschaerft = false;
 			return updatedSighting;
 		} catch (error) {
 			console.error('Fehler beim Speichern:', error);
@@ -67,6 +83,68 @@
 	let isValid = $derived(formContext.isValid);
 	let isSubmitting = $derived(formContext.isSubmitting);
 	let errors = $derived(formContext.errors);
+	let values = $derived(formContext.form);
+
+	/**
+	 * Die Fehlerliste ist die Begründung, auf die der Speichern-Knopf zeigt und
+	 * zu der sein Wächter springt. Beide Seiten teilen sich diese eine `id` —
+	 * ein `aria-describedby` ins Leere meldet niemand.
+	 */
+	const ERROR_SUMMARY_ID = 'admin-edit-error-summary';
+	let errorSummary = $state<HTMLDivElement | null>(null);
+	const hasErrors = $derived(
+		!!$errors &&
+			Object.values($errors).some((message) => typeof message === 'string' && message !== '')
+	);
+
+	function focusErrorSummary(): void {
+		errorSummary?.scrollIntoView({ block: 'center' });
+		errorSummary?.focus();
+	}
+
+	/**
+	 * Der Wächter aus `design-system.md`: Der Knopf bleibt frei klickbar, und ein
+	 * Klick mit bekannten Fehlern springt zur Fehlerliste, statt still zu
+	 * scheitern. Ein `disabled`/`aria-disabled` verbot hier beides — DaisyUI legt
+	 * an solche Knöpfe ein `pointer-events: none`, der Klick käme also nie an.
+	 */
+	function guardSave(event: MouseEvent): void {
+		if ($isValid) return;
+		event.preventDefault();
+		focusErrorSummary();
+	}
+
+	// Der erste Klick läuft durch den Wächter (noch keine Fehler bekannt) und
+	// bringt die Fehler erst hervor — der Sprung gehört deshalb auch an ihr
+	// Erscheinen, nicht nur an den Wiederholungsklick.
+	$effect(() => {
+		if (hasErrors) focusErrorSummary();
+	});
+
+	let guardEntschaerft = $state(false);
+	const hasUnsavedChanges = $derived(
+		!guardEntschaerft && isFormDirty($values, initProps.initialValues)
+	);
+
+	/**
+	 * Rückfrage vor dem Verlassen der Maske. `confirm()` statt eines
+	 * projektüblichen Dialogs, weil `beforeNavigate` synchron entscheiden muss:
+	 * Ein `cancel()` nach einem `await` kommt zu spät, die Navigation ist dann
+	 * längst gelaufen.
+	 */
+	beforeNavigate((navigation) => {
+		if (!hasUnsavedChanges) return;
+		if (navigation.type === 'leave') {
+			// Harter Reload oder Tab schließen: SvelteKit setzt `cancel()` hier in
+			// den `beforeunload`-Dialog des Browsers um. Ein eigenes `confirm()`
+			// zeigt in diesem Fenster kein Browser mehr an.
+			navigation.cancel();
+			return;
+		}
+		if (!confirm('Die Änderungen an dieser Sichtung sind nicht gespeichert. Seite verlassen?')) {
+			navigation.cancel();
+		}
+	});
 
 	// Abgeleiteter Status, dieselbe Quelle wie Eingang, Tabelle und
 	// Detailansicht — kein Bedienelement hier, die Maske bearbeitet Sachdaten.
@@ -87,7 +165,12 @@
 							{SIGHTING_STATUS_PRESENTATION[status].label}
 						</span>
 						{#if status === 'approved'}
-							— Freigegeben am {formatLocalDateTime(sighting.approvedAt, 'datetime')}
+							<!-- „durch …" nur bei bekannter Person — der Altbestand trägt kein
+							     `freigegeben_von` und darf kein „durch null" zeigen. -->
+							— Freigegeben am {formatLocalDateTime(
+								sighting.approvedAt,
+								'datetime'
+							)}{sighting.approvedBy ? ` durch ${sighting.approvedBy}` : ''}
 						{:else if status === 'rejected'}
 							— Abgelehnt am {formatLocalDateTime(
 								sighting.rejectedAt,
@@ -118,8 +201,17 @@
 		</div>
 	</div>
 	<!-- Fehler-Liste anzeigen, wenn es Validierungsfehler gibt -->
-	{#if $errors && Object.values($errors).some((message) => typeof message === 'string' && message !== '')}
-		<div class="alert alert-error">
+	{#if hasErrors}
+		<!-- `tabindex="-1"`, damit der Wächter des Speichern-Knopfes hierher
+		     fokussieren kann; die Fläche ist kein Bedienelement und bleibt
+		     deshalb außerhalb der Tab-Reihenfolge. -->
+		<div
+			class="alert alert-error"
+			id={ERROR_SUMMARY_ID}
+			bind:this={errorSummary}
+			tabindex="-1"
+			role="alert"
+		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				class="h-6 w-6 shrink-0 stroke-current"
@@ -147,7 +239,16 @@
 	<!-- Aktionsbuttons -->
 	<div class="mt-6 flex justify-end space-x-2">
 		<button type="button" class="btn btn-ghost" onclick={onCancel}> Abbrechen </button>
-		<button type="submit" class="btn btn-primary" disabled={$isSubmitting || !$isValid}>
+		<!-- Hart gesperrt bleibt einzig der laufende Submit: sehr kurz, nichts zu
+		     erklären, und ein Doppelklick schriebe zweimal. Fehlende Eingabe
+		     sperrt dagegen nicht — dafür gibt es den Wächter und die Fehlerliste. -->
+		<button
+			type="submit"
+			class="btn btn-primary"
+			disabled={$isSubmitting}
+			aria-describedby={hasErrors ? ERROR_SUMMARY_ID : undefined}
+			onclick={guardSave}
+		>
 			{#if $isSubmitting}
 				<span class="loading loading-spinner loading-xs mr-2"></span>
 			{/if}

--- a/src/lib/components/admin/AdminSightingEditForm.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte.test.ts
@@ -8,12 +8,34 @@
  * einzelne Statuszeile aus der gemeinsamen Quelle `sightingStatus.ts`, wie in
  * der Metazeile von `AdminSightingView.svelte`.
  */
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import AdminSightingEditForm from './AdminSightingEditForm.svelte';
 import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 import type { FrontendSighting } from '$lib/types';
+
+// `beforeNavigate` gibt es außerhalb des SvelteKit-Routers nicht — der Mock
+// fängt die registrierte Rückrufe ab, damit der Test eine Navigation auslösen
+// kann, ohne einen Router zu bauen.
+const navigation = vi.hoisted(() => ({
+	callbacks: [] as Array<(nav: { type: string; cancel: () => void }) => void>
+}));
+
+vi.mock('$app/navigation', () => ({
+	beforeNavigate: (callback: (nav: { type: string; cancel: () => void }) => void) => {
+		navigation.callbacks.push(callback);
+	}
+}));
+
+/** Löst eine Navigation aus und meldet, ob der Guard sie abgebrochen hat. */
+function navigiere(type = 'link'): { abgebrochen: boolean } {
+	let abgebrochen = false;
+	for (const callback of navigation.callbacks) {
+		callback({ type, cancel: () => (abgebrochen = true) });
+	}
+	return { abgebrochen };
+}
 
 function baseSighting(overrides: Record<string, unknown> = {}): FrontendSighting {
 	return {
@@ -29,6 +51,37 @@ function baseSighting(overrides: Record<string, unknown> = {}): FrontendSighting
 		uploadedFiles: [],
 		...overrides
 	} as unknown as FrontendSighting;
+}
+
+/**
+ * Eine Sichtung, die der Browser abschicken lässt: Ohne Werte in
+ * `waterway`, `sightingFrom`, `distance`, `entryChannel` und `boatDrive` hält
+ * die HTML-Pflichtfeldprüfung das `submit`-Ereignis auf, und die Maske käme nie
+ * bis zur Yup-Prüfung — der Test bestätigte dann nur die Browser-Sperre.
+ * Die Yup-Fehler kommen hier aus den Feldern, die das Formular gar nicht
+ * anzeigt (Referenz-ID, Kontaktdaten).
+ */
+function absendbareSichtung(overrides: Record<string, unknown> = {}): FrontendSighting {
+	return baseSighting({
+		waterway: 'Ostsee',
+		sightingFrom: 1,
+		distance: 1,
+		entryChannel: 1,
+		boatDrive: 1,
+		...overrides
+	});
+}
+
+/** Vollständig genug, damit `adminSightingSchema` die Werte durchlässt. */
+function gueltigeSichtung(overrides: Record<string, unknown> = {}): FrontendSighting {
+	return absendbareSichtung({
+		referenceId: 'REF-1',
+		firstName: 'Anna',
+		lastName: 'Beispiel',
+		email: 'anna@example.org',
+		privacyConsent: true,
+		...overrides
+	});
 }
 
 describe('AdminSightingEditForm — Technik-Karte', () => {
@@ -61,6 +114,19 @@ describe('AdminSightingEditForm — Technik-Karte', () => {
 		expect(document.body.textContent).toContain('Freigegeben am');
 	});
 
+	it('nennt bei freigegebenen Sichtungen auch die freigebende Person', async () => {
+		render(AdminSightingEditForm, {
+			sighting: baseSighting({
+				approvedAt: new Date('2026-03-12T09:00:00Z'),
+				approvedBy: 'bernd@example.org'
+			}),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		expect(document.body.textContent).toContain('bernd@example.org');
+	});
+
 	it('zeigt Zeitpunkt und Bearbeiter bei abgelehnten Sichtungen', async () => {
 		render(AdminSightingEditForm, {
 			sighting: baseSighting({
@@ -75,5 +141,168 @@ describe('AdminSightingEditForm — Technik-Karte', () => {
 			.element(page.getByText(SIGHTING_STATUS_PRESENTATION.rejected.label, { exact: true }))
 			.toBeVisible();
 		expect(document.body.textContent).toContain('anna@example.org');
+	});
+});
+
+/**
+ * Ändert ein Feld der Maske so, wie es ein Mensch täte.
+ *
+ * `fill` allein genügt nicht: Die Feld-Pipeline hängt an `onchange`, und der
+ * Helfer löst nur `input` aus — der Formular-Store bliebe unberührt und die
+ * Maske gälte fälschlich als unverändert.
+ */
+async function aendereAnzahl(wert: string): Promise<void> {
+	const feld = document.querySelector('[data-field="totalCount"] input');
+	expect(feld).not.toBeNull();
+	await page.elementLocator(feld as HTMLElement).fill(wert);
+	feld?.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+describe('AdminSightingEditForm — Speichern-Knopf', () => {
+	it('bleibt bei Validierungsfehlern bedienbar und verweist auf die Fehlerliste', async () => {
+		render(AdminSightingEditForm, {
+			sighting: absendbareSichtung(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		const speichern = page.getByRole('button', { name: 'Speichern' });
+		await speichern.click();
+
+		const knopf = speichern.element() as HTMLButtonElement;
+		await vi.waitFor(() => {
+			// Hart gesperrt bleibt einzig der laufende Submit — der ist hier vorbei.
+			expect(knopf.disabled).toBe(false);
+			expect(knopf.getAttribute('aria-disabled')).toBeNull();
+
+			const beschreibung = knopf.getAttribute('aria-describedby');
+			expect(beschreibung).toBeTruthy();
+			const fehlerliste = document.getElementById(beschreibung as string);
+			expect(fehlerliste?.textContent).toContain('Eingabefehler gefunden');
+		});
+	});
+
+	it('fokussiert die Fehlerliste, statt still auszusteigen', async () => {
+		render(AdminSightingEditForm, {
+			sighting: absendbareSichtung(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		await page.getByRole('button', { name: 'Speichern' }).click();
+
+		await vi.waitFor(() => {
+			const aktiv = document.activeElement as HTMLElement | null;
+			expect(aktiv?.textContent).toContain('Eingabefehler gefunden');
+			expect(aktiv?.getAttribute('tabindex')).toBe('-1');
+		});
+	});
+
+	it('verweist ohne Fehlerliste auf nichts', () => {
+		render(AdminSightingEditForm, {
+			sighting: baseSighting(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		const knopf = page.getByRole('button', { name: 'Speichern' }).element() as HTMLButtonElement;
+		// Ein `aria-describedby` ins Leere meldet niemand — es darf erst
+		// entstehen, wenn die Fläche im DOM steht.
+		expect(knopf.getAttribute('aria-describedby')).toBeNull();
+		expect(knopf.disabled).toBe(false);
+	});
+});
+
+describe('AdminSightingEditForm — Schutz vor ungespeicherten Änderungen', () => {
+	let bestaetigung: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		navigation.callbacks.length = 0;
+		bestaetigung = vi.spyOn(window, 'confirm').mockReturnValue(true);
+	});
+
+	afterEach(() => {
+		bestaetigung.mockRestore();
+		vi.restoreAllMocks();
+	});
+
+	it('lässt eine Navigation ohne Änderungen unbehelligt durch', () => {
+		render(AdminSightingEditForm, {
+			sighting: baseSighting(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		expect(navigiere().abgebrochen).toBe(false);
+		expect(bestaetigung).not.toHaveBeenCalled();
+	});
+
+	it('fragt vor dem Wegnavigieren mit Änderungen nach', async () => {
+		render(AdminSightingEditForm, {
+			sighting: baseSighting(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		await aendereAnzahl('7');
+
+		expect(navigiere().abgebrochen).toBe(false);
+		expect(bestaetigung).toHaveBeenCalledOnce();
+	});
+
+	it('bricht die Navigation ab, wenn die Rückfrage verneint wird', async () => {
+		bestaetigung.mockReturnValue(false);
+		render(AdminSightingEditForm, {
+			sighting: baseSighting(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		await aendereAnzahl('7');
+
+		expect(navigiere().abgebrochen).toBe(true);
+	});
+
+	it('hält einen harten Reload auf, ohne einen eigenen Dialog zu zeigen', async () => {
+		render(AdminSightingEditForm, {
+			sighting: baseSighting(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		await aendereAnzahl('7');
+
+		// Beim Verlassen der Seite gehört der Dialog dem Browser — ein `confirm()`
+		// zeigt in diesem Fenster kein Browser mehr an.
+		expect(navigiere('leave').abgebrochen).toBe(true);
+		expect(bestaetigung).not.toHaveBeenCalled();
+	});
+
+	it('fragt nach erfolgreichem Speichern nicht mehr nach', async () => {
+		const gespeichert = { ...gueltigeSichtung(), totalCount: 7 };
+		vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+			if (String(input).startsWith('/api/sightings/')) {
+				return new Response(JSON.stringify(gespeichert), {
+					status: 200,
+					headers: { 'content-type': 'application/json' }
+				});
+			}
+			return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+		});
+		const onSave = vi.fn();
+		render(AdminSightingEditForm, {
+			sighting: gueltigeSichtung(),
+			onSave,
+			onCancel: vi.fn()
+		});
+
+		await aendereAnzahl('7');
+		await page.getByRole('button', { name: 'Speichern' }).click();
+		await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
+
+		// Der Aufrufer navigiert in `onSave` — was jetzt noch abgefragt würde,
+		// wäre eine Rückfrage nach bereits gespeicherten Daten.
+		expect(navigiere().abgebrochen).toBe(false);
+		expect(bestaetigung).not.toHaveBeenCalled();
 	});
 });

--- a/src/lib/components/admin/AdminSightingEditForm.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingEditForm.svelte.test.ts
@@ -198,6 +198,31 @@ describe('AdminSightingEditForm — Speichern-Knopf', () => {
 		});
 	});
 
+	it('reißt den Fokus beim Korrigieren eines Feldes nicht zurück zur Fehlerliste', async () => {
+		render(AdminSightingEditForm, {
+			sighting: absendbareSichtung(),
+			onSave: vi.fn(),
+			onCancel: vi.fn()
+		});
+
+		await page.getByRole('button', { name: 'Speichern' }).click();
+		await vi.waitFor(() => {
+			expect((document.activeElement as HTMLElement | null)?.textContent).toContain(
+				'Eingabefehler gefunden'
+			);
+		});
+
+		/* Der Nutzer korrigiert ein Feld: `updateField` räumt dessen Eintrag aus
+		   dem errors-Store, die Liste bleibt wegen der übrigen Fehler stehen.
+		   Der Fokus muss im gerade bearbeiteten Feld bleiben — ein Rücksprung
+		   zur Liste risse die Korrektur mitten in der Eingabe ab. */
+		await aendereAnzahl('7');
+		await new Promise((r) => setTimeout(r, 80));
+		expect((document.activeElement as HTMLElement | null)?.textContent ?? '').not.toContain(
+			'Eingabefehler gefunden'
+		);
+	});
+
 	it('verweist ohne Fehlerliste auf nichts', () => {
 		render(AdminSightingEditForm, {
 			sighting: baseSighting(),

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -477,7 +477,13 @@
 		{/if}
 		{#if status === 'approved'}
 			<span class="text-base-content/70 text-sm">
-				Freigegeben am {formatLocalDateTime(currentSighting.approvedAt, 'datetime')}
+				<!-- „durch …" nur, wenn eine Person bekannt ist: Der Altbestand aus dem
+				     Altsystem trägt kein `freigegeben_von`, ein „durch null" wäre die
+				     sichtbare Folge eines bedingungslosen Templates. -->
+				Freigegeben am {formatLocalDateTime(
+					currentSighting.approvedAt,
+					'datetime'
+				)}{currentSighting.approvedBy ? ` durch ${currentSighting.approvedBy}` : ''}
 			</span>
 		{:else if status === 'rejected'}
 			<span class="text-base-content/70 text-sm">

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -190,6 +190,32 @@ describe('AdminSightingView — Statusleiste im Kopfbereich', () => {
 		expect(screen.getByRole('row', { name: /^Freigegeben am/ }).elements()).toHaveLength(0);
 	});
 
+	it('nennt Zeitpunkt und Bearbeiter der Freigabe', async () => {
+		const screen = render(AdminSightingView, {
+			sighting: baseSighting({
+				approvedAt: new Date('2026-03-12T09:00:00Z'),
+				approvedBy: 'bernd@example.org'
+			}),
+			onStatusChange: vi.fn()
+		});
+
+		await expect.element(screen.getByRole('radio', { name: 'Freigegeben' })).toBeChecked();
+		expect(screen.container.textContent).toContain('bernd@example.org');
+	});
+
+	// Altbestand aus dem Altsystem trägt `freigegeben_von` = NULL. Ein „durch
+	// null" wäre die sichtbare Folge eines naiven Templates.
+	it('zeigt bei Altbestand ohne Person nur das Freigabedatum', async () => {
+		const screen = render(AdminSightingView, {
+			sighting: baseSighting({ approvedAt: new Date('2026-03-12T09:00:00Z'), approvedBy: null }),
+			onStatusChange: vi.fn()
+		});
+
+		await expect.element(screen.getByRole('radio', { name: 'Freigegeben' })).toBeChecked();
+		expect(screen.container.textContent).toContain('Freigegeben am');
+		expect(screen.container.textContent).not.toContain('durch');
+	});
+
 	it('nennt Zeitpunkt und Bearbeiter der Ablehnung', async () => {
 		const screen = render(AdminSightingView, {
 			sighting: baseSighting({

--- a/src/lib/components/admin/sightingVerdict.test.ts
+++ b/src/lib/components/admin/sightingVerdict.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { submitVerdict } from './sightingVerdict';
+import { toast } from '$lib/stores/toastState.svelte';
 
 vi.mock('$lib/stores/toastState.svelte', () => ({
 	toast: { error: vi.fn(), success: vi.fn() }
@@ -11,6 +12,9 @@ vi.mock('$lib/logger', () => ({
 describe('submitVerdict', () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
+		/* `restoreAllMocks` fasst die `vi.fn()` aus der Modul-Factory oben nicht an
+		   — ohne dieses Leeren sähe ein späterer Test die Toasts der früheren. */
+		vi.mocked(toast.error).mockClear();
 	});
 
 	it('sendet PATCH mit verdict im Body und meldet Erfolg', async () => {
@@ -48,5 +52,33 @@ describe('submitVerdict', () => {
 
 		vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
 		expect(await submitVerdict(42, 'reject')).toBe(false);
+	});
+
+	/* Für die Bulk-Aktion der Tabelle: Dort werden bis zu 100 Zeilen nacheinander
+	   geschickt, und ein Fehler-Toast pro Zeile wäre eine Wand statt einer
+	   Rückmeldung. Die Zusammenfassung übernimmt der Aufrufer. */
+	it('unterdrückt im stillen Modus den Fehler-Toast, meldet aber weiterhin false', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ message: 'kaputt' }), { status: 500 })
+		);
+
+		expect(await submitVerdict(42, 'approve', { silent: true })).toBe(false);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('unterdrückt im stillen Modus auch den Netzwerkfehler-Toast', async () => {
+		vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'));
+
+		expect(await submitVerdict(42, 'approve', { silent: true })).toBe(false);
+		expect(toast.error).not.toHaveBeenCalled();
+	});
+
+	it('meldet ohne stillen Modus weiterhin per Toast', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ message: 'kaputt' }), { status: 500 })
+		);
+
+		await submitVerdict(42, 'approve');
+		expect(toast.error).toHaveBeenCalled();
 	});
 });

--- a/src/lib/components/admin/sightingVerdict.ts
+++ b/src/lib/components/admin/sightingVerdict.ts
@@ -12,7 +12,21 @@ const logger = createLogger('adminInboxVerdict');
 
 export type SightingVerdict = 'approve' | 'reject' | 'reset';
 
-export async function submitVerdict(id: number, verdict: SightingVerdict): Promise<boolean> {
+export interface SubmitVerdictOptions {
+	/**
+	 * Unterdrückt den Fehler-Toast — für die Bulk-Aktion der Tabelle
+	 * (`bulkVerdict.ts`), die bis zu 100 Zeilen nacheinander schickt und am Ende
+	 * **eine** Zusammenfassung zeigt. Der Rückgabewert bleibt unverändert, der
+	 * Logeintrag ebenfalls: Still ist nur die Oberfläche, nicht die Diagnose.
+	 */
+	silent?: boolean;
+}
+
+export async function submitVerdict(
+	id: number,
+	verdict: SightingVerdict,
+	{ silent = false }: SubmitVerdictOptions = {}
+): Promise<boolean> {
 	try {
 		const response = await fetch(`/api/sightings/${id}/verify`, {
 			method: 'PATCH',
@@ -25,17 +39,21 @@ export async function submitVerdict(id: number, verdict: SightingVerdict): Promi
 		}
 		const body: { message?: string } | null = await response.json().catch(() => null);
 		logger.error({ id, verdict, status: response.status, body }, 'Verdict fehlgeschlagen');
-		toast.error(body?.message || 'Status konnte nicht gespeichert werden', {
-			title: 'Fehler',
-			dismissible: true
-		});
+		if (!silent) {
+			toast.error(body?.message || 'Status konnte nicht gespeichert werden', {
+				title: 'Fehler',
+				dismissible: true
+			});
+		}
 		return false;
 	} catch (error) {
 		logger.error({ id, verdict, error }, 'Netzwerkfehler beim Verdict');
-		toast.error('Netzwerkfehler beim Speichern des Status', {
-			title: 'Verbindungsfehler',
-			dismissible: true
-		});
+		if (!silent) {
+			toast.error('Netzwerkfehler beim Speichern des Status', {
+				title: 'Verbindungsfehler',
+				dismissible: true
+			});
+		}
 		return false;
 	}
 }

--- a/src/lib/form/isFormDirty.test.ts
+++ b/src/lib/form/isFormDirty.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { isFormDirty } from './isFormDirty';
+
+describe('isFormDirty — ungespeicherte Änderungen erkennen', () => {
+	it('meldet keine Änderung, wenn die Werte den Startwerten entsprechen', () => {
+		const initial = { species: 0, totalCount: 1, notes: 'Hallo' };
+		expect(isFormDirty({ ...initial }, initial)).toBe(false);
+	});
+
+	it('meldet eine Änderung, sobald ein Wert abweicht', () => {
+		const initial = { species: 0, totalCount: 1 };
+		expect(isFormDirty({ ...initial, totalCount: 2 }, initial)).toBe(true);
+	});
+
+	it('hält den Eingabefeld-String für unverändert gegenüber der Startzahl', () => {
+		// Ein Zahlenfeld liefert nach dem Tippen einen String zurück. Wer den
+		// Originalwert wieder einträgt, hat nichts geändert.
+		expect(isFormDirty({ totalCount: '1' }, { totalCount: 1 })).toBe(false);
+	});
+
+	it('behandelt null, undefined und Leerstring als denselben Leerzustand', () => {
+		// Ein nie befülltes Select startet als `null` und meldet sich als `''` —
+		// das ist keine Bearbeitung.
+		expect(isFormDirty({ notes: '' }, { notes: null })).toBe(false);
+		expect(isFormDirty({ notes: undefined }, { notes: '' })).toBe(false);
+	});
+
+	it('vergleicht Datumswerte über den Zeitpunkt, nicht über die Objektidentität', () => {
+		expect(
+			isFormDirty(
+				{ created: new Date('2026-07-30T10:00:00Z') },
+				{ created: new Date('2026-07-30T10:00:00Z') }
+			)
+		).toBe(false);
+		expect(
+			isFormDirty(
+				{ created: new Date('2026-07-30T11:00:00Z') },
+				{ created: new Date('2026-07-30T10:00:00Z') }
+			)
+		).toBe(true);
+	});
+
+	it('vergleicht Listen über ihren Inhalt', () => {
+		expect(isFormDirty({ uploadedFiles: [] }, { uploadedFiles: [] })).toBe(false);
+		expect(isFormDirty({ uploadedFiles: [{ id: 1 }] }, { uploadedFiles: [] })).toBe(true);
+	});
+
+	it('bemerkt ein Feld, das erst im aktuellen Zustand einen Wert hat', () => {
+		expect(isFormDirty({ notes: 'neu' }, {})).toBe(true);
+	});
+
+	it('ignoriert ein zusätzliches, aber leeres Feld', () => {
+		expect(isFormDirty({ notes: '' }, {})).toBe(false);
+	});
+
+	it('gilt ohne Startwerte als unverändert', () => {
+		// Der Formular-Store steht beim ersten Rendern noch nicht bereit — daraus
+		// darf keine Warnung „ungespeicherte Änderungen" entstehen.
+		expect(isFormDirty(undefined, { totalCount: 1 })).toBe(false);
+		expect(isFormDirty({ totalCount: 1 }, undefined)).toBe(false);
+	});
+});

--- a/src/lib/form/isFormDirty.ts
+++ b/src/lib/form/isFormDirty.ts
@@ -1,0 +1,42 @@
+/**
+ * Vergleicht den aktuellen Formularzustand mit seinen Startwerten.
+ *
+ * **Warum ein Vergleich und kein `isDirty` aus `createForm`:** Die eigene
+ * Form-Implementierung führt kein solches Kennzeichen. Sie hat zwar `touched`,
+ * das aber nur die Anzeige steuert („grünes Häkchen an berührten Feldern") und
+ * bereits vom bloßen Antippen eines Feldes gesetzt wird — ein Feld, das der
+ * Bearbeiter angefasst und wieder auf den Ausgangswert gestellt hat, gälte
+ * damit als geändert. Für eine Rückfrage vor dem Wegnavigieren ist das die
+ * falsche Frage: Sie soll nur kommen, wenn wirklich etwas verloren ginge.
+ *
+ * Der Vergleich ist bewusst nachsichtig, weil Formularfelder Werte in einer
+ * anderen Form zurückgeben, als sie hineingegangen sind:
+ *
+ * - Ein Zahlenfeld liefert `'1'`, wo die Startwerte `1` trugen.
+ * - Ein nie befülltes Select startet als `null` und meldet sich als `''`.
+ * - Datumswerte sind Objekte und nie identisch, auch bei gleichem Zeitpunkt.
+ *
+ * Ohne diese Normalisierung fragte die Maske bei jedem Verlassen nach, auch
+ * wenn niemand etwas geändert hat — und eine Rückfrage, die immer kommt, wird
+ * weggeklickt, bevor sie einmal recht hat.
+ */
+function normalize(value: unknown): string {
+	if (value === null || value === undefined) return '';
+	if (value instanceof Date) return Number.isNaN(value.getTime()) ? '' : value.toISOString();
+	if (typeof value === 'object') return JSON.stringify(value);
+	return String(value);
+}
+
+export function isFormDirty(
+	current: Record<string, unknown> | undefined,
+	initial: Record<string, unknown> | undefined
+): boolean {
+	// Der Formular-Store hängt am Context und steht beim ersten Rendern noch
+	// nicht bereit. „Kein Zustand" heißt „nichts zu verlieren".
+	if (!current || !initial) return false;
+
+	for (const key of new Set([...Object.keys(current), ...Object.keys(initial)])) {
+		if (normalize(current[key]) !== normalize(initial[key])) return true;
+	}
+	return false;
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -124,7 +124,14 @@ export const sightings = pgTable(
 		// PATCH /api/sightings/[id]/verify (ein Update, alle Status-Spalten).
 		// Regeln: .claude/rules/api.md „Prüfstatus einer Sichtung".
 		rejectedAt: timestamp('abgelehnt_am', { mode: 'date' }),
-		rejectedBy: varchar('abgelehnt_von', { length: 255 })
+		rejectedBy: varchar('abgelehnt_von', { length: 255 }),
+		// Wer freigegeben hat — symmetrisch zu abgelehnt_von und Teil desselben
+		// Statusvorgangs. Nullable und ohne Default: Der Altbestand (bis 2025-11
+		// aus dem Altsystem, das auf derselben Datenbank liegt) hat diese
+		// Information nicht, und ein Platzhalter würde eine Person behaupten, die
+		// es nie gab. Geschrieben ausschließlich von
+		// PATCH /api/sightings/[id]/verify, gemeinsam mit allen Status-Spalten.
+		approvedBy: varchar('freigegeben_von', { length: 255 })
 	},
 	(table) => [
 		index('geom_sichtungen').using(

--- a/src/lib/server/db/sightingRepository.test.ts
+++ b/src/lib/server/db/sightingRepository.test.ts
@@ -465,6 +465,7 @@ describe('sightingRepository', () => {
 				...mockFormData,
 				verified: true,
 				approvedAt: new Date('2026-01-01T00:00:00.000Z'),
+				approvedBy: 'angreifer@example.com',
 				rejectedAt: new Date('2026-01-02T00:00:00.000Z'),
 				rejectedBy: 'angreifer@example.com'
 			} as any);
@@ -474,6 +475,7 @@ describe('sightingRepository', () => {
 			expect(updatePayload).toBeDefined();
 			expect(updatePayload).not.toHaveProperty('verified');
 			expect(updatePayload).not.toHaveProperty('approvedAt');
+			expect(updatePayload).not.toHaveProperty('approvedBy');
 			expect(updatePayload).not.toHaveProperty('rejectedAt');
 			expect(updatePayload).not.toHaveProperty('rejectedBy');
 		});

--- a/src/lib/server/db/sightingRepository.ts
+++ b/src/lib/server/db/sightingRepository.ts
@@ -226,6 +226,9 @@ export const updateSighting = async (
 		id: _id,
 		created: _created,
 		approvedAt: _approvedAt,
+		// `freigegeben_von` gehört zum Zeitstempel wie `abgelehnt_von` zu seinem —
+		// derselbe Vorgang, derselbe alleinige Schreiber (Verify-Endpunkt).
+		approvedBy: _approvedBy,
 		verified: _verified,
 		// Gleiche Regel wie für `verified`/`approvedAt`: Die Ablehnung ist Teil
 		// desselben Statusvorgangs. `PATCH /api/sightings/[id]/verify` schreibt

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -23,9 +23,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		throw redirect(301, `/admin/sichtungen?${url.searchParams.toString()}`);
 	}
 
-	// Sortierrichtung nach Meldedatum. Default älteste zuerst (FIFO — nichts
-	// bleibt liegen); per ?order=desc umkehrbar, gehalten in der URL.
-	const order: 'asc' | 'desc' = url.searchParams.get('order') === 'desc' ? 'desc' : 'asc';
+	// Sortierrichtung nach Meldedatum. Default neueste zuerst (Entscheidung
+	// Jan, 2026-08-08): der Altbestand ab 2013 macht FIFO als Default
+	// unbrauchbar — ~650 offene Meldungen, ein Bearbeiter sähe sonst zuerst
+	// 13 Jahre alte Fälle. `?order=asc` bleibt als bewusste Wahl erhalten,
+	// gehalten in der URL.
+	const order: 'asc' | 'desc' = url.searchParams.get('order') === 'asc' ? 'asc' : 'desc';
 
 	const openQuery = db
 		.select()

--- a/src/routes/admin/[id]/edit/+page.svelte
+++ b/src/routes/admin/[id]/edit/+page.svelte
@@ -24,35 +24,37 @@
 </script>
 
 <svelte:head>
-	<title>Sichtung #{data.sighting?.id} - Bearbeiten - Admin - Ostsee-Tiere</title>
-	<meta 
-		name="description" 
-		content="Bearbeitung der Sichtung #{data.sighting?.id}. Admin-Bereich zur Korrektur und Anpassung von Sichtungsdaten." 
+	<title>Sichtung #{data.sighting?.id} bearbeiten - Admin - Ostsee-Tiere</title>
+	<meta
+		name="description"
+		content="Bearbeitung der Sichtung #{data.sighting
+			?.id}. Admin-Bereich zur Korrektur und Anpassung von Sichtungsdaten."
 	/>
-	<meta 
-		name="keywords" 
-		content="Sichtung, Bearbeiten, Admin, {data.sighting?.species || 'Meerestier'}, Ostsee, Verwaltung" 
+	<meta
+		name="keywords"
+		content="Sichtung, Bearbeiten, Admin, {data.sighting?.species ||
+			'Meerestier'}, Ostsee, Verwaltung"
 	/>
-	
+
 	<!-- Open Graph -->
 	<meta property="og:title" content="Sichtung #{data.sighting?.id} bearbeiten - Admin" />
-	<meta 
-		property="og:description" 
-		content="Bearbeitung einer Meerestier-Sichtung im Admin-Bereich" 
+	<meta
+		property="og:description"
+		content="Bearbeitung einer Meerestier-Sichtung im Admin-Bereich"
 	/>
 	<meta property="og:type" content="website" />
-	
+
 	<!-- Twitter Card -->
 	<meta name="twitter:card" content="summary" />
 	<meta name="twitter:title" content="Sichtung #{data.sighting?.id} bearbeiten - Admin" />
-	<meta 
-		name="twitter:description" 
-		content="Bearbeitung einer Meerestier-Sichtung im Admin-Bereich" 
+	<meta
+		name="twitter:description"
+		content="Bearbeitung einer Meerestier-Sichtung im Admin-Bereich"
 	/>
 </svelte:head>
 
 <div class="mb-0 flex items-center justify-between">
-	<h2 class="text-xl font-bold">Sichtung Details</h2>
+	<h2 class="text-xl font-bold">Sichtung bearbeiten</h2>
 	<div class="flex gap-2">
 		<button
 			class="btn btn-ghost btn-sm"
@@ -65,7 +67,7 @@
 		</button>
 	</div>
 </div>
-<div class="mb-4 text-sm text-base-content/70">
+<div class="text-base-content/70 mb-4 text-sm">
 	Referenz-ID: {sighting.referenceId}
 </div>
 <AdminSightingEditForm {sighting} {onCancel} onSave={handleSave} />

--- a/src/routes/admin/[id]/edit/editPageHeading.test.ts
+++ b/src/routes/admin/[id]/edit/editPageHeading.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Die Bearbeitungsseite nannte sich „Sichtung Details" — derselbe
+ * Wortlaut wie die Detailansicht und derselbe `<title>`-Aufbau. Wer zwei Tabs
+ * offen hatte, konnte Lesen und Bearbeiten nicht auseinanderhalten.
+ */
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const quelle = readFileSync(new URL('./+page.svelte', import.meta.url), 'utf-8');
+
+describe('Bearbeitungsseite — Überschrift und Seitentitel', () => {
+	it('überschreibt die Seite mit „Sichtung bearbeiten"', () => {
+		expect(quelle).toContain('<h2 class="text-xl font-bold">Sichtung bearbeiten</h2>');
+	});
+
+	it('nennt die Bearbeitung nicht „Details"', () => {
+		expect(quelle).not.toContain('Sichtung Details');
+	});
+
+	it('trägt denselben Wortlaut im Seitentitel wie in der Überschrift', () => {
+		// Der Tab-Titel ist im Alltag die einzige Unterscheidung zwischen zwei
+		// offenen Tabs derselben Sichtung — er muss dieselbe Vokabel führen.
+		const titel = quelle.match(/<title>([^<]*)<\/title>/)?.[1] ?? '';
+		expect(titel).toBe('Sichtung #{data.sighting?.id} bearbeiten - Admin - Ostsee-Tiere');
+	});
+});

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -8,9 +8,11 @@
  * 1. Gemerkte Tabellen-URLs (`/admin?page=…`) landen per 301 auf
  *    `/admin/sichtungen` — mitsamt Query, sonst verlieren geteilte Filter-Links
  *    ihren Inhalt.
- * 2. Default-Sortierung ist `created` **aufsteigend** (FIFO): Die älteste offene
- *    Meldung steht oben, damit nichts liegen bleibt.
- * 3. `?order=` kennt genau zwei gültige Werte; alles andere fällt auf `asc`
+ * 2. Default-Sortierung ist `created` **absteigend** (neueste zuerst):
+ *    Entscheidung Jan, 2026-08-08 — der Altbestand ab 2013 macht FIFO als
+ *    Default unbrauchbar, ein Bearbeiter sähe sonst zuerst 13 Jahre alte
+ *    Meldungen. `?order=asc` bleibt als bewusste Wahl erhalten.
+ * 3. `?order=` kennt genau zwei gültige Werte; alles andere fällt auf `desc`
  *    zurück statt in die SQL zu wandern.
  * 4. Bildvorschauen kommen aus **einem** Query und werden in JS nach
  *    Sichtungs-ID gruppiert.
@@ -117,23 +119,23 @@ describe('Eingangs-Load', () => {
 		expect(recordedSelects).toHaveLength(0);
 	});
 
-	it('Default-Sortierung ist created aufsteigend (älteste zuerst)', async () => {
+	it('Default-Sortierung ist created absteigend (neueste zuerst)', async () => {
 		const result = await runLoad(makeUrl());
 
-		expect(result.order).toBe('asc');
+		expect(result.order).toBe('desc');
 		expect(recordedSelects[0]?.orderBySql).toMatch(/"created"/);
-		expect(recordedSelects[0]?.orderBySql).toMatch(/\basc\b/i);
+		expect(recordedSelects[0]?.orderBySql).toMatch(/\bdesc\b/i);
 	});
 
-	it('?order=desc dreht die Richtung, alles andere fällt auf asc zurück', async () => {
-		const absteigend = await runLoad(makeUrl({ order: 'desc' }));
-		expect(absteigend.order).toBe('desc');
-		expect(recordedSelects[0]?.orderBySql).toMatch(/\bdesc\b/i);
+	it('?order=asc dreht die Richtung, alles andere fällt auf desc zurück', async () => {
+		const aufsteigend = await runLoad(makeUrl({ order: 'asc' }));
+		expect(aufsteigend.order).toBe('asc');
+		expect(recordedSelects[0]?.orderBySql).toMatch(/\basc\b/i);
 
 		recordedSelects = [];
 		const kaputt = await runLoad(makeUrl({ order: 'kaputt' }));
-		expect(kaputt.order).toBe('asc');
-		expect(recordedSelects[0]?.orderBySql).toMatch(/\basc\b/i);
+		expect(kaputt.order).toBe('desc');
+		expect(recordedSelects[0]?.orderBySql).toMatch(/\bdesc\b/i);
 	});
 
 	it('gruppiert Bilddateien nach Sichtungs-ID', async () => {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { SvelteSet } from 'svelte/reactivity';
 	import { untrack } from 'svelte';
 	import CleanupPanel from './CleanupPanel.svelte';
+	import ResetSettingsButton from './ResetSettingsButton.svelte';
 	import { ACTIVE_CONFIG_KEYS, getConfigLabel } from './configLabels';
 
 	const logger = createLogger('admin:settings');
@@ -199,10 +200,6 @@
 	}
 
 	async function resetToDefaults() {
-		if (!confirm('Möchten Sie wirklich alle Einstellungen auf die Standardwerte zurücksetzen?')) {
-			return;
-		}
-
 		try {
 			const response = await fetch('/api/config/reset', {
 				method: 'POST',
@@ -328,11 +325,6 @@
 					Alle Änderungen speichern ({changedConfigs.size})
 				</button>
 			{/if}
-
-			<button onclick={resetToDefaults} class="btn btn-warning gap-2">
-				<Icon icon="lucide:refresh-cw" class="size-5" />
-				Zurücksetzen
-			</button>
 		</div>
 	</div>
 
@@ -564,5 +556,11 @@
 
 	<div class="mt-6">
 		<CleanupPanel />
+	</div>
+
+	<!-- Destruktive Aktion ans Seitenende, weg vom prominentesten Platz oben rechts
+	     (X2 im Admin-Improvements-Spec): eigener Bestätigungsdialog statt confirm(). -->
+	<div class="mt-6 flex justify-end">
+		<ResetSettingsButton onReset={resetToDefaults} />
 	</div>
 </div>

--- a/src/routes/admin/settings/ResetSettingsButton.svelte
+++ b/src/routes/admin/settings/ResetSettingsButton.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	/**
+	 * Destruktive Aktion "Einstellungen zurücksetzen" mit projektüblichem
+	 * Bestätigungsdialog (native <dialog>, Muster wie DeleteDialog.svelte).
+	 * Der Trigger-Button folgt der Destruktiv-Konvention aus design-system.md:
+	 * btn btn-outline btn-error btn-sm, nie ohne Bestätigung.
+	 */
+	import Icon from '$lib/components/Icon.svelte';
+
+	let { onReset }: { onReset: () => void } = $props();
+
+	let dialogElement = $state<HTMLDialogElement | null>(null);
+	let show = $state(false);
+
+	$effect(() => {
+		if (!dialogElement) return;
+		if (show && !dialogElement.open) {
+			dialogElement.showModal();
+		} else if (!show && dialogElement.open) {
+			dialogElement.close();
+		}
+	});
+
+	function openDialog() {
+		show = true;
+	}
+
+	function confirmReset() {
+		show = false;
+		onReset();
+	}
+
+	function cancel() {
+		show = false;
+	}
+</script>
+
+<button type="button" class="btn btn-outline btn-error btn-sm gap-2" onclick={openDialog}>
+	<Icon icon="lucide:refresh-cw" class="size-4" aria-hidden="true" />
+	Zurücksetzen
+</button>
+
+<dialog
+	bind:this={dialogElement}
+	class="modal"
+	aria-labelledby="reset-settings-dialog-title"
+	onclose={cancel}
+>
+	<div class="modal-box w-96">
+		<h3 id="reset-settings-dialog-title" class="mb-4 text-lg font-bold">
+			Einstellungen zurücksetzen
+		</h3>
+		<p class="mb-4">
+			Alle Einstellungen auf die Vorbelegung zurücksetzen — gespeicherte Werte gehen verloren.
+		</p>
+		<div class="modal-action">
+			<button type="button" class="btn" onclick={cancel}>Abbrechen</button>
+			<button type="button" class="btn btn-error" onclick={confirmReset}>
+				Endgültig zurücksetzen
+			</button>
+		</div>
+	</div>
+	<!-- Schleier über der Seite dahinter, kein Theme-Ton: bg-scrim/<n>
+	     (--scrim-surface in tokens.css), Muster wie DeleteDialog.svelte. -->
+	<form method="dialog" class="modal-backdrop bg-scrim/50">
+		<button aria-label="Dialog schließen" onclick={cancel}>
+			<span class="sr-only">Dialog schließen</span>
+		</button>
+	</form>
+</dialog>

--- a/src/routes/admin/settings/ResetSettingsButton.svelte.test.ts
+++ b/src/routes/admin/settings/ResetSettingsButton.svelte.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Der Reset-Button ist eine destruktive Aktion (X2 im Admin-Improvements-Spec):
+ * ein Klick darf niemals sofort zurücksetzen, sondern muss erst den
+ * Bestätigungsdialog öffnen. Erst "Endgültig zurücksetzen" löst den Callback aus,
+ * "Abbrechen" und das Schließen des Dialogs nie.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import ResetSettingsButton from './ResetSettingsButton.svelte';
+
+describe('ResetSettingsButton', () => {
+	it('öffnet den Bestätigungsdialog statt sofort zurückzusetzen', async () => {
+		const onReset = vi.fn();
+		render(ResetSettingsButton, { onReset });
+
+		await page.getByRole('button', { name: 'Zurücksetzen' }).click();
+
+		await expect
+			.element(page.getByRole('heading', { name: 'Einstellungen zurücksetzen' }))
+			.toBeVisible();
+		expect(onReset).not.toHaveBeenCalled();
+	});
+
+	it('löst den Reset erst beim Bestätigen aus', async () => {
+		const onReset = vi.fn();
+		render(ResetSettingsButton, { onReset });
+
+		await page.getByRole('button', { name: 'Zurücksetzen' }).click();
+		await page.getByRole('button', { name: 'Endgültig zurücksetzen' }).click();
+
+		expect(onReset).toHaveBeenCalledTimes(1);
+	});
+
+	it('bricht ohne Reset ab, wenn "Abbrechen" geklickt wird', async () => {
+		const onReset = vi.fn();
+		render(ResetSettingsButton, { onReset });
+
+		await page.getByRole('button', { name: 'Zurücksetzen' }).click();
+		await page.getByRole('button', { name: 'Abbrechen' }).click();
+
+		expect(onReset).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -39,6 +39,13 @@
 	} from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 	import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+	import {
+		COLUMN_PREFERENCES_STORAGE_KEY,
+		loadColumnPreferences,
+		serializeColumnPreferences
+	} from './columnPreferences';
+	import { getHeaderState, isSameIdList, setAllSelected, toggleSelection } from './bulkSelection';
+	import { buildBulkSummary, runBulkVerdict } from './bulkVerdict';
 
 	const logger = createLogger('SichtungenPage');
 
@@ -64,17 +71,25 @@
 	let showExportModal = $state(false);
 	let showColumnDropdown = $state(false);
 
-	// Column visibility configuration
-	let columnVisibility = $state({
+	/* Column visibility configuration
+	   `email`, `distance` und `distribution` starten aus: Mit ihnen war die
+	   Tabelle in der Default-Auswahl 1456 px breit, und aus dem Viewport liefen
+	   ausgerechnet Status und Aktionen — die Spalten, wegen derer man die
+	   Tabelle öffnet. Abgeschaltet sind sie nicht weg, sondern eine
+	   Checkbox im „Spalten"-Dropdown entfernt.
+	   Als eigene Konstante (statt inline in $state): `loadColumnPreferences`
+	   merged einen gespeicherten Stand gegen genau diese Werte, siehe
+	   `columnPreferences.ts`. */
+	const DEFAULT_COLUMN_VISIBILITY = {
 		referenceId: true,
 		sightingDate: true,
 		created: true,
-		email: true,
+		email: false,
 		species: true,
-		distance: true,
+		distance: false,
 		totalCount: true,
 		juvenileCount: true,
-		distribution: true,
+		distribution: false,
 		behavior: false,
 		seaState: false,
 		wind: false,
@@ -84,6 +99,40 @@
 		balticSea: true,
 		verified: true,
 		actions: true
+	};
+	/* SSR rendert immer mit dem Default — `localStorage` existiert dort nicht
+	   (architecture.md: kein window-Zugriff beim SSR-Rendern). Der `$effect`
+	   unten übernimmt den gespeicherten Stand direkt nach der Hydration; ein
+	   kurzes Umspringen der Spaltenauswahl im ersten Frame im Browser ist dabei
+	   bewusst in Kauf genommen.
+
+	   Direkter `localStorage`-Zugriff statt `$lib/storage/localStorage`: Dessen
+	   Helfer gehören zum Lebenszyklus des Meldeformulars — `STORAGE_KEYS` trägt
+	   den `sichtungen_`-Namespace und `clearStorage()` räumt diese Schlüssel
+	   beim Verwerfen des Formulars ab. Eine Admin-UI-Präferenz darf daran nicht
+	   hängen; Versionierung und tolerantes Parsen kapselt hier stattdessen
+	   `columnPreferences.ts`. */
+	let columnVisibility = $state({ ...DEFAULT_COLUMN_VISIBILITY });
+	let hatGespeicherteSpaltenGeladen = false;
+
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		if (!hatGespeicherteSpaltenGeladen) {
+			// Einmaliges Laden beim Mount. Kaputtes/altes JSON und unbekannte
+			// Schlüssel fallen in `loadColumnPreferences` still auf den Default
+			// zurück; neue Spalten erscheinen mit ihrem eigenen Default-Wert.
+			columnVisibility = loadColumnPreferences(
+				window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY),
+				DEFAULT_COLUMN_VISIBILITY
+			);
+			hatGespeicherteSpaltenGeladen = true;
+			return; // Diesen Durchlauf nicht sofort wieder zurückschreiben.
+		}
+		// Jede weitere Änderung (Checkbox im „Spalten"-Dropdown) wird persistiert.
+		window.localStorage.setItem(
+			COLUMN_PREFERENCES_STORAGE_KEY,
+			serializeColumnPreferences(columnVisibility)
+		);
 	});
 
 	// Available columns configuration
@@ -111,6 +160,15 @@
 		{ key: 'verified', label: 'Status', sortKey: null },
 		{ key: 'actions', label: 'Aktionen', sortKey: null }
 	];
+
+	/* Gemessene Breite der Aktionsspalte — die Statusspalte rastet links davon
+	   ein. Ein fester Wert ginge nicht: die Zahl der Aktions-Buttons hängt an
+	   `isSuperAdmin`, und der Spaltenkopf trägt dieselbe Breite wie die Zellen
+	   darunter (gleiche Tabellenspalte). */
+	let actionsColumnWidth = $state(0);
+	/* Ohne Aktionsspalte gehört die Statusspalte selbst an den Rand — sonst
+	   bliebe die zuletzt gemessene Breite als Lücke stehen. */
+	let stickyStatusRight = $derived(columnVisibility.actions ? actionsColumnWidth : 0);
 
 	// Prüft ob irgendwelche Filter aktiv sind
 	let hasActiveFilters = $derived(
@@ -359,6 +417,127 @@
 		} finally {
 			statusPending.delete(id);
 		}
+	}
+
+	/* ---------------------------------------------------------------------- */
+	/* Bulk-Aktionen (nur Desktop-Tabelle)                                      */
+	/* ---------------------------------------------------------------------- */
+
+	/**
+	 * Die gewählten Zeilen — immer nur aus der **aktuell sichtbaren** Seite.
+	 * Ein Cross-Page-Gedächtnis wäre gefährlich: „Freigeben" löste dann Zeilen
+	 * aus, die niemand mehr vor sich hat. Die Rechenregeln stehen in
+	 * `bulkSelection.ts`, hier liegt nur der Zustand.
+	 */
+	let selectedIds = $state<number[]>([]);
+	let visibleIds = $derived(sightings.map((sighting) => sighting.id));
+	let headerState = $derived(getHeaderState(selectedIds, visibleIds));
+
+	/* Zuletzt gesehene Liste als einfache Variable und nicht als `$state`: Sie ist
+	   nur Vergleichsgrundlage des Effekts unten; als reaktiver Wert löste ihr
+	   Schreiben denselben Effekt erneut aus. */
+	let zuletztGeseheneIds: number[] = [];
+	$effect(() => {
+		const ids = visibleIds;
+		if (isSameIdList(zuletztGeseheneIds, ids)) return;
+		// Seitenwechsel, Filterwechsel oder Neuladen nach einer Aktion — die
+		// Auswahl gehört geleert, sie bezog sich auf eine andere Liste.
+		zuletztGeseheneIds = ids;
+		selectedIds = [];
+	});
+
+	/** Läuft gerade eine Bulk-Ausführung? Sperrt die Leiste hart (siehe unten). */
+	let bulkPending = $state(false);
+	let bulkProgress = $state<{ done: number; total: number } | null>(null);
+
+	/* `indeterminate` ist eine reine DOM-Eigenschaft ohne HTML-Attribut — als
+	   `indeterminate={…}` im Markup wäre nicht verlässlich, dass Svelte sie als
+	   Property und nicht als Attribut setzt. Deshalb explizit über eine
+	   Referenz. */
+	let headerCheckbox = $state<HTMLInputElement | null>(null);
+	$effect(() => {
+		if (headerCheckbox) headerCheckbox.indeterminate = headerState === 'partial';
+	});
+
+	async function runBulkSequence(
+		ids: number[],
+		verdict: SightingVerdict,
+		options: { skipped?: number; allowUndo: boolean }
+	): Promise<void> {
+		bulkPending = true;
+		bulkProgress = { done: 0, total: ids.length };
+		/* Die Zeilen für die Dauer der Schleife sperren — dieselbe Wache wie beim
+		   Einzelwechsel. Sonst könnte ein Klick auf das Status-Control einer
+		   gerade laufenden Zeile ein zweites Verdict hinterherschicken. */
+		for (const id of ids) statusPending.add(id);
+		try {
+			const outcome = await runBulkVerdict(ids, verdict, {
+				/* `silent`: Sonst käme ein Fehler-Toast pro Zeile — bei 40 Zeilen eine
+				   Wand statt einer Rückmeldung. Gemeldet wird einmal, unten. */
+				submit: (id, v) => submitVerdict(id, v, { silent: true }),
+				onProgress: (done, total) => (bulkProgress = { done, total })
+			});
+
+			selectedIds = [];
+			await invalidateAll();
+
+			const summary = buildBulkSummary(outcome, verdict, options.skipped ?? 0);
+			/* Ein Toast statt N — `warning` bei Teilfehlern, damit die Fehlerzahl
+			   nicht in einem grünen Erfolgs-Toast untergeht. */
+			const zeigeToast = summary.hasFailures ? toast.warning : toast.success;
+			/* Die Aktion wird per Spread ergänzt statt als `action: … : undefined`
+			   gesetzt: Unter `exactOptionalPropertyTypes` ist ein explizites
+			   `undefined` nicht dasselbe wie ein fehlendes Feld. */
+			const undoAktion =
+				options.allowUndo && outcome.succeeded.length > 0
+					? {
+							label: 'Rückgängig',
+							/* Nur die Erfolge: Ein `reset` auf eine Zeile, deren Wechsel nie
+							   ankam, überschriebe einen fremden Zustand. */
+							onClick: () => void undoBulk(outcome.succeeded)
+						}
+					: null;
+			zeigeToast(summary.message, {
+				duration: SIGHTING_STATUS_UNDO_MS,
+				dismissible: true,
+				...(undoAktion ? { action: undoAktion } : {})
+			});
+		} finally {
+			for (const id of ids) statusPending.delete(id);
+			bulkPending = false;
+			bulkProgress = null;
+		}
+	}
+
+	async function runBulk(verdict: SightingVerdict): Promise<void> {
+		if (bulkPending) return;
+		const auswahl = [...selectedIds];
+		/* Zeilen mit laufender Einzelaktion bleiben außen vor: Ihr Vorgänger-Zustand
+		   ist gerade in Bewegung, ein zweites Verdict darüber wäre ein Rennen. */
+		const auszufuehren = auswahl.filter((id) => !statusPending.has(id));
+		const uebersprungen = auswahl.length - auszufuehren.length;
+
+		if (auszufuehren.length === 0) {
+			toast.error('Die gewählten Zeilen werden gerade noch bearbeitet — bitte kurz warten.', {
+				title: 'Aktion nicht möglich',
+				dismissible: true
+			});
+			return;
+		}
+
+		await runBulkSequence(auszufuehren, verdict, { skipped: uebersprungen, allowUndo: true });
+	}
+
+	/** Das Rückgängig des Bulk-Toasts — kein eigenes Undo darauf, sonst pendelt es. */
+	async function undoBulk(ids: number[]): Promise<void> {
+		if (bulkPending) {
+			toast.error('Es läuft noch eine Aktion — bitte kurz warten.', {
+				title: 'Rückgängig nicht möglich',
+				dismissible: true
+			});
+			return;
+		}
+		await runBulkSequence(ids, 'reset', { allowUndo: false });
 	}
 </script>
 
@@ -848,16 +1027,97 @@
 
 	<!-- Desktop Table Layout -->
 	<div class="hidden px-2 sm:px-4 md:block">
+		<!--
+			Aktionsleiste der Bulk-Auswahl. Sie erscheint nur bei Auswahl > 0 und steht
+			über der Tabelle, nicht als schwebender Balken: Bezugspunkt sind die
+			Checkboxen darunter, und ein Overlay verdeckte auf kurzen Listen die
+			erste Zeile.
+			„Freigeben" ist hier `btn-primary`, obwohl „Export" im Seitenkopf ebenfalls
+			primär ist — die Leiste ist ein eigener, temporärer Handlungsbereich mit
+			genau einer Primäraktion (Button-Hierarchie: eine pro Bereich). „Ablehnen"
+			bleibt `btn-outline`, „Auswahl aufheben" als reine Rücknahme `btn-ghost`.
+			`disabled` und nicht `aria-disabled` während des Laufs — mit offenem
+			Vorbehalt: Der Lauf ist bei vielen Zeilen NICHT kurz, Tastaturnutzer
+			verlieren für seine Dauer den Fokus. Trotzdem `disabled`, weil ein frei
+			fokussierbarer Knopf während eines Laufs, der gerade dutzende Zeilen
+			schreibt, Bedienbarkeit behauptete, die es nicht gibt (`runBulk` wiese
+			den Klick nur still ab); den Zustand erklärt die aria-live-Fortschritts-
+			anzeige daneben. Ein Doppelklick hätte hier echte Folgen.
+		-->
+		{#if selectedIds.length > 0}
+			<div
+				class="bg-base-200 border-base-300 mb-3 flex flex-wrap items-center gap-3 rounded-lg border p-3"
+				role="group"
+				aria-label="Aktionen für die ausgewählten Sichtungen"
+			>
+				<span class="font-semibold">{selectedIds.length} ausgewählt</span>
+				{#if bulkProgress}
+					<span class="text-base-content/70 flex items-center gap-2 text-sm" aria-live="polite">
+						<span class="loading loading-spinner loading-xs" aria-hidden="true"></span>
+						{bulkProgress.done}/{bulkProgress.total} verarbeitet
+					</span>
+				{/if}
+				<div class="ml-auto flex flex-wrap items-center gap-2">
+					<button
+						class="btn btn-sm btn-primary"
+						onclick={() => runBulk('approve')}
+						disabled={bulkPending}
+					>
+						<Icon icon={SIGHTING_STATUS_PRESENTATION.approved.icon} class="mr-1 h-4 w-4" />
+						Freigeben
+					</button>
+					<button
+						class="btn btn-sm btn-outline"
+						onclick={() => runBulk('reject')}
+						disabled={bulkPending}
+					>
+						<Icon icon={SIGHTING_STATUS_PRESENTATION.rejected.icon} class="mr-1 h-4 w-4" />
+						Ablehnen
+					</button>
+					<button
+						class="btn btn-sm btn-ghost"
+						onclick={() => (selectedIds = [])}
+						disabled={bulkPending}
+					>
+						Auswahl aufheben
+					</button>
+				</div>
+			</div>
+		{/if}
 		<div class="border-base-300 bg-base-100 w-full overflow-x-auto rounded-lg border shadow-sm">
 			<table class="table-zebra table w-full">
 				<thead class="bg-base-200 text-base-content">
 					<tr>
+						<!-- Auswahlspalte, ganz links und wie die Markerspalte daneben fest:
+						     Sie steht bewusst nicht in `availableColumns`. Abschaltbar wäre die
+						     Bulk-Funktion je nach gespeicherter Spaltenwahl unerreichbar — und
+						     der gespeicherte Stand überlebt seit U2 den Reload.
+						     Nicht `sticky-col`: Der fixierte Bereich liegt rechts (Status,
+						     Aktionen); eine zweite fixierte Kante links stahl auf schmalen
+						     Fenstern zusätzlich Platz vom scrollenden Mittelteil. -->
+						<th class="w-px p-0">
+							<label class="flex cursor-pointer items-center justify-center px-2">
+								<input
+									type="checkbox"
+									class="checkbox checkbox-sm"
+									bind:this={headerCheckbox}
+									checked={headerState === 'all'}
+									disabled={bulkPending}
+									onchange={(e) =>
+										(selectedIds = setAllSelected(visibleIds, e.currentTarget.checked))}
+									aria-label="Alle Sichtungen auf dieser Seite auswählen"
+								/>
+							</label>
+						</th>
 						<!-- Feste Markerspalte, nicht in der Spaltenauswahl: Sie steht vor
 						     allen konfigurierbaren Spalten und überlebt damit sowohl jede
 						     Spaltenwahl als auch das horizontale Scrollen der Tabelle. -->
 						<th class="w-px p-0"><span class="sr-only">Art der Meldung</span></th>
+						<!-- Kein `hover:bg-base-300` an den nicht sortierbaren Köpfen: Die
+						     Aufhellung unter dem Zeiger versprach eine Sortierung, die es hier
+						     nicht gibt — sortierbare Köpfe tragen sie am <button> in `sortableTh`. -->
 						{#if columnVisibility.referenceId}
-							<th class="hover:bg-base-300">Referenz-ID</th>
+							<th>Referenz-ID</th>
 						{/if}
 						{#if columnVisibility.sightingDate}
 							{@render sortableTh('Sichtungsdatum', 'sightingDate')}
@@ -896,25 +1156,51 @@
 							{@render sortableTh('Sichtweite', 'visibility')}
 						{/if}
 						{#if columnVisibility.mediaUpload}
-							<th class="hover:bg-base-300">Aufnahme</th>
+							<th>Aufnahme</th>
 						{/if}
 						{#if columnVisibility.spamScore}
 							{@render sortableTh('Spam', 'spamScore')}
 						{/if}
 						{#if columnVisibility.balticSea}
-							<th class="hover:bg-base-300">Ostsee</th>
+							<th>Ostsee</th>
 						{/if}
+						<!-- Status und Aktionen bleiben beim horizontalen Scrollen stehen: Sie
+						     sind der Grund, aus dem die Tabelle geöffnet wird, standen aber bei
+						     vielen aktiven Spalten außerhalb des Viewports. Die Trennkante an der
+						     linken Sticky-Zelle macht sichtbar, dass hier ein fixierter Bereich
+						     beginnt — ohne sie sieht der Durchlauf darunter nach einem Fehler aus. -->
 						{#if columnVisibility.verified}
-							<th class="hover:bg-base-300">Status</th>
+							<th class="sticky-col sticky-edge" style="right: {stickyStatusRight}px">Status</th>
 						{/if}
 						{#if columnVisibility.actions}
-							<th class="hover:bg-base-300">Aktionen</th>
+							<th
+								class="sticky-col {columnVisibility.verified ? '' : 'sticky-edge'}"
+								style="right: 0"
+								bind:clientWidth={actionsColumnWidth}
+							>
+								Aktionen
+							</th>
 						{/if}
 					</tr>
 				</thead>
 				<tbody>
 					{#each sightings as sighting (sighting.id)}
 						<tr class="hover:bg-base-200" data-sighting-id={sighting.id}>
+							<!-- Auswahl-Checkbox, Gegenstück zur Kopfspalte oben. Das `aria-label`
+							     nennt die Referenz-ID und nicht nur „Zeile 3": Beim Vorlesen ist
+							     die Nummer der Meldung das, woran die Zeile erkennbar ist. -->
+							<td class="w-px p-0">
+								<label class="flex cursor-pointer items-center justify-center px-2">
+									<input
+										type="checkbox"
+										class="checkbox checkbox-sm"
+										checked={selectedIds.includes(sighting.id)}
+										disabled={bulkPending}
+										onchange={() => (selectedIds = toggleSelection(selectedIds, sighting.id))}
+										aria-label="Sichtung {sighting.referenceId ?? sighting.id} auswählen"
+									/>
+								</label>
+							</td>
 							<!-- Kante und Icon zusammen: Die Kante wirkt beim Überfliegen, das
 							     Icon trägt zusätzlich eine Form — Farbe allein wäre kein
 							     Merkmal (WCAG 1.4.1). Der `sr-only`-Text benennt beides, sonst
@@ -1055,7 +1341,7 @@
 									approvedAt: sighting.approvedAt,
 									rejectedAt: sighting.rejectedAt
 								})}
-								<td>
+								<td class="sticky-col sticky-edge" style="right: {stickyStatusRight}px">
 									<SightingStatusControl
 										{status}
 										sightingId={sighting.id}
@@ -1066,7 +1352,12 @@
 								</td>
 							{/if}
 							{#if columnVisibility.actions}
-								<td class="w-px whitespace-nowrap">
+								<td
+									class="sticky-col w-px whitespace-nowrap {columnVisibility.verified
+										? ''
+										: 'sticky-edge'}"
+									style="right: 0"
+								>
 									<!-- flex-nowrap: sonst brechen die 44px hohen Buttons um und ziehen die Zeile auf -->
 									<div class="flex flex-nowrap items-center gap-1">
 										<button
@@ -1257,3 +1548,39 @@
 		</button>
 	</form>
 </dialog>
+
+<style>
+	/* Fixierte Spalten (Status, Aktionen) im horizontal scrollenden Container.
+	   Warum die Hintergründe hier von Hand stehen: `table-zebra` und der
+	   Zeilen-Hover färben das <tr>, nicht die Zellen — eine sticky-Zelle bliebe
+	   damit durchsichtig, und der wegscrollende Inhalt liefe sichtbar darunter
+	   durch. DaisyUIs Tabellenregeln setzen an `:where(th, td)` keinen
+	   Hintergrund und stehen zudem in `:where()` ohne Spezifität; diese
+	   ungelayerten Regeln gewinnen also. Farben nur als Theme-Token. */
+	.sticky-col {
+		position: sticky;
+		background-color: var(--color-base-100);
+	}
+
+	/* Zebra: `tbody tr:nth-child(even)` trägt base-200 — die fixierte Zelle muss
+	   dieselbe Fläche mitbringen, sonst blitzt sie beim Scrollen heller auf. */
+	tbody tr:nth-child(even) .sticky-col {
+		background-color: var(--color-base-200);
+	}
+
+	/* Zeilen-Hover (`hover:bg-base-200` am <tr>) — deckungsgleich für gerade und
+	   ungerade Zeilen, weil beide Zustände auf base-200 laufen. */
+	tbody tr:hover .sticky-col {
+		background-color: var(--color-base-200);
+	}
+
+	/* Der Tabellenkopf steht auf `bg-base-200` (am <thead>, nicht an den Zellen). */
+	thead .sticky-col {
+		background-color: var(--color-base-200);
+	}
+
+	/* Trennkante an der linken Kante des fixierten Bereichs. */
+	.sticky-edge {
+		border-left: var(--border, 1px) solid var(--color-base-300);
+	}
+</style>

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -117,22 +117,38 @@
 
 	$effect(() => {
 		if (typeof window === 'undefined') return;
-		if (!hatGespeicherteSpaltenGeladen) {
-			// Einmaliges Laden beim Mount. Kaputtes/altes JSON und unbekannte
-			// Schlüssel fallen in `loadColumnPreferences` still auf den Default
-			// zurück; neue Spalten erscheinen mit ihrem eigenen Default-Wert.
-			columnVisibility = loadColumnPreferences(
-				window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY),
-				DEFAULT_COLUMN_VISIBILITY
+		/* try/catch um beide Zugriffe: `localStorage` selbst kann werfen
+		   (Storage per Policy deaktiviert → SecurityError) und `setItem`
+		   ebenso (volle Quota, Safari im privaten Modus). Die Spaltenauswahl
+		   ist eine Bequemlichkeit — ohne Storage läuft die Seite einfach ohne
+		   Persistenz weiter, statt beim Hydratisieren zu crashen. */
+		try {
+			if (!hatGespeicherteSpaltenGeladen) {
+				// Einmaliges Laden beim Mount. Kaputtes/altes JSON und unbekannte
+				// Schlüssel fallen in `loadColumnPreferences` still auf den Default
+				// zurück; neue Spalten erscheinen mit ihrem eigenen Default-Wert.
+				columnVisibility = loadColumnPreferences(
+					window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY),
+					DEFAULT_COLUMN_VISIBILITY
+				);
+				return; // Diesen Durchlauf nicht sofort wieder zurückschreiben.
+			}
+			// Jede weitere Änderung (Checkbox im „Spalten"-Dropdown) wird persistiert.
+			window.localStorage.setItem(
+				COLUMN_PREFERENCES_STORAGE_KEY,
+				serializeColumnPreferences(columnVisibility)
 			);
+		} catch (err) {
+			logger.warn(
+				{ err },
+				'Spaltenauswahl kann nicht gespeichert werden — Storage nicht verfügbar'
+			);
+		} finally {
+			/* Im finally, damit auch ein geworfenes `getItem` den Lade-Versuch
+			   abschließt — sonst überschriebe der nächste Durchlauf jede
+			   Nutzerauswahl erneut mit dem (dann fehlgeschlagenen) Laden. */
 			hatGespeicherteSpaltenGeladen = true;
-			return; // Diesen Durchlauf nicht sofort wieder zurückschreiben.
 		}
-		// Jede weitere Änderung (Checkbox im „Spalten"-Dropdown) wird persistiert.
-		window.localStorage.setItem(
-			COLUMN_PREFERENCES_STORAGE_KEY,
-			serializeColumnPreferences(columnVisibility)
-		);
 	});
 
 	// Available columns configuration

--- a/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
+++ b/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
@@ -1,0 +1,203 @@
+import { render } from 'vitest-browser-svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+const invalidateAll = vi.fn(() => Promise.resolve());
+/* Signatur mitgeführt, damit `mockImplementation((id) => …)` in den Teilfehler-
+   Tests typgeprüft bleibt — ein `vi.fn(() => …)` nähme dort keine Argumente an. */
+const submitVerdict = vi.fn((_id: number, _verdict: string) => Promise.resolve(true));
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn(() => Promise.resolve()), invalidateAll }));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({ submitVerdict }));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+const { toast } = await import('$lib/stores/toastState.svelte');
+
+function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
+	return {
+		id: 1,
+		created: new Date('2026-08-01T10:00:00Z'),
+		sightingDate: new Date('2026-07-30T08:00:00Z'),
+		species: 0,
+		totalCount: 1,
+		juvenileCount: 0,
+		isDead: 0,
+		verified: 0,
+		approvedAt: null,
+		rejectedAt: null,
+		inBalticSea: 1,
+		inBalticSeaGeo: 1,
+		...overrides
+	} as unknown as SightingSelect;
+}
+
+function daten(rows: SightingSelect[]): PageData {
+	return {
+		sightings: rows,
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
+		pendingPhotoAnnouncements: 0
+	} as unknown as PageData;
+}
+
+/* Nur die Tabelle: Die Auswahl-Checkboxen gibt es bewusst allein in der
+   Desktop-Tabelle, die Mobilkarten bleiben unverändert (Spec U5). */
+function zeilenCheckboxen(container: HTMLElement): HTMLInputElement[] {
+	return [...container.querySelectorAll('tbody input[type="checkbox"]')] as HTMLInputElement[];
+}
+
+/** Einzelne Zeilen-Checkbox — kapselt den Indexzugriff, den `noUncheckedIndexedAccess` sonst als `| undefined` führt. */
+function zeilenCheckbox(container: HTMLElement, index: number): HTMLInputElement {
+	const checkbox = zeilenCheckboxen(container)[index];
+	if (!checkbox) throw new Error(`Keine Zeilen-Checkbox an Position ${index}`);
+	return checkbox;
+}
+
+function kopfCheckbox(container: HTMLElement): HTMLInputElement {
+	return container.querySelector('thead input[type="checkbox"]') as HTMLInputElement;
+}
+
+/** Der einzige erwartete Toast — der Punkt der Zusammenfassung ist ja, dass es genau einer ist. */
+function einzigerToast() {
+	expect(toast.current).toHaveLength(1);
+	const eintrag = toast.current[0];
+	if (!eintrag) throw new Error('Kein Toast vorhanden');
+	return eintrag;
+}
+
+describe('Sichtungstabelle — Bulk-Aktionen', () => {
+	beforeEach(() => {
+		submitVerdict.mockClear();
+		invalidateAll.mockClear();
+		toast.clear();
+	});
+
+	it('zeigt die Aktionsleiste erst bei einer Auswahl', async () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({ id: 1 })]) });
+
+		expect(screen.container.textContent).not.toContain('ausgewählt');
+
+		await zeilenCheckbox(screen.container, 0).click();
+
+		await expect.element(screen.getByText('1 ausgewählt')).toBeVisible();
+	});
+
+	it('wählt mit der Kopf-Checkbox alle Zeilen der Seite', async () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 1 }), sichtung({ id: 2 }), sichtung({ id: 3 })])
+		});
+
+		await kopfCheckbox(screen.container).click();
+
+		await expect.element(screen.getByText('3 ausgewählt')).toBeVisible();
+		expect(zeilenCheckboxen(screen.container).every((c) => c.checked)).toBe(true);
+	});
+
+	it('zeigt die Kopf-Checkbox bei Teilauswahl als indeterminate', async () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 1 }), sichtung({ id: 2 })])
+		});
+
+		await zeilenCheckbox(screen.container, 0).click();
+
+		const kopf = kopfCheckbox(screen.container);
+		expect(kopf.indeterminate).toBe(true);
+		expect(kopf.checked).toBe(false);
+	});
+
+	it('schickt „Freigeben" für jede gewählte Zeile über submitVerdict', async () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 4 }), sichtung({ id: 5 })])
+		});
+
+		await kopfCheckbox(screen.container).click();
+		await screen.getByRole('button', { name: 'Freigeben' }).click();
+
+		await vi.waitFor(() => expect(submitVerdict).toHaveBeenCalledTimes(2));
+		/* `silent: true` gehört zur Zusicherung und ist kein Beiwerk: Ohne die
+		   Option käme ein Fehler-Toast pro Zeile statt der einen Zusammenfassung. */
+		expect(submitVerdict.mock.calls).toEqual([
+			[4, 'approve', { silent: true }],
+			[5, 'approve', { silent: true }]
+		]);
+	});
+
+	it('leert die Auswahl nach der Ausführung', async () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({ id: 6 })]) });
+
+		await zeilenCheckbox(screen.container, 0).click();
+		await screen.getByRole('button', { name: 'Ablehnen' }).click();
+
+		await vi.waitFor(() => expect(screen.container.textContent).not.toContain('ausgewählt'));
+	});
+
+	it('hebt die Auswahl über „Auswahl aufheben" auf, ohne zu senden', async () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({ id: 9 })]) });
+
+		await zeilenCheckbox(screen.container, 0).click();
+		await screen.getByRole('button', { name: 'Auswahl aufheben' }).click();
+
+		expect(submitVerdict).not.toHaveBeenCalled();
+		expect(screen.container.textContent).not.toContain('ausgewählt');
+	});
+
+	it('fasst das Ergebnis in genau einem Toast mit Rückgängig zusammen', async () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 20 }), sichtung({ id: 21 })])
+		});
+
+		await kopfCheckbox(screen.container).click();
+		await screen.getByRole('button', { name: 'Freigeben' }).click();
+
+		await vi.waitFor(() => expect(toast.current).toHaveLength(1));
+		const eintrag = einzigerToast();
+		expect(eintrag.message).toBe('2 Sichtungen freigegeben');
+		expect(eintrag.action?.label).toBe('Rückgängig');
+	});
+
+	it('schickt beim Rückgängig ein reset für die erfolgreichen IDs', async () => {
+		submitVerdict.mockImplementation((id: number) => Promise.resolve(id !== 31));
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 30 }), sichtung({ id: 31 })])
+		});
+
+		await kopfCheckbox(screen.container).click();
+		await screen.getByRole('button', { name: 'Freigeben' }).click();
+		await vi.waitFor(() => expect(toast.current).toHaveLength(1));
+
+		submitVerdict.mockClear();
+		submitVerdict.mockImplementation(() => Promise.resolve(true));
+		einzigerToast().action?.onClick();
+
+		await vi.waitFor(() => expect(submitVerdict).toHaveBeenCalledTimes(1));
+		expect(submitVerdict).toHaveBeenCalledWith(30, 'reset', { silent: true });
+	});
+
+	/* Kein Cross-Page-Gedächtnis: Überlebte die Auswahl den Seitenwechsel, wirkte
+	   „Freigeben" auf Zeilen, die gerade niemand sieht. */
+	it('leert die Auswahl beim Wechsel auf eine andere Seite', async () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 1 }), sichtung({ id: 2 })])
+		});
+
+		await kopfCheckbox(screen.container).click();
+		await expect.element(screen.getByText('2 ausgewählt')).toBeVisible();
+
+		await screen.rerender({ data: daten([sichtung({ id: 40 }), sichtung({ id: 41 })]) });
+
+		await vi.waitFor(() => expect(screen.container.textContent).not.toContain('ausgewählt'));
+	});
+
+	/* Die Checkbox-Spalte ist fest wie die Totfund-Markerspalte: Sie darf im
+	   „Spalten"-Dropdown nicht abschaltbar sein, sonst ist die Bulk-Funktion je
+	   nach gespeicherter Spaltenwahl unerreichbar. */
+	it('bietet die Auswahlspalte nicht im Spalten-Dropdown an', () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({ id: 1 })]) });
+
+		const dropdown = screen.container.querySelector('.dropdown-content') as HTMLElement;
+		expect(dropdown.textContent).not.toContain('Auswahl');
+	});
+});

--- a/src/routes/admin/sichtungen/bulkSelection.test.ts
+++ b/src/routes/admin/sichtungen/bulkSelection.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { getHeaderState, isSameIdList, setAllSelected, toggleSelection } from './bulkSelection';
+
+describe('bulkSelection — Auswahl in der Sichtungstabelle', () => {
+	describe('toggleSelection', () => {
+		it('nimmt eine noch nicht gewählte ID auf', () => {
+			expect(toggleSelection([1, 2], 3)).toEqual([1, 2, 3]);
+		});
+
+		it('entfernt eine bereits gewählte ID', () => {
+			expect(toggleSelection([1, 2, 3], 2)).toEqual([1, 3]);
+		});
+
+		it('lässt die Eingabe unangetastet (kein In-Place-Mutieren)', () => {
+			const vorher = [1, 2];
+			toggleSelection(vorher, 3);
+			expect(vorher).toEqual([1, 2]);
+		});
+	});
+
+	describe('setAllSelected', () => {
+		it('wählt alle IDs der aktuellen Seite', () => {
+			expect(setAllSelected([7, 8, 9], true)).toEqual([7, 8, 9]);
+		});
+
+		it('leert die Auswahl beim Abwählen', () => {
+			expect(setAllSelected([7, 8, 9], false)).toEqual([]);
+		});
+	});
+
+	describe('getHeaderState', () => {
+		it('meldet „none" ohne Auswahl', () => {
+			expect(getHeaderState([], [1, 2, 3])).toBe('none');
+		});
+
+		it('meldet „partial" bei Teilauswahl — der indeterminate-Zustand', () => {
+			expect(getHeaderState([2], [1, 2, 3])).toBe('partial');
+		});
+
+		it('meldet „all", wenn alle sichtbaren Zeilen gewählt sind', () => {
+			expect(getHeaderState([3, 1, 2], [1, 2, 3])).toBe('all');
+		});
+
+		/* Ohne Zeilen gibt es nichts zu wählen — eine Kopf-Checkbox, die „alle"
+		   meldet, während die Tabelle leer ist, lädt zu einer Aktion über nichts ein. */
+		it('meldet „none" bei leerer Seite', () => {
+			expect(getHeaderState([], [])).toBe('none');
+		});
+
+		/* Auswahl aus einer früheren Seite darf „all" nicht auslösen: Sonst
+		   verspräche die Kopf-Checkbox eine Vollauswahl, die Unsichtbares enthält. */
+		it('ignoriert IDs, die nicht auf der Seite stehen', () => {
+			expect(getHeaderState([1, 99], [1, 2])).toBe('partial');
+		});
+	});
+
+	describe('isSameIdList', () => {
+		it('erkennt dieselbe Liste', () => {
+			expect(isSameIdList([1, 2, 3], [1, 2, 3])).toBe(true);
+		});
+
+		it('erkennt eine neue Seite (andere IDs)', () => {
+			expect(isSameIdList([1, 2, 3], [4, 5, 6])).toBe(false);
+		});
+
+		it('erkennt eine geänderte Länge', () => {
+			expect(isSameIdList([1, 2], [1, 2, 3])).toBe(false);
+		});
+
+		/* Sortierwechsel ist ein Datenwechsel: dieselben IDs in anderer Reihenfolge
+		   heißt, dass der Nutzer eine andere Liste vor sich hat. */
+		it('erkennt eine geänderte Reihenfolge', () => {
+			expect(isSameIdList([1, 2, 3], [3, 2, 1])).toBe(false);
+		});
+	});
+});

--- a/src/routes/admin/sichtungen/bulkSelection.ts
+++ b/src/routes/admin/sichtungen/bulkSelection.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Auswahl-Logik der Bulk-Aktionen in der Sichtungstabelle.
+ *
+ * Reine Funktionen über ID-Listen, bewusst ohne Runes: Die Tabelle hält den
+ * Zustand selbst (`$state`), hier steht nur die Rechnung. Das hält die Regeln —
+ * indeterminate-Zustand, „alle auf dieser Seite", Leeren bei Datenwechsel — an
+ * einem Ort testbar, statt sie im Markup zu verstreuen.
+ *
+ * **Es gibt bewusst kein Cross-Page-Gedächtnis.** Eine Auswahl, die über den
+ * Seiten- oder Filterwechsel überlebte, hieße: „Freigeben" wirkt auf Zeilen, die
+ * gerade niemand sieht. Deshalb prüft `isSameIdList` die sichtbare Liste, und die
+ * Tabelle leert die Auswahl, sobald sie sich ändert.
+ */
+
+/** Zustand der Kopf-Checkbox „Alle auf dieser Seite". */
+export type BulkHeaderState = 'none' | 'partial' | 'all';
+
+/** Nimmt eine ID auf oder entfernt sie — ohne die Eingabe zu verändern. */
+export function toggleSelection(selected: readonly number[], id: number): number[] {
+	return selected.includes(id)
+		? selected.filter((vorhanden) => vorhanden !== id)
+		: [...selected, id];
+}
+
+/** „Alle auf dieser Seite" — `ids` ist immer nur die aktuelle Tabellenseite. */
+export function setAllSelected(ids: readonly number[], checked: boolean): number[] {
+	return checked ? [...ids] : [];
+}
+
+/**
+ * Der Zustand der Kopf-Checkbox, berechnet **nur über die sichtbaren Zeilen**.
+ * Eine ID aus einer früheren Seite (die es hier nicht geben sollte, aber der
+ * Zustand ist billiger geprüft als bewiesen) darf „alle gewählt" nicht auslösen.
+ */
+export function getHeaderState(
+	selected: readonly number[],
+	ids: readonly number[]
+): BulkHeaderState {
+	if (ids.length === 0) return 'none';
+	const sichtbarGewaehlt = ids.filter((id) => selected.includes(id)).length;
+	if (sichtbarGewaehlt === 0) return 'none';
+	return sichtbarGewaehlt === ids.length && selected.length === ids.length ? 'all' : 'partial';
+}
+
+/**
+ * Zeigt die Tabelle noch dieselbe Liste? Reihenfolge zählt mit: Ein
+ * Sortierwechsel liefert dieselben IDs, stellt dem Nutzer aber eine andere Liste
+ * hin — die Auswahl gehört dann genauso geleert wie beim Seitenwechsel.
+ */
+export function isSameIdList(a: readonly number[], b: readonly number[]): boolean {
+	return a.length === b.length && a.every((id, index) => id === b[index]);
+}

--- a/src/routes/admin/sichtungen/bulkVerdict.test.ts
+++ b/src/routes/admin/sichtungen/bulkVerdict.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildBulkSummary, runBulkVerdict } from './bulkVerdict';
+
+describe('bulkVerdict — sequentielle Ausführung über den verify-Endpunkt', () => {
+	it('ruft submitVerdict für jede ID mit demselben Verdict auf', async () => {
+		const submit = vi.fn(() => Promise.resolve(true));
+
+		const ergebnis = await runBulkVerdict([1, 2, 3], 'approve', { submit });
+
+		expect(submit.mock.calls).toEqual([
+			[1, 'approve'],
+			[2, 'approve'],
+			[3, 'approve']
+		]);
+		expect(ergebnis.succeeded).toEqual([1, 2, 3]);
+		expect(ergebnis.failed).toEqual([]);
+	});
+
+	/* Sequentiell und nicht parallel: Der verify-Endpunkt schreibt pro Aufruf, und
+	   eine Welle gleichzeitiger PATCHes wäre für den Server ein Lastspitzen-Risiko
+	   ohne Gegenwert — die Liste ist auf eine Tabellenseite begrenzt. */
+	it('arbeitet die IDs nacheinander ab, nicht gleichzeitig', async () => {
+		let laufend = 0;
+		let maxGleichzeitig = 0;
+		const submit = vi.fn(async () => {
+			laufend += 1;
+			maxGleichzeitig = Math.max(maxGleichzeitig, laufend);
+			await Promise.resolve();
+			laufend -= 1;
+			return true;
+		});
+
+		await runBulkVerdict([1, 2, 3], 'reject', { submit });
+
+		expect(maxGleichzeitig).toBe(1);
+	});
+
+	it('blockiert bei einem Teilfehler die übrigen Zeilen nicht', async () => {
+		const submit = vi.fn((id: number) => Promise.resolve(id !== 2));
+
+		const ergebnis = await runBulkVerdict([1, 2, 3], 'approve', { submit });
+
+		expect(submit).toHaveBeenCalledTimes(3);
+		expect(ergebnis.succeeded).toEqual([1, 3]);
+		expect(ergebnis.failed).toEqual([2]);
+	});
+
+	/* Ein geworfener Fehler (Netzwerkabbruch mitten in der Schleife) darf die
+	   Schleife nicht abbrechen — sonst bliebe der Rest der Auswahl unbearbeitet,
+	   ohne dass irgendwo stünde, wo abgebrochen wurde. */
+	it('behandelt eine geworfene Ausnahme wie einen Fehlschlag', async () => {
+		const submit = vi.fn((id: number) => {
+			if (id === 2) return Promise.reject(new Error('Netzwerk weg'));
+			return Promise.resolve(true);
+		});
+
+		const ergebnis = await runBulkVerdict([1, 2, 3], 'approve', { submit });
+
+		expect(ergebnis.succeeded).toEqual([1, 3]);
+		expect(ergebnis.failed).toEqual([2]);
+	});
+
+	it('meldet den Fortschritt nach jeder Zeile', async () => {
+		const fortschritt: Array<[number, number]> = [];
+
+		await runBulkVerdict([1, 2, 3], 'approve', {
+			submit: () => Promise.resolve(true),
+			onProgress: (erledigt, gesamt) => fortschritt.push([erledigt, gesamt])
+		});
+
+		expect(fortschritt).toEqual([
+			[1, 3],
+			[2, 3],
+			[3, 3]
+		]);
+	});
+
+	/* Die Undo-IDs sind genau die Erfolge: Ein `reset` auf eine Zeile, deren
+	   Freigabe nie ankam, würde einen fremden Zustand überschreiben. */
+	it('liefert als Undo-Grundlage nur die erfolgreich geänderten IDs', async () => {
+		const ergebnis = await runBulkVerdict([10, 11, 12], 'approve', {
+			submit: (id: number) => Promise.resolve(id === 11)
+		});
+
+		expect(ergebnis.succeeded).toEqual([11]);
+	});
+
+	it('kommt mit einer leeren Auswahl aus, ohne zu senden', async () => {
+		const submit = vi.fn(() => Promise.resolve(true));
+
+		const ergebnis = await runBulkVerdict([], 'approve', { submit });
+
+		expect(submit).not.toHaveBeenCalled();
+		expect(ergebnis).toEqual({ succeeded: [], failed: [] });
+	});
+});
+
+describe('buildBulkSummary — ein Toast statt N Toasts', () => {
+	it('nennt bei vollem Erfolg nur die Zahl', () => {
+		const zusammenfassung = buildBulkSummary({ succeeded: [1, 2, 3], failed: [] }, 'approve');
+
+		expect(zusammenfassung.message).toBe('3 Sichtungen freigegeben');
+		expect(zusammenfassung.hasFailures).toBe(false);
+	});
+
+	it('setzt den Singular richtig', () => {
+		expect(buildBulkSummary({ succeeded: [1], failed: [] }, 'reject').message).toBe(
+			'1 Sichtung abgelehnt'
+		);
+	});
+
+	it('nennt bei Teilfehlern beide Zahlen', () => {
+		const zusammenfassung = buildBulkSummary({ succeeded: [1, 2], failed: [3] }, 'approve');
+
+		expect(zusammenfassung.message).toBe('2 von 3 Sichtungen freigegeben — 1 fehlgeschlagen');
+		expect(zusammenfassung.hasFailures).toBe(true);
+	});
+
+	it('benennt den Totalausfall als solchen', () => {
+		const zusammenfassung = buildBulkSummary({ succeeded: [], failed: [1, 2] }, 'reject');
+
+		expect(zusammenfassung.message).toBe('Keine Sichtung abgelehnt — 2 fehlgeschlagen');
+		expect(zusammenfassung.hasFailures).toBe(true);
+	});
+
+	it('weist übersprungene Zeilen aus', () => {
+		const zusammenfassung = buildBulkSummary({ succeeded: [1], failed: [] }, 'reset', 2);
+
+		expect(zusammenfassung.message).toBe(
+			'1 Sichtung zurückgesetzt (2 übersprungen — Einzelaktion lief noch)'
+		);
+	});
+});

--- a/src/routes/admin/sichtungen/bulkVerdict.ts
+++ b/src/routes/admin/sichtungen/bulkVerdict.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Ausführung einer Bulk-Aktion über den bestehenden
+ * verify-Endpunkt — Schleife plus Zusammenfassung.
+ *
+ * **Kein Bulk-Endpunkt.** `PATCH /api/sightings/[id]/verify` bleibt der einzige
+ * Schreibweg für den Status (CLAUDE.md, `.claude/rules/api.md`); die Schleife
+ * läuft deshalb im Client über dasselbe `submitVerdict` wie der Einzelwechsel.
+ * `submit` wird injiziert statt importiert, damit die Schleife ohne Netz und
+ * ohne Toast-Nebenwirkungen testbar bleibt.
+ *
+ * Sequentiell und nicht `Promise.all`: Jede Zeile ist ein eigener Schreibvorgang,
+ * und eine Tabellenseite kann 100 Zeilen haben — eine Welle gleichzeitiger
+ * PATCHes wäre eine Lastspitze ohne Gegenwert. Der Preis ist Wartezeit, die die
+ * Fortschrittsanzeige sichtbar macht.
+ */
+import type { SightingVerdict } from '$lib/components/admin/sightingVerdict';
+
+export interface BulkVerdictOutcome {
+	/** Die einzige Grundlage für „Rückgängig" — ein `reset` auf eine nie
+	 *  geänderte Zeile überschriebe einen fremden Zustand. */
+	succeeded: number[];
+	failed: number[];
+}
+
+export interface RunBulkVerdictOptions {
+	submit: (id: number, verdict: SightingVerdict) => Promise<boolean>;
+	onProgress?: (done: number, total: number) => void;
+}
+
+export async function runBulkVerdict(
+	ids: readonly number[],
+	verdict: SightingVerdict,
+	{ submit, onProgress }: RunBulkVerdictOptions
+): Promise<BulkVerdictOutcome> {
+	const succeeded: number[] = [];
+	const failed: number[] = [];
+
+	for (const id of ids) {
+		let ok = false;
+		try {
+			ok = await submit(id, verdict);
+		} catch {
+			/* Ein Netzabbruch mitten in der Schleife darf die übrigen Zeilen nicht
+			   mitreißen — sonst bliebe unklar, wo abgebrochen wurde. `submitVerdict`
+			   fängt selbst schon und meldet `false`; das `catch` deckt den Fall ab,
+			   dass eine andere Implementierung durchwirft. */
+			ok = false;
+		}
+		(ok ? succeeded : failed).push(id);
+		onProgress?.(succeeded.length + failed.length, ids.length);
+	}
+
+	return { succeeded, failed };
+}
+
+/**
+ * Partizip je Verdict. Nicht aus `SIGHTING_STATUS_PRESENTATION` ableitbar: Dort
+ * stehen Zustand („Freigegeben") und Handlung („Freigeben"), hier wird ein
+ * abgeschlossener Vorgang berichtet — und für `reset` heißt das „zurückgesetzt"
+ * und nicht „offen".
+ */
+const BULK_VERDICT_PARTICIPLE: Record<SightingVerdict, string> = {
+	approve: 'freigegeben',
+	reject: 'abgelehnt',
+	reset: 'zurückgesetzt'
+};
+
+export interface BulkSummary {
+	message: string;
+	hasFailures: boolean;
+}
+
+/**
+ * Ein Toast am Ende statt einem pro Zeile: Bei 40 gewählten Sichtungen wären 40
+ * Toasts kein Feedback mehr, sondern eine Wand.
+ */
+export function buildBulkSummary(
+	outcome: BulkVerdictOutcome,
+	verdict: SightingVerdict,
+	skipped = 0
+): BulkSummary {
+	const partizip = BULK_VERDICT_PARTICIPLE[verdict];
+	const erfolge = outcome.succeeded.length;
+	const fehler = outcome.failed.length;
+	const gesamt = erfolge + fehler;
+
+	let message: string;
+	if (fehler === 0) {
+		message = `${erfolge} ${erfolge === 1 ? 'Sichtung' : 'Sichtungen'} ${partizip}`;
+	} else if (erfolge === 0) {
+		message = `Keine Sichtung ${partizip} — ${fehler} fehlgeschlagen`;
+	} else {
+		message = `${erfolge} von ${gesamt} Sichtungen ${partizip} — ${fehler} fehlgeschlagen`;
+	}
+
+	/* Übersprungene Zeilen gehören genannt: Sonst zählt der Nutzer 12 Haken und
+	   liest „10 freigegeben", ohne zu erfahren, was mit den beiden anderen war. */
+	if (skipped > 0) {
+		message += ` (${skipped} übersprungen — Einzelaktion lief noch)`;
+	}
+
+	return { message, hasFailures: fehler > 0 };
+}

--- a/src/routes/admin/sichtungen/columnPreferences.test.ts
+++ b/src/routes/admin/sichtungen/columnPreferences.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+	COLUMN_PREFERENCES_STORAGE_KEY,
+	loadColumnPreferences,
+	mergeColumnPreferences,
+	serializeColumnPreferences
+} from './columnPreferences';
+
+const DEFAULTS = { a: true, b: false, c: true };
+
+describe('COLUMN_PREFERENCES_STORAGE_KEY', () => {
+	it('ist der vereinbarte Schlüssel', () => {
+		expect(COLUMN_PREFERENCES_STORAGE_KEY).toBe('admin.sichtungen.columns');
+	});
+});
+
+describe('mergeColumnPreferences', () => {
+	it('übernimmt gespeicherte Werte für bekannte Schlüssel', () => {
+		expect(mergeColumnPreferences(DEFAULTS, { a: false, c: false })).toEqual({
+			a: false,
+			b: false,
+			c: false
+		});
+	});
+
+	it('ignoriert unbekannte gespeicherte Schlüssel (entfernte Spalte)', () => {
+		expect(mergeColumnPreferences(DEFAULTS, { a: false, removedColumn: true })).toEqual({
+			a: false,
+			b: false,
+			c: true
+		});
+	});
+
+	it('füllt eine im gespeicherten Wert fehlende (neue) Spalte mit ihrem Default', () => {
+		// `b` fehlt im gespeicherten Objekt, weil die Spalte erst nach dem
+		// letzten Speichern hinzugekommen ist — sie darf nicht als false
+		// interpretiert werden, sondern muss ihren eigenen Default behalten.
+		expect(mergeColumnPreferences(DEFAULTS, { a: false, c: false })).toEqual({
+			a: false,
+			b: false,
+			c: false
+		});
+		expect(mergeColumnPreferences(DEFAULTS, { c: false })).toEqual({
+			a: true,
+			b: false,
+			c: false
+		});
+	});
+
+	it('liefert die Defaults, wenn nichts gespeichert ist', () => {
+		expect(mergeColumnPreferences(DEFAULTS, null)).toEqual(DEFAULTS);
+		expect(mergeColumnPreferences(DEFAULTS, undefined)).toEqual(DEFAULTS);
+	});
+
+	it('ignoriert einen gespeicherten Wert, der kein boolean ist', () => {
+		expect(mergeColumnPreferences(DEFAULTS, { a: 'ja' as unknown as boolean })).toEqual(DEFAULTS);
+	});
+});
+
+describe('loadColumnPreferences', () => {
+	it('fällt bei fehlendem Wert (kein Eintrag) auf die Defaults zurück', () => {
+		expect(loadColumnPreferences(null, DEFAULTS)).toEqual(DEFAULTS);
+	});
+
+	it('fällt bei kaputtem JSON still auf die Defaults zurück', () => {
+		expect(loadColumnPreferences('{nicht valides json', DEFAULTS)).toEqual(DEFAULTS);
+	});
+
+	it('fällt bei falscher/fehlender Version still auf die Defaults zurück', () => {
+		expect(
+			loadColumnPreferences(JSON.stringify({ v: 2, columns: { a: false } }), DEFAULTS)
+		).toEqual(DEFAULTS);
+		expect(loadColumnPreferences(JSON.stringify({ columns: { a: false } }), DEFAULTS)).toEqual(
+			DEFAULTS
+		);
+	});
+
+	it('fällt zurück, wenn "columns" fehlt oder kein Objekt ist', () => {
+		expect(loadColumnPreferences(JSON.stringify({ v: 1 }), DEFAULTS)).toEqual(DEFAULTS);
+		expect(loadColumnPreferences(JSON.stringify({ v: 1, columns: 'x' }), DEFAULTS)).toEqual(
+			DEFAULTS
+		);
+	});
+
+	it('mergt gültige gespeicherte Werte mit den Defaults (unbekannte Schlüssel raus, neue Spalten drin)', () => {
+		const raw = JSON.stringify({ v: 1, columns: { a: false, removedColumn: true } });
+		expect(loadColumnPreferences(raw, DEFAULTS)).toEqual({ a: false, b: false, c: true });
+	});
+
+	it('Roundtrip: serializeColumnPreferences → loadColumnPreferences liefert dieselbe Auswahl', () => {
+		const auswahl = { a: false, b: true, c: false };
+		const raw = serializeColumnPreferences(auswahl);
+		expect(loadColumnPreferences(raw, DEFAULTS)).toEqual(auswahl);
+	});
+});
+
+describe('serializeColumnPreferences', () => {
+	it('schreibt das versionierte Format', () => {
+		expect(JSON.parse(serializeColumnPreferences({ a: true }))).toEqual({
+			v: 1,
+			columns: { a: true }
+		});
+	});
+});

--- a/src/routes/admin/sichtungen/columnPreferences.ts
+++ b/src/routes/admin/sichtungen/columnPreferences.ts
@@ -1,0 +1,79 @@
+/**
+ * Persistenz der Spaltenauswahl (`columnVisibility` in `+page.svelte`) in
+ * `localStorage`. Reine Parse-/Merge-/Serialisierungslogik ohne Zugriff auf
+ * `window` — der Aufrufer entscheidet, wann und ob `localStorage` überhaupt
+ * erreichbar ist (SSR-Guard bleibt in der Seite, nicht hier).
+ *
+ * Format ist versioniert (`{ v: 1, columns: {...} }`), damit ein künftiger
+ * Formatwechsel den Altbestand gezielt verwerfen kann, statt ihn
+ * misszuinterpretieren.
+ */
+
+export const COLUMN_PREFERENCES_STORAGE_KEY = 'admin.sichtungen.columns';
+const CURRENT_VERSION = 1;
+
+export interface ColumnPreferences {
+	v: number;
+	columns: Record<string, boolean>;
+}
+
+/**
+ * Merged gespeicherte Werte mit den Defaults.
+ *
+ * - Unbekannte gespeicherte Schlüssel werden ignoriert — sonst würde ein
+ *   entfernter alter Schlüssel im Objekt herumliegen.
+ * - Im Default fehlende (= neue) Spalten erscheinen mit ihrem Default-Wert —
+ *   sonst würde ein alter localStorage-Eintrag künftige Spalten dauerhaft
+ *   verstecken, weil sie im gespeicherten Objekt schlicht nicht vorkamen.
+ */
+export function mergeColumnPreferences<T extends Record<string, boolean>>(
+	defaults: T,
+	stored: Record<string, boolean> | null | undefined
+): T {
+	if (!stored) return { ...defaults };
+	const merged = { ...defaults };
+	for (const key of Object.keys(defaults)) {
+		if (typeof stored[key] === 'boolean') {
+			merged[key as keyof T] = stored[key] as T[keyof T];
+		}
+	}
+	return merged;
+}
+
+/**
+ * Parst den rohen `localStorage`-Wert. Kaputtes JSON, eine fremde Version
+ * oder ein Wert, der keine Spaltentabelle ist, fallen still auf die Defaults
+ * zurück — ein Nutzer soll wegen eines defekten Eintrags nie eine leere
+ * Tabelle sehen.
+ */
+export function loadColumnPreferences<T extends Record<string, boolean>>(
+	raw: string | null,
+	defaults: T
+): T {
+	if (!raw) return { ...defaults };
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return { ...defaults };
+	}
+
+	if (
+		typeof parsed !== 'object' ||
+		parsed === null ||
+		(parsed as Partial<ColumnPreferences>).v !== CURRENT_VERSION ||
+		typeof (parsed as Partial<ColumnPreferences>).columns !== 'object' ||
+		(parsed as Partial<ColumnPreferences>).columns === null
+	) {
+		return { ...defaults };
+	}
+
+	return mergeColumnPreferences(defaults, (parsed as ColumnPreferences).columns);
+}
+
+/** Serialisiert die aktuelle Auswahl in das versionierte Speicherformat. */
+export function serializeColumnPreferences(columns: Record<string, boolean>): string {
+	const preferences: ColumnPreferences = { v: CURRENT_VERSION, columns };
+	return JSON.stringify(preferences);
+}

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -1,0 +1,129 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
+	return {
+		id: 1,
+		created: new Date('2026-08-01T10:00:00Z'),
+		sightingDate: new Date('2026-07-30T08:00:00Z'),
+		species: 0,
+		totalCount: 1,
+		juvenileCount: 0,
+		isDead: 0,
+		verified: 0,
+		approvedAt: null,
+		rejectedAt: null,
+		inBalticSea: 1,
+		inBalticSeaGeo: 1,
+		...overrides
+	} as unknown as SightingSelect;
+}
+
+/* Wie in `statusColumn.svelte.test.ts`: die Seite liest `data.pagination.*` und
+   stürzt ohne das Objekt schon an der Seitenzahl-Auswahl ab. */
+function daten(rows: SightingSelect[]): PageData {
+	return {
+		sightings: rows,
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
+		pendingPhotoAnnouncements: 0
+	} as unknown as PageData;
+}
+
+function kopfzeilen(container: HTMLElement): string[] {
+	return [...container.querySelectorAll('thead th')].map((th) => th.textContent?.trim() ?? '');
+}
+
+/* Die Client-Testumgebung lädt kein `app.css` — die Theme-Tokens existieren dort
+   also nicht, und `var(--color-base-100)` fiele auf „transparent" zurück. Die
+   Sticky-Zellen sind aber genau dann kaputt, wenn ihr Hintergrund durchsichtig
+   ist. Deshalb werden die beiden Tokens hier gesetzt: dann misst der Test die
+   tatsächlich gewählte Fläche statt nur die Existenz einer Deklaration. */
+const BASE_100 = 'rgb(255, 255, 255)';
+const BASE_200 = 'rgb(240, 240, 240)';
+
+describe('Sichtungstabelle — Spalten', () => {
+	beforeEach(() => {
+		document.documentElement.style.setProperty('--color-base-100', BASE_100);
+		document.documentElement.style.setProperty('--color-base-200', BASE_200);
+	});
+
+	afterEach(() => {
+		document.documentElement.style.removeProperty('--color-base-100');
+		document.documentElement.style.removeProperty('--color-base-200');
+	});
+
+	it('zeigt E-Mail, Entfernung und Verteilung per Default nicht', () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const kopf = kopfzeilen(screen.container);
+		expect(kopf).not.toContain('E-Mail');
+		expect(kopf).not.toContain('Entfernung');
+		expect(kopf).not.toContain('Verteilung');
+	});
+
+	it('behält Status und Aktionen in der Default-Auswahl', () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const kopf = kopfzeilen(screen.container);
+		expect(kopf).toContain('Status');
+		expect(kopf).toContain('Aktionen');
+	});
+
+	it('friert Status und Aktionen am rechten Rand fest', () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const zellen = [...screen.container.querySelectorAll('tbody tr td')];
+		const aktionen = zellen.at(-1) as HTMLElement;
+		const status = zellen.at(-2) as HTMLElement;
+
+		expect(getComputedStyle(aktionen).position).toBe('sticky');
+		expect(getComputedStyle(aktionen).right).toBe('0px');
+
+		// Die Statusspalte rastet links neben den Aktionen ein, nicht darunter.
+		expect(getComputedStyle(status).position).toBe('sticky');
+		expect(parseFloat(getComputedStyle(status).right)).toBeCloseTo(aktionen.offsetWidth, 0);
+	});
+
+	it('gibt den fixierten Zellen einen opaken Hintergrund, der Zebra mitmacht', () => {
+		const screen = render(SichtungenSeite, {
+			data: daten([sichtung({ id: 1 }), sichtung({ id: 2 })])
+		});
+
+		const zellen = [...screen.container.querySelectorAll('tbody tr td:last-child')];
+		const ersteAktionen = zellen.at(0) as HTMLElement;
+		const zweiteAktionen = zellen.at(1) as HTMLElement;
+
+		expect(getComputedStyle(ersteAktionen).backgroundColor).toBe(BASE_100);
+		// `table-zebra` färbt das <tr>, nicht die Zelle — ohne eigene Regel bliebe
+		// die fixierte Zelle hier durchsichtig und der Inhalt liefe darunter durch.
+		expect(getComputedStyle(zweiteAktionen).backgroundColor).toBe(BASE_200);
+	});
+
+	it('verspricht an nicht sortierbaren Spaltenköpfen keine Klickbarkeit', () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const nichtSortierbar = [...screen.container.querySelectorAll('thead th')].filter(
+			(th) => !th.querySelector('button')
+		);
+
+		expect(nichtSortierbar.length).toBeGreaterThan(0);
+		for (const th of nichtSortierbar) {
+			expect([...th.classList]).not.toContain('hover:bg-base-300');
+		}
+	});
+});

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -3,21 +3,14 @@
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import { berlinCalendarDayIso } from '$lib/utils/format/dateTime';
 	import Icon from '$lib/components/Icon.svelte';
+	import { formatNumber, formatPercentage } from './statisticsFormat';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
 
-	// Helper function to format numbers
-	function formatNumber(num: number | string | null | undefined): string {
-		const numValue = typeof num === 'string' ? parseFloat(num) : num || 0;
-		return new Intl.NumberFormat('de-DE').format(numValue);
-	}
-
-	// Helper function to format percentages
-	function formatPercentage(num: number | string | null | undefined): string {
-		const numValue = typeof num === 'string' ? parseFloat(num) : num || 0;
-		return `${numValue.toFixed(1)}%`;
-	}
+	/* Die Zahlformatierer kommen aus `statisticsFormat.ts` (Import oben) —
+	   die früheren Inline-Helfer hatten den Dezimalpunkt-Bruch („9.2%" neben
+	   „19.284") und rendeten nicht-numerische Eingaben als „NaN". */
 
 	/** Kurzformen für die Achse — „September" passt bei zwölf Balken nicht. */
 	const monthLabelsShort = [
@@ -286,7 +279,11 @@
 									<th>Sichtungen</th>
 									<th>Anteil</th>
 									<th>Ø Gruppe</th>
-									<th>Mortalität</th>
+									<!-- „Totfund-Anteil", nicht „Mortalität": die Kennzahl ist der Anteil der
+									     Totfund-MELDUNGEN an allen Meldungen einer Art, keine Mortalitätsrate —
+									     dafür fehlen Population und Beobachtungsaufwand. Begründung im großen
+									     Kommentar oben in dieser Datei. Die Schwellwerte (30 %/15 %) bleiben. -->
+									<th>Totfund-Anteil</th>
 								</tr>
 							</thead>
 							<tbody>

--- a/src/routes/admin/statistics/statisticsFormat.test.ts
+++ b/src/routes/admin/statistics/statisticsFormat.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview X4 — `formatNumber`/`formatPercentage` waren bis 2026-08-08 inline
+ * in `+page.svelte` definiert und damit nicht isoliert testbar. `formatPercentage`
+ * baute den String selbst (`${numValue.toFixed(1)}%`) mit einem Dezimalpunkt, direkt
+ * neben den deutsch formatierten Zahlen aus `formatNumber` (`19.284`) — auf einer
+ * Seite, die sonst durchgängig deutsches Zahlenformat zeigt, ein Bruch.
+ *
+ * Diese Tests belegen das gewählte Format: Komma statt Punkt, ein geschütztes
+ * Leerzeichen vor dem Prozentzeichen (`Intl.NumberFormat('de-DE', { style: 'percent' })`
+ * liefert das so). Aufrufer übergeben weiterhin Prozentpunkte (9.2 statt 0.092) —
+ * das entspricht dem, was `+page.svelte` bisher an `formatPercentage` reichte
+ * (z. B. `deadPercentage`, `repeatUserPercentage`), deshalb teilt die Funktion
+ * intern durch 100, bevor sie an `style: 'percent'` übergibt.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { formatNumber, formatPercentage } from './statisticsFormat';
+
+describe('formatPercentage', () => {
+	it('formatiert 0 als „0 %"', () => {
+		expect(formatPercentage(0)).toBe('0 %');
+	});
+
+	it('formatiert 9.2 mit Komma statt Punkt als „9,2 %"', () => {
+		expect(formatPercentage(9.2)).toBe('9,2 %');
+	});
+
+	it('formatiert 100 als „100 %"', () => {
+		expect(formatPercentage(100)).toBe('100 %');
+	});
+
+	it('parst einen String-Eingabewert wie die bisherige Implementierung', () => {
+		expect(formatPercentage('9.2')).toBe('9,2 %');
+	});
+
+	it('behandelt null wie 0', () => {
+		expect(formatPercentage(null)).toBe('0 %');
+	});
+
+	it('behandelt undefined wie 0', () => {
+		expect(formatPercentage(undefined)).toBe('0 %');
+	});
+
+	it('behandelt einen nicht-numerischen String wie 0 statt „NaN" zu rendern', () => {
+		expect(formatPercentage('abc')).toBe(formatPercentage(0));
+	});
+
+	it('rundet auf maximal eine Nachkommastelle', () => {
+		expect(formatPercentage(9.26)).toBe('9,3 %');
+	});
+});
+
+describe('formatNumber', () => {
+	it('formatiert eine Zahl im deutschen Tausendertrennzeichen', () => {
+		expect(formatNumber(19284)).toBe('19.284');
+	});
+
+	it('parst einen String-Eingabewert', () => {
+		expect(formatNumber('1.5')).toBe('1,5');
+	});
+
+	it('behandelt null wie 0', () => {
+		expect(formatNumber(null)).toBe('0');
+	});
+
+	it('behandelt undefined wie 0', () => {
+		expect(formatNumber(undefined)).toBe('0');
+	});
+
+	it('behandelt einen nicht-numerischen String wie 0 statt „NaN" zu rendern', () => {
+		expect(formatNumber('abc')).toBe('0');
+	});
+});

--- a/src/routes/admin/statistics/statisticsFormat.ts
+++ b/src/routes/admin/statistics/statisticsFormat.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Zahlenformat der Statistik-Seite (X4, siehe `docs/ADMIN_IMPROVEMENTS_SPEC.md`).
+ *
+ * `formatPercentage` gab bis 2026-08-08 `9.2%` mit Dezimalpunkt zurück, direkt neben
+ * den deutsch formatierten Zahlen aus `formatNumber` (`19.284`) — ein Bruch mitten auf
+ * derselben Seite. `Intl.NumberFormat('de-DE', { style: 'percent' })` multipliziert die
+ * Eingabe mit 100 (sie ist für Bruchwerte wie 0.092 gedacht); die Aufrufer hier übergeben
+ * aber durchgängig Prozent­punkte (9.2 statt 0.092, z. B. `deadPercentage`,
+ * `repeatUserPercentage`) — deshalb die Division vor dem Formatieren.
+ */
+
+/* `parseFloat('abc')` ist NaN, und das frühere `|| 0` fing das nicht — es stand
+   nur im Nicht-String-Zweig. `Number.isFinite` deckt beide Zweige ab, sonst
+   stünde wörtlich „NaN" auf der Seite. */
+function toFiniteNumber(num: number | string | null | undefined): number {
+	const parsed = typeof num === 'string' ? parseFloat(num) : num;
+	return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** Deutsches Tausendertrennzeichen, akzeptiert Zahl, numerischen String oder fehlenden Wert. */
+export function formatNumber(num: number | string | null | undefined): string {
+	return new Intl.NumberFormat('de-DE').format(toFiniteNumber(num));
+}
+
+/**
+ * Prozentwert im deutschen Format („9,2 %" statt „9.2%"). `num` ist ein Prozentpunkt
+ * (9.2 bedeutet 9,2 %, nicht 0,092) — passend zu den bisherigen Aufrufstellen in
+ * `+page.svelte`.
+ */
+export function formatPercentage(num: number | string | null | undefined): string {
+	return new Intl.NumberFormat('de-DE', { style: 'percent', maximumFractionDigits: 1 }).format(
+		toFiniteNumber(num) / 100
+	);
+}

--- a/src/routes/api/sightings/[id]/verify/+server.ts
+++ b/src/routes/api/sightings/[id]/verify/+server.ts
@@ -26,8 +26,9 @@ const logger = createLogger('api:sightings:verify');
  * Die Ablehnung (`abgelehnt_am`/`abgelehnt_von`) ist kein dritter
  * Veröffentlichungszustand, sondern eine Triage-Markierung: abgelehnt heißt
  * ungeprüft und nicht veröffentlicht, nur mit festgehaltener Entscheidung.
- * Deshalb schreibt dieser Endpunkt alle vier Spalten in EINEM Update —
- * `freigegeben_am` und `abgelehnt_am` sind nie gleichzeitig gesetzt.
+ * Deshalb schreibt dieser Endpunkt alle fünf Status-Spalten in EINEM Update —
+ * `freigegeben_am` und `abgelehnt_am` sind nie gleichzeitig gesetzt, und
+ * `freigegeben_von`/`abgelehnt_von` gehören untrennbar zu ihrem Zeitstempel.
  */
 export const PATCH: RequestHandler = async ({ params, request, locals, url, getClientAddress }) => {
 	// Authorization check - nur Admins dürfen prüfen und damit freigeben
@@ -91,15 +92,31 @@ export const PATCH: RequestHandler = async ({ params, request, locals, url, getC
 		// insbesondere sind freigegeben_am und abgelehnt_am nie gleichzeitig gesetzt.
 		const statusColumns =
 			verdict === 'approve'
-				? { verified: 1, approvedAt: now, rejectedAt: null, rejectedBy: null }
+				? {
+						verified: 1,
+						approvedAt: now,
+						// Wer freigibt, wird genauso festgehalten wie wer ablehnt.
+						// Ohne angemeldete Identität bleibt die Spalte NULL statt
+						// einen Platzhalter zu behaupten — wie beim Altbestand.
+						approvedBy: locals.user?.email ?? null,
+						rejectedAt: null,
+						rejectedBy: null
+					}
 				: verdict === 'reject'
 					? {
 							verified: 0,
 							approvedAt: null,
+							approvedBy: null,
 							rejectedAt: now,
 							rejectedBy: locals.user?.email ?? null
 						}
-					: { verified: 0, approvedAt: null, rejectedAt: null, rejectedBy: null };
+					: {
+							verified: 0,
+							approvedAt: null,
+							approvedBy: null,
+							rejectedAt: null,
+							rejectedBy: null
+						};
 
 		await db
 			.update(sightings)

--- a/src/routes/api/sightings/[id]/verify/verify.test.ts
+++ b/src/routes/api/sightings/[id]/verify/verify.test.ts
@@ -55,6 +55,7 @@ vi.mock('$lib/server/db/schema', () => ({
 		id: 'id',
 		verified: 'verified',
 		approvedAt: 'approvedAt',
+		approvedBy: 'approvedBy',
 		rejectedAt: 'rejectedAt',
 		rejectedBy: 'rejectedBy'
 	}
@@ -216,14 +217,24 @@ describe('PATCH mit verdict', () => {
 		mockLimit.mockResolvedValue([{ id: 1, verified: 0, approvedAt: null, rejectedAt: null }]);
 	});
 
-	it('approve markiert die Sichtung als geprüft, setzt freigegeben_am und löscht die Ablehnung', async () => {
+	it('approve markiert die Sichtung als geprüft, setzt freigegeben_am/_von und löscht die Ablehnung', async () => {
 		await PATCH(patchEvent('1', { verdict: 'approve' }));
 		expect(mockSet).toHaveBeenCalledWith({
 			verified: 1,
 			approvedAt: expect.any(Date),
+			approvedBy: 'admin@example.com',
 			rejectedAt: null,
 			rejectedBy: null
 		});
+	});
+
+	// Symmetrie zur Ablehnung: Ohne angemeldete Identität bleibt die Spalte
+	// NULL statt einen Platzhalter zu behaupten — genau wie beim Altbestand.
+	it('approve ohne Benutzer-E-Mail lässt freigegeben_von auf null', async () => {
+		const event = createMockEvent('1', { verdict: 'approve' });
+		event.locals.user = { email: undefined as unknown as string, roles: ['admin'] };
+		await PATCH(event as Parameters<typeof PATCH>[0]);
+		expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({ approvedBy: null }));
 	});
 
 	it('reject setzt abgelehnt_am/_von und zieht die Freigabe zurück', async () => {
@@ -231,16 +242,18 @@ describe('PATCH mit verdict', () => {
 		expect(mockSet).toHaveBeenCalledWith({
 			verified: 0,
 			approvedAt: null,
+			approvedBy: null,
 			rejectedAt: expect.any(Date),
 			rejectedBy: 'admin@example.com'
 		});
 	});
 
-	it('reset nullt alle Status-Spalten', async () => {
+	it('reset nullt alle Status-Spalten inklusive beider _von-Spalten', async () => {
 		await PATCH(patchEvent('1', { verdict: 'reset' }));
 		expect(mockSet).toHaveBeenCalledWith({
 			verified: 0,
 			approvedAt: null,
+			approvedBy: null,
 			rejectedAt: null,
 			rejectedBy: null
 		});


### PR DESCRIPTION
## Zusammenfassung

Setzt die 8 Agent-Punkte aus `docs/ADMIN_IMPROVEMENTS_SPEC.md` um (Welle 1+2 des Admin-Reviews vom 2026-08-08). **Stacked auf #800** — dieser PR zeigt nur die Wellen-Änderungen; nach dem Merge von #800 bitte Base auf `main` umstellen (macht GitHub beim Löschen des Basis-Branches automatisch).

### Usability
- **`freigegeben_von`** (U1): neue nullable Spalte + Migration `0006`; nur der verify-Endpunkt schreibt sie (approve stempelt, reject/reset räumen); Detail-/Edit-Ansicht zeigen „Freigegeben am … durch X", Altbestand ohne Person nur das Datum.
- **Eingang neueste zuerst** (U4): Default `desc` — der Backlog ab 2013 machte FIFO als Default unbrauchbar; `?order=asc` bleibt.
- **Spaltenauswahl merken** (U2): versioniertes localStorage-Format mit tolerantem Merge (neue Spalten erscheinen, kaputtes JSON fällt still auf Default).
- **Bulk-Aktionen** (U5): feste Checkbox-Spalte, Aktionsleiste „N ausgewählt", sequenzielle Verdicts über den bestehenden verify-Endpunkt, EIN Summen-Toast mit Undo (nur Erfolge), Auswahl leert sich bei Datenwechsel.

### UX
- **Status/Aktionen sticky rechts** (X1) mit opaken Theme-Flächen (DaisyUI färbt Zeile statt Zellen — im Code belegt); Default-Spalten bereinigt; irreführender Hover von nicht sortierbaren Köpfen entfernt.
- **Settings-Reset entschärft** (X2): `btn-outline btn-error` am Seitenende hinter Bestätigungsdialog (DeleteDialog-Muster).
- **Edit-Seite** (X3): Titel „Sichtung bearbeiten", Unsaved-Changes-Guard (Werte-Vergleich mit Normalisierung), Speichern-Button bleibt bei Fehlern bedienbar und springt zur Fehlerliste.
- **Statistik** (X4): „Totfund-Anteil" statt „Mortalität", Prozent in de-DE („9,2 %"), NaN-sicher.

## Review
`/review`-Skill gefahren: keine kritischen Befunde; die 3 Hinweise (localStorage-Begründung, Guard-Neubewaffnung nach Save, Bulk-`disabled`-Kommentar) und der NaN-Randfall sind in diesem Stand bereits behoben.

## Test plan
- [x] `npm run test:quick` grün: 259 Dateien, **3945 Tests** (inkl. Guards `verifiedReadScan`, `approvalPredicateScan`)
- [x] Neue Tests je Punkt (verify approve/reset, Inbox-Default, Reset-Dialog, Format-Modul, Sticky/Spalten, columnPreferences, bulkSelection/bulkVerdict, isFormDirty, Guard-Flows)
- [x] Live im Browser verifiziert (Dev-Server + Session): Sticky-Spalten mit Trennkante, Bulk-Freigabe stempelte `freigegeben_von` Ende-zu-Ende, Reset räumt beide Spalten, Eingang neueste zuerst, Reset-Dialog, Statistik-Texte
- [ ] **Deployment-Hinweis:** Migration `0006` muss vor dem neuen Code laufen (macht der Container per `db:migrate` automatisch) — ohne Spalte ist die Admin-Tabelle 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)