### PR TITLE
fix(a11y): Hochkontrast-Regeln auf den wirksamen Merkmalswert umstellen

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -93,6 +93,17 @@ Die Regel prüft den **Quelltext** aller `<style>`-Blöcke und CSS-Dateien auf H
 
 **Was der Scan nicht sieht:** `hover:`-Zustände — er liest den Ruhezustand. Dafür gilt die Regel „`text-error` nicht auf `base-300`" unten.
 
+**Erhöhter Kontrast heißt `prefers-contrast: more`, nie `high`** (seit 2026-08-09). `high` war der Entwurfsname des Merkmals; Media Queries Level 5 kennt `no-preference | more | less | custom`, und Tailwinds Variante `contrast-more:` erzeugt entsprechend `more`. Gemessen mit Playwright 1.62 bei aktiver Kontrasterhöhung (Kontext-Option `contrast: 'more'`):
+
+| Query                      | Chromium 151 | WebKit 26.5 |
+| -------------------------- | ------------ | ----------- |
+| `(prefers-contrast: more)` | ✅ trifft zu | ✅          |
+| `(prefers-contrast: high)` | ❌ nie       | ❌          |
+
+Gegengeprüft nicht nur über `matchMedia`, sondern über eine echte Regel: eine Deklaration unter `high` setzt auch bei aktiver Kontrasterhöhung nichts. Die drei Blöcke im Bestand (`MediaThumbnail`, `MediaModal`, `SpeciesIdentificationHelp`) waren damit seit ihrer Einführung tot — kein Linter und kein Browser meldet das, weil die Regel syntaktisch in Ordnung ist. Gewacht wird jetzt über `e2e/helpers/bannedMediaFeatures.ts` (Quelltext-Scan, läuft in `npm run test:quick`).
+
+**Konsequenz für neue Regeln:** Setzt die Regel nur Utilities (Rahmenbreite, Outline, Deckkraft), gehört sie als `contrast-more:`-Variante ins Markup und nicht als `@media`-Block ins Komponenten-CSS — dort steht der Merkmalsname dann gar nicht mehr von Hand.
+
 **Beim Beheben nicht mechanisch ersetzen:** Erst prüfen, ob die Farbe an der Stelle Bedeutung trägt. Dekorative Icons und Zierelemente gehören auf `base-content/70` — nicht auf eine Statusfarbe mit `-strong`. Trägt ein Zeichen gar keine Bedeutung (Trennpunkt, Zierglyphe), gehört zusätzlich `aria-hidden="true"` daran; Beispiel: die Danksagungs-Trennpunkte in `src/routes/about/+page.svelte`.
 
 Beim Prüfen per `grep` gilt außerdem: **`grep -o` schneidet das `-strong`-Suffix aus der Ausgabezeile**, ein nachgeschaltetes `grep -v -- -strong` filtert dann ins Leere und meldet jede korrekte Verwendung als Verstoß — so entstand die inzwischen korrigierte „32 Fundstellen"-Liste in `docs/DESIGN_SYSTEM.md`. Die Regeln im Scan umgehen das, indem sie die Klassenliste splitten und jede Klasse gegen ein verankertes Muster prüfen.

