### PR TITLE
refactor(admin): Spam-Score aus einer Quelle anzeigen

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -141,8 +141,34 @@ dieselbe, deshalb steht sie einmal.
 | `ExportModal.svelte`           | Export-Dialog                               |
 | `deadFinding.ts`               | Totfund-Auszeichnung                        |
 | `sightingStatus.ts`            | Statusableitung + Wort/Farbe/Icon/Verdict   |
+| `spamScorePresentation.ts`     | Spam-Risikostufe + Wort/Farbe/Icon          |
 | `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)    |
 | `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel     |
+
+### Spam-Score: vier Anzeigestellen, eine Schwelle
+
+Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts` — für
+Eingangskarte, Spam-Spalte der Tabelle, Spam-Check-Modal und die Inline-Karte
+der Detailansicht gemeinsam. Vorher lagen dort drei Schwellensätze, und Score 1
+war grau in der Liste, grün im Modal und gelb in der Detailansicht. Drei Dinge
+dabei nicht zurückdrehen:
+
+- **`null` ist nicht `0` und bekommt kein Badge.** `spam_score IS NULL` heißt
+  „nie bewertet" (Altbestand, Legacy-Eingang), `0` heißt „bewertet,
+  unauffällig" (`docs/SPAM_DETECTION.md`). Die Eingangskarte zeigte für NULL ein
+  graues „Spam: –" und behauptete damit ein Prüfergebnis.
+- **`isHighRisk` schlägt die Client-Schwelle, wo es vorliegt.** Für eine
+  geglückte Prüfung sagen beide dasselbe; der Fail-Safe-Zweig des Detektors
+  liefert aber Score 0 **mit** `isHighRisk: true`. Wörtlich genommen wäre das
+  „Hochrisiko ohne einen Indikator" — `getSpamRiskFromResult` liest ein
+  `failed`-Ergebnis deshalb als „nicht bewertet", genauso wie NULL.
+- **Jede bewertete Stufe hat ein eigenes Icon** (WCAG 1.4.1). An allen vier
+  Stellen hing die Bedeutung vorher allein an der Farbe.
+
+Die Flächen- und Icon-Farbe der Detail-Karte steht als `SpamRisk`-Record an
+ihrer Aufrufstelle — ein Leser, gleiche Begründung wie bei `deadFinding.ts`.
+Über die Stufe und nicht über den Score aufgeschlüsselt, damit die Schwellen
+nicht doch wieder auseinanderlaufen.
 
 ### Totfund vs. Lebendsichtung
 

--- a/docs/SPAM_DETECTION.md
+++ b/docs/SPAM_DETECTION.md
@@ -107,6 +107,27 @@ Zwei Spalten in `sichtungen`:
   Gegenteil dessen, was es aussagt.
 - `spam_indicators` (`jsonb`) — Array der ausgelösten Indikatortexte.
 
+### Wie der Score angezeigt wird
+
+Vier Stellen zeigen ihn — Eingangskarte, Spam-Spalte der Tabelle,
+Spam-Check-Modal und Inline-Karte der Detailansicht. Wort, Farbe, Icon und
+Schwelle stehen für alle vier in
+`src/lib/components/admin/spamScorePresentation.ts`:
+
+| Stufe        | Score               | Badge           | Icon                  |
+| ------------ | ------------------- | --------------- | --------------------- |
+| `unrated`    | `NULL`              | **kein Badge**  | —                     |
+| `clean`      | 0–1                 | `badge-ghost`   | `lucide:shield-check` |
+| `suspicious` | 2–4                 | `badge-warning` | `lucide:shield-alert` |
+| `high`       | ab 5 (`isHighRisk`) | `badge-error`   | `lucide:shield-x`     |
+
+`unrated` bekommt bewusst kein Badge: Ein graues „Spam: –" läse sich wie
+„geprüft, sauber" und ist das Gegenteil der Aussage. Ein **fehlgeschlagenes**
+Prüfergebnis (`failed: true`, Score 0 mit `isHighRisk: true`) wird aus demselben
+Grund als `unrated` angezeigt — die Prüfung ist nicht durchgelaufen, „Hochrisiko
+ohne einen einzigen Indikator" wäre keine ehrliche Auskunft. Das Fail-Safe-Flag
+bleibt trotzdem richtig: Es verhindert, dass Score 0 persistiert wird.
+
 In der Admin-Liste gibt es dafür eine sortierbare Spalte „Spam". Die Sortierung
 verwendet explizit `NULLS LAST` in **beiden** Richtungen: PostgreSQL sortiert
 `DESC` per Vorgabe `NULLS FIRST`, sonst stünde der unbewertete Altbestand über

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -91,6 +91,7 @@
 	import Settings from '~icons/lucide/settings';
 	import ShieldAlert from '~icons/lucide/shield-alert';
 	import ShieldCheck from '~icons/lucide/shield-check';
+	import ShieldX from '~icons/lucide/shield-x';
 	import Ship from '~icons/lucide/ship';
 	import SkipForward from '~icons/lucide/skip-forward';
 	import BookmarkPlus from '~icons/lucide/bookmark-plus';
@@ -153,6 +154,7 @@
 		'lucide:copy': Copy,
 		'lucide:info': Info,
 		'lucide:shield-alert': ShieldAlert,
+		'lucide:shield-x': ShieldX,
 		'lucide:waves': Waves,
 		'lucide:activity': Activity,
 		'lucide:camera': Camera,

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -11,6 +11,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { inboxDetailHref } from './adminReturn';
 	import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
+	import { SPAM_RISK_PRESENTATION, getSpamRisk } from './spamScorePresentation';
 
 	interface Props {
 		sighting: SightingSelect;
@@ -37,24 +38,14 @@
 	};
 
 	const balticSea = $derived(BALTIC_SEA_STATUS_PRESENTATION[getBalticSeaStatus(sighting)]);
-	/* Gleiche Schwellen wie die Spam-Spalte der Tabelle (/admin/sichtungen) —
-	   beide Ansichten müssen denselben Score gleich einfärben. */
-	const spamBadgeClass = $derived(
-		sighting.spamScore == null
-			? 'badge-ghost'
-			: sighting.spamScore >= 5
-				? 'badge-error'
-				: sighting.spamScore >= 2
-					? 'badge-warning'
-					: 'badge-ghost'
-	);
+	const spam = $derived(SPAM_RISK_PRESENTATION[getSpamRisk(sighting.spamScore)]);
 	const spamIndicators = $derived(
 		Array.isArray(sighting.spamIndicators) ? (sighting.spamIndicators as string[]) : []
 	);
 	const melderName = $derived([sighting.firstName, sighting.lastName].filter(Boolean).join(' '));
 </script>
 
-<article class="card border-base-300 bg-base-100 border shadow-raised">
+<article class="card border-base-300 bg-base-100 shadow-raised border">
 	<div class="card-body gap-3 p-4">
 		<div class="flex flex-wrap items-center gap-2">
 			{#if isDeadFinding(sighting.isDead)}
@@ -62,13 +53,28 @@
 					{DEAD_FINDING_PRESENTATION.label}
 				</span>
 			{/if}
-			<span
-				class="badge badge-sm {spamBadgeClass}"
-				data-testid="spam-badge"
-				title={spamIndicators.join(', ')}
-			>
-				Spam: {sighting.spamScore ?? '–'}
-			</span>
+			<!-- Kein Badge für „nie bewertet": Die Karte zeigte hier ein graues
+			     „Spam: –" und behauptete damit ein Prüfergebnis, das es nie gab.
+			     Die Tabellenspalte hatte das schon richtig — jetzt beide gleich
+			     (`spamScorePresentation.ts`). -->
+			{#if spam.badgeClass}
+				<span
+					class="badge badge-sm {spam.badgeClass}"
+					data-testid="spam-badge"
+					title={spamIndicators.length > 0 ? spamIndicators.join(', ') : spam.description}
+				>
+					<Icon icon={spam.icon} width="14" height="14" aria-hidden="true" />
+					Spam: {sighting.spamScore}
+					<!-- title ist nur per Maus erreichbar — dieselbe Aussage zusätzlich
+					     für Screenreader, und das Wort trägt die Bedeutung, die sonst
+					     nur an der Farbe hinge (WCAG 1.4.1). -->
+					<span class="sr-only">
+						{spam.label}{spamIndicators.length > 0
+							? ` — Spam-Indikatoren: ${spamIndicators.join(', ')}`
+							: ''}
+					</span>
+				</span>
+			{/if}
 			<span class="badge badge-sm {balticSea.badgeClass}">{balticSea.label}</span>
 		</div>
 

--- a/src/lib/components/admin/SightingInboxCard.svelte.test.ts
+++ b/src/lib/components/admin/SightingInboxCard.svelte.test.ts
@@ -75,7 +75,7 @@ describe('SightingInboxCard', () => {
 		await expect.element(tot.getByText('Totfund')).toBeInTheDocument();
 	});
 
-	it('Spam-Score: null → „–", hoher Score → error-Badge', async () => {
+	it('Spam-Score: hoher Score → error-Badge', async () => {
 		const hoch = render(SightingInboxCard, {
 			sighting: { ...basisSichtung, spamScore: 7 } as SightingSelect,
 			images: [],
@@ -85,6 +85,34 @@ describe('SightingInboxCard', () => {
 		});
 		const badge = hoch.getByTestId('spam-badge');
 		await expect.element(badge).toHaveClass(/badge-error/);
+		// Die Bedeutung hängt nicht allein an der Farbe (WCAG 1.4.1).
+		await expect.element(badge).toHaveTextContent('Hochrisiko');
+	});
+
+	it('Spam-Score null bekommt kein Badge — „nie bewertet" ist kein Prüfergebnis', async () => {
+		// `basisSichtung` trägt `spamScore: null`. Die Karte zeigte dafür ein
+		// graues „Spam: –" und sah damit aus wie Score 0 („geprüft, unauffällig").
+		// Die Tabellenspalte lässt das Badge weg; jetzt beide gleich.
+		const ohne = render(SightingInboxCard, {
+			sighting: basisSichtung,
+			images: [],
+			busy: false,
+			onApprove: noop,
+			onReject: noop
+		});
+		expect(ohne.container.querySelector('[data-testid="spam-badge"]')).toBeNull();
+	});
+
+	it('Spam-Score 0 bekommt ein Badge — bewertet und unauffällig', async () => {
+		const null_ist_nicht_null = render(SightingInboxCard, {
+			sighting: { ...basisSichtung, spamScore: 0 } as SightingSelect,
+			images: [],
+			busy: false,
+			onApprove: noop,
+			onReject: noop
+		});
+		const badge = null_ist_nicht_null.getByTestId('spam-badge');
+		await expect.element(badge).toHaveTextContent('Spam: 0');
 	});
 
 	it('Freigeben/Ablehnen rufen die Callbacks, busy deaktiviert beide', async () => {

--- a/src/lib/components/admin/spamScorePresentation.test.ts
+++ b/src/lib/components/admin/spamScorePresentation.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { SpamCheckResult } from '$lib/types/spam';
+import { HIGH_RISK_THRESHOLD } from '$lib/types/spam';
+import {
+	SPAM_RISK_PRESENTATION,
+	SPAM_SUSPICIOUS_THRESHOLD,
+	getSpamRisk,
+	getSpamRiskFromResult
+} from './spamScorePresentation';
+
+describe('getSpamRisk', () => {
+	it('unterscheidet „nie bewertet" von „bewertet, unauffällig"', () => {
+		// Der eigentliche Grund für dieses Modul: In der Eingangskarte war NULL
+		// bis 2026-08 ein `badge-ghost` mit „Spam: –" und damit optisch dasselbe
+		// wie Score 0 — „geprüft, sauber". `docs/SPAM_DETECTION.md` sagt das
+		// Gegenteil: NULL heißt Altbestand/Legacy-Eingang, nie geprüft.
+		expect(getSpamRisk(null)).toBe('unrated');
+		expect(getSpamRisk(0)).toBe('clean');
+		expect(getSpamRisk(null)).not.toBe(getSpamRisk(0));
+	});
+
+	it('behandelt undefined wie null', () => {
+		expect(getSpamRisk(undefined)).toBe('unrated');
+	});
+
+	it.each([
+		[0, 'clean'],
+		[1, 'clean'],
+		[2, 'suspicious'],
+		[4, 'suspicious'],
+		[5, 'high'],
+		[10, 'high']
+	] as const)('Score %i → %s', (score, erwartet) => {
+		expect(getSpamRisk(score)).toBe(erwartet);
+	});
+
+	it('hängt an den Schwellen und nicht an kopierten Zahlen', () => {
+		expect(getSpamRisk(SPAM_SUSPICIOUS_THRESHOLD - 1)).toBe('clean');
+		expect(getSpamRisk(SPAM_SUSPICIOUS_THRESHOLD)).toBe('suspicious');
+		expect(getSpamRisk(HIGH_RISK_THRESHOLD - 1)).toBe('suspicious');
+		expect(getSpamRisk(HIGH_RISK_THRESHOLD)).toBe('high');
+	});
+});
+
+describe('getSpamRiskFromResult', () => {
+	function ergebnis(overrides: Partial<SpamCheckResult>): SpamCheckResult {
+		return { score: 0, isHighRisk: false, indicators: [], ...overrides };
+	}
+
+	it('folgt dem Server-Urteil `isHighRisk`, nicht dem nachgerechneten Score', () => {
+		// Für eine geglückte Prüfung sagen beide dasselbe (`score >= 5`) — die
+		// Client-Schwelle wäre also meist folgenlos. Verlassen darf man sich
+		// darauf trotzdem nicht: `isHighRisk` ist das Urteil des Servers.
+		expect(getSpamRiskFromResult(ergebnis({ score: 5, isHighRisk: true }))).toBe('high');
+		expect(getSpamRiskFromResult(ergebnis({ score: 3, isHighRisk: false }))).toBe('suspicious');
+		expect(getSpamRiskFromResult(ergebnis({ score: 0, isHighRisk: false }))).toBe('clean');
+	});
+
+	it('eine fehlgeschlagene Prüfung ist nicht bewertet — trotz `isHighRisk: true`', () => {
+		// Der Fail-Safe-Zweig in `spamDetector.ts` liefert Score 0 UND
+		// `isHighRisk: true`. Beides wörtlich zu nehmen ergäbe „Hochrisiko ohne
+		// einen einzigen Indikator". Es ist derselbe Fall wie NULL in der
+		// Datenbank: geprüft wurde nichts.
+		const fehlgeschlagen = ergebnis({
+			score: 0,
+			isHighRisk: true,
+			indicators: ['Spam-Prüfung fehlgeschlagen'],
+			failed: true
+		});
+		expect(getSpamRiskFromResult(fehlgeschlagen)).toBe('unrated');
+	});
+});
+
+describe('SPAM_RISK_PRESENTATION', () => {
+	it('gibt „nie bewertet" bewusst kein Badge', () => {
+		expect(SPAM_RISK_PRESENTATION.unrated.badgeClass).toBeNull();
+	});
+
+	it('trägt die Bedeutung nicht allein über die Farbe (WCAG 1.4.1)', () => {
+		const bewertet = ['clean', 'suspicious', 'high'] as const;
+		const icons = bewertet.map((risk) => SPAM_RISK_PRESENTATION[risk].icon);
+		expect(icons.every((icon) => typeof icon === 'string' && icon.length > 0)).toBe(true);
+		expect(new Set(icons).size).toBe(bewertet.length);
+	});
+
+	it('verwendet Flächenfarben ohne `-strong`-Suffix', () => {
+		for (const risk of ['clean', 'suspicious', 'high'] as const) {
+			expect(SPAM_RISK_PRESENTATION[risk].badgeClass).toMatch(/^badge-(?!.*-strong)/);
+		}
+	});
+
+	it('benennt jeden Zustand eindeutig', () => {
+		const labels = Object.values(SPAM_RISK_PRESENTATION).map((p) => p.label);
+		expect(new Set(labels).size).toBe(labels.length);
+	});
+});

--- a/src/lib/components/admin/spamScorePresentation.ts
+++ b/src/lib/components/admin/spamScorePresentation.ts
@@ -1,0 +1,141 @@
+/**
+ * @fileoverview Risikostufe eines Spam-Scores — Wort, Farbe, Icon, Schwelle.
+ *
+ * Eine Quelle für die vier Anzeigestellen (Eingangskarte, Spam-Spalte der
+ * Tabelle, Spam-Check-Modal, Inline-Karte der Detailansicht), nach dem Vorbild
+ * von `SIGHTING_STATUS_PRESENTATION` und `DEAD_FINDING_PRESENTATION`.
+ *
+ * Vorher lagen dort **drei** Schwellensätze: Eingang und Tabelle färbten ab 5
+ * rot und ab 2 gelb, das Modal ab `isHighRisk` rot / ab 2 gelb / sonst **grün**,
+ * die Detailansicht ab `isHighRisk` rot / ab **1** gelb / sonst grün. Score 1
+ * war damit grau in der Liste, grün im Modal und gelb in der Detailansicht —
+ * derselbe Datensatz, drei Aussagen.
+ *
+ * **`null` ist nicht `0`.** `spam_score IS NULL` heißt „nie bewertet"
+ * (Altbestand, Legacy-Eingang), `0` heißt „bewertet, unauffällig"
+ * (`docs/SPAM_DETECTION.md`). Deshalb hat `unrated` bewusst **kein** Badge: Ein
+ * graues „Spam: –" in der Eingangskarte las sich wie ein Prüfergebnis, war aber
+ * die Abwesenheit einer Prüfung.
+ *
+ * **Farbe trägt die Bedeutung nicht allein** (WCAG 1.4.1) — jede bewertete
+ * Stufe hat zusätzlich ein eigenes Icon. An allen vier Stellen fehlte das.
+ *
+ * Client-sicher: nur Typen und Konstanten aus `$lib/types/spam`, kein Import
+ * aus `$lib/server/**` (der Bruch fiele erst in `npm run build` auf).
+ */
+import { HIGH_RISK_THRESHOLD, type SpamCheckResult } from '$lib/types/spam';
+
+export type SpamRisk = 'unrated' | 'clean' | 'suspicious' | 'high';
+
+/**
+ * Ab diesem Score wird eine Meldung als auffällig ausgezeichnet.
+ *
+ * Anders als `HIGH_RISK_THRESHOLD` ist das **keine** Server-Semantik: Der
+ * Detektor kennt nur „Hochrisiko ja/nein". Die Zwischenstufe existiert allein
+ * für die Triage-Oberfläche und gehört deshalb hierher und nicht nach
+ * `$lib/types/spam`. Der Wert 2 entspricht genau einem ausgelösten Indikator
+ * mittleren Gewichts (Keyword, Großbuchstaben, `noreply@`, Duplikat).
+ */
+export const SPAM_SUSPICIOUS_THRESHOLD = 2;
+
+/**
+ * Risikostufe aus dem rohen Score — für die Listenansichten, denen nur die
+ * persistierte Spalte `spam_score` vorliegt.
+ *
+ * `undefined` wird wie `null` behandelt: Die Spalte ist in manchen
+ * Teilauswahlen optional typisiert, und „Feld nicht dabei" ist genauso wenig
+ * ein Prüfergebnis wie „nie bewertet".
+ */
+export function getSpamRisk(score: number | null | undefined): SpamRisk {
+	if (score == null) return 'unrated';
+	if (score >= HIGH_RISK_THRESHOLD) return 'high';
+	if (score >= SPAM_SUSPICIOUS_THRESHOLD) return 'suspicious';
+	return 'clean';
+}
+
+/**
+ * Risikostufe aus einem frischen Prüfergebnis — für Modal und Detailansicht,
+ * die `GET /api/sightings/[id]/spam-check` aufrufen.
+ *
+ * **Warum nicht einfach `getSpamRisk(result.score)`:** `isHighRisk` und
+ * `score >= HIGH_RISK_THRESHOLD` sind nicht dasselbe. Für eine geglückte
+ * Prüfung stimmen sie überein (`spamDetector.ts` rechnet sie genau so aus) —
+ * der **Fail-Safe-Zweig** liefert dagegen Score 0 mit `isHighRisk: true`, damit
+ * eine gescheiterte Prüfung nicht als „kein Spam" durchgeht.
+ *
+ * Wörtlich genommen ergäbe das „Hochrisiko" ohne einen einzigen Indikator. Für
+ * die Anzeige ist der ehrliche Zustand derselbe wie bei `NULL` in der
+ * Datenbank: Es wurde nichts bewertet. Aus demselben Grund persistiert
+ * `saveSighting` ein `failed`-Ergebnis gar nicht erst
+ * (`docs/SPAM_DETECTION.md`, Abschnitt „Persistenz").
+ */
+export function getSpamRiskFromResult(result: SpamCheckResult): SpamRisk {
+	if (result.failed) return 'unrated';
+	if (result.isHighRisk) return 'high';
+	return getSpamRisk(result.score);
+}
+
+interface SpamRiskBase {
+	label: string;
+	/** Was die Stufe bedeutet — als `title`/Tooltip und für Screenreader. */
+	description: string;
+}
+
+/**
+ * Badge-Klasse und Icon treten immer gemeinsam auf — deshalb eine Union und
+ * nicht zweimal `| null`. Ein `{#if presentation.badgeClass}` an der
+ * Aufrufstelle verengt damit auch `icon` auf `string`; sonst bräuchte jede der
+ * vier Stellen ein `?? ''`, das nur den Typprüfer beruhigt.
+ */
+export type SpamRiskPresentation = SpamRiskBase &
+	(
+		| {
+				/**
+				 * **Kein Badge.** Für „nie bewertet" gibt es nichts anzuzeigen, und
+				 * ein graues Badge wäre eine Aussage über eine Prüfung, die nie
+				 * stattgefunden hat.
+				 */
+				badgeClass: null;
+				icon: null;
+		  }
+		| {
+				/** Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
+				badgeClass: string;
+				/**
+				 * Icon-Name für `$lib/components/Icon.svelte` — die zweite,
+				 * farbunabhängige Unterscheidung (WCAG 1.4.1).
+				 */
+				icon: string;
+		  }
+	);
+
+export const SPAM_RISK_PRESENTATION: Record<SpamRisk, SpamRiskPresentation> = {
+	unrated: {
+		label: 'Nicht bewertet',
+		badgeClass: null,
+		icon: null,
+		description: 'Nie auf Spam geprüft — Altbestand, Legacy-Eingang oder fehlgeschlagene Prüfung'
+	},
+	clean: {
+		/* `badge-ghost` und nicht `badge-success`: Der Score ist eine
+		   Triage-Hilfe, kein Freigabe-Urteil (`docs/SPAM_DETECTION.md`). Ein
+		   grünes Badge in jeder zweiten Tabellenzeile behauptete „geprüft und in
+		   Ordnung" — geprüft wird die Meldung erst vom Menschen. */
+		label: 'Unauffällig',
+		badgeClass: 'badge-ghost',
+		icon: 'lucide:shield-check',
+		description: 'Bewertet, keine nennenswerten Auffälligkeiten'
+	},
+	suspicious: {
+		label: 'Auffällig',
+		badgeClass: 'badge-warning',
+		icon: 'lucide:shield-alert',
+		description: 'Bewertet, einzelne Spam-Merkmale — vor der Freigabe ansehen'
+	},
+	high: {
+		label: 'Hochrisiko',
+		badgeClass: 'badge-error',
+		icon: 'lucide:shield-x',
+		description: 'Bewertet, deutliche Spam-Merkmale — höchstwahrscheinlich keine echte Meldung'
+	}
+};

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -29,6 +29,11 @@
 	import DeleteDialog from '$lib/components/ui/Dialog/DeleteDialog.svelte';
 	import { toast } from '$lib/stores/toastState.svelte';
 	import type { SpamCheckResult } from '$lib/types/spam';
