### PR TITLE
refactor(admin): verstreute Kleinbefunde des Admin-Reviews (8, 9, 16, 20, 21)

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -191,6 +191,23 @@ Größen werden nicht mehr pro Komponente gewählt. Die Rolle bestimmt die Grö�
 
 Dieselbe semantische Ebene darf nicht in zwei Größen erscheinen — heute ist der Abschnittstitel je nach Komponente `text-base`, `text-lg` oder `sm:text-lg`.
 
+### Die eine eingetragene Ausnahme: die Admin-Arbeitsflächen
+
+Die Admin-Seitentitel standen in drei Größen (`text-3xl`, `text-2xl`, `text-xl`),
+je nach Entstehungszeit. Sie sind mit Befund 9 auf `text-display` vereinheitlicht —
+**bis auf `admin/[id]/+page.svelte` (Detailansicht) und `admin/[id]/edit/+page.svelte`,
+die bei `text-xl` bleiben** (Entscheidung Jan, 2026-08-09).
+
+Die beiden Seiten sind Arbeitsflächen, keine Titelblätter: Der Kopf steht dort
+direkt über der Aktionsleiste, mit der entschieden wird, und im
+Warteschlangen-Modus schöbe ein 32px-Titel genau die Knöpfe nach unten, die man
+Meldung für Meldung braucht.
+
+Die Ausnahme ist **eine Zusage und kein Rest**: `adminPageHeadings.test.ts`
+verlangt für die fünf Übersichtsseiten `text-display` und für diese beiden
+`text-xl`. Wer sie mitzieht, macht den Test rot — und muss die Entscheidung
+bewusst umdrehen, statt sie beiläufig aufzuräumen.
+
 ---
 
 ## Elevation, Z-Index, Motion nur aus Tokens

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -6,14 +6,18 @@
 		getBalticSeaStatus
 	} from '$lib/utils/geo/balticSeaStatus';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
