### PR TITLE
feat(admin): Duplikat-Hinweis auf der Eingangsseite (Spec B2)

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -51,6 +51,7 @@
 	import Image from '~icons/lucide/image';
 	import Images from '~icons/lucide/images';
 	import Inbox from '~icons/lucide/inbox';
+	import Copy from '~icons/lucide/copy';
 	import Info from '~icons/lucide/info';
 	import LayoutGrid from '~icons/lucide/layout-grid';
 	import List from '~icons/lucide/list';
@@ -140,6 +141,7 @@
 		'lucide:github': Github,
 		'lucide:upload': Upload,
 		'lucide:loader-2': Loader2,
+		'lucide:copy': Copy,
 		'lucide:info': Info,
 		'lucide:shield-alert': ShieldAlert,
 		'lucide:waves': Waves,

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -7,18 +7,31 @@
 	} from '$lib/utils/geo/balticSeaStatus';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import type { SightingSelect } from '$lib/server/db/schema';
+	import type { DuplicateCandidate } from '$lib/server/db/duplicateCandidates';
 	import Icon from '$lib/components/Icon.svelte';
 	import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 
 	interface Props {
 		sighting: SightingSelect;
 		images: { id: number; filePath: string; originalName: string }[];
+		/** Mögliche Doppelmeldungen (Spec B2) — reiner Hinweis, kein Merge. */
+		duplicates?: DuplicateCandidate[];
 		busy: boolean;
 		onApprove: () => void;
 		onReject: () => void;
 	}
 
-	let { sighting, images, busy, onApprove, onReject }: Props = $props();
+	let { sighting, images, duplicates = [], busy, onApprove, onReject }: Props = $props();
+
+	/* „1 ähnliche Meldung" statt „1 ähnliche Meldungen": Die Karte ist die
+	   Arbeitsfläche des Museums, nicht eine Log-Zeile. */
+	const duplicateLabel = $derived(
+		duplicates.length === 1 ? '1 ähnliche Meldung' : `${duplicates.length} ähnliche Meldungen`
+	);
+	const DUPLICATE_REASON_LABEL: Record<DuplicateCandidate['reason'], string> = {
+		email: 'gleiche E-Mail, gleiche Stunde',
+		position: 'nahe Position, ähnliche Zeit'
+	};
 
 	const balticSea = $derived(BALTIC_SEA_STATUS_PRESENTATION[getBalticSeaStatus(sighting)]);
 	/* Gleiche Schwellen wie die Spam-Spalte der Tabelle (/admin/sichtungen) —
@@ -55,6 +68,40 @@
 			</span>
 			<span class="badge badge-sm {balticSea.badgeClass}">{balticSea.label}</span>
 		</div>
+
+		{#if duplicates.length > 0}
+			<!-- Aufklapper statt Direktanzeige: Der Hinweis soll die Karte nicht
+			     länger machen als die Meldung selbst. Zusammengeführt wird nichts —
+			     die Kandidaten sind Links in die Detailansicht, die Entscheidung
+			     bleibt beim Bearbeiter. -->
+			<details class="text-sm">
+				<summary class="btn btn-ghost btn-sm w-fit justify-start" data-testid="duplicate-badge">
+					<Icon icon="lucide:copy" width="16" height="16" aria-hidden="true" />
+					<span class="badge badge-sm badge-warning">{duplicateLabel}</span>
+					<!-- Der eigene Pfeil ersetzt den ::marker: DaisyUIs `btn` macht das
+					     `summary` zu `inline-flex`, und Chrome entfernt den Marker damit.
+					     Ohne ihn kündigt nichts an, dass sich hier etwas aufklappt. -->
+					<span class="duplicate-chevron inline-flex">
+						<Icon icon="lucide:chevron-down" width="16" height="16" aria-hidden="true" />
+					</span>
+				</summary>
+				<ul class="border-warning/30 mt-2 ml-2 space-y-1 border-l pl-3">
+					{#each duplicates as candidate (candidate.id)}
+						<li>
+							<a href={`/admin/${candidate.id}`} class="link link-hover font-medium">
+								#{candidate.id}
+							</a>
+							<span class="text-base-content/70">
+								{getSpeciesLabel(candidate.species)} · {formatLocalDateTime(
+									candidate.sightingDate,
+									'datetime'
+								)} · {DUPLICATE_REASON_LABEL[candidate.reason]}
+							</span>
+						</li>
+					{/each}
+				</ul>
+			</details>
+		{/if}
 
 		<div class="flex flex-wrap items-baseline justify-between gap-2">
 			<h3 class="text-base font-semibold">
@@ -122,3 +169,15 @@
 		</div>
 	</div>
 </article>
+
+<style>
+	/* Dauer und Kurve aus den Motion-Tokens (`design-system.md`): ein Hover-/
+	   Zustandswechsel ist `--motion-instant`, keine eigene Zahl. */
+	.duplicate-chevron {
+		transition: transform var(--motion-instant) var(--motion-ease);
+	}
+
+	details[open] .duplicate-chevron {
+		transform: rotate(180deg);
+	}
+</style>

