### PR TITLE
feat(api): Posteingang per HTTP nach Prod senden, showreports eindeutig sortieren

### DIFF
--- a/legacy-inbox/README.md
+++ b/legacy-inbox/README.md
@@ -244,6 +244,11 @@ Angreifer.
 
 ## Import
 
+Es gibt zwei Wege. Welcher passt, entscheidet die Erreichbarkeit der
+Zieldatenbank — nicht der Geschmack.
+
+### Direkt in die Datenbank (Entwicklung, eigener Server)
+
     npm run import:legacy-inbox -- /var/www/vhosts/schweinswalsichtung.de/legacy-inbox-data
 
 Läuft im Hauptrepo, nicht auf dem Plesk-Server, und ruft dieselben Bausteine
@@ -272,6 +277,45 @@ vergebene Sichtungs-ID auf der Konsole. Die Datei muss dann **von Hand** nach
 `importiert/` verschoben werden, bevor der Import erneut läuft — sonst liegt
 sie beim nächsten Lauf weiterhin in `posteingang/` und wird ein zweites Mal
 angelegt.
+
+### Über HTTP an eine laufende Instanz (Produktion)
+
+    npm run send:legacy-inbox -- https://dmm-prod-ostsee.ha.gecko.de
+
+Ohne weitere Angabe holt der Lauf die Dateien per SSH von
+`hawking:/var/www/vhosts/schweinswalsichtung.de/legacy-inbox-data` und
+verschiebt jede angenommene Datei dort nach `importiert/`. Ein anderer Ort geht
+mit `--ssh=host:/pfad` oder `--dir=/pfad` (lokales Verzeichnis).
+
+Warum nicht der direkte Weg von oben? Weil er eine Verbindung zur
+Produktionsdatenbank braucht. Deren Port ist auf dem Produktionsserver bewusst
+nicht veröffentlicht, und ein Lauf im Container scheidet aus, weil dort kein
+Quellcode liegt. Bleibt der Weg, den die App selbst genommen hat:
+`POST /rest_sichtungen`.
+
+Das ist kein Notbehelf, sondern die strengere Prüfung. Der Endpunkt validiert
+jede Meldung mit demselben Yup-Schema wie eine echte App-Meldung; der direkte
+Import ruft nur Mapping und Repository. Was hier durchkommt, hätte die App auch
+live einliefern können. Gesendet wird `roh` wörtlich — ein Re-Serialisieren aus
+`payload` wäre eine zweite Interpretation der Daten und damit genau die Art
+stiller Abweichung, die der Legacy-Vertrag nicht verträgt.
+
+Der Preis ist das Rate-Limit von **20 Meldungen pro Stunde und IP**. Beim
+ersten `429` bricht der Lauf ab und meldet, wo er stand. Das ist unkritisch,
+weil die Datei das Protokoll ist: Übernommenes liegt in `importiert/`, Offenes
+in `posteingang/`. Ein Neustart nach Ablauf des Fensters macht dort weiter und
+kann nichts doppelt anlegen. Bei 37 wartenden Dateien sind das zwei Läufe im
+Abstand einer Stunde.
+
+Ebenfalls abgebrochen wird bei einem Netzwerkfehler — dann ist unbekannt, ob
+die Sichtung angelegt wurde, und blind weiterzusenden hieße, ein mögliches
+Duplikat zu verstecken. Eine inhaltlich abgelehnte Datei (HTTP 400) hält den
+Lauf dagegen nicht auf: Sie bleibt liegen und wird am Ende aufgeführt — genau
+wie ein Eintrag in `abgewiesen/` ein Warnsignal ist und einen Menschen braucht.
+
+**Auch dieser Weg löst je Sichtung eine Benachrichtigungs-E-Mail aus** (siehe
+den Hinweis oben). Vor einem Rückstand-Lauf `notification.email.enabled`
+abschalten — und danach wieder ein.
 
 ## Tests
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"media:cleanup-orphans": "node src/tools/cleanup-orphaned-uploads.ts",
 		"generate:antworten": "TEST=true vite-node src/tools/generate-antworten-json.js",
 		"import:legacy-inbox": "TEST=true vite-node src/tools/import-legacy-inbox-cli.js --",
+		"send:legacy-inbox": "node src/tools/send-legacy-inbox-cli.js",
 		"spam:rescore": "TEST=true vite-node src/tools/rescore-spam.ts --",
 		"analyse:legacy-inbox": "node src/tools/analyse-legacy-inbox.js",
 		"sbom:generate": "npm run sbom:json && npm run sbom:xml",

--- a/src/routes/sichtungen/showreports.json/+server.ts
+++ b/src/routes/sichtungen/showreports.json/+server.ts
@@ -345,7 +345,15 @@ export async function GET(event: RequestEvent): Promise<Response> {
 			})
 			.from(sightings)
 			.where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
-			.orderBy(sql`${sightings.sightingDate} DESC`)
+			// `id` als zweites Kriterium ist nicht Kosmetik, sondern das, was die
+			// Antwort überhaupt erst reproduzierbar macht: `sichtungsdatum` ist
+			// nicht eindeutig (81 mehrfach belegte Zeitpunkte im Produktivbestand,
+			// größte Gruppe neun), und PostgreSQL darf gleiche Sortierschlüssel in
+			// beliebiger Reihenfolge liefern. Zusammen mit dem `.limit(1000)`, das
+			// im Normalbetrieb immer greift, entschied das bisher auch darüber,
+			// WELCHE Sichtungen am Rand noch mitkommen — zwei aufeinanderfolgende
+			// Aufrufe gegen dieselbe Datenbank lieferten verschiedene Reihenfolgen.
+			.orderBy(sql`${sightings.sightingDate} DESC`, sql`${sightings.id} DESC`)
 			.limit(1000); // Reasonable limit to prevent abuse
 
 		// Transform to PDF-compliant format with EXACT field names

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -159,6 +159,10 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		captured.where = null;
+		// Ohne diesen Reset sähe `capturedOrderByText()` noch die Sortierung
+		// eines früheren Tests und bliebe grün, selbst wenn die Implementierung
+		// gar kein `orderBy()` mehr aufruft — etwa nach einem frühen Return.
+		captured.orderBy = [];
 	});
 
 	describe('PDF Compliance - Response Format', () => {

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -20,7 +20,7 @@ import { sightings } from '$lib/server/db/schema';
 // tatsächlich erzeugte SQL prüfen können statt nur den HTTP-Status. Ohne das
 // bleibt der Suchfilter unsichtbar — genau so konnte die ungegatete Suche
 // über personenbezogene Felder unbemerkt bleiben.
-const captured = vi.hoisted(() => ({ where: null as unknown }));
+const captured = vi.hoisted(() => ({ where: null as unknown, orderBy: [] as unknown[] }));
 
 const dialect = new PgDialect();
 
@@ -31,6 +31,14 @@ function capturedWhereQuery(): { text: string; params: unknown[] } {
 	}
 	const query = dialect.sqlToQuery(captured.where as SQL);
 	return { text: query.sql, params: query.params };
+}
+
+/** Rendert die zuletzt erfasste ORDER-BY-Liste als SQL-Text. */
+function capturedOrderByText(): string {
+	if (captured.orderBy.length === 0) {
+		throw new Error('Keine Sortierung erfasst — wurde die Query ausgeführt?');
+	}
+	return captured.orderBy.map((teil) => dialect.sqlToQuery(teil as SQL).sql).join(', ');
 }
 
 // Mock database - simplified approach using partial database operations
@@ -98,9 +106,12 @@ vi.mock('$lib/server/db', () => {
 					where: vi.fn((condition: unknown) => {
 						captured.where = condition;
 						return {
-							orderBy: vi.fn(() => ({
-								limit: vi.fn(() => Promise.resolve(mockSightingData))
-							}))
+							orderBy: vi.fn((...teile: unknown[]) => {
+								captured.orderBy = teile;
+								return {
+									limit: vi.fn(() => Promise.resolve(mockSightingData))
+								};
+							})
 						};
 					})
 				}))
@@ -534,6 +545,24 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 
 			expect(response.status).toBe(200);
 			// Database ordering is tested through integration - query structure is mocked
