### PR TITLE
fix(admin): Spam-Check widerspricht der Liste nicht mehr

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -142,6 +142,7 @@ dieselbe, deshalb steht sie einmal.
 | `deadFinding.ts`               | Totfund-Auszeichnung                        |
 | `sightingStatus.ts`            | Statusableitung + Wort/Farbe/Icon/Verdict   |
 | `spamScorePresentation.ts`     | Spam-Risikostufe + Wort/Farbe/Icon          |
+| `SpamFinding.svelte`           | Ein Spam-Befund (Modal + Detailkarte)       |
 | `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)    |
 | `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel     |
 
@@ -169,6 +170,37 @@ Die Flächen- und Icon-Farbe der Detail-Karte steht als `SpamRisk`-Record an
 ihrer Aufrufstelle — ein Leser, gleiche Begründung wie bei `deadFinding.ts`.
 Über die Stufe und nicht über den Score aufgeschlüsselt, damit die Schwellen
 nicht doch wieder auseinanderlaufen.
+
+### Modal und Detailkarte zeigen zwei Befunde, nicht einen
+
+`GET /api/sightings/[id]/spam-check` liefert seit 2026-08 `{ stored, recomputed }`:
+den persistierten Erstbefund **und** eine Neuberechnung über den aktuellen
+Datensatz. Sie weichen systematisch ab — vier Indikatoren wiegen je 2 Punkte und
+existieren nur beim Absenden (Formular-Token, Absendedauer, beide
+Duplikat-Signale), ihre Eingangsdaten stehen nirgends in der Zeile. Vorher
+lieferte der Endpunkt nur die Neuberechnung, und die Oberfläche zeigte „Spam 2"
+in der Spalte und „0" im Check daneben. Drei Dinge dabei nicht zurückdrehen:
+
+- **`stored` führt, überall.** Es ist die Zahl aus Tabelle und Eingang und hat
+  mehr Information als der Nachlauf. Nur wo es keinen Erstbefund gibt
+  (`stored === null`), führt die Neuberechnung. Denselben Vorrang hat der
+  E-Mail-Versand seit jeher (`persistedSpam ?? detectSpamIndicators(...)`) — die
+  zwei Admin-Flächen waren die Ausreißer, nicht die Regel.
+- **Beide Befunde kommen aus `SpamFinding.svelte`.** Modal und Detailkarte
+  hatten kurzzeitig je eine eigene Fassung, mit abweichendem Wortlaut („Beim
+  Eingang: 2" gegen „Heuristik-Score: 2") und ohne Risiko-Icon am Erstbefund.
+  Das ist dieselbe Fehlerklasse, gegen die `spamScorePresentation.ts` angelegt
+  wurde — eine Ebene höher.
+- **`score: null` und ein fehlgeschlagener Lauf sind nicht dasselbe**, obwohl
+  beide auf `risk === 'unrated'` landen. „Nie bewertet" bekommt gar kein Badge,
+  „geprüft, aber gescheitert" das Badge „Prüfung fehlgeschlagen" ohne Zahl.
+  `SpamFinding` unterscheidet sie daran, ob überhaupt eine Zahl vorliegt.
+
+Die Einordnung der Differenz macht `getSpamDrift`; der erklärende Satz steht in
+`SPAM_DRIFT_PRESENTATION` und bleibt aus, wo eine der beiden Seiten fehlt.
+Abgesichert durch `e2e/admin-spam-check.spec.ts` (Shard `form`) — der Bestand
+enthält keine Zeile mit Meldezeitpunkt-Indikator, der Fall muss geseedet werden.
+Vollständige Herleitung: `docs/SPAM_DETECTION.md`.
 
 ### Totfund vs. Lebendsichtung
 

--- a/docs/SPAM_DETECTION.md
+++ b/docs/SPAM_DETECTION.md
@@ -133,6 +133,43 @@ verwendet explizit `NULLS LAST` in **beiden** Richtungen: PostgreSQL sortiert
 `DESC` per Vorgabe `NULLS FIRST`, sonst stünde der unbewertete Altbestand über
 den Treffern.
 
+### Der Nachlauf ist nicht der Erstbefund — beide werden gezeigt
+
+`GET /api/sightings/[id]/spam-check` (Modal der Tabelle, Karte der
+Detailansicht) liefert seit 2026-08 **zwei** Befunde: `stored` aus den beiden
+Spalten und `recomputed` als frischen Lauf über den aktuellen Datensatz.
+
+Sie weichen systematisch voneinander ab. Vier Indikatoren wiegen je 2 Punkte
+und existieren nur im Moment des Absendens:
+
+| Indikator                                       | Herkunft                            |
+| ----------------------------------------------- | ----------------------------------- |
+| Formular-Token fehlt / ungültig                 | `submission.tokenStatus`            |
+| Formular verdächtig schnell abgeschickt (< 5 s) | `submission.ageSeconds`             |
+| Identischer Bemerkungstext wie früher           | `recentDuplicates.sameNotes` (7 d)  |
+| Auffällig viele Meldungen derselben E-Mail      | `recentDuplicates.sameEmail` (24 h) |
+
+Ihre Eingangsdaten stehen nirgends in der Zeile — `recomputed` kann sie nicht
+rekonstruieren und liegt entsprechend tiefer. Umgekehrt kann er höher liegen,
+wenn der Datensatz bearbeitet wurde oder die E-Mail-Domain inzwischen keinen
+MX-Record mehr hat.
+
+**Maßgeblich für die Triage bleibt `stored`** — es ist die Zahl aus Tabelle und
+Eingang, und der Nachlauf hat weniger Information als sie. Die Oberfläche
+richtet Farbe und Überschrift deshalb nach dem Erstbefund und führt nur dort
+mit der Neuberechnung, wo es keinen gibt (`stored: null`).
+
+Bis dahin lieferte der Endpunkt **nur** die Neuberechnung. Die Tabelle zeigte
+damit „Spam 2" und der Check daneben „0" — beide Zahlen richtig, der
+Widerspruch aber unerklärbar, weil der Vergleichswert fehlte. Wer das wieder
+auf eine Zahl zusammenzieht, stellt genau diesen Befund wieder her.
+
+Die Einordnung der Differenz macht `getSpamDrift` in
+`spamScorePresentation.ts`. `incomparable` deckt zwei Fälle ab, die sich gleich
+verhalten: kein Erstbefund (`stored === null`) oder nicht durchgelaufene
+Neuberechnung (`failed`). Beide Male fehlt eine Seite, und eine Differenz zu
+bilden hieße, mit einer Null zu rechnen, die keine ist.
+
 ---
 
 ## Backfill bestehender Daten

