### PR TITLE
feat(ui): Ladeanzeige für Bild-Vorschaubilder wiederherstellen

### DIFF
--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -34,6 +34,23 @@
 	function hasGPSData(): boolean {
 		return !!(file.exifData?.latitude && file.exifData?.longitude);
 	}
+
+	let imageLoading = $state(true);
+
+	function handleImageLoad() {
+		imageLoading = false;
+	}
+
+	function handleImageError(event: Event) {
+		console.error('Image loading failed:', `/api/media/${file.filePath}`, event);
+		// Fallback to original URL if secure endpoint fails
+		const img = event.target as HTMLImageElement;
+		if (!img.src.includes('fallback=true')) {
+			img.src = `${file.url}?fallback=true`;
+			return;
+		}
+		imageLoading = false;
+	}
 </script>
 
 <div
@@ -47,19 +64,29 @@
 	{#if isImage(file.mimeType)}
 		<!-- Bild Thumbnail -->
 		<div class="relative aspect-square overflow-hidden">
+			<!-- Ladeanzeige, bis das Bild da ist. Sie hängt an `onload`/`onerror` und
+			     nicht an einem CSS-Selektor: Der Vorgänger an dieser Stelle war eine
+			     Streifen-Animation auf dem `img`, die eine Gegenregel im scoped CSS
+			     weiter unten dauerhaft abschaltete — dass sie nie lief, sah man dem
+			     Stylesheet nicht an (Begründung dort). Nur der Bild-Zweig hat etwas zu
+			     überbrücken: das Video lädt wegen `preload="none"` nichts, der
+			     Datei-Zweig zeigt bloß ein Icon.
+			     Ohne z-Angabe, aber vor dem Bild im Markup: `absolute` malt ohnehin
+			     über das statische `img` und die beiden Overlays danach über sie. -->
+			{#if imageLoading}
+				<div
+					class="skeleton absolute inset-0"
+					data-testid="media-thumbnail-skeleton"
+					aria-hidden="true"
+				></div>
+			{/if}
 			<img
 				src={`/api/media/${file.filePath}`}
 				alt={file.originalName}
 				class="h-full w-full object-contain transition-all group-hover:scale-110"
 				loading="lazy"
-				onerror={(e) => {
-					console.error('Image loading failed:', `/api/media/${file.filePath}`, e);
-					// Fallback to original URL if secure endpoint fails
-					const img = e.target as HTMLImageElement;
-					if (!img.src.includes('fallback=true')) {
-						img.src = `${file.url}?fallback=true`;
-					}
-				}}
+				onload={handleImageLoad}
+				onerror={handleImageError}
 			/>
 			<!-- Hover Overlay. bg-scrim/<n> statt bg-black/<n>: der Wert steht seit
 			     dem 2026-07-30 als --scrim-surface in tokens.css. Ein Schleier ist
@@ -223,7 +250,16 @@
 	   etwas gezeigt — die Gegenregel `.media-thumbnail img[src]` hebt es mit
 	   `background: none !important` wieder auf, und `src` steht im Markup als
 	   Literal, ist also ab dem ersten Paint da. Die Keyframe `loadingPattern`
-	   in app.css hatte hier ihre einzige Aufrufstelle und ist mit entfallen. */
+	   in app.css hatte hier ihre einzige Aufrufstelle und ist mit entfallen.
+
+	   Die Absicht dahinter lebt im Markup weiter, als DaisyUI-`skeleton` hinter
+	   `{#if imageLoading}`. Sie kommt bewusst nicht als CSS-Regel zurück: Ein
+	   Ladezustand, den ein Selektor beschreibt, ist genau dann falsch, wenn der
+	   Selektor den Zustand verfehlt — und dass er das tut, sieht man dem
+	   Stylesheet nicht an. Am Handler ist es prüfbar, und
+	   `MediaThumbnail.svelte.test.ts` prüft es: sichtbar vor `load`, weg danach,
+	   und weg auch dann, wenn der Fallback endgültig scheitert und `load` nie
+	   kommt. */
 
 	/* Animation for scale effect */
 	@media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -42,10 +42,16 @@
 	}
 
 	function handleImageError(event: Event) {
-		console.error('Image loading failed:', `/api/media/${file.filePath}`, event);
-		// Fallback to original URL if secure endpoint fails
-		const img = event.target as HTMLImageElement;
-		if (!img.src.includes('fallback=true')) {
+		const img = event.currentTarget as HTMLImageElement;
+		// Die tatsächlich gescheiterte URL, nicht `/api/media/…`: Beim zweiten
+		// Durchlauf ist das der Fallback, und ein Log, das dann weiter den
+		// Endpunkt nennt, schickt die Fehlersuche an die falsche Stelle.
+		console.error('Image loading failed:', img.src, event);
+
+		// Fallback to original URL if secure endpoint fails. `url` ist im Schema
+		// optional — ohne diese Prüfung entstünde daraus eine Anfrage auf
+		// `undefined?fallback=true`, die nur scheitern kann.
+		if (file.url && !img.src.includes('fallback=true')) {
 			img.src = `${file.url}?fallback=true`;
 			return;
 		}

--- a/src/lib/components/media/MediaThumbnail.svelte.test.ts
+++ b/src/lib/components/media/MediaThumbnail.svelte.test.ts
@@ -88,6 +88,20 @@ describe('MediaThumbnail — Ladezustand', () => {
 		expect(skeleton()).toBeNull();
 	});
 
+	it('beendet die Ladeanzeige sofort, wenn es keine Fallback-URL gibt', async () => {
+		// `url` ist im Schema optional. Ohne die Prüfung baute der Handler daraus
+		// `undefined?fallback=true` — eine Anfrage, die niemand beantworten kann,
+		// nur damit ihr Fehlschlag die Anzeige abräumt.
+		render(MediaThumbnail, { file: bildDatei({ url: undefined }) });
+		const vorher = bild().src;
+
+		bild().dispatchEvent(new Event('error'));
+		await tick();
+
+		expect(bild().src).toBe(vorher);
+		expect(skeleton()).toBeNull();
+	});
+
 	it('setzt keine Ladeanzeige an Nicht-Bild-Kacheln', () => {
 		// Der Video-Zweig lädt wegen `preload="none"` bewusst nichts, der
 		// Datei-Zweig zeigt nur ein Icon — beide haben nichts zu überbrücken.

--- a/src/lib/components/media/MediaThumbnail.svelte.test.ts
+++ b/src/lib/components/media/MediaThumbnail.svelte.test.ts
@@ -1,0 +1,100 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import { tick } from 'svelte';
+import type { UploadedFileInfo } from '$lib/types';
+import MediaThumbnail from './MediaThumbnail.svelte';
+
+/**
+ * Bis PR #819 stand hier ein CSS-Lademuster: ein Streifen-Gradient auf dem
+ * `img`, das bis zum Laden sichtbar sein sollte. Es hat nie etwas gezeigt — die
+ * Gegenregel `.media-thumbnail img[src] { background: none !important }` im
+ * selben Block hob es auf, und `src` steht im Markup als Literal, greift also ab
+ * dem ersten Paint. Entfernt wurde damit totes CSS, aber auch die Absicht.
+ *
+ * Diese Datei hält die Zusage fest, die das alte Muster nicht eingehalten hat:
+ * Der Ladezustand ist vor dem Laden sichtbar und danach weg — und zwar an einem
+ * eigenen Element, das ein `onload`-Handler abschaltet, nicht über einen
+ * CSS-Selektor, dessen Wirksamkeit man dem Stylesheet nicht ansieht.
+ *
+ * Zum Aufbau: `/api/media/...` beantwortet im Testbrowser niemand, das Bild läuft
+ * dort also von selbst in einen Fehler. Die Übergänge werden trotzdem als
+ * Ereignisse ausgelöst statt abgewartet — sonst hinge die Aussage jedes Tests
+ * daran, was der Vite-Server zufällig auf eine unbekannte URL antwortet, und ein
+ * grüner Lauf bewiese nicht, welcher der beiden Pfade die Anzeige abgeräumt hat.
+ */
+function bildDatei(overrides: Partial<UploadedFileInfo> = {}): UploadedFileInfo {
+	return {
+		uid: 'test-uid',
+		filePath: '2026/08/foto.jpg',
+		originalName: 'foto.jpg',
+		mimeType: 'image/jpeg',
+		size: 1024,
+		url: '/uploads/2026/08/foto.jpg',
+		...overrides
+	};
+}
+
+function skeleton(): HTMLElement | null {
+	return document.querySelector<HTMLElement>('[data-testid="media-thumbnail-skeleton"]');
+}
+
+function bild(): HTMLImageElement {
+	const element = document.querySelector<HTMLImageElement>('.media-thumbnail img');
+	if (!element) throw new Error('Vorschaubild nicht im DOM');
+	return element;
+}
+
+describe('MediaThumbnail — Ladezustand', () => {
+	it('zeigt vor dem Laden eine Ladeanzeige', () => {
+		render(MediaThumbnail, { file: bildDatei() });
+
+		expect(skeleton()).not.toBeNull();
+	});
+
+	it('nimmt die Ladeanzeige weg, sobald das Bild geladen ist', async () => {
+		render(MediaThumbnail, { file: bildDatei() });
+
+		bild().dispatchEvent(new Event('load'));
+		// `tick()` und nicht `expect.poll`: Ein Poll liefe hier auch dann grün,
+		// wenn erst der Fehlerpfad die Anzeige abräumt. Der Microtask flusht die
+		// Zustandsänderung, bevor irgendein Netzwerk-Ereignis drankommt.
+		await tick();
+
+		expect(skeleton()).toBeNull();
+	});
+
+	it('behält die Ladeanzeige, solange der Fallback noch läuft', async () => {
+		// `onerror` schaltet einmalig auf `file.url` um — das ist ein weiterer
+		// Ladeversuch, kein Ende des Ladens.
+		render(MediaThumbnail, { file: bildDatei() });
+
+		bild().dispatchEvent(new Event('error'));
+		await tick();
+
+		expect(bild().src).toContain('fallback=true');
+		expect(skeleton()).not.toBeNull();
+	});
+
+	it('beendet die Ladeanzeige, wenn auch der Fallback fehlschlägt', async () => {
+		// Sonst bliebe ein Dauer-Skeleton über einem kaputten Bild stehen: `load`
+		// kommt nie, und der zweite `onerror` findet `fallback=true` bereits vor.
+		render(MediaThumbnail, { file: bildDatei() });
+
+		bild().dispatchEvent(new Event('error'));
+		await tick();
+		bild().dispatchEvent(new Event('error'));
+		await tick();
+
+		expect(skeleton()).toBeNull();
+	});
+
+	it('setzt keine Ladeanzeige an Nicht-Bild-Kacheln', () => {
+		// Der Video-Zweig lädt wegen `preload="none"` bewusst nichts, der
+		// Datei-Zweig zeigt nur ein Icon — beide haben nichts zu überbrücken.
+		render(MediaThumbnail, {
+			file: bildDatei({ mimeType: 'video/mp4', originalName: 'clip.mp4' })
+		});
+
+		expect(skeleton()).toBeNull();
+	});
+});


### PR DESCRIPTION
## Worum es geht

PR #819 hat aus `MediaThumbnail.svelte` ein CSS-Lademuster entfernt, das **nie etwas gezeigt hat**: Die Gegenregel `.media-thumbnail img[src] { background: none !important }` im selben Block hob den Streifen-Gradienten auf, und `src` steht im Markup als Literal — sie griff also ab dem ersten Paint. Totes CSS zu entfernen war richtig, nahm aber auch die Absicht mit: Bis zum Laden steht seither über der `aspect-square`-Box nichts. In der Admin-Sichtungsansicht laufen dort mehrere `/api/media/...`-Anfragen gleichzeitig — eine Ladeanzeige ist da begründet.

## Was sich ändert

- **DaisyUI-`skeleton` hinter `{#if imageLoading}`**, abgeschaltet von `onload`. Bewusst kein CSS-Selektor mehr: Ein Ladezustand, den ein Selektor beschreibt, ist genau dann falsch, wenn der Selektor den Zustand verfehlt — und dass er das tut, sieht man dem Stylesheet nicht an. Am Handler ist es prüfbar.
- **Nur der Bild-Zweig** bekommt sie. Das Video lädt wegen `preload="none"` nichts, der Datei-Zweig zeigt bloß ein Icon.
- **Kein z-Index:** Das absolut positionierte Skeleton malt über das statische `img`, die beiden Overlays danach malen über beides. `aria-hidden="true"`, die Semantik trägt das `alt` am Bild.
- **Der bestehende `onerror` wandert aus dem Markup in `handleImageError`** und beendet den Ladezustand auf dem Endpfad: erster Fehler → wie bisher Umschalten auf `${file.url}?fallback=true`, Anzeige bleibt (es lädt ja noch); zweiter Fehler → `imageLoading = false`, sonst stünde ein Dauer-Skeleton über einem kaputten Bild, weil `load` nie kommt.

## Tests

`src/lib/components/media/MediaThumbnail.svelte.test.ts` ist neu (Browser-Test, Test-First): vor `load` da, nach `load` weg, beim ersten Fehler noch da, nach dem zweiten weg, an Nicht-Bild-Kacheln gar nicht.

- **RED vor der Implementierung:** die beiden „Skeleton da"-Fälle rot.
- **Gegenprobe:** `imageLoading = false` aus dem Fehlerpfad entfernt → genau der Fallback-Fall fällt aus, die anderen vier bleiben grün. Das Grün belegt also die Zusage und nicht nur, dass irgendwer die Anzeige abräumt.
- Die Übergänge werden als Ereignisse **ausgelöst statt abgewartet**: Mit `expect.poll` liefe der `load`-Fall auch dann grün, wenn erst der 404 des Testservers die Anzeige entfernt.

`npm run test:quick` grün (4308 Tests), der neue Browser-Test grün.

## Für den Review

Ein Nebenbefund, der beim Nachbauen Zeit kostet: `e2e/helpers/bannedCss.ts` hält ein **literales `<style>` in einem Markup-Kommentar** für den Anfang eines Style-Blocks und scannt danach das Markup als CSS — gemeldet wurde dadurch ein Hex-Wert aus einem ganz anderen, alten Kommentar weiter unten. Hier umformuliert; der Extractor bleibt unangetastet.

Nicht im Browser verifiziert: Der Zustand ist nur während des Ladens sichtbar und hängt an einer Admin-Session mit Medien im Bestand. Die `skeleton`-Klasse ist im Projekt bereits an zwei Stellen in Gebrauch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)