--- a/src/lib/components/admin/SightingInboxCard.svelte.test.ts
+++ b/src/lib/components/admin/SightingInboxCard.svelte.test.ts
@@ -131,6 +131,76 @@ describe('SightingInboxCard', () => {
 			.toBeInTheDocument();
 	});
 
+	/* Duplikat-Hinweis (Spec B2). Er ist ausdrücklich nur ein Hinweis: kein
+	   Auto-Merge, keine Vorauswahl — deshalb prüfen die Tests, dass er ohne
+	   Kandidaten gar nicht erscheint und mit Kandidaten in die Detailansicht
+	   verlinkt, statt selbst etwas zu entscheiden. */
+	describe('Duplikat-Hinweis', () => {
+		const kandidaten = [
+			{ id: 101, sightingDate: '2026-07-30T08:30:00Z', species: 0, reason: 'email' as const },
+			{ id: 102, sightingDate: '2026-07-30T09:15:00Z', species: 1, reason: 'position' as const }
+		];
+
+		it('bleibt ohne Kandidaten unsichtbar', async () => {
+			const screen = render(SightingInboxCard, {
+				sighting: basisSichtung,
+				images: [],
+				duplicates: [],
+				busy: false,
+				onApprove: noop,
+				onReject: noop
+			});
+			await expect.element(screen.getByTestId('duplicate-badge')).not.toBeInTheDocument();
+		});
+
+		it('nennt die Anzahl ähnlicher Meldungen', async () => {
+			const screen = render(SightingInboxCard, {
+				sighting: basisSichtung,
+				images: [],
+				duplicates: kandidaten,
+				busy: false,
+				onApprove: noop,
+				onReject: noop
+			});
+			await expect
+				.element(screen.getByTestId('duplicate-badge'))
+				.toHaveTextContent('2 ähnliche Meldungen');
+		});
+
+		it('sagt bei genau einem Kandidaten „1 ähnliche Meldung"', async () => {
+			const screen = render(SightingInboxCard, {
+				sighting: basisSichtung,
+				images: [],
+				duplicates: kandidaten.slice(0, 1),
+				busy: false,
+				onApprove: noop,
+				onReject: noop
+			});
+			await expect
+				.element(screen.getByTestId('duplicate-badge'))
+				.toHaveTextContent('1 ähnliche Meldung');
+		});
+
+		it('verlinkt jeden Kandidaten auf seine Detailansicht', async () => {
+			const screen = render(SightingInboxCard, {
+				sighting: basisSichtung,
+				images: [],
+				duplicates: kandidaten,
+				busy: false,
+				onApprove: noop,
+				onReject: noop
+			});
+			await screen.getByTestId('duplicate-badge').click();
+
+			await expect
+				.element(screen.getByRole('link', { name: /#101/ }))
+				.toHaveAttribute('href', '/admin/101');
+			await expect
+				.element(screen.getByRole('link', { name: /#102/ }))
+				.toHaveAttribute('href', '/admin/102');
+		});
+	});
+
 	it('rendert Bild-Vorschauen über /api/media', async () => {
 		const screen = render(SightingInboxCard, {
 			sighting: basisSichtung,

--- a/src/lib/server/db/duplicateCandidates.test.ts
+++ b/src/lib/server/db/duplicateCandidates.test.ts
@@ -1,0 +1,171 @@
+/**
+ * @fileoverview Duplikat-Hinweis der Eingangsseite (Spec B2).
+ *
+ * Geprüft wird beides, was an dieser Heuristik schiefgehen kann:
+ *
+ * 1. **Die Schwellen stehen wirklich in der SQL.** Zwei Meldungen sind
+ *    Kandidaten, wenn E-Mail und Kalenderstunde übereinstimmen ODER die
+ *    Positionen unter 1 km und die Sichtungszeiten unter 2 h auseinander
+ *    liegen. Eine Konstante, die niemand in die Abfrage einsetzt, fällt sonst
+ *    nicht auf — die Anzeige wäre nur „etwas" anders.
+ * 2. **Es bleibt bei einer einzigen Abfrage für alle Sichtungen.** Die
+ *    Eingangsseite listet bis zu 50 Karten; ein Query pro Karte wäre der
+ *    naheliegende und teure Rückfall.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '$lib/server/db';
+import {
+	DUPLICATE_BBOX_DEGREES,
+	DUPLICATE_CANDIDATE_LIMIT,
+	DUPLICATE_RADIUS_METERS,
+	DUPLICATE_TIME_WINDOW_HOURS,
+	findDuplicateCandidates
+} from './duplicateCandidates';
+
+vi.mock('$lib/server/db', () => ({ db: { execute: vi.fn() } }));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }))
+}));
+
+const dialect = new PgDialect();
+const mockDb = vi.mocked(db as unknown as { execute: ReturnType<typeof vi.fn> });
+
+/** Die zuletzt abgesetzte Abfrage als SQL-Text plus Parameterliste. */
+function letzteAbfrage(): { sql: string; params: unknown[] } {
+	const arg = mockDb.execute.mock.calls.at(-1)?.[0] as SQL;
+	const query = dialect.sqlToQuery(arg);
+	return { sql: query.sql, params: query.params };
+}
+
+function zeile(overrides: Record<string, unknown> = {}) {
+	return {
+		sighting_id: 1,
+		candidate_id: 2,
+		sighting_date: '2026-08-01T10:00:00Z',
+		species: 0,
+		same_email: true,
+		...overrides
+	};
+}
+
+describe('findDuplicateCandidates', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDb.execute.mockResolvedValue([]);
+	});
+
+	it('fragt ohne IDs gar nicht erst die Datenbank', async () => {
+		await expect(findDuplicateCandidates([])).resolves.toEqual({});
+		expect(mockDb.execute).not.toHaveBeenCalled();
+	});
+
+	it('holt alle Kandidaten in genau einer Abfrage', async () => {
+		await findDuplicateCandidates([1, 2, 3, 4, 5]);
+
+		expect(mockDb.execute).toHaveBeenCalledTimes(1);
+		expect(letzteAbfrage().params).toEqual(expect.arrayContaining([1, 2, 3, 4, 5]));
+	});
+
+	it('prüft E-Mail-Gleichheit auf dieselbe Kalenderstunde und ohne Groß-/Kleinschreibung', async () => {
+		await findDuplicateCandidates([1]);
+
+		const { sql } = letzteAbfrage();
+		expect(sql).toContain("date_trunc('hour'");
+		expect(sql).toMatch(/lower\([^)]*email\)\s*=\s*lower\([^)]*email\)/i);
+	});
+
+	it('prüft die Position per ST_DWithin mit 1 km und 2 h Zeitfenster', async () => {
+		await findDuplicateCandidates([1]);
+
+		const { sql, params } = letzteAbfrage();
+		expect(sql).toContain('ST_DWithin');
+		// Meter statt Grad: die Geometrie wird dafür nach geography gecastet.
+		expect(sql).toContain('geography');
+		expect(params).toContain(DUPLICATE_RADIUS_METERS);
+		expect(params).toContain(DUPLICATE_TIME_WINDOW_HOURS * 3600);
+	});
+
+	/**
+	 * Gemessen auf der lokalen DB (30k Zeilen, 2026-08-08): Beide Zweige mit
+	 * `OR` in **einer** WHERE-Klausel brauchten **5947 ms** — der Planer kann
+	 * für eine Oder-Verknüpfung keinen der beiden Indizes nutzen und fällt auf
+	 * einen Nested Loop über den gesamten Bestand zurück. Als `UNION ALL` mit
+	 * Bounding-Box-Vorfilter sind es 43 ms.
+	 *
+	 * Der Bounding-Box-Vorfilter ist dabei der Teil, der den Positions-Zweig
+	 * trägt: `ST_DWithin` auf `geography` kann den vorhandenen GIST-Index auf
+	 * der `geometry`-Spalte nicht verwenden, `&&` gegen ein `ST_Expand`-Rechteck
+	 * schon. Er ist bewusst großzügiger als der Radius — die exakte Grenze
+	 * bleibt `ST_DWithin`.
+	 */
+	it('trennt die beiden Zweige per UNION ALL und filtert die Position über den GIST-Index vor', async () => {
+		await findDuplicateCandidates([1]);
+
+		const { sql, params } = letzteAbfrage();
+		expect(sql).toContain('UNION ALL');
+		expect(sql).toContain('ST_Expand');
+		expect(params).toContain(DUPLICATE_BBOX_DEGREES);
+		// Der Vorfilter darf die Heuristik nur beschleunigen, nicht verengen:
+		// 1 km sind je nach Breitengrad bis zu 0,023° Länge.
+		expect(DUPLICATE_BBOX_DEGREES).toBeGreaterThan(0.023);
+	});
+
+	it('gruppiert die Kandidaten nach der gelisteten Sichtung', async () => {
+		mockDb.execute.mockResolvedValue([
+			zeile({ sighting_id: 1, candidate_id: 2 }),
+			zeile({ sighting_id: 1, candidate_id: 3, same_email: false }),
+			zeile({ sighting_id: 7, candidate_id: 9 })
+		]);
+
+		const result = await findDuplicateCandidates([1, 7]);
+
+		expect(Object.keys(result)).toEqual(['1', '7']);
+		expect(result[1]?.map((k) => k.id)).toEqual([2, 3]);
+		expect(result[1]?.[0]?.reason).toBe('email');
+		expect(result[1]?.[1]?.reason).toBe('position');
+		expect(result[7]?.[0]).toEqual({
+			id: 9,
+			sightingDate: '2026-08-01T10:00:00Z',
+			species: 0,
+			reason: 'email'
+		});
+	});
+
+	/* Beide Zweige der Heuristik können denselben Kandidaten liefern (gleicher
+	   Melder, gleiche Stunde, gleicher Ort). Ohne Entdopplung stünde „2 ähnliche
+	   Meldungen" über einer einzigen fremden Sichtung. */
+	it('nennt einen Kandidaten nur einmal, auch wenn beide Zweige greifen', async () => {
+		mockDb.execute.mockResolvedValue([
+			zeile({ candidate_id: 2, same_email: true }),
+			zeile({ candidate_id: 2, same_email: false })
+		]);
+
+		const result = await findDuplicateCandidates([1]);
+
+		expect(result[1]).toHaveLength(1);
+		expect(result[1]?.[0]?.reason).toBe('email');
+	});
+
+	it('kappt die Liste pro Sichtung auf die Obergrenze', async () => {
+		mockDb.execute.mockResolvedValue(
+			Array.from({ length: DUPLICATE_CANDIDATE_LIMIT + 3 }, (_, index) =>
+				zeile({ candidate_id: index + 2 })
+			)
+		);
+
+		const result = await findDuplicateCandidates([1]);
+
+		expect(result[1]).toHaveLength(DUPLICATE_CANDIDATE_LIMIT);
+	});
+
+	/* Der Hinweis ist eine Zusatzinformation. Fällt die Abfrage aus, soll die
+	   Eingangsseite ohne Hinweis erscheinen — nicht mit einem Fehler. */
+	it('ist fail-open: ein DB-Fehler liefert ein leeres Ergebnis statt eines Throws', async () => {
+		mockDb.execute.mockRejectedValue(new Error('DB nicht erreichbar'));
+
+		await expect(findDuplicateCandidates([1, 2])).resolves.toEqual({});
+	});
+});

--- a/src/lib/server/db/duplicateCandidates.ts
+++ b/src/lib/server/db/duplicateCandidates.ts
@@ -1,0 +1,196 @@
+/**
+ * Duplikat-Hinweis der Eingangsseite (`/admin`, Spec B2).
+ *
+ * Sucht zu den gelisteten Sichtungen andere Meldungen, die dasselbe Ereignis
+ * beschreiben könnten. Das Ergebnis ist ausdrücklich **nur ein Hinweis**: Es
+ * wird nichts zusammengeführt, nichts markiert und nichts gefiltert — die
+ * Entscheidung trifft der Bearbeiter in der Detailansicht.
+ *
+ * Die Heuristik hat zwei Zweige, weil derselbe Vorfall auf zwei Wegen doppelt
+ * ankommt: Ein Melder schickt sein Formular zweimal ab (gleiche E-Mail,
+ * gleiche Zeit), oder zwei Menschen sehen dieselben Tiere (gleicher Ort,
+ * ähnliche Zeit).
+ *
+ * **Eine Abfrage für alle Sichtungen, nicht eine pro Karte.** Die
+ * Eingangsseite listet bis zu 50 Karten; der naheliegende Rückfall auf einen
+ * Query je Karte kostete 50 Roundtrips für eine Nebeninformation.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { createLogger } from '$lib/logger.server';
+
+const logger = createLogger('duplicateCandidates');
+
+/**
+ * Radius des Positions-Zweigs. 1 km ist knapp genug, dass zwei Meldungen
+ * plausibel dieselben Tiere betreffen, und weit genug für die Streuung, die
+ * eine per Karte gesetzte Position mit sich bringt — Melder tippen den Punkt
+ * aus der Erinnerung, nicht aus dem GPS.
+ */
+export const DUPLICATE_RADIUS_METERS = 1000;
+
+/**
+ * Zeitfenster des Positions-Zweigs. 2 h deckt den typischen Fall ab, dass
+ * dieselbe Tiergruppe von zwei Booten kurz nacheinander gemeldet wird, ohne
+ * einen ganzen Beobachtungstag zu einem Duplikat zu erklären.
+ */
+export const DUPLICATE_TIME_WINDOW_HOURS = 2;
+
+/**
+ * Kantenlänge (halbe, in Grad) des Bounding-Box-Vorfilters im Positions-Zweig.
+ * Reine Beschleunigung: `ST_DWithin` auf `geography` rechnet in Metern, kann
+ * dafür aber den GIST-Index der `geometry`-Spalte nicht nutzen — ein
+ * `&&`-Vergleich gegen ein `ST_Expand`-Rechteck schon.
+ *
+ * Der Wert ist bewusst großzügiger als {@link DUPLICATE_RADIUS_METERS}: 1 km
+ * sind in der Ostsee je nach Breitengrad bis zu 0,023° Länge. 0,03° schließt
+ * damit garantiert keinen echten Kandidaten aus; die exakte Grenze zieht
+ * weiterhin `ST_DWithin`.
+ */
+export const DUPLICATE_BBOX_DEGREES = 0.03;
+
+/**
+ * Höchstzahl genannter Kandidaten pro Karte. Die Eingangsseite ist eine
+ * Arbeitsliste — eine aufgeklappte Liste mit 30 Links wäre dort kein Hinweis
+ * mehr, sondern eine zweite Tabelle. Wer mehr sehen will, geht in die
+ * Detailansicht.
+ */
+export const DUPLICATE_CANDIDATE_LIMIT = 5;
+
+/** Warum diese Meldung als Kandidat gilt — trägt die Erklärung in der UI. */
+export type DuplicateReason = 'email' | 'position';
+
+export interface DuplicateCandidate {
+	id: number;
+	/** Sichtungszeit als ISO-Zeichenkette in UTC (Formatierung erst in der UI). */
+	sightingDate: string;
+	species: number;
+	reason: DuplicateReason;
+}
+
+/** Rohzeile der Abfrage; Spaltennamen kommen aus dem `AS`-Alias der SQL. */
+interface CandidateRow {
+	sighting_id: number | string;
+	candidate_id: number | string;
+	sighting_date: string;
+	species: number | string;
+	same_email: boolean;
+}
+
+export async function findDuplicateCandidates(
+	ids: number[]
+): Promise<Record<number, DuplicateCandidate[]>> {
+	if (ids.length === 0) return {};
+
+	const zeitfensterSekunden = DUPLICATE_TIME_WINDOW_HOURS * 3600;
+	const idListe = sql.join(
+		ids.map((id) => sql`${id}`),
+		sql`, `
+	);
+
+	try {
+		/* `k` ist die gelistete Sichtung, `c` der Kandidat.
+		 *
+		 * **Die beiden Zweige stehen als `UNION ALL` und nicht als `OR`.** Mit
+		 * `OR` in einer WHERE-Klausel kann der Planer keinen der beiden Indizes
+		 * nutzen und fällt auf einen Nested Loop über den gesamten Bestand
+		 * zurück: gemessen auf der lokalen DB (30k Zeilen, 2026-08-08) **5947 ms**
+		 * gegenüber **43 ms** für diese Fassung. Wer das hier zu einer Klausel
+		 * zusammenzieht, macht die Eingangsseite unbenutzbar.
+		 *
+		 * **Der E-Mail-Zweig vergleicht die Kalenderstunde, kein ±1-h-Fenster** —
+		 * bewusst asymmetrisch: 10:01 und 10:59 sind Kandidaten, 10:59 und 11:01
+		 * nicht. Er zielt auf den doppelt abgeschickten Melder, und dort ist
+		 * `sichtungsdatum` die eingegebene Sichtungszeit, in beiden Meldungen also
+		 * identisch. Ein Intervall wie im Positions-Zweig zöge stattdessen zwei
+		 * getrennte Beobachtungen desselben Melders zusammen.
+		 *
+		 * Die Zeit trägt ihr `Z` per `to_char` schon aus der Datenbank. Roh käme
+		 * hier `"2026-08-01 10:00:00"` an — `TIMESTAMP_AS_TEXT` (`postgresTypes.ts`)
+		 * liefert `timestamp without time zone` bewusst als Text, und eine
+		 * `db.execute`-Abfrage läuft an Drizzles Spalten-Mapping vorbei, das
+		 * sonst das `+0000` anhängt. Ein solcher String ohne Zonenangabe wird von
+		 * `new Date(...)` in der Anzeige als **Ortszeit** gelesen: im Sommer zwei
+		 * Stunden daneben, und zwar lautlos. */
+		const result = await db.execute(sql`
+			SELECT sighting_id, candidate_id, sighting_date, species, same_email
+			FROM (
+				SELECT
+					k.id AS sighting_id,
+					c.id AS candidate_id,
+					to_char(c.sichtungsdatum, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS sighting_date,
+					c.tierart AS species,
+					true AS same_email,
+					c.sichtungsdatum AS sort_date
+				FROM sichtungen k
+				JOIN sichtungen c ON c.id <> k.id
+				WHERE k.id IN (${idListe})
+					AND k.email IS NOT NULL AND c.email IS NOT NULL
+					AND lower(k.email) = lower(c.email)
+					AND date_trunc('hour', k.sichtungsdatum) = date_trunc('hour', c.sichtungsdatum)
+
+				UNION ALL
+
+				SELECT
+					k.id,
+					c.id,
+					to_char(c.sichtungsdatum, 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+					c.tierart,
+					false,
+					c.sichtungsdatum
+				FROM sichtungen k
+				JOIN sichtungen c ON c.id <> k.id
+				WHERE k.id IN (${idListe})
+					AND k.location IS NOT NULL AND c.location IS NOT NULL
+					AND c.location && ST_Expand(k.location, ${DUPLICATE_BBOX_DEGREES})
+					AND ST_DWithin(
+						k.location::geography,
+						c.location::geography,
+						${DUPLICATE_RADIUS_METERS}
+					)
+					AND abs(extract(epoch from (k.sichtungsdatum - c.sichtungsdatum)))
+						< ${zeitfensterSekunden}
+			) kandidaten
+			ORDER BY sighting_id, same_email DESC, sort_date DESC
+		`);
+
+		/* postgres.js liefert seine `RowList` als echtes Array-Derivat — der
+		   Zweig ist keine Vorsichtsmaßnahme gegen einen anderen Treiber, sondern
+		   die Typwand zwischen Drizzles generischem Rückgabetyp und dieser
+		   rohen Abfrage. */
+		const rows = (Array.isArray(result) ? result : []) as CandidateRow[];
+		return gruppiere(rows);
+	} catch (error) {
+		/* Fail-open: Der Hinweis ist Zusatzinformation. Eine fehlgeschlagene
+		   Abfrage darf die Arbeitsliste nicht mitnehmen. */
+		logger.warn({ error }, 'Duplikat-Kandidaten konnten nicht ermittelt werden');
+		return {};
+	}
+}
+
+function gruppiere(rows: CandidateRow[]): Record<number, DuplicateCandidate[]> {
+	const result: Record<number, DuplicateCandidate[]> = {};
+	const gesehen = new Set<string>();
+
+	for (const row of rows) {
+		const sightingId = Number(row.sighting_id);
+		const candidateId = Number(row.candidate_id);
+		/* Beide Zweige können denselben Kandidaten liefern (gleicher Melder,
+		   gleiche Stunde, gleicher Ort). Die SQL sortiert `same_email` nach vorn,
+		   der erste Treffer trägt damit die aussagekräftigere Begründung. */
+		const schluessel = `${sightingId}:${candidateId}`;
+		if (gesehen.has(schluessel)) continue;
+		gesehen.add(schluessel);
+
+		const liste = (result[sightingId] ??= []);
+		if (liste.length >= DUPLICATE_CANDIDATE_LIMIT) continue;
+		liste.push({
+			id: candidateId,
+			sightingDate: row.sighting_date,
+			species: Number(row.species),
+			reason: row.same_email ? 'email' : 'position'
+		});
+	}
+
+	return result;
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,5 +1,6 @@
 import { db } from '$lib/server/db';
 import { openOnly } from '$lib/server/db/approvalFilter';
+import { findDuplicateCandidates } from '$lib/server/db/duplicateCandidates';
 import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
 	mediaUploadCondition
@@ -58,6 +59,10 @@ export const load: PageServerLoad = async ({ url }) => {
 	// zu warten (er hängt nur von der Liste ab).
 	const openWithImagesQuery = openQuery.then(async (open) => {
 		const ids = open.map((s) => s.id);
+		/* Duplikat-Hinweis (Spec B2): ein Zusatz-Query für alle gelisteten IDs
+		   gemeinsam, parallel zur Bild-Abfrage. Beide hängen nur an der Liste; den
+		   Leerfall fängt `findDuplicateCandidates` selbst ab. */
+		const duplicatesPromise = findDuplicateCandidates(ids);
 		const imageRows = ids.length
 			? await db
 					.select({
@@ -71,14 +76,11 @@ export const load: PageServerLoad = async ({ url }) => {
 						and(inArray(sightingFiles.sightingId, ids), like(sightingFiles.mimeType, 'image/%'))
 					)
 			: [];
-		return { open, imageRows };
+		return { open, imageRows, duplicatesBySighting: await duplicatesPromise };
 	});
 
-	const [{ open, imageRows }, openCountResult, pendingPhotoResult] = await Promise.all([
-		openWithImagesQuery,
-		openCountQuery,
-		pendingPhotoQuery
-	]);
+	const [{ open, imageRows, duplicatesBySighting }, openCountResult, pendingPhotoResult] =
+		await Promise.all([openWithImagesQuery, openCountQuery, pendingPhotoQuery]);
 
 	const imagesBySighting: Record<number, { id: number; filePath: string; originalName: string }[]> =
 		{};
@@ -100,6 +102,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		openTotal: Number(openCountResult[0]?.count ?? 0),
 		order,
 		imagesBySighting,
-		pendingPhotoAnnouncements: Number(pendingPhotoResult[0]?.count ?? 0)
+		pendingPhotoAnnouncements: Number(pendingPhotoResult[0]?.count ?? 0),
+		duplicatesBySighting
 	};
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -149,6 +149,7 @@
 							<SightingInboxCard
 								{sighting}
 								images={data.imagesBySighting[sighting.id] ?? []}
+								duplicates={data.duplicatesBySighting[sighting.id] ?? []}
 								busy={busy[sighting.id] ?? false}
 								onApprove={() => entscheiden(sighting.id, 'approve')}
 								onReject={() => entscheiden(sighting.id, 'reject')}
@@ -160,8 +161,8 @@
 		</ul>
 		{#if data.openTotal > data.open.length}
 			<p class="text-base-content/70 mt-4 text-center text-sm">
-				{data.open.length} von {data.openTotal} offenen Sichtungen angezeigt — die Liste füllt sich beim Abarbeiten
-				nach.
+				{data.open.length} von {data.openTotal} offenen Sichtungen angezeigt — die Liste füllt sich beim
+				Abarbeiten nach.
 			</p>
 		{/if}
 	{/if}

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -73,6 +73,17 @@ vi.mock('$lib/server/db', () => ({
 	}
 }));
 
+/* Der Duplikat-Hinweis (Spec B2) hat seine eigenen Tests in
+   `src/lib/server/db/duplicateCandidates.test.ts`. Hier zählt nur die
+   Verdrahtung: Der Loader reicht **alle** gelisteten IDs in **einem** Aufruf
+   hinein und gibt das Ergebnis unverändert an die Seite weiter. */
+const findDuplicateCandidates = vi
+	.fn<(ids: number[]) => Promise<Record<number, unknown[]>>>()
+	.mockResolvedValue({});
+vi.mock('$lib/server/db/duplicateCandidates', () => ({
+	findDuplicateCandidates: (ids: number[]) => findDuplicateCandidates(ids)
+}));
+
 function makeUrl(params: Record<string, string> = {}): URL {
 	const url = new URL('https://example.com/admin');
 	for (const [key, value] of Object.entries(params)) {
@@ -88,6 +99,7 @@ type InboxData = {
 	order: 'asc' | 'desc';
 	imagesBySighting: Record<number, { id: number; filePath: string; originalName: string }[]>;
 	pendingPhotoAnnouncements: number;
+	duplicatesBySighting: Record<number, unknown[]>;
 };
 
 const { load } = await import('./+page.server');
@@ -103,6 +115,30 @@ describe('Eingangs-Load', () => {
 	beforeEach(() => {
 		recordedSelects = [];
 		resolvedRows = [[{ id: 1 }, { id: 2 }], [{ count: 7 }], [{ count: 3 }], []];
+		findDuplicateCandidates.mockClear();
+		findDuplicateCandidates.mockResolvedValue({});
+	});
+
+	it('sucht Duplikat-Kandidaten für alle gelisteten IDs in einem Aufruf', async () => {
+		findDuplicateCandidates.mockResolvedValue({ 1: [{ id: 99 }] });
+
+		const result = await runLoad(makeUrl());
+
+		expect(findDuplicateCandidates).toHaveBeenCalledTimes(1);
+		expect(findDuplicateCandidates).toHaveBeenCalledWith([1, 2]);
+		expect(result.duplicatesBySighting).toEqual({ 1: [{ id: 99 }] });
+	});
+
+	/* Den Leerfall behandelt `findDuplicateCandidates` selbst (eigener Test:
+	   keine DB-Abfrage ohne IDs). Der Loader muss ihn deshalb nicht doppelt
+	   abfangen — er darf ihn nur nicht in eine leere ID-Liste verdrehen. */
+	it('reicht bei leerer Liste eine leere ID-Liste durch', async () => {
+		resolvedRows = [[], [{ count: 0 }], [{ count: 0 }], []];
+
+		const result = await runLoad(makeUrl());
+
+		expect(findDuplicateCandidates).toHaveBeenCalledWith([]);
+		expect(result.duplicatesBySighting).toEqual({});
 	});
 
 	it('leitet Tabellen-URLs mit 301 nach /admin/sichtungen weiter (Query bleibt erhalten)', async () => {

--- a/src/routes/admin/inboxUndo.svelte.test.ts
+++ b/src/routes/admin/inboxUndo.svelte.test.ts
@@ -46,7 +46,11 @@ function daten(ids: number[]): PageData {
 		openTotal: ids.length,
 		order: 'asc' as const,
 		imagesBySighting: {},
-		pendingPhotoAnnouncements: 0
+		pendingPhotoAnnouncements: 0,
+		/* Ohne dieses Feld wirft die Seite beim Rendern: Der Cast auf `PageData`
+		   unterdrückt die Typprüfung, die den fehlenden Loader-Schlüssel sonst
+		   gemeldet hätte. Ein neues Feld im Loader gehört deshalb hierher. */
+		duplicatesBySighting: {}
 	} as unknown as PageData;
 }
 


### PR DESCRIPTION
## Was

Jede Karte auf `/admin` zeigt jetzt, ob es zu einer Meldung ähnliche gibt — als Aufklapper „N ähnliche Meldungen" mit Links in die jeweilige Detailansicht. **Kein Auto-Merge**, keine Vorauswahl, keine Filterung: Die Entscheidung bleibt beim Bearbeiter.

Umsetzung von `docs/ADMIN_IMPROVEMENTS_SPEC.md`, Abschnitt „B2 — Duplikat-Hinweis".

## Heuristik

Zwei Zweige, weil derselbe Vorfall auf zwei Wegen doppelt ankommt:

| Zweig | Bedingung | Zielt auf |
| --- | --- | --- |
| E-Mail | gleiche Adresse (case-insensitiv) **und** gleiche Kalenderstunde | Melder schickt sein Formular zweimal ab |
| Position | `ST_DWithin` unter 1 km **und** Sichtungszeit unter 2 h Abstand | zwei Menschen sehen dieselben Tiere |

Die Schwellen stehen als benannte Konstanten mit Begründung in [duplicateCandidates.ts](src/lib/server/db/duplicateCandidates.ts) — `DUPLICATE_RADIUS_METERS`, `DUPLICATE_TIME_WINDOW_HOURS`, `DUPLICATE_CANDIDATE_LIMIT`. Der Test prüft sie gegen die tatsächlich abgesetzte SQL (kompiliert über `PgDialect`), nicht nur auf Existenz.

Dass der E-Mail-Zweig die **Kalenderstunde** vergleicht und kein ±1-h-Fenster, ist bewusst asymmetrisch und im Code begründet: Er zielt auf den doppelt abgeschickten Melder, dort ist `sichtungsdatum` in beiden Meldungen identisch. Ein Intervall zöge stattdessen zwei getrennte Beobachtungen desselben Melders zusammen.

## Performance — der eigentliche Aufwand

Ein Zusatz-Query für alle 50 gelisteten Sichtungen gemeinsam, nicht 50 Einzelabfragen. Entscheidend war aber etwas anderes:

| Fassung | Laufzeit (lokale DB, 30k Zeilen) |
| --- | --- |
| beide Zweige mit `OR` in einer WHERE-Klausel | **5947 ms** |
| `UNION ALL` + Bounding-Box-Vorfilter | **43 ms** |

Bei `OR` kann der Planer keinen der beiden Indizes nutzen und fällt auf einen Nested Loop über den gesamten Bestand zurück. Der Positions-Zweig filtert zusätzlich per `&& ST_Expand` über den vorhandenen GIST-Index vor, weil `ST_DWithin` auf `geography` den Index der `geometry`-Spalte nicht verwenden kann; `DUPLICATE_BBOX_DEGREES` ist dafür bewusst großzügiger als der Radius (1 km sind je nach Breitengrad bis zu 0,023° Länge), die exakte Grenze zieht weiterhin `ST_DWithin`.

Beide Zahlen stehen als Messwerte im Code **und** hängen an einem Test, der `UNION ALL` und `ST_Expand` in der SQL festnagelt — sonst zieht das jemand beim nächsten Aufräumen wieder zusammen.

Die Abfrage ist gegen die echte lokale Datenbank gelaufen und findet dort reale Kandidaten (u. a. 29281/29282, gleiche E-Mail und Stunde).

Bekannte Grenze, heute unkritisch: `lower(email)` hat keinen Ausdrucksindex, der E-Mail-Zweig ist damit ein Full-Self-Join. Bei deutlich größerem Bestand wäre ein Index auf `lower(email)` der Hebel.

## Robustheit

Fail-open — fällt die Abfrage aus, erscheint die Arbeitsliste ohne Hinweis statt mit einem Fehler. Kandidaten, die beide Zweige liefern, werden entdoppelt (sonst stünde „2 ähnliche Meldungen" über einer einzigen fremden Sichtung).

## Tests

Test-First, RED vor GREEN für alle drei Ebenen:

- 9 Server-Tests für die Heuristik (Schwellen in der SQL, eine einzige Abfrage, Gruppierung, Entdopplung, Obergrenze, Fail-open)
- 2 neue Loader-Tests (alle IDs in einem Aufruf, Durchreichen an die Seite)
- 4 Browser-Tests der Karte (unsichtbar ohne Kandidaten, Singular/Plural, Links nach dem Aufklappen)

`npm run test:quick` grün: 3993 Tests, `type-check` und `svelte-check` fehlerfrei.

## Offen

Die visuelle Prüfung im laufenden `/admin` steht aus — Port 4000 war während der Arbeit von einem anderen Worktree belegt. Abgedeckt ist die Anzeige durch die Browser-Komponententests; ein Blick auf die echte Karte vor dem Merge wäre trotzdem gut.

## Nebenbei

`lucide:copy` in `Icon.svelte` registriert (das Register meldete den fehlenden Namen zur Laufzeit). Der Chevron am Aufklapper ist nötig, weil DaisyUIs `btn` das `summary` zu `inline-flex` macht und Chrome damit den `::marker` entfernt — ohne ihn kündigt nichts an, dass sich dort etwas öffnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)