### PR TITLE
feat(api): GET /rest_sichtungen bedienen — der Index der Legacy-API

### DIFF
--- a/docs/LEGACY_API_SPECIFICATION.md
+++ b/docs/LEGACY_API_SPECIFICATION.md
@@ -361,6 +361,23 @@ JSON Object:
 
 ## 4. Retrieving Sighting Data
 
+> **Zwei Pfade, ein Endpunkt.** Dieselben Daten sind zusätzlich unter
+> `GET /rest_sichtungen` erreichbar. Das ist keine Erweiterung, sondern eine
+> Lücke dieser Spezifikation, die erst 2026-08 auffiel: Die Vorgänger-Anwendung
+> bildete `/rest_sichtungen` mit `Router::mapResources()` ab, wodurch `GET` auf
+> `RestSichtungenController::index()` traf — und diese Aktion besteht aus
+> denselben zwei Zeilen wie `SichtungenController::showReports()`
+> (`parseList()` + `getReports()`). Die Antwort ist in beiden Fällen dasselbe
+> blanke Array; `_serialize` als Zeichenkette hüllt in CakePHP nichts um.
+>
+> Die angebundene iOS-App (`OstSeeTiere/8`) benutzt **diesen** Pfad für ihre
+> Karte, nicht `showreports.json`. Bis 2026-08 antwortete er mit `405`, womit
+> die Karte in der App leer blieb. Parameter, Filter, Feldnamen und
+> Datenschutz-Regeln unten gelten für beide Pfade unverändert — es ist wörtlich
+> dieselbe Funktion (`src/routes/rest_sichtungen/+server.ts` re-exportiert sie).
+>
+> Belege: `docs/archive/legacy-cakephp/` (Originalquellen der Vorgänger-App).
+
 Returns all reports of a year that are approved and marked as lying in the Baltic Sea. Only "public" data is returned. Name, first name and ship name fields are only included if the user has released this data.
 
 ### Endpoint

--- a/docs/archive/legacy-cakephp/QueryParserComponent.php
+++ b/docs/archive/legacy-cakephp/QueryParserComponent.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jansinger
+ * Date: 04.03.14
+ * Time: 14:32
+ */
+App::uses('Component', 'Controller');
+class QueryParserComponent extends Component {
+
+    private $_Controller;
+
+    public static $chartBox = '9.4,53,30.2,66';
+
+    public function startup(Controller $controller) {
+        $this->_Controller = $controller;
+    }
+
+    public function parseList($defaultYear, $admin) {
+        $options['fields'] = array('namensnennung','schiffnamensnennung','gps_breite','gps_laenge','schiffsname','bootstyp','heimathafen','name','vorname','fahrwasser','bootsantrieb','vonwo','vonwo_text','entfernung','anzahl_schiffe','sichtungsdatum','anzahl_gesamt','anzahl_jung','id','totfund','tierart','verhalten','verhalten_text','reaktion','sonstige_auffaelligkeiten','verteilung','verteilung_text','windrichtung','windstaerke','sichtweite','seegang');
+        if ($admin) {
+            array_push($options['fields'], 'ostsee','ostsee_geo','geprueft','strasse','plz','ort','telefon','fax','email','kommentar_intern','aufnahme','aufnahmeHochladen','bemerkungen', 'created', 'eingangskanal', 'freigegeben_am', 'totfund', 'totfund_groesse', 'totfund_zustand', 'totfund_geschlecht');
+        } else {
+            $options['conditions'] = array('ostsee_geo >' => 0, 'geprueft' => '1');
+        }
+        $year = $this->_Controller->request->query('year');
+        if (!$year) {
+            $year = $this->_Controller->request->pass[0];
+        }
+        if ($year && is_numeric($year) && preg_match('/^[\d]{4}$/', $year)) {
+            $options['conditions']["EXTRACT(YEAR FROM sichtungsdatum) ="] = $year;
+        } else {
+            $options['conditions']["EXTRACT(YEAR FROM sichtungsdatum) ="] = $defaultYear;
+        }
+        if (isset($this->_Controller->request->query['search'])) {
+            $searchFor = strtolower(trim($this->_Controller->request->query('search')));
+            $options['conditions']['OR'] = array(
+                'lower(email) LIKE' => "%" . $searchFor . "%",
+                'lower(name) LIKE' => "%" . $searchFor . "%",
+                'lower(vorname) LIKE' => "%" . $searchFor . "%",
+                'lower(schiffsname) LIKE' => "%" . $searchFor . "%",
+            );
+        }
+        if (isset($this->_Controller->request->query['location'])) {
+            $found = preg_match('/^([\d\.-]+),([\d\.-]+)$/', $this->_Controller->request->query('location'), $match);
+            if ($found != 1)
+                throw new BadRequestException("Please check query parameters.");
+            list(,$lat,$lon) = $match;
+            $distance = (isset($this->_Controller->request->query['distance']))?$this->_Controller->request->query('distance'):100000;
+            $options['conditions']["ST_DWithin(location::geography, ST_MakePoint($lon,$lat), $distance) ="] = true;
+            $options['fields'][] = "ST_Distance(location::geography, ST_MakePoint($lon,$lat)) AS distance";
+            $options['order']= array('distance');
+        } else {
+            $bbox = $this->_Controller->request->query('bbox');
+            if ($bbox) {
+                $found = preg_match('/^([\d\.-]+),([\d\.-]+),([\d\.-]+),([\d\.-]+)$/', $bbox);
+                if ($found != 1) {
+                    throw new BadRequestException("Please check query parameters.");
+                }
+                $bbox = sprintf('ST_Intersection(ST_MakeEnvelope(%s,66,4326),ST_MakeEnvelope(%s))',QueryParserComponent::$chartBox,$bbox);
+            } else {
+                $bbox = sprintf('ST_MakeEnvelope(%s,4326)',QueryParserComponent::$chartBox);
+            }
+            $options['conditions']["Sichtung.location && $bbox ="] = true;
+            $options['order'] = array('sichtungsdatum');
+        }
+        return $options;
+    }
+}

--- a/docs/archive/legacy-cakephp/README.md
+++ b/docs/archive/legacy-cakephp/README.md
@@ -1,8 +1,20 @@
 # Originalquellen der abgelösten CakePHP-Anwendung
 
 Ausschnitt aus `sichtungen.tgz` (1,6 GB, nicht im Repo). Hier liegen nur die
-fünf Dateien, die den Vertrag der Legacy-API festlegen — als Beleg, nicht zum
+Dateien, die den Vertrag der Legacy-API festlegen — als Beleg, nicht zum
 Ausführen.
+
+> **Eine Änderung gegenüber dem Original:** In drei Dateien stand im
+> `@author`-Tag die private E-Mail-Adresse des ursprünglichen Entwicklers. Sie
+> ist entfernt, der Name bleibt stehen. Dieses Repository ist öffentlich, und
+> die Adresse gehört einer dritten Person, die dem nie zugestimmt hat — die
+> Urheberschaft ist ohne sie genauso belegt. Wer die Dateien erneut aus dem
+> Archiv zieht, muss das wiederholen.
+>
+> Die Rolladresse `sichtungen@meeresmuseum.de` in `SichtungenController.php`
+> steht bewusst noch drin: Sie ist die Absenderadresse der damaligen
+> Bestätigungsmails, also Teil des dokumentierten Verhaltens, und keine
+> personenbezogene Adresse.
 
 | Datei                          | wofür                                                    |
 | ------------------------------ | -------------------------------------------------------- |

