### PR TITLE
fix(admin): Sortieranzeige, Auswahlspalte und Referenz-ID in der Sichtungstabelle

### DIFF
--- a/e2e/admin-spam-check.spec.ts
+++ b/e2e/admin-spam-check.spec.ts
@@ -106,12 +106,15 @@ async function seedeSichtung(referenceId: string, mitErstbefund: boolean): Promi
 	});
 }
 
-/** Die Tabellenzeile einer geseedeten Sichtung. */
-function zeileZu(page: Page, referenceId: string) {
-	return page
-		.locator('tbody tr')
-		.filter({ has: page.locator(`a[href="/admin/ref/${referenceId}"]`) })
-		.first();
+/**
+ * Die Tabellenzeile einer geseedeten Sichtung — über `data-sighting-id` am
+ * `<tr>` und nicht über den Link der Referenz-ID-Spalte: Die ist seit dem
+ * 2026-08-09 standardmäßig abgeschaltet (`columns.ts`), der Link stand dann in
+ * keiner Zeile mehr und der Locator fand nichts. Die Zeilen-Id hängt dagegen an
+ * keiner Spaltenwahl.
+ */
+function zeileZu(page: Page, sichtungId: number) {
+	return page.locator(`tbody tr[data-sighting-id="${sichtungId}"]`).first();
 }
 
 test.describe('Spam-Check — Erstbefund und Neuberechnung nebeneinander', () => {
@@ -180,7 +183,7 @@ test.describe('Spam-Check — Erstbefund und Neuberechnung nebeneinander', () =>
 			   dafür das im Projekt etablierte Signal (`admin-sighting-status.spec.ts`). */
 			await page.waitForLoadState('networkidle');
 
-			const zeile = zeileZu(page, REFERENZ.tabelle);
+			const zeile = zeileZu(page, sichtungId);
 			await expect(zeile).toBeVisible();
 			// Die Spalte zeigt den Erstbefund — unverändert, das war nie der Fehler.
 			await expect(zeile).toContainText(String(ERSTBEFUND_SCORE));

--- a/e2e/admin-table-dead-finding.spec.ts
+++ b/e2e/admin-table-dead-finding.spec.ts
@@ -49,14 +49,20 @@ test.describe('Admin-Sichtungstabelle — Totfund-Marker', () => {
 		baseURL
 	}) => {
 		await seedAdminSession(context, baseURL!, ['admin']);
-		createdIds.push(await seedDeadFinding('e2e-tot', true));
-		createdIds.push(await seedDeadFinding('e2e-lebend', false));
+		const totfundId = await seedDeadFinding('e2e-tot', true);
+		const lebendId = await seedDeadFinding('e2e-lebend', false);
+		createdIds.push(totfundId, lebendId);
 
 		await page.setViewportSize({ width: 1280, height: 900 });
 		await page.goto('/admin/sichtungen');
 
-		const totfundZeile = page.getByRole('row').filter({ hasText: 'e2e-tot' });
-		const lebendZeile = page.getByRole('row').filter({ hasText: 'e2e-lebend' });
+		/* Zeilen über `data-sighting-id` statt über die Referenz-ID im Zeilentext:
+		   Die Referenz-ID-Spalte ist seit dem 2026-08-09 standardmäßig
+		   abgeschaltet (`columns.ts`), ihr Text steht dann in keiner Zeile mehr.
+		   Zugesagt wird hier der Totfund-Marker — nicht, über welche Spalte man
+		   die Zeile findet. */
+		const totfundZeile = page.locator(`tbody tr[data-sighting-id="${totfundId}"]`);
+		const lebendZeile = page.locator(`tbody tr[data-sighting-id="${lebendId}"]`);
 
 		// Über den Text und nicht über eine Test-ID: Was der Marker einem
 		// Screenreader mitteilt, ist hier die eigentliche Zusage — ein rein

--- a/src/routes/admin/[id]/tableReturnUrl.test.ts
+++ b/src/routes/admin/[id]/tableReturnUrl.test.ts
@@ -43,7 +43,10 @@ describe('tableReturnUrl — Rückweg aus der Detailansicht', () => {
 		// Abgleich gegen die Quelle statt gegen eine zweite Liste: Wer der Tabelle
 		// einen Filter hinzufügt, ohne ihn hier nachzuziehen, bekommt genau den
 		// Bug, um den es geht — der Rückweg verlöre ihn still.
-		const quellen = ['+page.server.ts', '+page.svelte'].map((datei) =>
+		// `sortParams.ts` steht mit in der Liste, seit `sort`/`order` nicht mehr
+		// im Loader ausgelesen werden, sondern dort — sonst prüfte der Abgleich
+		// die Sortierung stillschweigend nicht mehr mit.
+		const quellen = ['+page.server.ts', '+page.svelte', 'sortParams.ts'].map((datei) =>
 			readFileSync(new URL(`../sichtungen/${datei}`, import.meta.url), 'utf-8')
 		);
 		const gelesen = new Set<string>();

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -9,12 +9,14 @@ import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { searchCondition, normalizeSearchTerm } from '$lib/server/db/sightingSearchFilter';
 import { and, eq, sql, type SQL } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 import { ServerConfigService } from '$lib/services/configService';
 import { isValidDateParam } from './dateParam';
 import { SIGHTING_LIST_COLUMNS } from './listColumns';
+import { resolveSort, type SortColumn } from './sortParams';
 import { statusCondition } from './statusFilter';
 
 export const load: PageServerLoad = async ({ url }) => {
@@ -26,8 +28,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	);
 	// Enforce the maximum configured per page limit
 	const perPage = Math.min(requestedPerPage, paginationConfig.maxSightingsPerPage);
-	const sortBy = url.searchParams.get('sort') || 'sightingDate';
-	const sortOrder = url.searchParams.get('order') || 'desc';
+	const { column: sortBy, order: sortOrder } = resolveSort(url.searchParams);
 	const fromDate = url.searchParams.get('fromDate');
 	const toDate = url.searchParams.get('toDate');
 	const verified = url.searchParams.get('verified');
@@ -110,7 +111,16 @@ export const load: PageServerLoad = async ({ url }) => {
 				: and(...conditions)
 			: undefined;
 
-	// Sortierungs-Mapping
+	// Sortierungs-Mapping. Als `Record<SortColumn, …>` typisiert: Die Liste der
+	// sortierbaren Spalten steht in `sortParams.ts` und speist auch die
+	// Spaltenköpfe — ein Eintrag dort ohne Mapping hier bricht `type-check`.
+	//
+	// Vier davon fehlten bis 2026-08 (`behavior`, `seaState`, `wind`,
+	// `visibility`): Ihr Kopf rendert seit jeher über `sortableTh`, also als
+	// Knopf mit `aria-sort` — der Klick landete aber im `|| sightings.sightingDate`
+	// darunter und sortierte still nach Sichtungsdatum. Solange kein Pfeil zu
+	// sehen war, fiel das nicht auf; mit der Anzeige stünde die Behauptung
+	// sichtbar in der Tabelle.
 	const sortingMap = {
 		sightingDate: sightings.sightingDate,
 		created: sightings.created,
@@ -120,8 +130,15 @@ export const load: PageServerLoad = async ({ url }) => {
 		distance: sightings.distance,
 		juvenileCount: sightings.juvenileCount,
 		distribution: sightings.distribution,
+		behavior: sightings.behavior,
+		seaState: sightings.seaState,
+		// `windstaerke` ist varchar(2) — als Text sortiert stünde „10" vor „2".
+		// NULLIF, weil neben 7.591 NULL-Zeilen auch 2.691 leere Strings im
+		// Bestand stehen, die ein blankes CAST mit einem 22P02 quittieren würde.
+		wind: sql`cast(nullif(${sightings.windForce}, '') as integer)`,
+		visibility: sightings.visibility,
 		spamScore: sightings.spamScore
-	};
+	} satisfies Record<SortColumn, AnyPgColumn | SQL>;
 
 	// Abfrage bauen. Explizite Spaltenauswahl statt `db.select()`: Begründung,
 	// Umfang und Absicherung stehen in `listColumns.ts`.
@@ -134,11 +151,21 @@ export const load: PageServerLoad = async ({ url }) => {
 	// sortiert DESC per Default NULLS FIRST — bei der nullbaren Spam-Spalte
 	// stünden sonst die 19.000+ unbewerteten Altzeilen VOR den Treffern. Für
 	// NOT-NULL-Spalten ist der Zusatz wirkungslos.
-	const sortField = sortingMap[sortBy as keyof typeof sortingMap] || sightings.sightingDate;
+	//
+	// `id` als Tiebreaker in beiden Richtungen: Ohne eindeutiges Zweitkriterium
+	// ist die Reihenfolge innerhalb eines Gleichstands undefiniert, und Postgres
+	// darf sie je Abfrage anders wählen. Mit LIMIT/OFFSET über knapp 20.000
+	// Zeilen heißt das, dass eine Zeile auf Seite 1 UND Seite 2 auftaucht,
+	// während eine andere still ganz aus der Liste fällt. Latent war das immer;
+	// scharf wird es mit den vier neu sortierbaren Spalten oben — `seaState`
+	// kennt keine zehn verschiedenen Werte, die Sortierung besteht also aus
+	// wenigen riesigen Blöcken. Dieselbe Entscheidung und dieselbe Begründung
+	// wie `(created, id)` in `openQueueOrder.ts`.
+	const sortField = sortingMap[sortBy];
 	const sortedQuery =
 		sortOrder === 'desc'
-			? query.orderBy(sql`${sortField} desc nulls last`)
-			: query.orderBy(sql`${sortField} asc nulls last`);
+			? query.orderBy(sql`${sortField} desc nulls last, ${sightings.id} desc`)
+			: query.orderBy(sql`${sortField} asc nulls last, ${sightings.id} asc`);
 
 	// Paginierung hinzufügen
 	const paginatedQuery = sortedQuery.limit(perPage).offset((page - 1) * perPage);

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -35,6 +35,7 @@
 	import { setAllSelected, toggleSelection, type BulkHeaderState } from './bulkSelection';
 	import type { ColumnVisibility } from './columns';
 	import { NUR_WEIT_BLOCK } from './layoutSwitch';
+	import { naechsteRichtung, resolveSort, type SortColumn } from './sortParams';
 
 	interface Props {
 		sightings: SichtungenListRow[];
@@ -94,27 +95,41 @@
 		if (headerCheckbox) headerCheckbox.indeterminate = headerState === 'partial';
 	});
 
-	function updateSort(column: string): void {
-		const currentSort = page.url.searchParams.get('sort');
-		const currentOrder = page.url.searchParams.get('order');
+	/* Die wirksame Sortierung, nicht der rohe Query-Parameter: Beim ersten
+	   Aufruf steht in der URL nichts, sortiert ist die Liste trotzdem
+	   (`sortParams.ts`). */
+	let sort = $derived(resolveSort(page.url.searchParams));
 
-		const newOrder = currentSort === column && currentOrder === 'asc' ? 'desc' : 'asc';
-
+	function updateSort(column: SortColumn): void {
 		const url = new URL(page.url);
 		url.searchParams.set('sort', column);
-		url.searchParams.set('order', newOrder);
+		url.searchParams.set('order', naechsteRichtung(sort, column));
+		/* Die Seitenzahl ist eine Position in *einer* Reihenfolge und überlebt
+		   deren Wechsel nicht: Wer auf Seite 7 umsortiert, landete in der Mitte
+		   der neuen Sortierung — an einer Stelle, die mit dem gerade Gesuchten
+		   nichts zu tun hat. `perPage` bleibt dagegen stehen, das ist eine
+		   Einstellung und keine Position. */
+		url.searchParams.delete('page');
 		goto(url);
 	}
 </script>
 
-<!-- Sortierbarer Spaltenkopf: <button> im <th> mit aria-sort für Screenreader -->
-{#snippet sortableTh(label: string, key: string)}
-	{@const isActive = page.url.searchParams.get('sort') === key}
-	{@const isDesc = page.url.searchParams.get('order') === 'desc'}
+<!-- Sortierbarer Spaltenkopf: <button> im <th> mit aria-sort für Screenreader.
+     Der Pfeil steht an der aktiven Spalte auch dann, wenn sie nur die Vorgabe
+     des Loaders ist — sonst sähe der erste Aufruf unsortiert aus. Die
+     Richtungsangabe im aria-label wiederholt ihn für Screenreader: `aria-sort`
+     am <th> wird von den Browsern nicht überall an den Knopf durchgereicht,
+     und das Zeichen selbst ist als Vorlesetext nutzlos. -->
+{#snippet sortableTh(label: string, key: SortColumn)}
+	{@const isActive = sort.column === key}
+	{@const isDesc = sort.order === 'desc'}
 	<th class="p-0" aria-sort={isActive ? (isDesc ? 'descending' : 'ascending') : 'none'}>
 		<button
 			type="button"
 			class="hover:bg-base-300 flex w-full items-center gap-1 px-4 py-3 text-left font-semibold"
+			aria-label={isActive
+				? `${label}, sortiert ${isDesc ? 'absteigend' : 'aufsteigend'} — Richtung umkehren`
+				: `Nach ${label} sortieren`}
 			onclick={() => updateSort(key)}
 		>
 			{label}
@@ -195,8 +210,8 @@
 					     Nicht `sticky-col`: Der fixierte Bereich liegt rechts (Status,
 					     Aktionen); eine zweite fixierte Kante links stahl auf schmalen
 					     Fenstern zusätzlich Platz vom scrollenden Mittelteil. -->
-					<th class="w-px p-0">
-						<label class="flex cursor-pointer items-center justify-center px-2">
+					<th class="select-col w-px p-0">
+						<label class="target-exempt flex cursor-pointer justify-center">
 							<input
 								type="checkbox"
 								class="checkbox checkbox-sm"
@@ -289,8 +304,8 @@
 						<!-- Auswahl-Checkbox, Gegenstück zur Kopfspalte oben. Das `aria-label`
 						     nennt die Referenz-ID und nicht nur „Zeile 3": Beim Vorlesen ist
 						     die Nummer der Meldung das, woran die Zeile erkennbar ist. -->
-						<td class="w-px p-0">
-							<label class="flex cursor-pointer items-center justify-center px-2">
+						<td class="select-col w-px p-0">
+							<label class="target-exempt flex cursor-pointer justify-center">
 								<input
 									type="checkbox"
 									class="checkbox checkbox-sm"
@@ -516,6 +531,37 @@
 </div>
 
 <style>
+	/* Auswahlspalte: das Label ist hier eine einzeilige Zelle, kein Feld-Label.
+
+	   `items-center` als Utility reicht dafür nicht. `app.css` setzt für jedes
+	   `label:has(> .checkbox)` ungelayert `align-items: flex-start` und schlägt
+	   damit Tailwinds `@layer utilities` — die Checkbox hing oben in der Zelle,
+	   während die Nachbarzellen mittig standen. Die Regel dort ist richtig und
+	   bleibt: Sie hält das Control bei mehrzeiligen Feld-Labels oben bündig.
+	   Genau diesen Fall gibt es in einer Tabellenzeile aber nicht.
+
+	   Die `min-height: var(--target-min)` aus derselben Regel bleibt
+	   unangetastet — die 44px Trefferfläche trägt weiterhin das Label.
+
+	   Die Breite kommt jetzt allein aus der Checkbox (28px, `--control-size`)
+	   statt zusätzlich aus einem `px-2` am Label: 44px Spaltenbreite für ein
+	   28px-Control war der breiteste Teil einer Zeile, der nichts anzeigt.
+
+	   Damit ist das Ziel 44px hoch und 28px breit und unterschreitet das
+	   Projekt-Mindestmaß von 44×44 in der Breite. Das Label trägt deshalb
+	   `target-exempt` — die Klasse verlangt laut `design-system.md` eine
+	   Begründung, und die ist dieser Absatz: Die Tabelle erscheint erst ab
+	   768px (`layoutSwitch.ts`), die Auswahl ist auf einem Tablet im
+	   Touch-Betrieb also die schmalere der beiden Achsen, nicht die einzige
+	   Bedienform. Wer sie nicht trifft, verliert nichts — die Zeile bleibt
+	   über die Aktionsspalte und den Statuswechsel voll bedienbar, und die
+	   Bulk-Auswahl ist eine Abkürzung, kein einziger Weg. Wird die Spalte
+	   wieder breiter gebraucht, gehört das `px-2` zurück und diese Ausnahme
+	   weg — nicht die Regel aufgeweicht. */
+	.select-col label {
+		align-items: center;
+	}
+
 	/* Fixierte Spalten (Status, Aktionen) im horizontal scrollenden Container.
 	   Warum die Hintergründe hier von Hand stehen: `table-zebra` und der
 	   Zeilen-Hover färben das <tr>, nicht die Zellen — eine sticky-Zelle bliebe

--- a/src/routes/admin/sichtungen/columns.ts
+++ b/src/routes/admin/sichtungen/columns.ts
@@ -20,9 +20,19 @@
  * Status und Aktionen — die Spalten, wegen derer man die Tabelle öffnet.
  * Abgeschaltet sind sie nicht weg, sondern eine Checkbox im „Spalten"-Dropdown
  * entfernt.
+ *
+ * `referenceId` startet seit 2026-08-09 ebenfalls aus (Entscheidung Jan). Die
+ * ID selbst bleibt unverzichtbar — sie steht in der Team-Benachrichtigung, das
+ * Suchfeld sucht sie, `/admin/ref/[refId]` löst sie auf, und alle 19.953 Zeilen
+ * haben eine. Als **Spalte** trägt sie trotzdem wenig: Die echten Kennungen
+ * sind 24-stellige Zufallsketten (`fr6j2uikz8zsldhktfez7x3n`; nur die
+ * E2E-Testdaten sehen mit `E2E-024` handlich aus). Damit war sie die breiteste
+ * Spalte der Tabelle für einen Wert, den man weder überfliegen noch vergleichen
+ * kann — der Arbeitsweg ist „ID in die Suche einfügen und landen", und danach
+ * ist es ohnehin die einzige Zeile.
  */
 export const DEFAULT_COLUMN_VISIBILITY = {
-	referenceId: true,
+	referenceId: false,
 	sightingDate: true,
 	created: true,
 	email: false,

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -136,6 +136,22 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		expect(recordedSelects[0]?.orderBySql).toMatch(/nulls last/i);
 	});
 
+	it('hängt an jede Sortierung einen eindeutigen Tiebreaker', async () => {
+		// Ohne zweites Kriterium ist die Reihenfolge innerhalb eines
+		// Gleichstands undefiniert — Postgres darf sie je Abfrage anders
+		// wählen. Bei LIMIT/OFFSET über 19.953 Zeilen heißt das: Eine Zeile
+		// erscheint auf Seite 1 UND Seite 2, eine andere fällt still ganz aus
+		// der Liste. `seaState` kennt keine 10 verschiedene Werte, besteht also
+		// aus wenigen riesigen Blöcken. Dieselbe Fehlerklasse wie in
+		// `openQueueOrder.ts`, wo `(created, id)` aus genau diesem Grund
+		// festgeschrieben ist.
+		await load({
+			url: makeUrl({ sort: 'seaState', order: 'asc' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(recordedSelects[0]?.orderBySql).toMatch(/"id"/);
+	});
+
 	it('sortiert auch aufsteigend explizit mit NULLS LAST', async () => {
 		await load({
 			url: makeUrl({ sort: 'spamScore', order: 'asc' })

--- a/src/routes/admin/sichtungen/sortParams.test.ts
+++ b/src/routes/admin/sichtungen/sortParams.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_ORDER,
+	DEFAULT_SORT,
+	SORTABLE_COLUMNS,
+	naechsteRichtung,
+	resolveSort
+} from './sortParams';
+
+describe('Sortierung der Sichtungstabelle', () => {
+	it('liefert ohne Parameter die Vorgabe des Loaders', () => {
+		// Der Kern des Befunds: Beim ersten Aufruf steht kein `sort` in der URL,
+		// die Liste ist aber sortiert. Wer hier `null` zurückgibt, kann am
+		// Spaltenkopf nichts anzeigen.
+		expect(resolveSort(new URLSearchParams())).toEqual({
+			column: DEFAULT_SORT,
+			order: DEFAULT_ORDER
+		});
+	});
+
+	it('übernimmt eine gültige Spalte samt Richtung aus der URL', () => {
+		expect(resolveSort(new URLSearchParams('sort=species&order=asc'))).toEqual({
+			column: 'species',
+			order: 'asc'
+		});
+	});
+
+	it('fällt bei unbekannter Spalte auf die Vorgabe zurück — wie der Loader', () => {
+		// `+page.server.ts` kennt nur die Spalten aus SORTABLE_COLUMNS und
+		// sortiert sonst nach Sichtungsdatum. Ein Kopf, der bei `sort=quatsch`
+		// einen Pfeil an einer beliebigen Spalte zeigte, behauptete eine
+		// Sortierung, nach der gar nicht sortiert wurde.
+		expect(resolveSort(new URLSearchParams('sort=quatsch&order=asc')).column).toBe(DEFAULT_SORT);
+	});
+
+	it('fällt bei unbekannter Richtung auf die Vorgabe zurück', () => {
+		expect(resolveSort(new URLSearchParams('sort=species&order=seitwaerts')).order).toBe(
+			DEFAULT_ORDER
+		);
+	});
+
+	it('dreht die Richtung nur an der aktiven Spalte um', () => {
+		const aktiv = { column: 'species', order: 'asc' } as const;
+
+		expect(naechsteRichtung(aktiv, 'species')).toBe('desc');
+		expect(naechsteRichtung({ column: 'species', order: 'desc' }, 'species')).toBe('asc');
+		// Eine andere Spalte startet aufsteigend, egal wie die aktive steht.
+		expect(naechsteRichtung(aktiv, 'created')).toBe('asc');
+	});
+
+	it('führt jede sortierbare Spalte genau einmal', () => {
+		expect(new Set(SORTABLE_COLUMNS).size).toBe(SORTABLE_COLUMNS.length);
+	});
+});

--- a/src/routes/admin/sichtungen/sortParams.ts
+++ b/src/routes/admin/sichtungen/sortParams.ts
@@ -1,0 +1,78 @@
+/**
+ * Die Sortierung der Sichtungstabelle: sortierbare Spalten, Vorgabe und
+ * Auflösung aus der URL — für Loader und Spaltenkopf gemeinsam.
+ *
+ * **Warum als eigenes Modul.** Die Vorgabe (`sightingDate`/`desc`) stand nur im
+ * Loader, der Spaltenkopf las `?sort`/`?order` roh aus der URL. Beim ersten
+ * Aufruf steht dort nichts — die Liste war also sortiert, und die Tabelle
+ * zeigte an keinem Kopf einen Pfeil. Dasselbe galt für jeden unbekannten Wert:
+ * `?sort=quatsch` sortiert im Loader nach Sichtungsdatum, im Kopf leuchtete
+ * nichts.
+ *
+ * **Warum die Liste hier und nicht in `columns.ts`.** Sortierbarkeit und
+ * Sichtbarkeit sind nicht dasselbe: `referenceId`, `mediaUpload` und
+ * `balticSea` sind Spalten ohne Sortierung, `wind` sortiert über ein Feld
+ * (`windForce`), das anders heißt. Die Liste ist die **eine** Quelle für beide
+ * Seiten — `+page.server.ts` typisiert seine `sortingMap` als
+ * `Record<SortColumn, …>`, ein neuer Eintrag hier erzwingt dort also ein
+ * Mapping, statt still auf das Sichtungsdatum zurückzufallen.
+ */
+
+export const SORTABLE_COLUMNS = [
+	'sightingDate',
+	'created',
+	'email',
+	'species',
+	'distance',
+	'totalCount',
+	'juvenileCount',
+	'distribution',
+	'behavior',
+	'seaState',
+	'wind',
+	'visibility',
+	'spamScore'
+] as const;
+
+export type SortColumn = (typeof SORTABLE_COLUMNS)[number];
+export type SortOrder = 'asc' | 'desc';
+
+/** Was der Loader ohne `?sort` tut — hier notiert, damit der Kopf es zeigen kann. */
+export const DEFAULT_SORT: SortColumn = 'sightingDate';
+export const DEFAULT_ORDER: SortOrder = 'desc';
+
+export interface SortState {
+	column: SortColumn;
+	order: SortOrder;
+}
+
+function isSortColumn(value: string | null): value is SortColumn {
+	return SORTABLE_COLUMNS.includes(value as SortColumn);
+}
+
+/**
+ * Die tatsächlich wirksame Sortierung — nie `null`, weil auch die leere URL sortiert.
+ *
+ * Der Parameter heißt `searchParams` und nicht kürzer: `tableReturnUrl.test.ts`
+ * liest die Query-Parameter der Tabelle per Regex aus dem Quelltext und gleicht
+ * sie gegen die Liste ab, die der Rückweg aus der Detailansicht durchreicht.
+ * Das Muster verlangt den vollen Ausdruck; ein `params.get('sort')` fiele
+ * heraus, und der Abgleich prüfte die Sortierung still nicht mehr mit. Aus
+ * demselben Grund steht der Ausdruck hier nicht als Beispiel im Kommentar — er
+ * landete sonst als eigener „Parameter" im Ergebnis.
+ */
+export function resolveSort(searchParams: URLSearchParams): SortState {
+	const column = searchParams.get('sort');
+	const order = searchParams.get('order');
+
+	return {
+		column: isSortColumn(column) ? column : DEFAULT_SORT,
+		order: order === 'asc' || order === 'desc' ? order : DEFAULT_ORDER
+	};
+}
+
+/** Klick auf einen Spaltenkopf: aktive Spalte dreht um, jede andere startet aufsteigend. */
+export function naechsteRichtung(aktiv: SortState, geklickt: SortColumn): SortOrder {
+	if (aktiv.column !== geklickt) return 'asc';
+	return aktiv.order === 'asc' ? 'desc' : 'asc';
+}

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -62,9 +62,18 @@ describe('Sichtungstabelle — Spalten', () => {
 		document.documentElement.style.setProperty('--color-base-200', BASE_200);
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		document.documentElement.style.removeProperty('--color-base-100');
 		document.documentElement.style.removeProperty('--color-base-200');
+		/* Die URL im `$app/state`-Mock ist ein gemeinsames Objekt: Ein Test, der
+		   sie für seinen Fall umsetzt, dürfte sie den übrigen nicht dauerhaft
+		   unterschieben — der Sortier-Test daneben lebt gerade davon, dass keine
+		   Parameter darin stehen. */
+		const { page: appState } = await import('$app/state');
+		// Cast: SvelteKit typisiert `page.url.pathname` als Union aller Routen —
+		// eine frisch gebaute URL kennt diese Verengung nicht.
+		appState.url = new URL('https://localhost:4000/admin/sichtungen') as typeof appState.url;
+		vi.mocked((await import('$app/navigation')).goto).mockClear();
 	});
 
 	it('zeigt E-Mail, Entfernung und Verteilung per Default nicht', () => {
@@ -126,6 +135,58 @@ describe('Sichtungstabelle — Spalten', () => {
 			(el) => el.textContent?.trim() === '—'
 		);
 		expect(strich, 'der Gedankenstrich selbst wird nicht mit vorgelesen').toBeTruthy();
+	});
+
+	it('zeigt schon beim ersten Aufruf, wonach sortiert ist', () => {
+		// Die gemockte URL trägt keine Query-Parameter — genau der erste Aufruf.
+		// Der Loader sortiert dann nach Sichtungsdatum absteigend; vorher stand
+		// an keinem Kopf ein Pfeil.
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const aktiv = [...screen.container.querySelectorAll('thead th')].filter(
+			(th) => th.getAttribute('aria-sort') !== 'none' && th.getAttribute('aria-sort') !== null
+		);
+
+		expect(aktiv).toHaveLength(1);
+		const kopf = aktiv[0] as HTMLElement;
+		expect(kopf.textContent).toContain('Sichtungsdatum');
+		expect(kopf.getAttribute('aria-sort')).toBe('descending');
+		// Die Richtung darf nicht allein am Pfeilzeichen hängen (WCAG 1.4.1).
+		expect(kopf.querySelector('button')?.getAttribute('aria-label')).toContain('absteigend');
+	});
+
+	it('zentriert die Auswahl-Checkbox in ihrer Zelle', () => {
+		// `app.css` setzt für jedes `label:has(> .checkbox)` ungelayert
+		// `align-items: flex-start` — richtig für mehrzeilige Feld-Labels, in
+		// einer Tabellenzeile hängt die Checkbox damit oben. Ein `items-center`
+		// als Utility verliert dagegen.
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const label = screen.container.querySelector('tbody tr td label') as HTMLElement;
+		expect(getComputedStyle(label).alignItems).toBe('center');
+	});
+
+	it('springt beim Umsortieren zurück auf Seite 1', async () => {
+		// Sortierung und Seitenzahl gehören nicht zusammen: Wer auf Seite 7
+		// umsortiert, sah bisher die Mitte der neuen Reihenfolge — eine Stelle,
+		// die mit dem, was er gerade gesucht hat, nichts zu tun hat.
+		const { page: appState } = await import('$app/state');
+		const { goto } = await import('$app/navigation');
+		appState.url = new URL(
+			'https://localhost:4000/admin/sichtungen?page=7&perPage=20'
+		) as typeof appState.url;
+
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+		const tierart = [...screen.container.querySelectorAll('thead th button')].find((b) =>
+			b.textContent?.includes('Tierart')
+		) as HTMLButtonElement;
+		tierart.click();
+
+		const ziel = new URL(vi.mocked(goto).mock.calls.at(-1)?.[0] as URL);
+		expect(ziel.searchParams.get('sort')).toBe('species');
+		expect(ziel.searchParams.has('page'), 'die Seitenzahl fällt weg').toBe(false);
+		// `perPage` ist eine Einstellung, keine Position — die bleibt.
+		expect(ziel.searchParams.get('perPage')).toBe('20');
 	});
 
 	it('verspricht an nicht sortierbaren Spaltenköpfen keine Klickbarkeit', () => {


### PR DESCRIPTION
Drei Kleinigkeiten an `/admin/sichtungen` — plus vier Befunde, die beim Beheben aufgefallen sind.

## 1. Die Tabelle zeigte nicht, wonach sie sortiert ist

Der Loader sortiert ohne Query-Parameter nach `sightingDate desc`; der Spaltenkopf las aber roh `?sort`/`?order`. Beim ersten Aufruf steht dort nichts — also stand an keinem Kopf ein Pfeil, obwohl die Liste sortiert war. Die Vorgabe liegt jetzt in `sortParams.ts` und speist Loader und Kopf gemeinsam.

Die Richtung steht zusätzlich im `aria-label` des Knopfes: `aria-sort` am `<th>` wird nicht überall an den Knopf durchgereicht, und das Pfeilzeichen ist als Vorlesetext nutzlos.

Dabei fielen drei weitere Dinge auf:

- **Vier Spalten behaupteten Sortierbarkeit, die es nicht gab.** `behavior`, `seaState`, `wind` und `visibility` rendern seit jeher über `sortableTh`, standen aber in keiner `sortingMap` — der Klick lief ins `|| sightings.sightingDate` und sortierte still nach Datum. Solange kein Pfeil zu sehen war, fiel das nicht auf; mit der Anzeige stünde die Falschaussage sichtbar in der Tabelle. `wind` castet `windstaerke` (varchar) auf integer, sonst stünde „10" vor „2"; das `NULLIF` deckt die 2.691 Leerstrings im Bestand ab (7.591 NULL kommen dazu). `sortingMap` ist jetzt als `Record<SortColumn, …>` typisiert — ein Kopf ohne Mapping bricht `type-check`.
- **Kein Tiebreaker in der Sortierung.** Bei `LIMIT/OFFSET` über knapp 20.000 Zeilen und Spalten mit unter 15 verschiedenen Werten darf Postgres die Reihenfolge innerhalb eines Gleichstands je Abfrage anders wählen: eine Zeile erscheint auf Seite 1 **und** 2, eine andere fällt still ganz aus der Liste. `id` als zweites Kriterium, gleiche Entscheidung und Begründung wie `(created, id)` in `openQueueOrder.ts`.
- **`?page` blieb beim Umsortieren stehen.** Wer auf Seite 7 umsortiert, landete in der Mitte der neuen Reihenfolge. `perPage` bleibt — das ist eine Einstellung, keine Position.

## 2. Auswahl-Checkbox saß oben, Spalte war zu breit

Die Ursache lag nicht in der Zelle: `app.css` setzt für jedes `label:has(> .checkbox)` ungelayert `align-items: flex-start` und schlägt damit Tailwinds `items-center`. Die Regel ist richtig — sie hält das Control bei mehrzeiligen Feld-Labels oben bündig. Diesen Fall gibt es in einer Tabellenzeile nur nicht, deshalb eine scoped Regel in der Komponente statt einer globalen Änderung.

Gemessen bei 1400px im echten Browser: **Spalte 44px → 28px**, Checkbox 20px/21px von Ober- und Unterkante der Zelle (die 1px sind die ungerade Zeilenhöhe). Die 44px Trefferfläche bleibt als Label-Höhe erhalten; in der Breite unterschreitet das Ziel das Projekt-Mindestmaß, das Label trägt dafür `target-exempt` mit Begründung im CSS-Kommentar.

## 3. Referenz-ID-Spalte startet aus

Die ID selbst bleibt unverzichtbar: Sie steht in der Team-Benachrichtigung („beim Eintreffen bitte anhand der Referenz-ID zuordnen"), das Suchfeld sucht sie, `/admin/ref/[refId]` löst sie auf, und alle 19.953 Zeilen haben eine.

Als **Spalte** trägt sie wenig: Die echten Kennungen sind 24-stellige cuid2-Ketten wie `fr6j2uikz8zsldhktfez7x3n` — nur die E2E-Testdaten sehen mit `E2E-024` handlich aus. Damit war sie die breiteste Spalte der Tabelle für einen Wert, den man weder überfliegen noch vergleichen kann; der Arbeitsweg ist „ID in die Suche einfügen und landen", und danach ist es ohnehin die einzige Zeile. Im „Spalten"-Dropdown weiter zuschaltbar.

**Zu beachten:** `mergeColumnPreferences` lässt einen gespeicherten `true`-Wert gewinnen — wer die Tabelle schon einmal benutzt hat, sieht die Spalte weiterhin. Der Breiten-Gewinn tritt bei frischem `localStorage` ein.

Zwei E2E-Specs fanden ihre Zeile über den Link dieser Spalte (`a[href="/admin/ref/…"]` bzw. die ID im Zeilentext) und gehen jetzt über `data-sighting-id` am `<tr>` — was sie zusagen, ist der Spam-Befund bzw. der Totfund-Marker, nicht die Spaltenwahl.

## Verifikation

- `npm run test:quick`: 291 Dateien, 4397 Tests, grün (enthält Lint, `type-check`, `svelte-check`, Shard-Abgleich)
- Browser-Komponententests: 14 Dateien, 79 Tests, grün
- `npx playwright test e2e/admin-*.spec.ts`: 36 Tests, grün
- Die Tabelle im echten Browser vermessen (1400px, Admin-Session): genau ein `th` mit `aria-sort="descending"` an „Sichtungsdatum", Auswahlspalte 28px, Checkbox mittig
- Der `wind`-Cast gegen die lokale DB gefahren: `windstaerke` enthält ausschließlich Ziffern 0–11, das `NULLIF` ist nötig und ausreichend

Jeder Befund kam als fehlschlagender Test zuerst (u. a. „die Seitenzahl fällt weg: expected true to be false", „expected '"sichtungen"."seegang" asc nulls last' to match /"id"/").

## Nicht enthalten

Die **Filter** (Status, Ostsee, Zeitraum …) setzen `?page` ebenfalls nicht zurück — derselbe Denkfehler, sitzt aber in `+page.svelte` und betrifft ein Dutzend Bedienelemente. Bewusst separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