-	import type { SightingSelect } from '$lib/server/db/schema';
+	/* `InboxSighting` und nicht `SightingSelect`: Der Typ ist der Wächter dafür,
+	   dass der Loader jedes hier gelesene Feld auch wirklich abfragt. Mit der
+	   vollen Zeile ginge ein neu gelesenes Feld still durch und stünde in der
+	   Karte leer da (Begründung in `inboxColumns.ts`). */
+	import type { InboxSighting } from '$lib/server/db/inboxColumns';
 	import type { DuplicateCandidate } from '$lib/server/db/duplicateCandidates';
 	import Icon from '$lib/components/Icon.svelte';
 	import { inboxDetailHref } from './adminReturn';
 	import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 
 	interface Props {
-		sighting: SightingSelect;
+		sighting: InboxSighting;
 		images: { id: number; filePath: string; originalName: string }[];
 		/** Mögliche Doppelmeldungen (Spec B2) — reiner Hinweis, kein Merge. */
 		duplicates?: DuplicateCandidate[];
@@ -54,7 +58,7 @@
 	const melderName = $derived([sighting.firstName, sighting.lastName].filter(Boolean).join(' '));
 </script>
 
-<article class="card border-base-300 bg-base-100 border shadow-raised">
+<article class="card border-base-300 bg-base-100 shadow-raised border">
 	<div class="card-body gap-3 p-4">
 		<div class="flex flex-wrap items-center gap-2">
 			{#if isDeadFinding(sighting.isDead)}

--- a/src/lib/server/db/inboxColumns.ts
+++ b/src/lib/server/db/inboxColumns.ts
@@ -1,0 +1,59 @@
+/**
+ * Welche Spalten die Eingangsseite `/admin` aus `sichtungen` liest.
+ *
+ * Gleicher Befund wie bei der Sichtungstabelle (`sichtungen/listColumns.ts`):
+ * `load()` las mit `db.select()` die ganze Zeile, 50-mal pro Aufruf, und legte
+ * damit Anschrift, Telefonnummer und sämtliche Einwilligungs-Nachweisspalten
+ * ins ausgelieferte HTML. Die Karte zeigt achtzehn Felder.
+ *
+ * **Der Unterschied zur Tabelle:** Hier stehen Vor- und Nachname bewusst
+ * drin — die Karte nennt den Melder (`melderName`), weil die Triage im Zweifel
+ * eine Rückfrage nach sich zieht. `phone` dagegen nicht: Für die Telefonnummer
+ * gibt es die Detailansicht.
+ *
+ * **Warum die Karte auf `InboxSighting` typisiert ist und nicht auf
+ * `SightingSelect`.** Der Typ ist hier der eigentliche Wächter: Liest
+ * `SightingInboxCard.svelte` ein Feld, das diese Liste nicht führt, bricht
+ * `svelte-check` — und nicht erst die Karte im Betrieb mit einem leeren Platz.
+ * Mit `SightingSelect` (der vollen Zeile) wäre jede solche Erweiterung still
+ * durchgegangen.
+ */
+
+import { sightings, type SightingSelect } from './schema';
+
+/**
+ * Reihenfolge alphabetisch, damit ein Diff lesbar bleibt — sie hat keine
+ * Bedeutung für das erzeugte SQL.
+ */
+export const INBOX_FIELDS = [
+	'created',
+	'email',
+	'firstName',
+	'id',
+	'inBalticSea',
+	'inBalticSeaGeo',
+	'isDead',
+	'juvenileCount',
+	'lastName',
+	'latitude',
+	'longitude',
+	'notes',
+	'sightingDate',
+	'spamIndicators',
+	'spamScore',
+	'species',
+	'totalCount',
+	'waterway'
+] as const satisfies readonly (keyof SightingSelect)[];
+
+/** Eine Zeile der Eingangsliste — genau die Felder, die `load()` liest. */
+export type InboxSighting = Pick<SightingSelect, (typeof INBOX_FIELDS)[number]>;
+
+/**
+ * Das Select-Objekt für `db.select(…)`, aus der Feldliste erzeugt statt als
+ * zweites Literal geschrieben: Zwei Aufzählungen nebeneinander wären zwei
+ * Quellen, und die zweite altert.
+ */
+export const INBOX_COLUMNS = Object.fromEntries(
+	INBOX_FIELDS.map((field) => [field, sightings[field]])
+) as Pick<typeof sightings, (typeof INBOX_FIELDS)[number]>;

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,6 +1,7 @@
 import { db } from '$lib/server/db';
 import { openOnly } from '$lib/server/db/approvalFilter';
 import { findDuplicateCandidates } from '$lib/server/db/duplicateCandidates';
+import { INBOX_COLUMNS } from '$lib/server/db/inboxColumns';
 import {
 	MEDIA_UPLOAD_ANNOUNCED_MISSING,
 	mediaUploadCondition
@@ -32,8 +33,10 @@ export const load: PageServerLoad = async ({ url }) => {
 	// gehalten in der URL.
 	const order = resolveQueueOrder(url.searchParams.get('order'));
 
+	// Explizite Spaltenauswahl statt `db.select()`: Begründung, Umfang und die
+	// Typ-Absicherung über `InboxSighting` stehen in `inboxColumns.ts`.
 	const openQuery = db
-		.select()
+		.select(INBOX_COLUMNS)
 		.from(sightings)
 		.where(openOnly())
 		.orderBy(...openQueueOrderBy(order))

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -231,7 +231,7 @@
 
 <div class="container mx-auto max-w-3xl px-4 py-6">
 	<div class="mb-4 flex flex-wrap items-center justify-between gap-2">
-		<h1 class="text-2xl font-bold">
+		<h1 class="text-display font-bold">
 			Eingang
 			<span class="badge badge-outline align-middle">{data.openTotal} offen</span>
 		</h1>

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -463,8 +463,14 @@
 	<!-- `h1` und nicht `h2`: Das Root-Layout bringt keine Überschrift mit, die
 	     Struktur dieser Seite begann damit auf Ebene 2 — wer per Screenreader
 	     über Überschriften navigiert, fand hier keinen Einstieg (WCAG 1.3.1).
-	     Die Größe bleibt `text-xl`; sie ist eine Gestaltungsfrage und keine
-	     Aussage über die Gliederung. Abgesichert in `adminPageHeadings.test.ts`. -->
+	     **Die Größe bleibt `text-xl` und wird bewusst nicht `text-display`.**
+	     Die übrigen Admin-Seitentitel sind mit Befund 9 auf die Rolle `display`
+	     (32px) vereinheitlicht worden; Detailansicht und Bearbeiten-Maske sind
+	     davon ausgenommen (Entscheidung Jan, 2026-08-09). Sie sind
+	     Arbeitsflächen, keine Titelblätter: Der Kopf steht hier direkt über der
+	     Aktionsleiste, mit der entschieden wird, und ein 32px-Titel schöbe im
+	     Warteschlangen-Modus genau die Knöpfe nach unten, die man Meldung für
+	     Meldung braucht. Abgesichert in `adminPageHeadings.test.ts`. -->
 	<h1 class="text-xl font-bold" tabindex="-1" bind:this={ueberschrift}>
 		Sichtung Details #{sighting.id}
 	</h1>

--- a/src/routes/admin/[id]/edit/+page.svelte
+++ b/src/routes/admin/[id]/edit/+page.svelte
@@ -60,7 +60,9 @@
 
 <div class="mb-0 flex items-center justify-between">
 	<!-- `h1` aus demselben Grund wie in der Detailansicht nebenan: Ohne sie
-	     begann die Überschriftenstruktur auf Ebene 2 (WCAG 1.3.1). -->
+	     begann die Überschriftenstruktur auf Ebene 2 (WCAG 1.3.1). `text-xl`
+	     ebenfalls wie dort — die Begründung der Ausnahme von `text-display`
+	     steht in `[id]/+page.svelte`. -->
 	<h1 class="text-xl font-bold">Sichtung bearbeiten</h1>
 	<div class="flex gap-2">
 		<button

--- a/src/routes/admin/adminPageHeadings.test.ts
+++ b/src/routes/admin/adminPageHeadings.test.ts
@@ -73,3 +73,58 @@ describe('Admin-Seiten — Überschriftenstruktur beginnt bei h1', () => {
 		expect(lies('../../lib/components/docs/ApiDocumentation.svelte')).toMatch(/<h1[^>]*>\{title\}/);
 	});
 });
+
+/**
+ * Befund 9 des Admin-Reviews: Die Seitentitel standen in drei Größen
+ * (`text-3xl`, `text-2xl`, `text-xl`), je nachdem, wann die Seite entstanden
+ * ist. Die Typografie-Tabelle in `design-system.md` kennt für den Seitentitel
+ * genau eine Rolle — `display`, 32px, als Utility `text-display`.
+ *
+ * **Detailansicht und Bearbeiten-Maske sind die begründete Ausnahme**
+ * (Entscheidung Jan, 2026-08-09): Arbeitsflächen, deren Kopf direkt über der
+ * Aktionsleiste steht. Sie stehen deshalb hier mit einer eigenen Erwartung —
+ * damit die Ausnahme eine Zusage ist und nicht ein Rest, den der nächste
+ * Durchgang „vergessen" nennt und mitzieht.
+ *
+ * Quelltext-Scan aus demselben Grund wie oben: Beide Ausnahme-Routen brauchen
+ * einen Server-Load mit Datenbank.
+ */
+describe('Admin-Seiten — der Seitentitel hat eine Größe', () => {
+	/** Die Klassen des ersten `<h1>` einer Datei. */
+	const h1Klassen = (pfad: string): string =>
+		lies(pfad).match(/<h1[^>]*class="([^"]*)"/)?.[1] ?? '';
+
+	const UEBERSICHTEN = [
+		{ name: 'Eingang', pfad: './+page.svelte' },
+		{ name: 'Sichtungstabelle', pfad: './sichtungen/+page.svelte' },
+		{ name: 'Statistik', pfad: './statistics/+page.svelte' },
+		{ name: 'Einstellungen', pfad: './settings/+page.svelte' },
+		{ name: 'Referenz-Lookup', pfad: './ref/[refId]/+page.svelte' }
+	] as const;
+
+	for (const { name, pfad } of UEBERSICHTEN) {
+		it(`${name} trägt die Rolle display`, () => {
+			expect(h1Klassen(pfad).split(/\s+/)).toContain('text-display');
+		});
+	}
+
+	it('beide Kopfvarianten der Tabelle tragen dieselbe Größe', () => {
+		// Die kompakte und die weite Kopfzeile sind dasselbe Element in zwei
+		// Layouts — unterschiedliche Größen wären ein Sprung beim Drehen des
+		// Geräts, nicht eine Anpassung.
+		const treffer = [...lies('./sichtungen/+page.svelte').matchAll(/<h1[^>]*class="([^"]*)"/g)];
+		expect(treffer).toHaveLength(2);
+		expect(treffer[0]?.[1]).toBe(treffer[1]?.[1]);
+	});
+
+	for (const { name, pfad } of [
+		{ name: 'Detailansicht', pfad: './[id]/+page.svelte' },
+		{ name: 'Bearbeiten', pfad: './[id]/edit/+page.svelte' }
+	] as const) {
+		it(`${name} bleibt bewusst bei text-xl`, () => {
+			const klassen = h1Klassen(pfad).split(/\s+/);
+			expect(klassen).toContain('text-xl');
+			expect(klassen).not.toContain('text-display');
+		});
+	}
+});

--- a/src/routes/admin/destructiveButtonVariant.test.ts
+++ b/src/routes/admin/destructiveButtonVariant.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Destruktive Aktionen im Admin tragen genau eine Variante.
+ *
+ * **Der Befund (8).** `design-system.md` nennt die hier vorgefundene
+ * Kombination wörtlich als Anti-Pattern: „Nicht an einer Stelle `btn-warning`,
+ * an anderer `btn-ghost text-error`." Genau das lag vor — die Detailansicht
+ * löschte mit `btn btn-outline btn-error btn-sm`, die Tabellenzeile und die
+ * Mobilkarte mit `btn text-error btn-ghost`, das Ansichten-Dropdown mit einem
+ * nackten `text-error` am Menüeintrag.
+ *
+ * **Warum `btn` + `text-error` die richtige Bedingung ist und nicht
+ * „`btn-ghost` verboten".** `btn-ghost` ist für zurückhaltende Aktionen völlig
+ * korrekt und steht im Admin dutzendfach (Details anzeigen, Spam-Check,
+ * Abbrechen). Verboten ist, eine **Schaltfläche** ihre destruktive Bedeutung
+ * über die Textfarbe tragen zu lassen, statt über die dafür vorgesehene
+ * Variante. Das ist zugleich ein Kontrast-Thema: `text-error` erreicht auf
+ * `base-300` nur 4,13:1, und DaisyUIs Menü-Hover liegt noch darunter
+ * (`base-content` zu 10 %). Die Rahmen-Variante entzieht sich beidem.
+ *
+ * `text-error` **ohne** `btn` bleibt erlaubt — als Icon-, Kanten- oder
+ * Zahlenfarbe auf `base-100`/`base-200` (Totfund-Marker der Tabelle, die
+ * Kennzeichnung in `AdminSightingView`, Abweichungen in der Statistik).
+ *
+ * Quelltext-Scan und kein DOM-Test: `e2e/design-tokens.spec.ts` prüft im DOM,
+ * ob überhaupt Tokens verwendet werden — ob die **richtige Variante** gewählt
+ * ist, sieht es nicht, und ein `hover:`-Zustand steht dort ohnehin nie an.
+ * Dieselbe Bauart wie `adminPageHeadings.test.ts` nebenan.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const WURZELN = ['.', '../../lib/components/admin'].map((p) =>
+	fileURLToPath(new URL(p, import.meta.url))
+);
+
+function svelteDateien(verzeichnis: string): string[] {
+	return readdirSync(verzeichnis).flatMap((eintrag) => {
+		const pfad = join(verzeichnis, eintrag);
+		if (statSync(pfad).isDirectory()) return svelteDateien(pfad);
+		return pfad.endsWith('.svelte') ? [pfad] : [];
+	});
+}
+
+/**
+ * Alle Klassenlisten einer Datei — sowohl `class="…"` als auch die
+ * Zeichenketten-Anteile eines `class={…}`-Ausdrucks. Der zweite Fall ist nicht
+ * theoretisch: Der Filter-Knopf derselben Seite baut seine Variante so
+ * zusammen.
+ */
+function klassenlisten(quelle: string): string[] {
+	return [
+		...[...quelle.matchAll(/class="([^"]*)"/g)],
+		...[...quelle.matchAll(/class=\{([^}]*)\}/g)]
+	].map((treffer) => treffer[1] ?? '');
+}
+
+const dateien = WURZELN.flatMap(svelteDateien);
+
+describe('Admin — destruktive Schaltflächen tragen die kanonische Variante', () => {
+	it('findet überhaupt Dateien zum Prüfen', () => {
+		// Ohne diese Gegenprobe wäre ein kaputter Pfad ein grüner Test.
+		expect(dateien.length).toBeGreaterThan(10);
+	});
+
+	it('kombiniert nirgends btn mit text-error', () => {
+		const verstoesse = dateien.flatMap((pfad) =>
+			klassenlisten(readFileSync(pfad, 'utf-8'))
+				.filter((liste) => /\bbtn\b/.test(liste) && /\btext-error\b/.test(liste))
+				.map((liste) => `${pfad.split('/src/')[1]}: ${liste.trim()}`)
+		);
+		expect(verstoesse).toEqual([]);
+	});
+
+	it('löscht in Tabelle, Karte und Detailansicht mit derselben Variante', () => {
+		// Der Scan oben verbietet die falsche Variante; dieser Test verlangt die
+		// richtige. Ohne ihn wäre auch „gar kein Löschen-Knopf mehr" grün.
+		for (const pfad of [
+			'./sichtungen/SichtungenTable.svelte',
+			'./sichtungen/SichtungenCards.svelte',
+			'./[id]/+page.svelte'
+		]) {
+			const quelle = readFileSync(fileURLToPath(new URL(pfad, import.meta.url)), 'utf-8');
+			const loeschen = klassenlisten(quelle).filter((liste) => /\bbtn-error\b/.test(liste));
+			expect(loeschen.length, pfad).toBeGreaterThan(0);
+			for (const liste of loeschen) {
+				expect(liste, pfad).toMatch(/\bbtn-outline\b/);
+			}
+		}
+	});
+});

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -25,6 +25,7 @@ import type { SQL, SQLWrapper } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { openOnly } from '$lib/server/db/approvalFilter';
+import { INBOX_FIELDS } from '$lib/server/db/inboxColumns';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
@@ -117,6 +118,42 @@ describe('Eingangs-Load', () => {
 		resolvedRows = [[{ id: 1 }, { id: 2 }], [{ count: 7 }], [{ count: 3 }], []];
 		findDuplicateCandidates.mockClear();
 		findDuplicateCandidates.mockResolvedValue({});
+	});
+
+	/*
+	 * Befund 20, Eingangs-Hälfte: Die Liste lief als `db.select()` über die
+	 * ganze Zeile — 50 vollständige Datensätze pro Aufruf, mitsamt Anschrift,
+	 * Telefonnummer und allen acht Einwilligungs-Nachweisspalten. Dass die Karte
+	 * kein Feld liest, das hier fehlt, sichert der Typ `InboxSighting`; dass
+	 * `load()` die Auswahl auch übergibt, sichert dieser Test. Ein
+	 * zurückgedrehtes `db.select()` erzeugt `columns === undefined`.
+	 */
+	it('liest nur die Spalten aus inboxColumns, nicht die ganze Zeile', async () => {
+		await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0]);
+
+		expect(Object.keys(recordedSelects[0]?.columns ?? {}).sort()).toEqual([...INBOX_FIELDS].sort());
+	});
+
+	it('liefert keine Spalte aus, die die Eingangskarte nicht zeigt', () => {
+		// Aufzählung statt Namens-Heuristik: „alles mit Consent im Namen" sähe
+		// nach einer Regel aus, ließe aber `phone` und `internalComment` durch.
+		const nichtAusliefern = [
+			'phone',
+			'fax',
+			'street',
+			'zipCode',
+			'city',
+			'internalComment',
+			'privacyConsentAt',
+			'privacyConsentVersion',
+			'nameConsentAt',
+			'nameConsentVersion',
+			'shipNameConsentAt',
+			'shipNameConsentVersion',
+			'mediaConsentAt',
+			'mediaConsentVersion'
+		];
+		expect(nichtAusliefern.filter((feld) => INBOX_FIELDS.includes(feld as never))).toEqual([]);
 	});
 
 	it('sucht Duplikat-Kandidaten für alle gelisteten IDs in einem Aufruf', async () => {

--- a/src/routes/admin/ref/[refId]/+page.svelte
+++ b/src/routes/admin/ref/[refId]/+page.svelte
@@ -15,7 +15,7 @@
 <div class="container mx-auto px-4 py-8">
 	<div class="flex min-h-96 flex-col items-center justify-center text-center">
 		<div class="loading loading-spinner loading-lg mb-4"></div>
-		<h1 class="mb-2 text-2xl font-bold">Suche Sichtung...</h1>
+		<h1 class="text-display mb-2 font-bold">Suche Sichtung...</h1>
 		<p class="text-base-content/70 mb-4">
 			Suche nach Sichtung mit ReferenzID: <code class="bg-base-200 rounded px-2 py-1">{refId}</code>
 		</p>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -2,7 +2,7 @@
 	import { createLogger } from '$lib/logger';
 	import type { ConfigItem, ConfigValue } from '$lib/server/db/configRepository';
 	import Icon from '$lib/components/Icon.svelte';
-	import { SvelteSet } from 'svelte/reactivity';
+	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { untrack } from 'svelte';
 	import CleanupPanel from './CleanupPanel.svelte';
 	import ResetSettingsButton from './ResetSettingsButton.svelte';
@@ -94,13 +94,44 @@
 		return 'text';
 	}
 
-	function handleInputChange(config: ConfigItem, newValue: unknown) {
-		// Update the config value
-		config.value = newValue as ConfigValue;
-		changedConfigs = new SvelteSet(changedConfigs).add(config.key);
+	/**
+	 * Die vom Bearbeiter eingegebenen Werte — **neben** `data`, nicht darin.
+	 *
+	 * Vorher schrieb `handleInputChange` direkt `config.value`, also in ein
+	 * Objekt aus `data.groupedConfigs`. Dass das nicht auffiel, lag an einem
+	 * Zufall mit zwei Hälften:
+	 *
+	 * - Der Schreibvorgang erreichte `data` gar nicht. `groupedConfigs` ist ein
+	 *   `$state`-Proxy; Svelte 5 hält die Werte in eigenen Signalen und schreibt
+	 *   sie **nicht** in das Zielobjekt zurück. Die Eingabe lebte also im Proxy.
+	 * - Genau deshalb ging sie verloren, sobald der Proxy ersetzt wurde. Der
+	 *   „Alle Einstellungen anzeigen"-Toggle tut das (`groupedConfigs =
+	 *   data.groupedConfigs` bzw. das gefilterte Ergebnis): Das Feld sprang auf
+	 *   den Wert des Loaders zurück, `changedConfigs` meldete die Änderung aber
+	 *   weiter — und „Speichern" schrieb den alten Wert in die Datenbank, ohne
+	 *   dass irgendwo etwas rot geworden wäre.
+	 *
+	 * Ein `SvelteMap` über den **Schlüssel** hängt an nichts davon: Weder ein
+	 * neues `data` noch ein neu gebautes gefiltertes Array berührt ihn.
+	 *
+	 * Er wird beim Speichern **nicht** geleert. Der Loader läuft dabei nicht
+	 * erneut, `config.value` trüge also weiter den alten Stand — das Feld
+	 * spränge nach dem Speichern sichtbar zurück. Geleert wird stattdessen
+	 * `changedConfigs`: Das ist die Frage „ungespeichert?", und die ist eine
+	 * andere als „was steht im Feld?".
+	 */
+	const eigeneWerte = new SvelteMap<string, ConfigValue>();
 
-		// Force reactivity update for the specific config object
-		groupedConfigs = { ...groupedConfigs };
+	/** Was im Feld steht: die Eingabe, sonst der Wert des Loaders. */
+	function wertVon(config: ConfigItem): ConfigValue {
+		return eigeneWerte.has(config.key)
+			? (eigeneWerte.get(config.key) as ConfigValue)
+			: config.value;
+	}
+
+	function handleInputChange(config: ConfigItem, newValue: unknown) {
+		eigeneWerte.set(config.key, newValue as ConfigValue);
+		changedConfigs = new SvelteSet(changedConfigs).add(config.key);
 	}
 
 	function handleArrayChange(config: ConfigItem, event: Event) {
@@ -128,6 +159,14 @@
 
 	/**
 	 * Speichert eine Einstellung.
+	 *
+	 * **Die Meldungstexte tragen kein Emoji.** Sie landen im Textknoten eines
+	 * `alert-success`/`alert-error`, und dort trägt laut Alert-Regel
+	 * (`design-system.md`) das **Icon** die Bedeutung — jede Variante hat eine
+	 * eigene Form. Ein vorangestelltes „✅"/„❌" sagte dasselbe ein zweites Mal
+	 * und wurde von Screenreadern als „Häkchensymbol" mitgelesen. Das gilt für
+	 * alle Meldungen dieser Seite, auch die von `saveAllChanges`,
+	 * `resetToDefaults` und den beiden Test-Aktionen.
 	 *
 	 * **Der Rückgabewert ist neu und der Kern des Fixes:** `saveAllChanges` hat
 	 * den Ausgang vorher aus `changedConfigs.size` erschlossen und lag damit bei
@@ -157,7 +196,7 @@
 		try {
 			const requestBody = {
 				key: config.key,
-				value: config.value,
+				value: wertVon(config),
 				description: config.description,
 				category: config.category
 			};
@@ -180,10 +219,10 @@
 
 			// Special handling for maintenance mode
 			if (config.key === 'display.maintenanceMode') {
-				const isEnabled = Boolean(config.value);
-				saveMessage = `✅ Wartungsmodus ${isEnabled ? 'aktiviert' : 'deaktiviert'} - Änderung ist sofort wirksam`;
+				const isEnabled = Boolean(wertVon(config));
+				saveMessage = `Wartungsmodus ${isEnabled ? 'aktiviert' : 'deaktiviert'} - Änderung ist sofort wirksam`;
 			} else {
-				saveMessage = `✅ ${config.key} gespeichert`;
+				saveMessage = `${config.key} gespeichert`;
 			}
 
 			errorMessage = '';
@@ -193,7 +232,7 @@
 		} catch (error) {
 			logger.error({ error, config: config.key }, 'Failed to save configuration');
 			if (silent) return false;
-			errorMessage = `❌ Fehler beim Speichern von ${config.key}`;
+			errorMessage = `Fehler beim Speichern von ${config.key}`;
 			setTimeout(() => (errorMessage = ''), 5000);
 			return false;
 		} finally {
@@ -213,7 +252,7 @@
 		}
 
 		if (configsToSave.length === 0) {
-			saveMessage = 'ℹ️ Keine Änderungen zu speichern';
+			saveMessage = 'Keine Änderungen zu speichern';
 			setTimeout(() => (saveMessage = ''), 3000);
 			return;
 		}
@@ -239,10 +278,10 @@
 		   Erfolgsmeldung bekommt weiterhin ihren Timer; der Fehlerfall bleibt
 		   stehen, bis der nächste Versuch ihn ersetzt. */
 		if (summary.hasFailures) {
-			errorMessage = `❌ ${summary.message}`;
+			errorMessage = summary.message;
 			saveMessage = '';
 		} else {
-			saveMessage = `✅ ${summary.message}`;
+			saveMessage = summary.message;
 			errorMessage = '';
 			setTimeout(() => (saveMessage = ''), 5000);
 		}
@@ -262,7 +301,7 @@
 			   nur Netzwerkfehler und hat den Fall nie erreicht. */
 			if (!response.ok) {
 				logger.error({ status: response.status }, 'Failed to reset configurations');
-				errorMessage = `❌ Zurücksetzen fehlgeschlagen (Fehler ${response.status}) — die Einstellungen sind unverändert`;
+				errorMessage = `Zurücksetzen fehlgeschlagen (Fehler ${response.status}) — die Einstellungen sind unverändert`;
 				setTimeout(() => (errorMessage = ''), 5000);
 				return;
 			}
@@ -271,7 +310,7 @@
 			window.location.reload();
 		} catch (error) {
 			logger.error({ error }, 'Failed to reset configurations');
-			errorMessage = '❌ Fehler beim Zurücksetzen der Einstellungen';
+			errorMessage = 'Fehler beim Zurücksetzen der Einstellungen';
 			setTimeout(() => (errorMessage = ''), 5000);
 		}
 	}
@@ -287,27 +326,28 @@
 			const result = await response.json();
 
 			if (response.ok && result.success) {
-				saveMessage = '✅ Test-E-Mail wurde erfolgreich gesendet';
+				saveMessage = 'Test-E-Mail wurde erfolgreich gesendet';
 				setTimeout(() => (saveMessage = ''), 5000);
 			} else {
-				errorMessage = result.message || '❌ Test-E-Mail konnte nicht gesendet werden';
+				errorMessage = result.message || 'Test-E-Mail konnte nicht gesendet werden';
 				setTimeout(() => (errorMessage = ''), 5000);
 			}
 		} catch (error) {
 			logger.error({ error }, 'Failed to send test email');
-			errorMessage = '❌ Fehler beim Senden der Test-E-Mail';
+			errorMessage = 'Fehler beim Senden der Test-E-Mail';
 			setTimeout(() => (errorMessage = ''), 5000);
 		}
 	}
 
 	function handleTestEmail(_config: unknown) {
-		const recipient = groupedConfigs.email?.find(
-			(c) => c.key === 'notification.email.recipient'
-		)?.value;
+		/* `wertVon`, nicht `.value`: Wer die Empfängeradresse gerade korrigiert
+		   hat und dann „Test-E-Mail" drückt, meint die neue. */
+		const eintrag = groupedConfigs.email?.find((c) => c.key === 'notification.email.recipient');
+		const recipient = eintrag && wertVon(eintrag);
 		if (recipient && typeof recipient === 'string' && recipient.includes('@')) {
 			testEmailConfiguration(recipient);
 		} else {
-			errorMessage = '❌ Bitte konfigurieren Sie zuerst eine gültige Empfänger-E-Mail-Adresse';
+			errorMessage = 'Bitte konfigurieren Sie zuerst eine gültige Empfänger-E-Mail-Adresse';
 			setTimeout(() => (errorMessage = ''), 5000);
 		}
 	}