--- a/docs/archive/legacy-cakephp/README.md
+++ b/docs/archive/legacy-cakephp/README.md
@@ -1,0 +1,79 @@
+# Originalquellen der abgelösten CakePHP-Anwendung
+
+Ausschnitt aus `sichtungen.tgz` (1,6 GB, nicht im Repo). Hier liegen nur die
+fünf Dateien, die den Vertrag der Legacy-API festlegen — als Beleg, nicht zum
+Ausführen.
+
+| Datei                          | wofür                                                    |
+| ------------------------------ | -------------------------------------------------------- |
+| `routes.php`                   | Routenabbildung, Sprachpräfix                            |
+| `RestSichtungenController.php` | `/rest_sichtungen` — `add`, `index`, `view`, `antworten` |
+| `SichtungenController.php`     | `/sichtungen/showreports.json` (`showReports()`)         |
+| `QueryParserComponent.php`     | `parseList()` — Filter, Felder, Sichtbarkeit             |
+| `Sichtung.php`                 | `getReports()` und die übrigen Modellmethoden            |
+| `ReportUtils.php`              | `mapReport()` — die Ausgabeform der Sichtungsdaten       |
+
+## Der Befund, wegen dem diese Dateien hier liegen
+
+**`GET /rest_sichtungen` und `GET /sichtungen/showreports.json` sind derselbe
+Endpunkt unter zwei Namen.** Beide Aktionen bestehen aus denselben zwei Zeilen:
+
+```php
+$options = $this->QueryParser->parseList($this->Sichtung->getDefaultYear(), $this->Auth->user());
+$data    = $this->Sichtung->getReports($options, $this->Auth->user());
+```
+
+`getReports()` schickt jeden Datensatz durch `ReportUtils::mapReport()`, und
+das erzeugt die kompakte Form, die die heutige Anwendung unter
+`showreports.json` bereits ausliefert:
+
+```
+ts, id, dt, ti, lat, lon, ct, yo, ta, tf
+ar   nur wenn fahrwasser gesetzt
+sh   nur wenn schiffsname gesetzt UND (namensnennung ODER schiffnamensnennung)
+na   nur wenn namensnennung
+di   nur bei Umkreissuche (Distanz)
+bm, ba, va   nur für angemeldete Admins
+```
+
+Die 31 Feldnamen in `parseList()` sind die **Datenbankspalten** für das
+`SELECT`, nicht die Ausgabe. Wer nur `parseList()` liest, hält `index` für
+einen Endpunkt mit vollem Feldumfang — er ist es nicht.
+
+## Was daraus folgt
+
+Die iOS-App (`OstSeeTiere/8`) fragt `GET /rest_sichtungen` an und bekommt von
+der heutigen Anwendung `405` (`src/routes/rest_sichtungen/+server.ts`) — auf
+hawking wie auf Produktion. Damit ist die Karte in der App tot. Der Endpunkt
+fehlt außerdem in `docs/LEGACY_API_SPECIFICATION.md` vollständig.
+
+Die Behebung ist deshalb keine Neuentwicklung, sondern ein zweiter Name für
+vorhandene Logik: Der `GET`-Handler von
+`src/routes/sichtungen/showreports.json/+server.ts` muss unter
+`GET /rest_sichtungen` erreichbar werden, statt `405` zu liefern.
+
+Vor der Umsetzung zu klären:
+
+1. **Antwortform.** `showReports()` rendert über die View `export`,
+   `index` über `_serialize => 'Sichtungen'` (Zeichenkette, nicht Feld — in
+   CakePHP 2 serialisiert das den Wert direkt, also ein blankes Array). Die
+   heutige `showreports.json` liefert ein blankes Array. Das passt zusammen,
+   ist aber am Original zu verifizieren, bevor man sich darauf verlässt: Eine
+   Umhüllung `{"Sichtungen": […]}` wäre ein anderer Vertrag, und der Client
+   ist nicht testbar.
+2. **Jahresfilter.** `parseList()` schränkt ohne `year`-Parameter auf
+   `getDefaultYear()` ein. Prüfen, ob `showreports.json` das heute genauso
+   tut — sonst liefern die beiden Namen unterschiedliche Mengen.
+3. **`GET /rest_sichtungen/:id`.** `mapResources` bildet auch `view` ab, und
+   der Schreibpfad verweist im `Location`-Header darauf
+   (`/rest_sichtungen/view/<id>.json`). Diese Route fehlt heute ebenfalls
+   (404). Eigener Vorgang, aber im selben Zug zu entscheiden.
+4. **Rate-Limit.** `POST /rest_sichtungen` ist auf 20 Anfragen pro Stunde und
+   IP begrenzt. Das Limit sitzt am Anfang des `POST`-Handlers und darf den
+   neuen `GET`-Pfad nicht mitbegrenzen — eine Karte, die sich nach 20 Aufrufen
+   abschaltet, wäre schlimmer als gar keine.
+
+## Sprachpräfix
+
+`routes.php` akzeptiert `/de/` und `/en/` vor **jedem** Pfad, nicht nur vor
+`antworten.json`. Das ist ein eigener Vorgang und als Aufgabe hinterlegt.

--- a/docs/archive/legacy-cakephp/ReportUtils.php
+++ b/docs/archive/legacy-cakephp/ReportUtils.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jansinger
+ * Date: 04.03.14
+ * Time: 18:28
+ */
+
+class ReportUtils {
+
+    public $admin = false;
+    public $model = null;
+    public function arrayMapReport($data){
+        return ReportUtils::mapReport($data, $this->admin, $this->model);
+    }
+    public function arrayMapGeoJSON($data){
+        return ReportUtils::mapGeoJSON($data, $this->admin, $this->model);
+    }
+
+    public static function mapReport($data, $admin = false, $model = null){
+        $ts = strtotime($data['Sichtung']['sichtungsdatum']);
+        $report = array(
+            'ts' => $ts,
+            'id' => $data['Sichtung']['id'],
+            'dt' => date('d.m.y',$ts),
+            'ti' => date('H:i',$ts),
+            'lat' => $data['Sichtung']['gps_breite'],
+            'lon' => $data['Sichtung']['gps_laenge'],
+            'ct' => $data['Sichtung']['anzahl_gesamt'],
+            'yo' => $data['Sichtung']['anzahl_jung'],
+            'ta' => $data['Sichtung']['tierart'],
+            'tf' => $data['Sichtung']['totfund']
+        );
+        //if ($model != null) $report['ta'] = $model->getAntworten('tierart')[$report['ta']];
+        if ($data['Sichtung']['fahrwasser'] != "") $report['ar'] = $data['Sichtung']['fahrwasser'];
+        if ($data['Sichtung']['schiffsname'] != "" && ($data['Sichtung']['namensnennung'] || $data['Sichtung']['schiffnamensnennung'])) $report['sh'] = $data['Sichtung']['schiffsname'];
+        if ($data['Sichtung']['namensnennung']) $report['na'] = $data['Sichtung']['vorname'] . ' ' . $data['Sichtung']['name'];
+        if (isset($data[0]['distance'])) $report['di'] = $data[0]['distance'];
+        if ($admin) {
+            $report['bm'] = $data['Sichtung']['ostsee'];
+            $report['ba'] = $data['Sichtung']['ostsee_geo'];
+            $report['va'] = $data['Sichtung']['geprueft'];
+        }
+        return $report;
+    }
+
+    public static function mapGeoJSON($data, $admin = false, $model = null){
+        $report = ReportUtils::mapReport($data,$admin,$model);
+        return array(
+            "type" => "Feature",
+            "geometry" => array(
+                "type" => "Point",
+                "coordinates" => array(floatval($report['lon']),floatval($report['lat']))
+            ),
+            "properties" => $report
+        );
+    }
+
+
+} 

--- a/docs/archive/legacy-cakephp/RestSichtungenController.php
+++ b/docs/archive/legacy-cakephp/RestSichtungenController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Malte Srocke <maltesrocke@yahoo.de>
+ * @author Malte Srocke (E-Mail-Adresse entfernt, siehe README)
  * 
  */
 App::uses('AppController', 'Controller');

--- a/docs/archive/legacy-cakephp/RestSichtungenController.php
+++ b/docs/archive/legacy-cakephp/RestSichtungenController.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Malte Srocke <maltesrocke@yahoo.de>
+ * 
+ */
+App::uses('AppController', 'Controller');
+App::uses('ReportUtils','util');
+
+class RestSichtungenController extends AppController {
+
+	public $name = 'RestSichtungen';
+	public $components = array('RequestHandler','QueryParser');
+
+	public $uses = array('Sichtung');
+
+    public function beforeFilter(){
+        parent::beforeFilter();
+        $this->Auth->allow('add','antworten','inBaltic','index','view');
+        $this->Security->csrfCheck = false;
+        if (!$this->RequestHandler->ext) $this->RequestHandler->ext = 'json';
+    }
+
+	public function add(){
+        $this->request->allowMethod('post');
+		$this->layout = 'json/default';
+        $message['message'] = 'No data send.';
+        $data = $this->request->input('json_decode');
+		if(!empty($data)){
+			if($this->Sichtung->save($data)){
+				$message['message'] = 'Saved';
+                $this->response->statusCode(201);
+                $this->response->header('Location',
+                    Router::url(array('controller' => 'rest_sichtungen', 'action' => 'view','ext' => 'json', $this->Sichtung->id), true)
+                );
+			} else {
+				$message['message'] = 'Validation failed.';
+                $message['errors'] = $this->Sichtung->validationErrors;
+                $this->response->statusCode(400);
+            }
+		}
+        $this->set(array(
+            'message' => $message,
+            '_serialize' => array('message')
+        ));
+	}
+	
+	public function antworten(){
+		$this->set('antworten',$this->Sichtung->getAntworten());
+	}
+
+    public function view($id){
+        $report = $this->Sichtung->findById($id);
+        if (!$report || !isset($report['Sichtung'])){
+           throw new NotFoundException(__('Invalid report'));
+        }
+        if (!$this->Auth->user()) {
+            $report['Sichtung'] = ReportUtils::mapReport($report);
+        }
+        $this->set(array(
+            'Sichtung' => $report['Sichtung'],
+            '_serialize' => 'Sichtung'
+        ));
+    }
+
+    public function index(){
+        $options = $this->QueryParser->parseList($this->Sichtung->getDefaultYear(),$this->Auth->user());
+        $data = $this->Sichtung->getReports($options, $this->Auth->user());
+        $this->set(array(
+            'Sichtungen' => $data,
+            '_serialize' => 'Sichtungen'
+        ));
+    }
+
+    public function edit($id) {
+        $this->Sichtung->id = $id;
+        if ($this->Sichtung->save($this->request->data)) {
+            $message = 'Saved';
+        } else {
+            $message = 'Error';
+        }
+        $this->set(array(
+            'message' => $message,
+            '_serialize' => array('message')
+        ));
+    }
+
+    public function delete($id) {
+        if ($this->Sichtung->delete($id)) {
+            $message = 'Deleted';
+        } else {
+            $message = 'Error';
+        }
+        $this->set(array(
+            'message' => $message,
+            '_serialize' => array('message')
+        ));
+    }
+
+    public function inBaltic(){
+        $found = preg_match('/^([\d\.-]+),([\d\.-]+)$/', $this->request->query('location'), $match);
+        if ($found != 1)
+            throw new BadRequestException("Please check query parameters.");
+        list(,$lat,$lon) = $match;
+        $data = $this->Sichtung->getPointInBaltic($lon,$lat);
+        $this->set(array(
+            'sichtungen' => $data[0][0],
+            '_serialize' => 'sichtungen'
+            )
+        );
+    }
+	
+}
+?>

