### PR TITLE
feat(admin): Tastatur-Triage im Eingang (Spec B1)

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -47,19 +47,21 @@ Task-Liste — keine Filter/Spalten dorthin bauen, dafür gibt es
 
 ## Admin-Komponenten
 
-| Komponente                     | Zweck                                     |
-| ------------------------------ | ----------------------------------------- |
-| `AdminSightingEditForm.svelte` | Sichtung bearbeiten                       |
-| `AdminSightingView.svelte`     | Sichtung anzeigen (read-only)             |
-| `SightingInboxCard.svelte`     | Karte der Eingangsseite (`/admin`)        |
-| `inboxVerdict.ts`              | Verdict-Logik der Eingangsseite           |
-| `DataTableRow.svelte`          | Tabellen-Zeile                            |
-| `BooleanStatus.svelte`         | Boolean-Status Anzeige                    |
-| `ExportModal.svelte`           | Export-Dialog                             |
-| `deadFinding.ts`               | Totfund-Auszeichnung                      |
-| `sightingStatus.ts`            | Statusableitung + Wort/Farbe/Icon/Verdict |
-| `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)  |
-| `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel   |
+| Komponente                     | Zweck                                      |
+| ------------------------------ | ------------------------------------------ |
+| `AdminSightingEditForm.svelte` | Sichtung bearbeiten                        |
+| `AdminSightingView.svelte`     | Sichtung anzeigen (read-only)              |
+| `SightingInboxCard.svelte`     | Karte der Eingangsseite (`/admin`)         |
+| `inboxVerdict.ts`              | Verdict-Logik der Eingangsseite            |
+| `inboxShortcuts.ts`            | Tastatur-Triage des Eingangs (J/K/A/R/U/?) |
+| `InboxShortcutHelp.svelte`     | Overlay mit der Kürzel-Übersicht           |
+| `DataTableRow.svelte`          | Tabellen-Zeile                             |
+| `BooleanStatus.svelte`         | Boolean-Status Anzeige                     |
+| `ExportModal.svelte`           | Export-Dialog                              |
+| `deadFinding.ts`               | Totfund-Auszeichnung                       |
+| `sightingStatus.ts`            | Statusableitung + Wort/Farbe/Icon/Verdict  |
+| `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)   |
+| `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel    |
 
 ### Totfund vs. Lebendsichtung
 

--- a/e2e/admin-inbox.spec.ts
+++ b/e2e/admin-inbox.spec.ts
@@ -98,6 +98,63 @@ test.describe('Admin-Eingangsseite', () => {
 		}
 	});
 