@@ -323,15 +363,15 @@
 
 			if (response.ok) {
 				const status = result.enabled ? 'aktiviert' : 'deaktiviert';
-				saveMessage = `✅ Wartungsmodus-Status: ${status} (${result.timestamp})`;
+				saveMessage = `Wartungsmodus-Status: ${status} (${result.timestamp})`;
 				setTimeout(() => (saveMessage = ''), 5000);
 			} else {
-				errorMessage = result.message || '❌ Wartungsmodus-Status konnte nicht abgerufen werden';
+				errorMessage = result.message || 'Wartungsmodus-Status konnte nicht abgerufen werden';
 				setTimeout(() => (errorMessage = ''), 5000);
 			}
 		} catch (error) {
 			logger.error({ error }, 'Failed to test maintenance mode');
-			errorMessage = '❌ Fehler beim Testen des Wartungsmodus';
+			errorMessage = 'Fehler beim Testen des Wartungsmodus';
 			setTimeout(() => (errorMessage = ''), 5000);
 		}
 	}
@@ -345,7 +385,7 @@
 	<!-- Header -->
 	<div class="mb-8 flex items-center justify-between">
 		<div>
-			<h1 class="text-base-content flex items-center gap-3 text-3xl font-bold">
+			<h1 class="text-base-content text-display flex items-center gap-3 font-bold">
 				<Icon
 					icon="lucide:settings"
 					width="32"
