### PR TITLE
feat(api): Sprachpräfix /de/ und /en/ vor allen Legacy-Pfaden bedienen

### DIFF
--- a/.claude/rules/legacy-api.md
+++ b/.claude/rules/legacy-api.md
@@ -37,7 +37,14 @@ Clients.
 | `/rest_sichtungen/inBaltic.json`  | GET     | Positionsprüfung         |
 | `/sichtungen/showreports.json`    | GET     | Sichtungsdaten abrufen   |
 
-Zusätzlich existiert `/en/rest_sichtungen/antworten.json` (englische Variante).
+**Jeder dieser Pfade ist zusätzlich mit vorangestelltem `/de/` oder `/en/`
+erreichbar** — das Sprachpräfix der CakePHP-Vorgänger-App galt vor jeder Route,
+nicht nur vor `antworten.json`. Es ist keine Übersetzung, sondern Routenkosmetik:
+die Response ist in jeder Variante identisch. Umgesetzt einmalig im
+`reroute`-Hook (`src/hooks.ts` → `src/lib/legacy-api/languagePrefix.ts`), nicht
+als Alias-Route je Endpunkt. Keine weiteren Pfade eintragen — vor Seitenrouten
+und `/admin` bleibt das Präfix bewusst 404. Begründung und Grenzen:
+`docs/LEGACY_API_SPECIFICATION.md`, Abschnitt „Sprachpräfix `/de/` und `/en/`".
 
 ---
 

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -51,10 +51,15 @@ Pfade ohne Präfix ändern sich dadurch nicht — das Präfix kommt additiv dazu
 **Grenzen der Umsetzung**, bewusst gesetzt:
 
 - Nur `de` und `en`, nur in Kleinschreibung — wie im CakePHP-Muster `de|en`.
-- Nur vor den vier Legacy-Pfaden oben. `/en/` vor der Startseite oder vor
-  `/admin` bleibt 404: Die Anwendung ist einsprachig deutsch, ein `/en/` vor
-  einer Seitenroute wäre ein Sprachversprechen, das sie nicht einlöst — und vor
-  `/admin` zusätzlich ein zweiter Pfad auf geschützte Routen.
+- Nur vor genau den vier Pfaden aus der Tabelle oben — nicht vor deren
+  Verzeichnissen. `/en/rest_sichtungen/view/1840.json` bleibt also 404, und ein
+  neuer Legacy-Endpunkt bekommt das Präfix erst, wenn er in `LEGACY_PFADE`
+  eingetragen wird.
+- `/en/` vor der Startseite oder vor `/admin` bleibt 404: Die Anwendung ist
+  einsprachig deutsch, ein `/en/` vor einer Seitenroute wäre ein
+  Sprachversprechen, das sie nicht einlöst — und vor `/admin` zusätzlich ein
+  zweiter Pfad auf geschützte Routen, deren Schutz an `event.url.pathname`
+  hängt, das `reroute` nicht verändert.
 - `/de` bzw. `/en` allein zeigte in CakePHP auf das Meldeformular
   (`sichtungen/add`) und bleibt aus demselben Grund 404.
 
@@ -207,9 +212,9 @@ Retrieves response options for numeric fields as JSON array.
 - **URL**: `/rest_sichtungen/antworten.json`
 - **Method**: `GET`
 
