### PR TITLE
feat(admin): Rückweg aus der Detailansicht kennt den Eingang

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -45,6 +45,36 @@ werden per 301 auf `/admin/sichtungen` umgeleitet. **Die Eingangsseite ist eine
 Task-Liste — keine Filter/Spalten dorthin bauen, dafür gibt es
 `/admin/sichtungen`.**
 
+### Der Rückweg aus der Detailansicht kennt zwei Ziele
+
+`/admin/[id]` wird aus der Tabelle **und** aus dem Eingang geöffnet. Woher,
+steht in der URL: Die Tabelle verrät sich über ihre Filter-Parameter, der
+Eingang über `?from=inbox` (`$lib/components/admin/adminReturn.ts`).
+`returnTarget()` in `[id]/tableReturnUrl.ts` wertet beides aus und liefert Ziel
+**und** Beschriftung; der Rückweg in den Eingang trägt zusätzlich den Anker
+`#sichtung-<id>` auf die Karte, von der man kam.
+
+Zwei Dinge dabei nicht zurückdrehen:
+
+- **Kein `history.back()`.** Die Detailansicht lädt per `invalidateAll()` neu,
+  löscht ggf. den Datensatz und führt über „Bearbeiten" weiter — der Eintrag
+  hinter uns ist danach nicht verlässlich derselbe. Ein URL-Parameter überlebt
+  Reload, Bookmark und Direktaufruf.
+- **Jede weiterführende Route reicht die Parameter durch** (`carryReturnParams`).
+  `edit/` sprang bis 2026-08 auf `/admin/${id}` ohne Query-String; damit verlor
+  schon der Weg Tabelle → Detail → Bearbeiten → zurück die Filter. Wer eine
+  weitere Unterroute anlegt, muss dasselbe tun — sonst endet der Rückweg dort.
+
+**Bekannte Ausnahme:** `/admin/ref/[refId]` leitet auf `/admin/${id}` ohne
+Query-String um und verwirft damit den Kontext. Das war vor dem Rückweg-Umbau
+schon so; der Einstieg dorthin kommt aus der Tabelle, deren Filter der Umweg
+ohnehin nicht kennt. Wer den Lookup anfasst, kann es mitziehen.
+
+Der Eingang führt außerdem **einen eigenen** Parameter: `order`. Er steht
+bewusst nicht in `istTabellenUrl` (`admin/tableRedirect.ts`) und darf beim
+Rückweg nach `/admin` als einziger mitgegeben werden — die übrigen
+TABELLEN_PARAMETER lösten dort sofort die 301 auf die Tabelle aus.
+
 ## Admin-Komponenten
 
 | Komponente                     | Zweck                                     |
@@ -53,6 +83,7 @@ Task-Liste — keine Filter/Spalten dorthin bauen, dafür gibt es
 | `AdminSightingView.svelte`     | Sichtung anzeigen (read-only)             |
 | `SightingInboxCard.svelte`     | Karte der Eingangsseite (`/admin`)        |
 | `inboxVerdict.ts`              | Verdict-Logik der Eingangsseite           |
+| `adminReturn.ts`               | Herkunft `?from=inbox` + Karten-Anker     |
 | `DataTableRow.svelte`          | Tabellen-Zeile                            |
 | `BooleanStatus.svelte`         | Boolean-Status Anzeige                    |
 | `ExportModal.svelte`           | Export-Dialog                             |

--- a/e2e/admin-inbox.spec.ts
+++ b/e2e/admin-inbox.spec.ts
@@ -98,6 +98,96 @@ test.describe('Admin-Eingangsseite', () => {
 		}
 	});
 