@@ -465,6 +505,12 @@
 
 					<div class="space-y-6">
 						{#each configs as config (config.key)}
+							<!-- `config.value` und bewusst nicht `wertVon(config)`: Welches
+						     Bedienelement eine Einstellung braucht, entscheidet ihr
+						     gespeicherter Typ, nicht der halb getippte Zwischenstand. Bei
+						     ungültigem JSON legt `handleJsonChange` den Rohtext ab — aus
+						     der Eingabe gelesen wechselte das Feld dabei mitten im Tippen
+						     von der JSON-Textarea auf ein einzeiliges Textfeld. -->
 							{@const inputType = getInputType(config.value)}
 
 							<div
@@ -521,19 +567,19 @@
 											<input
 												type="checkbox"
 												class="checkbox checkbox-primary"
-												checked={Boolean(config.value)}
+												checked={Boolean(wertVon(config))}
 												onchange={(e) =>
 													handleInputChange(config, (e.target as HTMLInputElement).checked)}
 											/>
 											<span>
-												{config.value ? 'Aktiviert' : 'Deaktiviert'}
+												{wertVon(config) ? 'Aktiviert' : 'Deaktiviert'}
 											</span>
 										</label>
 									{:else if inputType === 'number'}
 										<input
 											type="number"
 											class="input w-full"
-											value={Number(config.value)}
+											value={Number(wertVon(config))}
 											oninput={(e) =>
 												handleInputChange(config, Number((e.target as HTMLInputElement).value))}
 											placeholder="Numerischer Wert"
@@ -543,29 +589,31 @@
 											<input
 												type="text"
 												class="input w-full"
-												value={Array.isArray(config.value) ? config.value.join(', ') : ''}
+												value={Array.isArray(wertVon(config))
+													? (wertVon(config) as string[]).join(', ')
+													: ''}
 												oninput={(e) => handleArrayChange(config, e)}
 												placeholder="Werte durch Komma getrennt"
 											/>
 											<div class="label">
 												<span class="text-base-content/60">
-													Aktuelle Werte: {getValueDisplay(config.value) || 'Keine'}
+													Aktuelle Werte: {getValueDisplay(wertVon(config)) || 'Keine'}
 												</span>
 											</div>
 										</div>
 									{:else if inputType === 'json'}
 										<textarea
 											class="textarea h-24 font-mono text-sm"
-											value={typeof config.value === 'object'
-												? JSON.stringify(config.value, null, 2)
-												: String(config.value)}
+											value={typeof wertVon(config) === 'object'
+												? JSON.stringify(wertVon(config), null, 2)
+												: String(wertVon(config))}
 											oninput={(e) => handleJsonChange(config, e)}
 											placeholder="JSON-Format"
 										></textarea>
 									{:else if inputType === 'textarea'}
 										<textarea
 											class="textarea h-32"
-											value={String(config.value)}
+											value={String(wertVon(config))}
 											oninput={(e) =>
 												handleInputChange(config, (e.target as HTMLTextAreaElement).value)}
 											placeholder="Mehrzeiliger Text"
@@ -574,7 +622,7 @@
 										<input
 											type="text"
 											class="input w-full"
-											value={String(config.value)}
+											value={String(wertVon(config))}
 											oninput={(e) =>
 												handleInputChange(config, (e.target as HTMLTextAreaElement).value)}
 											placeholder="Textwert"
@@ -584,9 +632,9 @@
 
 								<!-- Current Value Display (for complex types) -->
 								{#if inputType === 'json' || inputType === 'tags'}
-									<div class="bg-base-200 mt-2 rounded p-2 text-xs">
+									<div class="bg-base-200 text-support mt-2 rounded p-2">
 										<strong>Aktueller Wert:</strong>
-										<pre class="mt-1 whitespace-pre-wrap">{getValueDisplay(config.value)}</pre>
+										<pre class="mt-1 whitespace-pre-wrap">{getValueDisplay(wertVon(config))}</pre>
 									</div>
 								{/if}
 							</div>

--- a/src/routes/admin/settings/saveAllMessage.svelte.test.ts
+++ b/src/routes/admin/settings/saveAllMessage.svelte.test.ts
@@ -52,7 +52,13 @@ const daten = () =>
 		error: null
 	}) as unknown as PageData;
 
+/* Wie nebenan in `settingsMessagesAndEdits.svelte.test.ts`: `respondWith`
+   überschreibt `globalThis.fetch` per Zuweisung, und `vi.restoreAllMocks()`
+   nimmt eine Zuweisung nicht zurück. */
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
+	globalThis.fetch = originalFetch;
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 });

--- a/src/routes/admin/settings/settingsMessagesAndEdits.svelte.test.ts
+++ b/src/routes/admin/settings/settingsMessagesAndEdits.svelte.test.ts
@@ -67,7 +67,17 @@ const daten = (isSuperAdmin = false) =>
 		error: null
 	}) as unknown as PageData;
 
+/*
+ * `respondWith` unten setzt `globalThis.fetch` per Zuweisung, nicht per
+ * `vi.spyOn` — `vi.restoreAllMocks()` kennt deshalb kein Original, zu dem es
+ * zurückkehren könnte, und ließe den Stub stehen. Die echte Referenz wird
+ * hier festgehalten und zurückgeschrieben; gleiche Konstruktion und gleiche
+ * Begründung wie in `sections/Location.svelte.test.ts`.
+ */
+const originalFetch = globalThis.fetch;
+
 afterEach(() => {
+	globalThis.fetch = originalFetch;
 	vi.restoreAllMocks();
 });
 