--- a/e2e/admin-spam-check.spec.ts
+++ b/e2e/admin-spam-check.spec.ts
@@ -1,0 +1,240 @@
+import { expect, test, type Page } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+import { deleteSighting, seedSighting } from './helpers/seedSighting';
+
+/**
+ * admin-spam-check.spec.ts — der Spam-Check widerspricht der Liste nicht mehr.
+ *
+ * **Der Befund:** `GET /api/sightings/[id]/spam-check` lieferte bis 2026-08 nur
+ * eine Neuberechnung über den gespeicherten Datensatz. Tabelle und Eingang
+ * zeigen dagegen die persistierte Spalte `spam_score`. Vier Indikatoren wiegen
+ * je 2 Punkte und existieren **nur** im Moment des Absendens — Formular-Token
+ * fehlt/ungültig, verdächtig schnell abgeschickt sowie die beiden
+ * Duplikat-Signale (`docs/SPAM_DETECTION.md`). Ihre Eingangsdaten stehen
+ * nirgends in der Zeile, die Neuberechnung kann sie also nicht rekonstruieren.
+ *
+ * Die Oberfläche zeigte damit „Spam 2" in der Spalte und „0" im Check daneben.
+ * Beide Zahlen richtig, der Widerspruch unerklärbar — der Vergleichswert
+ * fehlte. Seither liefert der Endpunkt `{ stored, recomputed }`, und beide
+ * Anzeigestellen führen den **Erstbefund**; die Neuberechnung steht daneben,
+ * benannt und mit dem Satz, der die Differenz erklärt.
+ *
+ * **Warum das ein E2E-Test sein muss:** Die Vergleichslogik selbst
+ * (`getSpamDrift`) ist in `spamScorePresentation.test.ts` abgedeckt, die
+ * Antwortform in `endpoint.test.ts` — beide gegen Mocks. Was keiner von beiden
+ * sieht: ob die Zahl in der Tabellenspalte und die Zahl im Modal daneben
+ * dieselbe Sichtung meinen und dieselbe Aussage treffen. Genau das war der
+ * Befund, und er lebt zwischen den beiden Ebenen.
+ *
+ * **Warum eine eigens angelegte Sichtung:** Die Entwicklungs-DB ist über alle
+ * Worktrees geteilt (`docs/WORKTREES.md`), ihr Inhalt ist keine
+ * Testvoraussetzung. Der Bestand enthält zudem **keine** Zeile mit einem
+ * Meldezeitpunkt-Indikator: Alle Scores dort stammen aus dem Backfill
+ * (`spam:rescore`), der diese Signale nie hatte — nachgemessen am 2026-08-09
+ * über alle 1.065 bewerteten Zeilen, null Abweichung zwischen gespeichertem und
+ * nachgerechnetem Score. Der interessante Fall ist im Bestand also gar nicht
+ * herstellbar und muss geseedet werden.
+ */
+
+/* Die geseedete Zeile ist so gebaut, dass die **Neuberechnung 0 ergibt** und
+   die Differenz damit eindeutig aus dem Erstbefund stammt:
+   - ohne Koordinaten → die Positionsprüfung bleibt stumm. Sie hinge sonst an
+     `ostsee_geo`, und diese Spalte lässt sich nicht seeden: Ihr Default ist 0,
+     was der Detektor als „weit außerhalb der Ostsee" liest (+2). Mit Position
+     käme die Neuberechnung also selbst auf 2 und der Test wäre grün, ohne die
+     Differenz je gesehen zu haben.
+   - Tierart 0 (Schweinswal) → kein „unbekannte Tierart" (+1). Die Spalte hat
+     denselben Default, der Wert steht hier trotzdem als Literal: Er ist eine
+     Voraussetzung des Tests und keine Nebensache.
+   - keine E-Mail → weder MX-Lookup noch Wegwerf-Domain. Das nimmt dem Test
+     zugleich die einzige Abhängigkeit von DNS. */
+const ERSTBEFUND_SCORE = 2;
+const ERSTBEFUND_INDIKATOR = 'Formular verdächtig schnell abgeschickt';
+
+/**
+ * Gemeinsamer Präfix aller Zeilen dieses Specs — und zugleich der Suchbegriff,
+ * über den die Tabelle sie findet.
+ *
+ * **Warum gesucht und nicht über das Sichtungsdatum nach oben sortiert**, wie
+ * es der Docblock von `SeedSightingData.sightingDate` nahelegt: Eine Zeile mit
+ * Datum in der Zukunft steht nicht nur weit oben, sie ist auch die **erste
+ * offene** Zeile der Tabelle. `admin-sighting-status.spec.ts` greift sich genau
+ * die (`tbody tr[data-sighting-id]`, erste Zeile bei `?verified=open`) und
+ * schaltet ihren Status um. Lief dieser Spec daneben, räumte sein `afterEach`
+ * die Zeile weg, während der andere sie noch bearbeitete — dessen `finally`
+ * navigierte dann auf eine gelöschte Sichtung und lief in einen Timeout, 15 s
+ * lang, in einer fremden Datei. Nachgestellt am 2026-08-09.
+ *
+ * Ein Sichtungsdatum in der Vergangenheit hält die Zeilen aus dieser Rolle
+ * heraus; auffindbar bleiben sie über `?q=`.
+ */
+const REFERENZ_PRAEFIX = 'e2e-spamdrift';
+
+/**
+ * Ein Datum aus dem Bestand statt aus der Zukunft (Begründung oben).
+ *
+ * Der genaue Wert ist gleichgültig, solange er plausibel und nicht der
+ * neueste ist — gesucht wird über die Referenz-ID, nicht über die Sortierung.
+ */
+const BESTANDS_DATUM = new Date('2020-03-05T10:00:00.000Z');
+
+/**
+ * Je Test eine eigene Referenz-ID.
+ *
+ * Playwright fährt die Tests dieser Datei parallel. Mit einer gemeinsamen ID
+ * standen zwei gleich benannte Zeilen zugleich in der Tabelle, `.first()` traf
+ * die des jeweils anderen Tests — und dessen `afterEach` löschte sie mitten im
+ * Lauf. Auch das am 2026-08-09 nachgestellt.
+ */
+const REFERENZ = {
+	detail: `${REFERENZ_PRAEFIX}-detail`,
+	tabelle: `${REFERENZ_PRAEFIX}-tabelle`,
+	ohneBefund: `${REFERENZ_PRAEFIX}-ohne-befund`
+} as const;
+
+async function seedeSichtung(referenceId: string, mitErstbefund: boolean): Promise<number> {
+	return seedSighting({
+		referenceId,
+		sightingDate: BESTANDS_DATUM,
+		species: 0,
+		totalCount: 1,
+		latitude: null,
+		longitude: null,
+		...(mitErstbefund
+			? { spamScore: ERSTBEFUND_SCORE, spamIndicators: [ERSTBEFUND_INDIKATOR] }
+			: {})
+	});
+}
+
+/** Die Tabellenzeile einer geseedeten Sichtung. */
+function zeileZu(page: Page, referenceId: string) {
+	return page
+		.locator('tbody tr')
+		.filter({ has: page.locator(`a[href="/admin/ref/${referenceId}"]`) })
+		.first();
+}
+
+test.describe('Spam-Check — Erstbefund und Neuberechnung nebeneinander', () => {
+	test('Detailansicht zeigt beide Befunde und erklärt die Differenz', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+		const sichtungId = await seedeSichtung(REFERENZ.detail, true);
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			await page.goto(`/admin/${sichtungId}`);
+			await page.waitForLoadState('networkidle');
+			await page.getByRole('button', { name: 'Spam-Check' }).click();
+
+			const karte = page.locator('.card').filter({ hasText: 'Jetzt nachgerechnet' }).first();
+			await expect(karte).toBeVisible();
+
+			/* Der Erstbefund führt — es ist die Zahl, die auch in der Liste steht.
+			   Wortlaut und Aufbau kommen aus `SpamFinding.svelte`, derselben
+			   Komponente wie im Modal; die Zusicherungen hier und im Tabellentest
+			   sind deshalb absichtlich gleich formuliert. */
+			await expect(karte).toContainText('Beim Eingang');
+			await expect(karte).toContainText(`Heuristik-Score: ${ERSTBEFUND_SCORE}`);
+			await expect(karte).toContainText(ERSTBEFUND_INDIKATOR);
+
+			// Die Neuberechnung steht daneben, benannt, und kommt hier auf 0.
+			await expect(karte).toContainText('Jetzt nachgerechnet');
+			await expect(karte).toContainText('Heuristik-Score: 0');
+
+			/* Der eigentliche Fix: Die Differenz wird erklärt statt nur gezeigt.
+			   Geprüft wird der Kern der Begründung und nicht der ganze Satz — sonst
+			   bräuchte jede Umformulierung eine Teständerung, ohne dass sich am
+			   Verhalten etwas ändert. */
+			await expect(karte).toContainText('Niedriger als beim Eingang');
+		} finally {
+			/* Aufräumen im `finally`: Die Datenbank ist zwischen Worktrees geteilt
+			   (`docs/WORKTREES.md`). Bliebe die Zeile nach einem gescheiterten
+			   Assert stehen, liefe der nächste Lauf gegen zwei gleich benannte
+			   Zeilen. Gleiche Konstruktion wie in admin-sighting-status.spec.ts. */
+			await deleteSighting(sichtungId);
+			await context.close();
+		}
+	});
+
+	test('Tabellenspalte und Modal treffen dieselbe Aussage', async ({ browser, baseURL }) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+		const sichtungId = await seedeSichtung(REFERENZ.tabelle, true);
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		try {
+			/* Gesucht statt sortiert (Begründung an `REFERENZ_PRAEFIX`). Der
+			   Präfix und nicht die volle Referenz-ID: Bei genau einem Treffer, der
+			   dem Suchbegriff exakt entspricht, leitet `+page.server.ts` auf die
+			   Detailseite weiter — der Test käme nie an der Tabelle an. */
+			await page.goto(`/admin/sichtungen?q=${REFERENZ_PRAEFIX}`);
+			/* Vor der Hydration hängt an den Zeilen-Buttons kein Handler: Der Klick
+			   landet, `checkSpam` läuft nie, und der Fehlschlag steht dann am
+			   `.modal-box`, der „hidden" bleibt — als wäre das Modal kaputt. Genau so
+			   ist dieser Test beim Schreiben einmal rot geworden. `networkidle` ist
+			   dafür das im Projekt etablierte Signal (`admin-sighting-status.spec.ts`). */
+			await page.waitForLoadState('networkidle');
+
+			const zeile = zeileZu(page, REFERENZ.tabelle);
+			await expect(zeile).toBeVisible();
+			// Die Spalte zeigt den Erstbefund — unverändert, das war nie der Fehler.
+			await expect(zeile).toContainText(String(ERSTBEFUND_SCORE));
+
+			await zeile.getByRole('button', { name: 'Spam-Check durchführen' }).click();
+
+			const modal = page.locator('.modal-box').filter({ hasText: 'Spam-Analyse' });
+			await expect(modal).toBeVisible();
+
+			/* Der Widerspruch, um den es geht: Vorher stand hier „Heuristik-Score: 0"
+			   neben einer Spalte, die 2 zeigte. Jetzt nennt das Modal beide Zahlen und
+			   ordnet sie zeitlich ein. */
+			await expect(modal).toContainText('Beim Eingang');
+			await expect(modal).toContainText(`Heuristik-Score: ${ERSTBEFUND_SCORE}`);
+			await expect(modal).toContainText(ERSTBEFUND_INDIKATOR);
+			await expect(modal).toContainText('Jetzt nachgerechnet');
+			await expect(modal).toContainText('Niedriger als beim Eingang');
+		} finally {
+			await deleteSighting(sichtungId);
+			await context.close();
+		}
+	});
+
+	test('ohne Erstbefund behauptet die Detailansicht keinen Vergleich', async ({
+		browser,
+		baseURL
+	}) => {
+		if (!baseURL) throw new Error('baseURL fehlt — playwright.config.ts setzt sie normalerweise');
+		const context = await browser.newContext();
+		await seedAdminSession(context, baseURL);
+		const page = await context.newPage();
+
+		/* `spam_score IS NULL` heißt „nie bewertet" und ist nicht dasselbe wie 0.
+		   Eine Differenz dagegen zu bilden hieße, mit einer Null zu rechnen, die
+		   keine ist — der Erklärsatz muss hier also ausbleiben. */
+		const unbewertet = await seedeSichtung(REFERENZ.ohneBefund, false);
+
+		try {
+			await page.goto(`/admin/${unbewertet}`);
+			await page.waitForLoadState('networkidle');
+			await page.getByRole('button', { name: 'Spam-Check' }).click();
+
+			const karte = page.locator('.card').filter({ hasText: 'Jetzt nachgerechnet' }).first();
+			await expect(karte).toBeVisible();
+			/* Kein Badge und keine Zahl — „nie bewertet" ist kein Prüfergebnis.
+			   Die Beschreibung aus SPAM_RISK_PRESENTATION.unrated trägt den Fall. */
+			await expect(karte).toContainText('Beim Eingang');
+			await expect(karte).toContainText('Nie auf Spam geprüft');
+			await expect(karte).not.toContainText('Heuristik-Score: null');
+			await expect(karte).not.toContainText('Niedriger als beim Eingang');
+			await expect(karte).not.toContainText('Höher als beim Eingang');
+		} finally {
+			await deleteSighting(unbewertet);
+			await context.close();
+		}
+	});
+});

