### PR TITLE
feat(admin): Freitext-Suche über Sichtungen in der Admin-Tabelle

### DIFF
--- a/.claude/rules/export.md
+++ b/.claude/rules/export.md
@@ -26,12 +26,19 @@ Regeln für CSV, JSON, KML und XML Export.
 
 **Auth:** Alle Endpoints erfordern `requireUserRole(url, locals.user, ['admin'])`
 
-**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`, `balticSea`, `deadFinding`
+**Query-Parameter:** `fromDate`, `toDate`, `verified`, `entryChannel`, `mediaUpload`, `balticSea`, `deadFinding`, `q`
 
 `balticSea` nimmt einen der vier Werte aus `BalticSeaStatus` (`baltic`, `edge`,
 `outside`, `noPosition`) und übersetzt ihn über `$lib/server/db/balticSeaFilter`
 — dieselbe Fallunterscheidung, die die Admin-Liste anzeigt. Die Flag-Logik nicht
 hier nachbauen, sondern von dort importieren.
+
+`q` ist die Freitext-Suche der Admin-Tabelle und läuft über
+`$lib/server/db/sightingSearchFilter` — parametrisiertes `ILIKE '%…%'` über
+Referenz-ID, E-Mail, Vor-/Nachname und Fahrwasser. Der Export **muss** sie
+mitfiltern: Sonst enthielte die Datei mehr Zeilen, als der Nutzer gesehen hat.
+Die Index-Entscheidung (kein `pg_trgm`, mit Messwerten und Schwelle) steht im
+Docblock des Moduls.
 
 `deadFinding` (`1`=Totfund, `0`=Lebendsichtung) läuft über
 `$lib/server/db/deadFindingFilter` — Totfund heißt dort `totfund <> 0`, dieselbe

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -61,6 +61,7 @@
 	import Mail from '~icons/lucide/mail';
 	import Map from '~icons/lucide/map';
 	import MapPin from '~icons/lucide/map-pin';
+	import Search from '~icons/lucide/search';
 	import MessageCircle from '~icons/lucide/message-circle';
 	import MessageSquare from '~icons/lucide/message-square';
 	import Mountain from '~icons/lucide/mountain';
@@ -114,6 +115,7 @@
 
 	const iconMap: Record<string, Component> = {
 		'lucide:map-pin': MapPin,
+		'lucide:search': Search,
 		'lucide:calendar': Calendar,
 		'lucide:wind': Wind,
 		'lucide:cloud': Cloud,

--- a/src/lib/components/admin/ExportModal.svelte
+++ b/src/lib/components/admin/ExportModal.svelte
@@ -4,14 +4,7 @@
 	import { downloadHandlers, createTimestampedFilename } from '$lib/utils/download';
 	import type { FrontendSighting } from '$lib/types';
 	import { formatFileSize } from '$lib/utils/file/fileSize';
-	import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
-	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
-	import {
-		BALTIC_SEA_STATUS_PRESENTATION,
-		isBalticSeaStatus
-	} from '$lib/utils/geo/balticSeaStatus';
-	import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
-	import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+	import { getActiveFiltersDisplay } from '$lib/components/admin/exportFilterDisplay';
 	import Icon from '$lib/components/Icon.svelte';
 
 	const logger = createLogger('ExportModal');
@@ -25,6 +18,10 @@
 		currentFilters: Record<string, string | boolean>;
 		totalRecords: number;
 	} = $props();
+
+	// Reine Funktion (exportFilterDisplay.ts), deshalb $derived statt eines
+	// Aufrufs im Markup — sonst liefe sie bei jedem Render erneut.
+	let aktiveFilter = $derived(getActiveFiltersDisplay(currentFilters));
 
 	let selectedFormat = $state('csv');
 	let isLoading = $state(false);
@@ -69,55 +66,6 @@
 		};
 
 		return recordCount * (bytesPerRecord[format as keyof typeof bytesPerRecord] || 500);
-	}
-
-	// Aktive Filter als lesbare Strings formatieren. `fromDate`/`toDate` sind
-	// reine Kalendertag-Strings ("YYYY-MM-DD") aus dem Datumsfilter, kein
-	// Zeitpunkt — formatWallClockDateTime sortiert nur um, ohne Date-Objekt
-	// (sonst bestimmt die Browser-Zone den Tag mit, bis zu ±1 Tag).
-	function getActiveFiltersDisplay(): string[] {
-		const filterDisplays: string[] = [];
-
-		if (currentFilters.fromDate) {
-			filterDisplays.push(`Von: ${formatWallClockDateTime(currentFilters.fromDate as string)}`);
-		}
-		if (currentFilters.toDate) {
-			filterDisplays.push(`Bis: ${formatWallClockDateTime(currentFilters.toDate as string)}`);
-		}
-		const statusFilter = normalizeStatusParam(currentFilters.verified as string | null);
-		if (statusFilter) {
-			const statusLabel = {
-				open: 'Nur offene Sichtungen',
-				approved: 'Nur freigegebene Sichtungen',
-				rejected: 'Nur abgelehnte Sichtungen'
-			}[statusFilter];
-			filterDisplays.push(statusLabel);
-		}
-		if (currentFilters.entryChannel && currentFilters.entryChannel !== 'all') {
-			filterDisplays.push(`Kanal: ${currentFilters.entryChannel}`);
-		}
-		if (currentFilters.mediaUpload === '1') {
-			filterDisplays.push('Nur mit Aufnahmen');
-		} else if (currentFilters.mediaUpload === '0') {
-			filterDisplays.push('Nur ohne Aufnahmen');
-		} else if (currentFilters.mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
-			filterDisplays.push('Nur angekündigt, Foto fehlt noch');
-		}
-		if (isBalticSeaStatus(currentFilters.balticSea)) {
-			// Label aus BALTIC_SEA_STATUS_PRESENTATION statt neu formuliert, damit
-			// Filter-Panel und Export-Zusammenfassung nie auseinanderlaufen.
-			const presentation = BALTIC_SEA_STATUS_PRESENTATION[currentFilters.balticSea];
-			filterDisplays.push(`Ostsee-Status: ${presentation.label}`);
-		}
-		if (currentFilters.deadFinding === '1') {
-			// Label aus DEAD_FINDING_PRESENTATION statt neu formuliert, damit
-			// Filter-Panel und Export-Zusammenfassung nie auseinanderlaufen.
-			filterDisplays.push(`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`);
-		} else if (currentFilters.deadFinding === '0') {
-			filterDisplays.push('Meldeart: Lebendsichtung');
-		}
-
-		return filterDisplays.length > 0 ? filterDisplays : ['Keine Filter aktiv'];
 	}
 
 	// Export-Daten laden mit aktuellen Filtern
@@ -263,7 +211,7 @@
 			<div class="bg-base-200 rounded-lg p-4">
 				<h4 class="mb-2 text-sm font-medium">Aktuelle Filter:</h4>
 				<div class="flex flex-wrap gap-2">
-					{#each getActiveFiltersDisplay() as filter, index (index)}
+					{#each aktiveFilter as filter, index (index)}
 						<span class="badge badge-outline badge-sm">{filter}</span>
 					{/each}
 				</div>

--- a/src/lib/components/admin/exportFilterDisplay.test.ts
+++ b/src/lib/components/admin/exportFilterDisplay.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getActiveFiltersDisplay } from './exportFilterDisplay';
+
+describe('getActiveFiltersDisplay', () => {
+	it('meldet ohne Filter „Keine Filter aktiv"', () => {
+		expect(getActiveFiltersDisplay({})).toEqual(['Keine Filter aktiv']);
+	});
+
+	it('zeigt den Suchbegriff an', () => {
+		// Der Export erbt die Suche der Tabelle (exportFilterParams.ts). Fehlte
+		// sie hier, versprächen die Badges eine größere Menge als die Datei
+		// enthält — dieselbe Falle wie bei balticSea und deadFinding.
+		expect(getActiveFiltersDisplay({ q: 'müller' })).toContain('Suche: „müller"');
+	});
+
+	it('ignoriert einen leeren Suchbegriff', () => {
+		expect(getActiveFiltersDisplay({ q: '   ' })).toEqual(['Keine Filter aktiv']);
+	});
+
+	it('zeigt die Suche neben anderen aktiven Filtern', () => {
+		const anzeige = getActiveFiltersDisplay({
+			q: 'ostsee',
+			verified: 'approved',
+			deadFinding: '1'
+		});
+
+		expect(anzeige).toContain('Suche: „ostsee"');
+		expect(anzeige).toContain('Nur freigegebene Sichtungen');
+		expect(anzeige).toHaveLength(3);
+	});
+});

--- a/src/lib/components/admin/exportFilterDisplay.ts
+++ b/src/lib/components/admin/exportFilterDisplay.ts
@@ -1,0 +1,80 @@
+/**
+ * Lesbare Beschriftungen der aktiven Filter für den Export-Dialog
+ * (`ExportModal.svelte`).
+ *
+ * Eigenes Modul statt einer Funktion in der Komponente: Diese Liste ist die
+ * dritte Stelle, an der ein neuer Tabellenfilter nachgezogen werden muss —
+ * neben `exportFilterParams.ts` (was tatsächlich gefiltert wird) und
+ * `tableReturnUrl.ts` (was der Rückweg behält). Vergisst man sie, verspricht
+ * der Dialog eine andere Menge, als die Datei enthält; als reine Funktion ist
+ * das ohne Browser testbar (`exportFilterDisplay.test.ts`).
+ *
+ * Die Beschriftungen kommen, wo vorhanden, aus den Präsentations-Konstanten
+ * (`BALTIC_SEA_STATUS_PRESENTATION`, `DEAD_FINDING_PRESENTATION`) statt neu
+ * formuliert zu werden — sonst laufen Filter-Panel und Export-Zusammenfassung
+ * auseinander.
+ */
+import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+import { BALTIC_SEA_STATUS_PRESENTATION, isBalticSeaStatus } from '$lib/utils/geo/balticSeaStatus';
+import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+
+/**
+ * @param currentFilters Die Filterwerte der Tabelle, so wie sie auch an die
+ *   Export-API gehen.
+ * @returns Je ein Badge-Text pro aktivem Filter, oder `['Keine Filter aktiv']`.
+ */
+export function getActiveFiltersDisplay(
+	currentFilters: Record<string, string | boolean | undefined>
+): string[] {
+	const filterDisplays: string[] = [];
+
+	// `fromDate`/`toDate` sind reine Kalendertag-Strings ("YYYY-MM-DD") aus dem
+	// Datumsfilter, kein Zeitpunkt — formatWallClockDateTime sortiert nur um,
+	// ohne Date-Objekt (sonst bestimmt die Browser-Zone den Tag mit, bis zu
+	// ±1 Tag).
+	if (currentFilters.fromDate) {
+		filterDisplays.push(`Von: ${formatWallClockDateTime(currentFilters.fromDate as string)}`);
+	}
+	if (currentFilters.toDate) {
+		filterDisplays.push(`Bis: ${formatWallClockDateTime(currentFilters.toDate as string)}`);
+	}
+	const statusFilter = normalizeStatusParam(currentFilters.verified as string | null);
+	if (statusFilter) {
+		const statusLabel = {
+			open: 'Nur offene Sichtungen',
+			approved: 'Nur freigegebene Sichtungen',
+			rejected: 'Nur abgelehnte Sichtungen'
+		}[statusFilter];
+		filterDisplays.push(statusLabel);
+	}
+	if (currentFilters.entryChannel && currentFilters.entryChannel !== 'all') {
+		filterDisplays.push(`Kanal: ${currentFilters.entryChannel}`);
+	}
+	if (currentFilters.mediaUpload === '1') {
+		filterDisplays.push('Nur mit Aufnahmen');
+	} else if (currentFilters.mediaUpload === '0') {
+		filterDisplays.push('Nur ohne Aufnahmen');
+	} else if (currentFilters.mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
+		filterDisplays.push('Nur angekündigt, Foto fehlt noch');
+	}
+	if (isBalticSeaStatus(currentFilters.balticSea)) {
+		const presentation = BALTIC_SEA_STATUS_PRESENTATION[currentFilters.balticSea];
+		filterDisplays.push(`Ostsee-Status: ${presentation.label}`);
+	}
+	if (currentFilters.deadFinding === '1') {
+		filterDisplays.push(`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`);
+	} else if (currentFilters.deadFinding === '0') {
+		filterDisplays.push('Meldeart: Lebendsichtung');
+	}
+	// Getrimmt geprüft und getrimmt angezeigt — dieselbe Grenze wie serverseitig
+	// in `normalizeSearchTerm`, sonst stünde hier ein Badge für eine Suche, die
+	// die Abfrage gar nicht einschränkt.
+	const searchTerm = typeof currentFilters.q === 'string' ? currentFilters.q.trim() : '';
+	if (searchTerm) {
+		filterDisplays.push(`Suche: „${searchTerm}"`);
+	}
+
+	return filterDisplays.length > 0 ? filterDisplays : ['Keine Filter aktiv'];
+}