--- a/src/routes/admin/settings/settingsMessagesAndEdits.svelte.test.ts
+++ b/src/routes/admin/settings/settingsMessagesAndEdits.svelte.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Zwei Befunde des Admin-Reviews an der Einstellungsseite.
+ *
+ * **Befund 16 — das Emoji doppelt das Alert-Icon.** `saveMessage` und
+ * `errorMessage` trugen ein vorangestelltes „✅"/„❌"/„ℹ️". Diese Strings landen
+ * im Textknoten eines `alert-success`/`alert-error`, das laut Alert-Regel
+ * (`design-system.md`) seine Bedeutung bereits über das Icon trägt — und über
+ * genau eines. Screenreader lasen die Aussage damit zweimal, einmal davon als
+ * „Häkchensymbol".
+ *
+ * **Befund 21 — die Eingabe stand im Loader-Datensatz.** `handleInputChange`
+ * schrieb `config.value` direkt, also in ein Objekt aus `data.groupedConfigs`.
+ * Beim Nachmessen war der Befund schlimmer als beschrieben, und zwar in beide
+ * Richtungen:
+ *
+ * - **`data` wurde nie beschrieben.** `groupedConfigs` ist ein `$state`-Proxy,
+ *   und Svelte 5 hält die Werte in eigenen Signalen statt sie ins Zielobjekt
+ *   zurückzuschreiben. Der erste Test hier hält das fest — er war schon vor der
+ *   Änderung grün und ist trotzdem die Zusage, um die es geht.
+ * - **Dafür ging die Eingabe verloren.** Sie lebte im Proxy, und der
+ *   „Alle Einstellungen anzeigen"-Toggle ersetzt ihn (`groupedConfigs =
+ *   data.groupedConfigs`). Das Feld sprang auf den Wert des Loaders zurück,
+ *   „1 Änderung" stand weiter da — und „Speichern" schrieb den **alten** Wert
+ *   in die Datenbank. Der zweite Test war vor der Änderung rot.
+ *
+ * Der Toggle-Fall ist damit nicht nur die Stelle, an der ein naiver Umbau
+ * Eingaben verlöre, sondern die, an der der Bestand sie schon verlor.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import SettingsPage from './+page.svelte';
+import type { PageData } from './$types';
+
+/**
+ * `Extended_Pictographic` statt einer Aufzählung der drei entfernten Zeichen:
+ * Die Aufzählung wäre eine Liste der bekannten Fälle, nicht die Regel — ein
+ * neu ergänztes „⚠️" ginge durch.
+ */
+const EMOJI = /\p{Extended_Pictographic}/u;
+
+/**
+ * Ein aktiver Schlüssel und ein geplanter. `as unknown as PageData` wie in
+ * `saveAllMessage.svelte.test.ts`: Der echte Typ zieht über das Layout `user`,
+ * `buildInfo` und weitere Felder mit, von denen diese Seite keines liest.
+ */
+const daten = (isSuperAdmin = false) =>
+	({
+		groupedConfigs: {
+			email: [
+				{
+					key: 'notification.email.sender',
+					value: 'a@example.org',
+					description: '',
+					category: 'email'
+				},
+				{
+					// Nicht in ACTIVE_CONFIG_KEYS — erscheint erst mit dem Toggle.
+					key: 'notification.email.geplant',
+					value: 'geplant@example.org',
+					description: '',
+					category: 'email'
+				}
+			]
+		},
+		isSuperAdmin,
+		error: null
+	}) as unknown as PageData;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function respondWith(ok: boolean) {
+	globalThis.fetch = vi.fn(async () => ({
+		ok,
+		json: async () => ({})
+	})) as unknown as typeof fetch;
+}
+
+/** Tippt in das erste Textfeld und löst das `input`-Event aus. */
+async function ersteEinstellungAendern(wert: string) {
+	const feld = page.getByRole('textbox').elements()[0] as HTMLInputElement;
+	feld.value = wert;
+	feld.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+describe('Einstellungen — Meldungen tragen kein Emoji (Befund 16)', () => {
+	it('meldet den Erfolg ohne Häkchen-Emoji vor dem Text', async () => {
+		respondWith(true);
+		render(SettingsPage, { data: daten() });
+
+		await ersteEinstellungAendern('neu@example.org');
+		await page.getByRole('button', { name: /Alle Änderungen speichern/ }).click();
+
+		const alert = page.getByRole('status');
+		await expect.element(alert).toBeVisible();
+		expect(alert.element().textContent).not.toMatch(EMOJI);
+	});
+
+	it('meldet den Fehlschlag ohne Kreuz-Emoji vor dem Text', async () => {
+		respondWith(false);
+		render(SettingsPage, { data: daten() });
+
+		await ersteEinstellungAendern('neu@example.org');
+		await page.getByRole('button', { name: /Alle Änderungen speichern/ }).click();
+
+		const alert = page.getByRole('alert');
+		await expect.element(alert).toBeVisible();
+		expect(alert.element().textContent).not.toMatch(EMOJI);
+	});
+});
+
+describe('Einstellungen — Eingaben stehen neben data, nicht darin (Befund 21)', () => {
+	it('lässt die Loader-Daten unangetastet', async () => {
+		const data = daten();
+		render(SettingsPage, { data });
+
+		await ersteEinstellungAendern('neu@example.org');
+		// Sichtbar geändert …
+		await expect.element(page.getByText('notification.email.sender').first()).toBeVisible();
+		expect(
+			page.getByRole('button', { name: /Alle Änderungen speichern \(1\)/ }).elements()
+		).toHaveLength(1);
+
+		// … aber nicht im Datensatz des Loaders.
+		const konfigs = (data as unknown as { groupedConfigs: Record<string, { value: string }[]> })
+			.groupedConfigs;
+		expect(konfigs.email?.[0]?.value).toBe('a@example.org');
+	});
+
+	it('behält die Eingabe über den „Alle Einstellungen anzeigen"-Toggle hinweg', async () => {
+		render(SettingsPage, { data: daten(true) });
+
+		await ersteEinstellungAendern('neu@example.org');
+		await page.getByRole('checkbox', { name: /Alle Einstellungen anzeigen/ }).click();
+
+		/* Nach dem Umschalten rendert der `{#each}` über ein anderes Array — die
+		   Eingabe muss trotzdem stehen. Vorher hing sie an der Objekt-Identität
+		   der gefilterten Einträge und überlebte nur zufällig. */
+		const felder = page.getByRole('textbox').elements() as HTMLInputElement[];
+		expect(felder.map((feld) => feld.value)).toContain('neu@example.org');
+	});
+});

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -14,6 +14,7 @@ import type { PageServerLoad } from './$types';
 
 import { ServerConfigService } from '$lib/services/configService';
 import { isValidDateParam } from './dateParam';
+import { SIGHTING_LIST_COLUMNS } from './listColumns';
 import { statusCondition } from './statusFilter';
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -122,8 +123,9 @@ export const load: PageServerLoad = async ({ url }) => {
 		spamScore: sightings.spamScore
 	};
 
-	// Abfrage bauen
-	const baseQuery = db.select().from(sightings);
+	// Abfrage bauen. Explizite Spaltenauswahl statt `db.select()`: Begründung,
+	// Umfang und Absicherung stehen in `listColumns.ts`.
+	const baseQuery = db.select(SIGHTING_LIST_COLUMNS).from(sightings);
 
 	// WHERE-Klausel hinzufügen, wenn Bedingungen vorhanden sind
 	const query = whereCondition ? baseQuery.where(whereCondition) : baseQuery;

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -16,7 +16,8 @@
 	} from '$lib/components/admin/sightingStatus';
 	import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
 	import { toast } from '$lib/stores/toastState.svelte';
-	import type { FrontendSighting, PageData } from '$lib/types';
+	import type { PageData } from './$types';
+	import type { SichtungenListRow } from './listColumns';
 	import type { SpamCheckResult } from '$lib/types/spam';
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
@@ -67,7 +68,7 @@
 	let deadFinding = $state(page.url.searchParams.get('deadFinding') || '');
 	let searchTerm = $state(page.url.searchParams.get('q') || '');
 	let showDeleteDialog = $state(false);
-	let sightingToDelete = $state<FrontendSighting | null>(null);
+	let sightingToDelete = $state<SichtungenListRow | null>(null);
 	let isFilterPanelOpen = $state(false);
 	let showExportModal = $state(false);
 	let showColumnDropdown = $state(false);
@@ -385,7 +386,7 @@
 		goto(url);
 	}
 
