### PR TITLE
docs: fremde Dateien vor dem Commit auf personenbezogene Daten prüfen

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -191,6 +191,14 @@ function generateSecureFilename(originalName: string): string {
 
 ## GDPR / DSGVO
 
+> **Fremde Dateien vor dem Commit scannen.** Dieses Repository ist öffentlich;
+> ein Commit ist eine Veröffentlichung und praktisch nicht zurücknehmbar. Die
+> verbindliche Regel dazu steht in `CLAUDE.md` („Fremde Dateien vor dem Commit
+> auf personenbezogene Daten prüfen") — dort und nicht hier, weil diese Datei
+> nur bei Änderungen unter `src/lib/server/auth/**` und
+> `src/lib/server/storage/**` geladen wird und damit genau dann nicht, wenn
+> jemand ein Archiv nach `docs/` legt.
+
 ### Datenminimierung
 
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,44 @@ Beim Erstellen oder Ändern von `.ts`/`.svelte`-Dateien mit Business-Logik MUSS 
 
 Die Legacy-Endpunkte (`/rest_sichtungen`, `/sichtungen/showreports.json`) implementieren den Vertrag der Vorgänger-API für Mobile Clients. **Stand 2026-07-30 ist ein Client angebunden:** eine neu gebaute iOS-App (`OstSeeTiere/8`) sendet Sichtungen über `POST /rest_sichtungen`. Eine Abweichung kostet damit echte Daten und ist von hier aus nicht reparierbar — der alte Client ist nicht mehr testbar. Feldnamen, URL-Pfade und Datentypen deshalb nur bewusst und dokumentiert ändern; offensichtliche Fehler nur ergänzend beheben, nie einen bestehenden Codepfad ersetzen. Das ist ein datierter Stand, keine Dauerzusage — vor größeren Änderungen prüfen, ob weitere Clients dazugekommen sind. Details laden automatisch beim Bearbeiten der betroffenen Routen (`.claude/rules/legacy-api.md`); verbindliche Referenz ist `docs/LEGACY_API_SPECIFICATION.md`.
 
+### Fremde Dateien vor dem Commit auf personenbezogene Daten prüfen — PFLICHT
+
+**Dieses Repository ist öffentlich.** Ein Commit ist eine Veröffentlichung, und
+sie lässt sich praktisch nicht zurücknehmen: Ein Force-Push entfernt einen
+Commit nicht von GitHub, weil Pull-Request-Refs dauerhaft bestehen bleiben.
+Nur der GitHub-Support kann die Objekte löschen.
+
+Deshalb gilt für **jede Datei, die von außerhalb dieses Projekts hereinkommt** —
+Archive, Altsystem-Quellen, Exporte, Fremdkonfigurationen, Beispieldaten — vor
+dem `git add`:
+
+```bash
+grep -rnoE "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}" <pfad> | sort -u
+grep -rniE "password|passwd|secret|api[_-]?key|token|salt" <pfad>
+```
+
+Über den **ganzen** hereingeholten Bestand laufen lassen, nicht über die
+Dateien, die gerade auffallen. Am 2026-08-09 fand ein Review drei
+`@author`-Tags mit einer privaten Adresse; der Scan über das gesamte
+Verzeichnis fand eine vierte Stelle, die niemandem aufgefallen war.
+
+Was gefunden wird, ist nicht automatisch ein Problem — die Unterscheidung ist:
+
+| Fund                                                                   | Umgang                                               |
+| ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| Private Adresse einer Person (`@author`-Tag, Kommentar, Testdatensatz) | entfernen, Name darf bleiben                         |
+| Rolladresse einer Organisation, die ohnehin öffentlich steht           | darf bleiben, im README des Verzeichnisses begründen |
+| Zugangsdaten, Schlüssel, Tokens                                        | entfernen **und** rotieren — sie gelten als bekannt  |
+
+Schwärzungen dort dokumentieren, wo die Dateien liegen (siehe
+`docs/archive/legacy-cakephp/README.md`). Sonst holt der nächste Auszug aus
+derselben Quelle die Daten wieder herein.
+
+Diese Regel steht bewusst hier und nicht in `.claude/rules/security.md`: Jene
+Datei lädt nur bei Änderungen unter `src/lib/server/auth/**` und
+`src/lib/server/storage/**` — also gerade nicht, wenn jemand ein Archiv nach
+`docs/` legt.
+
 ### Sichtungs-Status — genau zwei Zustände
 
 Eine Sichtung ist **ungeprüft oder geprüft; geprüft heißt veröffentlicht**. Kein


### PR DESCRIPTION
## Warum

Mit den archivierten CakePHP-Quellen in #829 landete die **private E-Mail-Adresse eines Dritten** in diesem öffentlichen Repository. Aufgefallen ist sie erst im Review — also nach dem Push.

Der Schaden ließ sich danach nur begrenzen, nicht rückgängig machen: Ein Force-Push entfernt einen Commit nicht von GitHub, weil Pull-Request-Refs dauerhaft bestehen bleiben. Dass `main` sauber blieb, lag allein am Squash-Merge — der gequetschte Commit enthielt bereits den bereinigten Stand. Darauf kann man sich nicht verlassen.

## Was die Regel sagt

Für **jede Datei, die von außerhalb des Projekts hereinkommt** (Archive, Altsystem-Quellen, Exporte, Fremdkonfigurationen, Beispieldaten) vor dem `git add` zwei `grep`-Läufe — über den **ganzen** hereingeholten Bestand, nicht nur über die gerade auffälligen Dateien.

Das ist keine Formalie: Das Review meldete drei `@author`-Tags, der Scan über das Verzeichnis fand eine vierte Stelle.

Dazu die Unterscheidung, die im konkreten Fall den Ausschlag gab — nicht jeder Treffer ist ein Problem:

| Fund | Umgang |
| --- | --- |
| Private Adresse einer Person | entfernen, Name darf bleiben |
| Rolladresse einer Organisation, ohnehin öffentlich | darf bleiben, begründen |
| Zugangsdaten, Schlüssel, Tokens | entfernen **und** rotieren |

## Warum in CLAUDE.md und nicht in security.md

Der naheliegende Ort wäre `.claude/rules/security.md` gewesen. Der wäre falsch: Die Datei hat `paths`-Frontmatter für `src/lib/server/auth/**` und `src/lib/server/storage/**` und lädt damit **gerade dann nicht**, wenn jemand ein Archiv nach `docs/` legt — also genau im Fall, den sie verhindern soll. Ein Verweis dort zeigt auf die verbindliche Stelle.

## Verifikation

Die beiden dokumentierten Befehle sind ausgeführt worden:

- gegen `docs/archive/legacy-cakephp/` — findet die zwei bekannten Rolladressen, sonst nichts, keine Geheimnisse
- gegen eine Attrappe mit privater Adresse und `API_KEY` — findet beide

Eine Regel mit einem Kommando, das niemand ausprobiert hat, ist keine Regel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)