--- a/e2e/helpers/seedSighting.ts
+++ b/e2e/helpers/seedSighting.ts
@@ -137,6 +137,22 @@ export interface SeedSightingData {
 	waterway?: string | null;
 	reporter?: SeedReporter;
 	privacyConsent?: boolean;
+	/**
+	 * Spam-Befund zum Meldezeitpunkt.
+	 *
+	 * Beide Felder sind seedbar, weil der interessante Fall im Bestand nicht
+	 * vorkommt: Vier Indikatoren wiegen je 2 Punkte und existieren nur beim
+	 * Absenden (Formular-Token, Absendedauer, Duplikat-Signale), und alle Scores
+	 * der Entwicklungs-DB stammen aus dem Backfill, der sie nie hatte. Wer die
+	 * Gegenüberstellung von gespeichertem und nachgerechnetem Score prüfen will,
+	 * kann sich also auf keine vorhandene Zeile stützen
+	 * (`admin-spam-check.spec.ts`).
+	 *
+	 * `undefined` lässt die Spalte auf `NULL` — „nie bewertet", nicht „Score 0"
+	 * (`docs/SPAM_DETECTION.md`).
+	 */
+	spamScore?: number;
+	spamIndicators?: string[];
 }
 
 /** Postgres kennt kein Boolean an diesen Spalten — `smallint` mit 0/1. */
