### PR TITLE
refactor(ui): Elevation, Z-Index und Motion auf Design-Tokens umstellen

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -209,6 +209,19 @@ Ein Token, das **nur** im `@theme`-Block steht, ist über `var()` nicht erreichb
 **Welcher der beiden `app.css`-Blöcke, entscheidet Tailwind, nicht der Geschmack.** `@theme` erzeugt nur für die Namespaces eine Utility, die Tailwind kennt (`--color-*`, `--shadow-*`, `--text-*`, …). Für **Z-Index und Übergangsdauer gibt es keinen solchen Namespace** — `--layer-panel` im `@theme`-Block bliebe eine Variable ohne Klasse. Diese neun stehen deshalb als `@utility z-panel { z-index: var(--layer-panel) }` bzw. `@utility duration-quick { … }` in `app.css` und verweisen von dort auf `tokens.css`. Beide Blöcke zusammen sind gemeint, wenn unten „Keine toten Utility-Klassen" von einem Eintrag in `app.css` spricht.
 
 - **Z-Index:** `z-raised` (10), `z-panel` (20), `z-nav` (30), `z-overlay` (40), `z-skip` (50) — bzw. `--layer-*` über `var()`. Keine freien `z-*`-Utilities und keine `z-[…]`. Vorher lagen Navbar und Panel-Toggle beide auf `z-50` — welches Element oben lag, entschied damit die DOM-Position. Die Stufe nach **Zuständigkeit** wählen, nicht nach der Zahl, die vorher dort stand: Was muss dieses Element tatsächlich überlagern?
+
+  **Die Karte ist der Fall, an dem das schiefging** (#812). Dort standen die schwebenden Bedienelemente auf `z-30` und wanderten mechanisch auf `z-nav` — dieselbe Zahl, also scheinbar folgenlos. Im selben Schritt fiel das Bottom-Sheet von `z-40` auf `z-panel` (20), und damit lagen Bedienelemente und Leerzustands-Meldungen plötzlich **über** dem Sheet. Auf Mobil war der Vergrößern-Knopf des Sheets nicht mehr klickbar, und die Meldung „Alle Sichtungen durch Filter ausgeblendet" verdeckte das Filter-Panel, mit dem man sie auflöst. Die verbindliche Ordnung auf `/map`:
+
+  | Stufe            | Was dort liegt                                                                                                                  |
+  | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+  | `z-base` (0)     | Karten-Canvas (`ol-map-container`)                                                                                              |
+  | `z-raised` (10)  | Kartenfläche: Titel-Badge, Arten-Leiste, Tooltip, Zoom-Gruppe, Standort-FAB, Logo-Platte, Listenansicht, Leerzustands-Meldungen |
+  | `z-panel` (20)   | Karte/Liste-Umschalter, Panels und Bottom-Sheets                                                                                |
+  | `z-nav` (30)     | Panel-Toggle                                                                                                                    |
+  | `z-overlay` (40) | Fehler-Toast, Tastatur-Hilfe                                                                                                    |
+
+  Umschalter und Sheet liegen bewusst auf derselben Stufe: Der Umschalter muss über der Listenansicht bleiben, das Sheet über dem Umschalter — mit fünf Stufen geht das nur über die DOM-Reihenfolge, und die Panels stehen dafür hinter dem Umschalter im Markup.
+
 - **Dauer:**
 
   | Utility             | Token               | Wert  | Wofür                        | Kurve           |

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -199,22 +199,24 @@ Dieselbe semantische Ebene darf nicht in zwei Größen erscheinen — heute ist 
 
 **Zwei Zugriffswege, ein Name.** Jeder Token dieser Ebene ist als Utility (`class="text-warning-strong"`) **und** als Variable (`style="box-shadow: var(--shadow-raised)"`) benutzbar. Die beiden Wege entstehen unterschiedlich, und das hat eine Konsequenz:
 
-| Weg        | Woher                           | Gilt für                                                                                                                  |
-| ---------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Utility    | `@theme`-Block in `app.css`     | wird von Tailwind **on demand** erzeugt — nur wenn der Klassenname als vollständiger String im gescannten Quelltext steht |
-| `var(--…)` | `:root` in `src/css/tokens.css` | steht immer im ausgelieferten CSS                                                                                         |
+| Weg        | Woher                                        | Gilt für                                                                                                                  |
+| ---------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Utility    | `@theme`- oder `@utility`-Block in `app.css` | wird von Tailwind **on demand** erzeugt — nur wenn der Klassenname als vollständiger String im gescannten Quelltext steht |
+| `var(--…)` | `:root` in `src/css/tokens.css`              | steht immer im ausgelieferten CSS                                                                                         |
 
-Ein Token, das **nur** im `@theme`-Block steht, ist über `var()` nicht erreichbar: Tailwind backt Schatten- und Größenwerte direkt in die Utility und referenziert die Theme-Variable nie, sie landet also nicht im `:root`. Deshalb deklariert `tokens.css` jeden Wert selbst — inklusive der Aliase `--shadow-raised`/`--shadow-floating` auf `--elevation-*`. **Neuer Token heißt: Eintrag in `tokens.css` (für `var()`) UND im `@theme`-Block (für die Utility)** — sonst ist einer der beiden Wege still tot.
+Ein Token, das **nur** im `@theme`-Block steht, ist über `var()` nicht erreichbar: Tailwind backt Schatten- und Größenwerte direkt in die Utility und referenziert die Theme-Variable nie, sie landet also nicht im `:root`. Deshalb deklariert `tokens.css` jeden Wert selbst — inklusive der Aliase `--shadow-raised`/`--shadow-floating` auf `--elevation-*`. **Neuer Token heißt: Eintrag in `tokens.css` (für `var()`) UND ein Utility-Name in `app.css`** — sonst ist einer der beiden Wege still tot.
 
-- **Z-Index:** `--layer-raised` (10), `--layer-panel` (20), `--layer-nav` (30), `--layer-overlay` (40), `--layer-skip` (50). Keine freien `z-*`-Utilities. Vorher lagen Navbar und Panel-Toggle beide auf `z-50` — welches Element oben lag, entschied damit die DOM-Position.
+**Welcher der beiden `app.css`-Blöcke, entscheidet Tailwind, nicht der Geschmack.** `@theme` erzeugt nur für die Namespaces eine Utility, die Tailwind kennt (`--color-*`, `--shadow-*`, `--text-*`, …). Für **Z-Index und Übergangsdauer gibt es keinen solchen Namespace** — `--layer-panel` im `@theme`-Block bliebe eine Variable ohne Klasse. Diese neun stehen deshalb als `@utility z-panel { z-index: var(--layer-panel) }` bzw. `@utility duration-quick { … }` in `app.css` und verweisen von dort auf `tokens.css`. Beide Blöcke zusammen sind gemeint, wenn unten „Keine toten Utility-Klassen" von einem Eintrag in `app.css` spricht.
+
+- **Z-Index:** `z-raised` (10), `z-panel` (20), `z-nav` (30), `z-overlay` (40), `z-skip` (50) — bzw. `--layer-*` über `var()`. Keine freien `z-*`-Utilities und keine `z-[…]`. Vorher lagen Navbar und Panel-Toggle beide auf `z-50` — welches Element oben lag, entschied damit die DOM-Position. Die Stufe nach **Zuständigkeit** wählen, nicht nach der Zahl, die vorher dort stand: Was muss dieses Element tatsächlich überlagern?
 - **Dauer:**
 
-  | Token               | Wert  | Wofür                        | Kurve           |
-  | ------------------- | ----- | ---------------------------- | --------------- |
-  | `--motion-instant`  | 120ms | Hover, Fokus                 | `--motion-ease` |
-  | `--motion-quick`    | 200ms | Aufklappen, Toast            | `--motion-ease` |
-  | `--motion-panel`    | 300ms | Panel, Bottom-Sheet, Overlay | `--motion-ease` |
-  | `--motion-emphasis` | 400ms | Überschwung, Federung        | **`linear`**    |
+  | Utility             | Token               | Wert  | Wofür                        | Kurve           |
+  | ------------------- | ------------------- | ----- | ---------------------------- | --------------- |
+  | `duration-instant`  | `--motion-instant`  | 120ms | Hover, Fokus                 | `--motion-ease` |
+  | `duration-quick`    | `--motion-quick`    | 200ms | Aufklappen, Toast            | `--motion-ease` |
+  | `duration-panel`    | `--motion-panel`    | 300ms | Panel, Bottom-Sheet, Overlay | `--motion-ease` |
+  | `duration-emphasis` | `--motion-emphasis` | 400ms | Überschwung, Federung        | **`linear`**    |
 
   Die ersten drei beschreiben **Übergänge** und werden mit `--motion-ease` gefahren. `--motion-emphasis` ist keine Übergangsstufe: betonte Bewegungen bringen ihre Kurve über die Keyframe-Stops mit (`bounceIn`: `.3 → 1.05 → .9 → 1`). Eine zusätzliche Easing-Funktion biegt dort **jedes Segment einzeln** und lässt den Überschwung hektisch wirken — deshalb `linear`. Wer eine neue betonte Keyframe anlegt, nimmt diese Stufe und lässt die Kurve in den Stops.
 
@@ -547,7 +549,7 @@ Vor der Nutzung einer Utility prüfen, ob sie im Setup überhaupt existiert.
 - Für Ein-/Ausblendungen `transition:slide` / `transition:fade` aus `svelte/transition` verwenden (so gelöst in `sections/SightingDetails.svelte`).
 - Gleiches gilt für `dark:`-Varianten (kein Dark-Theme, siehe `daisyui.md`).
 - Umgekehrt gilt: **eine Keyframe ist nicht tot, nur weil keine Klasse sie nennt.** `fadeIn`, `bounceIn`, `loadingPattern` und `spin` in `app.css` hängen an inline-`style="animation: …"` (`map/LoadingOverlay.svelte`, `MaintenanceBanner.svelte`) bzw. an einem scoped `<style>`-Block (`media/MediaThumbnail.svelte`). Vor dem Löschen einer Keyframe deshalb nach dem **Namen** greppen, nicht nach einer Klasse.
-- Neue eigene Utility (`text-*-strong`, `shadow-raised`, `text-support`, …) heißt: Eintrag im `@theme`-Block von `app.css`. Ein Token, das nur in `src/css/tokens.css` steht, ist eine CSS-Variable — **keine** Utility-Klasse. Fehlt der `@theme`-Eintrag, ist `class="text-warning-strong"` genau so tot wie `animate-in`.
+- Neue eigene Utility (`text-*-strong`, `shadow-raised`, `text-support`, …) heißt: Eintrag im `@theme`-Block von `app.css` — oder, wo Tailwind keinen passenden Namespace hat (`z-panel`, `duration-quick`), im `@utility`-Block darunter. Ein Token, das nur in `src/css/tokens.css` steht, ist eine CSS-Variable — **keine** Utility-Klasse. Fehlt der Eintrag in `app.css`, ist `class="text-warning-strong"` genau so tot wie `animate-in`.
 - **Und ein Feld auf `/styleguide`.** Tailwind erzeugt eine Utility nur, wenn ihr Name als vollständiger String im gescannten Quelltext steht — sieben der dreizehn eigenen Utilities haben ihre einzige Aufrufstelle auf dieser Seite. Ein dort gelöschtes Farbfeld nimmt die Klasse still aus dem Build. Abgesichert durch `e2e/design-tokens.spec.ts` → „Utilities haben einen Vertreter auf /styleguide": Der Test liest die Tokens aus `tokens.css` und verlangt für jeden ein Element mit der zugehörigen Klasse.
 
   **`bg-scrim` und `text-on-scrim` stehen bewusst außerhalb dieser Gruppe.** Der Wächter zielt auf Utilities, deren einzige Aufrufstelle `/styleguide` ist — dort nimmt ein gelöschtes Farbfeld die Klasse still aus dem Build. Die Schleier-Utilities haben zehn Aufrufstellen in Komponenten; sie können nicht versehentlich verschwinden. Ein `UTILITY_GROUPS`-Eintrag würde außerdem ein Element mit dem unverdünnten `bg-scrim` auf der Seite erzwingen — eine Klasse, die es sonst nirgends gibt, nur damit ein Test grün wird. Wer den Schleier später auf `/styleguide` zeigen will (die Deckkraft-Tabelle oben wäre der Ort), kann die Gruppe nachziehen.

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -572,36 +572,22 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 		});
 
 		/* ---------------------------------------------------------------- *
-		 * Nicht-Farb-Tokens: Elevation, Z-Index, Motion — noch `fixme`.
+		 * Nicht-Farb-Tokens: Elevation, Z-Index, Motion.
 		 *
-		 * **Warum sie hier stehen, obwohl sie rot sind.** Die drei Regeln
-		 * darüber decken ausschließlich Farbe ab. `design-system.md` schreibt
-		 * Elevation, Z-Index und Bewegungsdauer genauso verbindlich aus Tokens
-		 * vor — dafür gab es bis 2026-08-09 keinen Wächter, und der Scan lief
-		 * grün. Das ist die Sorte Lücke, die `bannedClasses.ts` an drei Stellen
-		 * als Fehlerklasse beschreibt: Sie erzeugt Deckung, die es nicht gibt.
+		 * Die drei Regeln darüber decken ausschließlich Farbe ab.
+		 * `design-system.md` schreibt Elevation, Z-Index und Bewegungsdauer
+		 * genauso verbindlich aus Tokens vor — dafür gab es bis 2026-08-09
+		 * keinen Wächter, und der Scan lief grün. Das ist die Sorte Lücke, die
+		 * `bannedClasses.ts` an drei Stellen als Fehlerklasse beschreibt: Sie
+		 * erzeugt Deckung, die es nicht gibt.
 		 *
-		 * **Warum `fixme` und nicht aktiv.** Gemessen am 2026-08-09 steht der
-		 * Bestand bei 118 rohen Schatten-Utilities in 26 Dateien, 28 freien
-		 * Z-Index- und 19 freien Dauer-Angaben — verteilt über den ganzen
-		 * Frontend, nicht nur den Admin. Das ist ein eigener Aufräum-Schritt und
-		 * kein Beiwerk dieses PR; ihn hier mit hineinzuziehen hieße, 26 Dateien
-		 * ohne Bezug zum Rest der Änderung anzufassen. Die Regeln selbst sind
-		 * scharf gestellt und über `bannedClasses.test.ts` an konstruierten
-		 * Beispielen belegt — sie sind also nicht ungeprüft, nur noch nicht
-		 * durchgesetzt. Dieselbe Reihenfolge wie bei der Farb-Gruppe, die bis
+		 * Scharf gestellt wurden die Regeln in #811, aktiv sind sie seit dem
+		 * Aufräum-Schritt, der den Bestand (118 rohe Schatten-Utilities in 26
+		 * Dateien, 28 freie Z-Index- und 19 freie Dauer-Angaben) auf Tokens
+		 * umgestellt hat. Dieselbe Reihenfolge wie bei der Farb-Gruppe, die bis
 		 * PR #620 `fixme` war.
-		 *
-		 * **Beim Aktivieren zu beachten:** Für Schatten ist der Ersatz eine
-		 * echte Utility (`shadow-raised`/`shadow-floating`, im `@theme`-Block).
-		 * Für Z-Index und Dauer NICHT — `--layer-*` und `--motion-*` stehen nur
-		 * in `tokens.css` und sind über `var()` zu setzen. Wer dort `z-panel`
-		 * schreibt, tauscht einen gemeldeten Verstoß gegen eine tote Klasse.
-		 * Alternative wäre, die Stufen zusätzlich in den `@theme`-Block zu
-		 * heben; das ist eine Design-Entscheidung und gehört in den Aufräum-PR,
-		 * nicht hierher.
 		 * ---------------------------------------------------------------- */
