### PR TITLE
docs(admin): correct the undo-href rule and the queue sort-key comment

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -101,9 +101,15 @@ Drei Dinge dabei nicht zurückdrehen:
 
 **Der Undo-Href gehört ausschließlich dem Arbeitsmodus.** `planAdvance()`
 (`queueAdvance.ts`) liefert `undoHref` nur, wenn tatsächlich ein Advance
-stattgefunden hat (`queue !== null || queueFailed`). Aus der Tabelle heraus
-(`queue === null && !queueFailed`) bleibt er `null`, und der „Rückgängig"-Knopf
-setzt dann nur den Status zurück, ohne zu navigieren. Der Grund: `queueHref()`
+stattgefunden hat — die Bedingung dafür ist `target.kind !== 'stay'` und nicht
+etwa die Mitgliedschaft im Warteschlangen-Modus. `stay` deckt drei Fälle ab:
+aus der Tabelle geöffnet (`queue === null && !queueFailed`), fehlgeschlagene
+Queue-Abfrage (`queueFailed`) und `verdict === 'reset'`. In allen dreien bleibt
+der Href `null`, und der „Rückgängig"-Knopf setzt dann nur den Status zurück,
+ohne zu navigieren. Bei den letzten beiden wäre er zwar korrekt, aber nutzlos:
+Man steht bereits auf der entschiedenen Sichtung, ein `goto` darauf lädt nur neu
+und wirft die Scroll-Position weg. Beim ersten dagegen wäre er schädlich, und
+das ist der eigentliche Grund für die Regel: `queueHref()`
 stempelt über `inboxDetailHref` bedingungslos `?from=inbox` auf die Ziel-URL —
 ein unbedingt vergebener Undo-Href hätte damit auf eine aus der Tabelle
 geöffnete Sichtung die Herkunft des Eingangs geschrieben, und ein Klick darauf