--- a/e2e/helpers/bannedMediaFeatures.test.ts
+++ b/e2e/helpers/bannedMediaFeatures.test.ts
@@ -1,0 +1,108 @@
+import { globSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { extractStyleBlocks } from './bannedCss';
+import { findDeadMediaFeatures, type MediaFeatureOffender } from './bannedMediaFeatures';
+
+/**
+ * bannedMediaFeatures.test.ts — Media-Feature-Werte, die nie zutreffen.
+ *
+ * Aufbau wie in `bannedCss.test.ts`: konstruierte Beispiele stellen die Regel
+ * scharf, der Bestands-Scan hält den Bestand konform. Der Scan allein belegt
+ * nichts über die Regel — er wäre auch grün, wenn das Muster eine Lücke hat.
+ */
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+describe('findDeadMediaFeatures', () => {
+	/* Der Bestandsfall: stand bis 2026-08-09 in MediaThumbnail, MediaModal und
+	   SpeciesIdentificationHelp und hat dort nie etwas bewirkt. */
+	it('meldet prefers-contrast: high', () => {
+		const offenders = findDeadMediaFeatures('@media (prefers-contrast: high) {');
+
+		expect(offenders).toHaveLength(1);
+		expect(offenders[0].feature).toBe('prefers-contrast: high');
+		expect(offenders[0].replacement).toContain('more');
+	});
+
+	it('meldet prefers-contrast: low', () => {
+		expect(findDeadMediaFeatures('@media (prefers-contrast: low) {')).toHaveLength(1);
+	});
+
+	it('sieht durch beliebigen Abstand um den Doppelpunkt hindurch', () => {
+		expect(findDeadMediaFeatures('@media (prefers-contrast:high) {')).toHaveLength(1);
+		expect(findDeadMediaFeatures('@media (prefers-contrast   :   high) {')).toHaveLength(1);
+	});
+
+	/* Die Gegenbeispiele. Ohne sie wird die Regel beim ersten Fehlalarm
+	   abgeschaltet statt korrigiert. */
+	it('lässt die wirksamen Werte durch', () => {
+		for (const value of ['more', 'less', 'custom', 'no-preference']) {
+			expect(findDeadMediaFeatures(`@media (prefers-contrast: ${value}) {`)).toEqual([]);
+		}
+	});
+
+	it('lässt das merkmalslose (prefers-contrast) durch', () => {
+		expect(findDeadMediaFeatures('@media (prefers-contrast) {')).toEqual([]);
+	});
+
+	/* `forced-colors` ist ein eigenes Merkmal, kein Vorgänger — und `high`
+	   darin wäre ein anderer Fehler, den diese Regel nicht behauptet zu kennen. */
+	it('fasst forced-colors nicht an', () => {
+		expect(findDeadMediaFeatures('@media (forced-colors: active) {')).toEqual([]);
+	});
+
+	it('ignoriert den Wert in einem Kommentar', () => {
+		expect(findDeadMediaFeatures('/* früher: prefers-contrast: high */')).toEqual([]);
+	});
+
+	it('zählt Zeilen hinter einem mehrzeiligen Kommentar richtig weiter', () => {
+		const css = [
+			'/* eine',
+			'   Erklärung',
+			'   über drei Zeilen */',
+			'@media (prefers-contrast: high) {'
+		].join('\n');
+
+		expect(findDeadMediaFeatures(css)[0].line).toBe(4);
+	});
+
+	it('rechnet den Zeilenversatz der Datei auf', () => {
+		expect(findDeadMediaFeatures('@media (prefers-contrast: high) {', 40)[0].line).toBe(41);
+	});
+});
+
+/**
+ * Der Bestands-Scan — der eigentliche Wächter.
+ */
+describe('Bestand — keine toten Media-Feature-Werte', () => {
+	const format = (file: string, offenders: MediaFeatureOffender[]): string[] =>
+		offenders.map(
+			(o) => `${file}:${o.line} — ${o.feature} greift nie, gemeint ist ${o.replacement}`
+		);
+
+	it('kein toter Merkmalswert in einem <style>-Block einer Komponente', () => {
+		const findings = globSync('src/**/*.svelte', { cwd: repoRoot })
+			.map((file) => file.replaceAll('\\', '/'))
+			.flatMap((file) => {
+				const source = readFileSync(join(repoRoot, file), 'utf8');
+				return extractStyleBlocks(source).flatMap((block) =>
+					format(file, findDeadMediaFeatures(block.content, block.offset))
+				);
+			});
+
+		expect(findings).toEqual([]);
+	});
+
+	it('kein toter Merkmalswert in einer CSS-Datei', () => {
+		const findings = globSync('src/**/*.css', { cwd: repoRoot })
+			.map((file) => file.replaceAll('\\', '/'))
+			.flatMap((file) => {
+				const source = readFileSync(join(repoRoot, file), 'utf8');
+				return format(file, findDeadMediaFeatures(source));
+			});
+
+		expect(findings).toEqual([]);
+	});
+});

--- a/e2e/helpers/bannedMediaFeatures.ts
+++ b/e2e/helpers/bannedMediaFeatures.ts
@@ -1,0 +1,108 @@
+/**
+ * bannedMediaFeatures.ts — Media-Feature-Werte, die nie zutreffen.
+ *
+ * Eine `@media`-Regel mit einem Wert, den keine Engine kennt, ist keine
+ * fehlgeschlagene Regel, sondern eine **stille**: Sie parst, sie steht im
+ * Bundle, sie liest sich wie eine Zusage — und sie greift nie. Weder ein
+ * Linter noch der Browser meldet das, und ein Kontrast-Test misst sie nicht,
+ * weil sie schlicht nicht existiert.
+ *
+ * Der Bestandsfall war `@media (prefers-contrast: high)` in drei Komponenten.
+ * `high` war der Entwurfsname des Merkmals; Media Queries Level 5 kennt
+ * `no-preference | more | less | custom`, und Tailwinds Variante
+ * `contrast-more:` erzeugt entsprechend `more`. Gemessen am 2026-08-09 mit
+ * Playwright 1.62 (Chromium 151, WebKit 26.5), Kontext-Option
+ * `contrast: 'more'`: `matchMedia('(prefers-contrast: high)').matches` ist in
+ * beiden Engines `false`, `more` ist `true`, und eine CSS-Regel unter `high`
+ * setzt auch dann nichts, wenn die Kontrasterhöhung aktiv ist. Die drei Blöcke
+ * waren also seit ihrer Einführung tot.
+ *
+ * Geprüft wird — wie bei `bannedCss.ts` — der **Quelltext**, nicht das DOM: Ob
+ * ein Merkmalswert existiert, ist am Quelltext entscheidbar, und ein DOM-Scan
+ * könnte eine Regel, die nie greift, ohnehin nicht von einer unterscheiden,
+ * deren Bedingung gerade nicht erfüllt ist.
+ */
+
+/** Eine Fundstelle im CSS, mit Zeilennummer für die Fehlermeldung. */
+export interface MediaFeatureOffender {
+	/** 1-basierte Zeile innerhalb der geprüften Datei. */
+	readonly line: number;
+	/** Die anstößige Zeile, getrimmt. */
+	readonly text: string;
+	/** Der tote Wert, z. B. `prefers-contrast: high`. */
+	readonly feature: string;
+	/** Der Wert, der stattdessen gemeint ist. */
+	readonly replacement: string;
+}
+
+/**
+ * Tote Merkmalswerte und ihr wirksames Gegenstück.
+ *
+ * `low` steht neben `high`, obwohl es im Bestand keine Fundstelle hat: Beide
+ * kommen aus demselben Entwurf, und wer den einen aus einer alten Vorlage
+ * kopiert, kopiert auch den anderen. Eine Regel, die nur die Schreibweise
+ * kennt, die schon jemand benutzt hat, meldet die nächste nicht — dieselbe
+ * Begründung wie bei den Farbfunktionen in `bannedCss.ts`.
+ *
+ * **Nicht erfasst ist `forced-colors`.** Das ist ein eigenes Merkmal mit
+ * eigenen Werten (`active`/`none`) und kein Vorgänger von `prefers-contrast`;
+ * eine Regel darauf ist wirksam und gehört nicht hierher.
+ */
+const DEAD_FEATURE_VALUES: ReadonlyArray<{
+	readonly pattern: RegExp;
+	readonly feature: string;
+	readonly replacement: string;
+}> = [
+	{
+		pattern: /prefers-contrast\s*:\s*high\b/,
+		feature: 'prefers-contrast: high',
+		replacement: 'prefers-contrast: more (Tailwind: contrast-more:)'
+	},
+	{
+		pattern: /prefers-contrast\s*:\s*low\b/,
+		feature: 'prefers-contrast: low',
+		replacement: 'prefers-contrast: less (Tailwind: contrast-less:)'
+	}
+];
+
+/**
+ * Entfernt `/* … *\/`-Kommentare, behält aber die Zeilenstruktur.
+ *
+ * Aus demselben Grund wie in `bannedCss.ts`: Ohne das meldet der Test seine
+ * eigene Dokumentation — die Begründungen im Bestand führen den toten Wert als
+ * Gegenbeispiel auf —, und ohne Zeilenerhalt zeigt jede Fundstelle hinter dem
+ * ersten mehrzeiligen Kommentar auf die falsche Zeile.
+ */
+function stripComments(css: string): string {
+	return css.replace(/\/\*[\s\S]*?\*\//g, (comment) => comment.replace(/[^\n]/g, ' '));
+}
+
+/**
+ * Meldet Media-Feature-Werte in `css`, die keine Engine auswertet.
+ *
+ * @param css CSS-Quelltext (ein `<style>`-Blockinhalt oder eine ganze Datei).
+ * @param lineOffset Zeilen, die vor `css` in der Datei stehen — für die Nummer.
+ * @returns Fundstellen (leer = konform).
+ */
+export function findDeadMediaFeatures(css: string, lineOffset = 0): MediaFeatureOffender[] {
+	const offenders: MediaFeatureOffender[] = [];
+	const lines = css.split('\n');
+
+	stripComments(css)
+		.split('\n')
+		.forEach((line, index) => {
+			for (const { pattern, feature, replacement } of DEAD_FEATURE_VALUES) {
+				if (!pattern.test(line)) continue;
+
+				offenders.push({
+					line: lineOffset + index + 1,
+					// Aus der Originalzeile, damit die Meldung zeigt, was dort wirklich steht.
+					text: lines[index].trim(),
+					feature,
+					replacement
+				});
+			}
+		});
+
+	return offenders;
+}

--- a/src/lib/components/media/MediaModal.svelte
+++ b/src/lib/components/media/MediaModal.svelte
@@ -81,10 +81,22 @@
 	aria-labelledby="modal-title"
 	aria-describedby="modal-description"
 >
-	<div class="modal-box flex max-h-[90vh] w-11/12 max-w-6xl flex-col overflow-hidden p-0">
+	<!-- `contrast-more:` statt eines @media-Blocks im Style-Block: Beides sind reine
+	     Utilities (Rahmenbreite am Dialog, Rahmenfarbe an Kopf- und Fußleiste), und
+	     die Variante erzeugt `prefers-contrast: more` — den Wert, den die Engines
+	     auswerten. Bis 2026-08-09 stand das unter `prefers-contrast: high`; `high`
+	     war der Entwurfsname des Merkmals und greift nirgends (gemessen in Chromium
+	     151 und WebKit 26.5, Beleg in e2e/helpers/bannedMediaFeatures.ts). Mit dem
+	     Umzug entfällt die Klasse `modal-section`: Sie existierte nur als Anker für
+	     jene Regel — die Leisten stehen im Markup direkt nebeneinander, die beiden
+	     EXIF-Kästchen im Inneren (ebenfalls bg-base-200, aber ohne Rahmen) bleiben
+	     wie zuvor unberührt. -->
+	<div
+		class="modal-box flex max-h-[90vh] w-11/12 max-w-6xl flex-col overflow-hidden p-0 contrast-more:border-2"
+	>
 		<!-- Modal Header -->
 		<div
-			class="bg-base-200 border-base-300 modal-section flex items-center justify-between border-b p-4"
+			class="bg-base-200 border-base-300 flex items-center justify-between border-b p-4 contrast-more:border-current"
 		>
 			<div class="flex min-w-0 flex-1 items-center gap-3">
 				<Icon icon="lucide:file-type" width="20" class="text-primary flex-shrink-0" />
@@ -172,7 +184,7 @@
 		</div>
 
 		<!-- Modal Footer -->
-		<div class="bg-base-200 border-base-300 modal-section space-y-4 border-t p-4">
+		<div class="bg-base-200 border-base-300 space-y-4 border-t p-4 contrast-more:border-current">
 			<!-- Basis-Informationen -->
 			<div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-3">
 				<div class="flex items-center gap-2">
@@ -362,22 +374,6 @@
 		img,
 		video {
 			transition: none;
-		}
-	}
-
-	/* High contrast mode support */
-	@media (prefers-contrast: high) {
-		.modal-box {
-			border: 2px solid;
-		}
-
-		/* Kopf- und Fußleiste des Dialogs. Zielt auf `.modal-section` und nicht
-		   mehr auf `.bg-base-200`: Die Utility-Klasse trugen auch die beiden
-		   EXIF-Kästchen im Inneren, die gar keinen Rahmen haben — die Regel lief
-		   dort ins Leere und band gleichzeitig eine Zusage an einen Klassennamen,
-		   der jederzeit gegen einen anderen Farbton getauscht werden kann. */
-		.modal-section {
-			border-color: currentColor;
 		}
 	}
 

--- a/src/lib/components/media/MediaThumbnail.svelte
+++ b/src/lib/components/media/MediaThumbnail.svelte
@@ -59,8 +59,14 @@
 	}
 </script>
 