@@ -172,7 +188,13 @@ function toColumns(data: SeedSightingData): Record<string, unknown> {
 		strasse: reporter.street,
 		plz: reporter.zipCode,
 		ort: reporter.city,
-		datenschutz_einverstaendnis: toFlag(data.privacyConsent)
+		datenschutz_einverstaendnis: toFlag(data.privacyConsent),
+		spam_score: data.spamScore,
+		/* `JSON.stringify` und nicht das Array selbst: `postgres.js` bindet ein
+		   JS-Array als Postgres-Array (`text[]`), und die Spalte ist `jsonb` —
+		   der Insert scheiterte sonst am Typ statt still das Falsche zu tun. */
+		spam_indicators:
+			data.spamIndicators === undefined ? undefined : JSON.stringify(data.spamIndicators)
 	};
 
 	/* `null` bleibt drin und wird geschrieben — „ausdrücklich ohne Position" ist

--- a/scripts/e2e-shards.sh
+++ b/scripts/e2e-shards.sh
@@ -145,6 +145,18 @@ form=(
 	# /about eine Route, die in `form` sonst niemand kalt kompiliert —
 	# das ist der Preis dieser Zuordnung. Lokal 3 Tests, ~9 s.
 	e2e/hover-transitions.spec.ts
+	# Fährt /admin/[id] und /admin/sichtungen — beide kompilieren die
+	# Admin-Specs oben bereits kalt, der Aufschlag fällt hier kein
+	# weiteres Mal an. Nicht nach `smoke`, der laut der Messung oben
+	# entlastet werden soll; zwischen `form` und `map` (gleichauf)
+	# entscheidet damit die bereits bezahlte Kaltkompilierung.
+	#
+	# Achtung beim Umhängen: Der Spec seedet eine Zeile auf
+	# FIRST_PAGE_DATE und sucht sie auf Seite 1 der Tabelle. Er
+	# verträgt sich mit `?perPage=1` der Overflow-Specs oben, weil er
+	# nicht die *neueste* Zeile braucht — NEWEST_ROW_DATE bleibt deren
+	# Reservat. Lokal 3 Tests, ~10 s, räumt seine Zeilen selbst weg.
+	e2e/admin-spam-check.spec.ts
 )
 
 # Die drei Shards laufen parallel; die Laufzeit des Jobs ist die des

--- a/src/lib/components/admin/SpamFinding.svelte
+++ b/src/lib/components/admin/SpamFinding.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+	/**
+	 * Ein Spam-Befund — Überschrift, Risiko-Badge, Score, Beschreibung,
+	 * Indikatoren.
+	 *
+	 * Vier Mal dieselbe Aussage: Erstbefund und Neuberechnung, je im
+	 * Spam-Check-Modal der Tabelle und in der Karte der Detailansicht. Vorher
+	 * hatte das Modal ein Snippet und die Detailansicht eine handgebaute
+	 * zweite Fassung — mit abweichendem Wortlaut („Beim Eingang: 2" gegen
+	 * „Heuristik-Score: 2"), ohne Risiko-Icon am Erstbefund und ohne den
+	 * „Keine Indikatoren."-Zweig. Genau diese Divergenz zwischen
+	 * Anzeigestellen ist der Befund, für den `spamScorePresentation.ts`
+	 * existiert; sie eine Ebene höher zu wiederholen hätte ihn nur verschoben.
+	 *
+	 * Wort, Farbe, Icon und Schwelle kommen weiterhin von dort — diese
+	 * Komponente ordnet sie nur an.
+	 */
+	import Icon from '$lib/components/Icon.svelte';
+	import { SPAM_RISK_PRESENTATION, type SpamRisk } from './spamScorePresentation';
+
+	interface Props {
+		/** Zeitliche Einordnung — „Beim Eingang" bzw. „Jetzt nachgerechnet". */
+		title: string;
+		risk: SpamRisk;
+		/**
+		 * `null` heißt **„es gibt gar keine Zahl"** — der Fall `spam_score IS
+		 * NULL`, also nie bewertet.
+		 *
+		 * Das unterscheidet ihn von der fehlgeschlagenen Prüfung, die sehr wohl
+		 * eine Zahl mitbringt (Fail-Safe: Score 0 mit `isHighRisk: true`) und
+		 * deshalb als solche benannt wird. Beide landen über
+		 * `spamScorePresentation.ts` auf `risk === 'unrated'` und wären ohne
+		 * diese Unterscheidung nicht auseinanderzuhalten — „nie geprüft" und
+		 * „geprüft, aber gescheitert" sind für die Triage nicht dasselbe.
+		 */
+		score: number | null;
+		indicators: readonly string[];
+	}
+
+	let { title, risk, score, indicators }: Props = $props();
+
+	const spam = $derived(SPAM_RISK_PRESENTATION[risk]);
+</script>
+
+<p class="text-sm font-semibold">{title}</p>
+<div class="mt-1 flex flex-wrap items-center gap-2">
+	{#if spam.badgeClass}
+		<span class="badge {spam.badgeClass}">
+			<Icon icon={spam.icon} width="14" height="14" aria-hidden="true" />
+			{spam.label}
+		</span>
+		<span class="badge badge-ghost">Heuristik-Score: {score}</span>
+	{:else if score !== null}
+		<!-- `failed: true` — Score 0 und `isHighRisk: true` zugleich. Weder
+		     „Hochrisiko" noch „sauber" wäre wahr: geprüft wurde nichts. Die Zahl
+		     bleibt deshalb weg, sie wäre eine Behauptung über eine Prüfung, die
+		     nicht durchgelaufen ist. -->
+		<span class="badge badge-warning">
+			<Icon icon="lucide:triangle-alert" width="14" height="14" aria-hidden="true" />
+			Prüfung fehlgeschlagen
+		</span>
+	{/if}
+	<!-- Für „nie bewertet" bewusst gar kein Badge: Ein graues Etikett läse sich
+	     wie ein Prüfergebnis und ist das Gegenteil der Aussage. Die Beschreibung
+	     darunter trägt den Fall. -->
+</div>
+<p class="text-base-content/70 mt-2 text-sm">{spam.description}</p>
+{#if indicators.length > 0}
+	<ul class="mt-2 list-inside list-disc text-sm">
+		{#each indicators as indicator (indicator)}
+			<li>{indicator}</li>
+		{/each}
+	</ul>
+{:else if score !== null}
+	<!-- Nur wo tatsächlich gerechnet wurde. Ohne Bewertung wäre „Keine
+	     Indikatoren." eine Aussage über ein Ergebnis, das es nicht gibt. -->
+	<p class="text-base-content/70 mt-2 text-sm">Keine Indikatoren.</p>
+{/if}

--- a/src/lib/components/admin/spamScorePresentation.test.ts
+++ b/src/lib/components/admin/spamScorePresentation.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { SpamCheckResult } from '$lib/types/spam';
+import type { SpamCheckResponse, SpamCheckResult } from '$lib/types/spam';
 import { HIGH_RISK_THRESHOLD } from '$lib/types/spam';
 import {
+	SPAM_DRIFT_PRESENTATION,
 	SPAM_RISK_PRESENTATION,
 	SPAM_SUSPICIOUS_THRESHOLD,
+	getSpamDrift,
 	getSpamRisk,
 	getSpamRiskFromResult
 } from './spamScorePresentation';
@@ -68,6 +70,63 @@ describe('getSpamRiskFromResult', () => {
 			failed: true
 		});
 		expect(getSpamRiskFromResult(fehlgeschlagen)).toBe('unrated');
+	});
+});
+
+describe('getSpamDrift', () => {
+	function antwort(
+		stored: { score: number; indicators: string[] } | null,
+		recomputed: Partial<SpamCheckResult>
+	): SpamCheckResponse {
+		return { stored, recomputed: { score: 0, isHighRisk: false, indicators: [], ...recomputed } };
+	}
+
+	it('meldet keine Abweichung, wenn beide Läufe denselben Score ergeben', () => {
+		expect(getSpamDrift(antwort({ score: 3, indicators: ['a'] }, { score: 3 }))).toBe('unchanged');
+	});
+
+	it('erkennt den Regelfall: die Neuberechnung liegt niedriger', () => {
+		// Genau der Fall, für den es dieses Modul gibt. Vier Indikatoren wiegen je
+		// 2 Punkte und sind nachträglich nicht rekonstruierbar (Formular-Token,
+		// Absendedauer, beide Duplikatsignale) — der Nachlauf kommt dann auf 0,
+		// während die Tabelle weiterhin 2 zeigt.
+		const drift = getSpamDrift(
+			antwort({ score: 2, indicators: ['Formular verdächtig schnell abgeschickt'] }, { score: 0 })
+		);
+		expect(drift).toBe('lower');
+	});
+
+	it('erkennt eine höhere Neuberechnung', () => {
+		expect(getSpamDrift(antwort({ score: 1, indicators: [] }, { score: 4 }))).toBe('higher');
+	});
+
+	it('vergleicht nicht gegen einen Altbestand ohne Bewertung', () => {
+		// `stored: null` heißt „nie bewertet" und nicht „Score 0". Ein Vergleich
+		// dagegen behauptete eine Veränderung, wo es keinen Vorzustand gibt.
+		expect(getSpamDrift(antwort(null, { score: 3 }))).toBe('incomparable');
+		expect(getSpamDrift(antwort(null, { score: 0 }))).toBe('incomparable');
+	});
+
+	it('vergleicht nicht gegen eine fehlgeschlagene Neuberechnung', () => {
+		// Fail-Safe: Score 0 mit `isHighRisk: true`. Als „liegt niedriger"
+		// gelesen wäre das eine Aussage über eine Prüfung, die nie lief.
+		const drift = getSpamDrift(
+			antwort({ score: 3, indicators: [] }, { score: 0, isHighRisk: true, failed: true })
+		);
+		expect(drift).toBe('incomparable');
+	});
+});
+
+describe('SPAM_DRIFT_PRESENTATION', () => {
+	it('erklärt jede echte Abweichung im Klartext', () => {
+		for (const drift of ['lower', 'higher'] as const) {
+			expect(SPAM_DRIFT_PRESENTATION[drift].note).toBeTruthy();
+		}
+	});
+
+	it('schweigt, wo es nichts zu erklären gibt', () => {
+		expect(SPAM_DRIFT_PRESENTATION.unchanged.note).toBeNull();
+		expect(SPAM_DRIFT_PRESENTATION.incomparable.note).toBeNull();
 	});
 });
 

--- a/src/lib/components/admin/spamScorePresentation.ts
+++ b/src/lib/components/admin/spamScorePresentation.ts
@@ -23,7 +23,7 @@
  * Client-sicher: nur Typen und Konstanten aus `$lib/types/spam`, kein Import
  * aus `$lib/server/**` (der Bruch fiele erst in `npm run build` auf).
  */
-import { HIGH_RISK_THRESHOLD, type SpamCheckResult } from '$lib/types/spam';
+import { HIGH_RISK_THRESHOLD, type SpamCheckResponse, type SpamCheckResult } from '$lib/types/spam';
 
 export type SpamRisk = 'unrated' | 'clean' | 'suspicious' | 'high';
 
@@ -74,6 +74,47 @@ export function getSpamRiskFromResult(result: SpamCheckResult): SpamRisk {
 	if (result.isHighRisk) return 'high';
 	return getSpamRisk(result.score);
 }