--- a/e2e/admin-queue.spec.ts
+++ b/e2e/admin-queue.spec.ts
@@ -37,8 +37,12 @@ function seedQueueSighting(referenceId: string): Promise<number> {
 }
 
 test.describe('Admin-Warteschlange', () => {
-	// Älteste zuerst angelegt, damit bei `order=desc` (Default) C vor B vor A
-	// erscheint — `created` ist der einzige Sortierschlüssel (openQueueOrder.ts).
+	/* Älteste zuerst angelegt, damit bei `order=desc` (Default) C vor B vor A
+	   erscheint. Die Ordnung ist `(created, id)` — `created` allein genügt nicht
+	   und ist hier besonders heikel: Die drei Zeilen entstehen im selben
+	   `beforeEach` und können denselben Zeitstempel tragen. Dass die Reihenfolge
+	   trotzdem feststeht, leistet der Tiebreaker auf `id` (Begründung in
+	   `openQueueOrder.ts`, mechanisch bewacht von `openQueueOrderScan.test.ts`). */
 	let idA: number;
 	let idB: number;
 	let idC: number;

--- a/src/lib/components/admin/SightingQueueNav.svelte
+++ b/src/lib/components/admin/SightingQueueNav.svelte
@@ -10,8 +10,8 @@
 
 	let { queue, queueFailed, order }: Props = $props();
 
-	let prevHref = $derived(queue?.prev ? queueHref(queue.prev, order) : null);
-	let nextHref = $derived(queue?.next ? queueHref(queue.next, order) : null);
+	let prevHref = $derived(queue?.prev ? queueHref(queue.prev.id, order) : null);
+	let nextHref = $derived(queue?.next ? queueHref(queue.next.id, order) : null);
 	let zaehler = $derived(
 		queue
 			? queue.position

--- a/src/lib/components/admin/queueAdvance.ts
+++ b/src/lib/components/admin/queueAdvance.ts
@@ -51,7 +51,7 @@ export function planAdvance(request: AdvanceRequest): AdvancePlan {
 
 	return {
 		target,
-		undoHref: target.kind !== 'stay' ? queueHref({ id: sightingId, referenceId: '' }, order) : null,
+		undoHref: target.kind !== 'stay' ? queueHref(sightingId, order) : null,
 		toastMessage: `Sichtung #${sightingId} ${VERDICT_WORT[verdict]}`
 	};
 }

--- a/src/lib/components/admin/sightingQueue.test.ts
+++ b/src/lib/components/admin/sightingQueue.test.ts
@@ -20,7 +20,7 @@ const QUEUE: SightingQueue = {
 
 describe('queueHref', () => {
 	it('trägt Herkunft und Sortierung mit', () => {
-		const href = queueHref(NACHBAR, 'asc');
+		const href = queueHref(NACHBAR.id, 'asc');
 
 		expect(href).toBe('/admin/501?from=inbox&order=asc');
 	});
@@ -30,14 +30,14 @@ describe('advanceTarget', () => {
 	it('springt zur nächsten offenen Sichtung', () => {
 		expect(advanceTarget(QUEUE, false, 'desc')).toEqual({
 			kind: 'sighting',
-			href: queueHref(NACHBAR, 'desc')
+			href: queueHref(NACHBAR.id, 'desc')
 		});
 	});
 
 	it('reicht die Sortierung `asc` an den Ziel-Href durch', () => {
 		expect(advanceTarget(QUEUE, false, 'asc')).toEqual({
 			kind: 'sighting',
-			href: queueHref(NACHBAR, 'asc')
+			href: queueHref(NACHBAR.id, 'asc')
 		});
 	});
 

--- a/src/lib/components/admin/sightingQueue.ts
+++ b/src/lib/components/admin/sightingQueue.ts
@@ -33,8 +33,18 @@ export interface SightingQueue {
 	total: number;
 }
 
-export function queueHref(neighbor: QueueNeighbor, order: 'asc' | 'desc'): string {
-	return inboxDetailHref(neighbor.id, order);
+/**
+ * Der Ziel-Href einer Sichtung im Warteschlangen-Modus.
+ *
+ * Nimmt die ID und nicht den ganzen `QueueNeighbor`: Gebraucht wird ohnehin nur
+ * `.id`, und `planAdvance` (`queueAdvance.ts`) baut den Rückweg zur **gerade
+ * entschiedenen** Sichtung — die ist kein Nachbar und hat hier keinen
+ * `referenceId` beizusteuern. Mit der Objekt-Signatur entstand dort eine
+ * Attrappe (`{ id, referenceId: '' }`), deren leeres Feld nur den Typ
+ * befriedigte und einen Wert behauptete, den es nicht gibt.
+ */
+export function queueHref(sightingId: number, order: 'asc' | 'desc'): string {
+	return inboxDetailHref(sightingId, order);
 }
 
 /** Wohin die Seite nach einer Entscheidung geht. */
@@ -57,6 +67,6 @@ export function advanceTarget(
 	order: 'asc' | 'desc'
 ): AdvanceTarget {
 	if (queueFailed || !queue) return { kind: 'stay' };
-	if (queue.next) return { kind: 'sighting', href: queueHref(queue.next, order) };
+	if (queue.next) return { kind: 'sighting', href: queueHref(queue.next.id, order) };
 	return { kind: 'inbox' };
 }

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -291,10 +291,10 @@
 				}
 				return;
 			case 'focusNext':
-				if (queue?.next) void goto(queueHref(queue.next, queueOrder));
+				if (queue?.next) void goto(queueHref(queue.next.id, queueOrder));
 				return;
 			case 'focusPrevious':
-				if (queue?.prev) void goto(queueHref(queue.prev, queueOrder));
+				if (queue?.prev) void goto(queueHref(queue.prev.id, queueOrder));
 				return;
 			case 'approve':
 				void handleStatusChange('approve');
@@ -330,7 +330,7 @@
 	   auch wenn der Nachbar derselbe bleibt. Ein Effect an `queue.next` liefe
 	   dann bei jeder Neu-Identität erneut und lüde denselben Nachbarn nochmal —
 	   `nextHref` ist dagegen wertgleich vergleichbar. */
-	let nextHref = $derived(queue?.next ? queueHref(queue.next, queueOrder) : null);
+	let nextHref = $derived(queue?.next ? queueHref(queue.next.id, queueOrder) : null);
 
 	$effect(() => {
 		if (nextHref) void preloadData(nextHref).catch(() => {});


### PR DESCRIPTION
Nachbereitung des Reviews von #809. Drei Befunde, alle auf Prosa-Ebene — kein Verhalten ändert sich.

## 1. `.claude/rules/admin.md` beschrieb eine Bedingung, die der Code nicht erfüllt

Die Regeldatei nannte als Bedingung für `undoHref` ein `queue !== null || queueFailed`. `planAdvance()` prüft tatsächlich `target.kind !== 'stay'`, und `stay` deckt drei Fälle ab statt einem: aus der Tabelle geöffnet, fehlgeschlagene Queue-Abfrage **und** `verdict === 'reset'`. In den letzten beiden versprach die Regel einen Href, den der Code als `null` liefert.

Der Docblock an `AdvancePlan` war die ganze Zeit korrekt; `admin.md` war die veraltete Kopie. Da sie beim Bearbeiten von Admin-Dateien automatisch als Regel lädt, ist sie die sichtbarste Stelle, an der das falsch stehen kann.

## 2. Kommentar widersprach der zentralen Invariante der Warteschlange

`e2e/admin-queue.spec.ts` behauptete, `created` sei der einzige Sortierschlüssel. Die Ordnung ist `(created, id)` — `openQueueOrder.ts` begründet ausführlich, dass der Tiebreaker Voraussetzung und nicht Kosmetik ist, weil `created` nicht `unique` ist, und `openQueueOrderScan.test.ts` bewacht das mechanisch. Der Kommentar stand ausgerechnet über drei Zeilen, die im selben `beforeEach` entstehen und damit die Kollision am ehesten produzieren; dass ihre Reihenfolge feststeht, leistet genau der Tiebreaker.

## 3. `planAdvance` baute einen Schein-Nachbarn

`queueHref({ id: sightingId, referenceId: '' }, order)` erzeugte ein `QueueNeighbor`-Literal, dessen leeres `referenceId` nur den Typ befriedigte und einen Wert behauptete, den es nicht gibt: Der Rückweg zeigt auf die gerade **entschiedene** Sichtung, und die ist kein Nachbar. `queueHref` liest ohnehin nur `.id` und nimmt jetzt die ID.

## Tests

Keine neuen Tests — Befund 1 und 2 sind Textkorrekturen, Befund 3 eine Signaturänderung ohne Verhaltensänderung, abgedeckt von den bestehenden `sightingQueue`-Tests (der Href-Vergleich prüft weiterhin den vollständigen String).

- `npm run test:quick` — 277 Dateien, 4192 Tests grün
- `sightingQueueNav.svelte.test.ts`, `detailUndo.svelte.test.ts`, `detailShortcuts.svelte.test.ts` — 14 Tests grün
- `npx playwright test e2e/admin-queue.spec.ts` — 4 Tests grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)