+<!-- `contrast-more:border` statt eines @media-Blocks im Style-Block: Die Regel setzt
+     nur eine Rahmenbreite, und die Tailwind-Variante erzeugt dafür das
+     Media-Feature, das die Engines tatsächlich auswerten. Bis 2026-08-09 stand
+     hier `@media (prefers-contrast: high)` — `high` war der Entwurfsname, Level 5
+     kennt `more`, und der Block war deshalb seit seiner Einführung tot (gemessen
+     in Chromium 151 und WebKit 26.5, Beleg in e2e/helpers/bannedMediaFeatures.ts). -->
 <div
-	class="media-thumbnail group bg-base-100 shadow-raised duration-instant hover:shadow-floating relative cursor-pointer overflow-hidden rounded-lg transition-all hover:scale-105"
+	class="media-thumbnail group bg-base-100 shadow-raised duration-instant hover:shadow-floating relative cursor-pointer overflow-hidden rounded-lg transition-all hover:scale-105 contrast-more:border"
 	onclick={handleClick}
 	onkeydown={handleKeydown}
 	tabindex="0"
@@ -98,9 +104,16 @@
 			     dem 2026-07-30 als --scrim-surface in tokens.css. Ein Schleier ist
 			     keine Fläche des Themes, sondern eine Abdunklung des Fotos darunter —
 			     die Begründung, warum das Token neutrales Schwarz ist und nicht
