### PR TITLE
feat(admin): gespeicherte Filteransichten für die Sichtungstabelle (Spec B4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,6 +530,13 @@ jobs:
             # Shard. Lokal 1 Test, ~2 s — er legt sich seine Sichtung selbst an
             # und räumt sie per ON DELETE CASCADE wieder weg.
             e2e/admin-status-history.spec.ts
+            # Nach derselben Regel wie die Admin-Specs darüber: `form` ist laut
+            # der Messung oben weiterhin der kürzeste Shard, und
+            # /admin/sichtungen kompiliert der dead-finding-Spec bereits kalt —
+            # der Aufschlag fällt hier kein weiteres Mal an. Lokal 4 Tests,
+            # ~12 s; die Presets liegen in `localStorage`, der Spec räumt sie
+            # in `beforeEach` selbst ab und braucht keine Testzeilen in der DB.
+            e2e/admin-filter-presets.spec.ts
           )
 
           # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des

--- a/docs/ADMIN_IMPROVEMENTS_SPEC.md
+++ b/docs/ADMIN_IMPROVEMENTS_SPEC.md
@@ -312,6 +312,30 @@ Query-String-Teilmenge aus `tableReturnUrl.ts`-Parameterliste. Verwaltung:
 anlegen aus aktuellem Zustand, umbenennen, löschen. Später optional
 serverseitig teilbar.
 
+**Umgesetzt (2026-08-08)** in `src/routes/admin/sichtungen/filterPresets.ts`
+(Logik, unit-getestet) plus Chip-Leiste in `+page.svelte`; E2E in
+`e2e/admin-filter-presets.spec.ts`.
+
+Drei Festlegungen, die die Spec offenlässt:
+
+- **`page` gehört nicht ins Preset.** `PRESET_PARAMETER` leitet sich aus
+  `TABELLEN_PARAMETER` ab und lässt genau diesen einen aus: Eine Ansicht
+  beschreibt eine Menge, keine Position darin — gespeichert stünde man beim
+  Anwenden auf Seite 7 einer inzwischen dreiseitigen Liste.
+- **Anwenden ersetzt den Filterzustand, es ergänzt ihn nicht.** Die Ziel-URL
+  wird von `/admin/sichtungen` aus neu gebaut; sonst bliebe ein davor aktiver
+  Filter (typisch: die Freitext-Suche) heimlich stehen, und die angezeigte
+  Menge wäre eine andere als die, auf deren Chip man geklickt hat.
+- **Aktiv ist abgeleitet, nicht gemerkt.** Der markierte Chip ergibt sich aus
+  dem Vergleich mit der aktuellen URL. Ein gemerkter „zuletzt geklickter Chip"
+  liefe bei Filterwechsel, Zurück-Button und geteiltem Link daneben.
+- **Namen sind eindeutig, ohne Rücksicht auf Groß-/Kleinschreibung.** Der Name
+  ist das einzige Unterscheidungsmerkmal der Chips; bei zwei gleichnamigen
+  entschiede die Reihenfolge, welche man anwendet. Abgelehnt wird sichtbar per
+  Toast — ein stilles `return` ließe den Knopf wirkungslos aussehen. Den leeren
+  Namen fängt das `required` am Feld ab, also die Browser-Meldung dort, wo die
+  Eingabe entsteht.
+
 ### B5 — Statistik: Jahresfilter + echte Charts
 
 Jahres-Auswahl (URL-Parameter) für alle Abschnitte; Saisonalität und

