### PR TITLE
fix(test): Style-Block-Scan ignoriert Markup-Kommentare

### DIFF
--- a/e2e/helpers/bannedCss.test.ts
+++ b/e2e/helpers/bannedCss.test.ts
@@ -140,6 +140,53 @@ describe('extractStyleBlocks', () => {
 	it('findet auch <style lang="postcss">', () => {
 		expect(extractStyleBlocks('<style lang="postcss">a{}</style>')).toHaveLength(1);
 	});
+
+	/* Die Zeichenfolge `<style>` steht im Bestand auch in Prosa: Kommentare
+	   erklären, welcher Wert früher „im scoped <style>" stand. Ohne Maskierung
+	   beginnt der erste Treffer dort — der Ausschnitt trägt dann Kommentar-Rest
+	   und Markup, und ein Farbwert aus der Begründung wird als CSS gemeldet.
+	   Genau das ist am 2026-08-09 passiert. */
+	it('ignoriert die Zeichenfolge <style> in einem Markup-Kommentar', () => {
+		const source = [
+			'<!-- Stand vorher im scoped <style> als #abcdef und umging das Theme. -->',
+			'<div />',
+			'',
+			'<style>',
+			'\tcolor: var(--color-primary);',
+			'</style>'
+		].join('\n');
+
+		const blocks = extractStyleBlocks(source);
+
+		expect(blocks).toHaveLength(1);
+		expect(blocks.flatMap((b) => findCssColorOffenders(b.content, b.offset))).toEqual([]);
+	});
+
+	/* Der teurere Fall: Beginnt ein Treffer im Kommentar, verschmelzen der echte
+	   Block davor und der danach zu einer anderen Aufteilung — die Auswertung
+	   redet dann über etwas anderes als die Datei. Geprüft wird deshalb, dass
+	   genau das echte Literal gemeldet wird, mit seiner Zeile, und sonst nichts. */
+	it('meldet einen echten Block vor einem Kommentar mit der Zeichenfolge <style>', () => {
+		const source = [
+			'<style>',
+			'\tcolor: #123456;',
+			'</style>',
+			'',
+			'<!-- Der Wert stand vorher im <style> als #abcdef. -->',
+			'',
+			'<style>',
+			'\tcolor: var(--color-primary);',
+			'</style>'
+		].join('\n');
+
+		const blocks = extractStyleBlocks(source);
+		expect(blocks).toHaveLength(2);
+
+		const offenders = blocks.flatMap((b) => findCssColorOffenders(b.content, b.offset));
+		expect(offenders).toHaveLength(1);
+		expect(offenders[0].literal).toBe('#123456');
+		expect(offenders[0].line).toBe(2);
+	});
 });
 
 describe('isExemptFile', () => {

--- a/e2e/helpers/bannedCss.ts
+++ b/e2e/helpers/bannedCss.ts
@@ -142,25 +142,52 @@ export function isExemptFile(path: string): boolean {
 }
 
 /**
+ * Blendet Svelte-Markup-Kommentare (`<!-- … -->`) aus, **längentreu**.
+ *
+ * Der Inhalt wird durch Leerzeichen ersetzt, die `\n` bleiben stehen: Jeder
+ * Index im Ergebnis zeigt auf dasselbe Zeichen wie im Original, und damit
+ * bleiben auch die Zeilennummern der Fundstellen unverändert. Herausschneiden
+ * würde beides verschieben.
+ *
+ * Dass CSS selbst `<!--` enthält, ist nicht vorgesehen und kommt im Bestand
+ * nicht vor — die Maskierung läuft ohnehin nur über die Trefferfindung, der
+ * Blockinhalt wird unten aus dem **Original** geschnitten.
+ */
+function maskMarkupComments(source: string): string {
+	return source.replace(/<!--[\s\S]*?-->/g, (comment) => comment.replace(/[^\n]/g, ' '));
+}
+
+/**
  * Schneidet die `<style>`-Blöcke aus einer Svelte-Datei.
  *
  * Gibt Paare aus Zeilenversatz und Inhalt zurück, damit die Fundstelle später
  * eine Zeilennummer **in der Datei** tragen kann und nicht im Ausschnitt — eine
  * Meldung, die auf „Zeile 62 des dritten Style-Blocks" zeigt, kostet den Leser
  * genau die Suche, die der Test ihm abnehmen soll.
+ *
+ * **Gesucht wird im maskierten Quelltext, geschnitten wird aus dem Original.**
+ * Ein Muster allein unterscheidet ein `<style>`-Element nicht von der
+ * Zeichenfolge `<style>` in einem Markup-Kommentar — und die steht hier in
+ * Prosa, weil die Begründungen im Bestand erklären, welcher Wert früher „im
+ * scoped <style>" stand. Beginnt der Treffer dort, umfasst der Ausschnitt
+ * Kommentar-Rest, Markup und erst dann den echten Block: Ein Farbwert aus der
+ * Begründung wird als CSS gemeldet (so am 2026-08-09 geschehen), und die
+ * Aufteilung in Blöcke stimmt nicht mehr mit der Datei überein.
  */
 export function extractStyleBlocks(source: string): { offset: number; content: string }[] {
 	const blocks: { offset: number; content: string }[] = [];
-	const pattern = /<style[^>]*>([\s\S]*?)<\/style>/g;
+	const pattern = /<style[^>]*>[\s\S]*?<\/style>/g;
+	const masked = maskMarkupComments(source);
 
 	let match: RegExpExecArray | null;
-	while ((match = pattern.exec(source)) !== null) {
-		// Zeilen vor dem Blockinhalt zählen: der Treffer beginnt beim `<style`,
-		// der Inhalt erst hinter dem `>`.
-		const beforeContent = source.slice(0, match.index + match[0].indexOf('>') + 1);
+	while ((match = pattern.exec(masked)) !== null) {
+		// Der Treffer beginnt beim `<style`, der Inhalt erst hinter dem `>` und
+		// endet vor dem `</style>`.
+		const start = match.index + match[0].indexOf('>') + 1;
+		const end = match.index + match[0].length - '</style>'.length;
 		blocks.push({
-			offset: beforeContent.split('\n').length - 1,
-			content: match[1]
+			offset: source.slice(0, start).split('\n').length - 1,
+			content: source.slice(start, end)
 		});
 	}
 


### PR DESCRIPTION
## Problem

`extractStyleBlocks` in `e2e/helpers/bannedCss.ts` schnitt die Style-Blöcke per Regex `/<style[^>]*>([\s\S]*?)<\/style>/g` aus dem Quelltext. Das Muster unterscheidet ein `<style>`-Element nicht von der Zeichenfolge `<style>` in einem Svelte-Markup-Kommentar.

Nachweis im Bestand: `src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte` erklärt im Backdrop-Kommentar, welcher Wert früher „im scoped `<style>`" stand. Der erste Treffer begann deshalb dort und lief bis zum `</style>` am Dateiende — ausgeschnitten wurden Kommentar-Rest, Markup und erst dann der echte Block.

**Folge:** Ein Farbliteral, das in einer Begründung als Gegenbeispiel steht, wurde als CSS-Verstoß gemeldet. Das ist nicht konstruiert — genau so wurde der Test am 2026-08-09 rot, als beim daisyUI-Aufräumen ein zweiter Kommentar mit `<style>` weiter oben in derselben Datei entstand.

## Lösung

Markup-Kommentare werden vor dem Regex-Lauf **längentreu** ausgeblendet (Inhalt zu Leerzeichen, `\n` bleiben stehen). Gesucht wird im maskierten Text, geschnitten wird aus dem **Original** — so bleibt der Blockinhalt unangetastet, und die Zeilennummern bestehender Fundstellen verschieben sich nicht.

## Tests (zuerst geschrieben, beide vorher rot)

- `ignoriert die Zeichenfolge <style> in einem Markup-Kommentar` — Farbwert hinter dem `<style>` im Kommentar; vorher als Verstoß gemeldet.
- `meldet einen echten Block vor einem Kommentar mit der Zeichenfolge <style>` — prüft, dass genau das echte Literal mit seiner Zeile gemeldet wird und der Prosa-Wert nicht; vorher zwei Fundstellen.

## Einschränkung zur Ausgangsvermutung

Die vermutete Falsch-negativ-Lücke trägt so nicht. Weil `[\s\S]*?` faul matcht, ist der zu früh beginnende Treffer eine **Obermenge** des echten Blocks — dessen Inhalt wurde weiterhin mitgescannt. Verloren ging kein Literal; falsch war die Aufteilung in Blöcke und damit, worüber die Meldung redet. Der zweite Test hält genau das fest, statt eine Lücke zu behaupten, die es nicht gibt.

## Verifikation

`npm run test:quick` — 285 Test-Dateien, 4310 Tests grün (inkl. Bestands-Scan über alle `.svelte`-Dateien).

🤖 Generated with [Claude Code](https://claude.com/claude-code)