-			     bg-neutral, steht dort. -->
+			     bg-neutral, steht dort.
+
+			     Bei erhöhtem Kontrast wird der Schleier fast undurchsichtig — /90 statt
+			     /60, damit das Icon nicht mehr vom Foto darunter abhängt. Das stand
+			     bis 2026-08-09 als color-mix() in einem toten
+			     `@media (prefers-contrast: high)`-Block; als Deckkraft-Suffix an der
+			     Aufrufstelle hängt der Wert jetzt am Zweig, der ihn braucht. Der
+			     Video-Zweig unten bleibt deshalb bei /20. -->
 			<div
-				class="bg-scrim/60 thumbnail-overlay absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+				class="bg-scrim/60 thumbnail-overlay contrast-more:group-hover:bg-scrim/90 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 			>
 				<Icon icon="lucide:eye" width="24" class="text-on-scrim" />
 			</div>
@@ -175,7 +188,7 @@
 			     Foto und Video war das kein „hängt vom Inhalt ab", sondern ein fester,
 			     zu niedriger Wert. Mit /60 sind es 7,34:1. -->
 			<div
-				class="bg-scrim/60 thumbnail-overlay absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
+				class="bg-scrim/60 thumbnail-overlay contrast-more:group-hover:bg-scrim/90 absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover:opacity-100"
 			>
 				<Icon icon="lucide:download" width="20" class="text-on-scrim" />
 			</div>