+		});
+
+		// `sichtungsdatum` allein ist kein eindeutiger Schlüssel: In den
+		// Produktionsdaten teilen sich 81 Zeitpunkte mehrere Sichtungen, die
+		// größte Gruppe neun. Ohne eindeutiges zweites Kriterium ist die
+		// Reihenfolge innerhalb einer solchen Gruppe undefiniert — zwei
+		// aufeinanderfolgende Aufrufe gegen dieselbe Datenbank lieferten
+		// nachweislich verschiedene Reihenfolgen. Weil `.limit(1000)` im
+		// Normalbetrieb immer greift, entscheidet der Zufall damit auch
+		// darüber, WELCHE Sichtungen am Rand noch mitkommen.
+		it('sortiert eindeutig, damit dieselbe Anfrage dieselbe Antwort liefert', async () => {
+			const event = createMockRequestEvent();
+			await GET(event);
+
+			const orderBy = capturedOrderByText();
+
+			expect(orderBy).toContain('sichtungsdatum');
+			expect(orderBy).toMatch(/"id"/);
 		});
 
 		it('should apply reasonable result limit', async () => {

--- a/src/routes/sichtungen/showreports.json/showreports.test.ts
+++ b/src/routes/sichtungen/showreports.json/showreports.test.ts
@@ -559,10 +559,13 @@ describe('PDF-Compliant Legacy REST API - GET /sichtungen/showreports.json', () 
 			const event = createMockRequestEvent();
 			await GET(event);
 
-			const orderBy = capturedOrderByText();
-
-			expect(orderBy).toContain('sichtungsdatum');
-			expect(orderBy).toMatch(/"id"/);
+			// Die gesamte Sortierung festschreiben, nicht nur „id kommt vor":
+			// Eine vertauschte Reihenfolge (`id` zuerst) oder ein verlorenes
+			// `DESC` wäre eine andere Antwort für denselben Aufruf — und genau
+			// die Reproduzierbarkeit ist der Zweck dieses Tests.
+			expect(capturedOrderByText()).toBe(
+				'"sichtungen"."sichtungsdatum" DESC, "sichtungen"."id" DESC'
+			);
 		});
 
 		it('should apply reasonable result limit', async () => {

--- a/src/tools/send-legacy-inbox-cli.js
+++ b/src/tools/send-legacy-inbox-cli.js
@@ -1,0 +1,90 @@
+/**
+ * Kommandozeilen-Einstieg für den HTTP-Versand des Legacy-Posteingangs.
+ *
+ * Aufruf: npm run send:legacy-inbox -- <ziel-url> [--ssh=host:/pfad | --dir=/pfad]
+ *
+ * Beispiel (Produktion, Posteingang auf dem Plesk-Server):
+ *   npm run send:legacy-inbox -- https://dmm-prod-ostsee.ha.gecko.de
+ *
+ * Der Einstieg steht wie in import-legacy-inbox-cli.js auf der obersten Ebene
+ * und nicht hinter einer `import.meta.url`-Bedingung — unter einem Loader ist
+ * `process.argv[1]` der Loader, nie diese Datei, und die Bedingung wäre nie
+ * wahr. Anders als der Import braucht dieses Skript aber weder Datenbank noch
+ * `$lib/server/*`, es läuft deshalb unter blankem `node`.
+ */
+import {
+	erstelleDateiSpeicher,
+	erstelleSshSpeicher,
+	fehlerText,
+	sende
+} from './send-legacy-inbox.js';
+
+const STANDARD_SSH = 'hawking:/var/www/vhosts/schweinswalsichtung.de/legacy-inbox-data';
+
+const argumente = process.argv.slice(2);
+const zielUrl = argumente.find((a) => !a.startsWith('--'));
+const dirArg = argumente.find((a) => a.startsWith('--dir='))?.slice('--dir='.length);
+const sshArg = argumente.find((a) => a.startsWith('--ssh='))?.slice('--ssh='.length);
+
+if (!zielUrl) {
+	console.error(
+		'Aufruf: npm run send:legacy-inbox -- <ziel-url> [--ssh=host:/pfad | --dir=/pfad]\n' +
+			`Ohne --ssh/--dir wird ${STANDARD_SSH} verwendet.`
+	);
+	process.exit(1);
+}
+
+let speicher;
+
+if (dirArg) {
+	speicher = erstelleDateiSpeicher(dirArg);
+} else {
+	const roh = sshArg ?? STANDARD_SSH;
+	const trenner = roh.indexOf(':');
+	if (trenner < 1) {
+		console.error(`--ssh erwartet die Form host:/pfad, bekam: ${roh}`);
+		process.exit(1);
+	}
+	speicher = erstelleSshSpeicher({
+		host: roh.slice(0, trenner),
+		datenVerzeichnis: roh.slice(trenner + 1)
+	});
+}
+
+console.log(`Posteingang: ${speicher.beschreibung}`);
+console.log(`Ziel:        ${zielUrl}`);
+console.log(
+	'\nErinnerung: Jede angenommene Sichtung löst am Ziel eine Benachrichtigungs-E-Mail aus.\n' +
+		'Bei einem größeren Rückstand vorher notification.email.enabled abschalten — und danach\n' +
+		'wieder einschalten.\n'
+);
+
+let ergebnis;
+
+try {
+	ergebnis = await sende({ basisUrl: zielUrl, speicher });
+} catch (fehler) {
+	console.error(
+		`Der Posteingang ${speicher.beschreibung} war nicht lesbar: ${fehlerText(fehler)}\n` +
+			'Erwartet wird ein Verzeichnis mit den Unterverzeichnissen posteingang/ und importiert/.'
+	);
+	process.exit(1);
+}
+
+console.log(
+	`\n${ergebnis.uebernommen}/${ergebnis.gesamt} übernommen und nach importiert/ verschoben, ` +
+		`${ergebnis.abgelehnt.length} abgelehnt.`
+);
+
+for (const eintrag of ergebnis.abgelehnt) {
+	console.error(`  abgelehnt: ${eintrag.datei} — ${eintrag.grund ?? `HTTP ${eintrag.http}`}`);
+}
+
+if (ergebnis.abbruch) {
+	console.error(`\nLauf abgebrochen (${ergebnis.abbruch.grund}) bei ${ergebnis.abbruch.datei}.`);
+	if (ergebnis.abbruch.grund === 'rate-limit') {
+		console.error('In einer Stunde erneut starten — der Lauf macht dort weiter, wo er stand.');
+	}
+}
+
+process.exit(ergebnis.abbruch || ergebnis.abgelehnt.length > 0 ? 1 : 0);

--- a/src/tools/send-legacy-inbox-cli.js
+++ b/src/tools/send-legacy-inbox-cli.js
@@ -23,6 +23,9 @@ const STANDARD_SSH = 'hawking:/var/www/vhosts/schweinswalsichtung.de/legacy-inbo
 
 const argumente = process.argv.slice(2);
 const zielUrl = argumente.find((a) => !a.startsWith('--'));
+// `.find()` liefert das ganze Argument, `undefined` bedeutet also „nicht
+// angegeben" — ein leerer Wert (`--dir=`) ist dagegen eine Angabe und wird
+// unten abgelehnt, statt still auf den SSH-Standard zurückzufallen.
 const dirArg = argumente.find((a) => a.startsWith('--dir='))?.slice('--dir='.length);
 const sshArg = argumente.find((a) => a.startsWith('--ssh='))?.slice('--ssh='.length);
 
@@ -36,7 +39,11 @@ if (!zielUrl) {
 
 let speicher;
 
-if (dirArg) {
+if (dirArg !== undefined) {
+	if (dirArg === '') {
+		console.error('--dir= erwartet einen Pfad.');
+		process.exit(1);
+	}
 	speicher = erstelleDateiSpeicher(dirArg);
 } else {
 	const roh = sshArg ?? STANDARD_SSH;
@@ -58,6 +65,17 @@ console.log(
 		'Bei einem größeren Rückstand vorher notification.email.enabled abschalten — und danach\n' +
 		'wieder einschalten.\n'
 );
+
+// Die Ziel-URL vor dem `try` prüfen. `sende()` baut daraus als Erstes eine
+// `URL` und wirft bei einer unbrauchbaren Eingabe, noch bevor der Posteingang
+// überhaupt angefasst wird — der `catch` unten würde einen Tippfehler in der
+// URL dann als „Posteingang nicht lesbar" melden und in die Irre führen.
+try {
+	new URL('/rest_sichtungen', zielUrl);
+} catch {
+	console.error(`Keine brauchbare Ziel-URL: ${zielUrl}`);
+	process.exit(1);
+}
 
 let ergebnis;
 

--- a/src/tools/send-legacy-inbox.d.ts
+++ b/src/tools/send-legacy-inbox.d.ts
@@ -67,6 +67,8 @@ export function erstelleSshSpeicher(optionen: {
 	sudo?: boolean;
 	/** Nur zum Testen: ersetzt den `ssh`-Aufruf. */
 	ausfuehren?(argumente: string[]): Promise<{ stdout: string }>;
+	/** Nur zum Testen. Default: `console`. */
+	log?: { log(nachricht: string): void; error(nachricht: string): void };
 }): Speicher;
 
 export function fehlerText(fehler: unknown): string;

--- a/src/tools/send-legacy-inbox.d.ts
+++ b/src/tools/send-legacy-inbox.d.ts
@@ -1,0 +1,72 @@
+/**
+ * Handgeschriebene Typdeklaration für send-legacy-inbox.js.
+ *
+ * Gleicher Grund wie bei import-legacy-inbox.d.ts: `src/tools/**\/*.js` ist in
+ * tsconfig.json von der Typprüfung ausgeschlossen, aber der Test importiert das
+ * Modul und zöge es damit transitiv unter `strict` in den Programmgraphen. Eine
+ * co-lokierte `.d.ts` hat bei der Auflösung Vorrang und liefert bewusst lockere
+ * Typen für die Test-Stellvertreter.
+ */
+
+/** Ein Posteingang, egal ob lokal oder über SSH erreichbar. */
+export interface Speicher {
+	beschreibung?: string;
+	liste(): Promise<string[]>;
+	lies(datei: string): Promise<string>;
+	verschiebe(datei: string): Promise<void>;
+}
+
+export interface SendeOptionen {
+	/** Basis-URL der Zielinstanz, z. B. `https://dmm-prod-ostsee.ha.gecko.de`. */
+	basisUrl: string;
+	speicher: Speicher;
+	/** Nur zum Testen. Default: globales `fetch`. */
+	fetchImpl?(url: string, init: unknown): Promise<Response>;
+	/** Nur zum Testen. Default: `console`. */
+	log?: { log(nachricht: string): void; error(nachricht: string): void };
+}
+
+/**
+ * Eine Datei, die der Endpunkt nicht angenommen hat oder die gar nicht erst
+ * gesendet werden konnte. Sie bleibt im Posteingang liegen — jeder Eintrag
+ * hier braucht einen Menschen.
+ */
+export interface Ablehnung {
+	datei: string;
+	http?: number;
+	antwort?: string;
+	grund?: string;
+}
+
+/**
+ * Grund für einen abgebrochenen Lauf. Die drei Fälle sind bewusst
+ * unterscheidbar: `rate-limit` ist harmlos und wird durch einen späteren Lauf
+ * geheilt, `netzwerk` lässt offen, ob die Sichtung angelegt wurde, und
+ * `verschieben` heißt, dass die Sichtung sicher angelegt ist und die Datei von
+ * Hand nachgezogen werden muss.
+ */
+export interface Abbruch {
+	grund: 'rate-limit' | 'netzwerk' | 'verschieben';
+	datei: string;
+	sichtungId?: string | null;
+	meldung?: string;
+}
+
+export function sende(optionen: SendeOptionen): Promise<{
+	uebernommen: number;
+	abgelehnt: Ablehnung[];
+	abbruch: Abbruch | null;
+	gesamt: number;
+}>;
+
+export function erstelleDateiSpeicher(datenVerzeichnis: string): Speicher;
+
+export function erstelleSshSpeicher(optionen: {
+	host: string;
+	datenVerzeichnis: string;
+	sudo?: boolean;
+	/** Nur zum Testen: ersetzt den `ssh`-Aufruf. */
+	ausfuehren?(argumente: string[]): Promise<{ stdout: string }>;
+}): Speicher;
+
+export function fehlerText(fehler: unknown): string;

--- a/src/tools/send-legacy-inbox.js
+++ b/src/tools/send-legacy-inbox.js
@@ -1,0 +1,243 @@
+/**
+ * Schickt die Dateien des Legacy-Posteingangs an eine laufende Instanz und
+ * verschiebt jede angenommene Datei nach importiert/.
+ *
+ * Warum HTTP und nicht der direkte Weg wie in import-legacy-inbox.js? Weil das
+ * Ziel hier die Produktion ist. Der direkte Import braucht eine Verbindung zur
+ * Produktionsdatenbank; deren Port ist auf dem Produktionsserver bewusst nicht
+ * veröffentlicht, und ein Lauf im Container scheidet aus, weil dort kein
+ * Quellcode liegt. Bleibt der Weg, den die App selbst genommen hat:
+ * `POST /rest_sichtungen`.
+ *
+ * Das hat einen Nebeneffekt, der kein Nachteil ist: Der Endpunkt validiert
+ * jede Meldung mit demselben Yup-Schema wie bei einer echten App-Meldung.
+ * Der direkte Import tut das nicht — er ruft nur Mapping und Repository. Was
+ * hier durchkommt, hätte die App auch live einliefern können.
+ *
+ * Der Preis ist das Rate-Limit von 20 Meldungen pro Stunde und IP
+ * (`RATE_LIMITS.SIGHTING_SUBMISSION`). Bei einem `429` bricht der Lauf ab. Das
+ * ist unproblematisch, weil die Datei selbst das Protokoll ist: Übernommenes
+ * liegt in importiert/, Offenes in posteingang/. Ein Neustart nach Ablauf des
+ * Fensters macht dort weiter, wo der letzte Lauf stehen geblieben ist, und
+ * kann nichts doppelt anlegen.
+ *
+ * Aufruf über die Kommandozeile: npm run send:legacy-inbox -- <ziel-url>
+ * Der Einstiegspunkt liegt in send-legacy-inbox-cli.js; diese Datei ist reines
+ * Modul und führt beim Import nichts aus.
+ */
+import { execFile } from 'node:child_process';
+import { readdir, readFile, rename } from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Leitet aus einem geworfenen Wert eine Meldung ab, ohne selbst zu werfen.
+ * Gleiche Begründung wie in import-legacy-inbox.js: Die Fehler kommen aus
+ * fremdem Gebiet (JSON.parse über Client-Daten, fetch, ssh), und `throw null`
+ * ist erlaubt.
+ */
+export function fehlerText(fehler) {
+	if (fehler instanceof Error && typeof fehler.message === 'string') return fehler.message;
+	if (typeof fehler === 'string') return fehler;
+	try {
+		return String(fehler);
+	} catch {
+		return 'Unbekannter Fehler';
+	}
+}
+
+/**
+ * Posteingang im lokalen Dateisystem.
+ */
+export function erstelleDateiSpeicher(datenVerzeichnis) {
+	const eingang = path.join(datenVerzeichnis, 'posteingang');
+	const erledigt = path.join(datenVerzeichnis, 'importiert');
+
+	return {
+		beschreibung: datenVerzeichnis,
+		liste: async () => (await readdir(eingang)).filter((d) => d.endsWith('.json')).sort(),
+		lies: (datei) => readFile(path.join(eingang, datei), 'utf8'),
+		verschiebe: (datei) => rename(path.join(eingang, datei), path.join(erledigt, datei))
+	};
+}
+
+const ERLAUBTER_DATEINAME = /^[A-Za-z0-9._-]+\.json$/;
+
+/**
+ * Posteingang auf einem entfernten Rechner, erreichbar über SSH.
+ *
+ * Der Posteingang gehört dem Anwendungsbenutzer der Domain und ist mit 700
+ * gegen alle anderen abgeriegelt (legacy-inbox/README.md, Schritt 4) — genau
+ * so soll es sein, denn dort liegen Namen, Adressen und Telefonnummern der
+ * Melder. Ein Zugriff über den eigenen SSH-Benutzer kommt deshalb nur mit
+ * `sudo` daran.
+ *
+ * Dateinamen werden vor jedem Aufruf gegen ein enges Muster geprüft. `ssh`
+ * fügt seine Argumente auf der Gegenseite wieder zu einer Kommandozeile
+ * zusammen, die dort durch eine Shell läuft — `execFile` statt `exec`
+ * verhindert also nur die *lokale* Shell, nicht die entfernte. Ein Dateiname
+ * mit `;` oder `$(…)` wäre damit ausführbarer Code auf dem Plesk-Server. Der
+ * Posteingang-Dienst vergibt die Namen zwar selbst und nach festem Schema,
+ * aber diese Zusicherung liegt in einem anderen Projekt und kann sich ändern;
+ * die Prüfung hier kostet nichts und hängt von nichts ab.
+ */
+export function erstelleSshSpeicher({ host, datenVerzeichnis, sudo = true, ausfuehren }) {
+	const lauf = ausfuehren ?? ((argumente) => execFileAsync('ssh', [host, ...argumente]));
+	const praefix = sudo ? ['sudo', '-n'] : [];
+	const eingang = `${datenVerzeichnis}/posteingang`;
+	const erledigt = `${datenVerzeichnis}/importiert`;
+
+	const sichererName = (datei) => {
+		if (!ERLAUBTER_DATEINAME.test(datei)) {
+			throw new Error(`Dateiname nicht verwendbar: ${JSON.stringify(datei)}`);
+		}
+		return datei;
+	};
+
+	return {
+		beschreibung: `${host}:${datenVerzeichnis}`,
+		liste: async () => {
+			const { stdout } = await lauf([...praefix, 'ls', '-1', eingang]);
+			return stdout
+				.split('\n')
+				.map((zeile) => zeile.trim())
+				.filter((zeile) => ERLAUBTER_DATEINAME.test(zeile))
+				.sort();
+		},
+		lies: async (datei) => {
+			const { stdout } = await lauf([...praefix, 'cat', `${eingang}/${sichererName(datei)}`]);
+			return stdout;
+		},
+		verschiebe: async (datei) => {
+			sichererName(datei);
+			// `mv -n` überschreibt nichts. Läge in importiert/ schon eine Datei
+			// dieses Namens, wäre das ein Hinweis auf einen doppelten Lauf —
+			// dann soll der Vorgang auffallen und nicht die ältere Fassung
+			// stillschweigend ersetzen.
+			await lauf([...praefix, 'mv', '-n', `${eingang}/${datei}`, `${erledigt}/${datei}`]);
+		}
+	};
+}
+
+/**
+ * Baut den Request-Body aus einem Umschlag.
+ *
+ * Bevorzugt wird `roh` — das ist wörtlich das, was die App geschickt hat.
+ * Ein Re-Serialisieren aus `payload` wäre eine zweite Interpretation der Daten
+ * (Zahlenformate, Reihenfolge, Kodierung) und damit genau die Art von stiller
+ * Abweichung, die der Legacy-Vertrag nicht verträgt.
+ *
+ * Ausnahme: ein abgeschnittener Body. Der wäre als Rohtext unparsbar; dann ist
+ * der geparste Payload das Einzige, was noch trägt.
+ */
+function baueAnfrage(umschlag) {
+	const contentType = umschlag.quelle?.content_type || 'application/json';
+
+	if (typeof umschlag.roh === 'string' && umschlag.roh !== '' && umschlag.abgeschnitten !== true) {
+		return { body: umschlag.roh, contentType };
+	}
+
+	return { body: JSON.stringify(umschlag.payload), contentType: 'application/json' };
+}
+
+export async function sende({ basisUrl, speicher, fetchImpl = fetch, log = console }) {
+	const ziel = new URL('/rest_sichtungen', basisUrl).toString();
+	const dateien = await speicher.liste();
+
+	let uebernommen = 0;
+	const abgelehnt = [];
+	let abbruch = null;
+
+	for (const datei of dateien) {
+		let umschlag;
+
+		try {
+			umschlag = JSON.parse(await speicher.lies(datei));
+		} catch (fehler) {
+			// Eine unlesbare Datei hält den Rest nicht auf — sie bleibt liegen
+			// und braucht einen Menschen.
+			log.error(`${datei}: nicht lesbar (${fehlerText(fehler)}) — bleibt liegen`);
+			abgelehnt.push({ datei, grund: fehlerText(fehler) });
+			continue;
+		}
+
+		if (!umschlag.payload) {
+			log.error(`${datei}: kein Payload — bleibt liegen`);
+			abgelehnt.push({ datei, grund: 'kein Payload' });
+			continue;
+		}
+
+		const { body, contentType } = baueAnfrage(umschlag);
+
+		let antwort;
+		try {
+			antwort = await fetchImpl(ziel, {
+				method: 'POST',
+				headers: {
+					'content-type': contentType,
+					// Der ursprüngliche User-Agent macht die Meldung im
+					// Serverprotokoll als App-Meldung erkennbar, statt sie als
+					// Node-Aufruf erscheinen zu lassen.
+					'user-agent': umschlag.quelle?.user_agent || 'legacy-inbox-import'
+				},
+				body
+			});
+		} catch (fehler) {
+			// Ein Netzwerkfehler sagt nichts darüber aus, ob die Sichtung
+			// angelegt wurde — die Antwort ist auf dem Weg verloren gegangen,
+			// die Anfrage kann den Server sehr wohl erreicht haben. Weiter zu
+			// senden wäre falsch: Bei einer abgerissenen Verbindung würde ein
+			// späterer Lauf dieselbe Datei erneut schicken. Deshalb Abbruch mit
+			// klarer Ansage.
+			log.error(`${datei}: Verbindung fehlgeschlagen (${fehlerText(fehler)}) — Lauf abgebrochen`);
+			abbruch = { grund: 'netzwerk', datei, meldung: fehlerText(fehler) };
+			break;
+		}
+
+		if (antwort.status === 429) {
+			log.error(
+				`${datei}: Rate-Limit erreicht (429). Der Endpunkt lässt 20 Meldungen pro Stunde und ` +
+					`IP zu. Lauf abgebrochen — in einer Stunde erneut starten, ${datei} und alles ` +
+					`Folgende liegen unverändert im Posteingang.`
+			);
+			abbruch = { grund: 'rate-limit', datei };
+			break;
+		}
+
+		if (antwort.status !== 201) {
+			// Der Endpunkt hat die Meldung inhaltlich abgelehnt. Sie bleibt
+			// liegen — genau wie ein Eintrag in abgewiesen/ ein Warnsignal ist
+			// und einen Menschen braucht.
+			const text = await antwort.text().catch(() => '');
+			log.error(`${datei}: abgelehnt mit HTTP ${antwort.status} — ${text.slice(0, 300)}`);
+			abgelehnt.push({ datei, http: antwort.status, antwort: text.slice(0, 300) });
+			continue;
+		}
+
+		const ort = antwort.headers.get('location');
+
+		// Ab hier existiert die Sichtung in der Zieldatenbank. Scheitert jetzt
+		// das Verschieben, ist das eine gescheiterte Aufräumarbeit an einem
+		// abgeschlossenen Vorgang — und der einzige Fall, in dem ein weiterer
+		// Lauf etwas doppelt anlegen könnte. Deshalb sofortiger Abbruch mit
+		// Nennung der Datei, gleiche Begründung wie in import-legacy-inbox.js.
+		try {
+			await speicher.verschiebe(datei);
+		} catch (fehler) {
+			log.error(
+				`${datei}: Sichtung wurde angelegt (${ort}), aber die Datei konnte nicht nach ` +
+					`importiert/ verschoben werden (${fehlerText(fehler)}). Datei von Hand verschieben, ` +
+					`bevor der Lauf wiederholt wird — sonst wird die Sichtung doppelt angelegt.`
+			);
+			abbruch = { grund: 'verschieben', datei, sichtungId: ort, meldung: fehlerText(fehler) };
+			break;
+		}
+
+		uebernommen++;
+		log.log(`${datei} → ${ort}`);
+	}
+
+	return { uebernommen, abgelehnt, abbruch, gesamt: dateien.length };
+}

--- a/src/tools/send-legacy-inbox.js
+++ b/src/tools/send-legacy-inbox.js
@@ -26,7 +26,7 @@
  * Modul und führt beim Import nichts aus.
  */
 import { execFile } from 'node:child_process';
-import { readdir, readFile, rename } from 'node:fs/promises';
+import { access, readdir, readFile, rename } from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -49,6 +49,23 @@ export function fehlerText(fehler) {
 }
 
 /**
+ * Meldung für den einen Konflikt, den beide Speicher gleich behandeln müssen:
+ * In importiert/ liegt bereits eine Datei dieses Namens.
+ *
+ * Das ist immer ein Hinweis auf einen unterbrochenen früheren Lauf und darf
+ * niemals still hingenommen werden — weder durch Überschreiben (die ältere
+ * Fassung wäre weg) noch durch Nichtstun (die Datei bliebe in posteingang/
+ * liegen und der nächste Lauf legte dieselbe Sichtung ein zweites Mal an).
+ * Deshalb wirft es, und `sende()` bricht den Lauf mit Grund `verschieben` ab.
+ */
+function konflikt(datei) {
+	return new Error(
+		`In importiert/ liegt bereits ${datei} — der Lauf würde die ältere Fassung ` +
+			'überschreiben oder die Datei liegen lassen. Von Hand klären.'
+	);
+}
+
+/**
  * Posteingang im lokalen Dateisystem.
  */
 export function erstelleDateiSpeicher(datenVerzeichnis) {
@@ -59,8 +76,27 @@ export function erstelleDateiSpeicher(datenVerzeichnis) {
 		beschreibung: datenVerzeichnis,
 		liste: async () => (await readdir(eingang)).filter((d) => d.endsWith('.json')).sort(),
 		lies: (datei) => readFile(path.join(eingang, datei), 'utf8'),
-		verschiebe: (datei) => rename(path.join(eingang, datei), path.join(erledigt, datei))
+		verschiebe: async (datei) => {
+			const ziel = path.join(erledigt, datei);
+
+			// `rename()` überschreibt still — deshalb die Prüfung davor. Das ist
+			// kein Schutz gegen einen gleichzeitigen zweiten Lauf (dafür wäre es
+			// ein Wettlauf), sondern gegen den Fall, den es hier wirklich gibt:
+			// Reste eines abgebrochenen Laufs.
+			if (await existiert(ziel)) throw konflikt(datei);
+
+			await rename(path.join(eingang, datei), ziel);
+		}
 	};
+}
+
+async function existiert(pfad) {
+	try {
+		await access(pfad);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 const ERLAUBTER_DATEINAME = /^[A-Za-z0-9._-]+\.json$/;
@@ -83,8 +119,20 @@ const ERLAUBTER_DATEINAME = /^[A-Za-z0-9._-]+\.json$/;
  * aber diese Zusicherung liegt in einem anderen Projekt und kann sich ändern;
  * die Prüfung hier kostet nichts und hängt von nichts ab.
  */
-export function erstelleSshSpeicher({ host, datenVerzeichnis, sudo = true, ausfuehren }) {
-	const lauf = ausfuehren ?? ((argumente) => execFileAsync('ssh', [host, ...argumente]));
+export function erstelleSshSpeicher({
+	host,
+	datenVerzeichnis,
+	sudo = true,
+	ausfuehren,
+	log = console
+}) {
+	// `BatchMode=yes`: Ohne das bleibt ssh bei unbekanntem Hostkey oder
+	// passphrasegeschütztem Schlüssel an einer Eingabeaufforderung hängen. In
+	// einem Cron-Lauf wäre das kein Fehler, sondern ein Prozess, der ewig
+	// wartet und nie meldet, warum.
+	const lauf =
+		ausfuehren ??
+		((argumente) => execFileAsync('ssh', ['-o', 'BatchMode=yes', host, ...argumente]));
 	const praefix = sudo ? ['sudo', '-n'] : [];
 	const eingang = `${datenVerzeichnis}/posteingang`;
 	const erledigt = `${datenVerzeichnis}/importiert`;
@@ -100,11 +148,20 @@ export function erstelleSshSpeicher({ host, datenVerzeichnis, sudo = true, ausfu
 		beschreibung: `${host}:${datenVerzeichnis}`,
 		liste: async () => {
 			const { stdout } = await lauf([...praefix, 'ls', '-1', eingang]);
-			return stdout
+			const zeilen = stdout
 				.split('\n')
 				.map((zeile) => zeile.trim())
-				.filter((zeile) => ERLAUBTER_DATEINAME.test(zeile))
-				.sort();
+				.filter((zeile) => zeile !== '');
+
+			// Aussortierte Namen laut melden statt still verschlucken: Eine
+			// solche Datei taucht sonst weder in `gesamt` noch in `abgelehnt`
+			// auf, und niemand erfährt, dass im Posteingang etwas liegt, das
+			// nie jemand ansieht.
+			for (const zeile of zeilen.filter((z) => !ERLAUBTER_DATEINAME.test(z))) {
+				log.error(`${zeile}: unerwarteter Dateiname — wird übersprungen und bleibt liegen`);
+			}
+
+			return zeilen.filter((zeile) => ERLAUBTER_DATEINAME.test(zeile)).sort();
 		},
 		lies: async (datei) => {
 			const { stdout } = await lauf([...praefix, 'cat', `${eingang}/${sichererName(datei)}`]);
@@ -112,11 +169,30 @@ export function erstelleSshSpeicher({ host, datenVerzeichnis, sudo = true, ausfu
 		},
 		verschiebe: async (datei) => {
 			sichererName(datei);
-			// `mv -n` überschreibt nichts. Läge in importiert/ schon eine Datei
-			// dieses Namens, wäre das ein Hinweis auf einen doppelten Lauf —
-			// dann soll der Vorgang auffallen und nicht die ältere Fassung
-			// stillschweigend ersetzen.
-			await lauf([...praefix, 'mv', '-n', `${eingang}/${datei}`, `${erledigt}/${datei}`]);
+
+			// Zwei Aufrufe statt `mv -n`, und das ist der Kern der Sache:
+			// `mv -n` verweigert das Überschreiben zwar, endet dabei aber mit
+			// Exit 0 und lässt die Quelle liegen (auf macOS wie unter GNU
+			// nachgemessen). Für den Aufrufer sähe das aus wie ein geglücktes
+			// Verschieben — die Datei bliebe in posteingang/, und der nächste
+			// Lauf schickte dieselbe Sichtung ein zweites Mal an die Produktion.
+			// Ein Duplikat, erzeugt ausgerechnet von der Vorsichtsmaßnahme.
+			//
+			// `test -e` endet bei einem Treffer mit Exit 0 und nur bei fehlender
+			// Datei mit Exit 1. Der Konflikt steht deshalb im `try`-Zweig und
+			// das Weitermachen im `catch` — herum, wie man es zuerst erwartet.
+			// Kein `sh -c '… && …'`: `ssh` fügt seine Argumente auf der
+			// Gegenseite wieder zu einer Kommandozeile zusammen, die dort eine
+			// Shell parst — das `&&` würde dann vor `sh` ausgewertet.
+			let belegt = true;
+			try {
+				await lauf([...praefix, 'test', '-e', `${erledigt}/${datei}`]);
+			} catch {
+				belegt = false;
+			}
+			if (belegt) throw konflikt(datei);
+
+			await lauf([...praefix, 'mv', `${eingang}/${datei}`, `${erledigt}/${datei}`]);
 		}
 	};
 }

--- a/src/tools/send-legacy-inbox.js
+++ b/src/tools/send-legacy-inbox.js
@@ -102,6 +102,24 @@ async function existiert(pfad) {
 const ERLAUBTER_DATEINAME = /^[A-Za-z0-9._-]+\.json$/;
 
 /**
+ * Ein Rechnername darf nicht mit `-` beginnen: `execFile` übergibt ihn als
+ * Argument an `ssh`, und alles, was mit `-` anfängt, liest `ssh` als Option.
+ * Ein `host` wie `-oProxyCommand=…` wäre damit ein beliebiger lokaler Befehl.
+ * `@` ist erlaubt (`benutzer@rechner`), `:` nicht — der Trenner gehört in den
+ * Aufrufer, nicht in den Wert.
+ */
+const ERLAUBTER_HOST = /^[A-Za-z0-9._@][A-Za-z0-9._@-]*$/;
+
+/**
+ * Absoluter Pfad aus einem engen Zeichensatz. Anders als die Dateinamen kommt
+ * dieser Wert vom Aufrufer und nicht aus einem fremden Verzeichnis — die
+ * Begründung ist trotzdem dieselbe: Er landet in einer Kommandozeile, die auf
+ * der Gegenseite eine Shell parst. Ein Leerzeichen zerlegte den Pfad still in
+ * zwei Argumente, ein `;` wäre ausführbarer Code.
+ */
+const ERLAUBTES_VERZEICHNIS = /^\/[A-Za-z0-9._/-]*$/;
+
+/**
  * Posteingang auf einem entfernten Rechner, erreichbar über SSH.
  *
  * Der Posteingang gehört dem Anwendungsbenutzer der Domain und ist mit 700
@@ -126,13 +144,27 @@ export function erstelleSshSpeicher({
 	ausfuehren,
 	log = console
 }) {
+	if (!ERLAUBTER_HOST.test(host)) {
+		throw new Error(`Rechnername nicht verwendbar: ${JSON.stringify(host)}`);
+	}
+	if (!ERLAUBTES_VERZEICHNIS.test(datenVerzeichnis)) {
+		throw new Error(
+			`Datenverzeichnis nicht verwendbar: ${JSON.stringify(datenVerzeichnis)} — ` +
+				'erwartet wird ein absoluter Pfad ohne Leerzeichen und Sonderzeichen.'
+		);
+	}
+
 	// `BatchMode=yes`: Ohne das bleibt ssh bei unbekanntem Hostkey oder
 	// passphrasegeschütztem Schlüssel an einer Eingabeaufforderung hängen. In
 	// einem Cron-Lauf wäre das kein Fehler, sondern ein Prozess, der ewig
 	// wartet und nie meldet, warum.
+	//
+	// `--` beendet die Optionsauswertung von ssh. Die Prüfung oben schließt
+	// einen führenden Bindestrich bereits aus; beides zusammen heißt, dass
+	// diese Stelle auch dann hält, wenn jemand das Muster später lockert.
 	const lauf =
 		ausfuehren ??
-		((argumente) => execFileAsync('ssh', ['-o', 'BatchMode=yes', host, ...argumente]));
+		((argumente) => execFileAsync('ssh', ['-o', 'BatchMode=yes', '--', host, ...argumente]));
 	const praefix = sudo ? ['sudo', '-n'] : [];
 	const eingang = `${datenVerzeichnis}/posteingang`;
 	const erledigt = `${datenVerzeichnis}/importiert`;

--- a/src/tools/send-legacy-inbox.test.ts
+++ b/src/tools/send-legacy-inbox.test.ts
@@ -9,7 +9,10 @@
  * importiert/ wandern.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { erstelleSshSpeicher, sende } from './send-legacy-inbox.js';
+import { mkdtemp, mkdir, writeFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { erstelleDateiSpeicher, erstelleSshSpeicher, sende } from './send-legacy-inbox.js';
 
 /** Speicher-Attrappe: hält den Posteingang im Arbeitsspeicher. */
 function speicherMit(dateien: Record<string, unknown>) {
@@ -210,19 +213,63 @@ describe('erstelleSshSpeicher', () => {
 		expect(aufrufe[0]).toEqual(['sudo', '-n', 'ls', '-1', '/daten/posteingang']);
 	});
 
-	it('verschiebt mit mv -n, damit nichts überschrieben wird', async () => {
-		const { speicher, aufrufe } = speicherMitAufrufen();
+	it('bricht ab, wenn in importiert/ schon eine Datei dieses Namens liegt', async () => {
+		// `mv -n` wäre hier die naheliegende Wahl und die falsche: Es verweigert
+		// das Überschreiben, endet dabei aber mit Exit 0 und lässt die Quelle
+		// liegen. Der Aufrufer hielte das für ein geglücktes Verschieben, die
+		// Datei bliebe in posteingang/, und der nächste Lauf schickte dieselbe
+		// Sichtung ein zweites Mal an die Produktion.
+		const aufrufe: string[][] = [];
+		const speicher = erstelleSshSpeicher({
+			host: 'hawking',
+			datenVerzeichnis: '/daten',
+			ausfuehren: async (argumente: string[]) => {
+				aufrufe.push(argumente);
+				// `test -e` findet die Datei → Exit 0 → kein Wurf.
+				return { stdout: '' };
+			}
+		});
+
+		await expect(speicher.verschiebe('a.json')).rejects.toThrow('liegt bereits a.json');
+		expect(aufrufe).toEqual([['sudo', '-n', 'test', '-e', '/daten/importiert/a.json']]);
+	});
+
+	it('verschiebt, wenn das Ziel frei ist', async () => {
+		const aufrufe: string[][] = [];
+		const speicher = erstelleSshSpeicher({
+			host: 'hawking',
+			datenVerzeichnis: '/daten',
+			ausfuehren: async (argumente: string[]) => {
+				aufrufe.push(argumente);
+				// `test -e` findet nichts → Exit 1 → execFile wirft.
+				if (argumente.includes('test')) throw new Error('exit 1');
+				return { stdout: '' };
+			}
+		});
 
 		await speicher.verschiebe('a.json');
 
-		expect(aufrufe[0]).toEqual([
+		expect(aufrufe[1]).toEqual([
 			'sudo',
 			'-n',
 			'mv',
-			'-n',
 			'/daten/posteingang/a.json',
 			'/daten/importiert/a.json'
 		]);
+	});
+
+	it('meldet aussortierte Dateinamen, statt sie still zu verschlucken', async () => {
+		const gemeldet: string[] = [];
+		const speicher = erstelleSshSpeicher({
+			host: 'hawking',
+			datenVerzeichnis: '/daten',
+			ausfuehren: async () => ({ stdout: 'a.json\nkaputt name.json\n' }),
+			log: { log: () => {}, error: (n: string) => gemeldet.push(n) }
+		});
+
+		expect(await speicher.liste()).toEqual(['a.json']);
+		expect(gemeldet).toHaveLength(1);
+		expect(gemeldet[0]).toContain('kaputt name.json');
 	});
 
 	it('weist einen Dateinamen zurück, der auf der Gegenseite als Kommando wirken könnte', async () => {
@@ -234,5 +281,37 @@ describe('erstelleSshSpeicher', () => {
 		await expect(speicher.lies('a.json; rm -rf /')).rejects.toThrow('nicht verwendbar');
 		await expect(speicher.verschiebe('$(id).json')).rejects.toThrow('nicht verwendbar');
 		expect(aufrufe).toEqual([]);
+	});
+});
+
+describe('erstelleDateiSpeicher', () => {
+	async function verzeichnisMit(posteingang: string[], importiert: string[]) {
+		const wurzel = await mkdtemp(join(tmpdir(), 'inbox-'));
+		await mkdir(join(wurzel, 'posteingang'));
+		await mkdir(join(wurzel, 'importiert'));
+		for (const name of posteingang) await writeFile(join(wurzel, 'posteingang', name), 'neu');
+		for (const name of importiert) await writeFile(join(wurzel, 'importiert', name), 'alt');
+		return wurzel;
+	}
+
+	it('bricht ab, statt eine Datei in importiert/ zu überschreiben', async () => {
+		// `rename()` überschreibt still — der ältere Umschlag wäre weg, und
+		// weil er der Herkunftsnachweis der Sichtung ist, unwiederbringlich.
+		const wurzel = await verzeichnisMit(['a.json'], ['a.json']);
+		const speicher = erstelleDateiSpeicher(wurzel);
+
+		await expect(speicher.verschiebe('a.json')).rejects.toThrow('liegt bereits a.json');
+
+		expect(await readdir(join(wurzel, 'posteingang'))).toEqual(['a.json']);
+	});
+
+	it('verschiebt, wenn das Ziel frei ist', async () => {
+		const wurzel = await verzeichnisMit(['a.json'], []);
+		const speicher = erstelleDateiSpeicher(wurzel);
+
+		await speicher.verschiebe('a.json');
+
+		expect(await readdir(join(wurzel, 'posteingang'))).toEqual([]);
+		expect(await readdir(join(wurzel, 'importiert'))).toEqual(['a.json']);
 	});
 });

--- a/src/tools/send-legacy-inbox.test.ts
+++ b/src/tools/send-legacy-inbox.test.ts
@@ -272,6 +272,33 @@ describe('erstelleSshSpeicher', () => {
 		expect(gemeldet[0]).toContain('kaputt name.json');
 	});
 
+	it('weist einen Rechnernamen zurück, der als ssh-Option gelesen würde', () => {
+		// `execFile` übergibt den Wert als Argument an ssh; alles mit führendem
+		// Bindestrich liest ssh als Option. `-oProxyCommand=…` wäre ein
+		// beliebiger lokaler Befehl.
+		expect(() =>
+			erstelleSshSpeicher({ host: '-oProxyCommand=touch /tmp/x', datenVerzeichnis: '/daten' })
+		).toThrow('Rechnername nicht verwendbar');
+	});
+
+	it('weist ein Datenverzeichnis zurück, das die entfernte Shell zerlegen würde', () => {
+		expect(() =>
+			erstelleSshSpeicher({ host: 'hawking', datenVerzeichnis: '/mit leerzeichen' })
+		).toThrow('Datenverzeichnis nicht verwendbar');
+		expect(() => erstelleSshSpeicher({ host: 'hawking', datenVerzeichnis: '/a;rm -rf /' })).toThrow(
+			'Datenverzeichnis nicht verwendbar'
+		);
+		expect(() =>
+			erstelleSshSpeicher({ host: 'hawking', datenVerzeichnis: 'relativ/pfad' })
+		).toThrow('Datenverzeichnis nicht verwendbar');
+	});
+
+	it('lässt benutzer@rechner und übliche Pfade durch', () => {
+		expect(() =>
+			erstelleSshSpeicher({ host: 'jan@hawking.example.de', datenVerzeichnis: '/var/www/daten' })
+		).not.toThrow();
+	});
+
 	it('weist einen Dateinamen zurück, der auf der Gegenseite als Kommando wirken könnte', async () => {
 		// ssh setzt seine Argumente auf der Gegenseite wieder zu einer
 		// Kommandozeile zusammen, die dort durch eine Shell läuft. Ohne diese

--- a/src/tools/send-legacy-inbox.test.ts
+++ b/src/tools/send-legacy-inbox.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests für den HTTP-Versand des Legacy-Posteingangs an eine laufende Instanz.
+ *
+ * Der Unterschied zu import-legacy-inbox.test.ts ist der Weg: Dort werden
+ * `mapLegacyToCurrentSchema` und `saveSighting` direkt gerufen, hier geht jede
+ * Sichtung über `POST /rest_sichtungen` — denselben Endpunkt, den die App
+ * benutzt hat. Getestet wird deshalb genau das, was daran neu ist: Was passiert
+ * bei 429, was bei einer inhaltlichen Ablehnung, und wann darf eine Datei nach
+ * importiert/ wandern.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { erstelleSshSpeicher, sende } from './send-legacy-inbox.js';
+
+/** Speicher-Attrappe: hält den Posteingang im Arbeitsspeicher. */
+function speicherMit(dateien: Record<string, unknown>) {
+	const eingang = new Map(Object.entries(dateien).map(([name, inhalt]) => [name, inhalt]));
+	const verschoben: string[] = [];
+
+	return {
+		verschoben,
+		eingang,
+		liste: async () => [...eingang.keys()].sort(),
+		lies: async (name: string) => JSON.stringify(eingang.get(name)),
+		verschiebe: async (name: string) => {
+			eingang.delete(name);
+			verschoben.push(name);
+		}
+	};
+}
+
+function umschlag(payload: Record<string, unknown> | null, extra: Record<string, unknown> = {}) {
+	return {
+		empfangen_am: '2026-08-08T17:19:47.919Z',
+		quelle: { ip: '1.2.3.4', user_agent: 'OstSeeTiere/8', content_type: 'application/json' },
+		roh: payload === null ? '' : JSON.stringify(payload),
+		abgeschnitten: false,
+		payload,
+		validierung: { gueltig: true, fehler: {} },
+		...extra
+	};
+}
+
+const stumm = { log: () => {}, error: () => {} };
+
+function antwort(status: number, body = '{"message":"Saved"}') {
+	return new Response(body, { status, headers: { Location: '/rest_sichtungen/view/1.json' } });
+}
+
+describe('sende', () => {
+	it('schickt jede Datei an den Endpunkt und verschiebt sie nach einem 201', async () => {
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0 }),
+			'000002__b.json': umschlag({ tierart: 1 })
+		});
+		const fetchImpl = vi.fn().mockResolvedValue(antwort(201));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+		expect(fetchImpl.mock.calls[0]?.[0]).toBe('https://beispiel.test/rest_sichtungen');
+		expect(ergebnis).toMatchObject({ uebernommen: 2, abgelehnt: [], abbruch: null });
+		expect(speicher.verschoben).toEqual(['000001__a.json', '000002__b.json']);
+	});
+
+	it('schickt den Rohtext wörtlich, damit der Vertrag nicht durch ein Re-Serialisieren verändert wird', async () => {
+		const roh = '{"tierart":0,"gps_breite":"54.359396"}';
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0, gps_breite: '54.359396' }, { roh })
+		});
+		const fetchImpl = vi.fn().mockResolvedValue(antwort(201));
+
+		await sende({ basisUrl: 'https://beispiel.test', speicher, fetchImpl, log: stumm });
+
+		expect(fetchImpl.mock.calls[0]?.[1].body).toBe(roh);
+		expect(fetchImpl.mock.calls[0]?.[1].headers['content-type']).toBe('application/json');
+	});
+
+	it('bricht bei einem 429 ab, ohne die Datei zu verschieben', async () => {
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0 }),
+			'000002__b.json': umschlag({ tierart: 1 })
+		});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(antwort(201))
+			.mockResolvedValueOnce(antwort(429, 'Too Many Requests'));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(ergebnis.uebernommen).toBe(1);
+		expect(ergebnis.abbruch).toMatchObject({ grund: 'rate-limit', datei: '000002__b.json' });
+		expect(speicher.verschoben).toEqual(['000001__a.json']);
+		// Nach dem Abbruch darf nichts weiter gesendet werden.
+		expect(fetchImpl).toHaveBeenCalledTimes(2);
+	});
+
+	it('lässt eine inhaltlich abgelehnte Datei liegen und macht weiter', async () => {
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0 }),
+			'000002__b.json': umschlag({ tierart: 1 })
+		});
+		const fetchImpl = vi
+			.fn()
+			.mockResolvedValueOnce(antwort(400, '{"error":"Validation failed"}'))
+			.mockResolvedValueOnce(antwort(201));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(ergebnis.uebernommen).toBe(1);
+		expect(ergebnis.abgelehnt).toMatchObject([{ datei: '000001__a.json', http: 400 }]);
+		expect(ergebnis.abbruch).toBeNull();
+		expect(speicher.verschoben).toEqual(['000002__b.json']);
+	});
+
+	it('überspringt einen Umschlag ohne Payload, ohne ihn zu senden', async () => {
+		const speicher = speicherMit({ '000001__a.json': umschlag(null, { roh: 'kaputt' }) });
+		const fetchImpl = vi.fn().mockResolvedValue(antwort(201));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(fetchImpl).not.toHaveBeenCalled();
+		expect(ergebnis.uebernommen).toBe(0);
+		expect(ergebnis.abgelehnt).toMatchObject([{ datei: '000001__a.json', grund: 'kein Payload' }]);
+		expect(speicher.verschoben).toEqual([]);
+	});
+
+	it('bricht ab, wenn eine bereits angelegte Sichtung nicht verschoben werden kann', async () => {
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0 }),
+			'000002__b.json': umschlag({ tierart: 1 })
+		});
+		speicher.verschiebe = async () => {
+			throw new Error('Platte voll');
+		};
+		const fetchImpl = vi.fn().mockResolvedValue(antwort(201));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(ergebnis.abbruch).toMatchObject({
+			grund: 'verschieben',
+			datei: '000001__a.json',
+			sichtungId: '/rest_sichtungen/view/1.json'
+		});
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+	});
+
+	it('bricht bei einem Netzwerkfehler ab, statt die restlichen Dateien blind zu senden', async () => {
+		const speicher = speicherMit({
+			'000001__a.json': umschlag({ tierart: 0 }),
+			'000002__b.json': umschlag({ tierart: 1 })
+		});
+		const fetchImpl = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+		const ergebnis = await sende({
+			basisUrl: 'https://beispiel.test',
+			speicher,
+			fetchImpl,
+			log: stumm
+		});
+
+		expect(ergebnis.abbruch).toMatchObject({ grund: 'netzwerk', datei: '000001__a.json' });
+		expect(fetchImpl).toHaveBeenCalledTimes(1);
+		expect(speicher.verschoben).toEqual([]);
+	});
+});
+
+describe('erstelleSshSpeicher', () => {
+	function speicherMitAufrufen(stdout = '') {
+		const aufrufe: string[][] = [];
+		const speicher = erstelleSshSpeicher({
+			host: 'hawking',
+			datenVerzeichnis: '/daten',
+			ausfuehren: async (argumente: string[]) => {
+				aufrufe.push(argumente);
+				return { stdout };
+			}
+		});
+		return { speicher, aufrufe };
+	}
+
+	it('listet nur JSON-Dateien und ruft sudo -n auf', async () => {
+		const { speicher, aufrufe } = speicherMitAufrufen('b.json\na.json\n.gitkeep\n\n');
+
+		expect(await speicher.liste()).toEqual(['a.json', 'b.json']);
+		expect(aufrufe[0]).toEqual(['sudo', '-n', 'ls', '-1', '/daten/posteingang']);
+	});
+
+	it('verschiebt mit mv -n, damit nichts überschrieben wird', async () => {
+		const { speicher, aufrufe } = speicherMitAufrufen();
+
+		await speicher.verschiebe('a.json');
+
+		expect(aufrufe[0]).toEqual([
+			'sudo',
+			'-n',
+			'mv',
+			'-n',
+			'/daten/posteingang/a.json',
+			'/daten/importiert/a.json'
+		]);
+	});
+
+	it('weist einen Dateinamen zurück, der auf der Gegenseite als Kommando wirken könnte', async () => {
+		// ssh setzt seine Argumente auf der Gegenseite wieder zu einer
+		// Kommandozeile zusammen, die dort durch eine Shell läuft. Ohne diese
+		// Prüfung wäre ein solcher Name ausführbarer Code auf dem Plesk-Server.
+		const { speicher, aufrufe } = speicherMitAufrufen();
+
+		await expect(speicher.lies('a.json; rm -rf /')).rejects.toThrow('nicht verwendbar');
+		await expect(speicher.verschiebe('$(id).json')).rejects.toThrow('nicht verwendbar');
+		expect(aufrufe).toEqual([]);
+	});
+});

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -2166,6 +2166,16 @@ paths:
         - ar: Gebiet/Gewässer
         - ta: Tierart als deutsches Label (Erweiterung über Original-PDF hinaus)
         - tf: Totfund-Flag 0/1 (Erweiterung über Original-PDF hinaus)
