### PR TITLE
feat(admin): Status-Historie pro Sichtung (Spec B3)

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -89,6 +89,27 @@ gesetzt, und die öffentliche Grundmenge bleibt unverändert
   noch abgelehnt. `pendingOnly()` bedeutet weiterhin „nicht freigegeben"
   (inkl. abgelehnter) und bleibt die Gegenmenge der Statistik.
 
+### Status-Historie (seit 2026-08)
+
+`sichtung_status_log` hält jede über den Verify-Endpunkt getroffene Entscheidung
+fest (`sichtung_id`, `verdict`, `bearbeiter`, `zeitpunkt`). Sie **ergänzt** die
+Statusspalten und ersetzt sie nicht — das Altsystem liegt auf derselben
+Datenbank und liest sie weiterhin.
+
+- **Geschrieben wird sie ausschließlich von demselben Endpunkt**, in derselben
+  Transaktion wie die Statusspalten. Eine Historie mit Lücke sieht vollständig
+  aus und ist es nicht. Mechanisch abgesichert durch
+  `src/lib/server/db/statusLogWriteScan.test.ts` — Lesen ist überall erlaubt.
+- **Gelesen wird sie über `GET /api/sightings/[id]/verify`** (Feld `history`,
+  aufsteigend). Sie enthält Bearbeiter-Kennungen und bleibt deshalb hinter der
+  Admin-Prüfung; sie gehört nicht in `/api/sightings/[id]`.
+- **Eine leere Historie ist der Normalfall des Altbestands**, kein Fehler.
+  Entscheidungen vor der Einführung existieren nur als aktueller Status.
+
+Datenschutz und Aufbewahrung sind am Tabellen-Docblock in
+`src/lib/server/db/schema.ts` begründet, die Entscheidung selbst in
+`docs/ADMIN_IMPROVEMENTS_SPEC.md` (B3).
+
 ---
 
 ## Legacy API - KRITISCH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,12 +506,13 @@ jobs:
             # und /admin wie /admin/sichtungen kompilieren die Specs darüber
             # bereits kalt — der Aufschlag fällt hier kein weiteres Mal an.
             #
-            # ACHTUNG beim nächsten Ausbalancieren: Diese drei kamen zusammen
-            # mit dem Wegfall von admin-table-verified-column.spec.ts aus `map`.
-            # `form` wächst also um drei Specs, während `map` einen verliert —
-            # ob `form` damit noch der kürzeste Shard ist, wurde NICHT neu
-            # gemessen. Maßgeblich sind die Schrittdauern aus GitHub Actions,
-            # nicht lokale Zahlen (Begründung im Warnblock bei `smoke`).
+            # Die offene Frage von hier ist am 2026-08-08 beantwortet: über die
+            # letzten drei erfolgreichen main-Läufe misst `form` 188/192/207 s,
+            # `map` 211/215/216 s, `smoke` 247/260/273 s. `form` ist also auch
+            # nach dem Zuwachs weiterhin der kürzeste Shard — die Zuordnungen
+            # oben und unten bleiben damit gültig. Maßgeblich sind wie gehabt
+            # die Schrittdauern aus GitHub Actions, nicht lokale Zahlen
+            # (Begründung im Warnblock bei `smoke`).
             e2e/admin-sighting-status.spec.ts
             e2e/admin-table-mobile-status-overflow.spec.ts
             # Direkt beim Schwester-Spec darüber: dieselbe Route
@@ -523,6 +524,12 @@ jobs:
             # Fährt /admin/[id]/edit statt der Tabelle — der einzige der drei
             # mit einer eigenen kalt zu kompilierenden Route.
             e2e/admin-edit-toggle-no-wrap-lock.spec.ts
+            # Direkt beim Schwester-Spec admin-detail-actions oben: dieselbe
+            # Route (/admin/[id]), die dieser damit bereits kalt kompiliert
+            # hat. `form` ist laut der Messung oben weiterhin der kürzeste
+            # Shard. Lokal 1 Test, ~2 s — er legt sich seine Sichtung selbst an
+            # und räumt sie per ON DELETE CASCADE wieder weg.
+            e2e/admin-status-history.spec.ts
           )
 
           # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des

--- a/docs/ADMIN_IMPROVEMENTS_SPEC.md
+++ b/docs/ADMIN_IMPROVEMENTS_SPEC.md
@@ -273,6 +273,37 @@ geschrieben ausschließlich vom verify-Endpunkt. Anzeige als Zeitleiste in der
 Detailansicht. Ersetzt perspektivisch die Einzelfelder nicht (Legacy-DB!),
 ergänzt sie. Aufbewahrung/Datenschutz klären (Bearbeiter-Identität).
 
+**Entscheidungen (2026-08-08).**
+
+- **Bearbeiter-Identität: dieselbe Kennung wie `abgelehnt_von`** — die
+  E-Mail-Adresse aus der Auth0-Anmeldung (`locals.user.email`). Es entsteht
+  damit keine neue Datenkategorie, nur eine längere Reihe derselben. Ohne
+  angemeldete Identität bleibt die Spalte `NULL`; ein Platzhalter behauptete
+  eine Person, die es nie gab (dieselbe Begründung wie bei `freigegeben_von`).
+  Sichtbar ist die Historie ausschließlich im Admin-Bereich, nie öffentlich.
+- **Keine eigene Aufbewahrungsgrenze.** Die Einträge hängen per
+  `ON DELETE CASCADE` an der Sichtung und teilen deren Schicksal. Eine kürzere
+  Frist würde die Historie genau dann leeren, wenn die Sichtung noch öffentlich
+  steht — und die Frage „wer hat das freigegeben" unbeantwortbar machen,
+  obwohl `freigegeben_von` sie weiterhin beantwortet. Eine eigene Frist wird
+  erst sinnvoll, wenn die Sichtungen selbst eine bekommen; das ist der offene
+  Punkt §2.1 in `docs/DATENSCHUTZ_ABGLEICH_DMM_2026-08-02.md`.
+- **Eigene Tabelle statt `audit_logs`.** Das Audit-Log hält denselben Vorgang
+  fest, taugt aber nicht als Anzeigequelle: `logAuditEvent` schluckt
+  Schreibfehler bewusst, `details` ist formloses JSONB, und es gibt keinen
+  Index auf `resource_id` — die Historie einer Sichtung wäre ein Full Scan über
+  alle Aktionen aller Ressourcen.
+- **Spalten und Eintrag in einer Transaktion.** Eine Historie, die einen
+  stattgefundenen Wechsel verschweigt, sieht vollständig aus und ist es nicht —
+  sie wäre damit schlechter als gar keine.
+- **Leere Historie wird erklärt, nicht wortlos gezeigt.** Der Altbestand
+  (19.262 Freigaben aus dem Altsystem) hat keine Einträge; ohne Hinweis liest
+  sich das als „nie bearbeitet".
+
+Der einzige Schreibweg ist mechanisch abgesichert:
+`src/lib/server/db/statusLogWriteScan.test.ts` meldet jeden Schreibzugriff auf
+die Tabelle außerhalb des Verify-Endpunkts.
+
 ### B4 — Gespeicherte Filteransichten
 
 Benannte Filter-Presets als Chips über der Tabelle. Persistenz zunächst