-Wie jeder Pfad dieser API zusätzlich unter `/de/…` und `/en/…` erreichbar; die
-Response ist in allen Varianten dieselbe deutsche Liste (siehe „Sprachpräfix
-`/de/` und `/en/`" oben).
+Wie jeder Pfad dieser API ist auch dieser zusätzlich unter `/de/…` und `/en/…`
+erreichbar. Die Response ist in allen drei Varianten dieselbe deutsche Liste
+(siehe Abschnitt „Sprachpräfix `/de/` und `/en/`" oben).
 
 ### Response Format
 

--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -13,6 +13,57 @@ This is a dated status, not a standing guarantee — re-check whether further cl
 - Test System: `http://test.schweinswalsichtung.de`
 - Production System: `http://schweinswalsichtung.de`
 
+## Sprachpräfix `/de/` und `/en/` — gilt für alle Pfade
+
+Jeder in diesem Dokument genannte Pfad ist **zusätzlich** mit vorangestelltem
+`/de/` oder `/en/` erreichbar. Frühere Fassungen dieses Dokuments nannten das
+Präfix nur bei `antworten.json`; das war eine unvollständige Wiedergabe der
+Vorgänger-Anwendung, keine Einschränkung.
+
+Der CakePHP-Router band das Kürzel vor **jede** Route:
+
+```php
+Router::connect('/:language/:controller/:action/*', array(), array('language' => 'de|en'));
+Router::connect('/:language/:controller', array('action' => 'index'), array('language' => 'de|en'));
+Router::connect('/:language', array('controller' => 'sichtungen', 'action' => 'add'), array('language' => 'de|en'));
+```
+
+Es gab also `/de/rest_sichtungen/antworten.json` genauso wie
+`/en/rest_sichtungen`, `/de/sichtungen/showreports.json` und so weiter.
+
+**Das Präfix ist keine Übersetzung.** Der Übergangsdienst auf hawking
+(`legacy-inbox/src/server.js`) liefert unter `/en/rest_sichtungen/antworten.json`
+byte-identisch dieselbe deutsche Liste. Es ist reine Routenkosmetik — Responses
+unterscheiden sich in keiner Sprachvariante.
+
+| Pfad                              | zusätzlich erreichbar unter                   |
+| --------------------------------- | --------------------------------------------- |
+| `POST /rest_sichtungen`           | `/de/rest_sichtungen`, `/en/rest_sichtungen`  |
+| `/rest_sichtungen/antworten.json` | `/de/rest_sichtungen/antworten.json`, `/en/…` |
+| `/rest_sichtungen/inBaltic.json`  | `/de/rest_sichtungen/inBaltic.json`, `/en/…`  |
+| `/sichtungen/showreports.json`    | `/de/sichtungen/showreports.json`, `/en/…`    |
+
+Umgesetzt ist das in der aktuellen Anwendung durch den `reroute`-Hook in
+`src/hooks.ts`, der das Kürzel abschneidet, bevor SvelteKit die Route auflöst
+(`stripLegacyLanguagePrefix` in `src/lib/legacy-api/languagePrefix.ts`). Die
+Pfade ohne Präfix ändern sich dadurch nicht — das Präfix kommt additiv dazu.
+
+**Grenzen der Umsetzung**, bewusst gesetzt:
+
+- Nur `de` und `en`, nur in Kleinschreibung — wie im CakePHP-Muster `de|en`.
+- Nur vor den vier Legacy-Pfaden oben. `/en/` vor der Startseite oder vor
+  `/admin` bleibt 404: Die Anwendung ist einsprachig deutsch, ein `/en/` vor
+  einer Seitenroute wäre ein Sprachversprechen, das sie nicht einlöst — und vor
+  `/admin` zusätzlich ein zweiter Pfad auf geschützte Routen.
+- `/de` bzw. `/en` allein zeigte in CakePHP auf das Meldeformular
+  (`sichtungen/add`) und bleibt aus demselben Grund 404.
+
+Ob ein Client das Präfix nutzt, ist offen: Im Zugriffsprotokoll von hawking
+wurde am 2026-08-09 keine Präfix-Variante abgerufen — die Protokolle reichen
+dort aber nur einen Tag zurück (Plesk rotiert ohne Archiv). Die Unterstützung
+kostet nichts und schließt eine Lücke, die von hier aus nicht mehr reparierbar
+wäre.
+
 ## 1. Creating Sightings
 
 ### Endpoint
@@ -154,8 +205,11 @@ Retrieves response options for numeric fields as JSON array.
 ### Endpoint
 
 - **URL**: `/rest_sichtungen/antworten.json`
-- **URL (English)**: `/en/rest_sichtungen/antworten.json`
 - **Method**: `GET`
+
+Wie jeder Pfad dieser API zusätzlich unter `/de/…` und `/en/…` erreichbar; die
+Response ist in allen Varianten dieselbe deutsche Liste (siehe „Sprachpräfix
+`/de/` und `/en/`" oben).
 
 ### Response Format
 

--- a/e2e/legacy-language-prefix.spec.ts
+++ b/e2e/legacy-language-prefix.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Sprachpräfix der abgelösten CakePHP-Anwendung: Jeder Legacy-Pfad war dort
+ * zusätzlich unter `/de/…` und `/en/…` erreichbar, mit byte-identischer
+ * (deutscher) Antwort. Umgesetzt ist das im `reroute`-Hook (`src/hooks.ts`).
+ *
+ * Die Regel selbst ist als Unit-Test abgedeckt
+ * (`src/lib/legacy-api/languagePrefix.test.ts`). Hier steht das, was nur über
+ * HTTP prüfbar ist: dass SvelteKit den Hook überhaupt anwendet — ein
+ * vergessenes oder falsch benanntes `src/hooks.ts` fiele sonst nirgends auf.
+ *
+ * Ohne Browser: `request` spricht direkt mit dem Server.
+ */
+test.describe('Legacy-API: Sprachpräfix /de/ und /en/', () => {
+	const legacyGets = [
+		'/rest_sichtungen/antworten.json',
+		'/rest_sichtungen/inBaltic.json?location=54.5,12.5',
+		'/sichtungen/showreports.json?year=2024'
+	];
+
+	for (const pfad of legacyGets) {
+		for (const sprache of ['de', 'en']) {
+			test(`/${sprache}${pfad} antwortet identisch zu ${pfad}`, async ({ request }) => {
+				const ohne = await request.get(pfad);
+				const mit = await request.get(`/${sprache}${pfad}`);
+
+				expect(ohne.status()).toBe(200);
+				expect(mit.status()).toBe(200);
+				// Byte-identisch: Das Präfix ist Routenkosmetik, keine Übersetzung.
+				expect(await mit.body()).toEqual(await ohne.body());
+			});
+		}
+	}
+
+	test('POST /en/rest_sichtungen erreicht denselben Endpunkt', async ({ request }) => {
+		// Leerer Body: Die Fehlerantwort der Validierung genügt als Nachweis, dass
+		// die Route bedient wird — angelegt wird dabei nichts.
+		const ohne = await request.post('/rest_sichtungen', { data: {} });
+		const mit = await request.post('/en/rest_sichtungen', { data: {} });
+
+		expect(mit.status()).toBe(ohne.status());
+		expect(await mit.body()).toEqual(await ohne.body());
+	});
+
+	test('vor Seitenrouten und /admin gilt das Präfix bewusst nicht', async ({ request }) => {
+		// Die Anwendung ist einsprachig deutsch; /admin hängt zusätzlich an
+		// event.url.pathname, das reroute nicht verändert.
+		for (const pfad of ['/en/', '/en/admin', '/en/api/sightings']) {
+			const antwort = await request.get(pfad, { maxRedirects: 0 });
+			expect(antwort.status(), pfad).toBe(404);
+		}
+	});
+});

--- a/scripts/e2e-shards.sh
+++ b/scripts/e2e-shards.sh
@@ -185,6 +185,14 @@ map=(
 	# Komponente, die die map-*-Specs fahren.
 	e2e/form-position.spec.ts
 	e2e/form-position-photo.spec.ts
+	# Thematisch bei keinem der drei Shards zu Hause — er fährt gar keine
+	# Seite, sondern nur die Legacy-Endpunkte über `request`. Er kommt
+	# hierher, weil `smoke` laut der Messung vom 2026-08-09 (249–271 s)
+	# deutlich der längste Shard ist und `form` zuletzt alle Neuzugänge
+	# bekam. Kein Browser, kein Seed: 8 Tests, lokal ~2 s. Der
+	# Kaltkompilier-Aufschlag der /rest_sichtungen-Routen fällt einmalig
+	# an; kein anderer Spec fährt sie.
+	e2e/legacy-language-prefix.spec.ts
 )
 
 # design-tokens.spec.ts gehört hierher, nicht zu form: es prüft das

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { reroute } from './hooks';
+
+/**
+ * `reroute` ist der einzige Ort, an dem das Sprachkürzel der CakePHP-Vorgänger-App
+ * abgeschnitten wird. Die Regel selbst ist in `stripLegacyLanguagePrefix` getestet;
+ * hier steht nur die Verdrahtung — inklusive der Zusage, dass `undefined` (also
+ * „unverändert routen") zurückkommt, wenn nichts zutrifft.
+ */
+describe('reroute', () => {
+	// `fetch` gehört zum Reroute-Event, wird hier aber nicht gebraucht: Die Regel ist
+	// eine reine Pfad-Umschreibung ohne Netzzugriff. Ein Aufruf wäre ein Fehler und
+	// soll sich als solcher zeigen.
+	const fetchStub: typeof fetch = () => {
+		throw new Error('reroute darf nicht fetchen');
+	};
+
+	const rerouteUrl = (pfad: string) =>
+		reroute({ url: new URL(`https://example.org${pfad}`), fetch: fetchStub });
+
+	it('routet /en/rest_sichtungen/antworten.json auf die deutsche Route', () => {
+		expect(rerouteUrl('/en/rest_sichtungen/antworten.json')).toBe(
+			'/rest_sichtungen/antworten.json'
+		);
+	});
+
+	it('routet /de/sichtungen/showreports.json auf die bestehende Route', () => {
+		expect(rerouteUrl('/de/sichtungen/showreports.json')).toBe('/sichtungen/showreports.json');
+	});
+
+	it('lässt den Query-String unberührt (reroute betrifft nur den Pfad)', () => {
+		const url = new URL('https://example.org/en/sichtungen/showreports.json?year=2024');
+		expect(reroute({ url, fetch: fetchStub })).toBe('/sichtungen/showreports.json');
+		expect(url.search).toBe('?year=2024');
+	});
+
+	it('lässt bestehende Pfade unverändert', () => {
+		expect(rerouteUrl('/rest_sichtungen/antworten.json')).toBeUndefined();
+		expect(rerouteUrl('/')).toBeUndefined();
+		expect(rerouteUrl('/admin/sightings')).toBeUndefined();
+	});
+
+	it('legt keinen zweiten Pfad auf geschützte Routen', () => {
+		expect(rerouteUrl('/en/admin/sightings')).toBeUndefined();
+		expect(rerouteUrl('/en/api/sightings')).toBeUndefined();
+	});
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,15 @@
+import { stripLegacyLanguagePrefix } from '$lib/legacy-api/languagePrefix';
+import type { Reroute } from '@sveltejs/kit';
+
+/**
+ * Bildet die Sprachpräfixe der abgelösten CakePHP-Anwendung auf die bestehenden
+ * Routen ab: `/en/rest_sichtungen/antworten.json` wird von
+ * `src/routes/rest_sichtungen/antworten.json` bedient.
+ *
+ * Additiv — die Pfade ohne Präfix ändern sich nicht. `reroute` betrifft nur die
+ * Routenauflösung; `event.url` bleibt in `hooks.server.ts` und in den Endpunkten
+ * die vom Client gesendete URL.
+ *
+ * Welche Pfade das Präfix bekommen, steht in `stripLegacyLanguagePrefix`.
+ */
+export const reroute: Reroute = ({ url }) => stripLegacyLanguagePrefix(url.pathname);

--- a/src/lib/legacy-api/languagePrefix.test.ts
+++ b/src/lib/legacy-api/languagePrefix.test.ts
@@ -26,6 +26,29 @@ describe('stripLegacyLanguagePrefix', () => {
 
 	it('behält den Trailing Slash bei', () => {
 		expect(stripLegacyLanguagePrefix('/en/rest_sichtungen/')).toBe('/rest_sichtungen/');
+		expect(stripLegacyLanguagePrefix('/de/sichtungen/showreports.json/')).toBe(
+			'/sichtungen/showreports.json/'
+		);
+	});
+
+	describe('bedient genau die vier dokumentierten Pfade, nicht deren Verzeichnisse', () => {
+		// Sonst bekäme jeder künftige Pfad unter /sichtungen/ oder /rest_sichtungen/
+		// das Präfix stillschweigend mit — auch ein nicht-Legacy-Pfad. Ein neuer
+		// Legacy-Endpunkt gehört bewusst in die Liste eingetragen.
+		const keinDokumentierterPfad = [
+			'/en/sichtungen',
+			'/de/sichtungen',
+			// CakePHP-Actions, die es in dieser Anwendung nicht gibt (die URL steht
+			// als Beispiel in der Antwort von POST /rest_sichtungen).
+			'/en/rest_sichtungen/view/1840.json',
+			'/de/rest_sichtungen/add'
+		];
+
+		for (const pfad of keinDokumentierterPfad) {
+			it(`${pfad} bleibt unverändert`, () => {
+				expect(stripLegacyLanguagePrefix(pfad)).toBeUndefined();
+			});
+		}
 	});
 
 	describe('greift nur bei den Legacy-Pfaden', () => {

--- a/src/lib/legacy-api/languagePrefix.test.ts
+++ b/src/lib/legacy-api/languagePrefix.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { stripLegacyLanguagePrefix } from './languagePrefix';
+
+describe('stripLegacyLanguagePrefix', () => {
+	describe('bedient die Legacy-Pfade mit Sprachkürzel', () => {
+		const legacyPfade = [
+			'/rest_sichtungen',
+			'/rest_sichtungen/antworten.json',
+			'/rest_sichtungen/inBaltic.json',
+			'/sichtungen/showreports.json'
+		];
+
+		for (const pfad of legacyPfade) {
+			for (const sprache of ['de', 'en']) {
+				it(`/${sprache}${pfad} → ${pfad}`, () => {
+					expect(stripLegacyLanguagePrefix(`/${sprache}${pfad}`)).toBe(pfad);
+				});
+			}
+		}
+	});
+
+	it('lässt Legacy-Pfade ohne Sprachkürzel unverändert', () => {
+		expect(stripLegacyLanguagePrefix('/rest_sichtungen/antworten.json')).toBeUndefined();
+		expect(stripLegacyLanguagePrefix('/sichtungen/showreports.json')).toBeUndefined();
+	});
+
+	it('behält den Trailing Slash bei', () => {
+		expect(stripLegacyLanguagePrefix('/en/rest_sichtungen/')).toBe('/rest_sichtungen/');
+	});
+
+	describe('greift nur bei den Legacy-Pfaden', () => {
+		// Die Anwendung ist einsprachig deutsch. Ein /en/ vor der Startseite oder
+		// vor /admin wäre ein Sprachversprechen, das sie nicht einlöst — und vor
+		// /admin zusätzlich ein zweiter Pfad auf geschützte Routen.
+		const fremdePfade = [
+			'/en',
+			'/de',
+			'/en/',
+			'/en/admin',
+			'/en/admin/sightings',
+			'/en/api/sightings',
+			'/de/map',
+			'/en/bestimmungshilfe',
+			'/en/uploads/1/foto.jpg'
+		];
+
+		for (const pfad of fremdePfade) {
+			it(`${pfad} bleibt unverändert`, () => {
+				expect(stripLegacyLanguagePrefix(pfad)).toBeUndefined();
+			});
+		}
+	});
+
+	describe('greift nur bei genau einem Kürzel in Kleinschreibung', () => {
+		const keineTreffer = [
+			// CakePHP band das Kürzel an `de|en` — alles andere fiel schon dort durch.
+			'/fr/rest_sichtungen',
+			'/EN/rest_sichtungen',
+			'/De/rest_sichtungen/antworten.json',
+			// Zwei Kürzel hintereinander ergaben in CakePHP den Controller `de` → 404.
+			'/en/de/rest_sichtungen',
+			// Kein Präfix, sondern ein Namensbestandteil.
+			'/enrest_sichtungen',
+			'/en_rest_sichtungen',
+			// Ein Legacy-Pfad muss unmittelbar folgen, nicht irgendwo enthalten sein.
+			'/en/foo/rest_sichtungen',
+			// Präfixe, die nur zufällig gleich beginnen.
+			'/en/rest_sichtungen_alt',
+			'/en/sichtungenX'
+		];
+
+		for (const pfad of keineTreffer) {
+			it(`${pfad} bleibt unverändert`, () => {
+				expect(stripLegacyLanguagePrefix(pfad)).toBeUndefined();
+			});
+		}
+	});
+});

--- a/src/lib/legacy-api/languagePrefix.ts
+++ b/src/lib/legacy-api/languagePrefix.ts
@@ -1,0 +1,56 @@
+/**
+ * Sprachkürzel der abgelösten CakePHP-Anwendung.
+ *
+ * Deren Router akzeptierte vor **jedem** Pfad ein `/de/` oder `/en/`:
+ *
+ * ```php
+ * Router::connect('/:language/:controller/:action/*', array(), array('language' => 'de|en'));
+ * ```
+ *
+ * Es gab also nicht nur `/en/rest_sichtungen/antworten.json`, sondern genauso
+ * `/de/rest_sichtungen/antworten.json`, `/en/rest_sichtungen` oder
+ * `/en/sichtungen/showreports.json`. Das Präfix war dabei nie eine Übersetzung:
+ * der Übergangsdienst auf hawking liefert unter `/en/rest_sichtungen/antworten.json`
+ * byte-identisch dieselbe deutsche Liste. Reine Routenkosmetik.
+ *
+ * Ob ein Client das Präfix tatsächlich nutzt, ist offen — das Zugriffsprotokoll
+ * von hawking reicht nur einen Tag zurück (Plesk rotiert ohne Archiv) und zeigte
+ * am 2026-08-09 keinen Abruf. Die Regel kostet nichts und schließt eine Lücke,
+ * die von hier aus nicht mehr reparierbar wäre.
+ */
+const SPRACHKUERZEL = ['de', 'en'] as const;
+
+/**
+ * Pfade, für die das Sprachkürzel weiterhin gilt — die Legacy-API und sonst nichts.
+ *
+ * Bewusst **nicht** generisch über alle Routen: Die Anwendung ist einsprachig
+ * deutsch, ein `/en/` vor der Startseite wäre ein Sprachversprechen, das sie
+ * nicht einlöst. Und `/en/admin/...` wäre ein zweiter Pfad auf geschützte
+ * Routen, deren Schutz in `hooks.server.ts` an `event.url.pathname` hängt —
+ * die URL bleibt bei `reroute` die vom Client gesendete.
+ */
+const LEGACY_PFADE = ['/rest_sichtungen', '/sichtungen'] as const;
+
+const PRAEFIX_MUSTER = new RegExp(`^/(?:${SPRACHKUERZEL.join('|')})(/.*)?$`);
+
+function istLegacyPfad(pfad: string): boolean {
+	return LEGACY_PFADE.some((legacy) => pfad === legacy || pfad.startsWith(`${legacy}/`));
+}
+
+/**
+ * Entfernt ein führendes `/de/` oder `/en/` vor einem Legacy-API-Pfad.
+ *
+ * @param pathname Pfad der Anfrage (ohne Query-String)
+ * @returns den Pfad ohne Sprachkürzel, oder `undefined` wenn nichts zu tun ist
+ */
+export function stripLegacyLanguagePrefix(pathname: string): string | undefined {
+	const treffer = PRAEFIX_MUSTER.exec(pathname);
+	if (!treffer) return undefined;
+
+	const rest = treffer[1];
+	// `/en` ohne weiteren Pfad zeigte in CakePHP auf das Meldeformular. Das ist
+	// eine Seitenroute, keine API — siehe LEGACY_PFADE oben.
+	if (!rest || !istLegacyPfad(rest)) return undefined;
+
+	return rest;
+}

--- a/src/lib/legacy-api/languagePrefix.ts
+++ b/src/lib/legacy-api/languagePrefix.ts
@@ -21,20 +21,33 @@
 const SPRACHKUERZEL = ['de', 'en'] as const;
 
 /**
- * Pfade, für die das Sprachkürzel weiterhin gilt — die Legacy-API und sonst nichts.
+ * Pfade, für die das Sprachkürzel weiterhin gilt — die vier Legacy-Endpunkte
+ * aus `docs/LEGACY_API_SPECIFICATION.md` und sonst nichts.
  *
  * Bewusst **nicht** generisch über alle Routen: Die Anwendung ist einsprachig
  * deutsch, ein `/en/` vor der Startseite wäre ein Sprachversprechen, das sie
  * nicht einlöst. Und `/en/admin/...` wäre ein zweiter Pfad auf geschützte
  * Routen, deren Schutz in `hooks.server.ts` an `event.url.pathname` hängt —
  * die URL bleibt bei `reroute` die vom Client gesendete.
+ *
+ * Bewusst auch **nicht** als Verzeichnis-Präfix (`/sichtungen/**`): Sonst bekäme
+ * jeder künftige Pfad unter `/sichtungen/` oder `/rest_sichtungen/` das
+ * Sprachkürzel stillschweigend mit, auch ein nicht-Legacy-Pfad. Ein neuer
+ * Legacy-Endpunkt gehört hier eingetragen — das ist genau die bewusste
+ * Entscheidung, die der Legacy-Vertrag verlangt.
  */
-const LEGACY_PFADE = ['/rest_sichtungen', '/sichtungen'] as const;
+const LEGACY_PFADE = [
+	'/rest_sichtungen',
+	'/rest_sichtungen/antworten.json',
+	'/rest_sichtungen/inBaltic.json',
+	'/sichtungen/showreports.json'
+] as const;
 
 const PRAEFIX_MUSTER = new RegExp(`^/(?:${SPRACHKUERZEL.join('|')})(/.*)?$`);
 
+/** Trailing Slash zählt mit; über dessen Behandlung entscheidet SvelteKit. */
 function istLegacyPfad(pfad: string): boolean {
-	return LEGACY_PFADE.some((legacy) => pfad === legacy || pfad.startsWith(`${legacy}/`));
+	return LEGACY_PFADE.some((legacy) => pfad === legacy || pfad === `${legacy}/`);
 }
 
 /**

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1993,6 +1993,9 @@ paths:
       summary: '[LEGACY] Sichtung anlegen'
       description: |
         **Legacy REST API Endpunkt für Mobile App Kompatibilität**
+
+        Zusätzlich unter `/de/…` und `/en/…` erreichbar — Sprachpräfix der abgelösten
+        CakePHP-App, keine Übersetzung (siehe docs/LEGACY_API_SPECIFICATION.md).
         
         Erstellt eine neue Sichtung im Legacy-Format der ursprünglichen schweinswalsichtung.de API.
         
@@ -2097,6 +2100,9 @@ paths:
       summary: '[LEGACY] Antwortmöglichkeiten abrufen'
       description: |
         **Legacy REST API Endpunkt für Dropdown-Optionen**
+
+        Zusätzlich unter `/de/…` und `/en/…` erreichbar — Sprachpräfix der abgelösten
+        CakePHP-App, keine Übersetzung (siehe docs/LEGACY_API_SPECIFICATION.md).
         
         Stellt alle verfügbaren Optionen für numerische Felder bereit, genau wie in der ursprünglichen API.
         Die Feldnamen und Werte entsprechen exakt der PDF-Spezifikation.
@@ -2139,6 +2145,9 @@ paths:
       summary: '[LEGACY] Position prüfen'
       description: |
         **Legacy REST API Endpunkt für Koordinaten-Validierung**
+
+        Zusätzlich unter `/de/…` und `/en/…` erreichbar — Sprachpräfix der abgelösten
+        CakePHP-App, keine Übersetzung (siehe docs/LEGACY_API_SPECIFICATION.md).
         
         Überprüft, ob gegebene Koordinaten in der Ostsee bzw. im Kartenbereich liegen.
         
@@ -2202,6 +2211,9 @@ paths:
       summary: '[LEGACY] Sichtungsdaten abrufen'
       description: |
         **Legacy REST API Endpunkt für genehmigte Sichtungen**
+
+        Zusätzlich unter `/de/…` und `/en/…` erreichbar — Sprachpräfix der abgelösten
+        CakePHP-App, keine Übersetzung (siehe docs/LEGACY_API_SPECIFICATION.md).
         
         Gibt alle genehmigten Sichtungen zurück, mit optionaler Filterung nach Jahr, 
         Standort, Entfernung und Suchbegriffen.


### PR DESCRIPTION
## Was

Die Legacy-API-Pfade sind zusätzlich mit vorangestelltem `/de/` oder `/en/` erreichbar — umgesetzt generisch über einen `reroute`-Hook, nicht als Alias-Route je Endpunkt.

| Pfad                              | neu zusätzlich                                     |
| --------------------------------- | -------------------------------------------------- |
| `POST /rest_sichtungen`           | `/de/…`, `/en/…`                                   |
| `/rest_sichtungen/antworten.json` | `/de/…`, `/en/…`                                   |
| `/rest_sichtungen/inBaltic.json`  | `/de/…`, `/en/…`                                   |
| `/sichtungen/showreports.json`    | `/de/…`, `/en/…`                                   |

## Warum

Die abgelöste CakePHP-Anwendung band ein Sprachkürzel vor **jede** Route:

```php
Router::connect('/:language/:controller/:action/*', array(), array('language' => 'de|en'));
Router::connect('/:language/:controller', array('action' => 'index'), array('language' => 'de|en'));
Router::connect('/:language', array('controller' => 'sichtungen', 'action' => 'add'), array('language' => 'de|en'));
```

Es gab also nicht nur `/en/rest_sichtungen/antworten.json`, sondern genauso `/de/rest_sichtungen/antworten.json`, `/en/rest_sichtungen` und `/de/sichtungen/showreports.json`. Die aktuelle Anwendung antwortete auf all das mit 404 (am 2026-08-09 gegen Produktion verifiziert), der Übergangsdienst auf hawking bedient dagegen die `/en/`-Variante von `antworten.json` — und liefert dort byte-identisch die **deutsche** Liste. Das Präfix war nie eine Übersetzung, sondern reine Routenkosmetik.

## Für Reviewer

**Bestehende Pfade ändern sich nicht.** `reroute` greift nur, wenn ein Kürzel da ist; das Präfix kommt additiv dazu.

**Bewusst nur vor den vier Legacy-Pfaden**, nicht generisch vor allen Routen — zwei Gründe:

1. Die Anwendung ist einsprachig deutsch. Ein `/en/` vor der Startseite wäre ein Sprachversprechen, das sie nicht einlöst.
2. Der Admin-Schutz in `hooks.server.ts` hängt an `event.url.pathname`, das `reroute` **nicht** verändert. Ein generisches Abschneiden hätte `/en/admin/...` als zweiten Pfad auf geschützte Routen gelegt, an dem die Prefix-Prüfungen ins Leere greifen.

`/de` bzw. `/en` allein zeigte in CakePHP auf das Meldeformular (`sichtungen/add`) und bleibt aus Grund 1 ebenfalls 404. Ebenso `/fr/…`, `/EN/…` und doppelte Kürzel — wie im CakePHP-Muster `de|en`.

**Ob überhaupt ein Client das Präfix nutzt, ist offen.** Im Zugriffsprotokoll von hawking wurde am 2026-08-09 keine Variante abgerufen; die Protokolle reichen dort aber nur einen Tag zurück (Plesk rotiert ohne Archiv). Das ist kein Argument gegen die Regel, sondern der Grund, sie billig zu halten.

## Tests (Test-First)

RED zuerst bestätigt (`Cannot find module './languagePrefix'`), dann implementiert.

- `src/lib/legacy-api/languagePrefix.test.ts` — die Regel: 8 Legacy-Kombinationen, Trailing Slash, Abgrenzung gegen `/en/admin`, `/fr/`, `/EN/`, `/en/de/…`, `/enrest_sichtungen`, `/en/rest_sichtungen_alt`
- `src/hooks.test.ts` — Verdrahtung des Hooks
- `e2e/legacy-language-prefix.spec.ts` — das, was nur über HTTP prüfbar ist: dass SvelteKit den Hook überhaupt anwendet. Ein gelöschtes oder falsch benanntes `src/hooks.ts` fiele sonst nirgends auf. Ohne Browser (`request`), im `map`-Shard eingetragen (Begründung im Skript).

Zusätzlich manuell gegen einen laufenden Dev-Server verifiziert: alle vier Endpunkte byte-identisch mit und ohne Präfix (`diff` leer), inklusive `POST` — auch die CSRF-Antwort bei fremdem `Origin` ist gleich.

```
npm run test:quick                                     → 290 Dateien, 4386 Tests grün
npx playwright test e2e/legacy-language-prefix.spec.ts → 8 passed
```

## Dokumentation

- `docs/LEGACY_API_SPECIFICATION.md` — neuer Abschnitt „Sprachpräfix `/de/` und `/en/` — gilt für alle Pfade" nach den Base URLs. Die alte Zeile „URL (English)" bei `antworten.json` (Zeile 157) ist ersetzt: Sie las sich als Sonderfall, was sie nie war.
- `.claude/rules/legacy-api.md` — dieselbe Korrektur, plus der Hinweis, das nicht als Alias-Route je Endpunkt nachzubauen.
- `static/openapi.yml` — Hinweiszeile in allen vier Legacy-Beschreibungen statt acht duplizierter Pfad-Einträge; YAML validiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)