+
+        **Sortierung und Umfang**
+
+        Sortiert nach `sichtungsdatum` absteigend, bei gleichem Zeitpunkt nach `id`
+        absteigend. Das zweite Kriterium ist notwendig, weil `sichtungsdatum` nicht
+        eindeutig ist; ohne es liefert dieselbe Anfrage unterschiedliche Antworten.
+
+        Die Antwort ist auf **1000 Sichtungen** begrenzt. Diese Grenze greift im
+        Normalbetrieb auch ohne Filter — Clients, die einen vollständigen Bestand
+        erwarten, müssen über `year` einschränken.
       parameters:
         - name: year
           in: query


### PR DESCRIPTION
## Warum

Im Legacy-Posteingang auf hawking lagen 37 App-Sichtungen, die nie in die Datenbank kamen. Der bestehende `import:legacy-inbox` ruft Mapping und Repository direkt und braucht dafür eine Verbindung zur Zieldatenbank — für Produktion gibt es die nicht: Der DB-Port ist dort bewusst nicht veröffentlicht, und ein Lauf im Container scheidet aus, weil kein Quellcode auf dem Server liegt.

## Was drin ist

**1. `npm run send:legacy-inbox` — Versand über HTTP**

Geht den Weg, den die App selbst genommen hat: `POST /rest_sichtungen`. Das ist kein Notbehelf, sondern die strengere Prüfung — der Endpunkt validiert zusätzlich mit dem Yup-Schema, was der direkte Import nicht tut. Gesendet wird `roh` wörtlich; ein Re-Serialisieren aus `payload` wäre eine zweite Interpretation der Daten und damit genau die stille Abweichung, die der Legacy-Vertrag nicht verträgt.