--- a/e2e/admin-filter-presets.spec.ts
+++ b/e2e/admin-filter-presets.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * admin-filter-presets.spec.ts — gespeicherte Filteransichten (Spec B4).
+ *
+ * Die Preset-Logik selbst (Serialisierung, Vergleich, tolerantes Parsen) ist in
+ * `src/routes/admin/sichtungen/filterPresets.test.ts` als Unit-Test abgedeckt.
+ * Hier läuft nur die Strecke, die dort nicht prüfbar ist: dass die Chips den
+ * Filterzustand aus der **URL** aufnehmen, dass ein Klick wirklich navigiert,
+ * dass die aktive Ansicht markiert wird — und dass das Ganze einen Neuaufbau
+ * der Seite überlebt, also tatsächlich in `localStorage` liegt.
+ */
+
+/**
+ * Öffnet das Formular „Ansicht speichern" und trägt den Namen ein.
+ *
+ * Der Klick läuft in `toPass`, nicht einfach direkt: Die Leiste kommt aus dem
+ * SSR-Durchlauf, der Knopf ist also sichtbar und klickbar, **bevor** die
+ * Hydration seinen `onclick` angehängt hat. Ein einzelner Klick landet dann im
+ * Leeren, und der Test scheitert an der ausbleibenden Eingabezeile — mit einer
+ * Fehlermeldung, die nach einem kaputten Feature aussieht statt nach einem
+ * Timing-Problem.
+ */
+async function ansichtAnlegen(page: import('@playwright/test').Page, name: string): Promise<void> {
+	const nameFeld = page.getByLabel('Name der Ansicht');
+	await expect(async () => {
+		await page.getByRole('button', { name: 'Ansicht speichern' }).click();
+		await expect(nameFeld).toBeVisible({ timeout: 1000 });
+	}).toPass();
+	await nameFeld.fill(name);
+	await page.getByRole('button', { name: 'Speichern', exact: true }).click();
+}
+
+test.describe('Admin-Sichtungstabelle — gespeicherte Filteransichten', () => {
+	test.beforeEach(async ({ page, context, baseURL }) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+		/* Sauberer Ausgangszustand: Die Ansichten sind pro Browser gespeichert,
+		   ein Rest aus einem vorherigen Lauf ließe die Zählungen unten wandern. */
+		await page.goto('/admin/sichtungen');
+		await page.evaluate(() => window.localStorage.removeItem('admin.sichtungen.filterPresets'));
+	});
+
+	test('speichert den aktuellen Filterzustand, wendet ihn an und markiert ihn', async ({
+		page
+	}) => {
+		await page.goto('/admin/sichtungen?verified=open');
+
+		await ansichtAnlegen(page, 'Offene Meldungen');
+
+		const chip = page.getByRole('button', { name: 'Offene Meldungen' });
+		await expect(chip).toBeVisible();
+		// Die URL trägt den Filter, den das Preset beschreibt → aktiv markiert.
+		await expect(chip).toHaveAttribute('aria-current', 'true');
+
+		// Ein anderer Filterzustand hebt die Markierung auf …
+		await page.goto('/admin/sichtungen?verified=approved');
+		await expect(chip).not.toHaveAttribute('aria-current', 'true');
+
+		// … und ein Klick auf den Chip stellt den gespeicherten Zustand her.
+		await chip.click();
+		await expect(page).toHaveURL(/verified=open/);
+		await expect(chip).toHaveAttribute('aria-current', 'true');
+	});
+
+	test('überlebt einen Neuaufbau der Seite', async ({ page }) => {
+		await page.goto('/admin/sichtungen?deadFinding=1');
+		await ansichtAnlegen(page, 'Totfunde');
+		await expect(page.getByRole('button', { name: 'Totfunde' })).toBeVisible();
+
+		await page.reload();
+		await expect(page.getByRole('button', { name: 'Totfunde' })).toBeVisible();
+	});
+
+	test('lehnt einen bereits vergebenen Namen sichtbar ab', async ({ page }) => {
+		await page.goto('/admin/sichtungen?verified=open');
+		await ansichtAnlegen(page, 'Offene Meldungen');
+		await expect(page.getByRole('button', { name: 'Offene Meldungen' })).toHaveCount(1);
+
+		/* Anderer Filter, gleicher Name — und bewusst in anderer Schreibweise:
+		   Groß-/Kleinschreibung unterscheidet zwei Chips nicht brauchbar. */
+		await page.goto('/admin/sichtungen?deadFinding=1');
+		await ansichtAnlegen(page, 'offene meldungen');
+
+		await expect(page.getByText('Es gibt bereits eine Ansicht')).toBeVisible();
+		/* `exact`, weil `getByRole` sonst ohne Rücksicht auf Groß-/Kleinschreibung
+		   vergleicht — die abgelehnte Schreibweise träfe dann den vorhandenen Chip. */
+		await expect(page.getByRole('button', { name: 'offene meldungen', exact: true })).toHaveCount(
+			0
+		);
+		await expect(page.getByRole('button', { name: 'Offene Meldungen', exact: true })).toHaveCount(
+			1
+		);
+	});
+
+	test('benennt eine Ansicht um und löscht sie', async ({ page }) => {
+		await page.goto('/admin/sichtungen?verified=open');
+		await ansichtAnlegen(page, 'Erster Name');
+
+		/* `getByLabel` statt `getByRole('button')`: Das Verwalten-Element ist ein
+		   `summary` (DaisyUI-Dropdown wie die Spaltenauswahl daneben) und trägt
+		   deshalb nicht die Rolle `button`. */
+		await page.getByLabel('Ansicht „Erster Name“ verwalten').click();
+		await page.getByRole('button', { name: 'Umbenennen' }).click();
+		await page.getByLabel('Ansicht umbenennen').fill('Zweiter Name');
+		await page.getByRole('button', { name: 'Übernehmen' }).click();
+
+		await expect(page.getByRole('button', { name: 'Zweiter Name' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Erster Name' })).toHaveCount(0);
+
+		await page.getByLabel('Ansicht „Zweiter Name“ verwalten').click();
+		/* `exact`, sonst trifft der Name auch die „Eintrag löschen"-Knöpfe der
+		   Tabellenzeilen darunter. */
+		await page.getByRole('button', { name: 'Löschen', exact: true }).click();
+		await expect(page.getByRole('button', { name: 'Zweiter Name' })).toHaveCount(0);
+
+		// Auch das Löschen ist persistiert, nicht nur im Speicher der Seite.
+		await page.reload();
+		await expect(page.getByRole('button', { name: 'Zweiter Name' })).toHaveCount(0);
+	});
+});

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -92,6 +92,8 @@
 	import ShieldCheck from '~icons/lucide/shield-check';
 	import Ship from '~icons/lucide/ship';
 	import SkipForward from '~icons/lucide/skip-forward';
+	import BookmarkPlus from '~icons/lucide/bookmark-plus';
+	import EllipsisVertical from '~icons/lucide/ellipsis-vertical';
 	import Skull from '~icons/lucide/skull';
 	import Smartphone from '~icons/lucide/smartphone';
 	import SquarePen from '~icons/lucide/square-pen';
@@ -123,6 +125,8 @@
 		'lucide:mail': Mail,
 		'lucide:eye': Eye,
 		'lucide:trash-2': Trash2,
+		'lucide:bookmark-plus': BookmarkPlus,
+		'lucide:ellipsis-vertical': EllipsisVertical,
 		'lucide:settings': Settings,
 		'lucide:alert-circle': AlertCircle,
 		'lucide:check': Check,

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -44,6 +44,18 @@
 		loadColumnPreferences,
 		serializeColumnPreferences
 	} from './columnPreferences';
+	import {
+		addFilterPreset,
+		capturePresetParams,
+		FILTER_PRESETS_STORAGE_KEY,
+		loadFilterPresets,
+		matchesPreset,
+		presetUrl,
+		removeFilterPreset,
+		renameFilterPreset,
+		serializeFilterPresets,
+		type FilterPreset
+	} from './filterPresets';
 	import { getHeaderState, isSameIdList, setAllSelected, toggleSelection } from './bulkSelection';
 	import { buildBulkSummary, runBulkVerdict } from './bulkVerdict';
 
@@ -151,6 +163,124 @@
 			hatGespeicherteSpaltenGeladen = true;
 		}
 	});