--- a/src/lib/server/db/sightingSearchFilter.test.ts
+++ b/src/lib/server/db/sightingSearchFilter.test.ts
@@ -1,0 +1,56 @@
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQLWrapper } from 'drizzle-orm';
+import { describe, expect, it } from 'vitest';
+import { normalizeSearchTerm, searchCondition } from './sightingSearchFilter';
+
+const dialect = new PgDialect();
+const compile = (condition: SQLWrapper) => dialect.sqlToQuery(condition.getSQL());
+
+describe('normalizeSearchTerm', () => {
+	it('schneidet Leerraum ab', () => {
+		expect(normalizeSearchTerm('  Müller  ')).toBe('Müller');
+	});
+
+	it.each([null, undefined, '', '   '])('liefert für %p undefined', (eingabe) => {
+		expect(normalizeSearchTerm(eingabe)).toBeUndefined();
+	});
+});
+
+describe('searchCondition', () => {
+	it('liefert ohne Suchbegriff kein Prädikat', () => {
+		expect(searchCondition(null)).toBeUndefined();
+		expect(searchCondition('   ')).toBeUndefined();
+	});
+
+	it('sucht über alle fünf Felder mit ILIKE', () => {
+		const { sql } = compile(searchCondition('müller') as SQLWrapper);
+
+		for (const spalte of ['referenz_id', 'email', 'vorname', 'name', 'fahrwasser']) {
+			expect(sql).toContain(`"${spalte}" ilike`);
+		}
+	});
+
+	it('übergibt den Suchbegriff als Parameter, nicht als SQL-Text', () => {
+		// Kein SQL-String-Bau: Der Begriff darf nirgends im SQL-Text auftauchen,
+		// sondern ausschließlich in der Parameterliste. Sonst wäre `'; drop …`
+		// eine Injektion statt eines erfolglosen Suchbegriffs.
+		const { sql, params } = compile(searchCondition("o'brien") as SQLWrapper);
+
+		expect(sql).not.toContain("o'brien");
+		expect(params).toEqual(Array(5).fill("%o'brien%"));
+	});
+
+	it('entschärft LIKE-Platzhalter im Suchbegriff', () => {
+		// Ohne Escaping wäre `%` eine Suche nach allem und `_` ein Joker — der
+		// Nutzer tippt aber einen Literaltext, keinen Suchausdruck.
+		const { params } = compile(searchCondition('50%_rest') as SQLWrapper);
+
+		expect(params[0]).toBe('%50\\%\\_rest%');
+	});
+
+	it('entschärft den Escape-Backslash selbst', () => {
+		const { params } = compile(searchCondition('a\\b') as SQLWrapper);
+
+		expect(params[0]).toBe('%a\\\\b%');
+	});
+});