@@ -275,24 +288,6 @@
 		.thumbnail-overlay {
 			transition: none;
 			transform: none;
-		}
-	}
-
-	/* High contrast mode support */
-	@media (prefers-contrast: high) {
-		.media-thumbnail {
-			border: 1px solid;
-		}
-
-		/* Der Schleier wird im Hochkontrast-Modus fast undurchsichtig. Der Wert
-		   kommt aus --scrim-surface, nicht als rgba(0,0,0,.9) — es ist derselbe
-		   Ton wie beim bg-scrim/60 im Markup, nur dichter, und ein Farbwert
-		   gehört auch hier nur einmal ins Projekt (tokens.css). Bis 2026-08-09
-		   stand hier ein rohes rgba(): Der Klassen-Scan konnte es strukturell
-		   nicht melden, weil in einer CSS-Deklaration keine Klasse steht. Genau
-		   dafür gibt es jetzt e2e/helpers/bannedCss.ts. */
-		.media-thumbnail:hover .thumbnail-overlay {
-			background-color: color-mix(in oklab, var(--scrim-surface) 90%, transparent);
 		}
 	}
 

--- a/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
+++ b/src/lib/report/components/form/fields/SpeciesIdentificationHelp.svelte
@@ -267,9 +267,15 @@
 											>
 												{#each species.images as image (image.src)}
 													<div class="text-center">
+														<!-- `contrast-more:hover:outline-2` statt eines @media-Blocks im
+														     Style-Block: eine reine Utility, und die Variante erzeugt
+														     `prefers-contrast: more`. Bis 2026-08-09 stand die Regel unter
+														     `prefers-contrast: high` — dem Entwurfsnamen des Merkmals, den
+														     keine Engine auswertet (gemessen in Chromium 151 und WebKit 26.5,
+														     Beleg in e2e/helpers/bannedMediaFeatures.ts). -->
 														<button
 															type="button"
-															class="group shadow-raised hover:shadow-floating duration-instant relative overflow-hidden rounded-lg transition-all"
+															class="group shadow-raised hover:shadow-floating duration-instant relative overflow-hidden rounded-lg transition-all contrast-more:hover:outline-2"
 															onclick={() => openImageModal(image.src, image.alt, image.copyright)}
 															aria-label={`${image.alt} in Originalgröße anzeigen`}
 														>
@@ -505,7 +511,8 @@
 	data-testid="species-image-dialog"
 	onclose={handleDialogClose}
 >
-	<div class="modal-box w-11/12 max-w-5xl p-0">
+	<!-- Rahmen bei erhöhtem Kontrast, siehe die Begründung am Artfoto-Knopf oben. -->
+	<div class="modal-box w-11/12 max-w-5xl p-0 contrast-more:border-2">
 		{#if modalImageSrc}
 			<div class="relative">
 				<!-- Modal Header -->
@@ -656,16 +663,6 @@
 		.avatar .mask,
 		button {
 			transition: none;
-		}
-	}
-
-	@media (prefers-contrast: high) {
-		.group:hover {
-			outline: 2px solid;
-		}
-
-		.modal-box {
-			border: 2px solid;
 		}
 	}
 </style>


### PR DESCRIPTION
## Was war

Drei Komponenten trugen einen `@media (prefers-contrast: high)`-Block:
`MediaThumbnail.svelte`, `MediaModal.svelte`, `SpeciesIdentificationHelp.svelte`.
`high` war der Entwurfsname des Merkmals — Media Queries Level 5 kennt
`no-preference | more | less | custom`.

## Gemessen statt vermutet (2026-08-09)

Playwright 1.62, Kontext-Option `contrast: 'more'` (= aktivierte Kontrasterhöhung):

| Query | Chromium 151 | WebKit 26.5 |
| --- | --- | --- |
| `(prefers-contrast: more)` | trifft zu | trifft zu |
| `(prefers-contrast: high)` | trifft **nie** zu | trifft **nie** zu |

Gegengeprüft nicht nur über `matchMedia`, sondern über eine echte Regel: eine
Deklaration unter `high` setzt auch bei aktiver Kontrasterhöhung nichts
(`border-width` bleibt `0px`, unter `more` sind es die gesetzten `7px`). Die drei
Blöcke waren damit **seit ihrer Einführung tot** — syntaktisch in Ordnung, deshalb
meldet weder Linter noch Browser etwas.

Firefox ließ sich nicht messen (Playwright-Browser auf dieser Maschine nicht
installiert). Gemessen wurde über die Engine-Emulation, nicht über die
macOS-Systemeinstellung — derselbe Auswertungspfad, der Vollständigkeit halber genannt.

## Was jetzt

Alle drei `@media`-Blöcke entfallen ersatzlos; die Regeln setzen ausschließlich
Utilities und stehen als `contrast-more:`-Varianten im Markup:

- **MediaThumbnail** — `contrast-more:border` an der Kachel, `contrast-more:group-hover:bg-scrim/90` an den Schleiern
- **MediaModal** — `contrast-more:border-2` am Dialog, `contrast-more:border-current` an Kopf- und Fußleiste
- **SpeciesIdentificationHelp** — `contrast-more:hover:outline-2` am Artfoto-Knopf, `contrast-more:border-2` am Dialog

## Für Reviewer: zwei Stellen ändern sich inhaltlich

Weil die Regeln erstmals überhaupt greifen, ist „1:1 übertragen" hier nicht in
allen Punkten das Richtige gewesen:

1. **Der `/20`-Schleier im Video-Zweig bleibt `/20`.** Die alte CSS-Regel zielte auf
   `.media-thumbnail:hover .thumbnail-overlay` und hätte beim Aktivieren *alle drei*
   Overlays auf 90 % gezogen — auch den, der laut Markup-Kommentar und
   `design-system.md` bewusst leicht ist (kein Vordergrund, reine Andeutung über dem
   Videobild). Die Verdichtung hängt jetzt an den zwei `/60`-Overlays, die ein Icon tragen.
2. **Die Klasse `modal-section` entfällt.** Sie existierte nur als Anker jener Regel;
   die beiden EXIF-Kästchen im Inneren bleiben wie zuvor unberührt.

## Guard

Neuer Quelltext-Scan `e2e/helpers/bannedMediaFeatures.ts` + Test, Muster wie
`bannedCss.ts` (konstruierte Beispiele stellen die Regel scharf, der Bestands-Scan
hält sie durch), läuft in `npm run test:quick`. Zuerst rot mit genau den drei
bekannten Fundstellen, jetzt grün. `prefers-contrast: low` steht mit in der Regel,
obwohl es keine Fundstelle hat — wer den einen Entwurfswert aus einer alten Vorlage
kopiert, kopiert auch den anderen.

Das Messergebnis ist mit Datum in `bannedMediaFeatures.ts` und in
`.claude/rules/design-system.md` dokumentiert.

**Stolperfalle, die dabei auffiel:** Ein Markup-Kommentar mit dem Literal `<style>`
darin wird von `extractStyleBlocks` als echter Style-Block gelesen — der Farbscan
meldete daraufhin Hex-Werte aus benachbarter Prosa. Die Kommentare schreiben deshalb
„Style-Block".

## Verifikation

- `npm run test:quick` grün (4319 Tests; die zwei `any`-Lint-Warnungen sind vorbestehend in `src/tests/contract/helpers/createEvent.ts`)
- Produktions-Build gebaut, ausgeliefertes CSS geprüft: alle fünf Utilities landen unter `@media (prefers-contrast:more)`, `prefers-contrast: high` kommt im Bundle nicht mehr vor
- Nachgemessen, dass `outline-2` in beiden Engines dasselbe ergibt wie das alte `outline: 2px solid` (`solid 2px currentColor`)

Hintergrund: entstanden beim daisyUI-Aufräumen von `SpeciesIdentificationHelp` im
Anschluss an #819 — dort bewusst liegen gelassen, weil der Merkmalswert alle drei
Dateien gleichzeitig betrifft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)