--- a/docs/archive/legacy-cakephp/Sichtung.php
+++ b/docs/archive/legacy-cakephp/Sichtung.php
@@ -1,0 +1,677 @@
+<?php
+/**
+ * @author Malte Srocke <maltesrocke@yahoo.de>
+ * 
+ */
+App::uses('AppModel', 'Model');
+App::uses('SimpleXMLExtended', 'xml');
+App::uses('ReportUtils','util');
+
+class Sichtung extends AppModel {
+
+	public $useTable = 'sichtungen';
+    public $sequence = 'public.sichtungen_seq';
+
+    public function __construct($id = false, $table = null, $ds = null) {
+        if (!IS_PROD) $this->sequence = 'public.test_sichtungen_seq';
+        parent::__construct($id, $table, $ds);
+    }
+	
+	public $actsAs = array('Upload' => array(
+										'filenameField'=>'aufnahme',
+										'folder'=>'files'
+										));
+	
+	public $validate = array(
+        'sichtungsdatum' => array(
+            'required' => true,
+            'allowEmpty' => false,
+            'rule'=>'datetime',
+            'message'=> 'Bitte geben Sie ein gültiges Datum an.'
+        ),
+		'email'=>
+			array(
+                'required' => true,
+                'allowEmpty' => false,
+				'rule'=>'email',
+				'message'=> 'Bitte geben Sie eine gültige E-Mail-Adresse ein.'
+				),
+		'anzahl_gesamt'=>
+			array(
+                'required' => true,
+                'rule'    => array('naturalNumber', true),
+				'allowEmpty'=>false,
+				'message'=>'Dieses Feld kann nicht leer gelassen werden.'
+				),
+		'anzahl_jung'=>
+			array(
+                'required' => false,
+                'allowEmpty'=>true,
+                'rule'    => array('naturalNumber', true),
+				'message'=>'Dieses Feld kann nicht leer gelassen werden.'
+				),
+		'entfernung'=>
+			array(
+				'rule'=>array('inList', array('0','1','2','3','4','5')),
+				'message'=>'Bitte geben Sie eine ungefähre Entfernung an.'
+				),
+		'vorname'=>
+			array(
+                'required' => true,
+                'allowEmpty'=>false,
+                'rule'=> array('maxLength', 64),
+				'message'=>'Der Vorname darf nicht länger als 64 Zeichen sein.'
+				),
+		'name'=>
+			array(
+                'required' => true,
+                'allowEmpty'=>false,
+				'rule'=> array('maxLength', 64),
+				'message'=>'Der Name darf nicht länger als 64 Zeichen sein.'
+				),
+		'schiffsname_opt'=>
+			array(
+                'allowEmpty'=>true,
+				'rule'=>'nichtLeerBeiSchiffsnamensnennungJa',
+				'message'=>'Bei Nennungswunsch des Schiffsnamens darf dieses Feld nicht leer sein.'
+				),
+        'verteilung'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-3).'
+            ),
+        'verhalten'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-3).'
+            ),
+        'seegang'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3','4','5')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-5).'
+            ),
+        'bootsantrieb'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3','4')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-4).'
+            ),
+        'eingangskanal'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3','4','5')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-5).'
+            ),
+        'vonwo'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3','4')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-4).'
+            ),
+        'sichtweite'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=>array('inList', array('0','1','2','3','4')),
+                'message'=>'Der Wert liegt nicht im zugelassenen Bereich (0-4).'
+            ),
+        'windrichtung'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('inList', array('N','NW','W','SW','S','SO','O','NO')),
+                'message'=>'Bitte geben Sie eine gültige Windrichtung an.'
+            ),
+        'windstaerke'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('inList', array('0','1','2','3','4','5','6','7','8','9','10','11','12')),
+                'message'=>'Bitte geben Sie eine Windstärke zwischen 0 und 12 an.'
+            ),
+        'schiffsname'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Der Schiffsname darf nicht länger als 64 Zeichen sein.'
+            ),
+        'heimathafen'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Der Heimathafen darf nicht länger als 64 Zeichen sein.'
+            ),
+        'bootstyp'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Der Bootstyp darf nicht länger als 64 Zeichen sein.'
+            ),
+        'strasse'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Die Strasse darf nicht länger als 64 Zeichen sein.'
+            ),
+        'ort'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Der Ort darf nicht länger als 64 Zeichen sein.'
+            ),
+        'plz'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 5),
+                'message'=>'Die Postleitzahl darf nicht länger als 5 Zeichen sein.'
+            ),
+        'telefon'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Der Name darf nicht länger als 64 Zeichen sein.'
+            ),
+        'fax'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('maxLength', 64),
+                'message'=>'Die Telefonnummer darf nicht länger als 64 Zeichen sein.'
+            ),
+        'gps_laenge'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('myRange', -180, 180),
+                'message'=>'Der Längengrad muss zwischen -180 und 180 liegen.'
+            ),
+        'gps_breite'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('myRange', -90, 90),
+                'message'=>'Der Breitengrad muss zwischen -90 und 90 liegen.'
+            ),
+        'totfund_zustand'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('inList', array('0','1','2','3','4','5')),
+                'message'=>'Die Auswahl ist ungültig.'
+            ),
+        'totfund_geschlecht'=>
+            array(
+                'allowEmpty'=>true,
+                'required' => false,
+                'rule'=> array('inList', array('0','1','2')),
+                'message'=>'Die Auswahl ist ungültig.'
+            ),
+        'totfund_groesse'=>
+            array(
+                'allowEmpty' => true,
+                'required' => false,
+                'rule'    => array('naturalNumber', true),
+                'message'=>'Bitte geben Sie eine Zahl ein.'
+            )
+			);
+
+    public function nichtLeerBeiSchiffsnamensnennungJa($check){
+		if(!$this->data['Sichtung']['schiffnamensnennung']){
+			return true;
+		} else {
+			return !empty($check['schiffsname_opt']);
+		}
+	}
+
+    public function myRange($check, $lower = null, $upper = null) {
+        $check = end($check);
+        if (!is_numeric($check)) {
+            return false;
+        }
+        if (isset($lower) && isset($upper)) {
+            return ($check >= $lower && $check <= $upper);
+        }
+        return is_finite($check);
+    }
+
+    #benutztzahlenarray enthält die spaltennamen, die im add formular auf das array mit den zahlen 1-15 und dann '> 15' (hat dann den wert 16) zugreifen
+	#im afterfind wird dann 16 durch > 15 ersetzt...
+	public $benutztZahlenArray = array('anzahl_gesamt','anzahl_schiffe','anzahl_jung');
+
+	
+	public function massageData($data){
+		if(isset($data['sichtungsdatum'])){
+			$data['Sichtung']['sichtungsdatum'] = date('Y-m-d H:i',strtotime($data['sichtungsdatum']['datum'].' '.$data['sichtungsdatum']['uhrzeit']['hour'].':'.$data['sichtungsdatum']['uhrzeit']['min']));
+			unset($data['sichtungsdatum']);
+		}
+		if(isset($data['Sichtung']['intern'])){
+			if(!$data['Sichtung']['intern']){
+				$data['Sichtung']['ostsee'] = 1;
+			}
+			unset($data['Sichtung']['intern']);
+		}
+		if(!empty($data['Sichtung']['schiffsname_opt'])){
+			$data['Sichtung']['schiffsname'] = $data['Sichtung']['schiffsname_opt'];
+			unset($data['Sichtung']['schiffsname_opt']);
+		}
+		return $data;
+	}
+	
+	public function beforeSave($options = array()){
+		foreach($this->data['Sichtung'] as $key=>$val){
+			if(empty($val) AND !$this->id){
+				unset($this->data['Sichtung'][$key]);
+			}
+		}
+        if (isset($this->data['Sichtung']['gps_laenge']) && isset($this->data['Sichtung']['gps_breite'])) {
+            $lon =  floatval($this->data['Sichtung']['gps_laenge']);
+            $lat = floatval($this->data['Sichtung']['gps_breite']);
+            $obj = new stdClass();
+            $obj->type = 'expression';
+            $obj->value = 'ST_SetSRID(ST_MakePoint('.$lon.','.$lat.'),4326)';
+            $this->data['Sichtung']['location'] = $obj;
+            $inBaltic = $this->getPointInBaltic($lon, $lat);
+            if ($inBaltic[0][0]['inbaltic']==1) {
+                $this->data['Sichtung']['ostsee_geo'] = 2;
+            } else if ($inBaltic[0][0]['inchartarea']==1){
+                $this->data['Sichtung']['ostsee_geo'] = 1;
+            } else {
+                $this->data['Sichtung']['ostsee_geo'] = 0;
+            }
+        }
+		return true;
+	}
+
+    public function getPointInBaltic($lon, $lat){
+        $sql = sprintf("select ST_Contains(geom, ST_SetSRID(ST_MakePoint(%s,%s),4326)) as inBaltic, ST_SetSRID(ST_MakePoint(%s,%s),4326)  && ST_MakeEnvelope(%s,4326) as inChartArea from ne_10m_ocean As Sichtung where id = 2",$lon,$lat,$lon,$lat,QueryParserComponent::$chartBox);
+        return $this->query($sql);
+    }
+
+    public function getDefaultYear(){
+        return (date('n')>3)?date('Y'):date('Y')-1;
+    }
+	
+	public function getDataForEditForm($id = null){
+		if($id){
+			$this->id = $id;
+		}
+		$data = $this->read();
+		$data['Sichtung']['schiffsname_opt'] = $data['Sichtung']['schiffsname'];
+		$data['sichtungsdatum']['datum'] = date('d.m.Y',strtotime($data['Sichtung']['sichtungsdatum']));
+		$data['sichtungsdatum']['uhrzeit'] = date('H:i',strtotime($data['Sichtung']['sichtungsdatum']));
+		return $data;
+	}
+
+    private $excludeMap = array();
+
+	public function afterFind($results, $primary = false){
+		if($this->findQueryType != 'all'){
+			return $results;
+		}
+		foreach($results as &$result){
+			foreach($this->getAntworten() as $key=>$antworten){
+				if(isset($result['Sichtung'][$key]) && !in_array($key,$this->excludeMap)){
+					$antwort = $result['Sichtung'][$key];
+					if(isset($antworten[$antwort])){
+						$antwort = $antworten[$antwort];
+					}
+					if($result['Sichtung'][$key] == 0 AND !empty($result['Sichtung'][$key.'_text'])){
+						$antwort = $result['Sichtung'][$key.'_text'];
+					}
+					unset($result['Sichtung'][$key.'_text']);
+					$result['Sichtung'][$key] = $antwort;
+				}
+			}
+			foreach($this->benutztZahlenArray as $val){
+				if(isset($result['Sichtung'][$val])){
+					if($result['Sichtung'][$val] > 15){$result['Sichtung'][$val] = '> 15';}
+				}
+			}
+		}
+		return $results;
+	}
+
+								
+	public function getAntworten($auswahl = null){
+        $antworten =
+            array('verteilung' =>
+                array(1 =>__('einzeln'),
+                    2=>__('Mutter mit Jungtier'),
+                    3=>__('deutliche Schulen'),
+                    0 =>__('Sonstige Verteilung')
+                ),
+                'verhalten' =>
+                    array(1 => __('Konstanter Kurs, regelmäßiges Tauchen (schwimmen, ziehen)'),
+                        2 =>__('Unterschiedlicher Kurs, kreisend, unregelmäßiges Tauchen (futtersuchend)'),
+                        3 =>__('Langsames Schwimmen, längere Zeit an der Wasseroberfläche (ruhend)'),
+                        0 => __('Sonstiges Verhalten')
+                    ),
+                'seegang' =>
+                    array(1 => __('Glatte See, keine Wellen'),
+                        2 => __('Ruhige See, gekräuselte, kurze Wellen'),
+                        3 => __('Leicht bewegte See, Schaumköpfe'),
+                        4 => __('Grobe See, lange, brechende Wellen'),
+                        5 => __('Hohe See, Wellenberge und Gischt'),
+                        0 => __('Keine Angabe')
+                    ),
+                'bootsantrieb' =>
+                    array(1=>__('Motor'),
+                        2=>__('Segel'),
+                        3=>__('treibend'),
+                        4=>__('vor Anker'),
+                        0=>__('Sonstiger Bootsantrieb')
+                    ),
+                'eingangskanal' =>
+                    array(
+                        0=>__('Web'),
+                        1=>__('E-Mail'),
+                        2=>__('Post'),
+                        3=>__('Fax'),
+                        4=>__('App'),
+                        5=>__('Telefon')
+                    ),
+                'entfernung' =>
+                    array(
+                        1=>__('weniger als 10 Meter'),
+                        2=>__('10 bis 50 Meter'),
+                        3=>__('50 bis 100 Meter'),
+                        4=>__('100 bis 500 Meter'),
+                        5=>__('mehr als 500 Meter')
+                    ),
+                'vonwo' =>
+                    array(
+                        1=>__('Segelschiff'),
+                        2=>__('Motorboot'),
+                        3=>__('Land'),
+                        4=>__('Fähre'),
+                        0=>__('Sonstiges')
+                    ),
+                'sichtweite' =>
+                    array(1=>__('Außergewöhnlich klar (mehr als 20km)'),
+                        2=>__('Klar (bis 20km)'),
+                        3=>__('Diesig (bis 4km)'),
+                        4=>__('Nebel (bis 1km)')
+                    ),
+                'totfund_zustand' =>
+                    array(
+                        0 => __("unbekannt"),
+                        1 => __("keine Anzeichen von Verwesung"),
+                        2 => __("sehr frisch, als ob gerade gestorben"),
+                        3 => __("geringe Blutung, Haut pellt sich"),
+                        4 => __("beginnende Verwesung, Haut pellt sich stark, starke Blutung"),
+                        5 => __("fortgeschrittene Verwesung, Skelettteile sichtbar")
+                    ),
+                'totfund_geschlecht' =>
+                    array(
+                        0 => __('unbekannt'),
+                        1 => __('weiblich'),
+                        2 => __('männlich')
+                    ),
+                'tierart' =>
+                    array(
+                        0 => __('Schweinswal'),
+                        1 => __('Kegelrobbe'),
+                        2 => __('Seehund'),
+                        3 => __('Delphin (mehrere Arten)'),
+                        4 => __('Beluga'),
+                        5 => __('Zwergwal'),
+                        6 => __('Finnwal'),
+                        7 => __('Buckelwal'),
+                        8 => __('Unbekannte Walart'),
+                        9 => __('Ringelrobbe'),
+                        10 => __('Unbekannte Robbenart')
+                    )
+        );
+		if($auswahl){
+			if(isset($antworten[$auswahl])){
+				return $antworten[$auswahl];}
+		}
+		return $antworten;
+	}
+
+	public function getXmlData($options = array()){
+		$options['fields'] = array('namensnennung','schiffnamensnennung','gps_breite','gps_laenge','schiffsname','name','vorname','verteilung','fahrwasser','sichtungsdatum','anzahl_gesamt','anzahl_jung','id','totfund','tierart');
+		$sichtungen = $this->find('all',$options);
+        $sichtungenForXML = array();
+		foreach($sichtungen as $sichtung){
+			$sdt = strtotime($sichtung['Sichtung']['sichtungsdatum']);
+			$sichtungXML['nr'] = $sichtung['Sichtung']['id'];
+			$sichtungXML['datum'] = date('d.m.y',$sdt);
+		  	$sichtungXML['uhrzeit'] = date('Hi',$sdt);
+            $sichtungXML['tierart'] = $sichtung['Sichtung']['tierart'];
+		 	$sichtungXML['fahrwasser'] =$sichtung['Sichtung']['fahrwasser'];
+		  	$sichtungXML['dezigrad_n'] =$sichtung['Sichtung']['gps_breite'];
+		  	$sichtungXML['dezigrad_e'] =$sichtung['Sichtung']['gps_laenge'];
+            $sichtungXML['totfund'] = $sichtung['Sichtung']['totfund'];
+			$ag = $sichtung['Sichtung']['anzahl_gesamt'];
+            $sichtungXML['totfund'] = $sichtung['Sichtung']['totfund'];
+            if ($sichtungXML['totfund']) {
+                $sichtungXML['media'] = 'tot';
+                $sichtungXML['groessenklasse'] = 'tot';
+            }
+			switch($ag){
+				case 0:
+					$sichtungXML['media'] = 'tot';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = 'tot';
+                    $sichtungXML['totfund'] = 1;
+					break;
+				case 1:
+					$sichtungXML['media'] = 'Einzeltier';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = 'Einzeltier';
+					break;
+				case ($ag < 6):
+					$sichtungXML['media'] = '2_5';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = '2-5 Tiere';
+					break;
+				case ($ag < 11):
+					$sichtungXML['media'] = '6_10';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = '6-10 Tiere';
+					break;
+				case ($ag < 16):
+					$sichtungXML['media'] = '11_15';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = '11-15 Tiere';
+					break;
+				case ($ag > 15):
+					$sichtungXML['media'] = '_15';
+					$sichtungXML['anz_ber'] = $ag;
+					$sichtungXML['groessenklasse'] = 'Mehr als 15 Tiere';
+					break;
+					
+			}
+ 			$sichtungXML['jungtiere'] =$sichtung['Sichtung']['anzahl_jung'];
+			
+		  	$gps_n =$sichtung['Sichtung']['gps_breite'];
+		  	$gps_e =$sichtung['Sichtung']['gps_laenge'];
+			$X = round($gps_e*6371000*pi()/180,5);
+			$Y = round(log(tan($gps_n*pi()/360+pi()/4))*6371000,5);
+			$sichtungXML['x'] = round(($X-1050792.0567911)/628251.3355417,3);
+			$sichtungXML['y'] = round(($Y-7138521.4416712)/909594.5299957,3);
+			
+			
+		 	$sichtungXML['schiff'] = ($sichtung['Sichtung']['namensnennung'] OR $sichtung['Sichtung']['schiffnamensnennung'])?$sichtung['Sichtung']['schiffsname']:'';
+			
+		 	$sichtungXML['person'] = $sichtung['Sichtung']['namensnennung']?$sichtung['Sichtung']['vorname'] . ' ' . $sichtung['Sichtung']['name']:'';
+			
+			$sichtungenForXML[] = $sichtungXML;
+		}
+		return $sichtungenForXML;
+	}
+
+    private function cleanCsvData($data) {
+        $sichtung = $data;
+        $sichtung['Sichtung']['gps_breite'] = str_replace('.', ',', $sichtung['Sichtung']['gps_breite']);
+        $sichtung['Sichtung']['gps_laenge'] = str_replace('.', ',', $sichtung['Sichtung']['gps_laenge']);
+        unset($sichtung['Sichtung']['location'], $sichtung['Sichtung']['ostsee']);
+        foreach(array_keys($sichtung['Sichtung']) as $key) {
+            $sichtung['Sichtung'][$key] = str_replace('"','""',$sichtung['Sichtung'][$key]);
+            $sichtung['Sichtung'][$key] = str_replace(array("\r","\r\n"),'',$sichtung['Sichtung'][$key]);
+        }
+        return $sichtung;
+    }
+
+	public function getCsvData($options){
+        $this->excludeMap = array('totfund_zustand');
+		$data = $this->find('all',$options);
+        $data = array_map(array($this, "cleanCsvData"), $data);
+		$header['Sichtung'] = array_keys($data[0]['Sichtung']);
+		array_unshift($data,$header);
+		return $data;
+	}
+
+    public function getJsonData($options){
+        $this->excludeMap = array('tierart');
+        $data = $this->find('all',$options);
+        return $data;
+    }
+
+    public function getReports($options, $admin = false) {
+        $data = $this->find('all',$options);
+        $func = new ReportUtils();
+        $func->admin = $admin;
+        $func->model = $this;
+        $reports = array_map(array($func,'arrayMapReport'), $data);
+        return $reports;
+    }
+
+    public function _formatDMS($dec){
+        $vars = explode(".",$dec);
+        $deg = $vars[0];
+        $tempma = "0.".$vars[1];
+
+        $tempma = $tempma * 3600;
+        $min = floor($tempma / 60);
+        $sec = $tempma - ($min*60);
+
+        return array("deg"=>$deg,"min"=>$min,"sec"=>$sec);
+
+    }
+    public function formatDMS($lat, $lon) {
+        $alat = $this->_formatDMS($lat);
+        $alon = $this->_formatDMS($lon);
+        $ret = vsprintf("%02d° %02d' %02.2f\"",$alat) . (($alat['deg']<0)?"S":"N");
+        $ret .= vsprintf(" - %02d° %02d' %02.2f\"",$alon) . (($alon['deg']<0)?"W":"E");
+        return $ret;
+
+    }
+    public function getForKml($options) {
+        $this->excludeMap = array('tierart');
+        $data = $this->find('all',$options);
+        $counts = array(
+            "eq_1" => 0,
+            "2_5" => 0,
+            "5_10" => 0,
+            "11_15" => 0,
+            "gt_15" => 0,
+            "dead" => 0
+        );
+        $reports = new SimpleXMLExtended('<kml/>');
+        $folder = $reports->addChild("Folder");
+        $folder->addChild("styleUrl", "#style1");
+        $folder->addChild("name","Sichtungen");
+        //debug($data);
+        foreach($data as $sichtung) {
+            $desc = '';
+            $report = $folder->addChild("Placemark");
+            $report->addChild("name", date('d.m.y H:i', strtotime($sichtung['Sichtung']['sichtungsdatum'])));
+            if ($sichtung['Sichtung']['tierart'] != 0) $desc .= "<p><label>" . __("Tierart") . ": </label>" . $this->getAntworten('tierart')[$sichtung['Sichtung']['tierart']] . "</p>";
+            $desc .= "<p><label>" . __("Position") . ": </label>" . $this->formatDMS($sichtung['Sichtung']['gps_breite'], $sichtung['Sichtung']['gps_laenge']) . "</p>";
+            $desc .= "<p><label>" . __("Anzahl Tiere") . ": </label>" . $sichtung['Sichtung']['anzahl_gesamt'] . "</p>";
+            if (isset($sichtung['Sichtung']['anzahl_jung']) && $sichtung['Sichtung']['anzahl_jung'] > 0) $desc .= "<p><label>" . __("Davon Jungtiere") . ": </label>" . $sichtung['Sichtung']['anzahl_jung'] . "</p>";
+            if ($sichtung['Sichtung']['schiffsname'] != "" && ($sichtung['Sichtung']['namensnennung'] || $sichtung['Sichtung']['schiffnamensnennung'])) $desc .= "<p><label>" . __("Schiffsname") . ": </label>" . $sichtung['Sichtung']['schiffsname'] . "</p>";
+            if ($sichtung['Sichtung']['namensnennung']) $desc .= "<p><label>" . __("Name") . ": </label>" . $sichtung['Sichtung']['vorname'] . ' ' . $sichtung['Sichtung']['name'] . "</p>";
+            if ($sichtung['Sichtung']['fahrwasser'] != "") $desc .= "<p><label>" . __("Fahrwasser") . ": </label>" . $sichtung['Sichtung']['fahrwasser'] . "</p>";
+            $report->addChild("description")->addCData($desc);
+            $report->addChild("Point")->addChild("coordinates", $sichtung['Sichtung']['gps_laenge'] . "," . $sichtung['Sichtung']['gps_breite']);
+            $ct = $sichtung['Sichtung']['anzahl_gesamt'];
+            $report->addChild("TimeStamp")->addChild("when", date('Y-m-d\TH:i:sP', strtotime($sichtung['Sichtung']['sichtungsdatum'])));
+            $style = "#style1";
+            if ($sichtung['Sichtung']['totfund'] != 0) {
+                $style = "#style0";
+                $counts["dead"]++;
+            } else if ($sichtung['Sichtung']['tierart'] != 0) {
+                $style = "#style_ta";
+                @$counts[$sichtung['Sichtung']['tierart']]++;
+            } else {
+                switch ($ct) {
+                    case 1:
+                        $style = "#style1";
+                        $counts["eq_1"]++;
+                        break;
+                    case 0:
+                        $style = "#style0";
+                        $counts["dead"]++;
+                        break;
+                    case ($ct < 6):
+                        $style = "#style2";
+                        $counts["2_5"]++;
+                        break;
+                    case ($ct < 11):
+                        $style = "#style3";
+                        $counts["5_10"]++;
+                        break;
+                    case ($ct < 16):
+                        $style = "#style4";
+                        $counts["11_15"]++;
+                        break;
+                    case ($ct > 15):
+                        $style = "#style5";
+                        $counts["gt_15"]++;
+                        break;
+                }
+            }
+            $report->addChild('styleUrl', $style);
+        }
+        $ext = $folder->addChild("ExtendedData")->addChild("Data");
+        $ext->addAttribute("name","counts");
+        $ext->addChild("value", implode(",", $counts));
+        return $reports;
+    }
+	
+	public function getEmailAddresses(){
+		$data = $this->find('all', array(
+			'fields' => array('Sichtung.email','max(Sichtung.name) as name','max(Sichtung.vorname) as vorname','max(Sichtung.strasse) as strasse','max(Sichtung.plz) as plz','max(Sichtung.ort) as ort','max(Sichtung.telefon) as telefon','max(Sichtung.fax) as fax','max(Sichtung.sichtungsdatum) as letzte_Sichtung'),
+			'group' => array('Sichtung.email'),
+            'order' => array('max(sichtungsdatum) DESC')
+			));
+        //debug($data);
+		$header['Sichtung'] = array_keys($data[0]['Sichtung']);
+        $header[0] = array_keys($data[0][0]);
+		array_unshift($data,$header);
+		return $data;
+	}
+
+    public function getDistinctYears(){
+        $data = $this->find('all', array(
+            'fields' => array("DISTINCT EXTRACT('year' FROM sichtungsdatum) AS year"),
+            'order' => array('year ASC'),
+            'conditions' => array('EXTRACT(year FROM sichtungsdatum) > 2011','Sichtung.geprueft = 1')
+        ));
+        $years = [];
+        foreach ($data as $year) {
+            $years[$year[0]['year']] = $year[0]['year'];
+        }
+        return $years;
+    }
+
+}