Der Preis ist das Rate-Limit von 20 Meldungen pro Stunde und IP. Beim ersten `429` bricht der Lauf ab und meldet, wo er stand — unkritisch, weil die Datei das Protokoll ist: Übernommenes liegt in `importiert/`, Offenes in `posteingang/`. Abgebrochen wird auch bei Netzwerkfehler (unbekannt, ob die Sichtung angelegt wurde) und bei Verschiebe-Konflikt. Eine inhaltlich abgelehnte Datei hält den Lauf dagegen nicht auf.

Der SSH-Speicher prüft Dateinamen gegen ein enges Muster: `ssh` fügt seine Argumente auf der Gegenseite wieder zu einer Kommandozeile zusammen, die dort durch eine Shell läuft — `execFile` verhindert nur die *lokale* Shell, nicht die entfernte.

**2. `showreports.json` eindeutig sortieren**

`ORDER BY sichtungsdatum DESC` allein ist nicht eindeutig: Im Produktivbestand teilen sich **81 Zeitpunkte mehrere Sichtungen, die größte Gruppe neun**. Zwei aufeinanderfolgende Aufrufe gegen dieselbe Datenbank lieferten nachweislich verschiedene Reihenfolgen. Weil `.limit(1000)` im Normalbetrieb immer greift — auch der ungefilterte Aufruf liefert exakt 1000 Datensätze —, entschied das am Rand auch darüber, *welche* Sichtungen ausgeliefert werden. Die Karte zeigte einen zufälligen Ausschnitt.