+
+	/* Gespeicherte Filteransichten (Spec B4). Persistenz wie bei der
+	   Spaltenauswahl in `localStorage`, aber ohne Rückschreib-`$effect`:
+	   Ansichten ändern sich nur durch eine ausdrückliche Bedienung (anlegen,
+	   umbenennen, löschen), und jede dieser Funktionen speichert selbst. Ein
+	   Effect müsste stattdessen einen ersten Durchlauf ausklammern, um den
+	   geladenen Stand nicht sofort zurückzuschreiben — die Sonderregel, die bei
+	   den Spalten nötig ist, weil dort jede Checkbox den State ändert. */
+	let filterPresets = $state<FilterPreset[]>([]);
+	/* Nicht per `bind:open` an ein `details`: Nach dem Speichern soll das
+	   Formular zugehen, und dafür braucht es einen State, den der Handler
+	   setzen kann. */
+	let zeigeAnsichtFormular = $state(false);
+	let neueAnsichtName = $state('');
+	/* id der Ansicht, die gerade umbenannt wird — `null` heißt: keine. */
+	let umbenennenId = $state<string | null>(null);
+	let umbenennenName = $state('');
+	/* Element-Referenzen, um den Fokus in die frisch eingeblendete Eingabezeile
+	   zu setzen: Ohne das bliebe er am verschwundenen Auslöser hängen, und wer
+	   per Tastatur arbeitet, müsste sich zurück zum Feld tabben. */
+	let neueAnsichtFeld = $state<HTMLInputElement | null>(null);
+	let umbenennenFeld = $state<HTMLInputElement | null>(null);
+
+	/* Ohne Lade-Wächter: Der Effect liest keinen reaktiven Wert, läuft also
+	   genau einmal. Ein `typeof window`-Guard entfällt aus demselben Grund —
+	   Effects laufen im SSR-Durchlauf nicht.
+
+	   try/catch aus demselben Grund wie bei der Spaltenauswahl: `localStorage`
+	   kann per Browser-Policy werfen. Ohne Storage läuft die Seite dann ohne
+	   gespeicherte Ansichten weiter, statt beim Hydratisieren zu crashen. */
+	$effect(() => {
+		try {
+			filterPresets = loadFilterPresets(window.localStorage.getItem(FILTER_PRESETS_STORAGE_KEY));
+		} catch (err) {
+			logger.warn({ err }, 'Filteransichten können nicht gelesen werden — Storage nicht verfügbar');
+		}
+	});
+
+	$effect(() => {
+		neueAnsichtFeld?.focus();
+	});
+
+	$effect(() => {
+		umbenennenFeld?.focus();
+	});
+
+	function speichereAnsichten(): void {
+		if (typeof window === 'undefined') return;
+		try {
+			window.localStorage.setItem(
+				FILTER_PRESETS_STORAGE_KEY,
+				serializeFilterPresets(filterPresets)
+			);
+		} catch (err) {
+			logger.warn(
+				{ err },
+				'Filteransichten können nicht gespeichert werden — Storage nicht verfügbar'
+			);
+			toast.error('Die Ansicht konnte nicht dauerhaft gespeichert werden.');
+		}
+	}
+
+	/* Aktive Ansicht aus der URL abgeleitet, nicht als eigener State: Der
+	   Filterzustand steht in der URL, und ein zweiter gemerkter „zuletzt
+	   geklickter Chip" liefe bei jedem Filterwechsel, Zurück-Button oder
+	   geteilten Link daneben. */
+	let aktiveAnsichtId = $derived(
+		filterPresets.find((preset) => matchesPreset(preset, page.url))?.id ?? null
+	);
+
+	function ansichtAnwenden(preset: FilterPreset): void {
+		goto(presetUrl(preset, page.url));
+	}
+
+	function ansichtSpeichern(event: SubmitEvent): void {
+		event.preventDefault();
+		/* Aus der URL, nicht aus den Feld-States: Gespeichert gehört die Menge,
+		   die die Tabelle gerade zeigt — nicht eine im Filter-Panel getippte,
+		   aber nie angewendete. Derselbe Grund wie bei `currentFilters`. */
+		const neu = addFilterPreset(filterPresets, neueAnsichtName, capturePresetParams(page.url));
+		/* Unveränderte Liste heißt: Name schon vergeben. Der leere Name kann hier
+		   nicht mehr ankommen — den fängt das `required` am Feld ab, samt
+		   Browser-Meldung am Feld selbst. Ein stilles `return` wäre an beiden
+		   Stellen falsch: Der Knopf täte dann sichtbar nichts. */
+		if (neu === filterPresets) {
+			toast.error(`Es gibt bereits eine Ansicht „${neueAnsichtName.trim()}".`);
+			return;
+		}
+		filterPresets = neu;
+		speichereAnsichten();
+		neueAnsichtName = '';
+		zeigeAnsichtFormular = false;
+	}
+
+	function umbenennenStarten(preset: FilterPreset): void {
+		umbenennenId = preset.id;
+		umbenennenName = preset.name;
+	}
+
+	function umbenennenBestaetigen(event: SubmitEvent): void {
+		event.preventDefault();
+		if (!umbenennenId) return;
+		const neu = renameFilterPreset(filterPresets, umbenennenId, umbenennenName);
+		// Gleiche Begründung wie beim Anlegen: unverändert = Name schon vergeben.
+		if (neu === filterPresets) {
+			toast.error(`Es gibt bereits eine Ansicht „${umbenennenName.trim()}".`);
+			return;
+		}
+		filterPresets = neu;
+		speichereAnsichten();
+		umbenennenId = null;
+	}
+
+	function ansichtLoeschen(preset: FilterPreset): void {
+		filterPresets = removeFilterPreset(filterPresets, preset.id);
+		speichereAnsichten();
+		if (umbenennenId === preset.id) umbenennenId = null;
+	}
 
 	// Available columns configuration
 	const availableColumns = [
@@ -796,6 +926,129 @@
 			</label>
 			<button type="submit" class="btn btn-sm btn-outline">Suchen</button>
 		</form>
+
+		<!--
+			Gespeicherte Filteransichten (Spec B4). Über der Tabelle statt im
+			Filter-Panel: Eine Ansicht anzuwenden ist ein Sprung, kein
+			Filter-Detail — sie muss ohne Aufklappen erreichbar sein, wie die
+			Freitext-Suche darüber.
+
+			Echte `btn` statt klickbar gemachter `badge`: Nur `.btn` bekommt über
+			app.css die 44px-Touch-Target-Mindestgröße (design-system.md
+			„Feldmodus und Touch-Targets"); ein `badge` bliebe bei ~24px.
+			Die aktive Ansicht trägt `btn-primary` — sie ist die einzige
+			Vollton-Fläche der Leiste, alle übrigen sind `btn-outline`, damit
+			„aktiv" nicht mit „auswählbar" verschwimmt (Button-Hierarchie).
+			`aria-current="true"` sagt dasselbe für Screenreader, die die Farbe
+			nicht sehen.
+		-->
+		<div class="mt-3 flex flex-wrap items-center gap-2">
+			<span class="text-support text-base-content/70">Ansichten:</span>
+
+			{#each filterPresets as preset (preset.id)}
+				{#if umbenennenId === preset.id}
+					<form class="flex items-center gap-1" onsubmit={umbenennenBestaetigen}>
+						<label class="sr-only" for="ansicht-umbenennen">Ansicht umbenennen</label>
+						<input
+							id="ansicht-umbenennen"
+							class="input input-sm w-40"
+							bind:this={umbenennenFeld}
+							bind:value={umbenennenName}
+							maxlength="40"
+							required
+						/>
+						<button type="submit" class="btn btn-sm btn-primary">Übernehmen</button>
+						<button
+							type="button"
+							class="btn btn-sm btn-ghost"
+							onclick={() => (umbenennenId = null)}
+						>
+							Abbrechen
+						</button>
+					</form>
+				{:else}
+					<div class="join">
+						<button
+							type="button"
+							class="btn btn-sm join-item {aktiveAnsichtId === preset.id
+								? 'btn-primary'
+								: 'btn-outline'}"
+							aria-current={aktiveAnsichtId === preset.id ? 'true' : undefined}
+							onclick={() => ansichtAnwenden(preset)}
+						>
+							{preset.name}
+						</button>
+						<!-- Verwalten im Dropdown, nicht als zwei weitere Chips: Umbenennen und
+						     Löschen sind seltene Aktionen und würden die Leiste sonst mit jeder
+						     gespeicherten Ansicht verdreifachen. -->
+						<details class="dropdown dropdown-end join-item">
+							<summary
+								class="btn btn-sm btn-outline join-item"
+								aria-label="Ansicht „{preset.name}“ verwalten"
+								title="Umbenennen oder löschen"
+							>
+								<Icon icon="lucide:ellipsis-vertical" class="h-4 w-4" aria-hidden="true" />
+							</summary>
+							<ul
+								class="dropdown-content menu bg-base-100 rounded-box border-base-300 z-[1] mt-1 w-44 border p-2 shadow-lg"
+							>
+								<li>
+									<button type="button" onclick={() => umbenennenStarten(preset)}>
+										<Icon icon="lucide:square-pen" class="h-4 w-4" aria-hidden="true" />
+										Umbenennen
+									</button>
+								</li>
+								<li>
+									<button type="button" class="text-error" onclick={() => ansichtLoeschen(preset)}>
+										<Icon icon="lucide:trash-2" class="h-4 w-4" aria-hidden="true" />
+										Löschen
+									</button>
+								</li>
+							</ul>
+						</details>
+					</div>
+				{/if}
+			{/each}
+
+			{#if zeigeAnsichtFormular}
+				<form class="flex items-center gap-1" onsubmit={ansichtSpeichern}>
+					<label class="sr-only" for="ansicht-name">Name der Ansicht</label>
+					<!-- `required` statt einer eigenen Prüfung: Die Browser-Constraint-
+					     Validierung meldet den leeren Namen am Feld selbst, dort wo er
+					     entsteht. Ohne sie täte der Speichern-Knopf sichtbar nichts. -->
+					<input
+						id="ansicht-name"
+						class="input input-sm w-44"
+						bind:this={neueAnsichtFeld}
+						bind:value={neueAnsichtName}
+						placeholder="z. B. Offene Totfunde"
+						maxlength="40"
+						required
+					/>
+					<button type="submit" class="btn btn-sm btn-primary">Speichern</button>
+					<button
+						type="button"
+						class="btn btn-sm btn-ghost"
+						onclick={() => {
+							zeigeAnsichtFormular = false;
+							neueAnsichtName = '';
+						}}
+					>
+						Abbrechen
+					</button>
+				</form>
+			{:else}
+				<button
+					type="button"
+					class="btn btn-sm btn-ghost"
+					onclick={() => (zeigeAnsichtFormular = true)}
+					title="Aktuelle Filter als benannte Ansicht speichern"
+				>
+					<Icon icon="lucide:bookmark-plus" class="mr-1 h-4 w-4" aria-hidden="true" />
+					Ansicht speichern
+				</button>
+			{/if}
+		</div>
 	</div>
 
 	<!-- Filter Panel -->

--- a/src/routes/admin/sichtungen/filterPresets.test.ts
+++ b/src/routes/admin/sichtungen/filterPresets.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from 'vitest';
+import { TABELLEN_PARAMETER } from '../[id]/tableReturnUrl';
+import {
+	addFilterPreset,
+	capturePresetParams,
+	FILTER_PRESETS_STORAGE_KEY,
+	loadFilterPresets,
+	matchesPreset,
+	PRESET_PARAMETER,
+	presetUrl,
+	removeFilterPreset,
+	renameFilterPreset,
+	serializeFilterPresets,
+	type FilterPreset
+} from './filterPresets';
+
+const BASIS = 'https://localhost:4000/admin/sichtungen';
+
+function preset(name: string, params: Record<string, string>): FilterPreset {
+	return { id: `id-${name}`, name, params };
+}
+
+describe('PRESET_PARAMETER', () => {
+	it('leitet sich aus TABELLEN_PARAMETER ab, statt die Liste zu duplizieren', () => {
+		// Jeder Preset-Parameter muss auch ein Tabellen-Parameter sein — sonst
+		// speicherte ein Preset etwas, das die Tabelle gar nicht liest.
+		for (const param of PRESET_PARAMETER) {
+			expect(TABELLEN_PARAMETER).toContain(param);
+		}
+	});
+
+	it('lässt genau `page` aus', () => {
+		const fehlend = TABELLEN_PARAMETER.filter(
+			(param) => !(PRESET_PARAMETER as readonly string[]).includes(param)
+		);
+		expect(fehlend).toEqual(['page']);
+	});
+});
+
+describe('capturePresetParams', () => {
+	it('übernimmt gesetzte Tabellen-Parameter', () => {
+		const url = new URL(`${BASIS}?verified=open&deadFinding=1&sort=sightingDate&order=desc`);
+		expect(capturePresetParams(url)).toEqual({
+			verified: 'open',
+			deadFinding: '1',
+			sort: 'sightingDate',
+			order: 'desc'
+		});
+	});
+
+	it('ignoriert leere Werte und fremde Parameter', () => {
+		const url = new URL(`${BASIS}?verified=&q=Fahrwasser&unbekannt=x`);
+		expect(capturePresetParams(url)).toEqual({ q: 'Fahrwasser' });
+	});
+
+	it('ignoriert die Seitenzahl', () => {
+		const url = new URL(`${BASIS}?verified=open&page=7`);
+		expect(capturePresetParams(url)).toEqual({ verified: 'open' });
+	});
+});
+
+describe('presetUrl', () => {
+	it('baut die Tabellen-URL mit den gespeicherten Parametern', () => {
+		const url = new URL(
+			presetUrl(preset('Offen', { verified: 'open' }), new URL(`${BASIS}?q=alt`))
+		);
+		expect(url.pathname).toBe('/admin/sichtungen');
+		expect(url.searchParams.get('verified')).toBe('open');
+	});
+
+	it('verwirft Filter, die das Preset nicht trägt', () => {
+		const url = new URL(
+			presetUrl(preset('Offen', { verified: 'open' }), new URL(`${BASIS}?q=alt&deadFinding=1`))
+		);
+		expect(url.searchParams.get('q')).toBeNull();
+		expect(url.searchParams.get('deadFinding')).toBeNull();
+	});
+
+	it('springt auf Seite 1', () => {
+		const url = new URL(
+			presetUrl(preset('Offen', { verified: 'open' }), new URL(`${BASIS}?page=7`))
+		);
+		expect(url.searchParams.get('page')).toBe('1');
+	});
+});
+
+describe('matchesPreset', () => {
+	it('erkennt den exakt passenden Zustand', () => {
+		const p = preset('Offen', { verified: 'open' });
+		expect(matchesPreset(p, new URL(`${BASIS}?verified=open`))).toBe(true);
+	});
+
+	it('ignoriert die Seitenzahl beim Vergleich', () => {
+		const p = preset('Offen', { verified: 'open' });
+		expect(matchesPreset(p, new URL(`${BASIS}?verified=open&page=3`))).toBe(true);
+	});
+
+	it('passt nicht, wenn ein zusätzlicher Filter aktiv ist', () => {
+		const p = preset('Offen', { verified: 'open' });
+		expect(matchesPreset(p, new URL(`${BASIS}?verified=open&deadFinding=1`))).toBe(false);
+	});
+
+	it('passt nicht bei abweichendem Wert', () => {
+		const p = preset('Offen', { verified: 'open' });
+		expect(matchesPreset(p, new URL(`${BASIS}?verified=approved`))).toBe(false);
+	});
+
+	it('passt auf die ungefilterte Tabelle, wenn das Preset leer ist', () => {
+		const p = preset('Alle', {});
+		expect(matchesPreset(p, new URL(BASIS))).toBe(true);
+		expect(matchesPreset(p, new URL(`${BASIS}?q=x`))).toBe(false);
+	});
+});
+
+describe('loadFilterPresets', () => {
+	it('liest ein gespeichertes, versioniertes Format', () => {
+		const raw = serializeFilterPresets([preset('Offen', { verified: 'open' })]);
+		expect(loadFilterPresets(raw)).toEqual([
+			{ id: 'id-Offen', name: 'Offen', params: { verified: 'open' } }
+		]);
+	});
+
+	it('serialisiert mit Version', () => {
+		expect(JSON.parse(serializeFilterPresets([])).v).toBe(1);
+	});
+
+	it('gibt bei fehlendem Wert eine leere Liste zurück', () => {
+		expect(loadFilterPresets(null)).toEqual([]);
+	});
+
+	it('gibt bei kaputtem JSON eine leere Liste zurück', () => {
+		expect(loadFilterPresets('{nicht json')).toEqual([]);
+	});
+
+	it('verwirft eine fremde Version', () => {
+		expect(loadFilterPresets(JSON.stringify({ v: 99, presets: [preset('X', {})] }))).toEqual([]);
+	});
+
+	it('überspringt einzelne unbrauchbare Einträge, statt alles zu verwerfen', () => {
+		const raw = JSON.stringify({
+			v: 1,
+			presets: [
+				{ id: 'a', name: 'Gut', params: { verified: 'open' } },
+				{ id: 'b', name: '' },
+				'kaputt',
+				{ id: 'c', name: 'AuchGut', params: { fremd: 'x', q: 'ja' } }
+			]
+		});
+		expect(loadFilterPresets(raw)).toEqual([
+			{ id: 'a', name: 'Gut', params: { verified: 'open' } },
+			{ id: 'c', name: 'AuchGut', params: { q: 'ja' } }
+		]);
+	});
+
+	it('verwirft nicht-string Parameterwerte', () => {
+		const raw = JSON.stringify({
+			v: 1,
+			presets: [{ id: 'a', name: 'Gut', params: { verified: 3, q: 'ja' } }]
+		});
+		expect(loadFilterPresets(raw)).toEqual([{ id: 'a', name: 'Gut', params: { q: 'ja' } }]);
+	});
+});
+
+describe('addFilterPreset', () => {
+	it('hängt ein Preset mit eigener id an', () => {
+		const [neu, ...rest] = addFilterPreset([], 'Offene Meldungen', { verified: 'open' });
+		expect(rest).toEqual([]);
+		expect(neu?.name).toBe('Offene Meldungen');
+		expect(neu?.params).toEqual({ verified: 'open' });
+		expect(neu?.id).toBeTruthy();
+	});
+
+	it('vergibt eindeutige ids', () => {
+		const ids = addFilterPreset(addFilterPreset([], 'A', {}), 'B', {}).map((p) => p.id);
+		expect(new Set(ids).size).toBe(2);
+	});
+
+	it('trimmt den Namen', () => {
+		expect(addFilterPreset([], '  Offen  ', {}).map((p) => p.name)).toEqual(['Offen']);
+	});
+
+	it('ignoriert einen leeren Namen', () => {
+		expect(addFilterPreset([], '   ', { verified: 'open' })).toEqual([]);
+	});
+
+	it('ignoriert einen bereits vergebenen Namen', () => {
+		const liste = [preset('Offen', { verified: 'open' })];
+		expect(addFilterPreset(liste, 'Offen', { deadFinding: '1' })).toBe(liste);
+	});
+
+	it('erkennt die Dublette unabhängig von Groß-/Kleinschreibung und Rand-Leerzeichen', () => {
+		const liste = [preset('Offen', {})];
+		expect(addFilterPreset(liste, '  offen ', {})).toBe(liste);
+	});
+
+	it('lässt die übergebene Liste unverändert', () => {
+		const original: FilterPreset[] = [];
+		addFilterPreset(original, 'A', {});
+		expect(original).toEqual([]);
+	});
+});
+
+describe('renameFilterPreset', () => {
+	it('benennt das passende Preset um', () => {
+		const liste = [preset('Alt', {}), preset('Anderes', {})];
+		expect(renameFilterPreset(liste, 'id-Alt', ' Neu ').map((p) => p.name)).toEqual([
+			'Neu',
+			'Anderes'
+		]);
+	});
+
+	it('ignoriert einen leeren Namen', () => {
+		const liste = [preset('Alt', {})];
+		expect(renameFilterPreset(liste, 'id-Alt', '  ')).toEqual(liste);
+	});
+
+	it('ignoriert den Namen einer anderen Ansicht', () => {
+		const liste = [preset('Alt', {}), preset('Anderes', {})];
+		expect(renameFilterPreset(liste, 'id-Alt', 'Anderes')).toBe(liste);
+	});
+
+	it('lässt das Umbenennen auf den eigenen Namen zu (etwa nur Groß-/Kleinschreibung)', () => {
+		const liste = [preset('Alt', {})];
+		expect(renameFilterPreset(liste, 'id-Alt', 'ALT').map((p) => p.name)).toEqual(['ALT']);
+	});
+
+	it('ignoriert eine unbekannte id', () => {
+		const liste = [preset('Alt', {})];
+		expect(renameFilterPreset(liste, 'fremd', 'Neu')).toEqual(liste);
+	});
+});
+
+describe('removeFilterPreset', () => {
+	it('entfernt das passende Preset', () => {
+		const liste = [preset('A', {}), preset('B', {})];
+		expect(removeFilterPreset(liste, 'id-A').map((p) => p.name)).toEqual(['B']);
+	});
+
+	it('ignoriert eine unbekannte id', () => {
+		const liste = [preset('A', {})];
+		expect(removeFilterPreset(liste, 'fremd')).toEqual(liste);
+	});
+});
+
+describe('FILTER_PRESETS_STORAGE_KEY', () => {
+	it('liegt im Admin-Namespace, nicht im Formular-Namespace', () => {
+		expect(FILTER_PRESETS_STORAGE_KEY).toMatch(/^admin\.sichtungen\./);
+	});
+});

--- a/src/routes/admin/sichtungen/filterPresets.ts
+++ b/src/routes/admin/sichtungen/filterPresets.ts
@@ -1,0 +1,194 @@
+/**
+ * Gespeicherte Filteransichten der Admin-Sichtungstabelle (Spec B4).
+ *
+ * Reine Serialisierungs-, Vergleichs- und Listenlogik ohne Zugriff auf
+ * `window` — wie in `columnPreferences.ts` entscheidet der Aufrufer, wann
+ * `localStorage` überhaupt erreichbar ist (SSR-Guard bleibt in der Seite).
+ *
+ * Format ist versioniert (`{ v: 1, presets: [...] }`), damit ein künftiger
+ * Formatwechsel den Altbestand gezielt verwerfen kann, statt ihn
+ * misszuinterpretieren.
+ */
+
+import { TABELLEN_PARAMETER } from '../[id]/tableReturnUrl';
+
+export const FILTER_PRESETS_STORAGE_KEY = 'admin.sichtungen.filterPresets';
+const CURRENT_VERSION = 1;
+
+/**
+ * Der speicherbare Teil des Query-Strings.
+ *
+ * Abgeleitet aus `TABELLEN_PARAMETER` statt daneben gepflegt: Diese Liste ist
+ * schon einmal auseinandergelaufen (siehe Kommentar in `tableReturnUrl.ts`),
+ * und ein Preset, das einen später hinzugekommenen Filter nicht mitspeichert,
+ * führt genauso still in die falsche Menge wie der Rückweg damals.
+ *
+ * Ausgenommen ist `page`: Eine Filteransicht beschreibt eine Menge, keine
+ * Position darin. Gespeichert stünde man beim Anwenden auf Seite 7 einer
+ * Liste, die inzwischen drei Seiten hat.
+ */
+export const PRESET_PARAMETER = TABELLEN_PARAMETER.filter((param) => param !== 'page');
+
+export interface FilterPreset {
+	id: string;
+	name: string;
+	params: Record<string, string>;
+}
+
+interface GespeichertesFormat {
+	v: number;
+	presets: FilterPreset[];
+}
+
+/** Liest die speicherbaren Filter aus einer URL. Leere Werte zählen als nicht gesetzt. */
+export function capturePresetParams(url: URL): Record<string, string> {
+	const params: Record<string, string> = {};
+	for (const param of PRESET_PARAMETER) {
+		const wert = url.searchParams.get(param);
+		if (wert) params[param] = wert;
+	}
+	return params;
+}
+
+/**
+ * Baut die Ziel-URL eines Presets.
+ *
+ * Bewusst von `/admin/sichtungen` aus neu aufgebaut statt die aktuelle URL zu
+ * ergänzen: Ein Preset soll den Filterzustand *ersetzen*. Würde man nur die
+ * gespeicherten Parameter setzen, bliebe ein davor aktiver Filter (etwa eine
+ * Freitext-Suche) heimlich stehen, und die angezeigte Menge wäre eine andere
+ * als die, auf deren Chip man geklickt hat.
+ */
+export function presetUrl(preset: FilterPreset, currentUrl: URL): string {
+	const zielUrl = new URL('/admin/sichtungen', currentUrl.origin);
+	for (const [key, wert] of Object.entries(preset.params)) {
+		zielUrl.searchParams.set(key, wert);
+	}
+	zielUrl.searchParams.set('page', '1');
+	return zielUrl.toString();
+}
+
+/** Markiert ein Preset als aktiv, wenn die URL exakt seine Filtermenge trägt. */
+export function matchesPreset(preset: FilterPreset, url: URL): boolean {
+	const aktuell = capturePresetParams(url);
+	const gespeichert = preset.params;
+	const schluessel = Object.keys(gespeichert);
+	if (schluessel.length !== Object.keys(aktuell).length) return false;
+	return schluessel.every((key) => aktuell[key] === gespeichert[key]);
+}
+
+/**
+ * Prüft einen einzelnen gespeicherten Eintrag und säubert seine Parameter.
+ * Unbekannte Parameter fliegen raus — sonst trüge ein Preset nach dem Entfernen
+ * eines Filters dauerhaft einen Wert mit, den die Tabelle nicht mehr liest.
+ */
+function parsePreset(kandidat: unknown): FilterPreset | null {
+	if (typeof kandidat !== 'object' || kandidat === null) return null;
+	const { id, name, params } = kandidat as Partial<FilterPreset>;
+	if (typeof id !== 'string' || !id) return null;
+	if (typeof name !== 'string' || !name.trim()) return null;
+	if (typeof params !== 'object' || params === null) return null;
+
+	const gesaeubert: Record<string, string> = {};
+	for (const param of PRESET_PARAMETER) {
+		const wert = (params as Record<string, unknown>)[param];
+		if (typeof wert === 'string' && wert) gesaeubert[param] = wert;
+	}
+	return { id, name: name.trim(), params: gesaeubert };
+}
+
+/**
+ * Parst den rohen `localStorage`-Wert. Kaputtes JSON oder eine fremde Version
+ * ergeben eine leere Liste; einzelne unbrauchbare Einträge werden übersprungen,
+ * statt die übrigen Ansichten mitzureißen.
+ */
+export function loadFilterPresets(raw: string | null): FilterPreset[] {
+	if (!raw) return [];
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return [];
+	}
+
+	if (typeof parsed !== 'object' || parsed === null) return [];
+	const format = parsed as Partial<GespeichertesFormat>;
+	if (format.v !== CURRENT_VERSION || !Array.isArray(format.presets)) return [];
+
+	return format.presets
+		.map(parsePreset)
+		.filter((preset): preset is FilterPreset => preset !== null);
+}
+
+/** Serialisiert die Liste in das versionierte Speicherformat. */
+export function serializeFilterPresets(presets: FilterPreset[]): string {
+	const format: GespeichertesFormat = { v: CURRENT_VERSION, presets };
+	return JSON.stringify(format);
+}
+
+/* `crypto.randomUUID` ist in Browsern und Node vorhanden, aber nur in sicheren
+   Kontexten garantiert — der Zähler-Fallback hält die Ansicht auch dort
+   benutzbar, statt beim Anlegen zu werfen. */
+let idZaehler = 0;
+function neueId(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	idZaehler += 1;
+	return `preset-${idZaehler}-${performance.now()}`;
+}
+
+/**
+ * Prüft, ob der Name schon an eine **andere** Ansicht vergeben ist.
+ *
+ * Der Name ist das einzige Unterscheidungsmerkmal der Chips — zwei gleich
+ * benannte Ansichten wären in der Leiste nicht auseinanderzuhalten, und welche
+ * von beiden man anwendet, entschiede die Reihenfolge. Verglichen wird
+ * unabhängig von Groß-/Kleinschreibung: „Offen" und „offen" sähen im Chip
+ * verschieden aus, meinen aber dasselbe und lösen das Problem nicht.
+ *
+ * `ausserId` klammert die Ansicht aus, die gerade umbenannt wird — sonst
+ * scheiterte das Ändern der reinen Schreibweise am eigenen Namen.
+ */
+function nameVergeben(presets: FilterPreset[], name: string, ausserId?: string): boolean {
+	const vergleich = name.toLocaleLowerCase();
+	return presets.some(
+		(preset) => preset.id !== ausserId && preset.name.toLocaleLowerCase() === vergleich
+	);
+}
+
+/**
+ * Legt ein Preset aus dem aktuellen Filterzustand an. Ein leerer oder bereits
+ * vergebener Name ergibt keine Ansicht; die Liste kommt dann **unverändert**
+ * (identische Referenz) zurück — daran erkennt der Aufrufer, dass er eine
+ * Rückmeldung geben muss.
+ */
+export function addFilterPreset(
+	presets: FilterPreset[],
+	name: string,
+	params: Record<string, string>
+): FilterPreset[] {
+	const getrimmt = name.trim();
+	if (!getrimmt || nameVergeben(presets, getrimmt)) return presets;
+	return [...presets, { id: neueId(), name: getrimmt, params }];
+}
+
+/**
+ * Benennt ein Preset um. Leerer Name, unbekannte id oder ein an eine andere
+ * Ansicht vergebener Name lassen die Liste unverändert.
+ */
+export function renameFilterPreset(
+	presets: FilterPreset[],
+	id: string,
+	name: string
+): FilterPreset[] {
+	const getrimmt = name.trim();
+	if (!getrimmt || nameVergeben(presets, getrimmt, id)) return presets;
+	return presets.map((preset) => (preset.id === id ? { ...preset, name: getrimmt } : preset));
+}
+
+/** Entfernt ein Preset. Eine unbekannte id lässt die Liste unverändert. */
+export function removeFilterPreset(presets: FilterPreset[], id: string): FilterPreset[] {
+	return presets.filter((preset) => preset.id !== id);
+}

--- a/src/routes/admin/sichtungen/filterPresets.ts
+++ b/src/routes/admin/sichtungen/filterPresets.ts
@@ -136,7 +136,7 @@ function neueId(): string {
 		return crypto.randomUUID();
 	}
 	idZaehler += 1;
-	return `preset-${idZaehler}-${performance.now()}`;
+	return `preset-${idZaehler}-${Date.now()}`;
 }
 
 /**
@@ -148,13 +148,19 @@ function neueId(): string {
  * unabhängig von Groß-/Kleinschreibung: „Offen" und „offen" sähen im Chip
  * verschieden aus, meinen aber dasselbe und lösen das Problem nicht.
  *
+ * `toLowerCase`, **nicht** `toLocaleLowerCase`: Die Locale-Variante richtet
+ * sich nach der Umgebung des Browsers, und im türkischen Gebietsschema wird
+ * aus „I" ein punktloses „ı" statt „i". Ob zwei Namen als gleich gelten,
+ * hinge damit davon ab, wer die Ansicht anlegt — dieselben zwei Namen wären
+ * für einen Bearbeiter eine Dublette und für den nächsten nicht.
+ *
  * `ausserId` klammert die Ansicht aus, die gerade umbenannt wird — sonst
  * scheiterte das Ändern der reinen Schreibweise am eigenen Namen.
  */
 function nameVergeben(presets: FilterPreset[], name: string, ausserId?: string): boolean {
-	const vergleich = name.toLocaleLowerCase();
+	const vergleich = name.toLowerCase();
 	return presets.some(
-		(preset) => preset.id !== ausserId && preset.name.toLocaleLowerCase() === vergleich
+		(preset) => preset.id !== ausserId && preset.name.toLowerCase() === vergleich
 	);
 }
 


### PR DESCRIPTION
Benannte Filter-Presets als Chips über der Admin-Sichtungstabelle
(`/admin/sichtungen`). Umsetzung von Abschnitt **B4** aus
`docs/ADMIN_IMPROVEMENTS_SPEC.md`.

Persistenz pro Bearbeiter in `localStorage`, kein DB-Schema — versioniertes
Format (`{ v: 1, presets: [...] }`) mit tolerantem Parsen: Kaputtes JSON oder
eine fremde Version ergeben eine leere Liste, einzelne unbrauchbare Einträge
werden übersprungen, statt die übrigen Ansichten mitzureißen.

## Drei Festlegungen, die die Spec offenließ

**`page` gehört nicht ins Preset.** `PRESET_PARAMETER` leitet sich per `filter`
aus `TABELLEN_PARAMETER` ab — die Konstante bleibt damit die einzige Quelle,
statt neben ihr eine zweite Liste zu pflegen (genau der Fehler, den der
Docblock in `tableReturnUrl.ts` dokumentiert). Ausgelassen wird genau `page`:
Eine Ansicht beschreibt eine Menge, keine Position darin — gespeichert stünde
man beim Anwenden auf Seite 7 einer inzwischen dreiseitigen Liste. Ein Test
hält fest, dass `page` der einzige ausgelassene Parameter ist, damit ein
künftig hinzukommender Filter nicht still aus den Presets fällt.

**Anwenden ersetzt den Filterzustand, es ergänzt ihn nicht.** Die Ziel-URL wird
von `/admin/sichtungen` aus neu gebaut. Ergänzte man nur, bliebe ein davor
aktiver Filter — typisch die Freitext-Suche im Kopf — heimlich stehen, und die
angezeigte Menge wäre eine andere als die, auf deren Chip man geklickt hat.

**Aktiv ist abgeleitet, nicht gemerkt.** Der markierte Chip ergibt sich aus dem
Vergleich mit `page.url`. Ein gemerkter „zuletzt geklickter Chip" liefe bei
Filterwechsel, Zurück-Button und geteiltem Link daneben.

Dazu: **Namen sind eindeutig**, ohne Rücksicht auf Groß-/Kleinschreibung — der
Name ist das einzige Unterscheidungsmerkmal der Chips, bei zwei gleichnamigen
entschiede die Reihenfolge, welche man anwendet. Abgelehnt wird sichtbar per
Toast; ein stilles `return` ließe den Knopf wirkungslos aussehen. Den leeren
Namen fängt das `required` am Feld ab, also die Browser-Meldung dort, wo die
Eingabe entsteht.

## Aufbau

Die gesamte Logik liegt in `src/routes/admin/sichtungen/filterPresets.ts` —
reine Funktionen ohne `window`-Zugriff, wie bei `columnPreferences.ts` daneben;
der SSR-Guard bleibt in der Seite. `+page.svelte` hält nur State und Markup.

Persistiert wird nicht per Rückschreib-`$effect`, sondern in den drei
Bedienfunktionen selbst: Anders als bei der Spaltenauswahl ändert sich hier
nichts nebenbei, also braucht es auch keine Sonderregel, die den ersten
Durchlauf ausklammert.

## Oberfläche

Die Leiste steht unter der Freitext-Suche, außerhalb des Filter-Panels — eine
Ansicht anzuwenden ist ein Sprung und soll ohne Aufklappen erreichbar sein.
Chips sind echte `.btn` (44-px-Touch-Target aus `app.css`; ein `badge` bliebe
bei ~24 px). Der aktive trägt `btn-primary` als einzige Vollton-Fläche der
Leiste plus `aria-current="true"` für alle, die die Farbe nicht sehen; die
übrigen sind `btn-outline`, damit „aktiv" nicht mit „auswählbar" verschwimmt.
Umbenennen und Löschen liegen pro Chip in einem Dropdown — als weitere Chips
verdreifachte jede gespeicherte Ansicht die Leiste. Beim Einblenden einer
Eingabezeile wandert der Fokus mit, statt am verschwundenen Auslöser zu bleiben.

`lucide:bookmark-plus` und `lucide:ellipsis-vertical` sind dafür in
`Icon.svelte` registriert.

## Tests

Test-First: `filterPresets.test.ts` lief rot (Modul nicht auffindbar), bevor
die Implementierung folgte; die Dubletten-Regel ebenso (3 rote Tests vorab).

- **35 Unit-Tests** über Erfassen, URL-Bau, Aktiv-Vergleich, Parsing-Kanten
  (kaputtes JSON, fremde Version, Schrott-Einträge, Nicht-String-Werte) und die
  Listenoperationen.
- **4 E2E-Tests** in `e2e/admin-filter-presets.spec.ts` über die Strecke, die
  im Unit-Test nicht prüfbar ist: Speichern aus der URL, Anwenden, Markierung,
  Neuaufbau der Seite, Dublette, Umbenennen und Löschen.
- `npm run test:quick`: 4082 Tests grün. `npm run check`: 0 Fehler.

Zwei Stolpersteine sind im Spec kommentiert, damit sie beim nächsten Mal nicht
wieder Zeit kosten: Der Speichern-Knopf kommt aus dem SSR-Durchlauf und ist
klickbar, bevor die Hydration seinen `onclick` angehängt hat (der Klick läuft
deshalb in `toPass`), und das Verwalten-Element ist ein `summary`, trägt also
nicht die Rolle `button`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