--- a/docs/archive/legacy-cakephp/Sichtung.php
+++ b/docs/archive/legacy-cakephp/Sichtung.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Malte Srocke <maltesrocke@yahoo.de>
+ * @author Malte Srocke (E-Mail-Adresse entfernt, siehe README)
  * 
  */
 App::uses('AppModel', 'Model');

--- a/docs/archive/legacy-cakephp/SichtungenController.php
+++ b/docs/archive/legacy-cakephp/SichtungenController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @author Malte Srocke <maltesrocke@yahoo.de>
+ * @author Malte Srocke (E-Mail-Adresse entfernt, siehe README)
  * 
  */
 App::uses('AppController', 'Controller');

--- a/docs/archive/legacy-cakephp/SichtungenController.php
+++ b/docs/archive/legacy-cakephp/SichtungenController.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * @author Malte Srocke <maltesrocke@yahoo.de>
+ * 
+ */
+App::uses('AppController', 'Controller');
+App::uses('CakeEmail', 'Network/Email');
+
+class SichtungenController extends AppController {
+
+	public $name = 'Sichtungen';
+	public $helpers = array('Form','Paginator','Js'=>array('Jquery'));
+	public $components = array('RequestHandler','Paginator','QueryParser');
+
+	public $uses = array('Sichtung');
+	
+	public $paginate = array('order'=>'geprueft ASC, CASE WHEN geprueft = 1 THEN sichtungsdatum ELSE created END DESC');
+
+    public function beforeFilter(){
+        parent::beforeFilter();
+        $this->Auth->allow(array('add','export','antworten','showReports','inBaltic','all'));
+        $this->Security->csrfCheck = false;
+        $this->Security->validatePost = false;
+        if (IS_PROD) {
+            $this->Security->requireSecure('index', 'edit','delete','details','changeStatus');
+        }
+        if ($this->request->param('ext') == 'kml') {
+            $this->viewClass = "Kml";
+        }
+    }
+
+    public function clear(){
+        clearCache();
+        $this->view = 'add';
+        $intern = false;
+        $this->set('intern');
+    }
+
+	public function add($intern = false){
+		if(!empty($this->request->data)){
+			$data = $this->request->data;
+			$data = $this->Sichtung->massageData($data);
+			if($this->Sichtung->save($data)){
+				$this->Session->setFlash(__('Die Sichtung wurde erfolgreich in der Datenbank gespeichert.'));
+				unset($this->request->data);
+				if($intern){
+					$this->redirect(array('action'=>'index','op'=>1));
+				}
+			} else {
+				$this->Session->setFlash(__('Die Sichtung konnte nicht gespeichert werden.<br />Bitte füllen Sie alle Felder unter "Wichtigste Angaben" aus.'));
+			}
+		}
+		$antworten = $this->Sichtung->getAntworten();
+		$this->set(compact('antworten','intern'));
+	}
+	
+	public function edit($id = null){
+		$this->view = 'add';
+		$intern = true;
+		$this->Sichtung->id = $id;
+		if(!$this->Sichtung->exists()){
+			$this->redirect(array('action'=>'index','op'=>1));
+		}
+		if(!empty($this->request->data)){
+            $this->request->allowMethod('post','put');
+			$data = $this->Sichtung->massageData($this->request->data);
+            //pr($data);
+			if($this->Sichtung->save($data)){
+				$this->Session->setFlash(__('Die Sichtung wurde erfolgreich bearbeitet.'));
+				$this->redirect(array('action'=>'index','op'=>1));
+			} else {
+				$this->Session->setFlash(__('Die Sichtung konnte nicht bearbeitet werden.'));
+                pr($this->Sichtung->validationErrors);
+			}
+		}
+		$this->request->data = $this->Sichtung->getDataForEditForm();
+		$antworten = $this->Sichtung->getAntworten();
+		$this->set(compact('antworten','intern'));
+	}
+	
+	public function delete($id = null){
+        if ($this->Sichtung->delete($id)) {
+            $this->response->header('Code',200);
+        }
+		$this->response->header('Code',500);
+	}
+	
+	public function index(){
+		$isAjax = $this->request->is('ajax');
+        $tableOnly = $isAjax;
+        $this->Paginator->settings = $this->paginate;
+		if(!$isAjax && !isset($this->request->params['named']['op'])){
+			$this->Session->delete('paginationNamed');
+			$this->Session->delete('paginationConditions');
+		}
+		if(isset($this->request->params['named'])){
+			if(isset($this->request->params['named']['op'])){
+				$named = $this->Session->read('paginationNamed');
+			} else {
+				$named = $this->request->params['named'];
+				$this->Session->write('paginationNamed',$this->request->params['named']);
+			}
+		}
+        $conditions = $this->Session->read('paginationConditions');
+		if($this->request->data){
+			$conditions = array();
+            $year = $this->request->data('filterForm.year.year');
+			$filterFormData = $this->request->data['filterForm'];
+			if($this->request->data('filterForm.filterVonBis')){
+				$von = $filterFormData['von'];
+				$bis = $filterFormData['bis'];
+				$conditions['Sichtung.sichtungsdatum >='] = $year.'-'.$von['month'].'-'.$von['day'].' 00:00';
+				$conditions['Sichtung.sichtungsdatum <='] = $year.'-'.$bis['month'].'-'.$bis['day'].' 23:59';
+			} else {
+                $conditions["EXTRACT(YEAR FROM sichtungsdatum) ="] = $year;
+            }
+			if($filterFormData['geprueft'] != 'nein'){
+				$conditions['Sichtung.geprueft'] = $filterFormData['geprueft'];
+			}
+			if($filterFormData['eingangskanal'] != 'nein'){
+				$conditions['Sichtung.eingangskanal'] = $filterFormData['eingangskanal'];
+			}
+            $this->Session->write('showYear', $year);
+		} else if (count($conditions) == 0) {
+            $year = $this->Sichtung->getDefaultYear();
+            $this->request->data('filterForm.year.year', $year);
+            $conditions = array("EXTRACT(YEAR FROM sichtungsdatum) =" => $year);
+            $this->Session->write('showYear', $year);
+        } else {
+            $year = $this->Session->read('showYear');
+        }
+		$this->Session->write('paginationConditions',$conditions);
+		$this->request->params['named'] = (isset($named) && is_array($named))?$named:array();
+		$sichtungen = $this->Paginator->paginate('Sichtung',$conditions);
+		$eingangskanaele = $this->Sichtung->getAntworten('eingangskanal');
+		$this->set(compact('sichtungen','tableOnly','eingangskanaele','year'));
+	}
+	
+	public function details($id = null){
+		$this->Sichtung->id = $id;
+		if(!$this->Sichtung->exists()){
+			$this->Session->setFlash(__('Keine Sichtung mit dieser ID vorhanden.'));
+			$this->redirect(array('action'=>'index','op'=>1));
+		}
+		$sichtung = $this->Sichtung->find('all',array('conditions'=>array('Sichtung.id'=>$id)));
+		$sichtung = $sichtung[0];
+		$this->set(compact('sichtung'));
+	}
+	
+	
+	public function changeStatus($fieldName = null,$id = null,$redirect = null){
+		if(empty($fieldName) OR empty($id)){
+			$this->Session->setFlash(__('Feldname und ID fehlt!'));
+			$this->redirect(array('action'=>'index','op'=>1));
+            return;
+		}
+		if(!in_array($fieldName,array('ostsee','geprueft'))){
+			$this->Session->setFlash(__('Nicht erlaubt!'));
+			$this->redirect(array('action'=>'index','op'=>1));
+            return;
+		}
+		$this->Sichtung->id = $id;
+		if(!$this->Sichtung->exists()){
+			$this->Session->setFlash(__('Keine Sichtung mit dieser ID vorhanden.'));
+			$this->redirect(array('action'=>'index','op'=>1));
+            return;
+		}
+		// change status -> if true, set false now		
+		$status = ($this->Sichtung->field($fieldName) == 1)?0:1;
+		//print 'UPDATE sichtungen SET '.$fieldName.'='.$status.' WHERE id='.$id;
+		//$this->Sichtung->query('UPDATE sichtungen SET '.$fieldName.'='.$status.' WHERE id='.$id);
+        $this->Sichtung->saveField($fieldName, $status);
+		#wenn geprueft auf ja gesetzt wird:
+		if($fieldName == 'geprueft' AND $status == 1){
+			$this->Sichtung->saveField('freigegeben_am',date("Y-m-d H:i:s"));
+			$this->redirect(array('action'=>'sendeIstLiveMail',$id));
+		}
+		if($redirect == 'details'){
+			$this->redirect(array('action'=>'details',$id));
+		} else {
+			$this->redirect(array('action'=>'index','op'=>1));
+		}
+	}
+
+	public function sendeIstLiveMail($id = null){
+		$eingangskanalEmailText = array(
+								0=>__("emailTextOnline"),
+								1=>__("emailTextOnline"),
+								2=>__("emailTextOffline"),
+								3=>__("emailTextOffline"),
+								4=>__("emailTextApp"),
+								5=>__("emailTextOffline")
+								);
+		$this->layout = 'overlayer';
+		if(!$id){
+			return false;
+		}
+		$this->Sichtung->id;
+		if(isset($this->request->data['sendLiveMail'])){
+			extract($this->request->data['sendLiveMail']);
+			$mail = new CakeEmail();
+			$mail->emailFormat('html');
+            $mail->from($von);
+			$mail->to($an);
+			$mail->template('default');
+			$mail->viewVars(array('text'=>$text));
+			$mail->subject($betreff);
+			print_r($mail->send());
+			$this->Session->setFlash(__('Die E-Mail wurde an den Sichter verschickt.'));
+			$this->redirect(array('action'=>'index','op'=>1));
+		}
+		$sichterInfo = $this->Sichtung->find('first',array('fields'=>array('eingangskanal','email'),'conditions'=>'Sichtung.id = '.$id));
+		$this->request->data['sendLiveMail']['von'] = 'sichtungen@meeresmuseum.de';
+		$this->request->data['sendLiveMail']['an'] = $sichterInfo['Sichtung']['email'];
+		$this->request->data['sendLiveMail']['text'] = $eingangskanalEmailText[$sichterInfo['Sichtung']['eingangskanal']];
+		$this->request->data['sendLiveMail']['betreff'] = __('Vielen Dank für Ihre Sichtungsmeldung');
+		$this->set('header',__('E-Mail an Sichter schicken'));
+	}
+	
+	public function export(){
+        $options = $this->QueryParser->parseList($this->Sichtung->getDefaultYear(),$this->Auth->user());
+		if($this->request->params['ext'] == 'xml'){
+            if (!$this->Auth->user()) {
+			    $options['conditions'][] = array('Sichtung.geprueft'=>1);
+            }
+			$data = $this->Sichtung->getXmlData($options);
+		}
+		if($this->request->params['ext'] == 'csv'){
+			$data = $this->Sichtung->getCsvData($options);
+		}
+		if($this->request->params['ext'] == 'txt'){
+			$data = $this->Sichtung->getEmailAddresses();
+		}
+        if($this->request->params['ext'] == 'json'){
+            $data = $this->Sichtung->getJsonData($options);
+        }
+		if(empty($data)){
+			echo 'Keine Sichtungen gefunden!';
+		}
+		$this->set('sichtungen',$data);
+	}
+
+    public function showReports(){
+        $this->view = 'export';
+        $options = $this->QueryParser->parseList($this->Sichtung->getDefaultYear(),$this->Auth->user());
+        if($this->request->params['ext'] == 'kml'){
+            $data = $this->Sichtung->getForKml($options);
+        } else {
+            $data = $this->Sichtung->getReports($options, $this->Auth->user());
+        }
+        $this->set('sichtungen',$data);
+    }
+
+    public function all(){
+        $options = $this->QueryParser->parseList($this->Sichtung->getDefaultYear(),$this->Auth->user());
+        $data = $this->Sichtung->getJsonData($options);
+        $func = new ReportUtils();
+        $func->admin = $this->Auth->user();
+        $func->model = $this->Sichtung;
+        $data = array(
+            "type" => "FeatureCollection",
+            "crs" => array(
+                "type" => "name",
+                "properties" => array(
+                    "name" => "EPSG:4326"
+                )
+            ),
+            "features" => array_map(array($func,'arrayMapGeoJSON'), $data)
+        );
+        $this->set('sichtungen',$data);
+    }
+	
+	public function sichtungenInKarte($openInfowindowId = null){
+		$this->set('id',$openInfowindowId);
+	}
+
+    public function years(){
+        $this->view = 'export';
+        $data = $this->Sichtung->getDistinctYears();
+        $this->set('sichtungen', $data);
+    }
+
+    public function inBaltic(){
+        $this->view = 'export';
+        $found = preg_match('/^([\d\.-]+),([\d\.-]+)$/', $this->request->query('location'), $match);
+        if ($found != 1)
+            throw new BadRequestException("Please check query parameters.");
+        list(,$lat,$lon) = $match;
+        $data = $this->Sichtung->getPointInBaltic($lon,$lat);
+        $this->set('sichtungen', $data[0][0]);
+    }
+	
+}
+?>