`id DESC` als zweites Kriterium macht die Antwort reproduzierbar. Die Legacy-Sortierung nach `sichtungsdatum DESC` bleibt unverändert.

## Verifikation

- **Alle 37 wartenden Sichtungen lokal gegen `localhost:4000` geschickt: 37× HTTP 201**, keine Ablehnung. `analyse:legacy-inbox` meldet null Vertragsverstöße. Testzeilen danach aus der Dev-DB entfernt.
- **20 davon gegen Produktion gelaufen** (Sichtungen 29199–29218), der 21. lief planmäßig in den `429`. Zustand auf hawking anschließend: `posteingang` 37 → 17, `importiert` 0 → 20, `abgewiesen` 0. Die erste offene Datei ist genau die im Abbruch gemeldete.
- `test:quick` grün: 287 Dateien, 4336 Tests.

## Beim Review gefunden und behoben

`mv -n` verweigert das Überschreiben zwar, endet dabei aber mit **Exit 0** und lässt die Quelle liegen. Für den Aufrufer sah das aus wie ein geglücktes Verschieben — die Datei wäre in `posteingang/` geblieben und der nächste Lauf hätte dieselbe Sichtung ein zweites Mal an die Produktion geschickt. Ein Duplikat, erzeugt ausgerechnet von der Vorsichtsmaßnahme. Beide Speicher prüfen das Ziel jetzt explizit.

## Nicht in diesem PR

Beim Sichten der Zugriffsprotokolle sind zwei Dinge aufgefallen, die eigene Vorgänge sind:

- **`GET /rest_sichtungen` fehlt** und liefert `405`. Die iOS-App fragt ihn an — das ist die Datenquelle ihrer Karte. Vorarbeit inklusive Originalquellen liegt auf `claude/legacy-index-endpoint`.
- **Die erzwungene HTTPS-Umleitung auf `schweinswalsichtung.de` kostet laufend Meldungen.** Ein Android-Client (`okhttp/3.10.0`) postet über `http://`, wird mit `301` umgeleitet und verliert dabei den Body — an einem einzigen Tag 13 Meldungen. Betrifft Produktion genauso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)