+
+/**
+ * Verhältnis der Neuberechnung zum persistierten Erstbefund.
+ *
+ * `incomparable` deckt zwei Fälle ab, die sich hier gleich verhalten: Es gibt
+ * keinen Erstbefund (`stored === null`, Altbestand), oder die Neuberechnung ist
+ * gar nicht durchgelaufen (`failed`). Beide Male fehlt eine der zwei Seiten —
+ * eine Differenz zu bilden hieße, mit einer Null zu rechnen, die keine ist.
+ */
+export type SpamDrift = 'incomparable' | 'unchanged' | 'lower' | 'higher';
+
+export function getSpamDrift(response: SpamCheckResponse): SpamDrift {
+	const { stored, recomputed } = response;
+	if (stored == null || recomputed.failed) return 'incomparable';
+	if (recomputed.score === stored.score) return 'unchanged';
+	return recomputed.score < stored.score ? 'lower' : 'higher';
+}
+
+/**
+ * Der Satz, der die Abweichung erklärt — `null`, wo es nichts zu erklären gibt.
+ *
+ * Ohne diesen Text war die Gegenüberstellung nur eine zweite Zahl: Die
+ * Oberfläche zeigte „Spam 2" und „0" nebeneinander, und wer die Herkunft der
+ * Indikatoren nicht kennt, liest darin einen Defekt.
+ */
+export const SPAM_DRIFT_PRESENTATION: Record<SpamDrift, { note: string | null }> = {
+	incomparable: { note: null },
+	unchanged: { note: null },
+	lower: {
+		note:
+			'Niedriger als beim Eingang — das ist der Normalfall: Formular-Token, Absendedauer ' +
+			'und Duplikat-Signale gibt es nur im Moment des Absendens und lassen sich nicht ' +
+			'nachträglich rekonstruieren. Maßgeblich für die Triage bleibt der Erstbefund.'
+	},
+	higher: {
+		note:
+			'Höher als beim Eingang — die Bewertung stützt sich also auf etwas, das beim ' +
+			'Absenden noch nicht galt: bearbeitete Angaben oder eine E-Mail-Domain, die ' +
+			'inzwischen keine Mails mehr annimmt.'
+	}
+};
 
 interface SpamRiskBase {
 	label: string;

--- a/src/lib/types/spam.test.ts
+++ b/src/lib/types/spam.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { toStoredIndicators } from './spam';
+
+/**
+ * `spam_indicators` ist untypisiertes `jsonb`. Die Spalte wird heute
+ * ausschließlich aus `SpamCheckResult.indicators` befüllt und trägt damit immer
+ * Strings — nachweisen lässt sich das beim Lesen aber nicht, und ein
+ * `as string[]` ist genau die Behauptung, die keiner prüft.
+ *
+ * Der Helfer macht die Zusage der API (`items: { type: string }`) unabhängig
+ * vom Spalteninhalt wahr, statt sie zu behaupten.
+ */
+describe('toStoredIndicators', () => {
+	it('gibt eine Liste von Strings unverändert zurück', () => {
+		const indikatoren = ['Formular verdächtig schnell abgeschickt', 'Spam-Keywords gefunden: win'];
+		expect(toStoredIndicators(indikatoren)).toEqual(indikatoren);
+	});
+
+	it('wirft Nicht-Strings aus einem gemischten Array', () => {
+		// Der Fall, den `Array.isArray` allein durchgehen lässt: Der Container
+		// stimmt, der Inhalt nicht — die Antwort verletzte dann ihr eigenes Schema.
+		expect(toStoredIndicators(['echt', 42, null, { text: 'x' }, ['y'], 'auch echt'])).toEqual([
+			'echt',
+			'auch echt'
+		]);
+	});
+
+	it('liefert für alles, was kein Array ist, eine leere Liste', () => {
+		for (const wert of [null, undefined, 'string', 7, { kaputt: true }]) {
+			expect(toStoredIndicators(wert)).toEqual([]);
+		}
+	});
+
+	it('reicht kein leeres Ergebnis als „keine Indikatoren" durch, das der Score wäre', () => {
+		/* Bewusst festgehalten: Der Helfer sagt nur etwas über die Indikatorliste.
+		   Ein unbrauchbarer Spaltenwert darf den **Score** nicht mitreißen — der
+		   ist eine eigene Spalte und bleibt gültig (Zusicherung dazu steht im
+		   Endpunkt-Test). */
+		expect(toStoredIndicators({ kaputt: true })).toEqual([]);
+	});
+});

--- a/src/lib/types/spam.ts
+++ b/src/lib/types/spam.ts
@@ -41,6 +41,32 @@ export interface SpamStoredFinding {
 }
 
 /**
+ * Liest die Spalte `spam_indicators` als das, was sie zusagt: eine Liste von
+ * Strings.
+ *
+ * Die Spalte ist untypisiertes `jsonb`. Ein bloßes
+ * `Array.isArray(v) ? (v as string[]) : []` prüft nur den **Container** — ein
+ * Array mit Zahlen oder Objekten kommt unverändert durch, und die API bricht
+ * damit ihr eigenes Schema (`items: { type: string }`), ohne dass irgendwo
+ * etwas auffällt. Der Cast ist eine Behauptung, die niemand nachprüft; dieser
+ * Helfer macht die Zusage stattdessen wahr.
+ *
+ * **Er sagt nichts über den Score.** Der steht in einer eigenen Spalte und
+ * bleibt auch dann gültig, wenn die Indikatorliste unbrauchbar ist — eine
+ * leere Liste heißt hier „keine lesbaren Indikatoren", nicht „Score 0".
+ *
+ * Heute schreibt ausschließlich eigener Code in die Spalte
+ * (`saveSighting`, `rescoreSightings`), beide aus `SpamCheckResult.indicators`.
+ * Der Fall ist damit nicht erreichbar — nachweisen lässt sich das beim Lesen
+ * aber nicht, und die Datenbank teilt sich die App mit dem Altsystem.
+ */
+export function toStoredIndicators(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((eintrag): eintrag is string => typeof eintrag === 'string')
+		: [];
+}
+
+/**
  * Antwort von `GET /api/sightings/[id]/spam-check` — **zwei** Befunde, bewusst
  * nebeneinander statt einer Zahl.
  *

--- a/src/lib/types/spam.ts
+++ b/src/lib/types/spam.ts
@@ -30,6 +30,38 @@ export interface SpamCheckResult {
 }
 
 /**
+ * Der zum Meldezeitpunkt persistierte Befund (`spam_score`/`spam_indicators`).
+ * Kein `isHighRisk`: Das ist kein gespeichertes Feld, sondern wird überall aus
+ * `HIGH_RISK_THRESHOLD` rekonstruiert — eine zweite, mitgelieferte Fassung
+ * derselben Aussage könnte davon abweichen.
+ */
+export interface SpamStoredFinding {
+	score: number;
+	indicators: string[];
+}
+
+/**
+ * Antwort von `GET /api/sightings/[id]/spam-check` — **zwei** Befunde, bewusst
+ * nebeneinander statt einer Zahl.
+ *
+ * Vier Indikatoren wiegen je 2 Punkte und existieren nur im Moment des
+ * Absendens: Formular-Token fehlt/ungültig, verdächtig schnell abgeschickt und
+ * die beiden Duplikat-Signale. Ihre Eingangsdaten (Token, Absendedauer,
+ * 24-Stunden- bzw. 7-Tage-Fenster) stehen nirgends in der Zeile, also kann
+ * `recomputed` sie nicht rekonstruieren und liegt entsprechend tiefer.
+ *
+ * Bis 2026-08 lieferte der Endpunkt nur die Neuberechnung. Damit zeigte die
+ * Tabelle „Spam 2" und der Check daneben „0" — beide Zahlen richtig, der
+ * Widerspruch unerklärlich, weil der Vergleichswert fehlte.
+ */
+export interface SpamCheckResponse {
+	/** `null` heißt „nie bewertet" (Altbestand, Legacy-Eingang) — nicht `0`. */
+	stored: SpamStoredFinding | null;
+	/** Frischer Lauf über den aktuellen Datensatz, ohne Meldezeitpunkt-Signale. */
+	recomputed: SpamCheckResult;
+}
+
+/**
  * Minimal input type for spam detection.
  * Accepts only the fields actually used by detectSpamIndicators,
  * so callers don't need to pass a full SightingFormValues.

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -28,9 +28,13 @@
 	import { onDestroy } from 'svelte';
 	import DeleteDialog from '$lib/components/ui/Dialog/DeleteDialog.svelte';
 	import { toast } from '$lib/stores/toastState.svelte';
-	import type { SpamCheckResult } from '$lib/types/spam';
+	import type { SpamCheckResponse } from '$lib/types/spam';
+	import SpamFinding from '$lib/components/admin/SpamFinding.svelte';
 	import {
+		getSpamDrift,
+		getSpamRisk,
 		getSpamRiskFromResult,
+		SPAM_DRIFT_PRESENTATION,
 		SPAM_RISK_PRESENTATION,
 		type SpamRisk
 	} from '$lib/components/admin/spamScorePresentation';
@@ -397,7 +401,7 @@
 		/** Die Sichtung, zu der Ergebnis bzw. Fehler gehören. */
 		sightingId: number;
 		loading: boolean;
-		result: SpamCheckResult | null;
+		result: SpamCheckResponse | null;
 		error: string | null;
 	}
 
@@ -438,7 +442,7 @@
 			if (!response.ok) {
 				throw new Error(`Fehler ${response.status}: ${response.statusText}`);
 			}