--- a/docs/archive/legacy-cakephp/routes.php
+++ b/docs/archive/legacy-cakephp/routes.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Routes configuration
+ *
+ * In this file, you set up routes to your controllers and their actions.
+ * Routes are very important mechanism that allows you to freely connect
+ * different urls to chosen controllers and their actions (functions).
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2011, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.Config
+ * @since         CakePHP(tm) v 0.2.9
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+ 
+ Router::mapResources('rest_sichtungen');
+ Router::setExtensions('kml');
+ Router::parseExtensions();
+ 
+/**
+ * Here, we are connecting '/' (base path) to controller called 'Pages',
+ * its action called 'display', and we pass a param to select the view file
+ * to use (in this case, /app/View/Pages/home.ctp)...
+ */
+    Router::connect('/:language/:controller/:action/*',
+        array(),
+        array('language' => 'de|en'));
+
+    Router::connect('/:language/:controller',
+        array('action' => 'index'),
+        array('language' => 'de|en'));
+
+	Router::connect('/:language',
+        array('controller' => 'sichtungen', 'action' => 'add'),
+        array('language' => 'de|en'));
+
+
+	Router::connect('/', array('controller' => 'sichtungen', 'action' => 'add'), array('language' => 'de'));
+	Router::connect('/export/:year', array('controller' => 'sichtungen', 'action' => 'export'), array('language' => 'de', 'year' => '[12][0-9]{3}'));
+/**
+ * ...and connect the rest of 'Pages' controller's urls.
+ */
+	Router::connect('/pages/*', array('controller' => 'pages', 'action' => 'display'), array('language' => 'de'));
+
+/**
+ * Load all plugin routes.  See the CakePlugin documentation on 
+ * how to customize the loading of plugin routes.
+ */
+	CakePlugin::routes();
+
+/**
+ * Load the CakePHP default routes. Remove this if you do not want to use
+ * the built-in default routes.
+ */
+	require CAKE . 'Config' . DS . 'routes.php';