+	/* Der Rundweg Eingang → Detail → zurück. Bis 2026-08 führte der Zurück-Knopf
+	   der Detailansicht immer in die Tabelle: Die Eingangskarte verlinkte ohne
+	   jeden Parameter, und `tableReturnUrl` kannte nur ein Ziel. Wer eine Meldung
+	   prüfen wollte, verlor damit bei jedem Blick ins Detail seine Arbeitsliste.
+
+	   Lesend und ohne Fremdwirkung — es wird navigiert, nicht entschieden (siehe
+	   Kopf dieser Datei). */
+	test('führt aus der Detailansicht zurück in den Eingang, nicht in die Tabelle', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			/* `order=asc` statt des Defaults: Die Sortierung gehört dem Eingang und
+			   muss den Rundweg überleben — ohne sie stünde die Liste danach wieder
+			   auf `desc`, und der Anker träfe dieselbe Karte an anderer Stelle. Mit
+			   dem Default `desc` wäre dieser Teil der Assertion wirkungslos. */
+			await page.goto('/admin?order=asc');
+			await page.waitForLoadState('networkidle');
+
+			const details = page.getByRole('link', { name: 'Details' }).first();
+			/* Der Eingang kann am geteilten Bestand leer sein — dann ist hier nichts
+			   zu prüfen. Ein Fehlschlag wäre eine Aussage über die Daten, nicht über
+			   die Navigation. */
+			test.skip((await details.count()) === 0, 'Eingang ist leer — kein Detail zum Öffnen');
+
+			await details.click();
+			await expect(page).toHaveURL(/\/admin\/\d+\?.*from=inbox/);
+
+			const zurueck = page.getByRole('button', { name: /Zurück/ });
+			await expect(zurueck).toHaveText(/Zurück zum Eingang/);
+
+			await zurueck.click();
+			await expect(page).toHaveURL(/\/admin\?order=asc#sichtung-\d+$/);
+			await expect(page.getByRole('heading', { name: /Eingang/ })).toBeVisible();
+			await expect(page.getByRole('button', { name: /zuerst/ })).toHaveText(/Älteste zuerst/);
+		} finally {
+			await context.close();
+		}
+	});
+
+	/* Gegenprobe: Ohne Herkunfts-Marker bleibt es beim alten Ziel. Ohne sie
+	   belegte der Test oben nur, dass irgendein Rückweg funktioniert — nicht,
+	   dass er die Herkunft auswertet. */
+	test('führt aus der Tabelle heraus weiterhin in die Tabelle zurück', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/admin');
+			await page.waitForLoadState('networkidle');
+
+			const details = page.getByRole('link', { name: 'Details' }).first();
+			test.skip((await details.count()) === 0, 'Eingang ist leer — kein Detail zum Öffnen');
+			const href = await details.getAttribute('href');
+			const id = href?.match(/\/admin\/(\d+)/)?.[1];
+			expect(id).toBeTruthy();
+
+			await page.goto(`/admin/${id}?verified=open`);
+			/* Der Zurück-Knopf ist ein Client-Handler: vor der Hydration ein
+			   sichtbarer Knopf ohne `onclick`, der Klick läuft ins Leere und die URL
+			   bleibt stehen — genau so ist dieser Test beim ersten Lauf rot gewesen
+			   (dieselbe Falle wie beim Sortier-Umschalter oben). */
+			await page.waitForLoadState('networkidle');
+			const zurueck = page.getByRole('button', { name: /Zurück/ });
+			await expect(zurueck).toHaveText(/Zurück zur Tabelle/);
+
+			await zurueck.click();
+			/* Erst auf die Client-Navigation warten: `page.url()` direkt nach dem
+			   Klick liefert noch die Detail-URL. Danach den Query-String einzeln
+			   prüfen statt als Ganzes — die Reihenfolge der Parameter ist eine
+			   Eigenschaft von URLSearchParams.toString(), keine Zusage. */
+			await expect(page).toHaveURL(/\/admin\/sichtungen\?/);
+			expect(new URL(page.url()).searchParams.get('verified')).toBe('open');
+		} finally {
+			await context.close();
+		}
+	});
+
 	test('Navigation führt Eingang und Sichtungen als eigene Reiter', async ({
 		browser,
 		baseURL

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -9,6 +9,7 @@
 	import type { SightingSelect } from '$lib/server/db/schema';
 	import type { DuplicateCandidate } from '$lib/server/db/duplicateCandidates';
 	import Icon from '$lib/components/Icon.svelte';
+	import { inboxDetailHref } from './adminReturn';
 	import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 
 	interface Props {
@@ -16,12 +17,14 @@
 		images: { id: number; filePath: string; originalName: string }[];
 		/** Mögliche Doppelmeldungen (Spec B2) — reiner Hinweis, kein Merge. */
 		duplicates?: DuplicateCandidate[];
+		/** Sortierung des Eingangs — reist mit in die Detailansicht und zurück. */
+		order?: 'asc' | 'desc';
 		busy: boolean;
 		onApprove: () => void;
 		onReject: () => void;
 	}
 
-	let { sighting, images, duplicates = [], busy, onApprove, onReject }: Props = $props();
+	let { sighting, images, duplicates = [], order, busy, onApprove, onReject }: Props = $props();
 
 	/* „1 ähnliche Meldung" statt „1 ähnliche Meldungen": Die Karte ist die
 	   Arbeitsfläche des Museums, nicht eine Log-Zeile. */
@@ -88,7 +91,7 @@
 				<ul class="border-warning/30 mt-2 ml-2 space-y-1 border-l pl-3">
 					{#each duplicates as candidate (candidate.id)}
 						<li>
-							<a href={`/admin/${candidate.id}`} class="link link-hover font-medium">
+							<a href={inboxDetailHref(candidate.id, order)} class="link link-hover font-medium">
 								#{candidate.id}
 							</a>
 							<span class="text-base-content/70">
@@ -105,7 +108,7 @@
 
 		<div class="flex flex-wrap items-baseline justify-between gap-2">
 			<h3 class="text-base font-semibold">
-				<a href={`/admin/${sighting.id}`} class="link-hover">
+				<a href={inboxDetailHref(sighting.id, order)} class="link-hover">
 					{getSpeciesLabel(sighting.species)} — {sighting.totalCount}
 					{#if sighting.juvenileCount > 0}(davon {sighting.juvenileCount} Jungtiere){/if}
 				</a>
@@ -147,7 +150,7 @@
 		{/if}
 
 		<div class="card-actions justify-end">
-			<a href={`/admin/${sighting.id}`} class="btn btn-ghost btn-sm">Details</a>
+			<a href={inboxDetailHref(sighting.id, order)} class="btn btn-ghost btn-sm">Details</a>
 			<button type="button" class="btn btn-outline btn-sm" disabled={busy} onclick={onReject}>
 				<Icon
 					icon={SIGHTING_STATUS_PRESENTATION.rejected.icon}

--- a/src/lib/components/admin/SightingInboxCard.svelte.test.ts
+++ b/src/lib/components/admin/SightingInboxCard.svelte.test.ts
@@ -1,6 +1,7 @@
 import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi } from 'vitest';
 import SightingInboxCard from './SightingInboxCard.svelte';
+import { inboxDetailHref } from './adminReturn';
 import type { SightingSelect } from '$lib/server/db/schema';
 
 /* actionLabel ('Freigeben'/'Ablehnen') trägt zufällig dieselben Wörter wie die
@@ -194,11 +195,50 @@ describe('SightingInboxCard', () => {
 
 			await expect
 				.element(screen.getByRole('link', { name: /#101/ }))
-				.toHaveAttribute('href', '/admin/101');
+				.toHaveAttribute('href', inboxDetailHref(101));
 			await expect
 				.element(screen.getByRole('link', { name: /#102/ }))
-				.toHaveAttribute('href', '/admin/102');
+				.toHaveAttribute('href', inboxDetailHref(102));
 		});
+	});
+
+	/* Ohne den Herkunfts-Marker führt der Zurück-Knopf der Detailansicht in die
+	   Tabelle statt in den Eingang — das Abarbeiten der Liste reißt dann bei
+	   jedem Blick ins Detail ab. Der Marker gehört an *jeden* Link der Karte,
+	   nicht nur an den auffälligsten. */
+	it('markiert jeden Detail-Link mit der Herkunft „Eingang"', async () => {
+		const screen = render(SightingInboxCard, {
+			sighting: basisSichtung,
+			images: [],
+			busy: false,
+			onApprove: noop,
+			onReject: noop
+		});
+
+		await expect
+			.element(screen.getByRole('link', { name: 'Details' }))
+			.toHaveAttribute('href', inboxDetailHref(42));
+		await expect
+			.element(screen.getByRole('link', { name: /Schweinswal/ }))
+			.toHaveAttribute('href', inboxDetailHref(42));
+	});
+
+	/* Die Sortierung muss mit auf die Reise: Sie gehört dem Eingang, nicht der
+	   Tabelle, und ohne sie steht die Liste nach dem Rückweg wieder auf `desc`. */
+	it('nimmt die Sortierung des Eingangs in den Detail-Link auf', async () => {
+		const screen = render(SightingInboxCard, {
+			sighting: basisSichtung,
+			images: [],
+			order: 'asc' as const,
+			busy: false,
+			onApprove: noop,
+			onReject: noop
+		});
+
+		await expect
+			.element(screen.getByRole('link', { name: 'Details' }))
+			.toHaveAttribute('href', inboxDetailHref(42, 'asc'));
+		expect(inboxDetailHref(42, 'asc')).toContain('order=asc');
 	});
 
 	it('rendert Bild-Vorschauen über /api/media', async () => {

--- a/src/lib/components/admin/adminReturn.ts
+++ b/src/lib/components/admin/adminReturn.ts
@@ -1,0 +1,33 @@
+/**
+ * Herkunft eines Detailaufrufs im Admin-Bereich.
+ *
+ * Die Tabelle (`/admin/sichtungen`) verrät sich über ihre Filter-Parameter, die
+ * beim Öffnen einer Sichtung mitreisen. Der Eingang (`/admin`) hat keine — er
+ * braucht deshalb einen eigenen Marker, sonst landet jeder Rückweg zwangsläufig
+ * in der Tabelle, und das Abarbeiten der Liste reißt bei jedem Blick ins Detail ab.
+ *
+ * Hier stehen nur die Werte, die **beide** Seiten kennen müssen: die
+ * Eingangskarte, die den Link baut, und die Detailansicht, die ihn auswertet
+ * (`src/routes/admin/[id]/tableReturnUrl.ts`). Der Rückweg selbst gehört dorthin
+ * — er braucht die Parameterliste der Tabelle.
+ */
+export const HERKUNFT_PARAMETER = 'from';
+export const HERKUNFT_EINGANG = 'inbox';
+
+/** Anker der Eingangskarte — Gegenstück zur `id` am `<li>` in `/admin`. */
+export function inboxAnchor(sightingId: number | string): string {
+	return `sichtung-${sightingId}`;
+}
+
+/**
+ * Detail-Link aus dem Eingang heraus, inklusive Herkunfts-Marker.
+ *
+ * `order` reist mit, weil es dem Eingang gehört und nicht der Tabelle: Ohne den
+ * Parameter fällt die Liste auf dem Rückweg auf ihren Default `desc` zurück,
+ * und der Anker träfe dieselbe Karte an ganz anderer Stelle.
+ */
+export function inboxDetailHref(sightingId: number | string, order?: 'asc' | 'desc'): string {
+	const params = new URLSearchParams({ [HERKUNFT_PARAMETER]: HERKUNFT_EINGANG });
+	if (order) params.set('order', order);
+	return `/admin/${sightingId}?${params}`;
+}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
 	import SightingInboxCard from '$lib/components/admin/SightingInboxCard.svelte';
+	import { inboxAnchor } from '$lib/components/admin/adminReturn';
 	import { submitVerdict, type SightingVerdict } from '$lib/components/admin/sightingVerdict';
 	import {
 		SIGHTING_STATUS_PRESENTATION,
@@ -126,7 +127,10 @@
 			{#each data.open as sighting (sighting.id)}
 				{@const verdict = done[sighting.id]}
 				{#if !abgelaufen.has(sighting.id)}
-					<li>
+					<!-- Sprungziel für den Rückweg aus der Detailansicht: Wer eine Karte
+					     öffnet und zurückgeht, steigt an derselben Stelle wieder ein statt
+					     oben in der Liste. -->
+					<li id={inboxAnchor(sighting.id)}>
 						{#if verdict}
 							{@const status = SIGHTING_STATUS_PRESENTATION[verdictToStatus(verdict)]}
 							<div class="alert py-2" role="status">
@@ -150,6 +154,7 @@
 								{sighting}
 								images={data.imagesBySighting[sighting.id] ?? []}
 								duplicates={data.duplicatesBySighting[sighting.id] ?? []}
+								order={data.order}
 								busy={busy[sighting.id] ?? false}
 								onApprove={() => entscheiden(sighting.id, 'approve')}
 								onReject={() => entscheiden(sighting.id, 'reject')}

--- a/src/routes/admin/[id]/+layout.svelte
+++ b/src/routes/admin/[id]/+layout.svelte
@@ -2,12 +2,14 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import Icon from '$lib/components/Icon.svelte';
-	import { tableReturnUrl } from './tableReturnUrl';
+	import { returnTarget } from './tableReturnUrl';
 
 	let { children, data } = $props();
 
+	const zurueck = $derived(returnTarget(page.url, page.params.id));
+
 	function handleClose() {
-		goto(tableReturnUrl(page.url));
+		goto(zurueck.href);
 	}
 </script>
 
@@ -15,7 +17,7 @@
 	<div class="mb-2 flex justify-end">
 		<button class="btn btn-ghost btn-sm" onclick={handleClose}>
 			<Icon icon="lucide:arrow-left" class="mr-2 h-4 w-4" />
-			Zurück zur Tabelle
+			{zurueck.label}
 		</button>
 	</div>
 

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
+	import { page } from '$app/state';
 	import AdminSightingView from '$lib/components/admin/AdminSightingView.svelte';
+	import { carryReturnParams, returnTarget } from './tableReturnUrl';
 	import {
 		deleteSighting,
 		sendTestEmail,
@@ -51,7 +53,9 @@
 	}
 
 	function editSighting() {
-		goto(`/admin/${sighting.id}/edit`);
+		// Herkunft und Tabellenfilter reisen mit — sonst endet der Rückweg nach
+		// „Bearbeiten" in der ungefilterten Tabelle statt dort, wo man herkam.
+		goto(`/admin/${sighting.id}/edit${carryReturnParams(page.url)}`);
 	}
 
 	async function handleTestEmail() {
@@ -68,9 +72,10 @@
 
 	async function handleDelete() {
 		// Die Sichtung, die diese Seite anzeigt, existiert nach dem Löschen nicht
-		// mehr — zurück zur Tabelle statt auf einen 404 zu warten.
+		// mehr — zurück, woher man kam, statt auf einen 404 zu warten. Ohne
+		// `sighting.id`: Der Anker zeigte auf eine Karte, die es nicht mehr gibt.
 		if (await deleteSighting(sighting.id)) {
-			await goto('/admin/sichtungen');
+			await goto(returnTarget(page.url).href);
 		}
 	}
 

--- a/src/routes/admin/[id]/edit/+page.svelte
+++ b/src/routes/admin/[id]/edit/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import AdminSightingEditForm from '$lib/components/admin/AdminSightingEditForm.svelte';
+	import { carryReturnParams } from '../tableReturnUrl';
 	import { createLogger } from '$lib/logger';
 	import type { FrontendSighting } from '$lib/types/FrontendSighting.js';
 	import Icon from '$lib/components/Icon.svelte';
@@ -9,18 +11,21 @@
 
 	let { data } = $props();
 
+	let sighting = $derived(data.sighting);
+
+	/* Herkunft und Tabellenfilter zurück an die Detailansicht reichen — ohne sie
+	   endet deren Zurück-Knopf in der ungefilterten Tabelle, egal wo der
+	   Rundweg begonnen hat. */
+	const detailHref = $derived(`/admin/${sighting.id}${carryReturnParams(page.url)}`);
+
 	function onCancel() {
-		// Logic to handle cancel action
-		goto(`/admin/${sighting.id}`);
+		goto(detailHref);
 	}
 
 	function handleSave(updatedSighting: FrontendSighting) {
 		logger.info({ updatedSighting }, 'Sichtung gespeichert');
-		// Logic to save the updated sighting
-		goto(`/admin/${sighting.id}`, { invalidateAll: true });
+		goto(detailHref, { invalidateAll: true });
 	}
-
-	let sighting = $derived(data.sighting);
 </script>
 
 <svelte:head>

--- a/src/routes/admin/[id]/tableReturnUrl.test.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.test.ts
@@ -109,6 +109,17 @@ describe('returnTarget — der Rückweg kennt seine Herkunft', () => {
 		expect(url.hash).toBe('#sichtung-29518');
 	});
 
+	/* `/admin` versteht nur `asc` und `desc` und macht aus allem anderen wieder
+	   `desc` (`admin/+page.server.ts`). Ein durchgereichter Fremdwert wäre damit
+	   folgenlos, stünde aber sichtbar in der Adresszeile und behauptete eine
+	   Sortierung, die es nicht gibt. */
+	it('reicht nur gültige Sortierwerte weiter', () => {
+		const ziel = returnTarget(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}&order=hoch`)
+		);
+		expect(new URL(ziel.href).searchParams.has('order')).toBe(false);
+	});
+
 	it('behandelt eine unbekannte Herkunft wie keine', () => {
 		const ziel = returnTarget(new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=irgendwas`));
 		expect(new URL(ziel.href).pathname).toBe('/admin/sichtungen');
@@ -123,6 +134,20 @@ describe('carryReturnParams — der Rundweg über „Bearbeiten"', () => {
 		expect(returnTarget(new URL(`https://x/admin/29518/edit${query}`)).label).toBe(
 			'Zurück zum Eingang'
 		);
+	});
+
+	/* `order` gehört dem Eingang, steht aber trotzdem in TABELLEN_PARAMETER —
+	   die Tabelle sortiert damit ebenfalls. Es reist deshalb auf **beiden**
+	   Wegen mit, ohne Sonderfall für `from=inbox`. Ohne diesen Test liest sich
+	   das wie eine Lücke, und der Rundweg Detail → Bearbeiten → zurück verlöre
+	   bei einer „Korrektur" genau die Sortierung, um die es geht. */
+	it('reicht die Sortierung auch aus dem Eingang weiter', () => {
+		const query = carryReturnParams(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}&order=asc`)
+		);
+		const params = new URLSearchParams(query);
+		expect(params.get(HERKUNFT_PARAMETER)).toBe(HERKUNFT_EINGANG);
+		expect(params.get('order')).toBe('asc');
 	});
 
 	it('reicht die Tabellenfilter weiter', () => {

--- a/src/routes/admin/[id]/tableReturnUrl.test.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
-import { TABELLEN_PARAMETER, tableReturnUrl } from './tableReturnUrl';
+import { HERKUNFT_EINGANG, HERKUNFT_PARAMETER } from '$lib/components/admin/adminReturn';
+import {
+	TABELLEN_PARAMETER,
+	carryReturnParams,
+	returnTarget,
+	tableReturnUrl
+} from './tableReturnUrl';
 
 describe('tableReturnUrl — Rückweg aus der Detailansicht', () => {
 	it('behält den Ostsee-Filter (balticSea)', () => {
@@ -49,5 +55,90 @@ describe('tableReturnUrl — Rückweg aus der Detailansicht', () => {
 
 		expect(gelesen.size).toBeGreaterThan(0);
 		expect([...gelesen].sort()).toEqual([...TABELLEN_PARAMETER].sort());
+	});
+});
+
+describe('returnTarget — der Rückweg kennt seine Herkunft', () => {
+	it('führt aus dem Eingang zurück in den Eingang, nicht in die Tabelle', () => {
+		const ziel = returnTarget(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}`)
+		);
+		expect(new URL(ziel.href).pathname).toBe('/admin');
+		expect(ziel.label).toBe('Zurück zum Eingang');
+	});
+
+	it('springt dabei an die Karte, von der man kam', () => {
+		const ziel = returnTarget(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}`),
+			29518
+		);
+		expect(new URL(ziel.href).hash).toBe('#sichtung-29518');
+	});
+
+	it('lässt den Anker weg, wenn es die Sichtung nicht mehr gibt', () => {
+		const ziel = returnTarget(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}`)
+		);
+		expect(new URL(ziel.href).hash).toBe('');
+	});
+
+	it('führt ohne Herkunft in die Tabelle — mit ihren Filtern', () => {
+		const ziel = returnTarget(new URL('https://x/admin/29518?balticSea=baltic&page=3'), 29518);
+		const url = new URL(ziel.href);
+		expect(url.pathname).toBe('/admin/sichtungen');
+		expect(url.searchParams.get('balticSea')).toBe('baltic');
+		expect(url.searchParams.get('page')).toBe('3');
+		expect(ziel.label).toBe('Zurück zur Tabelle');
+		/* Der Anker gehört zur Eingangsliste; in der Tabelle gibt es ihn nicht —
+		   ein Sprungziel ins Leere scrollt nirgendwohin und sieht nach Defekt aus. */
+		expect(url.hash).toBe('');
+	});
+
+	/* Der Eingang hält seine Sortierung in `?order=` (`+page.server.ts`). Ohne
+	   sie steht die Liste nach dem Rückweg wieder auf `desc` — der Anker träfe
+	   dieselbe Karte an völlig anderer Stelle, also genau das Abreißen der
+	   Arbeitsliste, das dieser Rückweg verhindern soll. Nur im `asc`-Fall
+	   sichtbar, weil `desc` der Default ist. */
+	it('behält die Sortierung des Eingangs', () => {
+		const ziel = returnTarget(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}&order=asc`),
+			29518
+		);
+		const url = new URL(ziel.href);
+		expect(url.searchParams.get('order')).toBe('asc');
+		expect(url.hash).toBe('#sichtung-29518');
+	});
+
+	it('behandelt eine unbekannte Herkunft wie keine', () => {
+		const ziel = returnTarget(new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=irgendwas`));
+		expect(new URL(ziel.href).pathname).toBe('/admin/sichtungen');
+	});
+});
+
+describe('carryReturnParams — der Rundweg über „Bearbeiten"', () => {
+	it('reicht die Herkunft weiter, sonst endet der Rückweg dort', () => {
+		const query = carryReturnParams(
+			new URL(`https://x/admin/29518?${HERKUNFT_PARAMETER}=${HERKUNFT_EINGANG}`)
+		);
+		expect(returnTarget(new URL(`https://x/admin/29518/edit${query}`)).label).toBe(
+			'Zurück zum Eingang'
+		);
+	});
+
+	it('reicht die Tabellenfilter weiter', () => {
+		const query = carryReturnParams(new URL('https://x/admin/29518?verified=open&page=3'));
+		const params = new URLSearchParams(query);
+		expect(params.get('verified')).toBe('open');
+		expect(params.get('page')).toBe('3');
+	});
+
+	it('übernimmt fremde Parameter nicht', () => {
+		expect(
+			new URLSearchParams(carryReturnParams(new URL('https://x/admin/29518?tab=media'))).has('tab')
+		).toBe(false);
+	});
+
+	it('liefert ohne Parameter einen leeren String — keine nackte „?"-URL', () => {
+		expect(carryReturnParams(new URL('https://x/admin/29518'))).toBe('');
 	});
 });

--- a/src/routes/admin/[id]/tableReturnUrl.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.ts
@@ -78,9 +78,12 @@ export function returnTarget(currentUrl: URL, sightingId?: number | string): Ret
 		   trifft dieselbe Karte an anderer Stelle. Die übrigen
 		   TABELLEN_PARAMETER gehören hier nicht hin: `istTabellenUrl`
 		   (`admin/tableRedirect.ts`) leitete `/admin` mit ihnen sofort auf die
-		   Tabelle um — der Rückweg landete also genau dort, wo er nicht hin soll. */
+		   Tabelle um — der Rückweg landete also genau dort, wo er nicht hin soll.
+		   Nur `asc`/`desc`: Alles andere coerct `+page.server.ts` ohnehin zu
+		   `desc`, stünde aber sichtbar in der Adresszeile und behauptete eine
+		   Sortierung, die es nicht gibt. */
 		const order = currentUrl.searchParams.get('order');
-		if (order) zielUrl.searchParams.set('order', order);
+		if (order === 'asc' || order === 'desc') zielUrl.searchParams.set('order', order);
 		if (sightingId != null) zielUrl.hash = inboxAnchor(sightingId);
 		return { href: zielUrl.toString(), label: 'Zurück zum Eingang' };
 	}

--- a/src/routes/admin/[id]/tableReturnUrl.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.ts
@@ -1,5 +1,6 @@
 /**
- * Baut den Rückweg aus der Detailansicht zurück auf `/admin/sichtungen`.
+ * Baut den Rückweg aus der Detailansicht — zurück in die Tabelle
+ * (`/admin/sichtungen`) oder in den Eingang (`/admin`), je nach Herkunft.
  *
  * Die Detailansicht wird mit **allen** Parametern der Tabelle aufgerufen
  * (`viewSightingDetails` kopiert sie unbesehen); zurück gehen darf nur, was die
@@ -10,7 +11,19 @@
  * eigenes Modul statt Inline-Liste — `tableReturnUrl.test.ts` gleicht sie gegen
  * die tatsächlich in `sichtungen/` gelesenen Parameter ab und meldet die nächste
  * solche Lücke, statt sie still entstehen zu lassen.
+ *
+ * Die Herkunft steht bewusst in der URL und nicht in `history.back()`: Die
+ * Detailansicht ändert Status per `invalidateAll()`, löscht ggf. den Datensatz
+ * und führt über „Bearbeiten" weiter — der History-Eintrag hinter uns ist
+ * danach nicht verlässlich derselbe. Ein Parameter überlebt Reload, Bookmark
+ * und Direktaufruf.
  */
+import {
+	HERKUNFT_EINGANG,
+	HERKUNFT_PARAMETER,
+	inboxAnchor
+} from '$lib/components/admin/adminReturn';
+
 export const TABELLEN_PARAMETER = [
 	'fromDate',
 	'toDate',
@@ -26,15 +39,74 @@ export const TABELLEN_PARAMETER = [
 	'perPage'
 ] as const;
 
-export function tableReturnUrl(currentUrl: URL): string {
-	const zielUrl = new URL('/admin/sichtungen', currentUrl.origin);
+function pickTableParams(currentUrl: URL): URLSearchParams {
+	const params = new URLSearchParams();
 
 	for (const param of TABELLEN_PARAMETER) {
 		const wert = currentUrl.searchParams.get(param);
-		if (wert) {
-			zielUrl.searchParams.set(param, wert);
-		}
+		if (wert) params.set(param, wert);
+	}
+
+	return params;
+}
+
+export function tableReturnUrl(currentUrl: URL): string {
+	const zielUrl = new URL('/admin/sichtungen', currentUrl.origin);
+
+	for (const [param, wert] of pickTableParams(currentUrl)) {
+		zielUrl.searchParams.set(param, wert);
 	}
 
 	return zielUrl.toString();
+}
+
+export interface ReturnTarget {
+	href: string;
+	label: string;
+}
+
+/**
+ * Rückweg samt Beschriftung. `sightingId` setzt den Anker auf die Karte, von
+ * der man kam — weglassen, wenn die Sichtung das Ziel nicht mehr erreicht
+ * (gelöscht, oder gerade aus dem Eingang heraus entschieden).
+ */
+export function returnTarget(currentUrl: URL, sightingId?: number | string): ReturnTarget {
+	if (currentUrl.searchParams.get(HERKUNFT_PARAMETER) === HERKUNFT_EINGANG) {
+		const zielUrl = new URL('/admin', currentUrl.origin);
+		/* `order` ist der einzige Parameter, den der Eingang selbst führt — ohne
+		   ihn steht die Liste nach dem Rückweg wieder auf `desc`, und der Anker
+		   trifft dieselbe Karte an anderer Stelle. Die übrigen
+		   TABELLEN_PARAMETER gehören hier nicht hin: `istTabellenUrl`
+		   (`admin/tableRedirect.ts`) leitete `/admin` mit ihnen sofort auf die
+		   Tabelle um — der Rückweg landete also genau dort, wo er nicht hin soll. */
+		const order = currentUrl.searchParams.get('order');
+		if (order) zielUrl.searchParams.set('order', order);
+		if (sightingId != null) zielUrl.hash = inboxAnchor(sightingId);
+		return { href: zielUrl.toString(), label: 'Zurück zum Eingang' };
+	}
+
+	return { href: tableReturnUrl(currentUrl), label: 'Zurück zur Tabelle' };
+}
+
+/**
+ * Query-String, den die Detailansicht an weiterführende Routen (`/edit`)
+ * durchreicht — inklusive führendem `?`, oder leer.
+ *
+ * Ohne das endet der Rückweg beim ersten Zwischenschritt: `edit` sprang bis
+ * 2026-08 auf `/admin/${id}` **ohne** Parameter, der Weg Tabelle → Detail →
+ * Bearbeiten → zurück verlor also die Filter — derselbe Fehler wie beim
+ * Eingang, nur eine Route weiter.
+ */
+export function carryReturnParams(currentUrl: URL): string {
+	const params = new URLSearchParams();
+
+	const herkunft = currentUrl.searchParams.get(HERKUNFT_PARAMETER);
+	if (herkunft) params.set(HERKUNFT_PARAMETER, herkunft);
+
+	for (const [param, wert] of pickTableParams(currentUrl)) {
+		params.set(param, wert);
+	}
+
+	const query = params.toString();
+	return query ? `?${query}` : '';
 }


### PR DESCRIPTION
## Problem

Aus dem Eingang (`/admin`) eine Sichtung öffnen und zurückgehen landete **immer** in der Tabelle. Die Eingangskarte verlinkte `/admin/{id}` ohne jeden Parameter, und `tableReturnUrl` kannte nur ein Ziel — die Arbeitsliste riss bei jedem Blick ins Detail ab.

Dabei kam ein zweiter Bruch derselben Art mit heraus: `edit/` sprang auf `/admin/${id}` **ohne** Query-String. Schon der Weg Tabelle → Detail → Bearbeiten → zurück verlor also die Filter.

## Lösung

Die Herkunft steht in der URL. `returnTarget()` wertet sie aus und liefert Ziel **und** Beschriftung.

| Weg | vorher | jetzt |
| --- | --- | --- |
| Eingang → Detail → Zurück | Tabelle | Eingang, an derselben Karte (`#sichtung-<id>`), Sortierung erhalten |
| Tabelle → Detail → Zurück | Tabelle mit Filtern | unverändert |
| … → Detail → Bearbeiten → Abbrechen/Speichern → Zurück | ungefilterte Tabelle | zurück zur Herkunft |
| Detail → Löschen | Tabelle | zurück zur Herkunft (ohne Anker — die Karte gibt es nicht mehr) |

Zwei Entscheidungen, die im Code begründet stehen:

- **Kein `history.back()`.** Die Detailansicht lädt per `invalidateAll()` neu, löscht ggf. den Datensatz und führt über „Bearbeiten" weiter — der Eintrag hinter uns ist danach nicht verlässlich derselbe. Ein URL-Parameter überlebt Reload, Bookmark und Direktaufruf.
- **`order` reist mit, die übrigen Tabellenfilter nicht.** Die Sortierung gehört dem Eingang; ohne sie fiele die Liste auf `desc` zurück und der Anker träfe dieselbe Karte an anderer Stelle. Die anderen `TABELLEN_PARAMETER` an `/admin` lösten dagegen sofort die 301 auf die Tabelle aus — der Rückweg landete genau dort, wo er nicht hin soll.

## Änderungen

- **Neu** `src/lib/components/admin/adminReturn.ts` — Marker `?from=inbox`, Anker, `inboxDetailHref()`. In `$lib`, weil beide Seiten ihn brauchen: die Karte, die den Link baut, und die Detailroute, die ihn auswertet.
- `[id]/tableReturnUrl.ts` — `returnTarget()` und `carryReturnParams()`; die Parameter-Schleife liegt jetzt einmal in `pickTableParams()`.
- `SightingInboxCard.svelte` — alle drei Detail-Links (Titel, „Details", Duplikat-Kandidaten) tragen Marker und Sortierung.
- `[id]/+layout.svelte`, `[id]/+page.svelte`, `[id]/edit/+page.svelte`, `admin/+page.svelte` (Anker am `<li>`).
- `.claude/rules/admin.md` — Abschnitt „Der Rückweg aus der Detailansicht kennt zwei Ziele".

## Tests

Test-First, alle waren rot:

- **10 Fälle** in `tableReturnUrl.test.ts` für `returnTarget`/`carryReturnParams` — inkl. „unbekannte Herkunft = keine", „kein Anker in der Tabelle", „Sortierung bleibt".
- **2 Fälle** in `SightingInboxCard.svelte.test.ts` — der Marker muss an *jedem* Link hängen, und die Sortierung mit.
- **2 E2E** in `admin-inbox.spec.ts`: der Eingangs-Rundweg (startet auf `?order=asc`, sonst wäre die Sortier-Assertion wirkungslos) und die Gegenprobe aus der Tabelle. Ohne die Gegenprobe belegte der erste Test nur, dass irgendein Rückweg funktioniert — nicht, dass er die Herkunft auswertet.

Der Eingangs-E2E überspringt sich selbst bei leerem Eingang: Die DB ist zwischen den Worktrees geteilt, ein Fehlschlag wäre dort eine Aussage über die Daten.

**Läufe:** `lint` 0 Fehler (2 Alt-Warnungen in `src/tests/contract/`), `type-check` und `svelte-check` (2216 Dateien) sauber, Server-Unit 4057/4057, Client-Test 13/13, E2E `admin-inbox` 5/5 plus `admin-detail-actions`/`admin-edit-preserves-record`/`admin-sighting-status` 7/7.

## Bekannte Grenze

`/admin/ref/[refId]` leitet weiterhin auf `/admin/${id}` ohne Query-String um und verwirft den Kontext. War vor diesem PR genauso; der Einstieg dorthin kommt aus der Tabelle, deren Filter der Umweg ohnehin nicht kennt. In `admin.md` als Ausnahme notiert, statt sie still stehen zu lassen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)