-	function viewSightingDetails(sighting: FrontendSighting): void {
+	function viewSightingDetails(sighting: SichtungenListRow): void {
 		// Preserve current filter parameters when navigating to detail view
 		const currentParams = page.url.searchParams;
 		const detailUrl = new URL(`/admin/${sighting.id}`, page.url.origin);
@@ -688,7 +689,7 @@
 		     wie bei Kartenliste und Tabelle — vorher schaltete der Kopf bei `sm`,
 		     die Inhaltsfläche bei `md`. -->
 		<div class="{NUR_KOMPAKT} space-y-3">
-			<h1 class="text-2xl font-bold">Sichtungen</h1>
+			<h1 class="text-display font-bold">Sichtungen</h1>
 			<div class="flex flex-col gap-2">
 				<div class="flex items-center gap-2">
 					<button
@@ -731,7 +732,7 @@
 
 		<!-- Weiter Kopf -->
 		<div class="{NUR_WEIT_FLEX} items-center justify-between">
-			<h1 class="text-2xl font-bold">Sichtungen</h1>
+			<h1 class="text-display font-bold">Sichtungen</h1>
 			<div class="flex items-center gap-2">
 				<details
 					class="dropdown dropdown-end"
@@ -909,8 +910,22 @@
 										Umbenennen
 									</button>
 								</li>
+								<!-- Auch hier die kanonische destruktive Variante statt eines
+								     `text-error` am Menüeintrag. Zwei Gründe, und der zweite ist
+								     der härtere:
+								     1. Gleiche Aktion = gleiche Variante (Button-Hierarchie).
+								     2. DaisyUI färbt einen Menüeintrag beim Hovern mit
+								        `base-content` zu 10 % — eine Fläche dunkler als `base-300`,
+								        und dort liegt `text-error` schon bei 4,13:1, also unter AA
+								        (`design-system.md`, „Bekannte Grenze"). Die Menü-Regel
+								        greift ausdrücklich nicht auf `.btn`, der Rahmen-Button
+								        entzieht sich ihr also samt Hover-Fläche. -->
 								<li>
-									<button type="button" class="text-error" onclick={() => ansichtLoeschen(preset)}>
+									<button
+										type="button"
+										class="btn btn-outline btn-error btn-sm w-full justify-start"
+										onclick={() => ansichtLoeschen(preset)}
+									>
 										<Icon icon="lucide:trash-2" class="h-4 w-4" aria-hidden="true" />
 										Löschen
 									</button>
@@ -990,7 +1005,7 @@
 			<div class="grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6">
 				<div class="fieldset w-full">
 					<label for="fromDate" class="label py-0">
-						<span class="text-xs">Von</span>
+						<span class="text-support">Von</span>
 					</label>
 					<input
 						type="date"
@@ -1002,7 +1017,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="toDate" class="label py-0">
-						<span class="text-xs">Bis</span>
+						<span class="text-support">Bis</span>
 					</label>
 					<input
 						type="date"
@@ -1014,7 +1029,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="verified" class="label py-0">
-						<span class="text-xs">Status</span>
+						<span class="text-support">Status</span>
 					</label>
 					<select
 						id="verified"
@@ -1030,7 +1045,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="deadFinding" class="label py-0">
-						<span class="text-xs">Meldeart</span>
+						<span class="text-support">Meldeart</span>
 					</label>
 					<select
 						id="deadFinding"
@@ -1045,7 +1060,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="entryChannel" class="label py-0">
-						<span class="text-xs">Kanal</span>
+						<span class="text-support">Kanal</span>
 					</label>
 					<select
 						id="entryChannel"
@@ -1061,7 +1076,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="mediaUpload" class="label py-0">
-						<span class="text-xs">Aufnahme</span>
+						<span class="text-support">Aufnahme</span>
 					</label>
 					<select
 						id="mediaUpload"
@@ -1077,7 +1092,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="balticSea" class="label py-0">
-						<span class="text-xs">Ostsee</span>
+						<span class="text-support">Ostsee</span>
 					</label>
 					<select
 						id="balticSea"
@@ -1194,7 +1209,7 @@
 			     Bedienbarkeit zu behaupten; `aria-current="page"` sagt Screenreadern,
 			     wofür die Zahl steht. -->
 			<span
-				class="btn btn-active join-item btn-sm pointer-events-none min-w-32 text-xs md:text-sm"
+				class="btn btn-active join-item btn-sm pointer-events-none min-w-32 text-support md:text-label"
 				aria-current="page"
 			>
 				{data.pagination.page} / {seiten.totalPages}

--- a/src/routes/admin/sichtungen/SichtungenCards.svelte
+++ b/src/routes/admin/sichtungen/SichtungenCards.svelte
@@ -18,7 +18,7 @@
 	import { TEST_EMAIL_HINT } from '$lib/components/admin/sightingActions';
 	import type { SightingVerdict } from '$lib/components/admin/sightingVerdict';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
-	import type { FrontendSighting } from '$lib/types';
+	import type { SichtungenListRow } from './listColumns';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import {
 		BALTIC_SEA_STATUS_PRESENTATION,
@@ -27,15 +27,15 @@
 	import { NUR_KOMPAKT } from './layoutSwitch';
 
 	interface Props {
-		sightings: FrontendSighting[];
+		sightings: SichtungenListRow[];
 		/** Steuert nur das Bedienelement — das Gate steht zusätzlich am Endpunkt. */
 		isSuperAdmin: boolean;
 		/** Ids, deren Statuswechsel gerade läuft (je Zeile, nicht global). */
 		statusPending: ReadonlySet<number>;
-		onview: (sighting: FrontendSighting) => void;
+		onview: (sighting: SichtungenListRow) => void;
 		ontestemail: (id: number) => void;
 		onspamcheck: (id: number) => void;
-		ondelete: (sighting: FrontendSighting) => void;
+		ondelete: (sighting: SichtungenListRow) => void;
 		onstatuschange: (id: number, verdict: SightingVerdict, previous: SightingStatus) => void;
 	}
 
@@ -128,8 +128,11 @@
 					>
 						<Icon icon="lucide:shield-alert" class="h-4 w-4" />
 					</button>
+					<!-- Kanonische destruktive Variante, gleiche Begründung wie in der
+					     Tabellenzeile nebenan (`SichtungenTable.svelte`): dieselbe Aktion,
+					     dieselbe Variante, dasselbe Icon — unabhängig von der Ansicht. -->
 					<button
-						class="btn text-error btn-ghost btn-sm"
+						class="btn btn-outline btn-error btn-sm"
 						onclick={() => ondelete(sighting)}
 						title="Eintrag löschen"
 						aria-label="Eintrag löschen"
@@ -172,7 +175,7 @@
 			</div>
 
 			<div class="mt-3 flex items-center justify-between">
-				<span class="text-base-content/70 text-xs">
+				<span class="text-base-content/70 text-support">
 					Gemeldet: {formatLocalDateTime(sighting.created)}
 				</span>
 				<!-- size="sm" statt "md": Gemessen bei 320px/375px lief die Karte mit den

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -25,7 +25,7 @@
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import { getVisibilityLabel } from '$lib/report/formOptions/visibility';
 	import { getWindStrengthLabel } from '$lib/report/formOptions/windStrength';
-	import type { FrontendSighting } from '$lib/types';
+	import type { SichtungenListRow } from './listColumns';
 	import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 	import {
 		BALTIC_SEA_STATUS_PRESENTATION,
@@ -36,7 +36,7 @@
 	import { NUR_WEIT_BLOCK } from './layoutSwitch';
 
 	interface Props {
-		sightings: FrontendSighting[];
+		sightings: SichtungenListRow[];
 		/** Steuert nur das Bedienelement — das Gate steht zusätzlich am Endpunkt. */
 		isSuperAdmin: boolean;
 		columnVisibility: ColumnVisibility;
@@ -48,10 +48,10 @@
 		/** Ids, deren Statuswechsel gerade läuft (je Zeile, nicht global). */
 		statusPending: ReadonlySet<number>;
 		onbulk: (verdict: SightingVerdict) => void;
-		onview: (sighting: FrontendSighting) => void;
+		onview: (sighting: SichtungenListRow) => void;
 		ontestemail: (id: number) => void;
 		onspamcheck: (id: number) => void;
-		ondelete: (sighting: FrontendSighting) => void;
+		ondelete: (sighting: SichtungenListRow) => void;
 		onstatuschange: (id: number, verdict: SightingVerdict, previous: SightingStatus) => void;
 	}
 
@@ -483,8 +483,17 @@
 									>
 										<Icon icon="lucide:shield-alert" class="h-4 w-4" />
 									</button>
+									<!-- Die kanonische destruktive Variante (`btn btn-outline btn-error`,
+									     Button-Hierarchie in `design-system.md`) — vorher stand hier
+									     `btn-ghost text-error`, also genau die zweite Variante, die die
+									     Regel wörtlich als Anti-Pattern nennt. Der Rahmen zwischen drei
+									     rahmenlosen Icons ist dabei nicht Nebenwirkung, sondern Zweck:
+									     Löschen ist die einzige Aktion der Zeile, die man nicht
+									     zurücknehmen kann.
+									     `btn-xs` bleibt: Die Größe trägt die Zeilenhöhe, nicht die
+									     Variante — die 44px Trefferfläche kommen ohnehin aus app.css. -->
 									<button
-										class="btn text-error btn-ghost btn-xs"
+										class="btn btn-outline btn-error btn-xs"
 										onclick={() => ondelete(sighting)}
 										title="Eintrag löschen"
 										aria-label="Eintrag löschen"

--- a/src/routes/admin/sichtungen/listColumns.test.ts
+++ b/src/routes/admin/sichtungen/listColumns.test.ts
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Die Spaltenauswahl des Sichtungs-Loaders ist vollständig — und
+ * nicht mehr als vollständig.
+ *
+ * **Der Befund (20).** `load()` las mit `db.select()` die ganze Zeile und gab
+ * sie bis zu 100-mal ins ausgelieferte HTML: Telefonnummer, Klarname,
+ * Anschrift, interne Kommentare und alle acht Einwilligungs-Nachweisspalten.
+ * Angezeigt werden 18 Felder.
+ *
+ * **Warum dieser Test nötig ist und der Typcheck nicht reicht.** Dass jede
+ * konfigurierbare Spalte einen Eintrag in `COLUMN_FIELDS` hat, erzwingt schon
+ * der `satisfies Record<keyof ColumnVisibility, …>`. Was der Typ **nicht**
+ * sieht, ist der Inhalt: `getBalticSeaStatus()` nimmt seine vier Felder alle
+ * als optional entgegen — eine Zeile ohne `latitude` typprüft anstandslos und
+ * meldet zur Laufzeit stumm „ohne Position". Genau diese Klasse Fehler fällt
+ * erst auf, wenn ein Bearbeiter eine abgeschaltete Spalte einschaltet.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { sightings } from '$lib/server/db/schema';
+import { AVAILABLE_COLUMNS, DEFAULT_COLUMN_VISIBILITY } from './columns';
+import {
+	COLUMN_FIELDS,
+	FIXED_FIELDS,
+	SIGHTING_LIST_COLUMNS,
+	SIGHTING_LIST_FIELDS
+} from './listColumns';
+
+/**
+ * Spalten, die keine Ansicht dieser Seite zeigt und die deshalb auch nicht
+ * ausgeliefert gehören. Bewusst eine Aufzählung und keine Heuristik über
+ * Spaltennamen: Eine Heuristik („alles mit `Consent` im Namen") sähe nach
+ * einer Regel aus, wäre aber nur eine Schreibkonvention — `phone` und
+ * `internalComment` fielen durch.
+ */
+const NICHT_AUSLIEFERN = [
+	'phone',
+	'fax',
+	'firstName',
+	'lastName',
+	'street',
+	'zipCode',
+	'city',
+	'internalComment',
+	'privacyConsentAt',
+	'privacyConsentVersion',
+	'nameConsentAt',
+	'nameConsentVersion',
+	'shipNameConsentAt',
+	'shipNameConsentVersion',
+	'mediaConsentAt',
+	'mediaConsentVersion'
+] as const;
+
+/*
+ * Der Typ-Wächter, und er läuft in `tsc`, nicht hier.
+ *
+ * `SIGHTING_LIST_FIELDS` war zwischenzeitlich mit `readonly SightingField[]`
+ * annotiert — das weitet die Literal-Union auf *alle* Tabellenfelder, und
+ * `SIGHTING_LIST_COLUMNS` war damit als die ganze Zeile typisiert. Der Loader
+ * lieferte Datensätze, deren Typ weiterhin `phone` führte, obwohl das Feld zur
+ * Laufzeit `undefined` ist. Die Laufzeit-Erwartungen unten sahen das nicht: Sie
+ * prüfen die Konstante, nicht was Konsumenten davon zu sehen bekommen.
+ *
+ * `@ts-expect-error` dreht die Richtung um — verschwindet der Fehler, weil die
+ * Union wieder aufgeweitet wurde, bricht `npm run type-check`.
+ */
+// @ts-expect-error `phone` steht nicht im Select und darf im Typ nicht auftauchen.
+const _keinTelefon: keyof typeof SIGHTING_LIST_COLUMNS = 'phone';
+// @ts-expect-error dasselbe für die Einwilligungs-Nachweisspalten.
+const _keinNachweis: keyof typeof SIGHTING_LIST_COLUMNS = 'mediaConsentAt';
+void _keinTelefon;
+void _keinNachweis;
+
+describe('Sichtungs-Loader — Spaltenauswahl', () => {
+	it('kennt jede konfigurierbare Spalte des Dropdowns', () => {
+		const zugeordnet = Object.keys(COLUMN_FIELDS);
+		expect(zugeordnet.sort()).toEqual(AVAILABLE_COLUMNS.map((spalte) => spalte.key).sort());
+	});
+
+	it('deckt jede Spalte des Default-Zustands ab', () => {
+		// `AVAILABLE_COLUMNS` (Dropdown) und `DEFAULT_COLUMN_VISIBILITY`
+		// (Startzustand) sind zwei Listen derselben Menge — driften sie
+		// auseinander, gibt es eine Spalte, die niemand mehr einschalten kann.
+		expect(Object.keys(COLUMN_FIELDS).sort()).toEqual(
+			Object.keys(DEFAULT_COLUMN_VISIBILITY).sort()
+		);
+	});
+
+	it('liefert jedes Feld, das eine Spalte oder die Kartenansicht braucht', () => {
+		const gebraucht = new Set<string>([...FIXED_FIELDS, ...Object.values(COLUMN_FIELDS).flat()]);
+		const fehlend = [...gebraucht].filter((feld) => !SIGHTING_LIST_FIELDS.includes(feld as never));
+		expect(fehlend).toEqual([]);
+	});
+
+	it('nennt nur Felder, die es in der Tabelle wirklich gibt', () => {
+		const unbekannt = SIGHTING_LIST_FIELDS.filter((feld) => !(feld in sightings));
+		expect(unbekannt).toEqual([]);
+	});
+
+	it('übergibt dieselben Felder an db.select()', () => {
+		expect(Object.keys(SIGHTING_LIST_COLUMNS).sort()).toEqual([...SIGHTING_LIST_FIELDS].sort());
+	});
+
+	it('liefert keine Spalte aus, die keine Ansicht der Seite zeigt', () => {
+		const ausgeliefert = NICHT_AUSLIEFERN.filter((feld) =>
+			SIGHTING_LIST_FIELDS.includes(feld as never)
+		);
+		expect(ausgeliefert).toEqual([]);
+	});
+
+	it('bleibt deutlich unter der vollen Zeile', () => {
+		// Kein Selbstzweck: Die Zahl ist der Beleg dafür, dass hier überhaupt
+		// eine Auswahl steht. Wer versehentlich `db.select()` zurückbaut oder die
+		// Liste um „sicherheitshalber alles" ergänzt, landet wieder bei ~70.
+		const alleFelder = Object.keys(sightings).length;
+		expect(SIGHTING_LIST_FIELDS.length).toBeLessThan(alleFelder / 2);
+	});
+});

--- a/src/routes/admin/sichtungen/listColumns.ts
+++ b/src/routes/admin/sichtungen/listColumns.ts
@@ -1,0 +1,135 @@
+/**
+ * Welche Spalten der Loader von `/admin/sichtungen` aus `sichtungen` liest.
+ *
+ * Vorher stand dort `db.select()` — die **ganze** Zeile, bis zu 100-mal pro
+ * Seite. Damit gingen Telefonnummer, Klarname, Anschrift und sämtliche
+ * Einwilligungs-Nachweisspalten (`medien_einwilligung_am`/`_version` und die
+ * drei weiteren Paare) ins ausgelieferte HTML, obwohl die Tabelle 18 Felder
+ * anzeigt. Die Route ist Admin-only, ein Sicherheitsloch war das nicht;
+ * personenbezogene Daten zu verbreiten, die keine Ansicht der Seite zeigt,
+ * bleibt trotzdem unnötig (Datenminimierung).
+ *
+ * **Der Loader kennt die Spaltenwahl nicht.** Sie ist zur Laufzeit umschaltbar
+ * und liegt im `localStorage` des Bearbeiters (`columnPreferences.ts`) — die
+ * Auswahl hier muss deshalb die **Vereinigung aller** `AVAILABLE_COLUMNS`
+ * abdecken, nicht die gerade sichtbaren. Eine vergessene Spalte fällt sonst
+ * erst auf, wenn jemand sie einschaltet und dort „undefined" steht.
+ *
+ * Abgesichert ist das an drei Stellen, und zwar bewusst nicht dreimal
+ * dasselbe:
+ *
+ * - `COLUMN_FIELDS` ist als `Record<keyof ColumnVisibility, …>` typisiert —
+ *   eine neue Spalte in `columns.ts` erzwingt hier einen Eintrag, sonst bricht
+ *   `type-check`.
+ * - `listColumns.test.ts` prüft, dass jedes dort genannte Feld auch wirklich
+ *   im Select landet und dass die sensiblen Spalten draußen bleiben.
+ * - `page.server.test.ts` prüft, dass `load()` genau diese Auswahl an
+ *   `db.select()` übergibt — ein zurückgedrehtes `db.select()` ohne Argument
+ *   fällt dort auf, nicht erst beim Nutzer.
+ */
+
+import { sightings, type SightingSelect } from '$lib/server/db/schema';
+import type { ColumnVisibility } from './columns';
+
+/** Feldname der Tabelle `sichtungen` (Drizzle-Property, nicht Spaltenname). */
+type SightingField = keyof typeof sightings.$inferSelect;
+
+/**
+ * Welche Felder eine konfigurierbare Spalte zum Rendern braucht.
+ *
+ * Die Zuordnung ist nicht durchgängig 1:1 — genau deshalb steht sie hier und
+ * wird nicht aus den Spaltenschlüsseln geraten: `wind` liest `windForce`,
+ * `verified` leitet den Status aus **zwei** Zeitstempeln ab, `balticSea`
+ * braucht die beiden Flags **und** beide Koordinaten (`getBalticSeaStatus`),
+ * und `spamScore` zeigt die Indikatoren im `title`.
+ */
+export const COLUMN_FIELDS = {
+	referenceId: ['referenceId'],
+	sightingDate: ['sightingDate'],
+	created: ['created'],
+	email: ['email'],
+	species: ['species'],
+	distance: ['distance'],
+	totalCount: ['totalCount'],
+	juvenileCount: ['juvenileCount'],
+	distribution: ['distribution'],
+	behavior: ['behavior'],
+	seaState: ['seaState'],
+	wind: ['windForce'],
+	visibility: ['visibility'],
+	mediaUpload: ['mediaUpload'],
+	spamScore: ['spamScore', 'spamIndicators'],
+	balticSea: ['inBalticSea', 'inBalticSeaGeo', 'latitude', 'longitude'],
+	verified: ['approvedAt', 'rejectedAt'],
+	actions: ['id', 'referenceId']
+} as const satisfies Record<keyof ColumnVisibility, readonly SightingField[]>;
+
+/**
+ * Felder, die unabhängig von der Spaltenwahl gebraucht werden.
+ *
+ * Zwei Gruppen, die beide nicht in `AVAILABLE_COLUMNS` stehen:
+ *
+ * - Die **festen Spalten** der Tabelle — `id` (Zeilenschlüssel, Auswahl-
+ *   Checkbox, Detail-Link) und `isDead` (Markerspalte ganz links, bewusst
+ *   nicht abschaltbar, siehe `.claude/rules/admin.md`).
+ * - Alles, was die **Kartenansicht** (`SichtungenCards.svelte`) zeigt. Sie
+ *   kennt die Spaltenkonfiguration nicht und rendert ihre Felder immer; ohne
+ *   diese Liste hinge die kompakte Ansicht an der Spaltenwahl der weiten.
+ */
+export const FIXED_FIELDS = [
+	'id',
+	'isDead',
+	'referenceId',
+	'species',
+	'email',
+	'sightingDate',
+	'created',
+	'totalCount',
+	'mediaUpload',
+	'inBalticSea',
+	'inBalticSeaGeo',
+	'latitude',
+	'longitude',
+	'approvedAt',
+	'rejectedAt'
+] as const satisfies readonly SightingField[];
+
+/**
+ * Die Vereinigung aus beidem — als **Union der tatsächlich gelisteten Namen**,
+ * nicht als `SightingField`.
+ *
+ * Der Unterschied ist nicht kosmetisch: Mit der weiten Annotation
+ * (`readonly SightingField[]`) wäre `SIGHTING_LIST_COLUMNS` unten als
+ * `Pick<typeof sightings, SightingField>` typisiert, also als die **ganze
+ * Zeile** — und `load()` lieferte Datensätze, deren Typ weiterhin `phone`,
+ * `internalComment` und die Einwilligungsspalten führt, obwohl sie zur Laufzeit
+ * `undefined` sind. Genau die Fehlerklasse, gegen die die Schwester-Datei
+ * `inboxColumns.ts` konstruiert ist.
+ */
+type ListField =
+	(typeof FIXED_FIELDS)[number] | (typeof COLUMN_FIELDS)[keyof typeof COLUMN_FIELDS][number];
+
+/** Sortiert, damit die Reihenfolge nicht an der Schreibreihenfolge oben hängt. */
+export const SIGHTING_LIST_FIELDS: readonly ListField[] = [
+	...new Set<ListField>([...FIXED_FIELDS, ...Object.values(COLUMN_FIELDS).flat()])
+].sort();
+
+/**
+ * Das Select-Objekt für `db.select(…)`. Aus der Feldliste erzeugt und nicht
+ * als zweites Literal geschrieben: Zwei Aufzählungen nebeneinander wären zwei
+ * Quellen, und die zweite altert.
+ */
+export const SIGHTING_LIST_COLUMNS = Object.fromEntries(
+	SIGHTING_LIST_FIELDS.map((field) => [field, sightings[field]])
+) as Pick<typeof sightings, ListField>;
+
+/**
+ * Eine Zeile der Liste — genau die Felder, die `load()` liest.
+ *
+ * Tabelle und Kartenansicht sind darauf typisiert und **nicht** mehr auf
+ * `FrontendSighting`: Der volle Typ behauptete Felder, die der Loader seit der
+ * Spaltenauswahl nicht mehr liefert. Wer hier ein Feld liest, das nicht in
+ * `COLUMN_FIELDS`/`FIXED_FIELDS` steht, bekommt jetzt einen Typfehler statt
+ * einer leeren Zelle.
+ */
+export type SichtungenListRow = Pick<SightingSelect, ListField>;

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -30,6 +30,7 @@ import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { rejectedOnly } from '$lib/server/db/approvalFilter';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
 import { sightings } from '$lib/server/db/schema';
+import { SIGHTING_LIST_FIELDS } from './listColumns';
 
 const dialect = new PgDialect();
 const toSqlText = (condition: SQLWrapper): string => dialect.sqlToQuery(condition.getSQL()).sql;
@@ -107,6 +108,22 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		} as unknown as Parameters<typeof load>[0])) as { pendingPhotoAnnouncements: number };
 
 		expect(result.pendingPhotoAnnouncements).toBe(2);
+	});
+
+	/*
+	 * Befund 20: Die Hauptliste lief als `db.select()` über die ganze Zeile und
+	 * lieferte bis zu 100 vollständige Datensätze ins HTML — Telefonnummer,
+	 * Klarname und alle Einwilligungs-Nachweisspalten inklusive. Die Auswahl
+	 * steht jetzt in `listColumns.ts`; hier wird geprüft, dass `load()` sie auch
+	 * tatsächlich übergibt. Ein zurückgedrehtes `db.select()` ohne Argument
+	 * erzeugt `columns === undefined` und fällt damit hier auf — der Test in
+	 * `listColumns.test.ts` allein sähe das nicht, er kennt nur die Konstante.
+	 */
+	it('liest nur die Spalten aus listColumns, nicht die ganze Zeile', async () => {
+		await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0]);
+
+		const hauptliste = recordedSelects[0];
+		expect(Object.keys(hauptliste?.columns ?? {}).sort()).toEqual([...SIGHTING_LIST_FIELDS].sort());
 	});
 
 	it('sortiert die Spam-Spalte absteigend mit NULLS LAST (sonst stünde Altbestand oben)', async () => {

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -90,7 +90,7 @@
 		<!-- Header -->
 		<div class="flex flex-wrap items-start justify-between gap-4">
 			<div>
-				<h1 class="text-base-content text-3xl font-bold">
+				<h1 class="text-base-content text-display font-bold">
 					Statistiken{yearSuffix}
 				</h1>
 				<p class="text-base-content/70 mt-2">
@@ -463,7 +463,7 @@
 											{observer.lastSighting.slice(0, 4)}
 										</td>
 										<td>
-											<div class="text-xs">
+											<div class="text-support">
 												{Math.round(daysDiff)} Tage aktiv
 											</div>
 										</td>


### PR DESCRIPTION
Die fünf verstreuten Kleinbefunde des Admin-Reviews. Jeder für sich klein; zwei davon haben beim Nachmessen mehr ergeben als der Befund sagte.

## Was drin ist

**Befund 20 — Datenminimierung in den Loadern.** `db.select()` las in beiden Admin-Loadern die ganze Zeile (Tabelle bis zu 100-mal, Eingang 50-mal): Telefonnummer, Klarname, Anschrift, interne Kommentare, alle acht Einwilligungs-Nachweisspalten. Jetzt 24 bzw. 18 statt ~70 Feldern, definiert in `sichtungen/listColumns.ts` und `$lib/server/db/inboxColumns.ts`. Kein Sicherheitsloch — die Routen sind Admin-only —, aber unnötige Verbreitung personenbezogener Daten.

**Befund 8 — destruktive Buttons in zwei Varianten.** Tabellenzeile, Mobilkarte und Ansichten-Dropdown tragen jetzt wie die Detailansicht `btn btn-outline btn-error`. Beim Dropdown ist das zusätzlich ein Kontrast-Fix: DaisyUIs Menü-Hover ist `base-content` zu 10 % und damit dunkler als `base-300`, wo `text-error` schon bei 4,13:1 liegt; die Menü-Regel greift ausdrücklich nicht auf `.btn`.

**Befund 9 — Typografie-Rollen.** Fünf Übersichtsseiten auf `text-display`. Detailansicht und Bearbeiten-Maske bleiben nach Rücksprache `text-xl` — als eingetragene Ausnahme mit eigenem Test, nicht als Rest. Dazu die 12px-Stellen auf `text-support`.

**Befund 16 — Emoji doppeln die Alert-Icons.** Alle 15 Meldungen der Einstellungsseite emoji-frei.

**Befund 21 — Loader-Daten werden mutiert.** Eingaben liegen jetzt in einer `SvelteMap` neben `data`.

## Zwei Stellen, an denen der Befund nicht stimmte

**Befund 21 war anders und schlimmer.** `data` wurde nie beschrieben — `groupedConfigs` ist ein `$state`-Proxy, und Svelte 5 hält die Werte in eigenen Signalen statt sie ins Zielobjekt zurückzuschreiben. Der Befund vermutete, die Mutation „rette sogar die Eingaben über den Toggle hinweg". Das Gegenteil war der Fall: Der Toggle ersetzt den Proxy, das Feld sprang auf den Loader-Wert zurück, „1 Änderung" stand weiter da — und „Speichern" schrieb den **alten** Wert in die Datenbank, ohne dass irgendwo etwas rot wurde. Der Regressionstest dafür war vorher rot.

**Die Typ-Zusage von `listColumns.ts` trug zuerst nicht.** Eine `readonly SightingField[]`-Annotation weitete die Feld-Union auf alle Tabellenfelder; `SIGHTING_LIST_COLUMNS` war damit als ganze Zeile typisiert, und der Loader lieferte Datensätze, deren Typ weiterhin `phone` führte — zur Laufzeit `undefined`. Die Laufzeit-Tests sahen das nicht, sie prüfen die Konstante und nicht, was Konsumenten davon zu sehen bekommen. Gefunden im Review dieses Diffs, behoben, und mit `@ts-expect-error`-Sonden abgesichert, die `type-check` brechen, sobald die Union wieder aufgeweitet wird. Im selben Zug laufen Tabelle, Kartenansicht und Eingangskarte auf die Zeilentypen statt auf `FrontendSighting`/`SightingSelect` — wer dort ein nicht abgefragtes Feld liest, bekommt jetzt einen Typfehler.

## Absicherung

Vier neue bzw. erweiterte Testdateien; jeder neue Guard ist gegengeprüft (alte Fassung eingesetzt → rot, mit benannter Fundstelle):

- `listColumns.test.ts` + `@ts-expect-error`-Sonden
- `page.server.test.ts` / `inboxPage.server.test.ts` — `load()` übergibt die Auswahl
- `destructiveButtonVariant.test.ts`
- `adminPageHeadings.test.ts` — Titelgrößen inkl. der eingetragenen Ausnahme
- `settingsMessagesAndEdits.svelte.test.ts` — Emoji + Toggle-Regression

`npm run test:quick` (4266 Tests, Lint, `tsc`, `svelte-check` 0 Fehler) und `npm run test:unit:client` (702 Tests) grün. Visuell gegen die lokale DB geprüft (Tabelle, Mobilkarten, Filter-Panel, Einstellungen).

## Für den Review

- **Nicht angefasst:** `ApiDocumentation.svelte` (`text-4xl`) — die Komponente hängt auch am öffentlichen `/docs/api`, das ist kein Admin-Seitentitel.
- **Vorbestehend, nicht Teil dieses Diffs:** `saveAllChanges` iteriert über die *gefilterte* Konfigurationsmenge. Wer bei „Alle Einstellungen anzeigen" einen inaktiven Wert ändert und den Schalter dann ausschaltet, sieht weiter „1 ungespeicherte Änderung", bekommt beim Speichern aber „Keine Änderungen zu speichern". Der Fix wohnt in derselben Funktion, gehört aber in einen eigenen Vorgang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