--- a/src/routes/rest_sichtungen/+server.ts
+++ b/src/routes/rest_sichtungen/+server.ts
@@ -295,16 +295,29 @@ export async function POST(event: RequestEvent): Promise<Response> {
 }
 
 /**
- * Handle unsupported HTTP methods
+ * GET /rest_sichtungen — der Index der Legacy-API.
+ *
+ * Wörtlich dieselbe Funktion wie `GET /sichtungen/showreports.json`, nicht
+ * eine zweite Umsetzung daneben. Die Vorgänger-Anwendung machte es genauso:
+ * `RestSichtungenController::index()` und `SichtungenController::showReports()`
+ * bestehen aus denselben zwei Zeilen (`parseList()` und `getReports()`), und
+ * `getReports()` schickt jeden Datensatz durch `ReportUtils::mapReport()` —
+ * das erzeugt die kompakte Form, die `showreports.json` hier bereits
+ * ausliefert. Belege liegen unter `docs/archive/legacy-cakephp/`.
+ *
+ * Dass CakePHP bei `_serialize` als Zeichenkette (`'Sichtungen'`) den Wert
+ * direkt serialisiert und nicht in ein Objekt hüllt, steht im Klassenkommentar
+ * von `Cake/View/JsonView.php`. Die Antwort war also auch dort ein blankes
+ * Array — keine Umhüllung `{"Sichtungen": […]}`.
+ *
+ * Bis 2026-08 antwortete dieser Pfad mit `405`. Die angebundene iOS-App fragt
+ * ihn an; er ist die Datenquelle ihrer Karte, und die blieb dadurch leer.
+ *
+ * **Das Rate-Limit gilt bewusst nur für POST.** Es steht am Anfang des
+ * Schreibpfads und begrenzt Meldungen, nicht Abrufe. Eine Karte, die sich nach
+ * 20 Aufrufen abschaltet, wäre schlimmer als gar keine.
  */