--- a/src/lib/server/db/sightingSearchFilter.ts
+++ b/src/lib/server/db/sightingSearchFilter.ts
@@ -1,0 +1,82 @@
+/**
+ * Gemeinsames `q`-Suchprädikat für die Admin-Übersicht
+ * (`routes/admin/sichtungen/+page.server.ts`) und den Export
+ * (`routes/api/sightings/export/exportFilterParams.ts`).
+ *
+ * Reine, DB-lose Funktion wie `balticSeaFilter.ts` und `deadFindingFilter.ts`:
+ * Sie baut ein Drizzle-Prädikat über die Schema-Spalten, führt aber keine
+ * Abfrage aus. Beide Aufrufer hängen das Ergebnis an ihre eigene
+ * `and(...)`-Bedingungsliste — der Export erbt damit dieselbe Treffermenge, die
+ * der Nutzer in der Tabelle gesehen hat.
+ *
+ * **Gesucht wird über fünf Felder** — Referenz-ID, E-Mail, Vor- und Nachname
+ * und Fahrwasser. Das sind die Angaben, mit denen eine Rückfrage
+ * hereinkommt („Meine Meldung von gestern", eine weitergeleitete
+ * Bestätigungsmail, ein Anruf). Bewusst **nicht** dabei: `bemerkungen` und
+ * `kommentar_intern` — Freitextfelder, in denen jeder zweite Suchbegriff
+ * irgendwo vorkommt und die die Trefferliste unbrauchbar machen würden.
+ *
+ * **Performance (gemessen 2026-08-08, lokale Dev-DB, 19.947 Zeilen):** Der
+ * `ILIKE '%…%'`-Ausdruck über alle fünf Spalten läuft als Seq Scan in 13–30 ms
+ * (`EXPLAIN ANALYZE`, warm; „a" als Worst Case mit 18.734 Treffern: 13 ms).
+ * Ein `pg_trgm`-GIN-Index ist deshalb **bewusst nicht** angelegt: Er kostet
+ * Schreib- und Wartungsaufwand, greift bei Suchbegriffen unter drei Zeichen
+ * ohnehin nicht, und bei dieser Tabellengröße gäbe es nichts zu gewinnen, was
+ * ein Bearbeiter bemerkte. Neu bewerten, wenn die Tabelle die Größenordnung
+ * 200.000 Zeilen erreicht oder die Messung über 200 ms steigt — dann wäre
+ * `CREATE EXTENSION pg_trgm` plus je ein `gin_trgm_ops`-Index pro Spalte der
+ * nächste Schritt.
+ */
+import { ilike, or, type SQL } from 'drizzle-orm';
+import { sightings } from '$lib/server/db/schema';
+
+/** Spalten, über die gesucht wird — Reihenfolge bestimmt die `OR`-Kette. */
+const SUCHSPALTEN = [
+	sightings.referenceId,
+	sightings.email,
+	sightings.firstName,
+	sightings.lastName,
+	sightings.waterway
+] as const;
+
+/**
+ * Der rohe Query-Parameter, auf einen belastbaren Begriff reduziert.
+ *
+ * @returns Der getrimmte Begriff, oder `undefined` für „keine Suche" — damit
+ *   ein leeres Suchfeld nicht als Suche nach dem Leerstring gilt (die träfe
+ *   jede Zeile).
+ */
+export function normalizeSearchTerm(q: string | null | undefined): string | undefined {
+	const begriff = q?.trim();
+	return begriff ? begriff : undefined;
+}
+
+/**
+ * Entschärft die LIKE-Metazeichen im Suchbegriff.
+ *
+ * Der Nutzer tippt einen Literaltext, keinen Suchausdruck: Ohne diese
+ * Umwandlung wäre ein eingegebenes `%` eine Suche nach allem und `_` ein Joker
+ * für ein beliebiges Zeichen. Der Backslash muss zuerst dran, sonst
+ * verdoppelte der zweite Durchgang die gerade erst eingefügten Escapes.
+ *
+ * Postgres nimmt bei LIKE/ILIKE ohne `ESCAPE`-Klausel den Backslash als
+ * Escape-Zeichen — eine zusätzliche Klausel ist deshalb nicht nötig.
+ */
+function escapeLikePattern(begriff: string): string {
+	return begriff.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+/**
+ * @param q Der rohe `q`-Query-Parameter.
+ * @returns Ein Prädikat für `and(...)`, oder `undefined`, wenn nicht gesucht
+ *   wird. Der Begriff geht als **gebundener Parameter** in die Abfrage
+ *   (`ilike()` baut keinen SQL-Text) — es wird an keiner Stelle SQL aus
+ *   Nutzereingaben zusammengesetzt.
+ */
+export function searchCondition(q: string | null | undefined): SQL | undefined {
+	const begriff = normalizeSearchTerm(q);
+	if (!begriff) return undefined;
+
+	const muster = `%${escapeLikePattern(begriff)}%`;
+	return or(...SUCHSPALTEN.map((spalte) => ilike(spalte, muster)));
+}

--- a/src/routes/admin/[id]/tableReturnUrl.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.ts
@@ -19,6 +19,7 @@ export const TABELLEN_PARAMETER = [
 	'mediaUpload',
 	'balticSea',
 	'deadFinding',
+	'q',
 	'sort',
 	'order',
 	'page',

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -7,7 +7,9 @@ import {
 } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
+import { searchCondition, normalizeSearchTerm } from '$lib/server/db/sightingSearchFilter';
 import { and, eq, sql, type SQL } from 'drizzle-orm';
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 import { ServerConfigService } from '$lib/services/configService';
@@ -32,6 +34,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	const mediaUpload = url.searchParams.get('mediaUpload');
 	const balticSea = url.searchParams.get('balticSea');
 	const deadFinding = url.searchParams.get('deadFinding');
+	const q = url.searchParams.get('q');
 
 	// Bedingungen für die SQL-Abfrage sammeln
 	const conditions: SQL[] = [];
@@ -89,6 +92,13 @@ export const load: PageServerLoad = async ({ url }) => {
 	const deadFindingFilterCondition = deadFindingCondition(deadFinding);
 	if (deadFindingFilterCondition) {
 		conditions.push(deadFindingFilterCondition);
+	}
+
+	// Freitext-Suche über Referenz-ID, E-Mail, Name und Fahrwasser — parametrisiert
+	// via Drizzle, siehe sightingSearchFilter.ts (dort auch die Index-Entscheidung).
+	const searchFilterCondition = searchCondition(q);
+	if (searchFilterCondition) {
+		conditions.push(searchFilterCondition);
 	}
 
 	// Kombinierte WHERE-Bedingung erstellen
@@ -158,6 +168,39 @@ export const load: PageServerLoad = async ({ url }) => {
 	// Kopfzeile „1 Fotos ausstehend".
 	const count = Number(countResult[0]?.count ?? 0);
 	const pendingPhotoAnnouncements = Number(pendingPhotoResult[0]?.count ?? 0);
+
+	// Wer eine ganze Referenz-ID einfügt (aus einer Bestätigungsmail, einer
+	// Rückfrage), will die Sichtung sehen — nicht eine Trefferliste mit einer
+	// Zeile. Dasselbe Verhalten wie /admin/ref/[refId], nur ohne zweite
+	// Eingabemaske.
+	//
+	// Die Bedingung ist bewusst der tatsächliche Treffer und keine Formatheuristik:
+	// Ein Muster für „sieht aus wie eine CUID2" träfe auch Nachnamen, und eine
+	// zusätzliche Exact-Match-Abfrage kostete einen Round-Trip bei jeder Suche.
+	// Nur auf Seite 1, sonst stünde die Bedingung mit einer leeren Seite nie an.
+	const searchTerm = normalizeSearchTerm(q);
+	const einzigerTreffer = data.length === 1 ? data[0] : undefined;
+	if (
+		searchTerm &&
+		page === 1 &&
+		count === 1 &&
+		einzigerTreffer?.referenceId?.toLowerCase() === searchTerm.toLowerCase()
+	) {
+		// Die übrigen Filter reisen mit, **`q` bewusst nicht**: `tableReturnUrl.ts`
+		// nimmt `q` in den Rückweg auf, und dieser Rückweg liefe damit erneut in
+		// genau diese Weiterleitung — „Zurück zur Tabelle" landete wieder auf der
+		// Detailseite, die Trefferliste wäre nur noch über die Adresszeile
+		// erreichbar. Ohne `q` führt der Rückweg auf die Tabelle, die der
+		// Bearbeiter vor der Suche vor sich hatte; die einzeilige Trefferliste
+		// dieser Referenz-ID ist ohnehin kein Ziel, zu dem man zurückwill.
+		const zielParameter = new URLSearchParams(url.searchParams);
+		zielParameter.delete('q');
+		const anhang = zielParameter.toString();
+		redirect(
+			302,
+			anhang ? `/admin/${einzigerTreffer.id}?${anhang}` : `/admin/${einzigerTreffer.id}`
+		);
+	}
 
 	return {
 		sightings: data,

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -65,6 +65,11 @@
 	let mediaUpload = $state(page.url.searchParams.get('mediaUpload') || '');
 	let balticSea = $state(page.url.searchParams.get('balticSea') || '');
 	let deadFinding = $state(page.url.searchParams.get('deadFinding') || '');
+	/* Die Freitext-Suche steht bewusst außerhalb des Filter-Panels — sie ist der
+	   Weg für eine hereinkommende Rückfrage („meine Meldung von gestern", eine
+	   weitergeleitete Bestätigungsmail) und soll ohne Aufklappen erreichbar sein.
+	   Serverseitig läuft sie über `sightingSearchFilter.ts`. */
+	let searchTerm = $state(page.url.searchParams.get('q') || '');
 	let showDeleteDialog = $state(false);
 	let sightingToDelete = $state<FrontendSighting | null>(null);
 	let isFilterPanelOpen = $state(false);
@@ -195,7 +200,8 @@
 			(selectedChannel && selectedChannel !== 'all') ||
 			mediaUpload ||
 			balticSea ||
-			deadFinding
+			deadFinding ||
+			searchTerm
 		)
 	);
 
@@ -207,7 +213,13 @@
 		entryChannel: selectedChannel !== 'all' ? selectedChannel : '',
 		mediaUpload: mediaUpload || '',
 		balticSea: balticSea || '',
-		deadFinding: deadFinding || ''
+		deadFinding: deadFinding || '',
+		/* Aus der URL, nicht aus dem Feld-State: Das Suchfeld steht dauerhaft im
+		   Kopf, ein getippter, aber nicht abgeschickter Begriff ist damit leicht
+		   stehengelassen. Aus dem Feld gelesen, exportierte der Dialog dann eine
+		   Menge, die die sichtbare Tabelle gar nicht anwendet — und die Badges
+		   versprächen sie obendrein. */
+		q: page.url.searchParams.get('q') ?? ''
 	}));
 
 	function updateSort(column: string): void {
@@ -255,6 +267,13 @@
 		if (deadFinding) url.searchParams.set('deadFinding', deadFinding);
 		else url.searchParams.delete('deadFinding');
 
+		// Freitext-Suche. Getrimmt, damit ein versehentliches Leerzeichen nicht
+		// als aktive Suche in der URL stehen bleibt — der Server verwirft es
+		// ohnehin (normalizeSearchTerm).
+		const begriff = searchTerm.trim();
+		if (begriff) url.searchParams.set('q', begriff);
+		else url.searchParams.delete('q');
+
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -271,6 +290,16 @@
 		applyFilters();
 	}
 