+	import {
+		getSpamRiskFromResult,
+		SPAM_RISK_PRESENTATION,
+		type SpamRisk
+	} from '$lib/components/admin/spamScorePresentation';
 
 	let { data } = $props();
 
@@ -363,31 +368,87 @@
 		}
 	}
 
-	let spamCheck = $state<{
+	/**
+	 * Flächen- und Icon-Farbe der Spam-Karte — bewusst hier und nicht in
+	 * `spamScorePresentation.ts`, aus demselben Grund wie bei `deadFinding.ts`:
+	 * Beide haben genau einen Leser, und ein gemeinsames Modul mit
+	 * Ein-Leser-Konstanten wäre Indirektion ohne Nutzen. Die **Schwellen**
+	 * driften dadurch nicht — die Aufschlüsselung geht über `SpamRisk`, nicht
+	 * über den Score.
+	 *
+	 * `text-error` ist als Vordergrund zulässig (6,04:1 auf base-100), die
+	 * übrigen Statusfarben nur in ihrer `-strong`-Variante
+	 * (`.claude/rules/design-system.md`, „Statusfarben haben zwei Rollen").
+	 */
+	const SPAM_CARD_SURFACE: Record<SpamRisk, string> = {
+		unrated: 'border-warning bg-warning/10',
+		clean: 'border-base-300 bg-base-200',
+		suspicious: 'border-warning bg-warning/10',
+		high: 'border-error bg-error/10'
+	};
+	const SPAM_CARD_ICON: Record<SpamRisk, string> = {
+		unrated: 'text-warning-strong',
+		clean: 'text-base-content/70',
+		suspicious: 'text-warning-strong',
+		high: 'text-error'
+	};
+
+	interface SpamCheckState {
+		/** Die Sichtung, zu der Ergebnis bzw. Fehler gehören. */
+		sightingId: number;
 		loading: boolean;
 		result: SpamCheckResult | null;
 		error: string | null;
-	}>({
+	}
+
+	/**
+	 * Ein beschreibbares `$derived`: Der Zustand gehört immer zu **einer**
+	 * Sichtung und wird bei einem Wechsel verworfen.
+	 *
+	 * Im Arbeitsmodus springt die Detailansicht nach einer Entscheidung zur
+	 * nächsten Meldung, ohne die Komponente neu zu erzeugen — Karte und
+	 * Fehlermeldung der vorigen Prüfung blieben dabei stehen und lasen sich als
+	 * Aussage über die neue Sichtung. Die Tabelle hatte gegen dieselbe Klasse
+	 * von Fehler seit jeher einen Wächter (`spamCheckModal.sightingId`), hier
+	 * fehlte er ganz.
+	 *
+	 * `$derived` und nicht `$state` + `$effect`: Der Rückfall auf den leeren
+	 * Zustand ist genau das, was ein Derived beschreibt — und die Zuweisungen
+	 * unten überschreiben ihn bis zum nächsten Wechsel. Zugewiesen wird deshalb
+	 * immer das **ganze** Objekt; ein Derived ist kein Proxy, eine
+	 * Feld-Mutation daran löste kein Rerendering aus.
+	 */
+	let spamCheck = $derived<SpamCheckState>({
+		sightingId: sighting.id,
 		loading: false,
 		result: null,
 		error: null
 	});
 
 	async function runSpamCheck() {
-		spamCheck.loading = true;
-		spamCheck.error = null;
-		spamCheck.result = null;
+		/* Zweiter Teil desselben Problems: Eine bereits laufende Anfrage kommt
+		   nach dem Sprung zurück und schriebe ihr Ergebnis auf den inzwischen
+		   angezeigten Nachbarn. Das Derived oben kann sie nicht aufhalten. */
+		const sightingId = sighting.id;
+		spamCheck = { sightingId, loading: true, result: null, error: null };
 
 		try {
-			const response = await fetch(`/api/sightings/${sighting.id}/spam-check`);
+			const response = await fetch(`/api/sightings/${sightingId}/spam-check`);
+			if (spamCheck.sightingId !== sightingId) return;
 			if (!response.ok) {
 				throw new Error(`Fehler ${response.status}: ${response.statusText}`);
 			}
-			spamCheck.result = await response.json();
+			const result: SpamCheckResult = await response.json();
+			if (spamCheck.sightingId !== sightingId) return;
+			spamCheck = { sightingId, loading: false, result, error: null };
 		} catch (err) {
-			spamCheck.error = err instanceof Error ? err.message : 'Unbekannter Fehler';
-		} finally {
-			spamCheck.loading = false;
+			if (spamCheck.sightingId !== sightingId) return;
+			spamCheck = {
+				sightingId,
+				loading: false,
+				result: null,
+				error: err instanceof Error ? err.message : 'Unbekannter Fehler'
+			};
 		}
 	}
 </script>
@@ -541,44 +602,29 @@
 
 {#if spamCheck.result}
 	{@const result = spamCheck.result}
-	<div
-		class="card mb-4 border {result.isHighRisk
-			? 'border-error bg-error/10'
-			: result.score > 0
-				? 'border-warning bg-warning/10'
-				: 'border-success bg-success/10'}"
-	>
+	{@const risk = getSpamRiskFromResult(result)}
+	{@const spam = SPAM_RISK_PRESENTATION[risk]}
+	<!-- Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts` —
+	     dieselbe Quelle wie Modal, Tabellenspalte und Eingangskarte. Vorher zog
+	     diese Karte schon bei Score 1 gelb, während dieselbe Meldung in der
+	     Liste grau und im Modal grün war. -->
+	<div class="card mb-4 border {SPAM_CARD_SURFACE[risk]}">
 		<div class="card-body p-4">
 			<div class="flex items-center gap-2">
-				<Icon
-					icon="lucide:shield-alert"
-					class="h-5 w-5 {result.isHighRisk
-						? 'text-error'
-						: result.score > 0
-							? 'text-warning-strong'
-							: 'text-success-strong'}"
-				/>
-				<h3 class="card-title text-base">
-					{#if result.isHighRisk}
-						Spam-Warnung (Hochrisiko)
-					{:else if result.score > 0}
-						Spam-Hinweis (Geringes Risiko)
-					{:else}
-						Kein Spam erkannt
-					{/if}
-				</h3>
+				<Icon icon={spam.icon ?? 'lucide:shield-alert'} class="h-5 w-5 {SPAM_CARD_ICON[risk]}" />
+				<h3 class="card-title text-base">{spam.label}</h3>
 				<div class="ml-auto flex gap-2">
-					<span
-						class="badge {result.isHighRisk
-							? 'badge-error'
-							: result.score > 0
-								? 'badge-warning'
-								: 'badge-success'}"
-					>
-						Score: {result.score}
-					</span>
+					{#if spam.badgeClass}
+						<span class="badge {spam.badgeClass}">Score: {result.score}</span>
+					{:else}
+						<!-- `failed: true` — Score 0 und `isHighRisk: true` zugleich. Die
+						     Zahl wäre hier eine Behauptung über eine Prüfung, die gar
+						     nicht durchgelaufen ist. -->
+						<span class="badge badge-warning">Prüfung fehlgeschlagen</span>
+					{/if}
 				</div>
 			</div>
+			<p class="text-base-content/70 text-sm">{spam.description}</p>
 			{#if result.indicators.length > 0}
 				<ul class="mt-2 list-inside list-disc text-sm">
 					{#each result.indicators as indicator (indicator)}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -18,6 +18,10 @@
 	import { toast } from '$lib/stores/toastState.svelte';
 	import type { FrontendSighting, PageData } from '$lib/types';
 	import type { SpamCheckResult } from '$lib/types/spam';
+	import {
+		getSpamRiskFromResult,
+		SPAM_RISK_PRESENTATION
+	} from '$lib/components/admin/spamScorePresentation';
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
@@ -1265,33 +1269,39 @@
 				<span>{spamCheckModal.error}</span>
 			</div>
 		{:else if spamCheckModal.result}
-			<!-- Score badges -->
-			<div class="mt-4 flex flex-wrap gap-2">
-				<span
-					class="badge {spamCheckModal.result.isHighRisk
-						? 'badge-error'
-						: spamCheckModal.result.score >= 2
-							? 'badge-warning'
-							: 'badge-success'}"
-				>
-					Heuristik-Score: {spamCheckModal.result.score}
-				</span>
-				{#if spamCheckModal.result.isHighRisk}
-					<span class="badge badge-error">Hochrisiko</span>
+			{@const result = spamCheckModal.result}
+			{@const spam = SPAM_RISK_PRESENTATION[getSpamRiskFromResult(result)]}
+			<!-- Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts` —
+			     dieselbe Quelle wie Tabellenspalte, Eingangskarte und Detailansicht.
+			     Vorher stand hier ein eigener Schwellensatz, der Score 1 grün zeigte,
+			     während die Spalte dahinter grau war. -->
+			<div class="mt-4 flex flex-wrap items-center gap-2">
+				{#if spam.badgeClass}
+					<span class="badge {spam.badgeClass}">
+						<Icon icon={spam.icon} width="14" height="14" aria-hidden="true" />
+						{spam.label}
+					</span>
+					<span class="badge badge-ghost">Heuristik-Score: {result.score}</span>
 				{:else}
-					<span class="badge badge-success">Kein Hochrisiko</span>
+					<!-- `failed: true` — Score 0 und `isHighRisk: true` zugleich. Weder
+					     „Hochrisiko" noch „sauber" wäre wahr: geprüft wurde nichts. -->
+					<span class="badge badge-warning">
+						<Icon icon="lucide:triangle-alert" width="14" height="14" aria-hidden="true" />
+						Prüfung fehlgeschlagen
+					</span>
 				{/if}
 			</div>
+			<p class="text-base-content/70 mt-2 text-sm">{spam.description}</p>
 			<!-- Indicators list -->
-			{#if spamCheckModal.result.indicators.length > 0}
+			{#if result.indicators.length > 0}
 				<p class="mt-4 font-semibold">Indikatoren:</p>
 				<ul class="mt-1 list-inside list-disc text-sm">
-					{#each spamCheckModal.result.indicators as indicator (indicator)}
+					{#each result.indicators as indicator (indicator)}
 						<li>{indicator}</li>
 					{/each}
 				</ul>
 			{:else}
-				<p class="text-success-strong mt-4 text-sm">Keine Indikatoren gefunden.</p>
+				<p class="mt-4 text-sm">Keine Indikatoren gefunden.</p>
 			{/if}
 		{/if}
 

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -398,8 +398,14 @@
 							<td class="text-center">
 								{#if !spam.badgeClass}
 									<!-- NULL heißt „nie bewertet" (Altbestand, Legacy-Eingang) —
-									     bewusst kein Badge, sonst läse es sich wie „geprüft, sauber". -->
-									<span class="text-base-content/70" title={spam.description}>—</span>
+									     bewusst kein Badge, sonst läse es sich wie „geprüft, sauber".
+									     Der Gedankenstrich allein sagt am Screenreader gar nichts, und
+									     das `title` ist dort nicht verlässlich erreichbar — deshalb
+									     trägt hier die sr-only-Fassung die ganze Aussage. -->
+									<span class="text-base-content/70" title={spam.description} aria-hidden="true"
+										>—</span
+									>
+									<span class="sr-only">{spam.label} — {spam.description}</span>
 								{:else}
 									<span
 										class="badge badge-sm whitespace-nowrap {spam.badgeClass}"

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -18,6 +18,7 @@
 		type SightingStatus
 	} from '$lib/components/admin/sightingStatus';
 	import type { SightingVerdict } from '$lib/components/admin/sightingVerdict';
+	import { getSpamRisk, SPAM_RISK_PRESENTATION } from '$lib/components/admin/spamScorePresentation';
 	import { getAnimalBehaviorLabel } from '$lib/report/formOptions/animalBehavior';
 	import { getDistanceLabel } from '$lib/report/formOptions/distance';
 	import { getDistributionLabel } from '$lib/report/formOptions/distribution';
@@ -390,30 +391,28 @@
 							</td>
 						{/if}
 						{#if columnVisibility.spamScore}
+							{@const spam = SPAM_RISK_PRESENTATION[getSpamRisk(sighting.spamScore)]}
+							{@const spamIndicators = Array.isArray(sighting.spamIndicators)
+								? (sighting.spamIndicators as string[])
+								: []}
 							<td class="text-center">
-								{#if sighting.spamScore == null}
+								{#if !spam.badgeClass}
 									<!-- NULL heißt „nie bewertet" (Altbestand, Legacy-Eingang) —
 									     bewusst kein Badge, sonst läse es sich wie „geprüft, sauber". -->
-									<span class="text-base-content/70">—</span>
+									<span class="text-base-content/70" title={spam.description}>—</span>
 								{:else}
 									<span
-										class="badge badge-sm whitespace-nowrap {sighting.spamScore >= 5
-											? 'badge-error'
-											: sighting.spamScore >= 2
-												? 'badge-warning'
-												: 'badge-ghost'}"
-										title={Array.isArray(sighting.spamIndicators) &&
-										sighting.spamIndicators.length > 0
-											? sighting.spamIndicators.join(', ')
-											: 'Keine Auffälligkeiten'}
+										class="badge badge-sm whitespace-nowrap {spam.badgeClass}"
+										title={spamIndicators.length > 0 ? spamIndicators.join(', ') : spam.description}
 									>
+										<Icon icon={spam.icon} width="14" height="14" aria-hidden="true" />
 										{sighting.spamScore}
 										<!-- title ist nur per Maus erreichbar — derselbe Text
 										     zusätzlich für Screenreader. -->
 										<span class="sr-only">
-											{Array.isArray(sighting.spamIndicators) && sighting.spamIndicators.length > 0
-												? `Spam-Indikatoren: ${sighting.spamIndicators.join(', ')}`
-												: 'Keine Auffälligkeiten'}
+											{spam.label}{spamIndicators.length > 0
+												? ` — Spam-Indikatoren: ${spamIndicators.join(', ')}`
+												: ''}
 										</span>
 									</span>
 								{/if}

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -114,6 +114,20 @@ describe('Sichtungstabelle — Spalten', () => {
 		expect(getComputedStyle(zweiteAktionen).backgroundColor).toBe(BASE_200);
 	});
 
+	it('sagt am Screenreader, was der Gedankenstrich der Spam-Spalte bedeutet', () => {
+		// Die Zelle einer nie bewerteten Sichtung zeigt nur „—". Die Erklärung
+		// hing allein am `title`, und das ist an einem nicht fokussierbaren
+		// `span` für assistive Technik nicht verlässlich erreichbar.
+		const screen = render(SichtungenSeite, { data: daten([sichtung({ spamScore: null })]) });
+
+		const zeile = screen.container.querySelector('tbody tr') as HTMLElement;
+		expect(zeile.textContent).toContain('Nicht bewertet');
+		const strich = [...zeile.querySelectorAll('[aria-hidden="true"]')].find(
+			(el) => el.textContent?.trim() === '—'
+		);
+		expect(strich, 'der Gedankenstrich selbst wird nicht mit vorgelesen').toBeTruthy();
+	});
+
 	it('verspricht an nicht sortierbaren Spaltenköpfen keine Klickbarkeit', () => {
 		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
 


### PR DESCRIPTION
Befund 14 und 15 des Admin-Reviews.

## Das Problem

Der Spam-Score hatte vier Anzeigestellen und **drei** Schwellensätze:

| Stelle | Schwellen |
|---|---|
| Eingangskarte (`SightingInboxCard.svelte`) | `>=5` error / `>=2` warning / sonst ghost |
| Tabellenspalte (`SichtungenTable.svelte`) | `>=5` error / `>=2` warning / sonst ghost |
| Spam-Check-Modal (`sichtungen/+page.svelte`) | `isHighRisk` error / `>=2` warning / sonst **success** |
| Detailansicht (`[id]/+page.svelte`) | `isHighRisk` error / **`>0`** warning / sonst success |

Score 1 war damit grau in der Liste, grün im Modal und gelb in der Detailansicht — derselbe Datensatz, drei Aussagen.

## Die Lösung

`src/lib/components/admin/spamScorePresentation.ts` — `getSpamRisk(score)`, `getSpamRiskFromResult(result)` und `SPAM_RISK_PRESENTATION`, nach dem Vorbild von `SIGHTING_STATUS_PRESENTATION` und `deadFinding.ts`:

| Stufe | Score | Badge | Icon |
|---|---|---|---|
| `unrated` | `NULL` / `failed` | **keins** | — |
| `clean` | 0–1 | `badge-ghost` | `lucide:shield-check` |
| `suspicious` | 2–4 | `badge-warning` | `lucide:shield-alert` |
| `high` | ab `HIGH_RISK_THRESHOLD` | `badge-error` | `lucide:shield-x` |

### Die drei Entscheidungen

**`null` ist nicht `0`** — vereinheitlicht in Richtung Tabelle. `spam_score IS NULL` heißt „nie bewertet" (Altbestand, Legacy-Eingang), `0` heißt „bewertet, unauffällig" (`docs/SPAM_DETECTION.md`). Die Eingangskarte zeigte für `NULL` ein graues „Spam: –" und behauptete damit ein Prüfergebnis, das es nie gab; jetzt bleibt das Badge weg. Score `0` bekommt weiterhin eines.

**`isHighRisk` vs. `>= 5` meinen nicht dasselbe.** Für eine geglückte Prüfung stimmen sie überein (`spamDetector.ts` rechnet `score >= HIGH_RISK_THRESHOLD`). Der **Fail-Safe-Zweig** liefert dagegen Score 0 **mit** `isHighRisk: true` und `failed: true` — wörtlich genommen ergab das im Modal „Hochrisiko" ohne einen einzigen Indikator. `getSpamRiskFromResult` bevorzugt deshalb das Server-Urteil, liest ein `failed`-Ergebnis aber als `unrated`: dieselbe Aussage wie `NULL` in der Datenbank, und derselbe Grund, aus dem `saveSighting` es gar nicht erst persistiert. Die Client-Schwelle greift nur noch dort, wo bloß der rohe Score vorliegt (Liste, Karte).

**Farbe trägt die Bedeutung nicht mehr allein** (WCAG 1.4.1) — jede bewertete Stufe hat ein eigenes Icon, dazu das Wort im Badge bzw. `sr-only` und die `description` als Tooltip. Das fehlte an allen vier Stellen. `lucide:shield-x` ist dafür neu in `Icon.svelte` registriert.

## Nebenbei: Race-Guard in der Detailansicht

Die Detailansicht hatte keinen. Der eigentliche Fehler war dabei größer als der Race: Im Arbeitsmodus wechselt die Sichtung, ohne dass die Komponente neu entsteht — Karte und Fehlermeldung der vorigen Prüfung blieben stehen und lasen sich als Aussage über die neue Meldung. Der Zustand ist jetzt ein beschreibbares `$derived` auf `sighting.id` (verwirft bei Wechsel) plus `sightingId`-Wächter gegen die späte Antwort, analog zu `spamCheckModal.sightingId` in der Tabelle.

Die Zusammenlegung von Modal und Inline-Karte zu **einer** Darreichungsform habe ich als eigene Entscheidung stehen lassen — sie war im Auftrag ausdrücklich als solche markiert.

## Für Reviewer

- **Flächen- und Icon-Farbe der Detail-Karte stehen bewusst an der Aufrufstelle** (`SPAM_CARD_SURFACE` / `SPAM_CARD_ICON` in `[id]/+page.svelte`), nicht im gemeinsamen Modul — ein Leser je Konstante, gleiche Begründung wie im Docblock von `deadFinding.ts`. Aufgeschlüsselt wird über `SpamRisk`, nicht über den Score, damit die Schwellen nicht doch wieder auseinanderlaufen.
- `SpamRiskPresentation` ist eine Union statt zweimal `| null`: Badge und Icon treten immer gemeinsam auf, ein `{#if presentation.badgeClass}` verengt damit auch `icon`. Sonst bräuchte jede der vier Stellen ein `?? ''`, das nur den Typprüfer beruhigt.
- Der **Layout-Split** von `routes/admin/sichtungen/+page.svelte` war bereits gefahren; die Tabellenspalte liegt inzwischen in `SichtungenTable.svelte`. Der Konflikt-Hinweis aus dem Auftrag hat sich damit erledigt.
- `statusColumn.svelte.test.ts` musste nicht nachgezogen werden, nur `SightingInboxCard.svelte.test.ts`.

## Test-First

`spamScorePresentation.test.ts` zuerst geschrieben (RED belegt), mit den Grenzfällen `null`, `undefined`, `0`, `1`, `2`, `4`, `5`, `10` — darunter explizit der Beleg, dass `null` und `0` verschieden behandelt werden, und dass ein `failed`-Ergebnis nicht als Hochrisiko durchgeht. Dazu Komponententests an der Eingangskarte, weil genau dort der Unterschied verlorenging.

## Verifikation

- `npm run test:quick` — 281 Dateien / 4260 Tests grün
- `npm run test:unit:client` — 700 grün
- `npm run test:e2e -- e2e/design-tokens.spec.ts` — 112 grün (der Token-Guard fährt `/admin` und `/admin/sichtungen` mit)
- Sichtprüfung in der laufenden App (Admin-Session ohne Auth0): Modal und Detail-Karte zeigen für dieselbe Sichtung (Score 3) jetzt wortgleich „Auffällig" mit Shield-Icon und Begründungszeile; die Tabellenspalte zeigt für unbewertete Zeilen „—", die Eingangskarte kein Badge mehr.

## Doku

`docs/SPAM_DETECTION.md` (neuer Abschnitt „Wie der Score angezeigt wird") und `.claude/rules/admin.md` (Komponententabelle + Abschnitt mit den drei Dingen, die nicht zurückgedreht werden sollen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)