-export async function GET() {
-	const errorResponse = {
-		error: 'Method not allowed',
-		message: 'Only POST method is supported for this endpoint'
-	};
-
-	return json(errorResponse, { status: 405 });
-}
+export { GET } from '../sichtungen/showreports.json/+server';
 
 export async function PUT() {
 	const errorResponse = {

--- a/src/routes/rest_sichtungen/index.test.ts
+++ b/src/routes/rest_sichtungen/index.test.ts
@@ -1,0 +1,51 @@
+/**
+ * `GET /rest_sichtungen` — der Index der Legacy-API.
+ *
+ * Der Endpunkt fehlte bis 2026-08 vollständig und antwortete mit `405`. Die
+ * angebundene iOS-App (`OstSeeTiere/8`) fragt ihn an: Er ist die Datenquelle
+ * ihrer Karte, nachgewiesen im Zugriffsprotokoll von schweinswalsichtung.de
+ * und am Gerät bestätigt. Solange er fehlte, blieb die Karte in der App leer.
+ *
+ * Die Vorgänger-Anwendung liegt als Beleg unter `docs/archive/legacy-cakephp/`.
+ * Entscheidend sind zwei Stellen:
+ *
+ * `RestSichtungenController::index()` und `SichtungenController::showReports()`
+ * bestehen aus denselben zwei Zeilen — `parseList()` für die Filter und
+ * `getReports()` für die Daten. `getReports()` schickt jeden Datensatz durch
+ * `ReportUtils::mapReport()`, und das erzeugt die kompakte Form
+ * (`ts`, `id`, `dt`, `ti`, `lat`, `lon`, `ct`, `yo`, `ta`, `tf`), die diese
+ * Anwendung unter `showreports.json` bereits ausliefert.
+ *
+ * `GET /rest_sichtungen` und `GET /sichtungen/showreports.json` sind damit
+ * derselbe Endpunkt unter zwei Namen. Genau das schreibt dieser Test fest —
+ * und zwar als Identität der Funktion, nicht als Vergleich zweier Antworten:
+ * Zwei getrennte Implementierungen, die heute dasselbe liefern, laufen früher
+ * oder später auseinander, und die Legacy-API ist der eine Ort im Projekt, an
+ * dem das niemandem auffiele, bis ein nicht mehr testbarer Client bricht.
+ */
+import { describe, expect, it } from 'vitest';
+import { GET as showreportsGET } from '../sichtungen/showreports.json/+server';
+import { GET, POST } from './+server';
+
+describe('GET /rest_sichtungen', () => {
+	it('ist dieselbe Funktion wie GET /sichtungen/showreports.json', () => {
+		expect(GET).toBe(showreportsGET);
+	});
+
+	it('antwortet nicht mehr mit 405', async () => {
+		// Der frühere Handler gab einen festen 405-Körper zurück, ohne die
+		// Anfrage anzusehen. Ein Test, der nur `GET !== undefined` prüft, wäre
+		// auch damals grün gewesen.
+		expect(GET.toString()).not.toContain('Method not allowed');
+	});
+
+	it('lässt POST unangetastet', () => {
+		// Der Schreibpfad ist der kritische: Er trägt das Rate-Limit von 20
+		// Meldungen pro Stunde und die Yup-Validierung. Der Index darf daran
+		// nichts ändern — insbesondere darf das Rate-Limit nicht für den
+		// lesenden Pfad gelten, sonst schaltete sich die Karte nach 20
+		// Aufrufen ab.
+		expect(POST).toBeTypeOf('function');
+		expect(POST).not.toBe(GET);
+	});
+});

--- a/src/routes/rest_sichtungen/index.test.ts
+++ b/src/routes/rest_sichtungen/index.test.ts
@@ -32,13 +32,6 @@ describe('GET /rest_sichtungen', () => {
 		expect(GET).toBe(showreportsGET);
 	});
 
-	it('antwortet nicht mehr mit 405', async () => {
-		// Der frühere Handler gab einen festen 405-Körper zurück, ohne die
-		// Anfrage anzusehen. Ein Test, der nur `GET !== undefined` prüft, wäre
-		// auch damals grün gewesen.
-		expect(GET.toString()).not.toContain('Method not allowed');
-	});
-
 	it('lässt POST unangetastet', () => {
 		// Der Schreibpfad ist der kritische: Er trägt das Rate-Limit von 20
 		// Meldungen pro Stunde und die Yup-Validierung. Der Index darf daran

--- a/src/routes/rest_sichtungen/rest_sichtungen.test.ts
+++ b/src/routes/rest_sichtungen/rest_sichtungen.test.ts
@@ -426,15 +426,13 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 	});
 
 	describe('PDF Compliance - HTTP Methods', () => {
-		it('should reject GET requests with 405', async () => {
-			const response = await GET();
-
-			expect(response.status).toBe(405);
-			const responseData = await response.json();
-			expect(responseData).toMatchObject({
-				error: 'Method not allowed',
-				message: 'Only POST method is supported for this endpoint'
-			});
+		// `GET` gehört seit 2026-08 **nicht** mehr zu den abgelehnten Methoden:
+		// Der Pfad ist der Index der Legacy-API und die Datenquelle der Karte
+		// in der angebundenen iOS-App. Dass er hier bis dahin mit `405` als
+		// „unsupported" festgeschrieben war, hat die Lücke jahrelang wie eine
+		// Absicht aussehen lassen. Sein Verhalten prüft `index.test.ts`.
+		it('lehnt GET nicht mehr ab — der Index ist ein eigener Endpunkt', () => {
+			expect(GET).not.toBe(PUT);
 		});
 
 		it('should reject PUT requests with 405', async () => {

--- a/src/routes/rest_sichtungen/rest_sichtungen.test.ts
+++ b/src/routes/rest_sichtungen/rest_sichtungen.test.ts
@@ -11,7 +11,7 @@
 import type { LegacySightingRequest } from '$lib/legacy-api/types';
 import type { RequestEvent } from '@sveltejs/kit';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { DELETE, GET, POST, PUT } from './+server';
+import { DELETE, POST, PUT } from './+server';
 
 // Mock dependencies - these need to be hoisted before any imports
 vi.mock('$lib/server/db/sightingRepository', () => ({
@@ -426,14 +426,13 @@ describe('PDF-Compliant Legacy REST API - POST /rest_sichtungen', () => {
 	});
 
 	describe('PDF Compliance - HTTP Methods', () => {
-		// `GET` gehört seit 2026-08 **nicht** mehr zu den abgelehnten Methoden:
-		// Der Pfad ist der Index der Legacy-API und die Datenquelle der Karte
-		// in der angebundenen iOS-App. Dass er hier bis dahin mit `405` als
-		// „unsupported" festgeschrieben war, hat die Lücke jahrelang wie eine
-		// Absicht aussehen lassen. Sein Verhalten prüft `index.test.ts`.
-		it('lehnt GET nicht mehr ab — der Index ist ein eigener Endpunkt', () => {
-			expect(GET).not.toBe(PUT);
-		});
+		// `GET` fehlt hier bewusst. Der Pfad gehört seit 2026-08 nicht mehr zu
+		// den abgelehnten Methoden: Er ist der Index der Legacy-API und die
+		// Datenquelle der Karte in der angebundenen iOS-App. Dass er hier bis
+		// dahin mit `405` als „unsupported" festgeschrieben war, hat die Lücke
+		// jahrelang wie eine Absicht aussehen lassen. Geprüft wird er in
+		// `index.test.ts` — ein zweiter Test an dieser Stelle könnte nur
+		// wiederholen, was dort steht.
 
 		it('should reject PUT requests with 405', async () => {
 			const response = await PUT();

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1987,6 +1987,62 @@ paths:
                 error: "Fehler beim Abrufen der verfügbaren Jahre"
 
   /rest_sichtungen:
+    get:
+      tags:
+        - legacy
+      summary: '[LEGACY] Sichtungsdaten abrufen (Index)'
+      description: |
+        **Derselbe Endpunkt wie `GET /sichtungen/showreports.json`, unter dem
+        zweiten Namen der Vorgänger-API.**
+
+        Die abgelöste CakePHP-Anwendung bildete `/rest_sichtungen` mit
+        `Router::mapResources()` ab; `GET` traf dort auf `index()`, und diese
+        Aktion bestand aus denselben zwei Zeilen wie `showReports()`.
+        Parameter, Antwortformat, Sortierung, Limit und die
+        Datenschutz-Regeln sind identisch — maßgeblich ist die Beschreibung
+        unter `/sichtungen/showreports.json`. Es ist wörtlich dieselbe
+        Funktion, keine zweite Umsetzung.
+
+        Die angebundene iOS-App (`OstSeeTiere/8`) lädt ihre Karte über diesen
+        Pfad. Bis 2026-08 antwortete er mit `405`.
+      parameters:
+        - name: year
+          in: query
+          description: 'Jahr der Sichtungen (Standard: aktuelles Jahr bis März, sonst Vorjahr)'
+          schema:
+            type: integer
+            minimum: 2000
+        - name: location
+          in: query
+          description: 'Position als "Breite,Länge" für die Umkreissuche'
+          schema:
+            type: string
+        - name: distance
+          in: query
+          description: 'Radius in Metern, nur zusammen mit location (Standard: 100000)'
+          schema:
+            type: integer
+        - name: bbox
+          in: query
+          description: 'Bereich als "min_x,min_y,max_x,max_y" (OpenLayers-kompatibel)'
+          schema:
+            type: string
+        - name: search
+          in: query
+          description: >-
+            Freitextsuche. Für anonyme Aufrufer eingeschränkt auf freigegebene
+            Namen und Schiffsnamen — siehe /sichtungen/showreports.json.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Liste der Sichtungen im PDF-konformen Kurzformat
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PDFCompliantSightingResponse'
     post:
       tags:
         - legacy

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -1995,13 +1995,17 @@ paths:
         **Derselbe Endpunkt wie `GET /sichtungen/showreports.json`, unter dem
         zweiten Namen der Vorgänger-API.**
 
+        Zusätzlich unter `/de/…` und `/en/…` erreichbar — Sprachpräfix der abgelösten
+        CakePHP-App, keine Übersetzung (siehe docs/LEGACY_API_SPECIFICATION.md).
+
         Die abgelöste CakePHP-Anwendung bildete `/rest_sichtungen` mit
         `Router::mapResources()` ab; `GET` traf dort auf `index()`, und diese
         Aktion bestand aus denselben zwei Zeilen wie `showReports()`.
-        Parameter, Antwortformat, Sortierung, Limit und die
-        Datenschutz-Regeln sind identisch — maßgeblich ist die Beschreibung
-        unter `/sichtungen/showreports.json`. Es ist wörtlich dieselbe
-        Funktion, keine zweite Umsetzung.
+        Antwortformat, Sortierung, Limit und die Datenschutz-Regeln sind
+        identisch — maßgeblich ist die Beschreibung unter
+        `/sichtungen/showreports.json`. Es ist wörtlich dieselbe Funktion,
+        keine zweite Umsetzung; die Parameter unten sind deshalb absichtlich
+        Zeichen für Zeichen dieselben.
 
         Die angebundene iOS-App (`OstSeeTiere/8`) lädt ihre Karte über diesen
         Pfad. Bis 2026-08 antwortete er mit `405`.
@@ -2012,28 +2016,43 @@ paths:
           schema:
             type: integer
             minimum: 2000
+            maximum: 2030
+            example: 2024
         - name: location
           in: query
-          description: 'Position als "Breite,Länge" für die Umkreissuche'
+          description: 'Zentrumskoordinaten für Umkreissuche "breitengrad,längengrad"'
           schema:
             type: string
+            pattern: '^-?\d+\.?\d*,-?\d+\.?\d*$'
+            example: "54.0,13.0"
         - name: distance
           in: query
-          description: 'Radius in Metern, nur zusammen mit location (Standard: 100000)'
+          description: 'Suchradius in Metern (nur mit location Parameter)'
           schema:
             type: integer
+            minimum: 1000
+            maximum: 500000
+            default: 100000
+            example: 50000
         - name: bbox
           in: query
-          description: 'Bereich als "min_x,min_y,max_x,max_y" (OpenLayers-kompatibel)'
+          description: 'Begrenzungsbox "minLon,minLat,maxLon,maxLat" (OpenLayers-kompatibel)'
           schema:
             type: string
+            pattern: '^-?\d+\.?\d*,-?\d+\.?\d*,-?\d+\.?\d*,-?\d+\.?\d*$'
+            example: "9,53,31,66"
         - name: search
           in: query
-          description: >-
-            Freitextsuche. Für anonyme Aufrufer eingeschränkt auf freigegebene
-            Namen und Schiffsnamen — siehe /sichtungen/showreports.json.
+          description: >
+            Suchtext (Teilstring-Suche). Für nicht angemeldete Aufrufer werden
+            Vorname/Name nur bei vorliegender Namensfreigabe und der Schiffsname
+            nur bei vorliegender Schiffsnamensfreigabe durchsucht; die
+            E-Mail-Adresse wird nicht durchsucht. Angemeldete Admins durchsuchen
+            zusätzlich die E-Mail-Adresse und ohne Freigabe-Filter.
           schema:
             type: string
+            maxLength: 100
+            example: "Schneider"
       responses:
         '200':
           description: Liste der Sichtungen im PDF-konformen Kurzformat


### PR DESCRIPTION
## Warum

`GET /rest_sichtungen` fehlte vollständig und antwortete mit `405`. Die angebundene iOS-App (`OstSeeTiere/8`) fragt genau diesen Pfad an — nachgewiesen im Zugriffsprotokoll von `schweinswalsichtung.de` (rund fünf echte Aufrufe pro Tag) und vom Gerät bestätigt. **Er ist die Datenquelle ihrer Karte, und die blieb dadurch leer.**

In `docs/LEGACY_API_SPECIFICATION.md` fehlte der Endpunkt ebenfalls; die Spec kannte nur vier. Die Lücke sah dadurch wie eine Absicht aus — ein Test hielt sogar fest, dass `GET` mit `405` abzulehnen sei.

## Es war nichts zu erfinden

Die Originalquellen der abgelösten CakePHP-Anwendung liegen jetzt als Beleg unter `docs/archive/legacy-cakephp/`. Sie legen den Vertrag eindeutig fest:

- `routes.php` bildet `/rest_sichtungen` mit `Router::mapResources()` ab — `GET` trifft damit auf `RestSichtungenController::index()`, ausdrücklich öffentlich freigeschaltet.
- `index()` und `SichtungenController::showReports()` bestehen aus **denselben zwei Zeilen**: `parseList()` für die Filter, `getReports()` für die Daten.
- `getReports()` schickt jeden Datensatz durch `ReportUtils::mapReport()` — das erzeugt exakt die kompakte Form (`ts`, `id`, `dt`, `ti`, `lat`, `lon`, `ct`, `yo`, `ta`, `tf`), die diese Anwendung unter `showreports.json` bereits ausliefert.
- `Cake/View/JsonView.php` dokumentiert, dass `_serialize` als Zeichenkette den Wert **direkt** serialisiert. Die Antwort war ein blankes Array, keine Umhüllung `{"Sichtungen": […]}`.

`GET /rest_sichtungen` und `GET /sichtungen/showreports.json` sind damit derselbe Endpunkt unter zwei Namen.

## Umsetzung

Die Route re-exportiert **wörtlich dieselbe Funktion**, statt eine zweite Umsetzung danebenzustellen. Zwei Implementierungen, die heute dasselbe liefern, laufen früher oder später auseinander — und die Legacy-API ist der eine Ort im Projekt, an dem das erst auffiele, wenn ein nicht mehr testbarer Client bricht. Der Test schreibt deshalb die **Identität der Funktion** fest, nicht die Gleichheit zweier Antworten.

Das Rate-Limit bleibt beim `POST`: Es begrenzt Meldungen, nicht Abrufe. Eine Karte, die sich nach 20 Aufrufen abschaltet, wäre schlimmer als gar keine.

## Verifikation gegen den Dev-Server

| Prüfung | Ergebnis |
| --- | --- |
| `GET /rest_sichtungen` vs. `showreports.json` | `200`, **byte-identisch** (151.432 B) |
| `?year=2025` | wirkt auf beiden Pfaden gleich (126.349 B) |
| `/en/rest_sichtungen?year=2025` | identisch — das Sprachpräfix aus #828 greift auch hier |
| 22 aufeinanderfolgende GETs | alle `200`, das POST-Limit greift nicht für Abrufe |
| `test:quick` | 291 Dateien, 4393 Tests grün |

## Nicht in diesem PR

`GET /rest_sichtungen/view/<id>.json` fehlt weiterhin (404). Der Schreibpfad verweist im `Location`-Header darauf, und `mapResources` bildete auch `view` ab. Eigener Vorgang — die vier Punkte dazu stehen in `docs/archive/legacy-cakephp/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)