-			const result: SpamCheckResult = await response.json();
+			const result: SpamCheckResponse = await response.json();
 			if (spamCheck.sightingId !== sightingId) return;
 			spamCheck = { sightingId, loading: false, result, error: null };
 		} catch (err) {
@@ -607,36 +611,54 @@
 {/if}
 
 {#if spamCheck.result}
-	{@const result = spamCheck.result}
-	{@const risk = getSpamRiskFromResult(result)}
-	{@const spam = SPAM_RISK_PRESENTATION[risk]}
-	<!-- Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts` —
-	     dieselbe Quelle wie Modal, Tabellenspalte und Eingangskarte. Vorher zog
-	     diese Karte schon bei Score 1 gelb, während dieselbe Meldung in der
-	     Liste grau und im Modal grün war. -->
+	{@const response = spamCheck.result}
+	{@const stored = response.stored}
+	{@const recomputed = response.recomputed}
+	{@const drift = SPAM_DRIFT_PRESENTATION[getSpamDrift(response)]}
+	<!-- Die Karte richtet Farbe und Überschrift nach dem **Erstbefund**: Er ist
+	     die Zahl, die in Tabelle und Eingang steht, und die für die Triage
+	     maßgebliche. Nur wo es keinen gibt (Altbestand, `stored === null`),
+	     führt die Neuberechnung. Vorher führte sie immer — und widersprach dann
+	     der Liste, aus der man kam (`SpamCheckResponse`). -->
+	{@const risk = stored ? getSpamRisk(stored.score) : getSpamRiskFromResult(recomputed)}
+	<!-- Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts`,
+	     die Anordnung der beiden Befunde aus `SpamFinding.svelte` — dieselben
+	     Quellen wie im Modal der Tabelle. Vorher stand hier eine zweite,
+	     handgebaute Fassung mit abweichendem Wortlaut; das war genau die
+	     Divergenz zwischen Anzeigestellen, gegen die beide Module existieren.
+
+	     Die Karte trägt nur noch die Fläche: Farbe und Icon der **führenden**
+	     Stufe, dazu ein neutraler Titel. Stünde hier zusätzlich deren Label,
+	     wiederholte es das Badge des ersten Befunds direkt darunter. -->
 	<div class="card mb-4 border {SPAM_CARD_SURFACE[risk]}">
 		<div class="card-body p-4">
 			<div class="flex items-center gap-2">
-				<Icon icon={spam.icon ?? 'lucide:shield-alert'} class="h-5 w-5 {SPAM_CARD_ICON[risk]}" />
-				<h3 class="card-title text-base">{spam.label}</h3>
-				<div class="ml-auto flex gap-2">
-					{#if spam.badgeClass}
-						<span class="badge {spam.badgeClass}">Score: {result.score}</span>
-					{:else}
-						<!-- `failed: true` — Score 0 und `isHighRisk: true` zugleich. Die
-						     Zahl wäre hier eine Behauptung über eine Prüfung, die gar
-						     nicht durchgelaufen ist. -->
-						<span class="badge badge-warning">Prüfung fehlgeschlagen</span>
-					{/if}
-				</div>
+				<Icon
+					icon={SPAM_RISK_PRESENTATION[risk].icon ?? 'lucide:shield-alert'}
+					class="h-5 w-5 {SPAM_CARD_ICON[risk]}"
+					aria-hidden="true"
+				/>
+				<h3 class="card-title text-base">Spam-Bewertung</h3>
 			</div>
-			<p class="text-base-content/70 text-sm">{spam.description}</p>
-			{#if result.indicators.length > 0}
-				<ul class="mt-2 list-inside list-disc text-sm">
-					{#each result.indicators as indicator (indicator)}
-						<li>{indicator}</li>
-					{/each}
-				</ul>
+
+			<SpamFinding
+				title="Beim Eingang"
+				risk={stored ? getSpamRisk(stored.score) : 'unrated'}
+				score={stored?.score ?? null}
+				indicators={stored?.indicators ?? []}
+			/>
+
+			<div class="divider my-2"></div>
+
+			<SpamFinding
+				title="Jetzt nachgerechnet"
+				risk={getSpamRiskFromResult(recomputed)}
+				score={recomputed.score}
+				indicators={recomputed.indicators}
+			/>
+
+			{#if drift.note}
+				<p class="text-base-content/70 mt-2 text-sm">{drift.note}</p>
 			{/if}
 		</div>
 	</div>

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -18,10 +18,13 @@
 	import { toast } from '$lib/stores/toastState.svelte';
 	import type { PageData } from './$types';
 	import type { SichtungenListRow } from './listColumns';
-	import type { SpamCheckResult } from '$lib/types/spam';
+	import type { SpamCheckResponse } from '$lib/types/spam';
+	import SpamFinding from '$lib/components/admin/SpamFinding.svelte';
 	import {
+		getSpamDrift,
+		getSpamRisk,
 		getSpamRiskFromResult,
-		SPAM_RISK_PRESENTATION
+		SPAM_DRIFT_PRESENTATION
 	} from '$lib/components/admin/spamScorePresentation';
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
@@ -414,7 +417,7 @@
 		open: false,
 		loading: false,
 		sightingId: null as number | null,
-		result: null as SpamCheckResult | null,
+		result: null as SpamCheckResponse | null,
 		error: null as string | null
 	});
 
@@ -1213,7 +1216,7 @@
 			     Bedienbarkeit zu behaupten; `aria-current="page"` sagt Screenreadern,
 			     wofür die Zahl steht. -->
 			<span
-				class="btn btn-active join-item btn-sm pointer-events-none min-w-32 text-support md:text-label"
+				class="btn btn-active join-item btn-sm text-support md:text-label pointer-events-none min-w-32"
 				aria-current="page"
 			>
 				{data.pagination.page} / {seiten.totalPages}
@@ -1284,39 +1287,41 @@
 				<span>{spamCheckModal.error}</span>
 			</div>
 		{:else if spamCheckModal.result}
-			{@const result = spamCheckModal.result}
-			{@const spam = SPAM_RISK_PRESENTATION[getSpamRiskFromResult(result)]}
+			{@const response = spamCheckModal.result}
+			{@const stored = response.stored}
+			{@const drift = SPAM_DRIFT_PRESENTATION[getSpamDrift(response)]}
 			<!-- Wort, Farbe, Icon und Schwelle kommen aus `spamScorePresentation.ts` —
 			     dieselbe Quelle wie Tabellenspalte, Eingangskarte und Detailansicht.
 			     Vorher stand hier ein eigener Schwellensatz, der Score 1 grün zeigte,
 			     während die Spalte dahinter grau war. -->
-			<div class="mt-4 flex flex-wrap items-center gap-2">
-				{#if spam.badgeClass}
-					<span class="badge {spam.badgeClass}">
-						<Icon icon={spam.icon} width="14" height="14" aria-hidden="true" />
-						{spam.label}
-					</span>
-					<span class="badge badge-ghost">Heuristik-Score: {result.score}</span>
-				{:else}
-					<!-- `failed: true` — Score 0 und `isHighRisk: true` zugleich. Weder
-					     „Hochrisiko" noch „sauber" wäre wahr: geprüft wurde nichts. -->
-					<span class="badge badge-warning">
-						<Icon icon="lucide:triangle-alert" width="14" height="14" aria-hidden="true" />
-						Prüfung fehlgeschlagen
-					</span>
-				{/if}
+
+			<!-- Zwei Befunde, und der Erstbefund steht zuerst: Er ist die Zahl aus
+			     Tabelle und Eingang und die für die Triage maßgebliche. Stand hier
+			     nur die Neuberechnung, widersprach das Modal der Spalte, aus der es
+			     geöffnet wurde (`SpamCheckResponse`). -->
+			<div class="mt-4">
+				<SpamFinding
+					title="Beim Eingang"
+					risk={stored ? getSpamRisk(stored.score) : 'unrated'}
+					score={stored?.score ?? null}
+					indicators={stored?.indicators ?? []}
+				/>
 			</div>
-			<p class="text-base-content/70 mt-2 text-sm">{spam.description}</p>
-			<!-- Indicators list -->
-			{#if result.indicators.length > 0}
-				<p class="mt-4 font-semibold">Indikatoren:</p>
-				<ul class="mt-1 list-inside list-disc text-sm">
-					{#each result.indicators as indicator (indicator)}
-						<li>{indicator}</li>
-					{/each}
-				</ul>
-			{:else}
-				<p class="mt-4 text-sm">Keine Indikatoren gefunden.</p>
+
+			<div class="divider my-3"></div>
+
+			<SpamFinding
+				title="Jetzt nachgerechnet"
+				risk={getSpamRiskFromResult(response.recomputed)}
+				score={response.recomputed.score}
+				indicators={response.recomputed.indicators}
+			/>
+
+			{#if drift.note}
+				<div class="alert alert-info mt-4" role="note">
+					<Icon icon="lucide:info" class="shrink-0" aria-hidden="true" />
+					<span class="text-sm">{drift.note}</span>
+				</div>
 			{/if}
 		{/if}
 

--- a/src/routes/api/sightings/[id]/spam-check/+server.ts
+++ b/src/routes/api/sightings/[id]/spam-check/+server.ts
@@ -3,7 +3,7 @@ import { requireUserRole } from '$lib/server/auth/auth';
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { detectSpamIndicators } from '$lib/server/spam/spamDetector';
-import type { SpamDetectionInput } from '$lib/types/spam';
+import type { SpamCheckResponse, SpamDetectionInput, SpamStoredFinding } from '$lib/types/spam';
 import { error, isHttpError, json, type RequestHandler } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 
@@ -51,14 +51,33 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 			inBalticSeaGeo: sighting.inBalticSeaGeo
 		};
 
-		const result = await detectSpamIndicators(spamInput);
+		const recomputed = await detectSpamIndicators(spamInput);
+
+		// Der persistierte Erstbefund kommt mit — ohne ihn stünde die
+		// Neuberechnung unerklärt gegen die Zahl in Tabelle und Eingang
+		// (`SpamCheckResponse`). `spam_indicators` ist untypisiertes `jsonb`;
+		// ein Nicht-Array darf den Score nicht mitreißen, der bleibt gültig.
+		const stored: SpamStoredFinding | null =
+			sighting.spamScore != null
+				? {
+						score: sighting.spamScore,
+						indicators: Array.isArray(sighting.spamIndicators)
+							? (sighting.spamIndicators as string[])
+							: []
+					}
+				: null;
 
 		logger.info(
-			{ id, score: result.score, isHighRisk: result.isHighRisk },
+			{
+				id,
+				storedScore: stored?.score ?? null,
+				score: recomputed.score,
+				isHighRisk: recomputed.isHighRisk
+			},
 			'Spam-Check für Sichtung durchgeführt'
 		);
 
-		return json(result, {
+		return json({ stored, recomputed } satisfies SpamCheckResponse, {
 			headers: { 'Cache-Control': 'no-store' }
 		});
 	} catch (err) {

--- a/src/routes/api/sightings/[id]/spam-check/+server.ts
+++ b/src/routes/api/sightings/[id]/spam-check/+server.ts
@@ -4,6 +4,7 @@ import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { detectSpamIndicators } from '$lib/server/spam/spamDetector';
 import type { SpamCheckResponse, SpamDetectionInput, SpamStoredFinding } from '$lib/types/spam';
+import { toStoredIndicators } from '$lib/types/spam';
 import { error, isHttpError, json, type RequestHandler } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 
@@ -56,14 +57,14 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 		// Der persistierte Erstbefund kommt mit — ohne ihn stünde die
 		// Neuberechnung unerklärt gegen die Zahl in Tabelle und Eingang
 		// (`SpamCheckResponse`). `spam_indicators` ist untypisiertes `jsonb`;
-		// ein Nicht-Array darf den Score nicht mitreißen, der bleibt gültig.
+		// `toStoredIndicators` macht daraus verlässlich die Liste, die das
+		// OpenAPI-Schema zusagt. Ein unbrauchbarer Wert dort reißt den Score
+		// nicht mit — der steht in einer eigenen Spalte und bleibt gültig.
 		const stored: SpamStoredFinding | null =
 			sighting.spamScore != null
 				? {
 						score: sighting.spamScore,
-						indicators: Array.isArray(sighting.spamIndicators)
-							? (sighting.spamIndicators as string[])
-							: []
+						indicators: toStoredIndicators(sighting.spamIndicators)
 					}
 				: null;
 

--- a/src/routes/api/sightings/[id]/spam-check/endpoint.test.ts
+++ b/src/routes/api/sightings/[id]/spam-check/endpoint.test.ts
@@ -15,7 +15,9 @@ const mockSighting = {
 	seaMark: null,
 	notes: null,
 	isDead: null,
-	distribution: 0
+	distribution: 0,
+	spamScore: 2,
+	spamIndicators: ['Formular verdächtig schnell abgeschickt']
 };
 
 // Mutable so individual tests can override the result
@@ -108,13 +110,39 @@ describe('GET /api/sightings/[id]/spam-check', () => {
 		}
 	});
 
-	it('gibt SpamCheckResult als JSON zurück bei gültiger Sichtung', async () => {
+	it('stellt den persistierten Befund der Neuberechnung gegenüber', async () => {
+		// Der Kern des Endpunkts: Die Neuberechnung kennt die Signale des
+		// Meldezeitpunkts nicht (Formular-Token, Absendedauer, Duplikate) und
+		// kommt deshalb regelmäßig tiefer heraus als der gespeicherte Score.
+		// Nur die Neuberechnung auszuliefern hieß, den Erstbefund der Tabelle zu
+		// widersprechen, ohne den Unterschied benennen zu können.
+		mockDetectSpamIndicators.mockResolvedValue({ score: 0, isHighRisk: false, indicators: [] });
+
 		const response = await GET(createEvent('123'));
 		expect(response.status).toBe(200);
 		const body = await response.json();
-		expect(body).toHaveProperty('score');
-		expect(body).toHaveProperty('isHighRisk');
-		expect(body).toHaveProperty('indicators');
+
+		expect(body.stored).toEqual({
+			score: 2,
+			indicators: ['Formular verdächtig schnell abgeschickt']
+		});
+		expect(body.recomputed).toMatchObject({ score: 0, isHighRisk: false, indicators: [] });
+	});
+
+	it('liefert `stored: null` für nie bewerteten Altbestand', async () => {
+		// NULL ist nicht 0 (`docs/SPAM_DETECTION.md`). Ein `{ score: 0 }` hier
+		// läse sich als „damals geprüft, sauber" — das Gegenteil der Aussage.
+		mockDbResult = [{ ...mockSighting, spamScore: null, spamIndicators: null }];
+		const body = await (await GET(createEvent('123'))).json();
+		expect(body.stored).toBeNull();
+	});
+
+	it('lässt einen unbrauchbaren `spam_indicators`-Wert nicht durchschlagen', async () => {
+		// Die Spalte ist untypisiertes `jsonb`. Ein Nicht-Array dort darf den
+		// Befund nicht mitreißen — der Score ist auch ohne Indikatorliste gültig.
+		mockDbResult = [{ ...mockSighting, spamScore: 3, spamIndicators: { kaputt: true } }];
+		const body = await (await GET(createEvent('123'))).json();
+		expect(body.stored).toEqual({ score: 3, indicators: [] });
 	});
 
 	it('setzt Cache-Control: no-store Header', async () => {

--- a/src/routes/api/sightings/[id]/spam-check/endpoint.test.ts
+++ b/src/routes/api/sightings/[id]/spam-check/endpoint.test.ts
@@ -145,6 +145,18 @@ describe('GET /api/sightings/[id]/spam-check', () => {
 		expect(body.stored).toEqual({ score: 3, indicators: [] });
 	});
 
+	it('liefert nur Strings als Indikatoren aus', async () => {
+		/* `Array.isArray` prüft den Container, nicht die Elemente. Ein Array mit
+		   Zahlen oder Objekten kam vorher unverändert durch und verletzte damit
+		   die Zusage des eigenen Schemas (`items: { type: string }`) — der
+		   `as string[]` dahinter war eine Behauptung, die niemand prüft. */
+		mockDbResult = [
+			{ ...mockSighting, spamScore: 3, spamIndicators: ['echt', 42, null, { text: 'x' }] }
+		];
+		const body = await (await GET(createEvent('123'))).json();
+		expect(body.stored).toEqual({ score: 3, indicators: ['echt'] });
+	});
+
 	it('setzt Cache-Control: no-store Header', async () => {
 		const response = await GET(createEvent('123'));
 		expect(response.headers.get('cache-control')).toBe('no-store');

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2659,8 +2659,10 @@ components:
           items:
             type: string
           description: >-
-            Leer, wenn die Spalte spam_indicators keinen Array-Wert trägt — der
-            Score bleibt davon unberührt gültig.
+            Immer Strings: die Spalte spam_indicators ist untypisiertes jsonb
+            und wird beim Lesen auf String-Elemente gefiltert (kein Array-Wert
+            oder ein Element anderen Typs fällt weg). Der Score bleibt davon
+            unberührt gültig — er steht in einer eigenen Spalte.
           example: ['Formular verdächtig schnell abgeschickt']
     SpamCheckResult:
       type: object

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -445,6 +445,59 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/sightings/{id}/spam-check:
+    get:
+      tags:
+        - sightings
+      summary: Spam-Befund einer Sichtung — gespeichert und neu berechnet
+      description: |
+        Liefert **zwei** Befunde nebeneinander (Admin-Berechtigung erforderlich):
+        `stored` ist der zum Meldezeitpunkt persistierte Score aus
+        `spam_score`/`spam_indicators` — dieselbe Zahl, die Tabelle und Eingang
+        anzeigen. `recomputed` ist ein frischer Lauf der Heuristik über den
+        aktuellen Datensatz.
+
+        Die beiden weichen systematisch voneinander ab, und das ist kein Fehler:
+        Vier Indikatoren wiegen je 2 Punkte und existieren nur im Moment des
+        Absendens — Formular-Token fehlt/ungültig, verdächtig schnell
+        abgeschickt sowie die beiden Duplikat-Signale. Ihre Eingangsdaten
+        (Token, Absendedauer, 24-Stunden- bzw. 7-Tage-Fenster) stehen nirgends
+        in der Zeile, `recomputed` kann sie also nicht rekonstruieren und liegt
+        entsprechend tiefer. Umgekehrt kann er höher liegen, wenn der Datensatz
+        seit der Meldung bearbeitet wurde oder die E-Mail-Domain inzwischen
+        keinen MX-Record mehr hat.
+
+        Maßgeblich für die Triage ist `stored`. `stored: null` heißt „nie
+        bewertet" (Altbestand, Legacy-Eingang) und ist nicht dasselbe wie
+        Score 0 (`docs/SPAM_DETECTION.md`).
+      security:
+        - adminAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID der Sichtung
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Befund ermittelt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpamCheckResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/LoginRedirect'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/sightings/{id}/queue:
     get:
       tags:
@@ -2578,6 +2631,59 @@ components:
             Fachliche Referenz-ID; null bei Altbestand ohne Referenz-ID
             (Spalte `referenz_id` ist nicht `notNull`).
           example: REF-501
+    SpamCheckResponse:
+      type: object
+      required: [stored, recomputed]
+      properties:
+        stored:
+          nullable: true
+          description: >-
+            Persistierter Befund zum Meldezeitpunkt. null heißt "nie bewertet"
+            (Altbestand, Legacy-Eingang) und ist nicht dasselbe wie Score 0.
+            Kein isHighRisk: das ist kein gespeichertes Feld, sondern wird aus
+            der Schwelle 5 rekonstruiert.
+          allOf:
+            - $ref: '#/components/schemas/SpamStoredFinding'
+        recomputed:
+          $ref: '#/components/schemas/SpamCheckResult'
+    SpamStoredFinding:
+      type: object
+      required: [score, indicators]
+      properties:
+        score:
+          type: integer
+          minimum: 0
+          maximum: 10
+        indicators:
+          type: array
+          items:
+            type: string
+          description: >-
+            Leer, wenn die Spalte spam_indicators keinen Array-Wert trägt — der
+            Score bleibt davon unberührt gültig.
+          example: ['Formular verdächtig schnell abgeschickt']
+    SpamCheckResult:
+      type: object
+      required: [score, isHighRisk, indicators]
+      properties:
+        score:
+          type: integer
+          minimum: 0
+          maximum: 10
+        isHighRisk:
+          type: boolean
+          description: Urteil des Servers (Schwelle 5), nicht clientseitig nachrechnen.
+        indicators:
+          type: array
+          items:
+            type: string
+        failed:
+          type: boolean
+          description: >-
+            Die Prüfung selbst ist gescheitert (Fail-Safe). Dann gilt score 0
+            zusammen mit isHighRisk true — beides wörtlich zu nehmen ergäbe
+            "Hochrisiko ohne einen einzigen Indikator". Für die Anzeige ist der
+            ehrliche Zustand derselbe wie stored null: es wurde nichts bewertet.
     SpamRescoreReport:
       type: object
       required: [scored, skippedFailed, lastId, remaining, done, stalled, distribution]


### PR DESCRIPTION
## Befund

`GET /api/sightings/[id]/spam-check` lieferte nur eine **Neuberechnung** über den gespeicherten Datensatz. Tabelle und Eingang zeigen dagegen die persistierte Spalte `spam_score`. Ergebnis: „Spam 2" in der Spalte, „0" im Check daneben — beide Zahlen richtig, der Widerspruch unerklärbar, weil der Vergleichswert fehlte.

Vier Indikatoren wiegen je 2 Punkte und existieren **nur im Moment des Absendens**:

| Indikator | Herkunft |
| --- | --- |
| Formular-Token fehlt / ungültig | `submission.tokenStatus` |
| Formular verdächtig schnell abgeschickt (< 5 s) | `submission.ageSeconds` |
| Identischer Bemerkungstext wie früher | `recentDuplicates.sameNotes` (7 d) |
| Auffällig viele Meldungen derselben E-Mail | `recentDuplicates.sameEmail` (24 h) |

Ihre Eingangsdaten stehen nirgends in der Zeile — die Neuberechnung kann sie nicht rekonstruieren und liegt entsprechend tiefer.

## Änderung

Der Endpunkt liefert `{ stored, recomputed }`. Modal und Detailkarte führen den **Erstbefund**: Er ist die Zahl aus Tabelle und Eingang und hat mehr Information als der Nachlauf. Nur wo es keinen gibt (`stored === null`), führt die Neuberechnung.

Damit folgen jetzt alle fünf Anzeigestellen einer Regel. Der **E-Mail-Versand hatte das die ganze Zeit richtig** (`persistedSpam ?? detectSpamIndicators(...)`) — die zwei Admin-Flächen waren die Ausreißer.

`getSpamDrift` ordnet die Differenz ein und erklärt sie im Klartext. Wo eine der beiden Seiten fehlt — kein Erstbefund oder fehlgeschlagene Prüfung — bleibt der Satz aus: Eine Differenz zu bilden hieße, mit einer Null zu rechnen, die keine ist.

Beide Befunde kommen aus dem neuen `SpamFinding.svelte`. Im ersten Wurf hatten Modal und Karte je eine eigene Fassung mit abweichendem Wortlaut („Beim Eingang: 2" gegen „Heuristik-Score: 2") — dieselbe Fehlerklasse, gegen die `spamScorePresentation.ts` angelegt wurde, eine Ebene höher. Im Review gefunden und behoben.

## Kompatibilität

Die Antwortform ändert sich breaking, aber der Endpunkt ist admin-only mit genau zwei internen Aufrufern (beide mitgezogen) und nicht Teil der Legacy-REST-API. Kein Mobile-Client hängt daran.

## Tests

Neu: `getSpamDrift` / `SPAM_DRIFT_PRESENTATION` (6 Fälle), die neue Antwortform samt `jsonb`-Nicht-Array-Fallback (3 Fälle), und `e2e/admin-spam-check.spec.ts` (3 Tests, Shard `form`).

Der E2E-Guard seedet seine Zeilen selbst — der Bestand enthält **keine** Zeile mit Meldezeitpunkt-Indikator: alle Scores stammen aus dem Backfill, der diese Signale nie hatte (nachgemessen über alle 1.065 bewerteten Zeilen, null Abweichung). Dafür kann `seedSighting` jetzt `spamScore`/`spamIndicators`.

**Gegenprobe gefahren:** Mit auf `stored: null` verkrüppeltem Endpunkt gehen zwei der drei E2E-Tests rot, der dritte bleibt grün (er prüft genau diesen Zustand).

Zwei Fehler im Spec selbst gefunden und behoben, beide dort dokumentiert:
- Alle Tests teilten eine Referenz-ID; parallel laufend traf `.first()` die Zeile des Nachbartests, dessen Cleanup sie mitten im Lauf löschte.
- Die Zukunftsdatierung machte die Zeile zur **ersten offenen** der Tabelle — genau die, die `admin-sighting-status.spec.ts` sich greift. Dessen `finally` navigierte dann auf eine gelöschte Sichtung und lief in einer fremden Datei in einen Timeout. Die Zeilen liegen jetzt in der Vergangenheit und werden über `?q=` gefunden.

`npm run test:quick` grün (4330 Tests), Shard `form` grün (91 Tests), `npm run check` 0 Fehler.

## Doku

`docs/SPAM_DETECTION.md`, `.claude/rules/admin.md` und `static/openapi.yml` — der Endpunkt fehlte in der Spec bisher komplett.

🤖 Generated with [Claude Code](https://claude.com/claude-code)