+	test('Fokus-Ring liegt an der Karte, auch wenn eine Schaltfläche darin den Fokus hat', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+
+		/**
+		 * Warum das ein E2E-Test ist und kein Komponententest: Die Zusage steckt in
+		 * einer CSS-Regel (`.inbox-card:has(:global(:focus-visible))`), und der
+		 * Browser-Runner der Unit-Tests liefert die Seite ohne Tailwind und ohne
+		 * Svelte-Scoping-Klassen aus — dort ist keine Outline messbar.
+		 *
+		 * **Die Regel braucht ein `:global()` im `:has()`.** Ohne es hängt Svelte
+		 * die Scope-Klasse der Seite an das Argument; die Schaltflächen liegen aber
+		 * in `SightingInboxCard.svelte` und tragen eine andere Scope-Klasse — der
+		 * Ring blieb dann aus, während A und R sehr wohl auf die Karte wirkten.
+		 * Dieser Test ist rot, wenn das `:global()` fehlt (nachgestellt 2026-08-08).
+		 *
+		 * **Gemessen wird `outline-style`, nicht `outline-width`.** Ohne passende
+		 * Regel rechnet der Browser `outline-width` auf den Initialwert `medium`
+		 * — und der ist ausgerechnet `3px`. Eine Breiten-Assertion ist damit auch
+		 * ohne jede Regel grün; genau so war die erste Fassung dieses Tests
+		 * wirkungslos. `outline-style` steht ohne Regel auf `none`.
+		 *
+		 * Zustandsunabhängig: Es wird nur navigiert und fokussiert, nichts
+		 * entschieden — die Datenbank ist zwischen den Worktrees geteilt.
+		 */
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto('/admin?order=asc');
+			await page.waitForLoadState('networkidle');
+
+			const ersteKarte = page.locator('li.inbox-card').first();
+			if ((await ersteKarte.count()) === 0) {
+				// Leerer Eingang: Es gibt keine Karte, an der etwas zu messen wäre.
+				test.skip(true, 'Kein offener Eingang im geteilten Bestand');
+			}
+
+			const ringStil = () => ersteKarte.evaluate((el) => getComputedStyle(el).outlineStyle);
+			await expect.poll(ringStil).toBe('none');
+
+			await page.keyboard.press('j');
+			await expect.poll(ringStil).toBe('solid');
+
+			/* Vier Tabs führen von der Karte über „Details", „Ablehnen" bis
+			   „Freigeben" — der Ring muss die ganze Zeit an der Karte bleiben. */
+			for (let schritt = 0; schritt < 4; schritt++) await page.keyboard.press('Tab');
+			await expect(page.getByRole('button', { name: /Freigeben/ }).first()).toBeFocused();
+			await expect.poll(ringStil).toBe('solid');
+		} finally {
+			await context.close();
+		}
+	});
+
 	test('Navigation führt Eingang und Sichtungen als eigene Reiter', async ({
 		browser,
 		baseURL

--- a/src/lib/components/admin/InboxShortcutHelp.svelte
+++ b/src/lib/components/admin/InboxShortcutHelp.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import { INBOX_SHORTCUTS } from './inboxShortcuts';
+
+	interface Props {
+		onClose: () => void;
+	}
+
+	let { onClose }: Props = $props();
+
+	let box = $state<HTMLDivElement | null>(null);
+
+	/* Der Fokus muss in das Overlay wandern, und zwar aus zwei Gründen: Wer mit
+	   dem Screenreader arbeitet, erfährt sonst nicht, dass sich etwas geöffnet
+	   hat — und die Tastensperre der Seite erkennt den offenen Dialog daran, dass
+	   der Fokus darin steht (`resolveInboxShortcut`). Ohne das würde ein „a" im
+	   offenen Overlay die Meldung dahinter freigeben. */
+	$effect(() => {
+		box?.focus();
+	});
+</script>
+
+<div class="modal modal-open">
+	<div
+		class="modal-box"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="inbox-shortcut-help-title"
+		tabindex="-1"
+		bind:this={box}
+	>
+		<h2 id="inbox-shortcut-help-title" class="text-lg font-semibold">Tastaturkürzel</h2>
+		<p class="text-base-content/70 mt-1 text-sm">
+			Gültig, solange kein Eingabefeld und kein Dialog den Fokus hat.
+		</p>
+
+		<dl class="mt-4 grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-2">
+			{#each INBOX_SHORTCUTS as eintrag (eintrag.description)}
+				<dt class="flex gap-1">
+					{#each eintrag.keys as key (key)}
+						<kbd class="kbd kbd-sm">{key}</kbd>
+					{/each}
+				</dt>
+				<dd class="text-sm">{eintrag.description}</dd>
+			{/each}
+		</dl>
+
+		<div class="modal-action">
+			<button type="button" class="btn btn-primary btn-sm" onclick={onClose}>Schließen</button>
+		</div>
+	</div>
+	<!-- Der Klick daneben schließt, wie bei jedem Dialog im Projekt. Als Button
+	     und nicht als div, damit er ohne Maus erreichbar bleibt; Escape tut
+	     dasselbe und ist in der Liste oben aufgeführt. -->
+	<button
+		type="button"
+		class="modal-backdrop"
+		aria-label="Übersicht der Tastaturkürzel schließen"
+		onclick={onClose}
+	></button>
+</div>

--- a/src/lib/components/admin/InboxShortcutHelp.svelte
+++ b/src/lib/components/admin/InboxShortcutHelp.svelte
@@ -29,8 +29,12 @@
 		bind:this={box}
 	>
 		<h2 id="inbox-shortcut-help-title" class="text-lg font-semibold">Tastaturkürzel</h2>
+		<!-- Der Satz nennt nur das Eingabefeld und nicht mehr „kein Dialog": Esc und
+		     ? wirken auch hier im Overlay, sonst ließe es sich per Tastatur nicht
+		     schließen. Die frühere Fassung beschrieb damit eine Sperre, die für die
+		     zwei Tasten, die man gerade braucht, nicht gilt. -->
 		<p class="text-base-content/70 mt-1 text-sm">
-			Gültig, solange kein Eingabefeld und kein Dialog den Fokus hat.
+			Gültig, solange kein Eingabefeld den Fokus hat. Esc und ? wirken auch hier.
 		</p>
 
 		<dl class="mt-4 grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-2">

--- a/src/lib/components/admin/inboxShortcuts.test.ts
+++ b/src/lib/components/admin/inboxShortcuts.test.ts
@@ -46,6 +46,20 @@ function ziel(tagName: string, extra: Partial<ShortcutTarget> = {}): ShortcutTar
 	return { tagName, isContentEditable: false, closest: () => null, ...extra };
 }
 
+/**
+ * Ein Ziel innerhalb eines Dialogs. `closest` antwortet **selektorgenau** und
+ * nicht auf alles: Ein Fixture, das jeden Selektor bejaht, gilt gleichzeitig als
+ * contenteditable — und lässt damit die Dialog-Sperre richtig aussehen, obwohl
+ * in Wahrheit die Eingabefeld-Sperre gegriffen hat.
+ */
+function zielImDialog(tagName = 'BUTTON'): ShortcutTarget {
+	return {
+		tagName,
+		isContentEditable: false,
+		closest: (selector: string) => (selector.includes('dialog') ? {} : null)
+	};
+}
+
 describe('resolveInboxShortcut', () => {
 	it.each([
 		['j', 'focusNext'],
@@ -93,13 +107,22 @@ describe('resolveInboxShortcut', () => {
 	it('bleibt still, wenn der Fokus in einem Dialog steht', () => {
 		/* Der Hilfe-Overlay ist selbst ein Dialog: Ohne diese Sperre würde ein „a"
 		   im offenen Overlay die Sichtung im Hintergrund freigeben. */
-		const imDialog = ziel('BUTTON', { closest: (selektor: string) => (selektor ? {} : null) });
-		expect(resolveInboxShortcut(taste('a', { target: imDialog }))).toBeNull();
+		expect(resolveInboxShortcut(taste('a', { target: zielImDialog() }))).toBeNull();
+	});
+
+	it('lässt ? aus einem Dialog durch — die Taste blendet die Hilfe auch aus', () => {
+		/* Sonst wäre `toggleHelp` eine Einbahnstraße: Im offenen Overlay steht der
+		   Fokus im Dialog, und die Sperre schluckte genau den Tastendruck, der es
+		   wieder schließen soll. */
+		expect(resolveInboxShortcut(taste('?', { target: zielImDialog() }))).toBe('toggleHelp');
+	});
+
+	it('lässt ? im Eingabefeld liegen — dort ist es ein Satzzeichen', () => {
+		expect(resolveInboxShortcut(taste('?', { target: ziel('INPUT') }))).toBeNull();
 	});
 
 	it('lässt Escape auch aus einem Dialog und aus einem Eingabefeld durch', () => {
-		const imDialog = ziel('BUTTON', { closest: () => ({}) });
-		expect(resolveInboxShortcut(taste('Escape', { target: imDialog }))).toBe('closeHelp');
+		expect(resolveInboxShortcut(taste('Escape', { target: zielImDialog() }))).toBe('closeHelp');
 		expect(resolveInboxShortcut(taste('Escape', { target: ziel('INPUT') }))).toBe('closeHelp');
 	});
 });

--- a/src/lib/components/admin/inboxShortcuts.test.ts
+++ b/src/lib/components/admin/inboxShortcuts.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import {
+	INBOX_SHORTCUTS,
+	nextActionableIndex,
+	resolveInboxShortcut,
+	shiftFocusIndex,
+	type ShortcutTarget
+} from './inboxShortcuts';
+
+/**
+ * @fileoverview Tastatur-Triage des Eingangs (Spec B1) — die Entscheidungen,
+ * die ohne DOM prüfbar sind.
+ *
+ * Die drei Funktionen sind bewusst frei von `HTMLElement`-Prüfungen: Ein
+ * `instanceof HTMLElement` in `resolveInboxShortcut` hätte diesen Test in den
+ * Browser-Runner gezwungen (`*.svelte.test.ts`), obwohl es hier um eine
+ * Tastenzuordnung geht und nicht um Rendern. Die Strecke „echte Taste →
+ * fokussierte Karte" prüft `inboxShortcuts.svelte.test.ts` zusätzlich im
+ * Browser.
+ */
+
+/** Ein Ereignis, wie es `svelte:window onkeydown` liefert — nur die Felder, die zählen. */
+function taste(
+	key: string,
+	extra: Partial<{
+		ctrlKey: boolean;
+		metaKey: boolean;
+		altKey: boolean;
+		shiftKey: boolean;
+		target: ShortcutTarget | null;
+	}> = {}
+) {
+	return {
+		key,
+		ctrlKey: false,
+		metaKey: false,
+		altKey: false,
+		shiftKey: false,
+		target: null,
+		...extra
+	};
+}
+
+/** Ein Ziel ohne Vorfahren — `closest` findet nichts. */
+function ziel(tagName: string, extra: Partial<ShortcutTarget> = {}): ShortcutTarget {
+	return { tagName, isContentEditable: false, closest: () => null, ...extra };
+}
+
+describe('resolveInboxShortcut', () => {
+	it.each([
+		['j', 'focusNext'],
+		['k', 'focusPrevious'],
+		['a', 'approve'],
+		['r', 'reject'],
+		['u', 'undo'],
+		['?', 'toggleHelp'],
+		['Escape', 'closeHelp']
+	] as const)('ordnet %s der Aktion %s zu', (key, aktion) => {
+		expect(resolveInboxShortcut(taste(key))).toBe(aktion);
+	});
+
+	it('gilt auch für Großbuchstaben — Caps Lock ist keine andere Absicht', () => {
+		expect(resolveInboxShortcut(taste('J'))).toBe('focusNext');
+		expect(resolveInboxShortcut(taste('A'))).toBe('approve');
+	});
+
+	it('lässt unbelegte Tasten liegen', () => {
+		expect(resolveInboxShortcut(taste('x'))).toBeNull();
+		expect(resolveInboxShortcut(taste('Enter'))).toBeNull();
+	});
+
+	it.each(['ctrlKey', 'metaKey', 'altKey'] as const)(
+		'greift nicht bei %s — das sind Browser- und Systembefehle',
+		(modifikator) => {
+			expect(resolveInboxShortcut(taste('a', { [modifikator]: true }))).toBeNull();
+		}
+	);
+
+	it('greift bei Shift, weil ? ohne Shift nicht erreichbar ist', () => {
+		expect(resolveInboxShortcut(taste('?', { shiftKey: true }))).toBe('toggleHelp');
+	});
+
+	it.each(['INPUT', 'TEXTAREA', 'SELECT'])('bleibt still, wenn %s fokussiert ist', (tagName) => {
+		expect(resolveInboxShortcut(taste('a', { target: ziel(tagName) }))).toBeNull();
+	});
+
+	it('bleibt still in einem contenteditable-Bereich', () => {
+		expect(
+			resolveInboxShortcut(taste('j', { target: ziel('DIV', { isContentEditable: true }) }))
+		).toBeNull();
+	});
+
+	it('bleibt still, wenn der Fokus in einem Dialog steht', () => {
+		/* Der Hilfe-Overlay ist selbst ein Dialog: Ohne diese Sperre würde ein „a"
+		   im offenen Overlay die Sichtung im Hintergrund freigeben. */
+		const imDialog = ziel('BUTTON', { closest: (selektor: string) => (selektor ? {} : null) });
+		expect(resolveInboxShortcut(taste('a', { target: imDialog }))).toBeNull();
+	});
+
+	it('lässt Escape auch aus einem Dialog und aus einem Eingabefeld durch', () => {
+		const imDialog = ziel('BUTTON', { closest: () => ({}) });
+		expect(resolveInboxShortcut(taste('Escape', { target: imDialog }))).toBe('closeHelp');
+		expect(resolveInboxShortcut(taste('Escape', { target: ziel('INPUT') }))).toBe('closeHelp');
+	});
+});
+
+describe('shiftFocusIndex', () => {
+	it('startet bei J auf der ersten Karte', () => {
+		expect(shiftFocusIndex(null, 3, 1)).toBe(0);
+	});
+
+	it('startet bei K auf der letzten Karte', () => {
+		expect(shiftFocusIndex(null, 3, -1)).toBe(2);
+	});
+
+	it('läuft an den Enden auf — kein Umlauf', () => {
+		/* Ein Umlauf springt beim Abarbeiten unbemerkt zurück an den Anfang und
+		   lässt schon Entschiedenes wieder wie Arbeit aussehen. */
+		expect(shiftFocusIndex(2, 3, 1)).toBe(2);
+		expect(shiftFocusIndex(0, 3, -1)).toBe(0);
+	});
+
+	it('bewegt sich innerhalb der Liste', () => {
+		expect(shiftFocusIndex(0, 3, 1)).toBe(1);
+		expect(shiftFocusIndex(2, 3, -1)).toBe(1);
+	});
+
+	it('ergibt bei leerer Liste keine Position', () => {
+		expect(shiftFocusIndex(null, 0, 1)).toBeNull();
+		expect(shiftFocusIndex(0, 0, -1)).toBeNull();
+	});
+
+	it('fängt eine Position ab, die die Liste nicht mehr hat', () => {
+		// Nach einem Reload kann die Liste kürzer sein als der gemerkte Index.
+		expect(shiftFocusIndex(9, 3, 1)).toBe(2);
+		expect(shiftFocusIndex(9, 3, -1)).toBe(2);
+	});
+});
+
+describe('nextActionableIndex', () => {
+	it('nimmt die nächste noch offene Karte nach der bearbeiteten', () => {
+		expect(nextActionableIndex([false, false, true, true], 1)).toBe(2);
+	});
+
+	it('geht zurück, wenn nach unten nichts mehr offen ist', () => {
+		/* Die letzte Karte abzuarbeiten darf den Fokus nicht ins Nichts werfen —
+		   sonst landet er beim nächsten Tab am Seitenanfang. */
+		expect(nextActionableIndex([true, false, false], 1)).toBe(0);
+	});
+
+	it('bleibt stehen, wenn die Position selbst noch offen ist', () => {
+		expect(nextActionableIndex([true, true], 0)).toBe(0);
+	});
+
+	it('ergibt keine Position, wenn alles erledigt ist', () => {
+		expect(nextActionableIndex([false, false], 0)).toBeNull();
+		expect(nextActionableIndex([], 0)).toBeNull();
+	});
+});
+
+describe('INBOX_SHORTCUTS', () => {
+	it('beschreibt jede belegte Taste — die Liste ist die Quelle des Overlays', () => {
+		const belegt = INBOX_SHORTCUTS.flatMap((eintrag) => eintrag.keys);
+		expect(belegt).toEqual(expect.arrayContaining(['J', 'K', 'A', 'R', 'U', '?']));
+	});
+
+	it('führt zu jeder Taste eine Erklärung', () => {
+		for (const eintrag of INBOX_SHORTCUTS) {
+			expect(eintrag.keys.length).toBeGreaterThan(0);
+			expect(eintrag.description.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/components/admin/inboxShortcuts.ts
+++ b/src/lib/components/admin/inboxShortcuts.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Tastatur-Triage der Eingangsseite (`/admin`, Spec B1).
+ *
+ * Der Eingang ist eine Task-Liste, die am Stück abgearbeitet wird — J/K
+ * blättert, A gibt frei, R lehnt ab, U nimmt zurück, ? erklärt. Die
+ * Entscheidungen dazu (welche Taste, wann gesperrt, wohin der Fokus danach)
+ * stehen hier und nicht in `+page.svelte`, damit sie ohne gerenderte Seite
+ * prüfbar sind.
+ *
+ * **Bewusst DOM-frei.** `resolveInboxShortcut` prüft das Ereignisziel per
+ * Duck-Typing (`ShortcutTarget`) statt mit `instanceof HTMLElement`: So läuft
+ * der Test im Node-Runner, und die Sperre lässt sich mit einem Objektliteral
+ * durchspielen — mit `instanceof` wäre jeder Fall an einen echten Browser
+ * gebunden.
+ */
+
+export type InboxShortcutAction =
+	'focusNext' | 'focusPrevious' | 'approve' | 'reject' | 'undo' | 'toggleHelp' | 'closeHelp';
+
+/**
+ * Das Ereignisziel, soweit die Sperre es liest. `closest` ist optional, weil
+ * `event.target` auch das `document` oder das `window` sein kann — beide haben
+ * die Methode nicht.
+ */
+export interface ShortcutTarget {
+	tagName?: string;
+	isContentEditable?: boolean;
+	closest?: (selector: string) => unknown;
+}
+
+export interface InboxShortcutEvent {
+	key: string;
+	ctrlKey: boolean;
+	metaKey: boolean;
+	altKey: boolean;
+	/**
+	 * `EventTarget` steht mit im Typ, weil ein echtes `KeyboardEvent` genau den
+	 * liefert — und `EventTarget` deklariert keine der drei Eigenschaften unten,
+	 * wäre also mit `ShortcutTarget` allein nicht zuweisbar.
+	 */
+	target: EventTarget | ShortcutTarget | null;
+}
+
+/** Ein Eintrag der Hilfe — gleichzeitig die Quelle des Overlays und des Hinweises. */
+export interface InboxShortcutHint {
+	keys: string[];
+	description: string;
+}
+
+/**
+ * Reihenfolge wie im Arbeitsablauf: erst blättern, dann entscheiden, dann
+ * korrigieren, zuletzt die Hilfe selbst.
+ */
+export const INBOX_SHORTCUTS: readonly InboxShortcutHint[] = [
+	{ keys: ['J'], description: 'Nächste Meldung' },
+	{ keys: ['K'], description: 'Vorherige Meldung' },
+	{ keys: ['A'], description: 'Freigeben' },
+	{ keys: ['R'], description: 'Ablehnen' },
+	{ keys: ['U'], description: 'Letzte Entscheidung rückgängig' },
+	{ keys: ['?'], description: 'Diese Übersicht ein- und ausblenden' },
+	{ keys: ['Esc'], description: 'Übersicht schließen' }
+];
+
+const KEY_ACTIONS: Record<string, InboxShortcutAction> = {
+	j: 'focusNext',
+	k: 'focusPrevious',
+	a: 'approve',
+	r: 'reject',
+	u: 'undo',
+	'?': 'toggleHelp'
+};
+
+const TYPING_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+/**
+ * Steht der Fokus dort, wo eine Taste etwas anderes bedeutet? Das sind
+ * Eingabefelder — und Dialoge, denn im offenen Hilfe-Overlay dürfte ein „a"
+ * nicht die Meldung dahinter freigeben.
+ */
+function isGuardedTarget(eventTarget: EventTarget | ShortcutTarget | null): boolean {
+	if (!eventTarget) return false;
+	const target = eventTarget as ShortcutTarget;
+	if (target.tagName && TYPING_TAGS.has(target.tagName)) return true;
+	if (target.isContentEditable) return true;
+	return Boolean(target.closest?.('dialog, [role="dialog"], [contenteditable="true"]'));
+}
+
+export function resolveInboxShortcut(event: InboxShortcutEvent): InboxShortcutAction | null {
+	// Strg/Cmd/Alt gehören dem Browser und dem System — Shift nicht, sonst wäre
+	// „?" auf einer deutschen Tastatur gar nicht erreichbar.
+	if (event.ctrlKey || event.metaKey || event.altKey) return null;
+	// Escape schließt die Hilfe von überall, auch aus dem Overlay selbst.
+	if (event.key === 'Escape') return 'closeHelp';
+	if (isGuardedTarget(event.target)) return null;
+	return KEY_ACTIONS[event.key.toLowerCase()] ?? null;
+}
+
+/**
+ * Die neue Fokusposition nach J (`delta = 1`) oder K (`delta = -1`).
+ *
+ * Ohne bisherige Position beginnt J oben und K unten — die Taste sagt damit
+ * zugleich, aus welcher Richtung man in die Liste einsteigt. An den Enden wird
+ * geklemmt und nicht umgelaufen: Ein Umlauf brächte beim Abarbeiten längst
+ * Entschiedenes zurück ins Blickfeld.
+ */
+export function shiftFocusIndex(
+	current: number | null,
+	count: number,
+	delta: 1 | -1
+): number | null {
+	if (count <= 0) return null;
+	if (current === null) return delta === 1 ? 0 : count - 1;
+	/* Ein Reload kann die Liste verkürzt haben; der gemerkte Index zeigt dann
+	   hinter das Ende. Das Zurückholen an das Listenende ist die Bewegung dieses
+	   Tastendrucks — ein zusätzlicher Schritt würde eine Karte überspringen, die
+	   der Bearbeiter nie gesehen hat. */
+	if (current > count - 1) return count - 1;
+	return Math.min(Math.max(current + delta, 0), count - 1);
+}
+
+/**
+ * Wohin der Fokus nach einer Entscheidung wandert: auf die nächste Karte, die
+ * noch eine Entscheidung braucht.
+ *
+ * Gesucht wird ab `from` abwärts, danach aufwärts — die bearbeitete Karte
+ * bleibt als Undo-Zeile stehen, ihre Position ist also besetzt, aber nicht mehr
+ * bedienbar. Bleibt nichts übrig, gibt es keine Position; die Seite lässt den
+ * Fokus dann auf der Undo-Schaltfläche, statt ihn an den Seitenanfang zu
+ * verlieren.
+ */
+export function nextActionableIndex(actionable: readonly boolean[], from: number): number | null {
+	for (let index = Math.max(from, 0); index < actionable.length; index++) {
+		if (actionable[index]) return index;
+	}
+	for (let index = Math.min(from, actionable.length) - 1; index >= 0; index--) {
+		if (actionable[index]) return index;
+	}
+	return null;
+}

--- a/src/lib/components/admin/inboxShortcuts.ts
+++ b/src/lib/components/admin/inboxShortcuts.ts
@@ -66,23 +66,28 @@ const KEY_ACTIONS: Record<string, InboxShortcutAction> = {
 	k: 'focusPrevious',
 	a: 'approve',
 	r: 'reject',
-	u: 'undo',
-	'?': 'toggleHelp'
+	u: 'undo'
 };
 
 const TYPING_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
 
-/**
- * Steht der Fokus dort, wo eine Taste etwas anderes bedeutet? Das sind
- * Eingabefelder — und Dialoge, denn im offenen Hilfe-Overlay dürfte ein „a"
- * nicht die Meldung dahinter freigeben.
- */
-function isGuardedTarget(eventTarget: EventTarget | ShortcutTarget | null): boolean {
+/** Wo eine Taste ein Zeichen ist und kein Befehl. */
+function isTypingTarget(eventTarget: EventTarget | ShortcutTarget | null): boolean {
 	if (!eventTarget) return false;
 	const target = eventTarget as ShortcutTarget;
 	if (target.tagName && TYPING_TAGS.has(target.tagName)) return true;
 	if (target.isContentEditable) return true;
-	return Boolean(target.closest?.('dialog, [role="dialog"], [contenteditable="true"]'));
+	return Boolean(target.closest?.('[contenteditable="true"]'));
+}
+
+/**
+ * Steht der Fokus in einem Dialog? Dort darf kein Kürzel die Seite dahinter
+ * bedienen — ein „a" im offenen Hilfe-Overlay würde sonst die Meldung
+ * darunter freigeben.
+ */
+function isDialogTarget(eventTarget: EventTarget | ShortcutTarget | null): boolean {
+	if (!eventTarget) return false;
+	return Boolean((eventTarget as ShortcutTarget).closest?.('dialog, [role="dialog"]'));
 }
 
 export function resolveInboxShortcut(event: InboxShortcutEvent): InboxShortcutAction | null {
@@ -91,7 +96,13 @@ export function resolveInboxShortcut(event: InboxShortcutEvent): InboxShortcutAc
 	if (event.ctrlKey || event.metaKey || event.altKey) return null;
 	// Escape schließt die Hilfe von überall, auch aus dem Overlay selbst.
 	if (event.key === 'Escape') return 'closeHelp';
-	if (isGuardedTarget(event.target)) return null;
+	if (isTypingTarget(event.target)) return null;
+	/* „?" steht bewusst VOR der Dialog-Sperre: Es blendet die Übersicht auch
+	   wieder aus, und im offenen Overlay liegt der Fokus im Dialog. Hinter der
+	   Sperre wäre `toggleHelp` eine Einbahnstraße — der Name behauptete ein
+	   Umschalten, das nie eintritt. */
+	if (event.key === '?') return 'toggleHelp';
+	if (isDialogTarget(event.target)) return null;
 	return KEY_ACTIONS[event.key.toLowerCase()] ?? null;
 }
 

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -337,7 +337,11 @@
 </div>
 
 {#if hilfeOffen}
-	<InboxShortcutHelp onClose={() => (hilfeOffen = false)} />
+	<!-- `hilfeSchliessen` und nicht `hilfeOffen = false`: Knopf und Hintergrund
+	     brauchen denselben Fokus-Rückweg wie Escape. Sonst bliebe die gemerkte
+	     Position gesetzt, ohne dass eine Karte den Fokus sichtbar trägt — A und R
+	     wirkten dann auf eine Karte, die niemand sieht. -->
+	<InboxShortcutHelp onClose={hilfeSchliessen} />
 {/if}
 
 <style>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
 	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
+	import InboxShortcutHelp from '$lib/components/admin/InboxShortcutHelp.svelte';
 	import SightingInboxCard from '$lib/components/admin/SightingInboxCard.svelte';
+	import {
+		nextActionableIndex,
+		resolveInboxShortcut,
+		shiftFocusIndex
+	} from '$lib/components/admin/inboxShortcuts';
 	import { submitVerdict, type SightingVerdict } from '$lib/components/admin/sightingVerdict';
 	import {
 		SIGHTING_STATUS_PRESENTATION,
 		SIGHTING_STATUS_UNDO_MS,
 		verdictToStatus
 	} from '$lib/components/admin/sightingStatus';
-	import { onDestroy } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import ArrowDown from '~icons/lucide/arrow-down';
 	import ArrowUp from '~icons/lucide/arrow-up';
@@ -29,6 +35,90 @@
 	   `data.open`. Erst nach dem Reload ist der Server die Wahrheit. */
 	const abgelaufen = new SvelteSet<number>();
 
+	/* Tastatur-Triage (Spec B1). Die Fokusposition ist ein Index und keine ID:
+	   Nachrücken heißt „die nächste Karte in der Liste", und das ist eine Aussage
+	   über Positionen. Die Zuordnung Taste → Aktion und die Fokusarithmetik
+	   stehen in `inboxShortcuts.ts`. */
+	let fokusIndex = $state<number | null>(null);
+	let hilfeOffen = $state(false);
+	/* Die letzte Entscheidung für U. Sie wird auch beim Klick gesetzt — wer mit
+	   der Maus freigibt und die Korrektur per Taste sucht, findet sie damit. */
+	let letzteEntscheidungId = $state<number | null>(null);
+	/* `$state` und nicht ein einfaches Array: `bind:this` in ein nicht-reaktives
+	   Array schreibt zwar, warnt aber zur Laufzeit (`binding_property_non_reactive`)
+	   — und die Zuweisung wäre nicht nachvollziehbar, wenn die Liste sich ändert. */
+	let kartenElemente = $state<(HTMLLIElement | null)[]>([]);
+
+	/** Welche Positionen noch eine Entscheidung brauchen — Grundlage des Nachrückens. */
+	const bedienbar = $derived(
+		data.open.map((sighting) => !done[sighting.id] && !abgelaufen.has(sighting.id))
+	);
+
+	async function fokussiere(index: number | null) {
+		fokusIndex = index;
+		if (index === null) return;
+		// Erst nach dem Rendern: Nach einer Entscheidung wechselt die Zielkarte
+		// gerade ihren Inhalt, und ein Fokus davor landet am alten Knoten.
+		await tick();
+		kartenElemente[index]?.focus();
+	}
+
+	async function entscheidenPerTaste(verdict: Exclude<SightingVerdict, 'reset'>) {
+		const index = fokusIndex;
+		if (index === null) return;
+		const sichtung = data.open[index];
+		if (!sichtung || !bedienbar[index]) return;
+		await entscheiden(sichtung.id, verdict);
+		/* Nachrücken erst nach dem Abschluss und über `bedienbar`: Scheitert der
+		   Aufruf, ist die Karte weiter offen — `nextActionableIndex` liefert dann
+		   dieselbe Position, und der Fokus bleibt, wo die Arbeit liegt. */
+		await fokussiere(nextActionableIndex(bedienbar, index));
+	}
+
+	async function rueckgaengigPerTaste() {
+		const id = letzteEntscheidungId;
+		// Nur innerhalb des Undo-Fensters: Ist der Timer weg, ist die Zeile weg,
+		// und ein `reset` würde einen Zustand herstellen, den niemand mehr sieht.
+		if (id === null || !timers.has(id)) return;
+		await rueckgaengig(id);
+		const index = data.open.findIndex((sighting) => sighting.id === id);
+		if (index >= 0) await fokussiere(index);
+	}
+
+	function aufTaste(event: KeyboardEvent) {
+		const aktion = resolveInboxShortcut(event);
+		if (!aktion) return;
+		if (aktion === 'closeHelp') {
+			// Nur schlucken, wenn es etwas zu schließen gab — sonst nimmt die Seite
+			// Escape anderen Bedienelementen weg.
+			if (!hilfeOffen) return;
+			event.preventDefault();
+			hilfeOffen = false;
+			return;
+		}
+		event.preventDefault();
+		switch (aktion) {
+			case 'focusNext':
+				void fokussiere(shiftFocusIndex(fokusIndex, data.open.length, 1));
+				return;
+			case 'focusPrevious':
+				void fokussiere(shiftFocusIndex(fokusIndex, data.open.length, -1));
+				return;
+			case 'approve':
+				void entscheidenPerTaste('approve');
+				return;
+			case 'reject':
+				void entscheidenPerTaste('reject');
+				return;
+			case 'undo':
+				void rueckgaengigPerTaste();
+				return;
+			case 'toggleHelp':
+				hilfeOffen = !hilfeOffen;
+				return;
+		}
+	}
+
 	onDestroy(() => {
 		// Ohne dieses Aufräumen feuert ein laufender Undo-Timer nach dem Verlassen
 		// der Seite noch invalidateAll() und lädt fremde Routen neu.
@@ -43,6 +133,7 @@
 		busy[id] = false;
 		if (!ok) return;
 		done[id] = verdict;
+		letzteEntscheidungId = id;
 		timers.set(
 			id,
 			setTimeout(async () => {
@@ -76,7 +167,11 @@
 		busy[id] = true;
 		const ok = await submitVerdict(id, 'reset');
 		busy[id] = false;
-		if (ok) delete done[id];
+		if (!ok) return;
+		delete done[id];
+		// Zurückgenommen ist nichts mehr zurückzunehmen — ein zweites U darf nicht
+		// dieselbe Sichtung erneut zurücksetzen.
+		if (letzteEntscheidungId === id) letzteEntscheidungId = null;
 	}
 
 	function sortierungUmschalten() {
@@ -90,6 +185,8 @@
 <svelte:head>
 	<title>Eingang – Verwaltung</title>
 </svelte:head>
+
+<svelte:window onkeydown={aufTaste} />
 
 <div class="container mx-auto max-w-3xl px-4 py-6">
 	<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
@@ -105,6 +202,20 @@
 			{/if}
 		</button>
 	</div>
+
+	<!-- Der Hinweis steht über der Liste und nicht in einem Tooltip: Ein Kürzel,
+	     das man erst durch Ausprobieren findet, benutzt niemand. Die Taste selbst
+	     ist die Beschriftung des Knopfes, damit Hinweis und Overlay dieselbe
+	     Bedienung nennen. -->
+	<p class="text-base-content/70 mb-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+		<span>
+			Tastatur: <kbd class="kbd kbd-sm">J</kbd> / <kbd class="kbd kbd-sm">K</kbd> blättern,
+			<kbd class="kbd kbd-sm">A</kbd> freigeben, <kbd class="kbd kbd-sm">R</kbd> ablehnen
+		</span>
+		<button type="button" class="btn btn-ghost btn-xs" onclick={() => (hilfeOffen = true)}>
+			alle Kürzel <kbd class="kbd kbd-xs">?</kbd>
+		</button>
+	</p>
 
 	{#if data.pendingPhotoAnnouncements > 0}
 		<div class="alert alert-info mb-4">
@@ -123,10 +234,19 @@
 		</div>
 	{:else}
 		<ul class="flex flex-col gap-3">
-			{#each data.open as sighting (sighting.id)}
+			{#each data.open as sighting, index (sighting.id)}
 				{@const verdict = done[sighting.id]}
 				{#if !abgelaufen.has(sighting.id)}
-					<li>
+					<!-- `tabindex="-1"` macht die Karte für J/K anfokussierbar, ohne sie in
+					     die Tab-Reihenfolge zu hängen — dort stehen die Schaltflächen
+					     darin, und ein zusätzlicher Halt vor jeder Karte verdoppelte den
+					     Weg für alle, die ohne die Kürzel arbeiten. -->
+					<li
+						bind:this={kartenElemente[index]}
+						data-inbox-index={index}
+						tabindex="-1"
+						class="inbox-card"
+					>
 						{#if verdict}
 							{@const status = SIGHTING_STATUS_PRESENTATION[verdictToStatus(verdict)]}
 							<div class="alert py-2" role="status">
@@ -167,3 +287,18 @@
 		{/if}
 	{/if}
 </div>
+
+{#if hilfeOffen}
+	<InboxShortcutHelp onClose={() => (hilfeOffen = false)} />
+{/if}
+
+<style>
+	/* Der Fokus-Ring gehört an die Karte selbst: Bei J/K ist sie das bewegte
+	   Element, und ohne sichtbaren Ring wüsste niemand, welche Meldung ein
+	   folgendes A entscheidet. Maße und Farbe aus den Tokens. */
+	.inbox-card:focus-visible {
+		outline: 3px solid var(--color-primary);
+		outline-offset: 3px;
+		border-radius: var(--radius-box);
+	}
+</style>

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -38,7 +38,12 @@
 	/* Tastatur-Triage (Spec B1). Die Fokusposition ist ein Index und keine ID:
 	   Nachrücken heißt „die nächste Karte in der Liste", und das ist eine Aussage
 	   über Positionen. Die Zuordnung Taste → Aktion und die Fokusarithmetik
-	   stehen in `inboxShortcuts.ts`. */
+	   stehen in `inboxShortcuts.ts`.
+
+	   **Sie folgt dem echten DOM-Fokus** (`onfocusin`/`onfocusout` an der Liste)
+	   und nicht nur J und K. Sonst entschiede A über eine Karte, die niemand
+	   sieht: Der Ring hängt am DOM-Fokus, und wer nach einem J per Tab oder Klick
+	   in eine andere Karte wandert, hätte eine Freigabe an der ersten ausgelöst. */
 	let fokusIndex = $state<number | null>(null);
 	let hilfeOffen = $state(false);
 	/* Die letzte Entscheidung für U. Sie wird auch beim Klick gesetzt — wer mit
@@ -48,6 +53,8 @@
 	   Array schreibt zwar, warnt aber zur Laufzeit (`binding_property_non_reactive`)
 	   — und die Zuweisung wäre nicht nachvollziehbar, wenn die Liste sich ändert. */
 	let kartenElemente = $state<(HTMLLIElement | null)[]>([]);
+	/** Ziel des Fokus-Rückwegs, wenn das Overlay ohne fokussierte Karte geöffnet wurde. */
+	let hinweisKnopf = $state<HTMLButtonElement | null>(null);
 
 	/** Welche Positionen noch eine Entscheidung brauchen — Grundlage des Nachrückens. */
 	const bedienbar = $derived(
@@ -61,6 +68,27 @@
 		// gerade ihren Inhalt, und ein Fokus davor landet am alten Knoten.
 		await tick();
 		kartenElemente[index]?.focus();
+	}
+
+	/** Der Fokus ist irgendwo in der Liste angekommen — welche Karte trägt ihn? */
+	function fokusAufgenommen(event: FocusEvent) {
+		const karte = (event.target as Element | null)?.closest('[data-inbox-index]');
+		const index = Number(karte?.getAttribute('data-inbox-index'));
+		if (Number.isInteger(index)) fokusIndex = index;
+	}
+
+	/**
+	 * Verlässt der Fokus die Liste ganz, gibt es keine Karte mehr, auf die A oder
+	 * R wirken dürften. `relatedTarget` ist das Element, das den Fokus bekommt —
+	 * `null` heißt „gar keines" (Klick ins Leere, Wechsel des Fensters).
+	 */
+	function fokusAbgegeben(event: FocusEvent) {
+		const ziel = event.relatedTarget as Node | null;
+		if (ziel && event.currentTarget instanceof Node && event.currentTarget.contains(ziel)) return;
+		// Nicht während das Overlay offen ist: Dessen Fokuswechsel darf die Position
+		// nicht vergessen, sonst fällt der Fokus beim Schließen ins Nichts.
+		if (hilfeOffen) return;
+		fokusIndex = null;
 	}
 
 	async function entscheidenPerTaste(verdict: Exclude<SightingVerdict, 'reset'>) {
@@ -85,6 +113,17 @@
 		if (index >= 0) await fokussiere(index);
 	}
 
+	/**
+	 * Beim Schließen wandert der Fokus zurück — auf die Karte, die ihn vorher
+	 * hatte, sonst auf den Knopf, der das Overlay geöffnet hat. Ohne das fällt er
+	 * auf `<body>`, und die J/K-Position wäre danach unsichtbar.
+	 */
+	function hilfeSchliessen() {
+		hilfeOffen = false;
+		if (fokusIndex !== null) void fokussiere(fokusIndex);
+		else hinweisKnopf?.focus();
+	}
+
 	function aufTaste(event: KeyboardEvent) {
 		const aktion = resolveInboxShortcut(event);
 		if (!aktion) return;
@@ -93,7 +132,7 @@
 			// Escape anderen Bedienelementen weg.
 			if (!hilfeOffen) return;
 			event.preventDefault();
-			hilfeOffen = false;
+			hilfeSchliessen();
 			return;
 		}
 		event.preventDefault();
@@ -114,7 +153,8 @@
 				void rueckgaengigPerTaste();
 				return;
 			case 'toggleHelp':
-				hilfeOffen = !hilfeOffen;
+				if (hilfeOffen) hilfeSchliessen();
+				else hilfeOffen = true;
 				return;
 		}
 	}
@@ -212,7 +252,12 @@
 			Tastatur: <kbd class="kbd kbd-sm">J</kbd> / <kbd class="kbd kbd-sm">K</kbd> blättern,
 			<kbd class="kbd kbd-sm">A</kbd> freigeben, <kbd class="kbd kbd-sm">R</kbd> ablehnen
 		</span>
-		<button type="button" class="btn btn-ghost btn-xs" onclick={() => (hilfeOffen = true)}>
+		<button
+			type="button"
+			class="btn btn-ghost btn-xs"
+			bind:this={hinweisKnopf}
+			onclick={() => (hilfeOffen = true)}
+		>
 			alle Kürzel <kbd class="kbd kbd-xs">?</kbd>
 		</button>
 	</p>
@@ -233,7 +278,10 @@
 			<p class="text-base-content/70 mt-1 text-sm">Keine offenen Sichtungen.</p>
 		</div>
 	{:else}
-		<ul class="flex flex-col gap-3">
+		<!-- Die Fokus-Handler sitzen an der Liste und nicht an jeder Karte: `focusin`
+		     und `focusout` steigen auf, und nur hier ist entscheidbar, ob der Fokus
+		     die Liste ganz verlassen hat. -->
+		<ul class="flex flex-col gap-3" onfocusin={fokusAufgenommen} onfocusout={fokusAbgegeben}>
 			{#each data.open as sighting, index (sighting.id)}
 				{@const verdict = done[sighting.id]}
 				{#if !abgelaufen.has(sighting.id)}
@@ -295,8 +343,13 @@
 <style>
 	/* Der Fokus-Ring gehört an die Karte selbst: Bei J/K ist sie das bewegte
 	   Element, und ohne sichtbaren Ring wüsste niemand, welche Meldung ein
-	   folgendes A entscheidet. Maße und Farbe aus den Tokens. */
-	.inbox-card:focus-visible {
+	   folgendes A entscheidet. Maße und Farbe aus den Tokens.
+
+	   `:has(:focus-visible)` gehört dazu, weil der Fokus per Tab auch auf einer
+	   Schaltfläche *innerhalb* der Karte landet — A wirkt dann auf diese Karte,
+	   und der Ring muss das zeigen. */
+	.inbox-card:focus-visible,
+	.inbox-card:has(:global(:focus-visible)) {
 		outline: 3px solid var(--color-primary);
 		outline-offset: 3px;
 		border-radius: var(--radius-box);

--- a/src/routes/admin/inboxShortcuts.svelte.test.ts
+++ b/src/routes/admin/inboxShortcuts.svelte.test.ts
@@ -131,6 +131,59 @@ describe('Eingangsseite — Tastatur-Triage', () => {
 		expect(submitVerdict).not.toHaveBeenCalled();
 	});
 
+	it('entscheidet über die Karte, die den Fokus sichtbar hat', async () => {
+		/* Ohne diese Kopplung entschied A über eine Karte, die niemand sieht: Der
+		   Ring folgt dem DOM-Fokus, die gemerkte Position folgte nur J und K. Wer
+		   nach einem J per Tab oder Klick in eine andere Karte wandert und dann A
+		   drückt, gibt sonst die erste frei. */
+		const screen = render(AdminInbox, { data: daten([81, 82]) });
+
+		await userEvent.keyboard('j');
+		const zweiteFreigabe = screen.getByRole('button', { name: 'Freigeben' }).elements()[1];
+		(zweiteFreigabe as HTMLElement).focus();
+
+		await userEvent.keyboard('a');
+
+		expect(submitVerdict).toHaveBeenCalledWith(82, 'approve');
+	});
+
+	it('entscheidet nichts, wenn der Fokus die Liste verlassen hat', async () => {
+		const screen = render(AdminInbox, { data: daten([91]) });
+
+		await userEvent.keyboard('j');
+		/* Der Sortier-Umschalter steht außerhalb der Liste — er ist der kürzeste
+		   echte Weg aus ihr heraus. `document.body.focus()` taugt dafür nicht: Der
+		   Body ist nicht fokussierbar, der Fokus bliebe auf der Karte, und der Test
+		   prüfte am Ende nichts. */
+		(screen.getByRole('button', { name: /zuerst/ }).element() as HTMLElement).focus();
+
+		await userEvent.keyboard('a');
+
+		expect(submitVerdict).not.toHaveBeenCalled();
+	});
+
+	it('blendet die Übersicht mit einem zweiten ? wieder aus', async () => {
+		const screen = render(AdminInbox, { data: daten([101]) });
+
+		await userEvent.keyboard('?');
+		const overlay = screen.getByRole('dialog', { name: /Tastaturkürzel/ });
+		await expect.element(overlay).toBeInTheDocument();
+
+		await userEvent.keyboard('?');
+		await expect.element(overlay).not.toBeInTheDocument();
+	});
+
+	it('gibt den Fokus nach dem Schließen an die Karte zurück', async () => {
+		render(AdminInbox, { data: daten([111, 112]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('?');
+		await userEvent.keyboard('{Escape}');
+
+		await vi.waitFor(() => expect(fokussierteKarte()).toBe('1'));
+	});
+
 	it('macht die Shortcuts ohne Overlay entdeckbar', async () => {
 		const screen = render(AdminInbox, { data: daten([51]) });
 

--- a/src/routes/admin/inboxShortcuts.svelte.test.ts
+++ b/src/routes/admin/inboxShortcuts.svelte.test.ts
@@ -1,0 +1,161 @@
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+/**
+ * @fileoverview Tastatur-Triage des Eingangs (Spec B1) — die Strecke von der
+ * echten Taste bis zum Fokus und zum Verdict.
+ *
+ * Die Tastenzuordnung selbst prüft `inboxShortcuts.test.ts` im Node-Runner.
+ * Hier geht es um das, was nur ein Browser zeigt: Wer hat den Fokus, wandert er
+ * nach einer Entscheidung weiter, und öffnet „?" das Overlay.
+ */
+
+const invalidateAll = vi.fn(() => Promise.resolve());
+const submitVerdict = vi.fn(() => Promise.resolve(true));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict
+}));
+
+const AdminInbox = (await import('./+page.svelte')).default;
+
+function sichtung(id: number): SightingSelect {
+	return {
+		id,
+		created: new Date('2026-08-01T10:00:00Z'),
+		sightingDate: new Date('2026-07-30T08:00:00Z'),
+		species: 0,
+		totalCount: 1,
+		juvenileCount: 0,
+		isDead: 0,
+		email: `melder${id}@example.com`,
+		firstName: 'Kim',
+		lastName: 'Muster',
+		spamScore: null,
+		inBalticSea: 1,
+		inBalticSeaGeo: 1
+	} as unknown as SightingSelect;
+}
+
+function daten(ids: number[]): PageData {
+	return {
+		open: ids.map(sichtung),
+		openTotal: ids.length,
+		order: 'asc' as const,
+		imagesBySighting: {},
+		pendingPhotoAnnouncements: 0,
+		duplicatesBySighting: {}
+	} as unknown as PageData;
+}
+
+/** Die Position der fokussierten Karte — `null`, wenn keine den Fokus hat. */
+function fokussierteKarte(): string | null {
+	return (
+		document.activeElement?.closest('[data-inbox-index]')?.getAttribute('data-inbox-index') ?? null
+	);
+}
+
+describe('Eingangsseite — Tastatur-Triage', () => {
+	beforeEach(() => {
+		invalidateAll.mockClear();
+		submitVerdict.mockClear();
+	});
+
+	it('fokussiert mit J vorwärts und mit K zurück', async () => {
+		render(AdminInbox, { data: daten([1, 2, 3]) });
+
+		await userEvent.keyboard('j');
+		expect(fokussierteKarte()).toBe('0');
+
+		await userEvent.keyboard('j');
+		expect(fokussierteKarte()).toBe('1');
+
+		await userEvent.keyboard('k');
+		expect(fokussierteKarte()).toBe('0');
+
+		// Am oberen Ende bleibt der Fokus stehen, statt umzulaufen.
+		await userEvent.keyboard('k');
+		expect(fokussierteKarte()).toBe('0');
+	});
+
+	it('gibt die fokussierte Karte mit A frei und rückt den Fokus nach', async () => {
+		const screen = render(AdminInbox, { data: daten([11, 12]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('a');
+
+		expect(submitVerdict).toHaveBeenCalledWith(11, 'approve');
+		await expect.element(screen.getByRole('button', { name: 'Rückgängig' })).toBeInTheDocument();
+		/* Die bearbeitete Karte bleibt als Undo-Zeile stehen — der Fokus darf dort
+		   nicht kleben bleiben, sonst tut das nächste A nichts. */
+		await vi.waitFor(() => expect(fokussierteKarte()).toBe('1'));
+	});
+
+	it('lehnt die fokussierte Karte mit R ab', async () => {
+		render(AdminInbox, { data: daten([21, 22]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('r');
+
+		expect(submitVerdict).toHaveBeenCalledWith(22, 'reject');
+	});
+
+	it('nimmt die letzte Entscheidung mit U zurück', async () => {
+		const screen = render(AdminInbox, { data: daten([31, 32]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('a');
+		await expect.element(screen.getByRole('button', { name: 'Rückgängig' })).toBeInTheDocument();
+
+		await userEvent.keyboard('u');
+
+		await vi.waitFor(() => expect(submitVerdict).toHaveBeenCalledWith(31, 'reset'));
+	});
+
+	it('tut bei A nichts, solange keine Karte fokussiert ist', async () => {
+		render(AdminInbox, { data: daten([41]) });
+
+		await userEvent.keyboard('a');
+
+		expect(submitVerdict).not.toHaveBeenCalled();
+	});
+
+	it('macht die Shortcuts ohne Overlay entdeckbar', async () => {
+		const screen = render(AdminInbox, { data: daten([51]) });
+
+		await expect.element(screen.getByText(/Tastatur/)).toBeInTheDocument();
+	});
+
+	it('öffnet mit ? die Übersicht und schließt sie mit Escape', async () => {
+		const screen = render(AdminInbox, { data: daten([61]) });
+
+		await userEvent.keyboard('?');
+		const overlay = screen.getByRole('dialog', { name: /Tastaturkürzel/ });
+		await expect.element(overlay).toBeInTheDocument();
+		await expect.element(screen.getByText('Nächste Meldung')).toBeInTheDocument();
+
+		await userEvent.keyboard('{Escape}');
+		await expect.element(overlay).not.toBeInTheDocument();
+	});
+
+	it('entscheidet nichts, während die Übersicht offen ist', async () => {
+		render(AdminInbox, { data: daten([71]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('?');
+		await userEvent.keyboard('a');
+
+		expect(submitVerdict).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/admin/inboxShortcuts.svelte.test.ts
+++ b/src/routes/admin/inboxShortcuts.svelte.test.ts
@@ -184,6 +184,50 @@ describe('Eingangsseite — Tastatur-Triage', () => {
 		await vi.waitFor(() => expect(fokussierteKarte()).toBe('1'));
 	});
 
+	it('gibt den Fokus auch beim Schließen per Schaltfläche zurück', async () => {
+		/* Der Knopf und der Hintergrund laufen über `onClose` und nicht über den
+		   Escape-Zweig — genau dort wird der Fokus-Rückweg leicht vergessen. Ohne
+		   ihn bliebe die gemerkte Position gesetzt, während keine Karte den Fokus
+		   sichtbar trägt: A und R wirkten dann wieder auf eine unsichtbare Karte. */
+		const screen = render(AdminInbox, { data: daten([121, 122]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('?');
+		await screen.getByRole('button', { name: 'Schließen', exact: true }).click();
+
+		await vi.waitFor(() => expect(fokussierteKarte()).toBe('1'));
+	});
+
+	it('gibt den Fokus beim Klick auf den Hintergrund zurück', async () => {
+		const screen = render(AdminInbox, { data: daten([131]) });
+
+		await userEvent.keyboard('j');
+		await userEvent.keyboard('?');
+		await screen.getByRole('button', { name: /Tastaturkürzel schließen/ }).click();
+
+		await vi.waitFor(() => expect(fokussierteKarte()).toBe('0'));
+	});
+
+	it('gibt den Fokus an den Hinweis-Knopf, wenn keine Karte ihn hatte', async () => {
+		/* Geöffnet wird hier per Taste und nicht per Klick auf den Hinweis-Knopf:
+		   Nach einem Klick trägt der Knopf den Fokus schon, und Chromium stellt ihn
+		   beim Entfernen des Dialogs von selbst wieder her — der Test wäre auch ohne
+		   den Rückweg im Code grün. Über die Taste gibt es kein solches Vorher, und
+		   ohne den Rückweg landet der Fokus auf `<body>`.
+
+		   Verglichen wird das **Element** und nicht sein `textContent`: Fällt der
+		   Fokus auf `<body>`, enthält deren Textinhalt den ganzen Seitentext und
+		   damit auch „alle Kürzel" — eine Text-Assertion wäre hier immer grün. */
+		const screen = render(AdminInbox, { data: daten([141]) });
+		const knopf = screen.getByRole('button', { name: /alle Kürzel/ }).element();
+
+		await userEvent.keyboard('?');
+		await userEvent.keyboard('{Escape}');
+
+		await vi.waitFor(() => expect(document.activeElement).toBe(knopf));
+	});
+
 	it('macht die Shortcuts ohne Overlay entdeckbar', async () => {
 		const screen = render(AdminInbox, { data: daten([51]) });
 


### PR DESCRIPTION
Der Eingang ist eine Task-Liste, die am Stück abgearbeitet wird — bisher nur mit der Maus. Diese Änderung setzt Spec B1 um: `J`/`K` blättert durch die Karten, `A` gibt frei, `R` lehnt ab, `U` nimmt die letzte Entscheidung innerhalb des bestehenden 8-Sekunden-Fensters zurück, `?` öffnet eine Übersicht.

## Aufbau

Die Logik liegt als reine Funktionen in `src/lib/components/admin/inboxShortcuts.ts` — **bewusst DOM-frei**: Das Ereignisziel wird per Duck-Typing geprüft statt mit `instanceof HTMLElement`, damit die Tastenzuordnung im Node-Runner prüfbar ist und nicht an einen Browser gebunden ist.

Drei Entscheidungen daraus, die im Code begründet stehen:

- **Strg/Cmd/Alt sperren, Shift nicht.** Ohne Shift ist `?` auf einer deutschen Tastatur nicht erreichbar.
- **Die Sperre erfasst Eingabefelder und Dialoge.** Ein `A` im offenen Overlay darf nicht die Meldung dahinter freigeben. `?` steht bewusst *vor* der Dialog-Sperre — sonst wäre es eine Einbahnstraße und könnte die Übersicht nie wieder schließen.
- **`shiftFocusIndex` klemmt an den Listenenden statt umzulaufen.** Ein Umlauf brächte beim Abarbeiten längst Entschiedenes zurück ins Blickfeld.

**Fokus nach einer Entscheidung** übernimmt `nextActionableIndex`: Die bearbeitete Karte bleibt als Undo-Zeile stehen, ihre Position ist also besetzt, aber nicht mehr bedienbar — der Fokus rückt auf die nächste offene Karte, sonst auf die vorherige. Scheitert der Verdict-Aufruf, liefert dieselbe Funktion die Ausgangsposition, der Ring bleibt also dort, wo die Arbeit liegt.

## Zwei Befunde aus dem Review, die schon behoben sind

- **A/R wirkten auf eine Karte, die niemand sieht.** Die gemerkte Position folgte nur `J`/`K`, der Ring aber dem DOM-Fokus. Wer nach einem `J` per Tab oder Klick in eine andere Karte wanderte, löste die Freigabe an der ersten aus. Die Position folgt jetzt `focusin`/`focusout` an der Liste, und der Ring liegt auch dann an der Karte, wenn eine Schaltfläche darin den Fokus hat.
- **Fokus-Rückweg beim Schließen des Overlays.** Vorher fiel er auf `<body>`, jetzt geht er an die Karte zurück (sonst an den auslösenden Knopf).

## A11y

Die Karten tragen `tabindex="-1"` — anfokussierbar für `J`/`K`, aber ohne zusätzlichen Halt in der Tab-Reihenfolge; dort stehen weiterhin die Schaltflächen. Der Ring kommt aus den Theme-Tokens (`--color-primary`, `--radius-box`), die Kürzel sind über eine dauerhafte Hinweiszeile und das Overlay entdeckbar.

## Tests

- 33 Unit-Tests für Tastenzuordnung, Sperre und Fokusarithmetik (`inboxShortcuts.test.ts`)
- 12 Browser-Tests für die Strecke Taste → Fokus → Verdict (`inboxShortcuts.svelte.test.ts`), inklusive der Fälle „Fokus außerhalb der Liste" und „Overlay offen"
- Ein E2E-Test für den Fokus-Ring. Er misst `outline-style` und **nicht** `outline-width`: Letzteres rechnet ohne jede Regel auf den Initialwert `medium` = 3px, weshalb die erste Fassung des Tests auch bei entfernter Regel grün war. Beide Richtungen sind nachgestellt — ohne das `:global()` im `:has()` ist er rot.

`npm run test:quick` (4080 Tests) grün, ebenso `admin-inbox`, `modal-overflow` und der Design-Token-Scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)