--- a/drizzle/0007_aspiring_meteorite.sql
+++ b/drizzle/0007_aspiring_meteorite.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "sichtung_status_log" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"sichtung_id" bigint NOT NULL,
+	"verdict" varchar(16) NOT NULL,
+	"bearbeiter" varchar(255),
+	"zeitpunkt" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "sichtung_status_log_verdict_check" CHECK ("sichtung_status_log"."verdict" IN ('approve', 'reject', 'reset'))
+);
+--> statement-breakpoint
+ALTER TABLE "sichtung_status_log" ADD CONSTRAINT "sichtung_status_log_sichtung_id_sichtungen_id_fk" FOREIGN KEY ("sichtung_id") REFERENCES "public"."sichtungen"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_sichtung_status_log_sichtung" ON "sichtung_status_log" USING btree ("sichtung_id","zeitpunkt");

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1228 @@
+{
+  "id": "3e5a6706-ffc4-4f60-aecb-93658350976c",
+  "prevId": "9d32c1e7-8b43-4740-bf60-b2e7f2023623",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_config": {
+      "name": "app_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_app_config_key": {
+          "name": "idx_app_config_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_app_config_category": {
+          "name": "idx_app_config_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_config_key_unique": {
+          "name": "app_config_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_email": {
+          "name": "user_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'success'"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_timestamp": {
+          "name": "idx_audit_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action_timestamp": {
+          "name": "idx_audit_logs_action_timestamp",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_email_timestamp": {
+          "name": "idx_audit_logs_user_email_timestamp",
+          "columns": [
+            {
+              "expression": "user_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sub": {
+          "name": "sub",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roles": {
+          "name": "roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "user_claims": {
+          "name": "user_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "absolute_expires_at": {
+          "name": "absolute_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_sub": {
+          "name": "idx_sessions_sub",
+          "columns": [
+            {
+              "expression": "sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtungen_dateien": {
+      "name": "sichtungen_dateien",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sichtung_id": {
+          "name": "sichtung_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_name": {
+          "name": "datei_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "datei_pfad": {
+          "name": "datei_pfad",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_typ": {
+          "name": "mime_typ",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hochgeladen_am": {
+          "name": "hochgeladen_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exif_daten": {
+          "name": "exif_daten",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "erstellt_am": {
+          "name": "erstellt_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sichtungen_dateien_sichtung_id": {
+          "name": "idx_sichtungen_dateien_sichtung_id",
+          "columns": [
+            {
+              "expression": "sichtung_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_referenz_id": {
+          "name": "idx_sichtungen_dateien_referenz_id",
+          "columns": [
+            {
+              "expression": "referenz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungen_dateien_uid": {
+          "name": "idx_sichtungen_dateien_uid",
+          "columns": [
+            {
+              "expression": "uid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sichtungen_dateien_sichtung_id_sichtungen_id_fk": {
+          "name": "sichtungen_dateien_sichtung_id_sichtungen_id_fk",
+          "tableFrom": "sichtungen_dateien",
+          "tableTo": "sichtungen",
+          "columnsFrom": [
+            "sichtung_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sichtung_status_log": {
+      "name": "sichtung_status_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sichtung_id": {
+          "name": "sichtung_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearbeiter": {
+          "name": "bearbeiter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zeitpunkt": {
+          "name": "zeitpunkt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sichtung_status_log_sichtung": {
+          "name": "idx_sichtung_status_log_sichtung",
+          "columns": [
+            {
+              "expression": "sichtung_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zeitpunkt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sichtung_status_log_sichtung_id_sichtungen_id_fk": {
+          "name": "sichtung_status_log_sichtung_id_sichtungen_id_fk",
+          "tableFrom": "sichtung_status_log",
+          "tableTo": "sichtungen",
+          "columnsFrom": [
+            "sichtung_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sichtung_status_log_verdict_check": {
+          "name": "sichtung_status_log_verdict_check",
+          "value": "\"sichtung_status_log\".\"verdict\" IN ('approve', 'reject', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sichtungen": {
+      "name": "sichtungen",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval('sichtungen_seq'::regclass)"
+        },
+        "gps_breite": {
+          "name": "gps_breite",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gps_laenge": {
+          "name": "gps_laenge",
+          "type": "numeric(8, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fahrwasser": {
+          "name": "fahrwasser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seezeichen": {
+          "name": "seezeichen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtungsdatum": {
+          "name": "sichtungsdatum",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vonwo": {
+          "name": "vonwo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vonwo_text": {
+          "name": "vonwo_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entfernung": {
+          "name": "entfernung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_schiffe": {
+          "name": "anzahl_schiffe",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anzahl_gesamt": {
+          "name": "anzahl_gesamt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anzahl_jung": {
+          "name": "anzahl_jung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung": {
+          "name": "verteilung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verteilung_text": {
+          "name": "verteilung_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahme": {
+          "name": "aufnahme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aufnahmeHochladen": {
+          "name": "aufnahmeHochladen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten": {
+          "name": "verhalten",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "verhalten_text": {
+          "name": "verhalten_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reaktion": {
+          "name": "reaktion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sonstige_auffaelligkeiten": {
+          "name": "sonstige_auffaelligkeiten",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seegang": {
+          "name": "seegang",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "windrichtung": {
+          "name": "windrichtung",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "windstaerke": {
+          "name": "windstaerke",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sichtweite": {
+          "name": "sichtweite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffsname": {
+          "name": "schiffsname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heimathafen": {
+          "name": "heimathafen",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstyp": {
+          "name": "bootstyp",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootsantrieb": {
+          "name": "bootsantrieb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bootsantrieb_text": {
+          "name": "bootsantrieb_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vorname": {
+          "name": "vorname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "strasse": {
+          "name": "strasse",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plz": {
+          "name": "plz",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ort": {
+          "name": "ort",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telefon": {
+          "name": "telefon",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fax": {
+          "name": "fax",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung": {
+          "name": "namensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "namensnennung_am": {
+          "name": "namensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "namensnennung_version": {
+          "name": "namensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung": {
+          "name": "schiffnamensnennung",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "schiffnamensnennung_am": {
+          "name": "schiffnamensnennung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schiffnamensnennung_version": {
+          "name": "schiffnamensnennung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bemerkungen": {
+          "name": "bemerkungen",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eingangskanal": {
+          "name": "eingangskanal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "freigegeben_am": {
+          "name": "freigegeben_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geprueft": {
+          "name": "geprueft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ostsee": {
+          "name": "ostsee",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "kommentar_intern": {
+          "name": "kommentar_intern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(point)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ostsee_geo": {
+          "name": "ostsee_geo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund": {
+          "name": "totfund",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_groesse": {
+          "name": "totfund_groesse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totfund_zustand": {
+          "name": "totfund_zustand",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_geschlecht": {
+          "name": "totfund_geschlecht",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totfund_telefon": {
+          "name": "totfund_telefon",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tierart": {
+          "name": "tierart",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis": {
+          "name": "datenschutz_einverstaendnis",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "datenschutz_einverstaendnis_am": {
+          "name": "datenschutz_einverstaendnis_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "datenschutz_einverstaendnis_version": {
+          "name": "datenschutz_einverstaendnis_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung": {
+          "name": "medien_einwilligung",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "medien_einwilligung_am": {
+          "name": "medien_einwilligung_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "medien_einwilligung_version": {
+          "name": "medien_einwilligung_version",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenz_id": {
+          "name": "referenz_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data": {
+          "name": "weather_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_fetched_at": {
+          "name": "weather_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_provider": {
+          "name": "weather_provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'open-meteo'"
+        },
+        "weather_api_version": {
+          "name": "weather_api_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weather_data_type": {
+          "name": "weather_data_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'historical'"
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spam_indicators": {
+          "name": "spam_indicators",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abgelehnt_am": {
+          "name": "abgelehnt_am",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abgelehnt_von": {
+          "name": "abgelehnt_von",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freigegeben_von": {
+          "name": "freigegeben_von",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "geom_sichtungen": {
+          "name": "geom_sichtungen",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gist_geometry_ops_2d"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        },
+        "idx_sichtungsdatum": {
+          "name": "idx_sichtungsdatum",
+          "columns": [
+            {
+              "expression": "sichtungsdatum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sichtungsdatum_berlin_tag": {
+          "name": "idx_sichtungsdatum_berlin_tag",
+          "columns": [
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_year_sichtungen": {
+          "name": "idx_year_sichtungen",
+          "columns": [
+            {
+              "expression": "EXTRACT(year FROM \"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_data_gin": {
+          "name": "idx_weather_data_gin",
+          "columns": [
+            {
+              "expression": "weather_data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_weather_fetched": {
+          "name": "idx_weather_fetched",
+          "columns": [
+            {
+              "expression": "weather_fetched_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_weather_provider": {
+          "name": "idx_weather_provider",
+          "columns": [
+            {
+              "expression": "weather_provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_position_date_weather": {
+          "name": "idx_position_date_weather",
+          "columns": [
+            {
+              "expression": "ROUND(\"gps_breite\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ROUND(\"gps_laenge\"::numeric, 2)",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "DATE(\"sichtungsdatum\" AT TIME ZONE 'UTC' AT TIME ZONE 'Europe/Berlin')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sichtungen\".\"weather_data\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {
+    "public.sichtungen_seq": {
+      "name": "sichtungen_seq",
+      "schema": "public",
+      "increment": "1",
+      "startWith": "1840",
+      "minValue": "1",
+      "maxValue": "9223372036854775807",
+      "cache": "1",
+      "cycle": false
+    }
+  },
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786175923049,
       "tag": "0006_tense_redwing",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1786184950447,
+      "tag": "0007_aspiring_meteorite",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/admin-status-history.spec.ts
+++ b/e2e/admin-status-history.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+import { deleteSighting, seedSighting } from './helpers/seedSighting';
+
+/**
+ * admin-status-history.spec.ts — die Status-Historie entsteht am Bedienelement.
+ *
+ * **Warum E2E und nicht nur Unit-Tests.** Die Historie hängt an drei Teilen, die
+ * je einzeln geprüft sind: der Verify-Endpunkt schreibt (`verify.test.ts`), die
+ * Zeitleiste stellt dar (`SightingStatusTimeline.svelte.test.ts`), und `+page.ts`
+ * lädt. Was keiner der drei prüft, ist die **Strecke** — dass ein Klick auf
+ * „Freigeben" am Ende als Eintrag in der Zeitleiste ankommt. Genau dort sitzen
+ * die Fehler, die keiner der Einzeltests sieht: eine nicht neu geladene Seite,
+ * ein vergessenes `history` in der Antwort, ein Prop, das nicht durchgereicht
+ * wird (Präzedenz: `FieldRenderer`, `design-system.md`).
+ *
+ * Eigene Testzeile über `e2e/helpers/seedSighting.ts` — die Historie schreibt in
+ * die Datenbank, und ein fremder Datensatz behielte die Einträge.
+ */
+test.describe('Admin-Detailansicht — Status-Historie', () => {
+	const createdIds: number[] = [];
+
+	test.afterEach(async () => {
+		// Die Einträge verschwinden per ON DELETE CASCADE mit der Sichtung.
+		while (createdIds.length > 0) {
+			await deleteSighting(createdIds.pop()!);
+		}
+	});
+
+	test('hält jede Entscheidung mit Zeitpunkt und Bearbeiter fest', async ({
+		page,
+		context,
+		baseURL
+	}) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+		const id = await seedSighting({
+			referenceId: 'e2e-status-historie',
+			sightingDate: new Date('2024-06-01T08:30:00.000Z')
+		});
+		createdIds.push(id);
+
+		await page.goto(`/admin/${id}`);
+
+		const historie = page.getByRole('group', { name: /Bearbeitungs-Historie/ });
+
+		// Vor der ersten Entscheidung: leer — und der Grund steht dabei, sonst
+		// liest sich das wie „nie bearbeitet".
+		// Aufgeklappt wird über das `summary`, nicht über das `details`: Letzteres
+		// trifft nur deshalb, weil der Inhalt zugeklappt Höhe 0 hat — der Test
+		// hinge damit an einer Layout-Eigenschaft statt am Bedienelement.
+		await historie.locator('summary').click();
+		await expect(historie.getByText(/Aufzeichnung beginnt/)).toBeVisible();
+
+		/* `evaluate(el => el.click())` wie in `admin-sighting-status.spec.ts`: Der
+		   Radio-Input liegt unter seinem Label, ein Playwright-Klick landet auf
+		   der sticky Navbar, sobald die Seite gescrollt ist. */
+		await page
+			.getByRole('radio', { name: 'Freigegeben' })
+			.evaluate((el: HTMLInputElement) => el.click());
+		await expect(historie.getByRole('listitem')).toHaveCount(1);
+
+		await page
+			.getByRole('radio', { name: 'Abgelehnt' })
+			.evaluate((el: HTMLInputElement) => el.click());
+		await expect(historie.getByRole('listitem')).toHaveCount(2);
+
+		// Älteste zuerst: Die Zeitleiste wird von oben nach unten gelesen.
+		const eintraege = historie.getByRole('listitem');
+		await expect(eintraege.nth(0)).toContainText('Freigegeben');
+		await expect(eintraege.nth(1)).toContainText('Abgelehnt');
+
+		// Die Bearbeiter-Kennung ist dieselbe wie in `freigegeben_von`/
+		// `abgelehnt_von` — die E-Mail aus der Anmeldung, kein Platzhalter.
+		await expect(eintraege.nth(1)).toContainText('@');
+	});
+});

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -36,6 +36,8 @@
 	import { getSightingStatus, SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 	import type { SightingVerdict } from './sightingVerdict';
 	import SightingStatusControl from './SightingStatusControl.svelte';
+	import SightingStatusTimeline from './SightingStatusTimeline.svelte';
+	import type { SightingStatusLogEntry } from './sightingStatusLog';
 
 	// Definiere die Struktur einer Datenzeile
 	interface DataRowType {
@@ -51,12 +53,18 @@
 		sighting,
 		loading = false,
 		onStatusChange,
-		statusBusy = false
+		statusBusy = false,
+		statusLog = [],
+		statusLogFailed = false
 	} = $props<{
 		sighting: FrontendSighting;
 		loading?: boolean;
 		onStatusChange?: ((verdict: SightingVerdict) => void) | undefined;
 		statusBusy?: boolean;
+		/** Status-Historie (Spec B3) — leer für den Altbestand, siehe Zeitleiste. */
+		statusLog?: SightingStatusLogEntry[];
+		/** Die Historie konnte nicht geladen werden — von „leer" zu unterscheiden. */
+		statusLogFailed?: boolean;
 	}>();
 
 	// State für die aktuellen Sichtungsdaten mit reaktiver Wetterdaten-Aktualisierung
@@ -494,6 +502,24 @@
 			</span>
 		{/if}
 	</div>
+
+	<!-- Zugeklappt und direkt unter der Statusleiste: Die Historie gehört fachlich
+	     zum Status, wird aber selten gebraucht — aufgeklappt schöbe sie alle
+	     Sichtungsdaten nach unten. `summary` als eigenes Bedienelement, damit der
+	     Zustand per Tastatur erreichbar bleibt. -->
+	{@const historyLabel = `Bearbeitungs-Historie${statusLog.length > 0 ? ` (${statusLog.length})` : ''}`}
+	<!-- `aria-label` am `details`: Ein `summary` mit `collapse-title` wird als
+	     namenloses `group` exponiert, die Zusammenfassung selbst als `generic` —
+	     ein Screenreader meldete den Bereich damit gar nicht. Der Text ist
+	     derselbe wie der sichtbare, sonst bräche WCAG 2.5.3 (Label in Name). -->
+	<details class="collapse-arrow bg-base-200 rounded-box collapse mb-4" aria-label={historyLabel}>
+		<summary class="collapse-title text-base font-medium">
+			{historyLabel}
+		</summary>
+		<div class="collapse-content">
+			<SightingStatusTimeline entries={statusLog} failed={statusLogFailed} />
+		</div>
+	</details>
 
 	{#if isDead}
 		<!-- Steht über allen Angaben und nicht zwischen den Karten: Die Art der

--- a/src/lib/components/admin/SightingStatusTimeline.svelte
+++ b/src/lib/components/admin/SightingStatusTimeline.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
+	import { SIGHTING_STATUS_PRESENTATION, verdictToStatus } from './sightingStatus';
+	import { VERDICT_LOG_LABEL } from './sightingStatusLog';
+	import type { SightingStatusLogEntry } from './sightingStatusLog';
+
+	let {
+		entries,
+		failed = false
+	}: {
+		entries: SightingStatusLogEntry[];
+		/** Die Historie konnte nicht geladen werden — siehe Markup, nicht dasselbe wie „leer". */
+		failed?: boolean;
+	} = $props();
+</script>
+
+{#if failed}
+	<!-- Der dritte Fall, und der Grund, warum es ihn gibt: „leer" und „nicht
+	     geladen" sähen sonst identisch aus. Der Satz unten behauptete dann, es
+	     habe keine Entscheidungen gegeben — über einen Datensatz, der sehr wohl
+	     welche haben kann. Wer nichts weiß, soll wissen, dass er nichts weiß. -->
+	<div class="alert alert-warning" role="alert">
+		<Icon icon="lucide:triangle-alert" class="shrink-0" aria-hidden="true" />
+		<span>
+			Die Historie konnte nicht geladen werden. Ob zu dieser Sichtung Einträge vorliegen, ist damit
+			offen — der aktuelle Status oben bleibt gültig.
+		</span>
+	</div>
+{:else if entries.length === 0}
+	<!-- Eine leere Liste wortlos zu zeigen wäre eine falsche Aussage: Die
+	     Aufzeichnung beginnt mit dieser Tabelle, nicht mit der Sichtung. 19.262
+	     Freigaben stammen aus dem Altsystem und haben deshalb keinen Eintrag —
+	     ohne diesen Satz liest sich das als „nie bearbeitet". -->
+	<p class="text-base-content/70 text-sm">
+		Keine Einträge. Die Aufzeichnung beginnt mit der Einführung der Historie — ältere Entscheidungen
+		sind nur als aktueller Status erhalten.
+	</p>
+{:else}
+	<ul class="space-y-3">
+		{#each entries as entry (entry.id)}
+			{@const status = verdictToStatus(entry.verdict)}
+			{@const presentation = SIGHTING_STATUS_PRESENTATION[status]}
+			<li class="flex items-start gap-3">
+				<!-- Icon trägt die Bedeutung mit, nicht nur die Farbe: Freigabe und
+				     Ablehnung müssen auch ohne Farbwahrnehmung unterscheidbar sein. -->
+				<span class="badge {presentation.badgeClass} mt-0.5 shrink-0 gap-1">
+					<Icon icon={presentation.icon} width="14" aria-hidden="true" />
+					{VERDICT_LOG_LABEL[entry.verdict]}
+				</span>
+				<span class="text-base-content/70 text-sm">
+					{formatLocalDateTime(entry.recordedAt, 'datetime')}{entry.editor
+						? ` durch ${entry.editor}`
+						: ''}
+				</span>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/src/lib/components/admin/SightingStatusTimeline.svelte.test.ts
+++ b/src/lib/components/admin/SightingStatusTimeline.svelte.test.ts
@@ -1,0 +1,78 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import SightingStatusTimeline from './SightingStatusTimeline.svelte';
+import type { SightingStatusLogEntry } from './sightingStatusLog';
+
+const eintrag = (
+	id: number,
+	verdict: SightingStatusLogEntry['verdict'],
+	recordedAt: string,
+	editor: string | null = 'pruefer@example.com'
+): SightingStatusLogEntry => ({ id, verdict, editor, recordedAt });
+
+describe('SightingStatusTimeline', () => {
+	it('zeigt jeden Eintrag mit dem Wort des Zustands, den er hergestellt hat', async () => {
+		const screen = render(SightingStatusTimeline, {
+			entries: [
+				eintrag(1, 'reject', '2026-08-01T10:00:00Z'),
+				eintrag(2, 'approve', '2026-08-02T10:00:00Z')
+			]
+		});
+
+		await expect.element(screen.getByText('Abgelehnt')).toBeVisible();
+		await expect.element(screen.getByText('Freigegeben')).toBeVisible();
+	});
+
+	it('nennt den Bearbeiter, wenn einer bekannt ist', async () => {
+		const screen = render(SightingStatusTimeline, {
+			entries: [eintrag(1, 'approve', '2026-08-02T10:00:00Z', 'anna@example.com')]
+		});
+
+		await expect.element(screen.getByText(/anna@example\.com/)).toBeVisible();
+	});
+
+	/* Kein „durch null": Ohne angemeldete Identität bleibt `bearbeiter` NULL —
+	   dieselbe Lage wie beim Altbestand in `freigegeben_von`. Ein Platzhalter
+	   behauptete eine Person, die es nie gab. */
+	it('behauptet ohne bekannten Bearbeiter keine Person', async () => {
+		const screen = render(SightingStatusTimeline, {
+			entries: [eintrag(1, 'approve', '2026-08-02T10:00:00Z', null)]
+		});
+
+		await expect.element(screen.getByText(/null|undefined/)).not.toBeInTheDocument();
+	});
+
+	/* Die Aufzeichnung beginnt mit der Tabelle, nicht mit der Sichtung. Ohne
+	   diesen Hinweis liest sich eine leere Liste als „nie bearbeitet" — falsch
+	   für 19.262 Freigaben aus dem Altsystem. */
+	it('erklärt eine leere Historie, statt sie wortlos zu zeigen', async () => {
+		const screen = render(SightingStatusTimeline, { entries: [] });
+
+		await expect.element(screen.getByText(/Aufzeichnung/)).toBeVisible();
+	});
+
+	/* Der wichtigste Fall des Bauteils. Fällt das Laden aus, ist die leere Liste
+	   nicht dieselbe Aussage wie „Altbestand": Sie behauptete, es habe keine
+	   Entscheidungen gegeben, während in Wahrheit unbekannt ist, ob es welche
+	   gab. Genau der Fehlermodus, gegen den das Feature selbst antritt — eine
+	   Zeitleiste mit Lücke sieht vollständig aus und ist es nicht. */
+	it('unterscheidet einen Ladefehler von einer leeren Historie', async () => {
+		const screen = render(SightingStatusTimeline, { entries: [], failed: true });
+
+		await expect.element(screen.getByRole('alert')).toBeVisible();
+		await expect.element(screen.getByText(/konnte nicht geladen/)).toBeVisible();
+		await expect.element(screen.getByText(/Aufzeichnung beginnt/)).not.toBeInTheDocument();
+	});
+
+	it('ist eine Liste — Screenreader melden die Anzahl der Einträge', async () => {
+		const screen = render(SightingStatusTimeline, {
+			entries: [
+				eintrag(1, 'approve', '2026-08-01T10:00:00Z'),
+				eintrag(2, 'reset', '2026-08-02T10:00:00Z')
+			]
+		});
+
+		await expect.element(screen.getByRole('list')).toBeInTheDocument();
+		expect(screen.getByRole('listitem').elements()).toHaveLength(2);
+	});
+});

--- a/src/lib/components/admin/sightingStatusLog.test.ts
+++ b/src/lib/components/admin/sightingStatusLog.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { SIGHTING_STATUS_PRESENTATION, verdictToStatus } from './sightingStatus';
+import { VERDICT_LOG_LABEL } from './sightingStatusLog';
+
+/**
+ * @fileoverview Der Wortlaut der Historie darf nicht vom Statuswort abdriften.
+ *
+ * `VERDICT_LOG_LABEL` führt eigene Literale, und der Docblock dort begründet
+ * genau **eine** Abweichung: `reset` heißt „Zurückgesetzt" statt „Offen", weil
+ * ein Eintrag ein Ereignis beschreibt und keinen Zustand. Für `approve` und
+ * `reject` fallen Ereignis und Zustand zusammen — dass sie das auch bleiben,
+ * prüft dieser Test. Ohne ihn wäre eine Umbenennung in
+ * `SIGHTING_STATUS_PRESENTATION` an einer Stelle sichtbar und an der anderen
+ * nicht, und niemandem fiele auf, welche der beiden die richtige ist.
+ */
+describe('VERDICT_LOG_LABEL', () => {
+	it.each(['approve', 'reject'] as const)(
+		'sagt bei %s dasselbe wie das Statuswort',
+		(verdict) => {
+			expect(VERDICT_LOG_LABEL[verdict]).toBe(
+				SIGHTING_STATUS_PRESENTATION[verdictToStatus(verdict)].label
+			);
+		}
+	);
+
+	it('weicht bei reset bewusst ab — Ereignis statt Zustand', () => {
+		expect(VERDICT_LOG_LABEL.reset).toBe('Zurückgesetzt');
+		expect(SIGHTING_STATUS_PRESENTATION[verdictToStatus('reset')].label).toBe('Offen');
+	});
+});

--- a/src/lib/components/admin/sightingStatusLog.ts
+++ b/src/lib/components/admin/sightingStatusLog.ts
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Status-Historie einer Sichtung — Typ und Wortlaut der Einträge.
+ *
+ * Die Einträge kommen aus `sichtung_status_log` über
+ * `GET /api/sightings/[id]/verify` (Spec B3). Geschrieben werden sie
+ * ausschließlich vom Verify-Endpunkt; Begründung, Datenschutz und Aufbewahrung
+ * stehen am Tabellen-Docblock in `$lib/server/db/schema`.
+ *
+ * Client-sicher: **kein** Import aus `$lib/server/…` — wie bei
+ * `sightingStatus.ts` fiele der Bruch sonst erst in `npm run build` auf.
+ */
+import type { SightingVerdict } from './sightingVerdict';
+
+/**
+ * Ein Eintrag, so wie ihn der Endpunkt liefert.
+ *
+ * `recordedAt` ist ein String und kein `Date`: Der Weg führt durch JSON, und
+ * ein `Date` im Typ wäre eine Behauptung, die erst eine Umwandlung wahr macht.
+ */
+export interface SightingStatusLogEntry {
+	id: number;
+	verdict: SightingVerdict;
+	/** Die Kennung des Bearbeiters (E-Mail aus der Anmeldung) — `null` beim Altbestand. */
+	editor: string | null;
+	recordedAt: string;
+}
+
+/**
+ * Das Wort für die **Handlung**, die der Eintrag festhält.
+ *
+ * Bewusst nicht `SIGHTING_STATUS_PRESENTATION[…].label`: Dort steht der
+ * *Zustand* („Offen"), hier steht ein abgeschlossenes *Ereignis*. Für
+ * `approve`/`reject` fallen beide Wörter zusammen, für `reset` nicht — „Offen"
+ * als Eintrag einer Zeitleiste liest sich wie ein Zustandsbericht, nicht wie
+ * eine Entscheidung, die jemand getroffen hat.
+ *
+ * Farbe und Icon kommen weiterhin aus der einen Quelle
+ * (`SIGHTING_STATUS_PRESENTATION` über `verdictToStatus`) — hier ist nur der
+ * Wortlaut eigen, und nur aus diesem Grund.
+ */
+export const VERDICT_LOG_LABEL: Record<SightingVerdict, string> = {
+	approve: 'Freigegeben',
+	reject: 'Abgelehnt',
+	reset: 'Zurückgesetzt'
+};

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import { berlinCalendarDate, berlinDatePart } from './sqlTimeZone';
 import {
 	bigint,
+	check,
 	geometry,
 	index,
 	integer,
@@ -164,6 +165,69 @@ export const sightings = pgTable(
 
 // Type for selecting from sightings table
 export type SightingSelect = typeof sightings.$inferSelect;
+
+/**
+ * Status-Historie einer Sichtung (Spec B3).
+ *
+ * **Ergänzt die Statusspalten, ersetzt sie nicht.** `freigegeben_am`,
+ * `abgelehnt_am` und `abgelehnt_von` bleiben unverändert die Wahrheit über den
+ * *aktuellen* Zustand — das Altsystem liegt auf derselben Datenbank und liest
+ * sie. Diese Tabelle beantwortet die andere Frage: wie der Zustand zustande kam.
+ *
+ * **Geschrieben ausschließlich von `PATCH /api/sightings/[id]/verify`,** in
+ * derselben Transaktion wie die Statusspalten. Das ist keine Stilfrage: Eine
+ * Historie, die einen Wechsel verschweigt, sieht vollständig aus und ist es
+ * nicht. Mechanisch abgesichert durch `statusLogWriteScan.test.ts`.
+ *
+ * **Warum eine eigene Tabelle neben `audit_logs`.** Das Audit-Log hält denselben
+ * Vorgang bereits fest, taugt aber nicht als Anzeigequelle: Es ist bewusst
+ * bestbemüht (`logAuditEvent` schluckt Schreibfehler), sein `details`-JSONB hat
+ * keine feste Form, und es hat keinen Index auf `resource_id` — die Historie
+ * einer Sichtung wäre ein Full Scan über alle Aktionen aller Ressourcen.
+ *
+ * **Bearbeiter-Identität (DSGVO).** `bearbeiter` trägt dieselbe Kennung wie
+ * `freigegeben_von`/`abgelehnt_von`: die E-Mail-Adresse aus der
+ * Auth0-Anmeldung. Es entsteht damit keine neue Datenkategorie, nur eine
+ * längere Reihe derselben. Ohne angemeldete Identität bleibt die Spalte `NULL`
+ * statt einen Platzhalter zu behaupten. Sichtbar ist die Historie nur im
+ * Admin-Bereich (`requireUserRole`), nie auf einer öffentlichen Fläche.
+ *
+ * **Aufbewahrung.** Keine eigene Frist. Die Einträge sind über
+ * `ON DELETE CASCADE` an die Sichtung gebunden und teilen deren Schicksal —
+ * eine kürzere Frist würde die Historie genau dann leeren, wenn die Sichtung
+ * noch öffentlich steht, und die Frage „wer hat das freigegeben" unbeantwortbar
+ * machen, obwohl `freigegeben_von` sie weiterhin beantwortet. Eine eigene Frist
+ * wäre erst dann sinnvoll, wenn die Sichtungen selbst eine bekommen — die steht
+ * als offener Punkt in `docs/DATENSCHUTZ_ABGLEICH_DMM_2026-08-02.md` (§2.1).
+ */
+export const sightingStatusLog = pgTable(
+	'sichtung_status_log',
+	{
+		id: serial().primaryKey().notNull(),
+		sightingId: bigint('sichtung_id', { mode: 'number' })
+			.references(() => sightings.id, { onDelete: 'cascade' })
+			.notNull(),
+		/* 'approve' | 'reject' | 'reset' — dieselben drei Werte, die der
+		   Verify-Endpunkt annimmt. Bewusst kein pgEnum: Ein Enum-Typ ist in
+		   einer Datenbank, die ein zweites System mitbenutzt, nur mit
+		   ALTER TYPE erweiterbar. Den Wertebereich hält stattdessen der
+		   CHECK unten — ohne ihn käme ein Fremdwert (manuelles SQL, Altsystem)
+		   ungeprüft bis in die Zeitleiste und fiele dort auf „Offen" zurück:
+		   Eine abgelehnte Sichtung sähe aus wie eine unbearbeitete. */
+		verdict: varchar('verdict', { length: 16 }).notNull(),
+		editor: varchar('bearbeiter', { length: 255 }),
+		recordedAt: timestamp('zeitpunkt', { withTimezone: true }).notNull().defaultNow()
+	},
+	(table) => [
+		// Die einzige Abfrage: alle Einträge einer Sichtung in zeitlicher
+		// Reihenfolge. Deshalb zusammengesetzt und nicht zwei einzelne Indizes.
+		index('idx_sichtung_status_log_sichtung').on(table.sightingId, table.recordedAt),
+		check('sichtung_status_log_verdict_check', sql`${table.verdict} IN ('approve', 'reject', 'reset')`)
+	]
+);
+
+export type SightingStatusLogSelect = typeof sightingStatusLog.$inferSelect;
+export type SightingStatusLogInsert = typeof sightingStatusLog.$inferInsert;
 
 // Table for storing file references linked to sightings
 export const sightingFiles = pgTable(

--- a/src/lib/server/db/statusLogWriteScan.test.ts
+++ b/src/lib/server/db/statusLogWriteScan.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { collectHits, sourceFiles, stripComments } from '$lib/testing/sourceScan.testutil';
+import type { SourceHit } from '$lib/testing/sourceScan.testutil';
+
+/**
+ * @fileoverview In `sichtung_status_log` schreibt nur der Verify-Endpunkt
+ *
+ * **Warum es diesen Test gibt.** Die Status-Historie ist nur so viel wert wie
+ * ihre Vollständigkeit. Ein zweiter Schreibweg — ein Wartungsskript, ein
+ * Bulk-Import, ein „schnell noch nachtragen" — erzeugt Einträge ohne die
+ * Statusspalten oder Statusspalten ohne Eintrag, und beides ist von außen nicht
+ * unterscheidbar: Die Zeitleiste sieht in jedem Fall vollständig aus. Dieselbe
+ * Sorge trägt schon die Regel „ein Endpunkt schreibt den Prüfstatus"
+ * (`.claude/rules/api.md`); dieser Scan zieht sie auf die Historie nach.
+ *
+ * Die Kontrolle „ein zweiter Schreibweg fällt beim Review auf" hat in diesem
+ * Repo zweimal versagt — bei `freigegeben_am` (PR #701) und bei `geprueft`
+ * (`verifiedReadScan.test.ts`). Deshalb hier von Anfang an ein Scan.
+ *
+ * **Was er prüft.** Jede `.ts`/`.js`-Datei unter `src/` wird nach einer
+ * schreibenden Operation auf der Tabelle durchsucht — in Drizzle-Schreibweise
+ * (`insert(sightingStatusLog)`, `update(…)`, `delete(…)`) wie in rohem SQL
+ * (`INSERT INTO sichtung_status_log`). Lesende Zugriffe sind ausdrücklich
+ * erlaubt: Eine zweite Anzeigestelle ist kein Problem, ein zweiter Autor schon.
+ *
+ * **Warum konstruierte Beispiele.** Ein Scan über einen konformen Bestand
+ * belegt nichts über die Regel — er ist auch dann grün, wenn das Muster eine
+ * Lücke hat. Unter „Mustererkennung" steht deshalb je Schreibweise ein
+ * gebautes Beispiel, unter „Gegenproben", was **nicht** anschlagen darf. Vorbild
+ * und Textaufbereitung: `approvalPredicateScan.test.ts`.
+ *
+ * Läuft im Node-Projekt (`npm run test:unit`, damit auch in `test:quick`).
+ */
+
+/** Was der Entwickler stattdessen tun soll — erscheint in jeder Fehlermeldung. */
+const REMEDIATION = [
+	'Die Status-Historie wird nicht neben dem Verify-Endpunkt geschrieben:',
+	'  PATCH /api/sightings/[id]/verify  ({ verdict: "approve" | "reject" | "reset" })',
+	'',
+	'Dort entstehen Statusspalten und Historien-Eintrag in EINER Transaktion.',
+	'Ein zweiter Schreibweg erzeugt Einträge ohne Spaltenänderung oder umgekehrt —',
+	'eine Zeitleiste mit Lücke sieht vollständig aus und ist es nicht.',
+	'',
+	'Lesen ist erlaubt: select() auf sightingStatusLog darf überall stehen.'
+].join('\n');
+
+/** Die Tabelle in beiden Schreibweisen — Drizzle-Bezeichner und DB-Name. */
+const TABLE = String.raw`(?:sightingStatusLog|sichtung_status_log)`;
+
+/**
+ * Drizzle: `insert(sightingStatusLog)`, `tx.update(sightingStatusLog)`, …
+ *
+ * Zwischen Operator und Tabelle darf nur Weißraum und ein Anführungszeichen
+ * stehen — ein Komma oder Bezeichner beendet die Brücke, damit
+ * `eq(sightingStatusLog.sightingId, …)` innerhalb eines `delete(other)` nicht
+ * fälschlich anschlägt.
+ */
+const DRIZZLE_WRITE = new RegExp(String.raw`\b(?:insert|update|delete)\s*\(\s*["']?${TABLE}`, 'gi');
+
+/** Rohes SQL: `INSERT INTO sichtung_status_log`, `DELETE FROM …`, `UPDATE …`. */
+const SQL_WRITE = new RegExp(
+	String.raw`\b(?:insert\s+into|delete\s+from|update)\s+["']?${TABLE}`,
+	'gi'
+);
+
+const PATTERNS = [DRIZZLE_WRITE, SQL_WRITE] as const;
+
+/**
+ * Meldet jeden Schreibzugriff auf die Historien-Tabelle in `source`.
+ *
+ * @returns Fundstellen (leer = konform), aufsteigend nach Zeile.
+ */
+export function findStatusLogWrites(source: string): SourceHit[] {
+	return collectHits(stripComments(source), PATTERNS);
+}
+
+/**
+ * Dateien, in denen geschrieben werden darf — je mit Begründung.
+ *
+ * Namentlich und kurz. Ein pauschales `**\/*.test.ts` wäre bequem und würde die
+ * Regel aushöhlen: Eine Testhilfe, die Historie an der Transaktion vorbei
+ * anlegt, erzeugt genau die Lücke, gegen die die Regel existiert.
+ */
+const ALLOWED_FILES: ReadonlyMap<string, string> = new Map([
+	[
+		'src/routes/api/sightings/[id]/verify/+server.ts',
+		'Der einzige Schreibweg. Legt Statusspalten und Historien-Eintrag in einer Transaktion an.'
+	],
+	[
+		'src/lib/server/db/statusLogWriteScan.test.ts',
+		'Diese Datei. Die konstruierten Beispiele unter „Mustererkennung" sind Verstöße — das ist ihr Zweck.'
+	]
+]);
+
+const SOURCE_ROOT = 'src';
+
+describe('Mustererkennung — jede Schreibweise wird gefunden', () => {
+	it.each([
+		['Drizzle insert', 'await db.insert(sightingStatusLog).values({ verdict: "approve" });'],
+		['Drizzle update über tx', 'await tx.update(sightingStatusLog).set({ verdict: "reset" });'],
+		['Drizzle delete', 'await db.delete(sightingStatusLog).where(eq(x, y));'],
+		['SQL INSERT', 'sql`INSERT INTO sichtung_status_log (verdict) VALUES (${v})`'],
+		['SQL DELETE mit DB-Namen', 'sql`DELETE FROM "sichtung_status_log" WHERE sichtung_id = 1`'],
+		['SQL UPDATE', 'sql`UPDATE sichtung_status_log SET bearbeiter = NULL`']
+	])('%s', (_name, code) => {
+		expect(findStatusLogWrites(code)).not.toHaveLength(0);
+	});
+});
+
+describe('Gegenproben — was nicht anschlagen darf', () => {
+	it.each([
+		['Lesen per select', 'await db.select().from(sightingStatusLog).where(eq(a, b));'],
+		['Spaltenzugriff', 'orderBy(asc(sightingStatusLog.recordedAt))'],
+		['Schema-Definition', "export const sightingStatusLog = pgTable('sichtung_status_log', {"],
+		['Schreiben auf eine andere Tabelle', 'await db.insert(sightings).values(data);'],
+		[
+			'Spalte als Argument in fremdem Delete',
+			'await db.delete(other).where(eq(sightingStatusLog.sightingId, id));'
+		],
+		['auskommentiert', '// await db.insert(sightingStatusLog).values({});']
+	])('%s', (_name, code) => {
+		expect(findStatusLogWrites(code)).toHaveLength(0);
+	});
+});
+
+describe('Bestand — nur der Verify-Endpunkt schreibt Historie', () => {
+	it('findet außerhalb der erlaubten Dateien keinen Schreibzugriff', () => {
+		const verstoesse = sourceFiles(SOURCE_ROOT, /\.(ts|js)$/)
+			.filter((datei) => !ALLOWED_FILES.has(datei))
+			.flatMap((datei) =>
+				findStatusLogWrites(readFileSync(datei, 'utf8')).map(
+					(hit) => `${datei}:${hit.line} — ${hit.text}`
+				)
+			);
+
+		expect(verstoesse, `\n${REMEDIATION}\n`).toEqual([]);
+	});
+
+	it('führt jede erlaubte Datei mit Begründung', () => {
+		for (const [datei, begruendung] of ALLOWED_FILES) {
+			expect(begruendung.length, `${datei} braucht eine Begründung`).toBeGreaterThan(30);
+		}
+	});
+});

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -256,4 +256,10 @@
 	</div>
 {/if}
 
-<AdminSightingView {sighting} onStatusChange={handleStatusChange} {statusBusy} />
+<AdminSightingView
+	{sighting}
+	onStatusChange={handleStatusChange}
+	{statusBusy}
+	statusLog={data.statusLog}
+	statusLogFailed={data.statusLogFailed}
+/>

--- a/src/routes/admin/[id]/+page.ts
+++ b/src/routes/admin/[id]/+page.ts
@@ -1,0 +1,42 @@
+import type { SightingStatusLogEntry } from '$lib/components/admin/sightingStatusLog';
+import type { PageLoad } from './$types';
+
+/**
+ * Status-Historie der Detailansicht (Spec B3).
+ *
+ * Steht hier und nicht im `+layout.ts`: Die Bearbeitungsmaske (`[id]/edit`)
+ * hängt am selben Layout, zeigt den Status aber nur an — sie soll die Abfrage
+ * nicht mitschleppen.
+ *
+ * Die Historie enthält Bearbeiter-Kennungen und kommt deshalb aus dem
+ * admin-geschützten Verify-Endpunkt, nicht aus `/api/sightings/[id]`.
+ *
+ * **Ein Fehler hier darf die Seite nicht kosten** — die Historie ist eine
+ * Ergänzung, ohne sie bleibt die Sichtung vollständig lesbar. Er darf aber auch
+ * nicht als Altbestand durchgehen: Eine leere Liste behauptet „es gab keine
+ * Entscheidungen", ein Fehlschlag heißt „unbekannt, ob es welche gab". Beides
+ * sieht im DOM gleich aus, und die Verwechslung wäre derselbe Fehlermodus,
+ * gegen den das Feature antritt — eine Zeitleiste mit Lücke sieht vollständig
+ * aus und ist es nicht. Deshalb `statusLogFailed`, das die Zeitleiste als
+ * dritten Fall darstellt.
+ *
+ * Eine Antwort ohne `history` zählt dabei als Fehlschlag und nicht als leere
+ * Historie: Sie ist ein Vertragsbruch des Endpunkts, kein Altbestand.
+ */
+export const load: PageLoad = async ({ params, fetch }) => {
+	try {
+		const response = await fetch(`/api/sightings/${params.id}/verify`);
+		if (!response.ok) {
+			return { statusLog: [] as SightingStatusLogEntry[], statusLogFailed: true };
+		}
+
+		const body = await response.json();
+		if (!Array.isArray(body?.history)) {
+			return { statusLog: [] as SightingStatusLogEntry[], statusLogFailed: true };
+		}
+
+		return { statusLog: body.history as SightingStatusLogEntry[], statusLogFailed: false };
+	} catch {
+		return { statusLog: [] as SightingStatusLogEntry[], statusLogFailed: true };
+	}
+};

--- a/src/routes/admin/[id]/statusLogLoad.test.ts
+++ b/src/routes/admin/[id]/statusLogLoad.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SightingStatusLogEntry } from '$lib/components/admin/sightingStatusLog';
+import { load } from './+page';
+
+/**
+ * @fileoverview Der Lade-Fallback der Status-Historie muss unterscheidbar sein.
+ *
+ * **Warum dieser Test existiert.** Der `load` fängt jeden Fehler ab, damit ein
+ * Ausfall der Historie nicht die ganze Detailansicht kostet. Genau dabei
+ * entsteht die Falle: Fällt er stumm auf `[]` zurück, rendert die Zeitleiste
+ * den Altbestands-Satz („Die Aufzeichnung beginnt mit der Einführung…") — eine
+ * Tatsachenbehauptung über einen Datensatz, der sehr wohl Einträge haben kann.
+ * Das ist derselbe Fehlermodus, gegen den das Feature antritt: Eine Zeitleiste
+ * mit Lücke sieht vollständig aus und ist es nicht.
+ *
+ * Der Unterschied zwischen „leer" und „unbekannt" hängt damit an einem
+ * einzigen Flag, und der E2E-Test deckt nur den Erfolgsfall ab.
+ */
+
+/** Minimaler Load-Event — mehr liest die Funktion nicht. */
+const ladeEvent = (fetchImpl: typeof fetch) =>
+	({ params: { id: '42' }, fetch: fetchImpl }) as unknown as Parameters<typeof load>[0];
+
+const antwort = (body: unknown, ok = true) =>
+	vi.fn().mockResolvedValue({ ok, json: () => Promise.resolve(body) }) as unknown as typeof fetch;
+
+/* SvelteKits `PageLoad` weitet den Rückgabetyp auf `void | Record<string, any>`
+   — die Zusicherung holt die zwei Felder zurück, um die es hier geht. */
+const laden = async (fetchImpl: typeof fetch) =>
+	(await load(ladeEvent(fetchImpl))) as unknown as {
+		statusLog: SightingStatusLogEntry[];
+		statusLogFailed: boolean;
+	};
+
+describe('load der Status-Historie', () => {
+	it('reicht die Einträge des Endpunkts durch', async () => {
+		const eintraege = [
+			{ id: 1, verdict: 'approve', editor: 'a@example.com', recordedAt: '2026-08-01T10:00:00Z' }
+		];
+
+		const result = await laden(antwort({ history: eintraege }));
+
+		expect(result).toEqual({ statusLog: eintraege, statusLogFailed: false });
+	});
+
+	it('meldet einen leeren Altbestand als Erfolg, nicht als Fehler', async () => {
+		const result = await laden(antwort({ history: [] }));
+
+		expect(result).toEqual({ statusLog: [], statusLogFailed: false });
+	});
+
+	it('kennzeichnet eine Fehlerantwort als Fehlschlag', async () => {
+		const result = await laden(antwort({}, false));
+
+		expect(result.statusLogFailed).toBe(true);
+		expect(result.statusLog).toEqual([]);
+	});
+
+	it('kennzeichnet einen Netzwerkfehler als Fehlschlag', async () => {
+		const kaputt = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+		const result = await laden(kaputt);
+
+		expect(result.statusLogFailed).toBe(true);
+		expect(result.statusLog).toEqual([]);
+	});
+
+	/* Eine Antwort ohne `history` ist ein Vertragsbruch des Endpunkts, kein
+	   Altbestand — sie darf nicht als „nie bearbeitet" durchgehen. */
+	it('behandelt eine Antwort ohne history-Feld als Fehlschlag', async () => {
+		const result = await laden(antwort({ id: 42, verified: 1 }));
+
+		expect(result.statusLogFailed).toBe(true);
+		expect(result.statusLog).toEqual([]);
+	});
+});

--- a/src/routes/api/sightings/[id]/verify/+server.ts
+++ b/src/routes/api/sightings/[id]/verify/+server.ts
@@ -4,10 +4,10 @@ import { requireUserRole } from '$lib/server/auth/auth';
 import { getClientIp } from '$lib/server/utils/getClientIp';
 import { db } from '$lib/server/db';
 import { isSightingApproved, isSightingRejected } from '$lib/server/db/approvalFilter';
-import { sightings } from '$lib/server/db/schema';
+import { sightings, sightingStatusLog } from '$lib/server/db/schema';
 import type { RequestHandler } from '@sveltejs/kit';
 import { error, isHttpError, json } from '@sveltejs/kit';
-import { eq } from 'drizzle-orm';
+import { asc, eq } from 'drizzle-orm';
 
 // Logger für diesen API-Endpunkt erstellen
 const logger = createLogger('api:sightings:verify');
@@ -118,10 +118,26 @@ export const PATCH: RequestHandler = async ({ params, request, locals, url, getC
 							rejectedBy: null
 						};
 
-		await db
-			.update(sightings)
-			.set(statusColumns)
-			.where(eq(sightings.id, Number(id)));
+		// Spalten und Historien-Eintrag in EINER Transaktion. Eine Historie, die
+		// einen stattgefundenen Wechsel verschweigt, sieht vollständig aus und ist
+		// es nicht — sie wäre damit schlechter als gar keine. Der Eintrag hält
+		// bewusst nur fest, WAS entschieden wurde; der Zustand davor steht in der
+		// jeweils vorherigen Zeile bzw. ist für den Altbestand unbekannt.
+		await db.transaction(async (tx) => {
+			await tx
+				.update(sightings)
+				.set(statusColumns)
+				.where(eq(sightings.id, Number(id)));
+
+			await tx.insert(sightingStatusLog).values({
+				sightingId: Number(id),
+				verdict,
+				// Dieselbe Kennung wie in `freigegeben_von`/`abgelehnt_von` — keine
+				// neue Datenkategorie. Ohne Anmeldung NULL statt Platzhalter.
+				editor: locals.user?.email ?? null,
+				recordedAt: now
+			});
+		});
 
 		const ipAddress = getClientIp(getClientAddress, request);
 		await logAuditEvent({
@@ -204,11 +220,26 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 			throw error(404, 'Sichtung nicht gefunden');
 		}
 
+		// Aufsteigend: Die Zeitleiste wird von oben nach unten gelesen, älteste
+		// Entscheidung zuerst. Der Altbestand liefert hier eine leere Liste — die
+		// Aufzeichnung beginnt mit dieser Tabelle, nicht mit der Sichtung.
+		const history = await db
+			.select({
+				id: sightingStatusLog.id,
+				verdict: sightingStatusLog.verdict,
+				editor: sightingStatusLog.editor,
+				recordedAt: sightingStatusLog.recordedAt
+			})
+			.from(sightingStatusLog)
+			.where(eq(sightingStatusLog.sightingId, Number(id)))
+			.orderBy(asc(sightingStatusLog.recordedAt));
+
 		return json({
 			id: sighting[0]?.id,
 			verified: sighting[0]?.verified,
 			approvedAt: sighting[0]?.approvedAt ?? null,
-			rejectedAt: sighting[0]?.rejectedAt ?? null
+			rejectedAt: sighting[0]?.rejectedAt ?? null,
+			history
 		});
 	} catch (err) {
 		if (isHttpError(err)) {

--- a/src/routes/api/sightings/[id]/verify/verify.test.ts
+++ b/src/routes/api/sightings/[id]/verify/verify.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PATCH, GET } from './+server';
 
-const { mockWhere, mockSet, mockUpdate, mockLimit } = vi.hoisted(() => {
-	const mockWhere = vi.fn().mockResolvedValue(undefined);
-	const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-	const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
-	const mockLimit = vi
-		.fn()
-		.mockResolvedValue([{ id: 1, verified: 0, approvedAt: null, rejectedAt: null }]);
-	return { mockWhere, mockSet, mockUpdate, mockLimit };
-});
+const { mockWhere, mockSet, mockUpdate, mockLimit, mockOrderBy, mockLogValues, mockLogInsert } =
+	vi.hoisted(() => {
+		const mockWhere = vi.fn().mockResolvedValue(undefined);
+		const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
+		const mockUpdate = vi.fn().mockReturnValue({ set: mockSet });
+		const mockLimit = vi
+			.fn()
+			.mockResolvedValue([{ id: 1, verified: 0, approvedAt: null, rejectedAt: null }]);
+		// Historien-Abfrage des GET: select().from().where().orderBy()
+		const mockOrderBy = vi.fn().mockResolvedValue([]);
+		// Historien-Eintrag des PATCH: tx.insert().values()
+		const mockLogValues = vi.fn().mockResolvedValue(undefined);
+		const mockLogInsert = vi.fn().mockReturnValue({ values: mockLogValues });
+		return { mockWhere, mockSet, mockUpdate, mockLimit, mockOrderBy, mockLogValues, mockLogInsert };
+	});
 
 vi.mock('$lib/server/audit/auditService', () => ({
 	logAuditEvent: vi.fn().mockResolvedValue(undefined)
@@ -42,11 +48,18 @@ vi.mock('$lib/server/db', () => ({
 		select: vi.fn().mockReturnValue({
 			from: vi.fn().mockReturnValue({
 				where: vi.fn().mockReturnValue({
-					limit: mockLimit
+					limit: mockLimit,
+					orderBy: mockOrderBy
 				})
 			})
 		}),
-		update: mockUpdate
+		update: mockUpdate,
+		// Statusspalten und Historien-Eintrag gehören in eine Transaktion — der
+		// Mock reicht dieselben Doubles durch, damit die bestehenden
+		// Update-Erwartungen unverändert gelten.
+		transaction: vi.fn((callback: (tx: unknown) => unknown) =>
+			callback({ update: mockUpdate, insert: mockLogInsert })
+		)
 	}
 }));
 
@@ -58,6 +71,13 @@ vi.mock('$lib/server/db/schema', () => ({
 		approvedBy: 'approvedBy',
 		rejectedAt: 'rejectedAt',
 		rejectedBy: 'rejectedBy'
+	},
+	sightingStatusLog: {
+		id: 'id',
+		sightingId: 'sightingId',
+		verdict: 'verdict',
+		editor: 'editor',
+		recordedAt: 'recordedAt'
 	}
 }));
 
@@ -70,6 +90,8 @@ vi.mock('$lib/server/db/schema', () => ({
 
 vi.mock('drizzle-orm', () => ({
 	eq: vi.fn((a, b) => ({ a, b })),
+	// Sortierung der Historie im GET
+	asc: vi.fn((a) => ({ asc: a })),
 	// von approvalFilter importiert; im Endpunkt-Test nie aufgerufen
 	and: vi.fn((...args) => ({ and: args })),
 	isNull: vi.fn((a) => ({ isNull: a })),
@@ -339,5 +361,109 @@ describe('/api/sightings/[id]/verify GET endpoint', () => {
 		} catch (e: unknown) {
 			expect((e as { status: number }).status).toBe(404);
 		}
+	});
+});
+
+/**
+ * Status-Historie (Spec B3).
+ *
+ * Der Verify-Endpunkt ist laut `.claude/rules/api.md` der einzige Schreibweg
+ * für Statusänderungen — die Historie hängt deshalb hier und nirgends sonst.
+ * Geprüft wird beides: dass jeder Verdict genau einen Eintrag erzeugt, und
+ * dass Spaltenschreibung und Eintrag in **einer** Transaktion laufen. Ohne die
+ * Transaktion könnte die Historie eine Änderung verschweigen, die stattgefunden
+ * hat — und eine lückenhafte Historie ist schlimmer als keine, weil sie so
+ * aussieht, als wäre sie vollständig.
+ */
+describe('PATCH schreibt die Status-Historie', () => {
+	const patchEvent = (id: string, body: Record<string, unknown>, userEmail?: string) =>
+		createMockEvent(id, body, userEmail ? { userEmail } : undefined) as Parameters<typeof PATCH>[0];
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockWhere.mockResolvedValue(undefined);
+		mockSet.mockReturnValue({ where: mockWhere });
+		mockUpdate.mockReturnValue({ set: mockSet });
+		mockLogInsert.mockReturnValue({ values: mockLogValues });
+		mockLogValues.mockResolvedValue(undefined);
+		mockLimit.mockResolvedValue([{ id: 1, verified: 0, approvedAt: null, rejectedAt: null }]);
+	});
+
+	it.each([
+		['approve', { verdict: 'approve' }],
+		['reject', { verdict: 'reject' }],
+		['reset', { verdict: 'reset' }]
+	])('legt für %s genau einen Eintrag an', async (verdict, body) => {
+		await PATCH(patchEvent('42', body, 'pruefer@example.com'));
+
+		expect(mockLogValues).toHaveBeenCalledOnce();
+		expect(mockLogValues).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sightingId: 42,
+				verdict,
+				editor: 'pruefer@example.com'
+			})
+		);
+	});
+
+	it('hält den Alias { verified: 1 } als approve fest', async () => {
+		await PATCH(patchEvent('7', { verified: 1 }));
+
+		expect(mockLogValues).toHaveBeenCalledWith(expect.objectContaining({ verdict: 'approve' }));
+	});
+
+	it('schreibt Spalten und Historie in derselben Transaktion', async () => {
+		const { db } = await import('$lib/server/db');
+		await PATCH(patchEvent('1', { verdict: 'approve' }));
+
+		expect(db.transaction).toHaveBeenCalledOnce();
+		expect(mockSet).toHaveBeenCalledOnce();
+		expect(mockLogValues).toHaveBeenCalledOnce();
+	});
+
+	it('speichert ohne angemeldete Identität kein Bearbeiter-Kennzeichen', async () => {
+		// Kein Platzhalter, sondern NULL — dieselbe Regel wie bei
+		// `freigegeben_von`/`abgelehnt_von`: ein erfundener Name behauptete eine
+		// Person, die es nie gab.
+		const event = createMockEvent('1', { verdict: 'reject' });
+		(event.locals as { user?: unknown }).user = undefined;
+
+		await PATCH(event as Parameters<typeof PATCH>[0]);
+
+		expect(mockLogValues).toHaveBeenCalledWith(expect.objectContaining({ editor: null }));
+	});
+});
+
+describe('GET liefert die Status-Historie', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockLimit.mockResolvedValue([{ id: 1, verified: 1, approvedAt: new Date(), rejectedAt: null }]);
+		mockOrderBy.mockResolvedValue([]);
+	});
+
+	it('gibt die Einträge aufsteigend nach Zeitpunkt zurück', async () => {
+		const erster = new Date('2026-08-01T10:00:00Z');
+		const zweiter = new Date('2026-08-02T10:00:00Z');
+		mockOrderBy.mockResolvedValueOnce([
+			{ id: 1, verdict: 'reject', editor: 'a@example.com', recordedAt: erster },
+			{ id: 2, verdict: 'approve', editor: 'b@example.com', recordedAt: zweiter }
+		]);
+
+		const event = createMockEvent('1', {});
+		const response = await GET(event as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(body.history).toHaveLength(2);
+		expect(body.history[0]).toMatchObject({ verdict: 'reject', editor: 'a@example.com' });
+		expect(body.history[1]).toMatchObject({ verdict: 'approve', editor: 'b@example.com' });
+	});
+
+	it('gibt für den Altbestand eine leere Historie zurück, keinen Fehler', async () => {
+		const event = createMockEvent('1', {});
+		const response = await GET(event as Parameters<typeof GET>[0]);
+		const body = await response.json();
+
+		expect(response.status).toBe(200);
+		expect(body.history).toEqual([]);
 	});
 });

--- a/src/tests/contract/verify.contract.test.ts
+++ b/src/tests/contract/verify.contract.test.ts
@@ -11,11 +11,29 @@ import { asApiResponse } from './helpers/asApiResponse';
 // einzigen db.update(...).set(...)-Aufruf. Ein dritter Zustand "geprüft aber nicht
 // veröffentlicht" existiert nicht mehr. Der separate /approve-Endpunkt entfällt.
 
-const { mockSelectLimit, mockUpdateSet, mockUpdateWhere } = vi.hoisted(() => {
+const {
+	mockSelectLimit,
+	mockSelectOrderBy,
+	mockUpdate,
+	mockUpdateSet,
+	mockUpdateWhere,
+	mockLogValues
+} = vi.hoisted(() => {
 	const mockSelectLimit = vi.fn().mockResolvedValue([{ id: 1, verified: 0, approvedAt: null }]);
+	// Status-Historie des GET (B3): select().from().where().orderBy()
+	const mockSelectOrderBy = vi.fn().mockResolvedValue([]);
 	const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
 	const mockUpdateSet = vi.fn().mockReturnValue({ where: mockUpdateWhere });
-	return { mockSelectLimit, mockUpdateSet, mockUpdateWhere };
+	const mockUpdate = vi.fn().mockReturnValue({ set: mockUpdateSet });
+	const mockLogValues = vi.fn().mockResolvedValue(undefined);
+	return {
+		mockSelectLimit,
+		mockSelectOrderBy,
+		mockUpdate,
+		mockUpdateSet,
+		mockUpdateWhere,
+		mockLogValues
+	};
 });
 
 vi.mock('$lib/server/db', () => ({
@@ -23,13 +41,21 @@ vi.mock('$lib/server/db', () => ({
 		select: vi.fn().mockReturnValue({
 			from: vi.fn().mockReturnValue({
 				where: vi.fn().mockReturnValue({
-					limit: mockSelectLimit
+					limit: mockSelectLimit,
+					orderBy: mockSelectOrderBy
 				})
 			})
 		}),
-		update: vi.fn().mockReturnValue({
-			set: mockUpdateSet
-		})
+		update: mockUpdate,
+		// Statusspalten und Historien-Eintrag laufen in einer Transaktion (B3) —
+		// die Attrappe reicht dieselben Doubles durch, damit die Erwartung
+		// „genau ein set()" unverändert gilt.
+		transaction: vi.fn((callback: (tx: unknown) => unknown) =>
+			callback({
+				update: mockUpdate,
+				insert: vi.fn().mockReturnValue({ values: mockLogValues })
+			})
+		)
 	}
 }));
 
@@ -42,6 +68,13 @@ vi.mock('$lib/server/db/schema', async () => {
 			verified: 'verified',
 			rejectedAt: 'rejectedAt',
 			rejectedBy: 'rejectedBy'
+		},
+		sightingStatusLog: {
+			id: 'id',
+			sightingId: 'sightingId',
+			verdict: 'verdict',
+			editor: 'editor',
+			recordedAt: 'recordedAt'
 		}
 	});
 });
@@ -49,7 +82,8 @@ vi.mock('$lib/server/db/schema', async () => {
 vi.mock('drizzle-orm', async () => {
 	const { strictModuleMock } = await import('./helpers/strictModuleMock');
 	return strictModuleMock('drizzle-orm', {
-		eq: vi.fn((a, b) => ({ a, b }))
+		eq: vi.fn((a, b) => ({ a, b })),
+		asc: vi.fn((a) => ({ asc: a }))
 	});
 });
 
@@ -75,6 +109,8 @@ describe('Contract: PATCH /api/sightings/{id}/verify', () => {
 		mockSelectLimit.mockResolvedValue([{ id: 1, verified: 0, approvedAt: null }]);
 		mockUpdateWhere.mockResolvedValue(undefined);
 		mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+		mockUpdate.mockReturnValue({ set: mockUpdateSet });
+		mockSelectOrderBy.mockResolvedValue([]);
 	});
 
 	it('returns 200 verified=1 and satisfies the OpenAPI spec', async () => {
@@ -374,7 +410,7 @@ describe('Contract: GET /api/sightings/{id}/verify', () => {
 		expect(apiRes).toSatisfyApiSpec();
 	});
 
-	it('gibt id, verified, approvedAt und rejectedAt zurück', async () => {
+	it('gibt id, verified, approvedAt, rejectedAt und die Status-Historie zurück', async () => {
 		const event = createEvent('/api/sightings/1/verify', {
 			params: { id: '1' },
 			locals: { user: mockAdminUser }
@@ -386,7 +422,10 @@ describe('Contract: GET /api/sightings/{id}/verify', () => {
 			id: 1,
 			verified: 1,
 			approvedAt: '2026-01-01T00:00:00.000Z',
-			rejectedAt: null
+			rejectedAt: null,
+			// Leer ist der Normalfall des Altbestands (B3): Die Aufzeichnung
+			// beginnt mit der Tabelle, nicht mit der Sichtung.
+			history: []
 		});
 	});
 

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -373,8 +373,16 @@ paths:
     get:
       tags:
         - sightings
-      summary: Prüfstatus abrufen
-      description: Gibt den aktuellen Prüf- und Freigabestatus einer Sichtung zurück (Admin-Berechtigung erforderlich)
+      summary: Prüfstatus und Status-Historie abrufen
+      description: |
+        Gibt den aktuellen Prüf- und Freigabestatus einer Sichtung zurück sowie
+        die Historie aller über diesen Endpunkt getroffenen Entscheidungen
+        (Admin-Berechtigung erforderlich).
+
+        Die Historie beginnt mit ihrer Einführung: Sichtungen, deren Status aus
+        dem Altsystem stammt, liefern eine leere Liste. Das ist kein Fehler und
+        bedeutet nicht, dass nie entschieden wurde — der aktuelle Zustand steht
+        in `approvedAt`/`rejectedAt`.
       security:
         - adminAuth: []
       parameters:
@@ -398,6 +406,7 @@ paths:
                   - verified
                   - approvedAt
                   - rejectedAt
+                  - history
                 properties:
                   id:
                     type: integer
@@ -418,6 +427,13 @@ paths:
                     nullable: true
                     description: Zeitpunkt der Ablehnung; null wenn nicht abgelehnt
                     example: null
+                  history:
+                    type: array
+                    description: >
+                      Alle Statusentscheidungen, älteste zuerst. Leer für
+                      Sichtungen aus dem Altsystem.
+                    items:
+                      $ref: '#/components/schemas/SightingStatusLogEntry'
         '400':
           $ref: '#/components/responses/BadRequest'
         '302':
@@ -2416,6 +2432,38 @@ components:
         example: "1"
 
   schemas:
+    SightingStatusLogEntry:
+      type: object
+      description: >
+        Ein Eintrag der Status-Historie (`sichtung_status_log`). Geschrieben
+        ausschließlich von PATCH /api/sightings/{id}/verify, in derselben
+        Transaktion wie die Statusspalten.
+      required:
+        - id
+        - verdict
+        - editor
+        - recordedAt
+      properties:
+        id:
+          type: integer
+          example: 17
+        verdict:
+          type: string
+          enum: [approve, reject, reset]
+          description: Die getroffene Entscheidung
+          example: approve
+        editor:
+          type: string
+          nullable: true
+          description: >
+            Kennung des Bearbeiters — dieselbe wie in `freigegeben_von` /
+            `abgelehnt_von` (E-Mail-Adresse aus der Anmeldung). null, wenn keine
+            Identität bekannt war; es wird kein Platzhalter erfunden.
+          example: pruefer@example.com
+        recordedAt:
+          type: string
+          format: date-time
+          example: "2026-08-08T09:12:44.000Z"
     SpamRescoreReport:
       type: object
       required: [scored, skippedFailed, lastId, remaining, done, stalled, distribution]


### PR DESCRIPTION
Setzt **B3 — Status-Historie pro Sichtung** aus `docs/ADMIN_IMPROVEMENTS_SPEC.md` um.

## Was neu ist

Eine Tabelle `sichtung_status_log` (`sichtung_id`, `verdict`, `bearbeiter`, `zeitpunkt`) hält jede Statusentscheidung fest. In der Detailansicht steht sie als zugeklappte Zeitleiste direkt unter der Statusleiste — fachlich gehört sie zum Status, wird aber selten gebraucht; aufgeklappt schöbe sie alle Sichtungsdaten nach unten.

Die bestehenden Spalten (`freigegeben_am`, `abgelehnt_am`/`_von`) bleiben unverändert. Das Altsystem liegt auf derselben Datenbank und liest sie; die Historie ergänzt sie, sie ersetzt nichts.

## Die zwei Punkte, die die Spec vorab klären wollte

**Bearbeiter-Identität.** `bearbeiter` trägt dieselbe Kennung wie `abgelehnt_von`: die E-Mail-Adresse aus der Auth0-Anmeldung. Es entsteht damit keine neue Datenkategorie, nur eine längere Reihe derselben. Ohne angemeldete Identität bleibt die Spalte `NULL` statt einen Platzhalter zu behaupten — dieselbe Begründung wie bei `freigegeben_von`. Sichtbar ist die Historie ausschließlich im Admin-Bereich; sie hängt bewusst am admin-geschützten Verify-Endpunkt und nicht an `/api/sightings/[id]`.

**Aufbewahrung: keine eigene Frist.** Die Einträge hängen per `ON DELETE CASCADE` an der Sichtung und teilen deren Schicksal. Eine kürzere Frist würde die Historie genau dann leeren, wenn die Sichtung noch öffentlich steht, und die Frage „wer hat das freigegeben" unbeantwortbar machen — obwohl `freigegeben_von` sie weiterhin beantwortet. Eine eigene Frist wird erst sinnvoll, wenn die Sichtungen selbst eine bekommen; das ist der offene Punkt §2.1 in `docs/DATENSCHUTZ_ABGLEICH_DMM_2026-08-02.md`.

Beides ist am Tabellen-Docblock in `schema.ts`, in der Spec und in `.claude/rules/api.md` festgehalten.

## Warum eine eigene Tabelle neben `audit_logs`

Das Audit-Log hält denselben Vorgang bereits fest, taugt aber nicht als Anzeigequelle: `logAuditEvent` schluckt Schreibfehler bewusst, `details` ist formloses JSONB, und es gibt keinen Index auf `resource_id` — die Historie einer Sichtung wäre ein Full Scan über alle Aktionen aller Ressourcen.

## Der einzige Schreibweg, mechanisch abgesichert

Geschrieben wird ausschließlich von `PATCH /api/sightings/[id]/verify`, und zwar in **derselben Transaktion** wie die Statusspalten. Eine Historie, die einen stattgefundenen Wechsel verschweigt, sieht vollständig aus und ist es nicht — sie wäre damit schlechter als gar keine.

Dass es dabei bleibt, prüft `src/lib/server/db/statusLogWriteScan.test.ts`: ein Scan über `src/`, der jeden Schreibzugriff außerhalb des Endpunkts meldet, mit konstruierten Positiv- und Gegenproben statt eines Laufs über den konformen Bestand. Lesen bleibt überall erlaubt. Die Kontrolle „ein zweiter Schreibweg fällt beim Review auf" hat in diesem Repo zweimal versagt (`freigegeben_am` in #701, `geprueft` im `verifiedReadScan`) — deshalb hier von Anfang an ein Scan.

## Drei Dinge aus dem Review

**Ladefehler ≠ Altbestand.** Der `load` fängt Fehler ab, damit ein Ausfall der Historie nicht die ganze Seite kostet. Fiele er stumm auf `[]` zurück, zeigte die Zeitleiste den Altbestands-Satz („Die Aufzeichnung beginnt mit der Einführung…") — eine falsche Tatsachenbehauptung über einen Datensatz, der sehr wohl Einträge hat. Das ist derselbe Fehlermodus, gegen den das Feature antritt. Es gibt deshalb einen dritten Zustand: „Die Historie konnte nicht geladen werden … ob Einträge vorliegen, ist damit offen." Wer nichts weiß, soll wissen, dass er nichts weiß.

**CHECK statt pgEnum.** `verdict` ist `varchar(16)`; ein Fremdwert (manuelles SQL, Altsystem) käme ungeprüft bis in die Zeitleiste und fiele dort still auf „Offen"/`badge-warning` zurück — eine abgelehnte Sichtung sähe aus wie eine unbearbeitete. Ein `CHECK (verdict IN (…))` hat dieselbe Wirkung wie ein Enum, ohne dessen `ALTER TYPE`-Falle in einer Datenbank, die ein zweites System mitbenutzt. Verifiziert: ein Insert mit Fremdwert wird abgewiesen.

**A11y-Lücke.** DaisyUIs `collapse-title` an einem `<summary>` wird als namenloses `group` exponiert, die Zusammenfassung selbst nur als `generic` — ein Screenreader hätte den Bereich gar nicht gemeldet. Das `details` trägt jetzt ein `aria-label` mit demselben Text wie die sichtbare Beschriftung (WCAG 2.5.3).

## Tests

Test-First gefahren (RED → GREEN) für Endpunkt, Zeitleiste und `load`.

- `npm run test:quick`: 4012 Unit-Tests, Lint, Types, svelte-check — grün
- Browser-Komponententests `src/lib/components/admin/`: 52 — grün
- E2E `admin-status-history.spec.ts` fährt die ganze Strecke: Klick auf „Freigeben" bis zum Eintrag in der Zeitleiste. Zusammen mit `admin-detail-actions` und `admin-sighting-status`: 5 — grün
- Die Guards `approvalPredicateScan.test.ts` und `verifiedReadScan.test.ts` bleiben grün
- Migration `drizzle/0007_aspiring_meteorite.sql` ist committet (CI `migration-check`), `static/openapi.yml` mitgezogen und validiert

## Was ein Reviewer wissen sollte

Für Bestandsdaten ist die Historie leer — die Aufzeichnung beginnt mit dieser Tabelle, nicht mit der Sichtung. Die 19.262 Freigaben aus dem Altsystem haben deshalb keinen Eintrag; die Zeitleiste sagt das ausdrücklich, weil eine wortlos leere Liste sich als „nie bearbeitet" läse.

`history` ist nicht limitiert. Bei wenigen Entscheidungen pro Sichtung ist das praktisch unkritisch, aber es ist eine bewusste Auslassung, keine Übersehung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