+	/**
+	 * Absenden der Suche. Läuft über `applyFilters()`, damit ein aktiver
+	 * Filter erhalten bleibt und die Seitenzahl auf 1 zurückspringt — sonst
+	 * stünde man mit einer frischen Suche auf einer leeren Seite 7.
+	 */
+	function submitSearch(event: SubmitEvent): void {
+		event.preventDefault();
+		applyFilters();
+	}
+
 	function resetFilters(): void {
 		fromDate = '';
 		toDate = '';
@@ -279,6 +308,7 @@
 		mediaUpload = '';
 		balticSea = '';
 		deadFinding = '';
+		searchTerm = '';
 
 		const url = new URL(page.url);
 		url.searchParams.delete('fromDate');
@@ -288,6 +318,7 @@
 		url.searchParams.delete('mediaUpload');
 		url.searchParams.delete('balticSea');
 		url.searchParams.delete('deadFinding');
+		url.searchParams.delete('q');
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -737,6 +768,28 @@
 				{/if}
 			</div>
 		</div>
+
+		<!--
+			Eigene Zeile unter beiden Kopf-Layouts statt zweier Kopien: Das Feld ist
+			in jeder Breite gleich breit nützlich, und ein zweites Exemplar im DOM
+			hätte zwei Elemente mit demselben Label (`getByRole('searchbox')` wäre
+			mehrdeutig, und Screenreader läsen die Suche doppelt).
+			`type="search"` statt `text`: liefert die Rolle `searchbox` und auf
+			Mobilgeräten die passende Tastatur mit „Suchen"-Taste.
+		-->
+		<form class="mt-3 flex items-center gap-2" onsubmit={submitSearch} role="search">
+			<label class="input input-sm flex flex-1 items-center gap-2">
+				<Icon icon="lucide:search" class="h-4 w-4 opacity-70" aria-hidden="true" />
+				<span class="sr-only">Suche nach Referenz-ID, E-Mail, Name oder Fahrwasser</span>
+				<input
+					type="search"
+					class="grow"
+					bind:value={searchTerm}
+					placeholder="Referenz-ID, E-Mail, Name oder Fahrwasser"
+				/>
+			</label>
+			<button type="submit" class="btn btn-sm btn-outline">Suchen</button>
+		</form>
 	</div>
 
 	<!-- Filter Panel -->

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -65,10 +65,6 @@
 	let mediaUpload = $state(page.url.searchParams.get('mediaUpload') || '');
 	let balticSea = $state(page.url.searchParams.get('balticSea') || '');
 	let deadFinding = $state(page.url.searchParams.get('deadFinding') || '');
-	/* Die Freitext-Suche steht bewusst außerhalb des Filter-Panels — sie ist der
-	   Weg für eine hereinkommende Rückfrage („meine Meldung von gestern", eine
-	   weitergeleitete Bestätigungsmail) und soll ohne Aufklappen erreichbar sein.
-	   Serverseitig läuft sie über `sightingSearchFilter.ts`. */
 	let searchTerm = $state(page.url.searchParams.get('q') || '');
 	let showDeleteDialog = $state(false);
 	let sightingToDelete = $state<FrontendSighting | null>(null);
@@ -269,9 +265,14 @@
 
 		// Freitext-Suche. Getrimmt, damit ein versehentliches Leerzeichen nicht
 		// als aktive Suche in der URL stehen bleibt — der Server verwirft es
-		// ohnehin (normalizeSearchTerm).
-		const begriff = searchTerm.trim();
-		if (begriff) url.searchParams.set('q', begriff);
+		// ohnehin (normalizeSearchTerm). Der getrimmte Wert geht zurück in den
+		// State, nicht nur in die URL: Sonst zeigte das Feld nach dem Suchen
+		// weiter die ungetrimmte Eingabe, und ein Feld aus lauter Leerzeichen
+		// zählte in `hasActiveFilters` als aktiver Filter — die
+		// Filter-Schaltfläche stünde markiert da, während die URL gar keine
+		// Suche trägt.
+		searchTerm = searchTerm.trim();
+		if (searchTerm) url.searchParams.set('q', searchTerm);
 		else url.searchParams.delete('q');
 
 		url.searchParams.set('page', '1');
@@ -770,6 +771,11 @@
 		</div>
 
 		<!--
+			Die Freitext-Suche steht bewusst außerhalb des Filter-Panels — sie ist
+			der Weg für eine hereinkommende Rückfrage („meine Meldung von gestern",
+			eine weitergeleitete Bestätigungsmail) und soll ohne Aufklappen
+			erreichbar sein. Serverseitig läuft sie über `sightingSearchFilter.ts`.
+
 			Eigene Zeile unter beiden Kopf-Layouts statt zweier Kopien: Das Feld ist
 			in jeder Breite gleich breit nützlich, und ein zweites Exemplar im DOM
 			hätte zwei Elemente mit demselben Label (`getByRole('searchbox')` wäre

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -17,8 +17,10 @@
  * kompiliert.
  */
 import { PgDialect } from 'drizzle-orm/pg-core';
-import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { and, sql, type SQL, type SQLWrapper } from 'drizzle-orm';
+import { isRedirect, type Redirect } from '@sveltejs/kit';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { searchCondition } from '$lib/server/db/sightingSearchFilter';
 import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
 	mediaUploadCondition
@@ -278,6 +280,113 @@ describe('admin/sichtungen/+page.server load() — Datumsfilter mit offenen Gren
 		} as unknown as Parameters<typeof load>[0]);
 
 		expect(recordedSelects[0]?.whereSql).toBeUndefined();
+	});
+});
+
+/**
+ * Freitext-Suche (`?q=`). Die Bedingung selbst ist in `sightingSearchFilter.test.ts`
+ * abgesichert; hier zählt die Verdrahtung — dass der Parameter bis in die
+ * WHERE-Klausel durchschlägt — und der Sonderfall Referenz-ID.
+ */
+describe('admin/sichtungen/+page.server load() — Freitext-Suche', () => {
+	beforeEach(() => {
+		recordedSelects = [];
+		resolvedRows = [[{ id: 1 }], [{ count: 5 }], [{ count: 2 }]];
+	});
+
+	it('?q=… filtert Liste und Zähler mit derselben Bedingung', async () => {
+		await load({
+			url: makeUrl({ q: 'müller' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(searchCondition('müller') as unknown as SQLWrapper);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+		expect(recordedSelects[1]?.whereSql).toBe(expected);
+	});
+
+	it('ein leerer Suchbegriff filtert gar nicht', async () => {
+		await load({
+			url: makeUrl({ q: '   ' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(recordedSelects[0]?.whereSql).toBeUndefined();
+	});
+
+	it('kombiniert die Suche mit einem aktiven Statusfilter', async () => {
+		await load({
+			url: makeUrl({ q: 'müller', verified: 'rejected' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const expected = toSqlText(
+			and(rejectedOnly(), searchCondition('müller')) as unknown as SQLWrapper
+		);
+		expect(recordedSelects[0]?.whereSql).toBe(expected);
+	});
+
+	it('leitet bei genau einem exakten Referenz-ID-Treffer auf die Detailseite', async () => {
+		// Verhalten wie /admin/ref/[refId]: Wer eine Referenz-ID einfügt, will die
+		// Sichtung sehen, nicht eine einzeilige Trefferliste.
+		resolvedRows = [[{ id: 4711, referenceId: 'abc123xyz' }], [{ count: 1 }], [{ count: 0 }]];
+
+		let fehler: unknown;
+		try {
+			await load({ url: makeUrl({ q: 'ABC123XYZ' }) } as unknown as Parameters<typeof load>[0]);
+		} catch (err) {
+			fehler = err;
+		}
+
+		expect(isRedirect(fehler)).toBe(true);
+		expect((fehler as Redirect).location).toBe('/admin/4711');
+	});
+
+	it('gibt den Suchbegriff beim Weiterleiten NICHT mit', async () => {
+		// Sonst führt der Rückweg aus der Detailansicht (tableReturnUrl.ts nimmt
+		// `q` mit) direkt wieder in dieselbe Weiterleitung: „Zurück zur Tabelle"
+		// landete erneut auf der Detailseite, und die Liste wäre ohne Handarbeit
+		// an der URL nicht mehr erreichbar.
+		resolvedRows = [[{ id: 4711, referenceId: 'abc123xyz' }], [{ count: 1 }], [{ count: 0 }]];
+
+		let fehler: unknown;
+		try {
+			await load({
+				url: makeUrl({ q: 'abc123xyz', verified: 'open' })
+			} as unknown as Parameters<typeof load>[0]);
+		} catch (err) {
+			fehler = err;
+		}
+
+		const ziel = new URL((fehler as Redirect).location, 'https://example.com');
+		expect(ziel.searchParams.has('q')).toBe(false);
+		// Die übrigen Filter bleiben erhalten — der Rückweg führt damit auf die
+		// Tabelle, die der Bearbeiter vor der Suche vor sich hatte.
+		expect(ziel.searchParams.get('verified')).toBe('open');
+	});
+
+	it('leitet nicht weiter, wenn der Begriff nur Teil der Referenz-ID ist', async () => {
+		resolvedRows = [[{ id: 4711, referenceId: 'abc123xyz' }], [{ count: 1 }], [{ count: 0 }]];
+
+		const result = await load({
+			url: makeUrl({ q: 'abc123' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(result).toBeDefined();
+	});
+
+	it('leitet nicht weiter, wenn die Suche mehrere Treffer hat', async () => {
+		resolvedRows = [
+			[
+				{ id: 4711, referenceId: 'abc123xyz' },
+				{ id: 4712, referenceId: 'anderes' }
+			],
+			[{ count: 2 }],
+			[{ count: 0 }]
+		];
+
+		const result = await load({
+			url: makeUrl({ q: 'abc123xyz' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(result).toBeDefined();
 	});
 });
 

--- a/src/routes/admin/sichtungen/searchParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/searchParam.svelte.test.ts
@@ -60,6 +60,35 @@ describe('Sichtungstabelle — Freitext-Suche', () => {
 		expect(ziel.searchParams.get('page')).toBe('1');
 	});
 
+	it('übernimmt den getrimmten Begriff auch ins Feld zurück', async () => {
+		// Nur die URL zu trimmen genügt nicht: Das Feld zeigte danach weiter die
+		// ungetrimmte Eingabe, und ein Feld aus lauter Leerzeichen zählte in
+		// `hasActiveFilters` als aktiver Filter — die Filter-Schaltfläche stünde
+		// also markiert da, während die URL gar keine Suche trägt.
+		goto.mockClear();
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		const feld = screen.getByRole('searchbox', { name: /suche/i });
+		await feld.fill('  ostsee  ');
+		await screen.getByRole('button', { name: 'Suchen' }).click();
+
+		await expect.element(feld).toHaveValue('ostsee');
+	});
+
+	it('leert ein Feld aus lauter Leerzeichen beim Suchen', async () => {
+		goto.mockClear();
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		const feld = screen.getByRole('searchbox', { name: /suche/i });
+		await feld.fill('   ');
+		await screen.getByRole('button', { name: 'Suchen' }).click();
+
+		await expect.element(feld).toHaveValue('');
+		const ziel = goto.mock.lastCall?.[0];
+		if (!ziel) throw new Error('goto wurde nicht aufgerufen');
+		expect(ziel.searchParams.has('q')).toBe(false);
+	});
+
 	it('entfernt den Parameter, wenn das Feld geleert wird', async () => {
 		goto.mockClear();
 		const screen = render(SichtungenSeite, { data: daten([]) });

--- a/src/routes/admin/sichtungen/searchParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/searchParam.svelte.test.ts
@@ -1,0 +1,74 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+/**
+ * searchParam.svelte.test.ts — Freitext-Suche (U3).
+ *
+ * Das Suchfeld steht im Kopf der Tabelle, nicht im Filter-Panel: Wer eine
+ * Referenz-ID oder eine E-Mail sucht, soll dafür kein Panel aufklappen müssen.
+ * Geprüft wird die Verdrahtung mit der URL in beide Richtungen — Feldwert aus
+ * `?q=`, und Absenden schreibt `?q=` zurück (inkl. Rücksprung auf Seite 1,
+ * sonst stünde man mit einer neuen Suche auf einer leeren Seite 7).
+ *
+ * Eigene Datei mit eigenem `$app/state`-Mock, aus demselben Grund wie bei
+ * `statusFilterParam.svelte.test.ts`: `vi.mock` gilt für das ganze Modul.
+ */
+
+const goto = vi.fn<(url: URL) => Promise<void>>(() => Promise.resolve());
+
+vi.mock('$app/navigation', () => ({
+	goto: (url: URL | string) => goto(url as URL),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen?q=m%C3%BCller&page=7') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function daten(rows: SightingSelect[]): PageData {
+	return {
+		sightings: rows,
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
+		pendingPhotoAnnouncements: 0
+	} as unknown as PageData;
+}
+
+describe('Sichtungstabelle — Freitext-Suche', () => {
+	it('übernimmt den Suchbegriff aus der URL ins Feld', async () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		await expect.element(screen.getByRole('searchbox', { name: /suche/i })).toHaveValue('müller');
+	});
+
+	it('schreibt den Suchbegriff in die URL und springt auf Seite 1', async () => {
+		goto.mockClear();
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		const feld = screen.getByRole('searchbox', { name: /suche/i });
+		await feld.fill('ostsee');
+		await screen.getByRole('button', { name: 'Suchen' }).click();
+
+		const ziel = goto.mock.lastCall?.[0];
+		if (!ziel) throw new Error('goto wurde nicht aufgerufen');
+		expect(ziel.searchParams.get('q')).toBe('ostsee');
+		expect(ziel.searchParams.get('page')).toBe('1');
+	});
+
+	it('entfernt den Parameter, wenn das Feld geleert wird', async () => {
+		goto.mockClear();
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		await screen.getByRole('searchbox', { name: /suche/i }).fill('');
+		await screen.getByRole('button', { name: 'Suchen' }).click();
+
+		const ziel = goto.mock.lastCall?.[0];
+		if (!ziel) throw new Error('goto wurde nicht aufgerufen');
+		expect(ziel.searchParams.has('q')).toBe(false);
+	});
+});

--- a/src/routes/api/sightings/export/exportFilterParams.test.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.test.ts
@@ -15,7 +15,8 @@ vi.mock('drizzle-orm', () => ({
 	eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
 	ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
 	isNull: vi.fn((column) => ({ op: 'isNull', column })),
-	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column }))
+	isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+	ilike: vi.fn((column, value) => ({ op: 'ilike', column, value }))
 }));
 
 vi.mock('$lib/server/db/schema', () => ({
@@ -30,7 +31,12 @@ vi.mock('$lib/server/db/schema', () => ({
 		latitude: 'latitude',
 		longitude: 'longitude',
 		approvedAt: 'approvedAt',
-		rejectedAt: 'rejectedAt'
+		rejectedAt: 'rejectedAt',
+		referenceId: 'referenceId',
+		email: 'email',
+		firstName: 'firstName',
+		lastName: 'lastName',
+		waterway: 'waterway'
 	}
 }));
 
@@ -47,7 +53,8 @@ function dateRange(fromDate: string, toDate: string): { start: Date; endExclusiv
 		entryChannel: null,
 		mediaUpload: null,
 		deadFinding: null,
-		balticSea: null
+		balticSea: null,
+		q: null
 	}) as unknown as Condition[];
 
 	const onDate = conditions.filter((condition) => condition.column === 'sightingDate');
@@ -74,7 +81,8 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			entryChannel: null,
 			mediaUpload: null,
 			deadFinding: null,
-			balticSea: null
+			balticSea: null,
+			q: null
 		});
 
 		expect(between).not.toHaveBeenCalled();
@@ -142,7 +150,8 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			entryChannel: null,
 			mediaUpload: null,
 			deadFinding: null,
-			balticSea: null
+			balticSea: null,
+			q: null
 		}) as unknown as Condition[];
 
 		expect(conditions.map((condition) => condition.op)).toEqual(['gte']);
@@ -157,7 +166,8 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			entryChannel: null,
 			mediaUpload: null,
 			deadFinding: null,
-			balticSea: null
+			balticSea: null,
+			q: null
 		}) as unknown as Condition[];
 
 		expect(conditions.map((condition) => condition.op)).toEqual(['lt']);
@@ -173,7 +183,8 @@ describe('buildExportConditions — Datumsfilter meint Berliner Kalendertage', (
 			entryChannel: null,
 			mediaUpload: null,
 			deadFinding: null,
-			balticSea: null
+			balticSea: null,
+			q: null
 		}) as unknown as Condition[];
 
 		expect(conditions).toHaveLength(0);
@@ -194,7 +205,8 @@ describe('Export-Filter — Ostsee-Status', () => {
 		verified: null,
 		entryChannel: null,
 		mediaUpload: null,
-		deadFinding: null
+		deadFinding: null,
+		q: null
 	};
 
 	it('parseExportFilterParams liest balticSea aus der URL', () => {
@@ -254,7 +266,8 @@ describe('Export-Filter — Meldeart (Totfund)', () => {
 		verified: null,
 		entryChannel: null,
 		mediaUpload: null,
-		balticSea: null
+		balticSea: null,
+		q: null
 	};
 
 	it('parseExportFilterParams liest deadFinding aus der URL', () => {
@@ -302,5 +315,42 @@ describe('Export-Filter — Status', () => {
 	it('filtert über dieselben Prädikate wie die Tabelle', () => {
 		expect(normalizeStatusParam('1')).toBe('approved');
 		expect(normalizeStatusParam('rejected')).toBe('rejected');
+	});
+});
+
+/**
+ * Die Freitext-Suche der Tabelle (`?q=`) muss der Export mitfiltern — sonst
+ * enthielte die Datei mehr Zeilen, als der Nutzer gesehen hat. Dieselbe Falle
+ * wie bei `mediaUpload` und `balticSea`; die Bedingung selbst ist in
+ * `$lib/server/db/sightingSearchFilter.test.ts` abgesichert.
+ */
+describe('Export-Filter — Freitext-Suche', () => {
+	const noFilters = {
+		fromDate: '',
+		toDate: '',
+		verified: null,
+		entryChannel: null,
+		mediaUpload: null,
+		deadFinding: null,
+		balticSea: null,
+		q: null
+	};
+
+	it('parseExportFilterParams liest q aus der URL', () => {
+		const result = parseExportFilterParams(
+			new URL('https://example.com/api/sightings/export?format=json&q=m%C3%BCller')
+		);
+
+		expect(result).toHaveProperty('params');
+		expect((result as { params: { q: string | null } }).params.q).toBe('müller');
+	});
+
+	it('buildExportConditions hängt für einen Suchbegriff eine Bedingung an', () => {
+		expect(buildExportConditions({ ...noFilters, q: 'müller' })).toHaveLength(1);
+	});
+
+	it('ein leerer Suchbegriff erzeugt keine Bedingung', () => {
+		expect(buildExportConditions({ ...noFilters, q: null })).toHaveLength(0);
+		expect(buildExportConditions({ ...noFilters, q: '   ' })).toHaveLength(0);
 	});
 });

--- a/src/routes/api/sightings/export/exportFilterParams.ts
+++ b/src/routes/api/sightings/export/exportFilterParams.ts
@@ -6,6 +6,7 @@ import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { statusCondition } from '../../../admin/sichtungen/statusFilter';
+import { searchCondition } from '$lib/server/db/sightingSearchFilter';
 
 export function xmlEscape(str: string | null | undefined): string {
 	if (!str) return '';
@@ -25,6 +26,7 @@ export type ExportFilterParams = {
 	mediaUpload: string | null;
 	deadFinding: string | null;
 	balticSea: string | null;
+	q: string | null;
 };
 
 type ValidationError = { field: 'fromDate' | 'toDate'; message: string };
@@ -38,6 +40,7 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 	const mediaUpload = url.searchParams.get('mediaUpload');
 	const deadFinding = url.searchParams.get('deadFinding');
 	const balticSea = url.searchParams.get('balticSea');
+	const q = url.searchParams.get('q');
 
 	if (fromDate && !isValidDateParam(fromDate)) {
 		return {
@@ -51,12 +54,13 @@ export function parseExportFilterParams(url: URL): ParseExportFilterResult {
 	}
 
 	return {
-		params: { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea }
+		params: { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea, q }
 	};
 }
 
 export function buildExportConditions(params: ExportFilterParams) {
-	const { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea } = params;
+	const { fromDate, toDate, verified, entryChannel, mediaUpload, deadFinding, balticSea, q } =
+		params;
 	const conditions = [];
 
 	// fromDate/toDate meinen Berliner Kalendertage, die Spalte hält UTC.
@@ -102,6 +106,12 @@ export function buildExportConditions(params: ExportFilterParams) {
 	const balticSeaFilterCondition = balticSeaCondition(balticSea);
 	if (balticSeaFilterCondition) {
 		conditions.push(balticSeaFilterCondition);
+	}
+
+	// Dieselbe Freitext-Suche wie die Admin-Liste, siehe sightingSearchFilter.ts.
+	const searchFilterCondition = searchCondition(q);
+	if (searchFilterCondition) {
+		conditions.push(searchFilterCondition);
 	}
 
 	return conditions;

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -470,6 +470,7 @@ paths:
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
         - $ref: '#/components/parameters/ExportDeadFinding'
+        - $ref: '#/components/parameters/ExportSearch'
       responses:
         '200':
           description: Exportdatei
@@ -511,6 +512,7 @@ paths:
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
         - $ref: '#/components/parameters/ExportDeadFinding'
+        - $ref: '#/components/parameters/ExportSearch'
       responses:
         '200':
           description: JSON-Datei mit Sichtungen
@@ -582,6 +584,7 @@ paths:
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
         - $ref: '#/components/parameters/ExportDeadFinding'
+        - $ref: '#/components/parameters/ExportSearch'
       responses:
         '200':
           description: CSV-Datei mit Sichtungen
@@ -616,6 +619,7 @@ paths:
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
         - $ref: '#/components/parameters/ExportDeadFinding'
+        - $ref: '#/components/parameters/ExportSearch'
       responses:
         '200':
           description: XML-Datei mit Sichtungen
@@ -650,6 +654,7 @@ paths:
         - $ref: '#/components/parameters/ExportMediaUpload'
         - $ref: '#/components/parameters/ExportBalticSea'
         - $ref: '#/components/parameters/ExportDeadFinding'
+        - $ref: '#/components/parameters/ExportSearch'
       responses:
         '200':
           description: KML-Datei mit Sichtungen
@@ -2414,6 +2419,18 @@ components:
         type: string
         enum: ["0", "1"]
         example: "1"
+
+    ExportSearch:
+      name: q
+      in: query
+      description: >-
+        Freitext-Suche über Referenz-ID, E-Mail, Vor- und Nachname und
+        Fahrwasser (ILIKE, Teiltreffer; leer = kein Filter). Dieselbe Bedingung
+        wie die Suche in der Admin-Tabelle (sightingSearchFilter.ts) — der
+        Export liefert damit genau die Menge, die dort angezeigt wird.
+      schema:
+        type: string
+        example: "müller"
 
   schemas:
     SpamRescoreReport:


### PR DESCRIPTION
Setzt **U3 — Suche über Sichtungen** aus `docs/ADMIN_IMPROVEMENTS_SPEC.md` um.

## Warum

Es gab keinen Weg, eine Sichtung anhand einer hereinkommenden Rückfrage zu finden — „meine Meldung von gestern", eine weitergeleitete Bestätigungsmail, ein Anruf. Der Ref-Lookup (`/admin/ref/[refId]`) existierte, hatte aber kein Eingabefeld in der UI.

## Was

Ein Suchfeld im Kopf von `/admin/sichtungen` schreibt `?q=` in die URL. Serverseitig sucht `sightingSearchFilter.ts` per parametrisiertem Drizzle-`ilike` über Referenz-ID, E-Mail, Vor-/Nachname und Fahrwasser. Der Begriff geht als gebundener Parameter in die Abfrage; LIKE-Metazeichen (`%`, `_`, `\`) werden escaped, sonst wäre ein eingetipptes `%` eine Suche nach allem.

Das Feld steht bewusst **außerhalb** des Filter-Panels: Eine Rückfrage sollte nicht erst ein Aufklappen verdienen. Absenden läuft über dasselbe `applyFilters()` wie das Panel — aktive Filter bleiben erhalten, die Seitenzahl springt auf 1.

`q` ist in alle drei bestehenden Parameterlisten nachgezogen:

| Liste | Datei | Ohne den Eintrag |
| --- | --- | --- |
| Export | `exportFilterParams.ts` | Datei enthielte mehr Zeilen als die Ansicht |
| Rückweg | `tableReturnUrl.ts` | Detailansicht verlöre die Suche |
| Filteranzeige | `exportFilterDisplay.ts` | Badges versprächen die falsche Menge |

Der eingebaute Wächter hat funktioniert: `tableReturnUrl.test.ts` wurde rot, sobald der Loader `q` las.

**Referenz-ID-Weiterleitung:** Ein exakter Treffer springt direkt auf `/admin/<id>`, wie der Ref-Lookup. Die Bedingung ist der tatsächliche Treffer (genau eine Zeile, exakte `referenz_id`, Seite 1) statt einer Formatheuristik — ein Muster für „sieht aus wie eine CUID2" träfe auch Nachnamen, und eine separate Exact-Match-Abfrage kostete einen Round-Trip bei jeder Suche.

**Nebenbei:** `getActiveFiltersDisplay` ist aus `ExportModal.svelte` in ein reines Modul gewandert — als dritte Nachzieh-Stelle gehört sie ohne Browser testbar.

## Index-Entscheidung: kein `pg_trgm`

Gemessen auf der lokalen DB mit 19.947 Zeilen (`EXPLAIN ANALYZE`, warm):

| Suchbegriff | Treffer | Zeit |
| --- | --- | --- |
| `mueller` | 99 | 30 ms |
| `ostsee` | 216 | 18 ms |
| `a` (Worst Case) | 18.734 | 13 ms |

Ein GIN-Trigramm-Index kostet Schreib- und Wartungsaufwand, greift bei Begriffen unter drei Zeichen ohnehin nicht, und bei dieser Größe gäbe es nichts zu gewinnen, was ein Bearbeiter bemerkte. Die Begründung samt Schwelle für eine Neubewertung (ab ~200.000 Zeilen oder über 200 ms) steht im Docblock des Moduls, damit sie nicht in einer Commit-Message verschwindet.

## Aus dem Review behoben

- **Navigations-Falle (kritisch):** Der Redirect gab `q` an die Detailseite weiter, und `tableReturnUrl` nimmt `q` mit — „Zurück zur Tabelle" lief damit erneut in dieselbe Weiterleitung, die Trefferliste war nur noch über die Adresszeile erreichbar. Der Redirect lässt `q` jetzt weg (übrige Filter reisen mit); ein eigener Test hält das fest.
- **Export folgte dem Tippen:** `currentFilters.q` kam aus dem Feld-State. Ein getippter, nicht abgeschickter Begriff hätte Export und Badges beeinflusst, ohne dass die Tabelle ihn anwendet. Kommt jetzt aus der URL.
- Doppelte Beschriftung am Suchfeld entfernt (`aria-label` neben `sr-only`-Label), `getActiveFiltersDisplay` im Modal auf `$derived` gestellt.

## Tests

Test-First durchgehend, RED vor GREEN belegt.

- `sightingSearchFilter.test.ts` (10) — Escaping und Parametrisierung über den kompilierten SQL-Text, nicht über die Implementierung
- `page.server.test.ts` (+8) — Verdrahtung, Kombination mit Statusfilter, Redirect-Verhalten inkl. der Nicht-Weiterleitungsfälle
- `searchParam.svelte.test.ts` (3) — Feldwert aus der URL, Schreiben, Leeren
- `exportFilterDisplay.test.ts` (4), `exportFilterParams.test.ts` (+3)

`npm run test:quick` grün (4006 Tests, Lint 0 Fehler, `tsc` sauber), dazu 28 Browser-Tests der Sichtungstabelle.

Nachgezogen: `static/openapi.yml` (neuer `q`-Parameter an allen fünf Export-Routen, YAML validiert), `.claude/rules/export.md`, `lucide:search` im Icon-Registry.

## Nicht verifiziert

Die Optik des Suchfelds habe ich nicht im Browser angesehen — nur funktional über die Playwright-Komponententests. Ein Screenshot hätte einen Admin-Login über Auth0 am laufenden Dev-Server gebraucht; die Darstellung des DaisyUI-`label.input`-Containers ist damit ungeprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)