-		test.fixme(`${route.path}: keine rohen Schatten-Utilities`, async ({
+		test(`${route.path}: keine rohen Schatten-Utilities`, async ({
 			page,
 			context,
 			request,
@@ -611,7 +597,7 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			expect(findOffenders(RAW_ELEVATION, elements), RAW_ELEVATION.hint).toEqual([]);
 		});
 
-		test.fixme(`${route.path}: keine freien Z-Index-Utilities`, async ({
+		test(`${route.path}: keine freien Z-Index-Utilities`, async ({
 			page,
 			context,
 			request,
@@ -621,7 +607,7 @@ test.describe('Design-Tokens — verbotene Kombinationen im DOM', () => {
 			expect(findOffenders(RAW_Z_INDEX, elements), RAW_Z_INDEX.hint).toEqual([]);
 		});
 
-		test.fixme(`${route.path}: keine freien Übergangsdauern`, async ({
+		test(`${route.path}: keine freien Übergangsdauern`, async ({
 			page,
 			context,
 			request,
@@ -847,4 +833,115 @@ test.describe('Design-Tokens — Utilities haben einen Vertreter auf /styleguide
 			});
 		}
 	}
+});
+
+/**
+ * Layer- und Motion-Utilities: greifen sie überhaupt?
+ *
+ * **Warum das ein eigener Test ist.** Der Klassen-Scan oben meldet `z-50` und
+ * `duration-300` — er kann aber nicht sehen, ob `z-nav` und `duration-panel`
+ * wirken. Beide Fehler sähen im DOM identisch aus, und der zweite ist der
+ * schlechtere: Ein gemeldeter Verstoß ist sichtbar, eine tote Utility nicht.
+ * Genau davor warnt `design-system.md` („Keine toten Utility-Klassen"), und
+ * genau dieses Risiko ist beim Umstellen des Bestands entstanden — 47
+ * Aufrufstellen hängen daran.
+ *
+ * Die neun stehen als `@utility` in `app.css`, weil Tailwind 4 für Z-Index und
+ * Übergangsdauer keinen Theme-Namespace hat. Sie fallen deshalb nicht in die
+ * UTILITY_GROUPS oben, die aus `tokens.css` ableiten und einen Vertreter auf
+ * /styleguide verlangen — hier ist die Wirkung die bessere Frage als die
+ * Anwesenheit.
+ *
+ * **Was dieser Test belegt — und was nicht.** Er belegt, dass die `@utility`
+ * in `app.css` existiert und auf einen vorhandenen Token zeigt. Vorgeführt am
+ * 2026-08-09: `@utility z-nav` aus `app.css` entfernt → dieser Test rot.
+ *
+ * Er belegt **nicht**, dass die Klasse eine Aufrufstelle in `src/` hat.
+ * Tailwinds Content-Detection scannt das Projekt inklusive `e2e/` (`daisyui.md`:
+ * kein `@source` nötig, weil unter dem Repo nichts ignoriert wird), und die neun
+ * Namen stehen zwangsläufig als Literale in `helpers/bannedClasses.ts` — deren
+ * `hint`-Strings müssen sie ja nennen. Gemessen: `duration-emphasis` kommt in
+ * `src/` an keiner Stelle vor und steht trotzdem im Produktions-CSS, gehalten
+ * allein von diesen Test-Strings.
+ *
+ * Der Klassenname wird hier trotzdem zur Laufzeit zusammengesetzt (`'z-' + stufe`).
+ * Das ist keine Absicherung mehr, sondern nur noch Hygiene: Diese Datei soll
+ * nicht die dritte Stelle sein, die eine Utility am Leben hält. Wer eine echte
+ * Aufrufstellen-Garantie will, braucht dafür einen anderen Wächter — die
+ * UTILITY_GROUPS oben sind der für die `@theme`-Utilities.
+ */
+test.describe('Design-Tokens — Layer- und Motion-Utilities wirken', () => {
+	/** Stufe → erwarteter berechneter Wert. */
+	const LAYERS = { raised: '10', panel: '20', nav: '30', overlay: '40', skip: '50' };
+	const DURATIONS = { instant: '0.12s', quick: '0.2s', panel: '0.3s', emphasis: '0.4s' };
+
+	const computeWith = (page: Page, className: string, property: string) =>
+		page.evaluate(
+			([cls, prop]) => {
+				const probe = document.createElement('div');
+				probe.className = cls;
+				probe.style.position = 'fixed';
+				probe.style.transitionProperty = 'opacity';
+				document.body.appendChild(probe);
+				const value = getComputedStyle(probe).getPropertyValue(prop);
+				probe.remove();
+				return value;
+			},
+			[className, property]
+		);
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/styleguide');
+	});
+
+	for (const [step, expected] of Object.entries(LAYERS)) {
+		test(`z-${step} setzt z-index auf ${expected}`, async ({ page }) => {
+			expect(
+				await computeWith(page, `z-${step}`, 'z-index'),
+				`Die Utility z-${step} erzeugt keinen z-index. Sie steht als @utility in src/app.css und greift auf --layer-${step} in src/css/tokens.css zu — fehlt eines von beidem, ist die Klasse tot und jede Aufrufstelle wirkungslos.`
+			).toBe(expected);
+		});
+	}
+
+	for (const [step, expected] of Object.entries(DURATIONS)) {
+		test(`duration-${step} setzt transition-duration auf ${expected}`, async ({ page }) => {
+			expect(
+				await computeWith(page, `duration-${step}`, 'transition-duration'),
+				`Die Utility duration-${step} erzeugt keine transition-duration. Sie steht als @utility in src/app.css und greift auf --motion-${step} in src/css/tokens.css zu.`
+			).toBe(expected);
+		});
+	}
+
+	/* Die Kurve gehört laut design-system.md zur Stufe — sie soll an der
+	   Aufrufstelle nicht getrennt gepflegt werden. `emphasis` fährt dabei
+	   `linear`: betonte Bewegungen bringen ihren Verlauf in den Keyframe-Stops
+	   mit, eine zweite Easing-Funktion böge dort jedes Segment einzeln.
+
+	   **Auf `linear` geprüft und nicht auf „irgendetwas anderes als ease".**
+	   Die erste Fassung dieses Tests verlangte nur `not.toBe(ease)` — damit
+	   wäre auch der CSS-Default `ease` durchgegangen, den man bekommt, wenn die
+	   Utility die Eigenschaft gar nicht setzt. Genau dieser Fall stand hier
+	   kurzzeitig im Code: die Tabelle in design-system.md schreibt `linear`
+	   vor, geliefert wurde `ease`, und der Test war grün. Eine Negativ-Assertion
+	   trifft die Fehlklasse nicht, um die es geht. */
+	test('jede Stufe bringt ihre Kurve mit — die drei Übergänge --motion-ease, emphasis linear', async ({
+		page
+	}) => {
+		const ease = await page.evaluate(() =>
+			getComputedStyle(document.documentElement).getPropertyValue('--motion-ease').trim()
+		);
+		expect(ease, '--motion-ease fehlt in tokens.css').not.toBe('');
+
+		for (const step of ['instant', 'quick', 'panel']) {
+			expect(
+				await computeWith(page, `duration-${step}`, 'transition-timing-function'),
+				`duration-${step} muss --motion-ease mitbringen (design-system.md).`
+			).toBe(ease);
+		}
+
+		expect(
+			await computeWith(page, 'duration-emphasis', 'transition-timing-function'),
+			'duration-emphasis muss linear fahren (design-system.md). Wird die Eigenschaft nicht gesetzt, liefert CSS den Default `ease` — also genau die gebogene Kurve, die die Stufe ausschließen will.'
+		).toBe('linear');
+	});
 });

--- a/e2e/design-tokens.spec.ts
+++ b/e2e/design-tokens.spec.ts
@@ -872,7 +872,7 @@ test.describe('Design-Tokens — Utilities haben einen Vertreter auf /styleguide
  */
 test.describe('Design-Tokens — Layer- und Motion-Utilities wirken', () => {
 	/** Stufe → erwarteter berechneter Wert. */
-	const LAYERS = { raised: '10', panel: '20', nav: '30', overlay: '40', skip: '50' };
+	const LAYERS = { base: '0', raised: '10', panel: '20', nav: '30', overlay: '40', skip: '50' };
 	const DURATIONS = { instant: '0.12s', quick: '0.2s', panel: '0.3s', emphasis: '0.4s' };
 
 	const computeWith = (page: Page, className: string, property: string) =>

--- a/e2e/helpers/bannedClasses.test.ts
+++ b/e2e/helpers/bannedClasses.test.ts
@@ -340,17 +340,21 @@ describe('RAW_Z_INDEX', () => {
 		expect(RAW_Z_INDEX.offends('z-50')).toBe(RAW_Z_INDEX.offends('z-[50]'));
 	});
 
-	/* `z-auto` ist keine Stufenwahl. Und: Es gibt bewusst KEIN `z-panel` —
-	   die Layer-Tokens stehen nur in tokens.css. Ein solcher Klassenname wäre
-	   eine tote Utility; die Regel meldet ihn nicht, weil sie über Klassennamen
-	   nicht entscheiden kann, ob eine Utility existiert. Der Hinweis der Regel
-	   nennt deshalb var() als Ersatz und nicht eine Klasse. */
+	/* `z-auto` ist keine Stufenwahl, `z-panel` der vorgesehene Ersatz. */
 	it.each(['z-auto', 'z-panel'])('lässt %s durch', (className) => {
 		expect(RAW_Z_INDEX.offends(className)).toBe(false);
 	});
 
-	it('nennt var() und nicht eine Utility als Ersatz', () => {
-		expect(RAW_Z_INDEX.hint).toContain('var(--layer-panel)');
+	/* Der Hinweis muss die Stufen beim Namen nennen, unter dem sie im Markup
+	   stehen. Bis der Bestand umgestellt war, gab es diese Utilities nicht und
+	   der Hinweis zeigte auf `var(--layer-panel)`; seit sie als `@utility` in
+	   app.css stehen, wäre das der Umweg. Die Zuständigkeiten stehen mit dabei,
+	   weil die Stufe danach gewählt wird und nicht nach der Zahl, die vorher am
+	   Element stand. */
+	it('nennt die Layer-Utilities als Ersatz', () => {
+		for (const utility of ['z-raised', 'z-panel', 'z-nav', 'z-overlay', 'z-skip']) {
+			expect(RAW_Z_INDEX.hint).toContain(utility);
+		}
 	});
 
 	it.each(['size-10', 'gz-10'])('lässt %s durch', (className) => {
@@ -363,12 +367,19 @@ describe('RAW_MOTION_DURATION', () => {
 		expect(RAW_MOTION_DURATION.offends(className)).toBe(true);
 	});
 
-	/* Wie beim Z-Index gibt es keine `duration-quick`-Utility — der Hinweis
-	   muss auf var() zeigen, sonst führt die Korrektur von einem Verstoß in
-	   eine wirkungslose Klasse. */
-	it('nennt die Motion-Tokens und var() als Ersatz', () => {
-		expect(RAW_MOTION_DURATION.hint).toContain('--motion-quick');
-		expect(RAW_MOTION_DURATION.hint).toContain('var()');
+	/* Wie beim Z-Index: die Stufen unter dem Namen, unter dem sie im Markup
+	   stehen. Die Dauer gehört mit in den Hinweis — ohne sie ist „quick oder
+	   panic?" an der Aufrufstelle nicht entscheidbar. */
+	it('nennt die Motion-Utilities samt Dauer als Ersatz', () => {
+		for (const utility of [
+			'duration-instant',
+			'duration-quick',
+			'duration-panel',
+			'duration-emphasis'
+		]) {
+			expect(RAW_MOTION_DURATION.hint).toContain(utility);
+		}
+		expect(RAW_MOTION_DURATION.hint).toContain('200ms');
 	});
 
 	it.each(['duration-quick', 'transition-all', 'delay-300'])('lässt %s durch', (className) => {

--- a/e2e/helpers/bannedClasses.ts
+++ b/e2e/helpers/bannedClasses.ts
@@ -272,9 +272,9 @@ export const TAILWIND_PALETTE: BannedRule = {
  * `shadow-floating`.
  *
  * Die Regeln sind deshalb hier scharf gestellt und über
- * `bannedClasses.test.ts` belegt; der DOM-Scan führt sie vorerst als
- * `test.fixme`, weil der Bestand sie noch nicht erfüllt (Begründung an der
- * Gruppe in `design-tokens.spec.ts`).
+ * `bannedClasses.test.ts` belegt. Im DOM-Scan liefen sie zunächst als
+ * `test.fixme`; seit der Bestand auf Tokens umgestellt ist, sind sie dort
+ * aktiv.
  */
 
 /**
@@ -302,37 +302,38 @@ export const RAW_ELEVATION: BannedRule = {
 /**
  * Freie Z-Index-Utilities — `z-50`, `z-[100]`, auch negativ (`-z-10`).
  *
- * **Der Ersatz ist hier ausnahmsweise keine Utility.** `--layer-raised` bis
- * `--layer-skip` stehen in `src/css/tokens.css` im `:root`, aber **nicht** im
- * `@theme`-Block von `app.css` — es gibt deshalb kein `z-panel`, und wer eines
- * schreibt, bekommt eine tote Klasse (`design-system.md`, „Keine toten
- * Utility-Klassen"). Erreichbar sind die Stufen über `var()`, also per
- * `style="z-index: var(--layer-panel)"` oder aus einem scoped `<style>`-Block.
- * Der Hinweis sagt das ausdrücklich, weil die naheliegende Korrektur sonst von
- * einem Verstoß in einen wirkungslosen Klassennamen führt.
+ * Der Ersatz sind `z-raised`/`-panel`/`-nav`/`-overlay`/`-skip`. Sie kommen
+ * **nicht** aus dem `@theme`-Block: Tailwind 4 hat für Z-Index gar keinen
+ * Theme-Namespace, ein `--layer-panel` dort erzeugte also keine Utility. Sie
+ * stehen deshalb als `@utility`-Definitionen in `app.css` und greifen jeweils
+ * auf `--layer-*` in `tokens.css` zu — der `var()`-Weg
+ * (`style="z-index: var(--layer-panel)"`) bleibt daneben gültig.
  *
  * `z-auto` ist keine Stufenwahl und kommt durch.
  */
 const RAW_Z_INDEX_PATTERN = /^-?z-(?:\[[^\]]*\]|\d+)$/;
 
 export const RAW_Z_INDEX: BannedRule = {
-	hint: 'Z-Index kommt aus den Layer-Tokens (--layer-raised/-panel/-nav/-overlay/-skip). Sie sind KEINE Utilities — sie stehen nur in tokens.css und werden über style="z-index: var(--layer-panel)" oder einen scoped <style>-Block gesetzt. Vorher lagen Navbar und Panel-Toggle beide auf z-50, und die DOM-Position entschied.',
+	hint: 'Z-Index kommt aus den Layer-Tokens: z-raised (10), z-panel (20), z-nav (30), z-overlay (40), z-skip (50) — definiert als @utility in app.css, Werte in tokens.css. Vorher lagen Navbar und Panel-Toggle beide auf z-50, und die DOM-Position entschied.',
 	offends: (className) => RAW_Z_INDEX_PATTERN.test(className)
 };
 
 /**
  * Freie Übergangsdauern — `duration-300`, `duration-[450ms]`.
  *
- * Dieselbe Lage wie beim Z-Index: `--motion-instant`/`-quick`/`-panel`/
- * `-emphasis` sind Variablen, keine Utilities. Die vier Stufen tragen zudem
- * eine Zuständigkeit (Hover/Fokus, Aufklappen, Panel, Überschwung) und die
- * Angabe, mit welcher Kurve sie gefahren werden — eine nackte Zahl im
- * Klassennamen verliert beides.
+ * Dieselbe Lage wie beim Z-Index: `duration-instant`/`-quick`/`-panel`/
+ * `-emphasis` sind `@utility`-Definitionen in `app.css`, weil Tailwind 4 auch
+ * für die Dauer keinen Theme-Namespace kennt. Die vier Stufen tragen eine
+ * Zuständigkeit (Hover/Fokus, Aufklappen, Panel, Überschwung) und die Angabe,
+ * mit welcher Kurve sie gefahren werden — eine nackte Zahl im Klassennamen
+ * verliert beides. Die drei Übergangsstufen bringen `--motion-ease` deshalb
+ * gleich mit; `duration-emphasis` bewusst nicht (die Kurve steckt dort in den
+ * Keyframe-Stops).
  */
 const RAW_MOTION_DURATION_PATTERN = /^duration-(?:\[[^\]]*\]|\d+)$/;
 
 export const RAW_MOTION_DURATION: BannedRule = {
-	hint: 'Übergangsdauern kommen aus den Motion-Tokens (--motion-instant 120ms, --motion-quick 200ms, --motion-panel 300ms, --motion-emphasis 400ms mit linear). Auch sie sind KEINE Utilities — über var() in einem scoped <style>-Block setzen, zusammen mit --motion-ease.',
+	hint: 'Übergangsdauern kommen aus den Motion-Tokens: duration-instant (120ms, Hover/Fokus), duration-quick (200ms, Aufklappen/Toast), duration-panel (300ms, Panel/Bottom-Sheet), duration-emphasis (400ms, Überschwung) — definiert als @utility in app.css.',
 	offends: (className) => RAW_MOTION_DURATION_PATTERN.test(className)
 };
 

--- a/src/app.css
+++ b/src/app.css
@@ -185,6 +185,9 @@
    dort zielt auf Utilities, deren einzige Aufrufstelle /styleguide ist. Diese
    haben Dutzende Aufrufstellen in Komponenten und können nicht still aus dem
    Build fallen. */
+@utility z-base {
+	z-index: var(--layer-base);
+}
 @utility z-raised {
 	z-index: var(--layer-raised);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -159,6 +159,75 @@
 	--text-support: 0.8125rem;
 }
 
+/* ===== Utilities für Z-Index und Bewegungsdauer =====
+   Die Stufen selbst stehen wie alle Werte in css/tokens.css; hier bekommen sie
+   ihren Utility-Namen.
+
+   **Warum `@utility` und nicht der `@theme`-Block darüber.** Tailwind 4 hat für
+   Z-Index und Übergangsdauer gar keinen Theme-Namespace — `z-*` und `duration-*`
+   nehmen nackte Zahlen und arbitrary values, aber keine Theme-Variablen. Ein
+   `--layer-panel` im `@theme`-Block erzeugte deshalb kein `z-panel`, sondern nur
+   eine weitere Variable. Die beiden Zugriffswege aus design-system.md („Zwei
+   Zugriffswege, ein Name") bleiben trotzdem gewahrt: die Utility hier, `var()`
+   über das :root in tokens.css.
+
+   **Warum überhaupt eine Utility.** Bis 2026-08-09 war der dokumentierte Weg
+   `style="z-index: var(--layer-panel)"`. Das trägt nicht überall: Ein Teil der
+   Fundstellen setzt die Stufe aus einem konditional zusammengesetzten
+   Klassen-String oder aus einer JS-Variablen (`titleClass` in
+   `SightingsMapView.svelte` und `LazyMapWrapper.svelte`), und ein inline-`style`
+   kann eine Klasse nicht ersetzen, ohne die Aufrufstelle umzubauen. Bei der
+   Dauer kommt dazu, dass sie im Verbund mit `transition-*` und `hover:`-Varianten
+   steht — dort ist eine Utility die Form, die zum Rest passt.
+
+   Diese neun stehen bewusst NICHT in den UTILITY_GROUPS von
+   `e2e/design-tokens.spec.ts` — aus demselben Grund wie `bg-scrim`: Der Wächter
+   dort zielt auf Utilities, deren einzige Aufrufstelle /styleguide ist. Diese
+   haben Dutzende Aufrufstellen in Komponenten und können nicht still aus dem
+   Build fallen. */
+@utility z-raised {
+	z-index: var(--layer-raised);
+}
+@utility z-panel {
+	z-index: var(--layer-panel);
+}
+@utility z-nav {
+	z-index: var(--layer-nav);
+}
+@utility z-overlay {
+	z-index: var(--layer-overlay);
+}
+@utility z-skip {
+	z-index: var(--layer-skip);
+}
+
+/* Jede Stufe bringt ihre Kurve mit — sie gehört laut design-system.md zur
+   Stufe und soll an der Aufrufstelle nicht getrennt gepflegt werden.
+
+   Für `emphasis` ist diese Kurve `linear`, und das ist keine Auslassung:
+   Betonte Bewegungen bringen ihren Verlauf über die Keyframe-Stops mit
+   (`bounceIn`: .3 → 1.05 → .9 → 1); eine zusätzliche Easing-Funktion böge dort
+   jedes Segment einzeln und ließe den Überschwung hektisch wirken. `linear`
+   muss dabei ausgeschrieben stehen — die Eigenschaft wegzulassen ergäbe den
+   CSS-Default `ease`, also genau das gebogene Verhalten, das die Stufe
+   ausschließen will. */
+@utility duration-instant {
+	transition-duration: var(--motion-instant);
+	transition-timing-function: var(--motion-ease);
+}
+@utility duration-quick {
+	transition-duration: var(--motion-quick);
+	transition-timing-function: var(--motion-ease);
+}
+@utility duration-panel {
+	transition-duration: var(--motion-panel);
+	transition-timing-function: var(--motion-ease);
+}
+@utility duration-emphasis {
+	transition-duration: var(--motion-emphasis);
+	transition-timing-function: linear;
+}
+
 /* ===== Base Styles ===== */
 body {
 	font-family: 'Roboto', 'system-ui', 'sans-serif';

--- a/src/lib/components/MaintenanceBanner.svelte
+++ b/src/lib/components/MaintenanceBanner.svelte
@@ -6,7 +6,7 @@
 
 <!-- Maintenance Mode Banner for Admins -->
 {#if isAdmin}
-	<div class="alert alert-warning shadow-lg">
+	<div class="alert alert-warning">
 		<div class="flex items-center gap-2">
 			<Icon icon="lucide:settings" class="size-5" style="animation: spin 3s linear infinite" />
 			<Icon icon="lucide:alert-circle" class="size-5" />

--- a/src/lib/components/PublicNavbar.svelte
+++ b/src/lib/components/PublicNavbar.svelte
@@ -82,7 +82,7 @@
 
 {#if isNotIFrame}
 	<!-- Fixed Navbar -->
-	<header class="bg-base-200/95 sticky top-0 z-50 shadow-md backdrop-blur-lg">
+	<header class="bg-base-200/95 sticky top-0 z-nav shadow-floating backdrop-blur-lg">
 		<div class="container mx-auto">
 			<!--
 				`justify-between` + `w-auto` an beiden Seiten ersetzt DaisyUIs feste
@@ -148,7 +148,7 @@
 							<Icon icon="lucide:list" width="24" class="h-6 w-6 shrink-0" />
 						</summary>
 						<ul
-							class="dropdown-content menu menu-sm rounded-box bg-base-100 absolute right-0 z-50 mt-3 w-52 p-2 shadow"
+							class="dropdown-content menu menu-sm rounded-box bg-base-100 absolute right-0 z-overlay mt-3 w-52 p-2 shadow-floating"
 						>
 							{@render publicItems()}
 

--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -71,7 +71,7 @@
 
 {#if visible}
 	<div
-		class="{alertClasses[type]} pointer-events-auto mb-4 max-w-sm shadow-lg"
+		class="{alertClasses[type]} pointer-events-auto mb-4 max-w-sm shadow-floating"
 		style="animation: slideIn 0.3s ease-out"
 		role="alert"
 		aria-live="polite"

--- a/src/lib/components/ToastContainer.svelte
+++ b/src/lib/components/ToastContainer.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <!-- Toast Container positioned at top right -->
-<div class="toast toast-top toast-end z-50">
+<div class="toast toast-top toast-end z-overlay">
 	{#each toasts as toast (toast.id)}
 		<Toast
 			type={toast.type}

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -67,7 +67,7 @@
 
 		<!-- Dropdown Menu -->
 		<div
-			class="dropdown-content bg-base-100 rounded-box border-base-300 z-[100] mt-2 w-64 border p-2 shadow-xl"
+			class="dropdown-content bg-base-100 rounded-box border-base-300 z-overlay mt-2 w-64 border p-2 shadow-floating"
 		>
 			<!-- User Info Header -->
 			<div class="border-base-200 border-b px-4 py-2">

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -556,7 +556,7 @@
 	<div class="grid grid-cols-1 gap-4 md:grid-cols-2">
 		<div class="space-y-4">
 			<!-- Datum & Zeit -->
-			<div class="card bg-base-200 shadow-sm">
+			<div class="card bg-base-200 shadow-raised">
 				<div class="card-body">
 					<h3 class="card-title flex items-center gap-2 text-lg">
 						<Icon icon="lucide:calendar" width="20" class="text-primary" />
@@ -575,7 +575,7 @@
 			</div>
 
 			<!-- Tierinformationen -->
-			<div class="card bg-base-200 shadow-sm">
+			<div class="card bg-base-200 shadow-raised">
 				<div class="card-body">
 					<h3 class="card-title flex items-center gap-2 text-lg">
 						<Icon icon="lucide:eye" width="20" class="text-primary" />
@@ -599,7 +599,7 @@
 				     tragen `text-primary` am Icon, diese hob sich damit in nichts
 				     ab. Die Kante trägt die Farbe, das Icon zusätzlich die Form —
 				     Farbe allein wäre kein Merkmal (WCAG 1.4.1). -->
-				<div class="card bg-base-200 border-error border-l-4 shadow-sm">
+				<div class="card bg-base-200 border-error shadow-raised border-l-4">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon
@@ -625,7 +625,7 @@
 
 			<!-- Sichtungsdetails -->
 			{#if sightingDetailRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:activity" width="20" class="text-primary" />
@@ -646,7 +646,7 @@
 
 			<!-- Umweltbedingungen -->
 			{#if environmentRows.length > 0 || currentSighting.weatherData}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:waves" width="20" class="text-primary" />
@@ -680,7 +680,7 @@
 
 			<!-- Kontakt -->
 			{#if contactRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:user" width="20" class="text-primary" />
@@ -703,7 +703,7 @@
 		<div class="space-y-4">
 			<!-- Karte, falls Koordinaten vorhanden -->
 			{#if hasCoordinates}
-				<div class="card bg-base-200 overflow-hidden shadow-sm">
+				<div class="card bg-base-200 shadow-raised overflow-hidden">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:map-pin" width="20" class="text-primary" />
@@ -724,7 +724,7 @@
 
 			<!-- Ortsangaben -->
 			{#if locationRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:map-pin" width="20" class="text-primary" />
@@ -745,7 +745,7 @@
 
 			<!-- Schiffs-/Bootsangaben -->
 			{#if shipRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:anchor" width="20" class="text-primary" />
@@ -766,7 +766,7 @@
 
 			<!-- Status -->
 			{#if statusRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:settings" width="20" class="text-primary" />
@@ -787,7 +787,7 @@
 
 			<!-- Medien-Gallerie -->
 			{#if currentSighting.uploadedFiles && currentSighting.uploadedFiles.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:camera" width="20" class="text-primary" />
@@ -798,7 +798,7 @@
 					</div>
 				</div>
 			{:else if mediaRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:camera" width="20" class="text-primary" />
@@ -819,7 +819,7 @@
 
 			<!-- Bemerkungen, falls vorhanden -->
 			{#if noteRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:message-square" width="20" class="text-primary" />
@@ -840,7 +840,7 @@
 
 			<!-- Interner Kommentar, falls vorhanden -->
 			{#if hasValue(currentSighting.internalComment)}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:settings" width="20" class="text-primary" />
@@ -863,7 +863,7 @@
 
 			<!-- Technische Informationen -->
 			{#if techRows.length > 0}
-				<div class="card bg-base-200 shadow-sm">
+				<div class="card bg-base-200 shadow-raised">
 					<div class="card-body">
 						<h3 class="card-title flex items-center gap-2 text-lg">
 							<Icon icon="lucide:file-text" width="20" class="text-primary" />
@@ -886,13 +886,22 @@
 {/if}
 
 <style>
-	/* Card hover effects */
-	.card {
-		transition: all 0.2s ease;
-	}
+	/* Nur das Anheben. Schatten und Übergang der Karten-Hover kommen aus dem
+	   `.card:hover`-Block in app.css (--elevation-floating, --motion-quick) —
+	   hier standen sie als handgeschriebener box-shadow und `transition: all
+	   0.2s ease` daneben und schlugen ihn, weil ein scoped Block ungelayert
+	   ist. Dieselbe Doppelung wurde in SectionCard.svelte schon entfernt.
 
+	   **Bewusst in Kauf genommen:** app.css deklariert den Übergang INNERHALB
+	   von `.card:hover`. Eine solche Regel greift nur beim Betreten — beim
+	   Verlassen springt die Karte hart zurück. Das entfernte `transition: all`
+	   stand in der Basisregel und lief deshalb in beide Richtungen weich.
+	   Diese Karten waren damit die einzigen der App mit symmetrischem Hover;
+	   `.btn:hover` in app.css hat dasselbe einseitige Verhalten. Den Übergang
+	   in eine Basisregel zu heben wäre die richtige Korrektur, ändert aber
+	   jede Karte und jeden Button der Anwendung — das ist eine eigene
+	   Entscheidung und nicht Teil der Token-Migration. */
 	.card:hover {
 		transform: translateY(-1px);
-		box-shadow: 0 8px 25px -8px var(--color-base-300);
 	}
 </style>

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -54,7 +54,7 @@
 	const melderName = $derived([sighting.firstName, sighting.lastName].filter(Boolean).join(' '));
 </script>
 
-<article class="card border-base-300 bg-base-100 border shadow-sm">
+<article class="card border-base-300 bg-base-100 border shadow-raised">
 	<div class="card-body gap-3 p-4">
 		<div class="flex flex-wrap items-center gap-2">
 			{#if isDeadFinding(sighting.isDead)}

--- a/src/lib/components/form/UnifiedDropzone.svelte
+++ b/src/lib/components/form/UnifiedDropzone.svelte
@@ -268,7 +268,7 @@
 
 			<div class="grid gap-3 {multiple ? 'md:grid-cols-2 lg:grid-cols-3' : 'grid-cols-1'}">
 				{#each files as file, index (file.name + index)}
-					<div class="card bg-base-100 shadow-sm">
+					<div class="card bg-base-100 shadow-raised">
 						<div class="card-body p-3">
 							<!-- File Info -->
 							<div class="flex items-start gap-3">
@@ -325,7 +325,7 @@
 	     der Fläche — und damit das Ziel unter dem Zeiger, der es gerade erst
 	     getroffen hatte. Rahmen und Tint melden die Bereitschaft genauso. -->
 	<div
-		class="rounded-lg border-2 border-dashed transition-all duration-200
+		class="rounded-lg border-2 border-dashed transition-all duration-quick
 			{compact ? 'p-4' : 'p-6'}
 			{actionLabel ? '' : 'cursor-pointer'}
 			{isDragOver

--- a/src/lib/components/map/LazyMapWrapper.svelte
+++ b/src/lib/components/map/LazyMapWrapper.svelte
@@ -10,7 +10,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-nav rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-raised rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;

--- a/src/lib/components/map/LazyMapWrapper.svelte
+++ b/src/lib/components/map/LazyMapWrapper.svelte
@@ -10,7 +10,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-nav rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;

--- a/src/lib/components/map/LoadingOverlay.svelte
+++ b/src/lib/components/map/LoadingOverlay.svelte
@@ -41,14 +41,14 @@
 		<!-- Backdrop (rein visuell). Schleier über der Kartenkachel, kein Theme-Ton:
 		     bg-scrim/<n> (--scrim-surface in tokens.css). -->
 		<div
-			class="animate-fade-in bg-scrim/30 fixed inset-0 z-40 backdrop-blur-sm transition-all duration-300"
+			class="animate-fade-in bg-scrim/30 fixed inset-0 z-overlay backdrop-blur-sm transition-all duration-panel"
 		></div>
 
 		<!-- Loading Content -->
-		<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+		<div class="fixed inset-0 z-overlay flex items-center justify-center p-4">
 			<div
 				data-testid="map-loading-content"
-				class="animate-bounce-in bg-base-100 mx-auto w-full max-w-sm scale-100 transform rounded-2xl p-8 shadow-2xl transition-all duration-300"
+				class="animate-bounce-in bg-base-100 mx-auto w-full max-w-sm scale-100 transform rounded-2xl p-8 shadow-floating transition-all duration-panel"
 			>
 				<!-- Header -->
 				<div class="mb-6 text-center">

--- a/src/lib/components/map/OLMap.svelte
+++ b/src/lib/components/map/OLMap.svelte
@@ -207,7 +207,7 @@
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
 	bind:this={mapElement}
-	class="ol-map-container z-raised h-full w-full overflow-hidden"
+	class="ol-map-container z-base h-full w-full overflow-hidden"
 	role="application"
 	data-position={hasPosition ? 'set' : 'unset'}
 	aria-label={readonly

--- a/src/lib/components/map/OLMap.svelte
+++ b/src/lib/components/map/OLMap.svelte
@@ -207,7 +207,7 @@
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
 	bind:this={mapElement}
-	class="ol-map-container z-10 h-full w-full overflow-hidden"
+	class="ol-map-container z-raised h-full w-full overflow-hidden"
 	role="application"
 	data-position={hasPosition ? 'set' : 'unset'}
 	aria-label={readonly

--- a/src/lib/components/map/Panel/LegendPanel.svelte
+++ b/src/lib/components/map/Panel/LegendPanel.svelte
@@ -142,7 +142,7 @@
 				<!-- 0/0-Arten ausgrauen: visuelle Teile abschwächen, Checkbox bleibt bedienbar -->
 				<div class="flex flex-1 items-center gap-3 {total === 0 ? 'opacity-60 grayscale' : ''}">
 					<div
-						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-sm"
+						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-raised"
 						style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {symbol
 							? symbol.baseColor
 							: speciesGroupStyles.unbekannt.color};"
@@ -192,7 +192,7 @@
 			<div class="hover:bg-base-200 flex items-center gap-3 rounded-lg p-2 transition-colors">
 				{#if group.key === 'ct0'}
 					<span
-						class="h-5 w-5 shrink-0 rounded-full shadow-sm"
+						class="h-5 w-5 shrink-0 rounded-full shadow-raised"
 						style="background-color: {MARKER_BACKGROUND_COLOR}; border: 3px solid {TOTFUND_RING_COLOR};"
 						aria-hidden="true"
 					></span>

--- a/src/lib/components/map/Panel/MapPanel.svelte
+++ b/src/lib/components/map/Panel/MapPanel.svelte
@@ -72,7 +72,7 @@
 <button
 	bind:this={toggleEl}
 	onclick={togglePanel}
-	class="glass text-base-content hover:bg-base-200 {accentBorderClass} {togglePositionClass} fixed right-0 z-50 flex h-32 w-11 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-xl backdrop-blur-sm transition-all duration-300 md:w-8 {isOpen
+	class="glass text-base-content hover:bg-base-200 {accentBorderClass} {togglePositionClass} fixed right-0 z-nav flex h-32 w-11 cursor-pointer flex-col items-center justify-center rounded-l-lg border-2 border-r-0 shadow-floating backdrop-blur-sm transition-all duration-panel md:w-8 {isOpen
 		? 'md:-translate-x-80'
 		: ''} {toggleHidden ? 'max-md:hidden' : ''}"
 	aria-label={title}
@@ -100,7 +100,7 @@
 	bind:this={panelEl}
 	id={panelId}
 	data-sheet-state={sheetExpanded ? 'expanded' : 'peek'}
-	class="glass {accentBorderClass} fixed z-40 overflow-hidden shadow-2xl backdrop-blur-sm transition-[transform,height] duration-300 ease-in-out max-md:inset-x-0 max-md:bottom-0 max-md:rounded-t-2xl max-md:border-t-2 md:top-20 md:right-0 md:h-[calc(100%-5rem)] md:w-80 md:border-l-2 {sheetExpanded
+	class="glass {accentBorderClass} fixed z-panel overflow-hidden shadow-floating backdrop-blur-sm transition-[transform,height] duration-panel max-md:inset-x-0 max-md:bottom-0 max-md:rounded-t-2xl max-md:border-t-2 md:top-20 md:right-0 md:h-[calc(100%-5rem)] md:w-80 md:border-l-2 {sheetExpanded
 		? 'max-md:h-[85dvh]'
 		: 'max-md:h-[45dvh]'} {isOpen
 		? 'translate-x-0 translate-y-0'

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -41,7 +41,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-30 rounded-lg px-3 py-1.5 font-bold shadow-xl backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-nav rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;
@@ -663,7 +663,7 @@
 	{#if viewMode === 'map'}
 		<a
 			href="#map-skip-target"
-			class="btn btn-primary sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-1/2 focus:z-[70] focus:-translate-x-1/2"
+			class="btn btn-primary focus:z-skip sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-1/2 focus:-translate-x-1/2"
 		>
 			Karte überspringen
 		</a>
@@ -681,7 +681,7 @@
 	     genau diesen Filter; „Alle zurücksetzen" stellt den Grundzustand her. -->
 	{#if hasActiveFilters}
 		<div
-			class="scroll-styled absolute top-16 left-1/2 z-30 flex w-max max-w-[92vw] -translate-x-1/2 flex-nowrap items-center justify-start gap-1.5 overflow-x-auto px-1 pb-1"
+			class="scroll-styled z-nav absolute top-16 left-1/2 flex w-max max-w-[92vw] -translate-x-1/2 flex-nowrap items-center justify-start gap-1.5 overflow-x-auto px-1 pb-1"
 			role="group"
 			aria-label="Aktive Filter"
 		>
@@ -782,7 +782,7 @@
 		</p>
 		<div
 			id="info"
-			class="border-base-300 bg-base-100 pointer-events-none absolute z-10 hidden max-w-sm rounded border p-2 shadow-lg"
+			class="border-base-300 bg-base-100 z-raised shadow-floating pointer-events-none absolute hidden max-w-sm rounded border p-2"
 		></div>
 		<!-- M7: Vollbild-Overlay nur beim Initial-Load — Filter-/Jahreswechsel
 		     zeigen stattdessen den Inline-Spinner im Filter-Panel (isLoading-Prop),
@@ -801,7 +801,7 @@
 		<!-- Keine Sichtungen für das gewählte Jahr -->
 		{#if showNoResults}
 			<div
-				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				class="bg-base-100 rounded-box z-nav absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
 				style="box-shadow: var(--shadow-floating)"
 			>
 				<StatusBlock
@@ -822,7 +822,7 @@
 		<!-- Alle Sichtungen durch Filter ausgeblendet -->
 		{#if showNoVisibleResults}
 			<div
-				class="bg-base-100 rounded-box absolute top-1/2 left-1/2 z-30 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				class="bg-base-100 rounded-box z-nav absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
 				style="box-shadow: var(--shadow-floating)"
 			>
 				<StatusBlock
@@ -833,11 +833,20 @@
 			</div>
 		{/if}
 
-		<!-- Error-Toast -->
+		<!-- Error-Toast.
+
+		     `z-overlay` wie das Tastatur-Hilfe-Modal weiter unten, und damit
+		     bewusst NICHT mehr darüber: vorher stand hier `z-[60]` gegen dessen
+		     `z-50`, der Toast durchstieß also den Schleier eines
+		     `aria-modal="true"`-Dialogs. Auf derselben Stufe entscheidet die
+		     DOM-Position, und die gibt dem Modal den Vorrang — was ein Modal
+		     gerade ausmacht. Wer den Toast wieder nach oben holen will, hat
+		     kein Z-Index-Problem, sondern die Frage zu klären, ob eine Meldung
+		     einen modalen Dialog überlagern darf. -->
 		{#if errorMessage}
 			<div
 				role="alert"
-				class="alert alert-error fixed top-20 left-1/2 z-[60] max-w-md -translate-x-1/2 transform shadow-lg"
+				class="alert alert-error z-overlay shadow-floating fixed top-20 left-1/2 max-w-md -translate-x-1/2 transform"
 			>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -865,7 +874,7 @@
 		<!-- K3: Listenansicht — barrierefreie Tabellen-Alternative zur Karte -->
 		{#if viewMode === 'list'}
 			<section
-				class="bg-base-100 absolute inset-0 z-20 overflow-y-auto pt-16 pb-24"
+				class="bg-base-100 z-panel absolute inset-0 overflow-y-auto pt-16 pb-24"
 				aria-label="Listenansicht der Sichtungen"
 			>
 				<div class="mx-auto max-w-3xl px-4">
@@ -880,11 +889,11 @@
 
 	<!-- K3: Umschalter Karte/Liste -->
 	<div
-		class="absolute bottom-4 left-1/2 z-30 -translate-x-1/2"
+		class="z-nav absolute bottom-4 left-1/2 -translate-x-1/2"
 		role="group"
 		aria-label="Darstellung der Sichtungen wählen"
 	>
-		<div class="join shadow-lg">
+		<div class="join shadow-floating">
 			<button
 				type="button"
 				class="btn join-item min-h-11 {viewMode === 'map' ? 'btn-primary' : ''}"
@@ -930,7 +939,7 @@
 	<!-- Tastatur-Hilfe Button -->
 	<button
 		onclick={() => (showKeyboardHelp = true)}
-		class="bg-info text-info-content hover:bg-info/80 fixed bottom-4 left-4 z-30 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full shadow-lg transition-colors duration-300"
+		class="bg-info text-info-content hover:bg-info/80 z-nav shadow-floating duration-panel fixed bottom-4 left-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors"
 		aria-label="Tastatur-Hilfe anzeigen"
 		title="Tastaturkürzel anzeigen (H oder ?)"
 	>
@@ -947,7 +956,7 @@
 		     360, -22px bei 320); bei 375px blieben nur 5px übrig. Die Umschaltung
 		     belegt 16–60px über der Unterkante, bottom-20 setzt die Platte auf 80px
 		     und räumt sie. -->
-		<div class="absolute right-1 bottom-20 z-30 md:bottom-6">
+		<div class="z-nav absolute right-1 bottom-20 md:bottom-6">
 			<!-- Helle Platte, weil /logo_dmm_positiv.svg einfarbig im Markenblau
 			     #003777 zeichnet (relative Luminanz 0,041 — auf Weiß 11,6:1, über
 			     einer dunklen Kachel nur noch ~1,2:1) und dort sonst verschwindet.
@@ -956,7 +965,7 @@
 			     Für dunkle Flächen gibt es /logo_dmm_negativ.svg (gleiche Geometrie,
 			     weiß) — das nutzt die About-Seite auf bg-primary. -->
 			<div
-				class="border-primary/10 bg-base-100/95 rounded-xl border p-1 shadow-lg backdrop-blur-md transition-all duration-300 hover:scale-105 hover:shadow-2xl"
+				class="border-primary/10 bg-base-100/95 shadow-floating duration-panel rounded-xl border p-1 backdrop-blur-md transition-all hover:scale-105"
 				data-testid="map-logo-plate"
 			>
 				<!-- Kein flex-Wrapper um das Bild: Tailwinds Preflight setzt img auf
@@ -978,12 +987,12 @@
 	{#if showKeyboardHelp}
 		<!-- Schleier über der Karte, kein Theme-Ton: bg-scrim/<n>
 		     (--scrim-surface in tokens.css). -->
-		<div class="bg-scrim/50 fixed inset-0 z-50 flex items-center justify-center">
+		<div class="bg-scrim/50 z-overlay fixed inset-0 flex items-center justify-center">
 			<div
 				role="dialog"
 				aria-modal="true"
 				aria-labelledby="help-modal-title"
-				class="bg-base-100 max-h-[80vh] max-w-md rounded-lg p-6 shadow-xl"
+				class="bg-base-100 shadow-floating max-h-[80vh] max-w-md rounded-lg p-6"
 			>
 				<div class="mb-4 flex items-center justify-between">
 					<h3 id="help-modal-title" class="text-lg font-bold">Tastaturkürzel</h3>

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -41,7 +41,7 @@
 		title = 'Sichtungskarte',
 		showLogo = true,
 		containerClass = 'relative h-screen w-screen overflow-hidden',
-		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-nav rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
+		titleClass = 'glass text-base-content text-sm absolute top-4 left-12 z-raised rounded-lg px-3 py-1.5 font-bold shadow-floating backdrop-blur-md flex items-center gap-2'
 	} = $props<{
 		mapContainerId?: string;
 		showTitle?: boolean;
@@ -681,7 +681,7 @@
 	     genau diesen Filter; „Alle zurücksetzen" stellt den Grundzustand her. -->
 	{#if hasActiveFilters}
 		<div
-			class="scroll-styled z-nav absolute top-16 left-1/2 flex w-max max-w-[92vw] -translate-x-1/2 flex-nowrap items-center justify-start gap-1.5 overflow-x-auto px-1 pb-1"
+			class="scroll-styled z-raised absolute top-16 left-1/2 flex w-max max-w-[92vw] -translate-x-1/2 flex-nowrap items-center justify-start gap-1.5 overflow-x-auto px-1 pb-1"
 			role="group"
 			aria-label="Aktive Filter"
 		>
@@ -889,7 +889,7 @@
 
 	<!-- K3: Umschalter Karte/Liste -->
 	<div
-		class="z-nav absolute bottom-4 left-1/2 -translate-x-1/2"
+		class="z-raised absolute bottom-4 left-1/2 -translate-x-1/2"
 		role="group"
 		aria-label="Darstellung der Sichtungen wählen"
 	>
@@ -939,7 +939,7 @@
 	<!-- Tastatur-Hilfe Button -->
 	<button
 		onclick={() => (showKeyboardHelp = true)}
-		class="bg-info text-info-content hover:bg-info/80 z-nav shadow-floating duration-panel fixed bottom-4 left-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors"
+		class="bg-info text-info-content hover:bg-info/80 z-raised shadow-floating duration-panel fixed bottom-4 left-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors"
 		aria-label="Tastatur-Hilfe anzeigen"
 		title="Tastaturkürzel anzeigen (H oder ?)"
 	>
@@ -956,7 +956,7 @@
 		     360, -22px bei 320); bei 375px blieben nur 5px übrig. Die Umschaltung
 		     belegt 16–60px über der Unterkante, bottom-20 setzt die Platte auf 80px
 		     und räumt sie. -->
-		<div class="z-nav absolute right-1 bottom-20 md:bottom-6">
+		<div class="z-raised absolute right-1 bottom-20 md:bottom-6">
 			<!-- Helle Platte, weil /logo_dmm_positiv.svg einfarbig im Markenblau
 			     #003777 zeichnet (relative Luminanz 0,041 — auf Weiß 11,6:1, über
 			     einer dunklen Kachel nur noch ~1,2:1) und dort sonst verschwindet.

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -801,7 +801,7 @@
 		<!-- Keine Sichtungen für das gewählte Jahr -->
 		{#if showNoResults}
 			<div
-				class="bg-base-100 rounded-box z-nav absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				class="bg-base-100 rounded-box z-raised absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
 				style="box-shadow: var(--shadow-floating)"
 			>
 				<StatusBlock
@@ -822,7 +822,7 @@
 		<!-- Alle Sichtungen durch Filter ausgeblendet -->
 		{#if showNoVisibleResults}
 			<div
-				class="bg-base-100 rounded-box z-nav absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
+				class="bg-base-100 rounded-box z-raised absolute top-1/2 left-1/2 w-[min(24rem,90%)] -translate-x-1/2 -translate-y-1/2"
 				style="box-shadow: var(--shadow-floating)"
 			>
 				<StatusBlock
@@ -874,7 +874,7 @@
 		<!-- K3: Listenansicht — barrierefreie Tabellen-Alternative zur Karte -->
 		{#if viewMode === 'list'}
 			<section
-				class="bg-base-100 z-panel absolute inset-0 overflow-y-auto pt-16 pb-24"
+				class="bg-base-100 z-raised absolute inset-0 overflow-y-auto pt-16 pb-24"
 				aria-label="Listenansicht der Sichtungen"
 			>
 				<div class="mx-auto max-w-3xl px-4">
@@ -889,7 +889,7 @@
 
 	<!-- K3: Umschalter Karte/Liste -->
 	<div
-		class="z-raised absolute bottom-4 left-1/2 -translate-x-1/2"
+		class="z-panel absolute bottom-4 left-1/2 -translate-x-1/2"
 		role="group"
 		aria-label="Darstellung der Sichtungen wählen"
 	>

--- a/src/lib/components/map/SightingsMapView.svelte
+++ b/src/lib/components/map/SightingsMapView.svelte
@@ -939,7 +939,7 @@
 	<!-- Tastatur-Hilfe Button -->
 	<button
 		onclick={() => (showKeyboardHelp = true)}
-		class="bg-info text-info-content hover:bg-info/80 z-raised shadow-floating duration-panel fixed bottom-4 left-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors"
+		class="bg-info text-info-content hover:bg-info/80 z-raised shadow-floating duration-instant fixed bottom-4 left-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors"
 		aria-label="Tastatur-Hilfe anzeigen"
 		title="Tastaturkürzel anzeigen (H oder ?)"
 	>
@@ -965,7 +965,7 @@
 			     Für dunkle Flächen gibt es /logo_dmm_negativ.svg (gleiche Geometrie,
 			     weiß) — das nutzt die About-Seite auf bg-primary. -->
 			<div
-				class="border-primary/10 bg-base-100/95 shadow-floating duration-panel rounded-xl border p-1 backdrop-blur-md transition-all hover:scale-105"
+				class="border-primary/10 bg-base-100/95 shadow-floating duration-instant rounded-xl border p-1 backdrop-blur-md transition-all hover:scale-105"
 				data-testid="map-logo-plate"
 			>
 				<!-- Kein flex-Wrapper um das Bild: Tailwinds Preflight setzt img auf

--- a/src/lib/components/media/MediaGallery.svelte
+++ b/src/lib/components/media/MediaGallery.svelte
@@ -100,7 +100,7 @@
 				</div>
 				<div class="space-y-2">
 					{#each otherFiles as file (file.id)}
-						<div class="bg-base-100 flex items-center gap-3 rounded-lg p-3 shadow-sm">
+						<div class="bg-base-100 flex items-center gap-3 rounded-lg p-3 shadow-raised">
 							<Icon icon={getFileTypeIcon(file.mimeType)} width="20" class="text-base-content/60" />
 							<div class="min-w-0 flex-1">
 								<p class="text-base-content truncate text-sm font-medium">

--- a/src/lib/components/media/MediaModal.svelte
+++ b/src/lib/components/media/MediaModal.svelte
@@ -318,21 +318,19 @@
 <style>
 	/* Modal styling improvements */
 	.modal-box {
-		box-shadow:
-			0 20px 25px -5px rgb(0 0 0 / 0.1),
-			0 10px 10px -5px rgb(0 0 0 / 0.04);
+		box-shadow: var(--shadow-floating);
 	}
 
 	/* Image styling */
 	img {
 		border-radius: 0.5rem;
-		box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+		box-shadow: var(--shadow-raised);
 	}
 
 	/* Video styling */
 	video {
 		border-radius: 0.5rem;
-		box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+		box-shadow: var(--shadow-raised);
 	}
 
 	/* Better mobile responsiveness */

--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <div
-	class="media-thumbnail group bg-base-100 relative cursor-pointer overflow-hidden rounded-lg shadow-sm transition-all hover:scale-105 hover:shadow-md"
+	class="media-thumbnail group bg-base-100 relative cursor-pointer overflow-hidden rounded-lg shadow-raised transition-all hover:scale-105 hover:shadow-floating"
 	onclick={handleClick}
 	onkeydown={handleKeydown}
 	tabindex="0"
@@ -75,7 +75,7 @@
 			<!-- GPS Badge für Bilder -->
 			{#if hasGPSData()}
 				<div
-					class="bg-success text-success-content absolute top-2 right-2 rounded-full p-1 shadow-md"
+					class="bg-success text-success-content absolute top-2 right-2 rounded-full p-1 shadow-raised"
 				>
 					<Icon icon="lucide:map-pin" width="12" />
 				</div>

--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -37,7 +37,7 @@
 </script>
 
 <div
-	class="media-thumbnail group bg-base-100 relative cursor-pointer overflow-hidden rounded-lg shadow-raised transition-all hover:scale-105 hover:shadow-floating"
+	class="media-thumbnail group bg-base-100 shadow-raised duration-instant hover:shadow-floating relative cursor-pointer overflow-hidden rounded-lg transition-all hover:scale-105"
 	onclick={handleClick}
 	onkeydown={handleKeydown}
 	tabindex="0"
@@ -75,7 +75,7 @@
 			<!-- GPS Badge für Bilder -->
 			{#if hasGPSData()}
 				<div
-					class="bg-success text-success-content absolute top-2 right-2 rounded-full p-1 shadow-raised"
+					class="bg-success text-success-content shadow-raised absolute top-2 right-2 rounded-full p-1"
 				>
 					<Icon icon="lucide:map-pin" width="12" />
 				</div>

--- a/src/lib/report/components/form/fields/BaseInput.svelte
+++ b/src/lib/report/components/form/fields/BaseInput.svelte
@@ -75,7 +75,7 @@
 	{#if icon !== undefined}
 		<div
 			aria-hidden="true"
-			class="pointer-events-none absolute inset-y-0 left-0 z-10 flex w-10 items-center justify-center"
+			class="pointer-events-none absolute inset-y-0 left-0 z-raised flex w-10 items-center justify-center"
 		>
 			<Icon {icon} width="16" class="text-base-content/60" />
 		</div>

--- a/src/lib/report/components/form/fields/BaseSelect.svelte
+++ b/src/lib/report/components/form/fields/BaseSelect.svelte
@@ -34,7 +34,7 @@
 
 	// Dynamic CSS classes
 	let selectClasses = $derived.by(() => {
-		const base = 'select w-full transition-all duration-200';
+		const base = 'select w-full transition-all duration-quick';
 		const stateClass = hasError ? 'select-error' : isValid ? 'select-success' : '';
 		const sizeClass = size === 'sm' ? 'select-sm' : size === 'lg' ? 'select-lg' : '';
 		const focusClass = 'focus:ring-2 focus:ring-primary/20 focus:border-primary';
@@ -60,7 +60,7 @@
 	{#if icon !== undefined}
 		<div
 			aria-hidden="true"
-			class="pointer-events-none absolute inset-y-0 left-0 z-10 flex w-10 items-center justify-center"
+			class="pointer-events-none absolute inset-y-0 left-0 z-raised flex w-10 items-center justify-center"
 		>
 			<Icon {icon} width="16" class="text-base-content/60" />
 		</div>

--- a/src/lib/report/components/form/fields/BaseTextarea.svelte
+++ b/src/lib/report/components/form/fields/BaseTextarea.svelte
@@ -30,7 +30,7 @@
 
 	// Dynamic CSS classes
 	let textareaClasses = $derived.by(() => {
-		const base = 'textarea w-full transition-all duration-200 resize-y';
+		const base = 'textarea w-full transition-all duration-quick resize-y';
 		const stateClass = hasError ? 'textarea-error' : isValid ? 'textarea-success' : '';
 		const sizeClass = size === 'sm' ? 'textarea-sm' : size === 'lg' ? 'textarea-lg' : '';
 		const focusClass = 'focus:ring-2 focus:ring-primary/20 focus:border-primary';
@@ -54,7 +54,7 @@
 <div class="relative">
 	<!-- Icon (if available) -->
 	{#if icon !== undefined}
-		<div aria-hidden="true" class="pointer-events-none absolute top-3 left-3 z-10">
+		<div aria-hidden="true" class="pointer-events-none absolute top-3 left-3 z-raised">
 			<Icon {icon} width="16" class="text-base-content/60" />
 		</div>
 	{/if}

--- a/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
+++ b/src/lib/report/components/form/fields/DropzoneEnhanced.svelte
@@ -573,7 +573,7 @@
 				{#each mediaFiles as mediaFile (mediaFile.uid)}
 					<!-- Media File Card -->
 					{#if mediaFile}
-						<div class="card bg-base-100 shadow-sm">
+						<div class="card bg-base-100 shadow-raised">
 							<div class="card-body p-3">
 								{#await mediaFile.metadata then fileMetadata}
 									<!-- Thumbnail -->

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -269,7 +269,7 @@
 													<div class="text-center">
 														<button
 															type="button"
-															class="group relative overflow-hidden rounded-lg shadow-sm transition-all hover:shadow-md"
+															class="group shadow-raised hover:shadow-floating relative overflow-hidden rounded-lg transition-all"
 															onclick={() => openImageModal(image.src, image.alt, image.copyright)}
 															aria-label={`${image.alt} in Originalgröße anzeigen`}
 														>
@@ -546,9 +546,18 @@
 		{/if}
 	</div>
 
-	<!-- Backdrop - click to close -->
+	<!-- Backdrop, Klick schließt. Schleier über der Seite dahinter, kein
+	     Theme-Ton: bg-scrim/<n> (--scrim-surface in tokens.css). Deckkraft an
+	     der Aufrufstelle, Farbton im Token — und /60, weil der Schleier den
+	     Schließen-Bereich trägt. Stand vorher als oklch(0% 0 0 / 0.6) im
+	     scoped <style> und umging das Theme damit vollständig.
+
+	     Der Weichzeichner wird dabei von 4px auf 8px angehoben: `backdrop-blur-sm`
+	     ist unter Tailwind 4 acht Pixel (4px hieße `backdrop-blur-xs`). Das ist
+	     Absicht — MediaModal.svelte fährt denselben Wert, und zwei
+	     Modal-Schleier derselben App sollen nicht unterschiedlich weich sein. -->
 	<div
-		class="modal-backdrop cursor-pointer"
+		class="modal-backdrop bg-scrim/60 cursor-pointer backdrop-blur-sm"
 		onclick={closeImageModal}
 		onkeydown={(e) => e.key === 'Escape' && closeImageModal()}
 		role="button"
@@ -588,19 +597,12 @@
 	}
 
 	.modal-box {
-		box-shadow:
-			0 20px 25px -5px oklch(0% 0 0 / 0.1),
-			0 10px 10px -5px oklch(0% 0 0 / 0.04);
-	}
-
-	.modal-backdrop {
-		backdrop-filter: blur(4px);
-		background-color: oklch(0% 0 0 / 0.6);
+		box-shadow: var(--shadow-floating);
 	}
 
 	.modal img {
 		border-radius: 0.5rem;
-		box-shadow: 0 4px 6px -1px oklch(0% 0 0 / 0.1);
+		box-shadow: var(--shadow-raised);
 	}
 
 	/* Copyright-Links stammen aus {@html} und brauchen daher globale Selektoren.

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -269,14 +269,14 @@
 													<div class="text-center">
 														<button
 															type="button"
-															class="group shadow-raised hover:shadow-floating relative overflow-hidden rounded-lg transition-all"
+															class="group shadow-raised hover:shadow-floating duration-instant relative overflow-hidden rounded-lg transition-all"
 															onclick={() => openImageModal(image.src, image.alt, image.copyright)}
 															aria-label={`${image.alt} in Originalgröße anzeigen`}
 														>
 															<img
 																src={image.src}
 																alt={image.alt}
-																class="h-32 w-full object-cover transition-all group-hover:brightness-110"
+																class="duration-instant h-32 w-full object-cover transition-all group-hover:brightness-110"
 																loading="lazy"
 															/>
 															<!-- Schleier über dem Artfoto, kein Theme-Ton: bg-scrim/<n>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -100,7 +100,7 @@
 <div class="bg-base-200 flex min-h-screen items-center justify-center p-4">
 	<div class="w-full max-w-md">
 		<!-- Hauptfehler-Karte -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body items-center text-center">
 				<!-- Fehler-Icon -->
 				<div class="avatar placeholder mb-4">
@@ -166,7 +166,7 @@
 		</div>
 
 		<!-- Zusätzliche Hilfe-Karte -->
-		<div class="card bg-base-100 mt-4 shadow-lg">
+		<div class="card bg-base-100 mt-4 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title text-lg">
 					<Icon icon="lucide:info" class="mr-2 h-5 w-5" />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 	<!-- Skip-Link: erster fokussierbarer Inhalt vor der Navigation -->
 	<a
 		href="#main-content"
-		class="btn btn-primary sr-only z-[100] focus:not-sr-only focus:absolute focus:top-2 focus:left-2"
+		class="btn btn-primary sr-only z-skip focus:not-sr-only focus:absolute focus:top-2 focus:left-2"
 	>
 		Zum Hauptinhalt springen
 	</a>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -96,7 +96,7 @@
 				</div>
 			</div>
 			<div
-				class="card from-primary/5 via-secondary/5 to-accent/5 border-primary/20 bg-gradient-to-br shadow-xl"
+				class="card from-primary/5 via-secondary/5 to-accent/5 border-primary/20 bg-gradient-to-br shadow-raised"
 			>
 				<div class="card-body p-10 text-center">
 					<div class="mb-6 flex justify-center">
@@ -110,7 +110,7 @@
 					<!-- Jahreszahl kommt aus der Datenbank (älteste freigegebene Sichtung),
 					     nicht aus dem Template — Begründung in +page.server.ts. -->
 					{#if data.earliestSightingYear != null}
-						<div class="stats stats-vertical mt-6 shadow-sm">
+						<div class="stats stats-vertical mt-6 shadow-raised">
 							<div class="stat">
 								<div class="stat-title text-xs">Sichtungen seit</div>
 								<div class="stat-value text-primary text-2xl">{data.earliestSightingYear}</div>
@@ -141,10 +141,10 @@
 		</div>
 
 		<div class="grid gap-8 md:grid-cols-3">
-			<div class="card bg-base-100 group shadow-xl transition-all duration-300 hover:shadow-2xl">
+			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-300 group-hover:scale-110"
+						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
 					>
 						<Icon icon="lucide:pen-line" width="48" class="text-primary" />
 					</div>
@@ -159,10 +159,10 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 group shadow-xl transition-all duration-300 hover:shadow-2xl">
+			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-300 group-hover:scale-110"
+						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
 					>
 						<Icon icon="lucide:map" width="48" class="text-secondary-strong" />
 					</div>
@@ -181,10 +181,10 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 group shadow-xl transition-all duration-300 hover:shadow-2xl">
+			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-300 group-hover:scale-110"
+						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
 					>
 						<Icon icon="lucide:chart-pie" width="48" class="text-accent-strong" />
 					</div>
@@ -314,7 +314,7 @@
 			Datenschutz & Sicherheit
 		</h2>
 
-		<div class="card bg-base-100 border-success/20 border shadow-xl">
+		<div class="card bg-base-100 border-success/20 border shadow-raised">
 			<div class="card-body">
 				<p class="text-base-content/80 mb-4">
 					Ihre Meldung verarbeiten wir nach der EU-Datenschutz-Grundverordnung (DSGVO) und dem
@@ -468,7 +468,7 @@
 				<div class="mb-8">
 					<div class="avatar mb-6">
 						<div
-							class="ring-primary ring-offset-base-100 from-primary/10 to-secondary/10 w-32 rounded-full bg-gradient-to-br shadow-xl ring ring-offset-4"
+							class="ring-primary ring-offset-base-100 from-primary/10 to-secondary/10 w-32 rounded-full bg-gradient-to-br shadow-raised ring ring-offset-4"
 						>
 							<OstseeTiereLogo size="lg" showText={false} />
 						</div>
@@ -500,7 +500,7 @@
 					  eine erfundene (siehe .claude/rules/design-system.md, „Zahlen in
 					  Nutzertexten nur mit Quelle").
 				-->
-				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-xl">
+				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-raised">
 					{#if data.totalSightings != null}
 						<div class="stat">
 							<div class="stat-title">Veröffentlicht</div>
@@ -534,14 +534,14 @@
 				<div class="flex flex-wrap justify-center gap-6">
 					<a
 						href="/"
-						class="btn btn-primary btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
+						class="btn btn-primary btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
 					>
 						<Icon icon="custom:porpoise" width="20" height="20" class="mr-2" aria-hidden="true" />
 						Sichtung melden
 					</a>
 					<a
 						href="/map"
-						class="btn btn-secondary btn-outline btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
+						class="btn btn-secondary btn-outline btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
 					>
 						<Icon icon="lucide:map" width="20" height="20" class="mr-2" />
 						Karte erkunden
@@ -556,7 +556,7 @@
 					     und mit einer Beschriftung, die es benennt statt zu umschreiben. -->
 					<a
 						href="/bestimmungshilfe"
-						class="btn btn-accent btn-outline btn-lg px-8 py-4 text-lg shadow-lg transition-all duration-300 hover:shadow-xl"
+						class="btn btn-accent btn-outline btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
 					>
 						<Icon icon="lucide:book-open" width="20" height="20" class="mr-2" />
 						Tiere bestimmen

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -96,7 +96,7 @@
 				</div>
 			</div>
 			<div
-				class="card from-primary/5 via-secondary/5 to-accent/5 border-primary/20 bg-gradient-to-br shadow-raised"
+				class="card from-primary/5 via-secondary/5 to-accent/5 border-primary/20 shadow-raised bg-gradient-to-br"
 			>
 				<div class="card-body p-10 text-center">
 					<div class="mb-6 flex justify-center">
@@ -110,7 +110,7 @@
 					<!-- Jahreszahl kommt aus der Datenbank (älteste freigegebene Sichtung),
 					     nicht aus dem Template — Begründung in +page.server.ts. -->
 					{#if data.earliestSightingYear != null}
-						<div class="stats stats-vertical mt-6 shadow-raised">
+						<div class="stats stats-vertical shadow-raised mt-6">
 							<div class="stat">
 								<div class="stat-title text-xs">Sichtungen seit</div>
 								<div class="stat-value text-primary text-2xl">{data.earliestSightingYear}</div>
@@ -141,10 +141,12 @@
 		</div>
 
 		<div class="grid gap-8 md:grid-cols-3">
-			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
+			<div
+				class="card bg-base-100 group shadow-raised duration-instant hover:shadow-floating transition-all"
+			>
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
+						class="duration-instant mb-6 flex justify-center transition-transform group-hover:scale-110"
 					>
 						<Icon icon="lucide:pen-line" width="48" class="text-primary" />
 					</div>
@@ -159,10 +161,12 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
+			<div
+				class="card bg-base-100 group shadow-raised duration-instant hover:shadow-floating transition-all"
+			>
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
+						class="duration-instant mb-6 flex justify-center transition-transform group-hover:scale-110"
 					>
 						<Icon icon="lucide:map" width="48" class="text-secondary-strong" />
 					</div>
@@ -181,10 +185,12 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 group shadow-raised transition-all duration-panel hover:shadow-floating">
+			<div
+				class="card bg-base-100 group shadow-raised duration-instant hover:shadow-floating transition-all"
+			>
 				<div class="card-body p-8 text-center">
 					<div
-						class="mb-6 flex justify-center transition-transform duration-panel group-hover:scale-110"
+						class="duration-instant mb-6 flex justify-center transition-transform group-hover:scale-110"
 					>
 						<Icon icon="lucide:chart-pie" width="48" class="text-accent-strong" />
 					</div>
@@ -314,7 +320,7 @@
 			Datenschutz & Sicherheit
 		</h2>
 
-		<div class="card bg-base-100 border-success/20 border shadow-raised">
+		<div class="card bg-base-100 border-success/20 shadow-raised border">
 			<div class="card-body">
 				<p class="text-base-content/80 mb-4">
 					Ihre Meldung verarbeiten wir nach der EU-Datenschutz-Grundverordnung (DSGVO) und dem
@@ -468,7 +474,7 @@
 				<div class="mb-8">
 					<div class="avatar mb-6">
 						<div
-							class="ring-primary ring-offset-base-100 from-primary/10 to-secondary/10 w-32 rounded-full bg-gradient-to-br shadow-raised ring ring-offset-4"
+							class="ring-primary ring-offset-base-100 from-primary/10 to-secondary/10 shadow-raised w-32 rounded-full bg-gradient-to-br ring ring-offset-4"
 						>
 							<OstseeTiereLogo size="lg" showText={false} />
 						</div>
@@ -500,7 +506,9 @@
 					  eine erfundene (siehe .claude/rules/design-system.md, „Zahlen in
 					  Nutzertexten nur mit Quelle").
 				-->
-				<div class="stats stats-vertical sm:stats-horizontal bg-base-100/50 mb-8 w-full shadow-raised">
+				<div
+					class="stats stats-vertical sm:stats-horizontal bg-base-100/50 shadow-raised mb-8 w-full"
+				>
 					{#if data.totalSightings != null}
 						<div class="stat">
 							<div class="stat-title">Veröffentlicht</div>
@@ -534,14 +542,14 @@
 				<div class="flex flex-wrap justify-center gap-6">
 					<a
 						href="/"
-						class="btn btn-primary btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
+						class="btn btn-primary btn-lg shadow-raised duration-instant hover:shadow-floating px-8 py-4 text-lg transition-all"
 					>
 						<Icon icon="custom:porpoise" width="20" height="20" class="mr-2" aria-hidden="true" />
 						Sichtung melden
 					</a>
 					<a
 						href="/map"
-						class="btn btn-secondary btn-outline btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
+						class="btn btn-secondary btn-outline btn-lg shadow-raised duration-instant hover:shadow-floating px-8 py-4 text-lg transition-all"
 					>
 						<Icon icon="lucide:map" width="20" height="20" class="mr-2" />
 						Karte erkunden
@@ -556,7 +564,7 @@
 					     und mit einer Beschriftung, die es benennt statt zu umschreiben. -->
 					<a
 						href="/bestimmungshilfe"
-						class="btn btn-accent btn-outline btn-lg px-8 py-4 text-lg shadow-raised transition-all duration-panel hover:shadow-floating"
+						class="btn btn-accent btn-outline btn-lg shadow-raised duration-instant hover:shadow-floating px-8 py-4 text-lg transition-all"
 					>
 						<Icon icon="lucide:book-open" width="20" height="20" class="mr-2" />
 						Tiere bestimmen

--- a/src/routes/admin/[id]/+layout.svelte
+++ b/src/routes/admin/[id]/+layout.svelte
@@ -26,7 +26,7 @@
 			<span class="loading loading-spinner loading-lg"></span>
 		</div>
 	{:then}
-		<div class="bg-base-100 rounded-lg shadow-lg">
+		<div class="bg-base-100 rounded-lg shadow-raised">
 			<div class="p-6">
 				{@render children()}
 			</div>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -427,7 +427,7 @@
 	<div class="grid gap-8 lg:grid-cols-2">
 		{#each Object.entries(groupedConfigs) as [category, configs] (category)}
 			{@const iconName = categoryIcons[category] || 'lucide:settings'}
-			<div class="card bg-base-100 shadow-lg">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title mb-4 flex items-center gap-3">
 						<Icon icon={iconName} class="text-primary size-7" />

--- a/src/routes/admin/settings/CleanupPanel.svelte
+++ b/src/routes/admin/settings/CleanupPanel.svelte
@@ -47,7 +47,7 @@
 	}
 </script>
 
-<section class="card bg-base-100 border-base-300 border shadow-sm">
+<section class="card bg-base-100 border-base-300 border shadow-raised">
 	<div class="card-body">
 		<h2 class="card-title">
 			<Icon icon="lucide:trash-2" width="20" class="text-primary" aria-hidden="true" />

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -845,7 +845,7 @@
 						Spalten
 					</summary>
 					<div
-						class="dropdown-content menu bg-base-100 rounded-box border-base-300 z-[1] mt-1 w-64 border p-2 shadow-lg"
+						class="dropdown-content menu bg-base-100 rounded-box border-base-300 z-raised shadow-floating mt-1 w-64 border p-2"
 					>
 						<div class="menu-title flex items-center justify-between pb-2">
 							<span class="text-sm font-semibold">Spalten anzeigen</span>
@@ -997,7 +997,7 @@
 								<Icon icon="lucide:ellipsis-vertical" class="h-4 w-4" aria-hidden="true" />
 							</summary>
 							<ul
-								class="dropdown-content menu bg-base-100 rounded-box border-base-300 z-[1] mt-1 w-44 border p-2 shadow-lg"
+								class="dropdown-content menu bg-base-100 rounded-box border-base-300 z-raised shadow-floating mt-1 w-44 border p-2"
 							>
 								<li>
 									<button type="button" onclick={() => umbenennenStarten(preset)}>
@@ -1058,11 +1058,19 @@
 		</div>
 	</div>
 
-	<!-- Filter Panel -->
+	<!-- Filter Panel.
+
+	     Hier stand `transition-all duration-300`. Das ist als einzige der 19
+	     Dauer-Fundstellen NICHT auf ein Motion-Token gewandert, sondern
+	     ersatzlos entfallen: Das Panel hängt an einem `{#if}` und wird ein- und
+	     ausgehängt statt ein- und ausgeblendet — es gibt keinen Zustand, von
+	     dem aus ein Übergang laufen könnte, und die Klasse hat nie gewirkt.
+	     Ein `duration-panel` an ihrer Stelle sähe token-konform aus und täte
+	     weiterhin nichts. Wer hier wirklich animieren will, braucht
+	     `transition:slide` aus `svelte/transition` (design-system.md, „Keine
+	     toten Utility-Klassen"). -->
 	{#if isFilterPanelOpen}
-		<div
-			class="bg-base-200 container mx-auto mb-4 rounded-lg p-3 px-4 shadow-sm transition-all duration-300 sm:px-6"
-		>
+		<div class="bg-base-200 shadow-raised container mx-auto mb-4 rounded-lg p-3 px-4 sm:px-6">
 			<div class="mb-2 flex items-center justify-between">
 				<h2 class="text-base font-semibold">Filter</h2>
 				<button
@@ -1195,7 +1203,7 @@
 				approvedAt: sighting.approvedAt,
 				rejectedAt: sighting.rejectedAt
 			})}
-			<div class="bg-base-100 border-base-300 rounded-lg border p-4 shadow-sm">
+			<div class="bg-base-100 border-base-300 shadow-raised rounded-lg border p-4">
 				<div class="mb-3 flex items-start justify-between">
 					<div class="flex-1">
 						<!-- Referenz und Kennzeichen als eigene Flex-Zeile: Nebeneinander,
@@ -1419,7 +1427,7 @@
 				</div>
 			</div>
 		{/if}
-		<div class="border-base-300 bg-base-100 w-full overflow-x-auto rounded-lg border shadow-sm">
+		<div class="border-base-300 bg-base-100 shadow-raised w-full overflow-x-auto rounded-lg border">
 			<table class="table-zebra table w-full">
 				<thead class="bg-base-200 text-base-content">
 					<tr>

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -169,7 +169,7 @@
 		     also nicht). Bei 3 Spalten ordnen sich die fünf Karten als 3+2 an — gegenüber 4+1 die
 		     ruhigere Aufteilung, deshalb keine vierte Spalte ab 2xl. -->
 		<div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-			<div class="stats w-full shadow">
+			<div class="stats w-full shadow-raised">
 				<div class="stat">
 					<div class="stat-figure text-primary">
 						<Icon icon="lucide:users" class="h-8 w-8" />
@@ -186,7 +186,7 @@
 				</div>
 			</div>
 
-			<div class="stats w-full shadow">
+			<div class="stats w-full shadow-raised">
 				<div class="stat">
 					<div class="stat-figure text-secondary-strong">
 						<Icon icon="lucide:activity" class="h-8 w-8" />
@@ -203,7 +203,7 @@
 				</div>
 			</div>
 
-			<div class="stats w-full shadow">
+			<div class="stats w-full shadow-raised">
 				<div class="stat">
 					<div class="stat-figure text-warning-strong">
 						<Icon icon="lucide:trending-up" class="h-8 w-8" />
@@ -226,7 +226,7 @@
 				</div>
 			</div>
 
-			<div class="stats w-full shadow">
+			<div class="stats w-full shadow-raised">
 				<div class="stat">
 					<div class="stat-figure text-accent-strong">
 						<Icon icon="lucide:calendar" class="h-8 w-8" />
@@ -245,7 +245,7 @@
 				</div>
 			</div>
 
-			<div class="stats w-full shadow">
+			<div class="stats w-full shadow-raised">
 				<div class="stat">
 					<div class="stat-figure text-info-strong">
 						<Icon icon="lucide:users" class="h-8 w-8" />
@@ -265,7 +265,7 @@
 
 		<!-- Species Distribution -->
 		<div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:chart-pie" class="h-6 w-6" />
@@ -316,7 +316,7 @@
 			</div>
 
 			<!-- Monthly Seasonality -->
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:calendar" class="h-6 w-6" />
@@ -348,7 +348,7 @@
 			</div>
 
 			<!-- Data Quality & User Engagement -->
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:users" class="h-6 w-6" />
@@ -356,7 +356,7 @@
 					</h2>
 
 					<!-- User Engagement Stats -->
-					<div class="stats stats-vertical lg:stats-horizontal mb-4 shadow">
+					<div class="stats stats-vertical lg:stats-horizontal mb-4 shadow-raised">
 						<div class="stat">
 							<div class="stat-title">Eindeutige Nutzer</div>
 							<div class="stat-value text-primary">
@@ -422,7 +422,7 @@
 
 		<!-- Top Observers -->
 		{#if data.topObservers && data.topObservers.length > 0}
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:trending-up" class="h-6 w-6" />
@@ -477,7 +477,7 @@
 		{/if}
 
 		<!-- Yearly Trends -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:trending-up" class="h-6 w-6" />
@@ -547,7 +547,7 @@
 				(sum, a) => sum + Number(a.count),
 				0
 			)}
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title">
 						<Icon icon="lucide:calendar" class="h-6 w-6" />
@@ -600,7 +600,7 @@
 					</div>
 
 					<!-- Summary Stats -->
-					<div class="stats stats-vertical lg:stats-horizontal shadow">
+					<div class="stats stats-vertical lg:stats-horizontal shadow-raised">
 						<div class="stat">
 							<div class="stat-title">Neue Sichtungen</div>
 							<div class="stat-value text-primary">{formatNumber(totalRecentSightings)}</div>

--- a/src/routes/docs/+page.svelte
+++ b/src/routes/docs/+page.svelte
@@ -44,7 +44,7 @@
 
 	<div class="grid gap-6 md:grid-cols-2">
 		<!-- API Documentation Card -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:zap" width="24" height="24" class="text-primary" />
@@ -73,7 +73,7 @@
 		</div>
 
 		<!-- Getting Started Card -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:play" width="24" height="24" class="text-primary" />
@@ -105,7 +105,7 @@
 		</div>
 
 		<!-- Download Card -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:file-text" width="24" height="24" class="text-primary" />
@@ -133,7 +133,7 @@
 		</div>
 
 		<!-- Authentication Card -->
-		<div class="card bg-base-100 shadow-xl">
+		<div class="card bg-base-100 shadow-raised">
 			<div class="card-body">
 				<h2 class="card-title">
 					<Icon icon="lucide:lock" width="24" height="24" class="text-primary" />

--- a/src/routes/docs/api/fallback/+page.svelte
+++ b/src/routes/docs/api/fallback/+page.svelte
@@ -87,7 +87,7 @@
 	{:else if openApiSpec}
 		<!-- Quick API Overview -->
 		<div class="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔍 Sichtungen</h2>
 					<div class="space-y-1 text-sm">
@@ -106,7 +106,7 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">🔐 Authentifizierung</h2>
 					<div class="space-y-1 text-sm">
@@ -117,7 +117,7 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">📁 Dateien</h2>
 					<div class="space-y-1 text-sm">
@@ -127,7 +127,7 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">📊 Export</h2>
 					<div class="space-y-1 text-sm">
@@ -139,7 +139,7 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">⚙️ Admin</h2>
 					<div class="space-y-1 text-sm">
@@ -150,7 +150,7 @@
 				</div>
 			</div>
 
-			<div class="card bg-base-100 shadow-xl">
+			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
 					<h2 class="card-title text-lg">🌍 Geo</h2>
 					<div class="space-y-1 text-sm">

--- a/src/routes/maintenance/+page.svelte
+++ b/src/routes/maintenance/+page.svelte
@@ -15,7 +15,7 @@
 </svelte:head>
 
 <div class="bg-base-200 flex min-h-screen items-center justify-center">
-	<div class="card bg-base-100 w-full max-w-md shadow-xl">
+	<div class="card bg-base-100 w-full max-w-md shadow-raised">
 		<div class="card-body text-center">
 			<!-- Logo -->
 			<div class="mb-6 flex justify-center">


### PR DESCRIPTION
Schritt 3 des Admin-Reviews, repo-weit: Der Bestand wandert auf die Elevation-, Z-Index- und Motion-Tokens, danach werden die drei Wächter aus #811 scharf gestellt.

## Ausgangslage

#811 hat `RAW_ELEVATION`, `RAW_Z_INDEX` und `RAW_MOTION_DURATION` in `e2e/helpers/bannedClasses.ts` ergänzt und an konstruierten Beispielen belegt. Im DOM-Scan standen sie als `test.fixme`, weil der Bestand sie nicht erfüllte: **118 rohe Schatten-Utilities in 26 Dateien, 28 freie Z-Index- und 19 freie Dauer-Angaben.**

## Die Entscheidung, die den Rest bestimmt hat

Schatten hatten einen echten Utility-Ersatz (`shadow-raised`/`shadow-floating` aus dem `@theme`-Block). Z-Index und Dauer nicht — und sie konnten auch keinen aus `@theme` bekommen: **Tailwind 4 hat für beides gar keinen Theme-Namespace.** Ein `--layer-panel` dort wäre eine Variable ohne Klasse geblieben.

Beide Gruppen stehen deshalb als `@utility` in `app.css` und zeigen auf die `--layer-*`/`--motion-*`-Werte in `tokens.css`:

| Utility | Wert | | Utility | Wert |
| --- | --- | --- | --- | --- |
| `z-raised` | 10 | | `duration-instant` | 120ms, `--motion-ease` |
| `z-panel` | 20 | | `duration-quick` | 200ms, `--motion-ease` |
| `z-nav` | 30 | | `duration-panel` | 300ms, `--motion-ease` |
| `z-overlay` | 40 | | `duration-emphasis` | 400ms, `linear` |
| `z-skip` | 50 | | | |

Der `var()`-Weg bleibt gültig. `design-system.md` und die Hinweistexte in `bannedClasses.ts` sind nachgezogen — sie sagten bisher „sind KEINE Utilities".

## Zugeordnet nach Rolle, nicht nach Größe

Karten und Stat-Blöcke werden `shadow-raised`, Dropdowns/Modals/Toasts/schwebende Karten-Panels `shadow-floating`. Ein `shadow-xl` an einer Statistik-Karte wird also `raised`, nicht `floating`. Z-Index-Stufen nach dem, was ein Element tatsächlich überlagern muss.

Vier handgeschriebene `box-shadow` in Komponenten gehen auf `var(--shadow-*)` — darunter ein scoped Block in `AdminSightingView.svelte`, der den globalen `.card:hover` aus `app.css` still überschrieb.

## Zwei bewusste Verhaltensänderungen

- **Das Filter-Panel in `admin/sichtungen`** verliert `transition-all duration-300` ersatzlos statt ein Token zu bekommen. Es hängt an einem `{#if}`, wird also ein- und ausgehängt statt animiert — die Klasse hat nie gewirkt, und ein `duration-panel` sähe token-konform aus und täte weiterhin nichts.
- **Der Error-Toast der Karte** fällt von `z-[60]` auf `z-overlay`, dieselbe Stufe wie der Tastatur-Hilfe-Dialog. Er durchstößt damit nicht mehr den Schleier eines `aria-modal`-Dialogs; die DOM-Position gibt dem Modal den Vorrang. Begründet im Markup.

Zusätzlich mitgenommen: Der Backdrop des Bestimmungshilfe-Modals stand als `oklch(0% 0 0 / 0.6)` in einem scoped `<style>` und umging das Theme. Er ist jetzt `bg-scrim/60` wie in `MediaModal.svelte`. Der Weichzeichner geht dabei von 4px auf 8px — `backdrop-blur-sm` ist unter Tailwind 4 acht Pixel, und zwei Modal-Schleier derselben App sollten nicht unterschiedlich weich sein.

## Neuer Wächter

Der Klassen-Scan liest Namen — er hätte nie bemerkt, wenn `z-nav` eine tote Klasse wäre, und daran hängen jetzt 47 Aufrufstellen. Eine neue Gruppe in `design-tokens.spec.ts` misst deshalb die **Wirkung**: `z-nav` → 30, `duration-panel` → 0.3s mit `--motion-ease`, `duration-emphasis` → `linear`.

Gegenproben gefahren:
- `@utility z-nav` aus `app.css` entfernt → Test rot.
- `transition-timing-function: linear` aus `duration-emphasis` entfernt → Test rot. Diese Assertion entstand erst durch das Review: Die erste Fassung prüfte nur „nicht `--motion-ease`" und hätte den CSS-Default `ease` durchgelassen — genau den Zustand, in dem der Code kurzzeitig war, während `design-system.md` `linear` vorschreibt.

## Verifikation

- `npm run test:quick`: 4245 Tests grün
- `e2e/design-tokens.spec.ts`: 111 grün, darunter alle 24 neu aktivierten Scans über 8 Routen
- `modal-overflow`, `form-a11y`, `horizontal-overflow`: 136 grün
- Sichtprüfung `/`, `/map`, `/about` per Playwright, Navbar-Elevation und Karten-Ebenen im Browser nachgemessen

## Was hier bewusst NICHT drin ist

Zwei Befunde aus dem Review sind als eigene Aufgaben ausgelagert, weil sie über die Migration hinausgehen:

1. **`e2e/map-panels.spec.ts` → „Vergrößern-Button schaltet das Sheet auf expanded" schlägt fehl.** Per `git stash` gegen den Basis-Commit `dce7ad82` gegengeprüft: **schlägt dort identisch fehl**, also vorbestehend und nicht von diesem PR.
2. **`.card:hover` und `.btn:hover` in `app.css` deklarieren ihre `transition` innerhalb der Hover-Regel** — der Effekt fährt weich hinein und springt beim Verlassen zurück. `AdminSightingView.svelte` war mit seinem eigenen `transition: all` die einzige Ausnahme der App; mit dem entfernten Block verhält es sich jetzt wie alles andere. Die Korrektur wäre eine Basisregel und beträfe jede Karte und jeden Button — eine eigene Entscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)