### PR TITLE
ci: Validate bei reinen Doku-PRs überspringen

### DIFF
--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -263,3 +263,22 @@ Tests werden automatisch in GitHub Actions ausgeführt:
 - E2E Tests bei Pull Requests — in drei parallelen Shards, deren Zusammensetzung
   in `scripts/e2e-shards.sh` steht (siehe „Neuer Spec → Shard zuordnen")
 - Coverage-Report wird generiert
+
+### Was bei reinen Doku-PRs läuft
+
+Ändert ein PR ausschließlich `*.md`, `docs/**` oder `.claude/**`, laufen weder
+`Validate` (Lint, Typen, svelte-check, Unit Tests, Build) noch Component- oder
+E2E-Tests — keiner dieser Schritte fasst dann eine geänderte Datei an. Übrig
+bleibt `Commit Lint`; die Commit-Konvention gilt auch für Doku.
+
+Entschieden wird das über zwei `paths-filter`-Schritte in
+`.github/workflows/ci.yml`. Der zweite arbeitet mit Negationen und
+`predicate-quantifier: every`, fragt also „gibt es eine geänderte Datei, die
+**kein** Dokument ist" — eine Positivliste würde beim Vergessen still zu wenig
+prüfen, diese Richtung prüft im Zweifel zu viel.
+
+Wer daran etwas ändert, hat einen Wächter: `scripts/ciJobGating.test.ts` liest
+den Workflow und rechnet die Gates für Beispiel-Dateimengen nach (in
+`test:quick` enthalten). Er benutzt bewusst **picomatch** wie paths-filter und
+nicht `node:path.matchesGlob` — letzteres lässt `**` nicht in
+Punkt-Verzeichnisse laufen und würde `.github/…md` fälschlich als Code zählen.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       needs-e2e: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.dependencies == 'true' || steps.filter.outputs.e2e == 'true' || github.event_name == 'push' }}
       has-code-changes: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs.backend == 'true' }}
       needs-migration-check: ${{ steps.filter.outputs.db-schema == 'true' || steps.filter.outputs.db-migrations == 'true' }}
+      needs-validate: ${{ steps.code-filter.outputs.non-docs == 'true' || github.event_name == 'push' }}
 
     permissions:
       contents: read
@@ -76,10 +77,6 @@ jobs:
               - 'vite.config.ci.ts'
               - 'scripts/seed-e2e.ts'
               - '.github/workflows/ci.yml'
-            docs:
-              - '*.md'
-              - 'docs/**'
-              - '.github/**/*.md'
             dependencies:
               - 'package-lock.json'
               - 'package.json'
@@ -89,12 +86,83 @@ jobs:
             db-migrations:
               - 'drizzle/**'
 
-  # Lint, type-check, unit tests, build — runs in parallel with E2E
+      # Läuft `Validate` überhaupt? Die Frage ist nicht „welcher Code hat sich
+      # geändert", sondern „hat sich irgendetwas geändert, das KEIN Dokument
+      # ist". Deshalb Negationen mit `predicate-quantifier: every`: Der Filter
+      # ist wahr, sobald **eine** geänderte Datei ALLE Muster erfüllt, also
+      # weder Markdown noch Doku noch Claude-Konfiguration ist.
+      #
+      # Eine Positivliste („src/**, scripts/**, .husky/**, Dockerfile, …") wäre
+      # die falsche Richtung: Sie müsste bei jeder neuen Datei am Repo-Rand
+      # nachgezogen werden, und wer das vergisst, überspringt still die
+      # Prüfung. Hier ist das Vergessen harmlos — Unbekanntes zählt als Code
+      # und lässt `Validate` laufen. Der Filter kann nur zu viel prüfen, nie
+      # zu wenig.
+      #
+      # `.claude/**` steht mit drin, weil dort Regeln und Agenten-Konfiguration
+      # liegen; ESLint übergeht Punkt-Verzeichnisse ohnehin, tsc und Vite sehen
+      # sie nicht. Bei `docs/**` gilt dasselbe für das Archiv (PDF, altes
+      # CakePHP) — nichts davon wird gebaut, gelintet oder getestet.
+      - name: Detect non-documentation changes
+        id: code-filter
+        uses: dorny/paths-filter@v4
+        with:
+          predicate-quantifier: every
+          filters: |
+            non-docs:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.claude/**'
+
+  # Die Commit-Konvention gilt für JEDEN Commit, auch für reine Doku-PRs —
+  # deshalb steht commitlint in einem eigenen Job und nicht mehr in `Validate`,
+  # das seit demselben Umbau bei Doku-Änderungen übersprungen wird. Der Job
+  # installiert mit `--ignore-scripts`: gebraucht wird nur die commitlint-CLI,
+  # `prepare` (husky) hat in CI nichts zu tun.
+  commit-lint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      !startsWith(github.head_ref, 'release-please') &&
+      github.actor != 'dependabot[bot]'
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate commit messages
+        run: npx commitlint --from=origin/main --to=HEAD --verbose
+
+  # Lint, type-check, unit tests, build — runs in parallel with E2E.
+  # Übersprungen, wenn ein PR ausschließlich Dokumentation ändert: Weder
+  # ESLint noch tsc, svelte-check, Vitest oder der Build fassen dann eine
+  # geänderte Datei an, das Ergebnis wäre per Konstruktion das des letzten
+  # Laufs auf `main`. Gemessen an einem Doku-PR sind das rund zwei Minuten
+  # Runner-Zeit ohne Aussage. Das `main`-Ruleset verlangt keine Status-Checks,
+  # ein übersprungener Job blockiert also nichts.
   validate:
     name: Validate
     runs-on: ubuntu-latest
     needs: changes
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: |
+      (github.event_name == 'push' || github.event.pull_request.draft == false) &&
+      needs.changes.outputs.needs-validate == 'true'
 
     permissions:
       contents: read
@@ -121,16 +189,6 @@ jobs:
 
       - name: Ensure Svelte Kit is in sync
         run: npx svelte-kit sync
-
-      # Commit message validation (skip for release-please and dependabot)
-      - name: Validate commit messages
-        if: |
-          github.event_name == 'pull_request' &&
-          !startsWith(github.head_ref, 'release-please') &&
-          github.actor != 'dependabot[bot]'
-        run: |
-          echo "Validating commit messages..."
-          npx commitlint --from=origin/main --to=HEAD --verbose
 
       - name: Run linting
         run: npm run lint

--- a/scripts/ciJobGating.test.ts
+++ b/scripts/ciJobGating.test.ts
@@ -28,6 +28,24 @@ describe('CI-Job-Gating', () => {
 			expect(matchPattern(pattern, file)).toBe(expected);
 		});
 
+		it('hält Extglob und Negation auseinander', () => {
+			// `!(src)/a.ts` ist ein Extglob und heißt „a.ts in einem
+			// Verzeichnis, das nicht src ist" — NICHT „alles außer
+			// src/a.ts". Wer das `!` von Hand abschneidet und das Ergebnis
+			// invertiert, bekommt Letzteres und rechnet damit etwas anderes
+			// als CI. Deshalb geht das Muster unzerlegt an picomatch.
+			expect(matchPattern('!(src)/a.ts', 'docs/a.ts')).toBe(true);
+			expect(matchPattern('!(src)/a.ts', 'src/a.ts')).toBe(false);
+			// Der Fall, der die beiden Lesarten trennt: Eine Datei, die die
+			// Form gar nicht hat. Beim Zerlegen von Hand käme hier `true`
+			// heraus, weil „passt nicht" zu „passt" invertiert wird.
+			expect(matchPattern('!(src)/a.ts', 'README.md')).toBe(false);
+
+			// Zum Vergleich die echte Negation, auf die sich der Workflow stützt.
+			expect(matchPattern('!src/**', 'docs/a.md')).toBe(true);
+			expect(matchPattern('!src/**', 'src/a.ts')).toBe(false);
+		});
+
 		it('weicht bei Punkt-Verzeichnissen von node:path.matchesGlob ab', () => {
 			// Festgehalten, damit niemand die Abhängigkeit „vereinfacht":
 			// matchesGlob kennt kein `{dot: true}` und liefert hier das

--- a/scripts/ciJobGating.test.ts
+++ b/scripts/ciJobGating.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { matchesGlob } from 'node:path';
+import { jobsFor, matchPattern, readFilterSteps, readJobGates, readWorkflow } from './ciJobGating';
+
+/**
+ * Wächter über die Job-Gates in `.github/workflows/ci.yml`.
+ *
+ * Der teure Teil von CI (E2E in drei Shards, Component Tests, seit diesem
+ * Branch auch `Validate`) läuft nur, wenn passende Dateien geändert wurden.
+ * Ein zu weit gefasster Filter macht daraus einen stillen Ausfall: grüner PR,
+ * ungelaufene Prüfung. Die Tabellen unten sind die Gegenprobe.
+ */
+describe('CI-Job-Gating', () => {
+	describe('Glob-Annahmen', () => {
+		it.each([
+			['src/lib/a.ts', 'src/**', true],
+			['CLAUDE.md', '**/*.md', true],
+			['docs/archive/x.php', 'docs/**', true],
+			['.claude/rules/api.md', '.claude/**', true],
+			['.github/workflows/ci.yml', '.claude/**', false],
+			['vite.config.ts', '*.config.ts', true],
+			['docs/a/b.md', '*.md', false],
+			// Der Fall, der die Umstellung auf picomatch erzwungen hat, siehe
+			// Kommentar in ciJobGating.ts.
+			['.github/PULL_REQUEST_TEMPLATE.md', '**/*.md', true],
+			['.github/PULL_REQUEST_TEMPLATE.md', '!**/*.md', false]
+		])('%s ~ %s → %s', (file, pattern, expected) => {
+			expect(matchPattern(pattern, file)).toBe(expected);
+		});
+
+		it('weicht bei Punkt-Verzeichnissen von node:path.matchesGlob ab', () => {
+			// Festgehalten, damit niemand die Abhängigkeit „vereinfacht":
+			// matchesGlob kennt kein `{dot: true}` und liefert hier das
+			// Gegenteil dessen, was CI tut.
+			expect(matchesGlob('.github/PULL_REQUEST_TEMPLATE.md', '**/*.md')).toBe(false);
+		});
+	});
+
+	describe('Nur Dokumentation geändert', () => {
+		const docsOnly = [
+			['CLAUDE.md'],
+			['docs/WORKTREES.md', 'README.md'],
+			['.claude/rules/api.md'],
+			['.claude/settings.json'],
+			['docs/archive/legacy-cakephp/Sichtung.php'],
+			['.github/PULL_REQUEST_TEMPLATE.md']
+		];
+
+		it.each(docsOnly)('%s → kein Job läuft außer Commit Lint', (...files) => {
+			const jobs = jobsFor(files);
+
+			expect(jobs.validate).toBe(false);
+			expect(jobs.e2e).toBe(false);
+			expect(jobs['component-tests']).toBe(false);
+			expect(jobs['migration-check']).toBe(false);
+			// Die Commit-Konvention gilt auch für Docs-Commits — dieser Job hat
+			// deshalb kein Gate und ist der Grund, warum commitlint aus
+			// `Validate` heraus musste.
+			expect(jobs['commit-lint']).toBe(true);
+		});
+	});
+
+	describe('Code geändert', () => {
+		it('eine einzige Nicht-Doku-Datei genügt für Validate', () => {
+			expect(jobsFor(['README.md', 'src/lib/utils/date.ts']).validate).toBe(true);
+		});
+
+		it('auch Dateien, die kein Filter namentlich kennt', () => {
+			// Der Sinn der Negativliste: Unbekanntes zählt als Code. Eine
+			// Positivliste („src/**, scripts/**, …") müsste bei jeder neuen
+			// Datei am Repo-Rand nachgezogen werden und würde beim Vergessen
+			// still zu wenig prüfen.
+			expect(jobsFor(['scripts/e2e-shards.sh']).validate).toBe(true);
+			expect(jobsFor(['.husky/pre-push']).validate).toBe(true);
+			expect(jobsFor(['Dockerfile']).validate).toBe(true);
+		});
+
+		it('E2E und Component Tests bei Änderungen unter src/', () => {
+			const jobs = jobsFor(['src/routes/+page.svelte']);
+			expect(jobs.e2e).toBe(true);
+			expect(jobs['component-tests']).toBe(true);
+		});
+
+		it('E2E auch, wenn nur die Specs selbst sich ändern (#636, #641)', () => {
+			expect(jobsFor(['e2e/design-tokens.spec.ts']).e2e).toBe(true);
+		});
+
+		it('Migration Check nur bei Schema oder Migrationen', () => {
+			expect(jobsFor(['src/lib/server/db/schema.ts'])['migration-check']).toBe(true);
+			expect(jobsFor(['drizzle/0042_foo.sql'])['migration-check']).toBe(true);
+			expect(jobsFor(['src/lib/utils/date.ts'])['migration-check']).toBe(false);
+		});
+	});
+
+	describe('Push auf main', () => {
+		it('lässt Validate und E2E unabhängig von den Dateien laufen', () => {
+			const jobs = jobsFor(['CLAUDE.md'], 'push');
+			expect(jobs.validate).toBe(true);
+			expect(jobs.e2e).toBe(true);
+		});
+	});
+
+	describe('Aufbau des Workflows', () => {
+		it('hat genau einen Filter-Schritt je Quantor', () => {
+			const steps = readFilterSteps(readWorkflow());
+			expect(steps.map((step) => [step.id, step.quantifier])).toEqual([
+				['filter', 'some'],
+				['code-filter', 'every']
+			]);
+		});
+
+		it('gated Validate über needs-validate', () => {
+			expect(readJobGates(readWorkflow()).validate).toEqual(['needs-validate']);
+		});
+
+		it('lässt Commit Lint ungegated', () => {
+			expect(readJobGates(readWorkflow())['commit-lint']).toEqual([]);
+		});
+	});
+});

--- a/scripts/ciJobGating.ts
+++ b/scripts/ciJobGating.ts
@@ -54,14 +54,22 @@ export function readWorkflow(): string {
 }
 
 /**
- * Ein Muster gegen einen Pfad prüfen. `!muster` ist bei picomatch die Negation
- * eines einzelnen Musters — sie wird erst zusammen mit
- * `predicate-quantifier: every` sinnvoll, siehe `evaluateFilters`.
+ * Ein Muster gegen einen Pfad prüfen — das Muster geht unverändert an
+ * picomatch, genau wie in paths-filter.
+ *
+ * Das führende `!` selbst abzuschneiden und das Ergebnis zu invertieren wäre
+ * für `!**\/*.md` dasselbe, aber nicht für alles: `!(foo)` ist bei picomatch
+ * ein Extglob („alles außer foo"), keine Negation. Wer es von Hand zerlegt,
+ * macht daraus stillschweigend `(foo)` mit umgedrehtem Ergebnis — der Wächter
+ * würde bei so einem Filter etwas anderes rechnen als CI. picomatch invertiert
+ * negierte Muster ohnehin selbst; das ist die Unterscheidung, die es kennt und
+ * wir nicht nachbauen sollten.
+ *
+ * Negationen werden erst zusammen mit `predicate-quantifier: every` sinnvoll,
+ * siehe `evaluateFilters`.
  */
 export function matchPattern(pattern: string, file: string): boolean {
-	const negated = pattern.startsWith('!');
-	const matches = picomatch(negated ? pattern.slice(1) : pattern, { dot: true })(file);
-	return negated ? !matches : matches;
+	return picomatch(pattern, { dot: true })(file);
 }
 
 function parseFilterBlock(lines: string[], stepId: string): Record<string, string[]> {

--- a/scripts/ciJobGating.ts
+++ b/scripts/ciJobGating.ts
@@ -1,0 +1,288 @@
+/**
+ * Welche CI-Jobs laufen für eine gegebene Menge geänderter Dateien?
+ *
+ * Die Antwort steht in `.github/workflows/ci.yml` — verteilt auf zwei
+ * `dorny/paths-filter`-Schritte, die `outputs:` des `changes`-Jobs und die
+ * `if:`-Bedingungen der übrigen Jobs. Dieses Modul liest genau diese Stellen
+ * und rechnet sie nach; es hält **keine** zweite Kopie der Filterlisten.
+ *
+ * Der Grund für den Aufwand ist der Fehlermodus: Ein zu weit gefasster Filter
+ * lässt einen Job **still** aus. Der PR wird grün, ohne dass die Prüfung lief —
+ * genau so kamen #636 und #641 durch (siehe Kommentar am `e2e`-Filter in
+ * ci.yml). Ein Fehlschlag hier ist die einzige Rückmeldung, die es vor dem
+ * Merge gibt.
+ */
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Dieselbe Glob-Implementierung wie in dorny/paths-filter, mit derselben
+ * Option: `picomatch(pattern, { dot: true })`.
+ *
+ * Der naheliegende Weg wäre `node:path.matchesGlob` gewesen — ohne
+ * Abhängigkeit, und für `src/**` oder `*.config.ts` deckungsgleich. Er ist
+ * still falsch, sobald Punkt-Verzeichnisse im Spiel sind: `**` läuft dort
+ * nicht hinein, `.github/PULL_REQUEST_TEMPLATE.md` gilt damit **nicht** als
+ * `**\/*.md`. Der Test hätte dann „Validate läuft" behauptet, während CI den
+ * Job überspringt — genau die Richtung, die ein Wächter nicht verwechseln
+ * darf. `createRequire` statt `import`, weil picomatch v4 keine Typen
+ * mitbringt; die Signatur steht hier lokal.
+ */
+const picomatch = createRequire(import.meta.url)('picomatch') as (
+	pattern: string,
+	options?: { dot?: boolean }
+) => (input: string) => boolean;
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_PATH = join(REPO_ROOT, '.github/workflows/ci.yml');
+
+export type PredicateQuantifier = 'some' | 'every';
+
+export interface FilterStep {
+	/** `id:` des Schritts — so wird er in den `outputs:` referenziert. */
+	id: string;
+	quantifier: PredicateQuantifier;
+	filters: Record<string, string[]>;
+}
+
+export type EventName = 'pull_request' | 'push';
+
+export function readWorkflow(): string {
+	return readFileSync(WORKFLOW_PATH, 'utf8');
+}
+
+/**
+ * Ein Muster gegen einen Pfad prüfen. `!muster` ist bei picomatch die Negation
+ * eines einzelnen Musters — sie wird erst zusammen mit
+ * `predicate-quantifier: every` sinnvoll, siehe `evaluateFilters`.
+ */
+export function matchPattern(pattern: string, file: string): boolean {
+	const negated = pattern.startsWith('!');
+	const matches = picomatch(negated ? pattern.slice(1) : pattern, { dot: true })(file);
+	return negated ? !matches : matches;
+}
+
+function parseFilterBlock(lines: string[], stepId: string): Record<string, string[]> {
+	const filters: Record<string, string[]> = {};
+	let name: string | null = null;
+
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (line === '' || line.startsWith('#')) continue;
+
+		const filterName = /^([\w-]+):$/.exec(line);
+		if (filterName?.[1]) {
+			name = filterName[1];
+			filters[name] = [];
+			continue;
+		}
+
+		const pattern = /^-\s*'(.+)'$/.exec(line);
+		if (pattern?.[1]) {
+			if (!name) throw new Error(`Muster ohne Filternamen in Schritt "${stepId}": ${raw}`);
+			filters[name]?.push(pattern[1]);
+			continue;
+		}
+
+		throw new Error(`Unerwartete Zeile im filters-Block von "${stepId}": ${raw}`);
+	}
+
+	return filters;
+}
+
+/** Alle `dorny/paths-filter`-Schritte aus dem Workflow, in Reihenfolge. */
+export function readFilterSteps(yamlText: string): FilterStep[] {
+	const lines = yamlText.split('\n');
+	const steps: FilterStep[] = [];
+	let id: string | null = null;
+	let quantifier: PredicateQuantifier = 'some';
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+
+		const stepId = /^\s*id:\s*([\w-]+)\s*$/.exec(line);
+		if (stepId?.[1]) {
+			id = stepId[1];
+			quantifier = 'some';
+			continue;
+		}
+
+		const quant = /^\s*predicate-quantifier:\s*'?(some|every)'?\s*$/.exec(line);
+		if (quant?.[1]) {
+			quantifier = quant[1] as PredicateQuantifier;
+			continue;
+		}
+
+		const blockStart = /^(\s*)filters:\s*\|\s*$/.exec(line);
+		if (!blockStart) continue;
+		if (!id) throw new Error(`filters-Block ohne vorangehendes "id:" in Zeile ${i + 1}`);
+
+		const blockIndent = (blockStart[1] ?? '').length;
+		const block: string[] = [];
+		let j = i + 1;
+		for (; j < lines.length; j++) {
+			const current = lines[j] ?? '';
+			if (current.trim() === '') {
+				block.push('');
+				continue;
+			}
+			if (current.length - current.trimStart().length <= blockIndent) break;
+			block.push(current);
+		}
+
+		steps.push({ id, quantifier, filters: parseFilterBlock(block, id) });
+		id = null;
+		i = j - 1;
+	}
+
+	return steps;
+}
+
+/**
+ * Ein Filter ist wahr, sobald **eine** geänderte Datei ihn erfüllt. Was
+ * „erfüllt" heißt, hängt am Quantor: bei `some` reicht ein passendes Muster,
+ * bei `every` müssen alle passen. Letzteres ist die Kombination, die aus einer
+ * Liste von Negationen ein „es gibt eine Datei, die nichts davon ist" macht.
+ */
+export function evaluateFilters(step: FilterStep, changedFiles: string[]): Record<string, boolean> {
+	const result: Record<string, boolean> = {};
+
+	for (const [name, patterns] of Object.entries(step.filters)) {
+		result[name] = changedFiles.some((file) =>
+			step.quantifier === 'every'
+				? patterns.every((pattern) => matchPattern(pattern, file))
+				: patterns.some((pattern) => matchPattern(pattern, file))
+		);
+	}
+
+	return result;
+}
+
+/** Die `outputs:` des `changes`-Jobs als Rohausdrücke, ohne `${{ }}`. */
+export function readChangesOutputs(yamlText: string): Record<string, string> {
+	const outputs: Record<string, string> = {};
+
+	for (const line of yamlText.split('\n')) {
+		const match = /^ {6}([\w-]+):\s*\$\{\{\s*(.+?)\s*\}\}$/.exec(line);
+		if (match?.[1] && match[2]) outputs[match[1]] = match[2];
+	}
+
+	if (Object.keys(outputs).length === 0) {
+		throw new Error('Keine outputs im changes-Job gefunden — hat sich die Einrückung geändert?');
+	}
+
+	return outputs;
+}
+
+/**
+ * Ein GitHub-Ausdruck der Form `a || b || c`, wobei jeder Term entweder
+ * `steps.<id>.outputs.<filter> == 'true'` oder `github.event_name == 'push'`
+ * ist. Alles andere ist ein Fehler statt eines stillen `false` — ein neuer
+ * Ausdruckstyp soll hier auffallen, nicht durchrutschen.
+ */
+function evaluateExpression(
+	expression: string,
+	filterOutputs: Record<string, Record<string, boolean>>,
+	eventName: EventName
+): boolean {
+	return expression
+		.split('||')
+		.map((term) => term.trim())
+		.some((term) => {
+			if (term === "github.event_name == 'push'") return eventName === 'push';
+
+			const match = /^steps\.([\w-]+)\.outputs\.([\w-]+) == 'true'$/.exec(term);
+			if (!match?.[1] || !match[2]) throw new Error(`Unbekannter Ausdruck: ${term}`);
+
+			const step = filterOutputs[match[1]];
+			if (!step) throw new Error(`Ausdruck verweist auf unbekannten Schritt: ${match[1]}`);
+			if (!(match[2] in step)) throw new Error(`Filter "${match[2]}" existiert nicht`);
+
+			return step[match[2]] === true;
+		});
+}
+
+/**
+ * Welche `needs.changes.outputs.*` ein Job in seinem `if:` liest. Damit prüft
+ * der Test die Zuordnung Job → Output gegen die Datei, statt sie ein zweites
+ * Mal zu behaupten.
+ */
+export function readJobGates(yamlText: string): Record<string, string[]> {
+	const gates: Record<string, string[]> = {};
+	const lines = yamlText.split('\n');
+	let job: string | null = null;
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+
+		const jobName = /^ {2}([\w-]+):$/.exec(line);
+		if (jobName?.[1]) {
+			job = jobName[1];
+			gates[job] = [];
+			continue;
+		}
+		if (!job) continue;
+
+		const ifStart = /^ {4}if:\s*(.*)$/.exec(line);
+		if (!ifStart) continue;
+
+		let condition = ifStart[1] ?? '';
+		if (condition.trim() === '|') {
+			condition = '';
+			for (let j = i + 1; j < lines.length; j++) {
+				const current = lines[j] ?? '';
+				if (current.trim() !== '' && current.length - current.trimStart().length <= 4) break;
+				condition += `\n${current}`;
+			}
+		}
+
+		gates[job] = [...condition.matchAll(/needs\.changes\.outputs\.([\w-]+)/g)].map(
+			(match) => match[1] as string
+		);
+	}
+
+	return gates;
+}
+
+export interface JobDecision {
+	/** Job-Key aus ci.yml → läuft er? */
+	[job: string]: boolean;
+}
+
+/**
+ * Läuft ein Job? Jeder gegatete Job verknüpft seine Outputs mit `&&` (im
+ * Workflow stehen sie als `… == 'true' && … == 'true'`), ein Job ohne
+ * Output-Verweis läuft immer. Die Zusatzbedingungen, die nicht von den
+ * Dateien abhängen (Draft-PR, release-please-Branch, `pull_request`-only),
+ * bleiben hier bewusst außen vor — sie sind nicht das, was still ausfällt.
+ */
+export function jobsFor(
+	changedFiles: string[],
+	eventName: EventName = 'pull_request'
+): JobDecision {
+	const yamlText = readWorkflow();
+
+	const filterOutputs: Record<string, Record<string, boolean>> = {};
+	for (const step of readFilterSteps(yamlText)) {
+		filterOutputs[step.id] = evaluateFilters(step, changedFiles);
+	}
+
+	const changesOutputs = readChangesOutputs(yamlText);
+	const resolved: Record<string, boolean> = {};
+	for (const [name, expression] of Object.entries(changesOutputs)) {
+		resolved[name] = evaluateExpression(expression, filterOutputs, eventName);
+	}
+
+	const decisions: JobDecision = {};
+	for (const [job, outputs] of Object.entries(readJobGates(yamlText))) {
+		if (job === 'changes') continue;
+		decisions[job] = outputs.every((name) => {
+			if (!(name in resolved)) throw new Error(`Job "${job}" liest unbekannten Output: ${name}`);
+			return resolved[name] === true;
+		});
+	}
+
+	return decisions;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -87,7 +87,12 @@ export default defineConfig({
 					include: [
 						'src/**/*.{test,spec}.{js,ts}',
 						'e2e/helpers/*.{test,spec}.{js,ts}',
-						'legacy-inbox/**/*.test.js'
+						'legacy-inbox/**/*.test.js',
+						/* `scripts/` steht hier wegen `ciJobGating.test.ts`: dem Wächter
+						   über die Job-Gates in .github/workflows/ci.yml. Der gehört in
+						   `test:quick`, weil sein Fehlermodus — ein Job läuft still nicht
+						   mehr — sonst erst nach dem Merge sichtbar würde. */
+						'scripts/*.{test,spec}.ts'
 					],
 					// Das node_modules-Muster muss explizit mit: Ein eigenes `exclude`
 					// ersetzt Vitests Default. Ohne den Eintrag würde das


### PR DESCRIPTION
## Was

Ein PR, der nur `*.md`, `docs/**` oder `.claude/**` ändert, zog bisher den vollen `Validate`-Job. E2E und Component Tests waren schon gegated, `Validate` nicht — es hatte gar kein `if` auf `changes`.

| PR-Inhalt | vorher | nachher |
| --- | --- | --- |
| nur Docs / `.claude` | Validate (~2m24s) | Commit Lint (~1m) |
| Code | alles | alles, unverändert |

## Warum

Bei einem Doku-PR fasst **kein** Schritt in `Validate` eine geänderte Datei an: ESLint hat keine Markdown-Konfiguration und übergeht Punkt-Verzeichnisse, `tsc`/`svelte-check`/`vite build` sehen `docs/` und `.claude/` nicht, die Unit-Tests laufen gegen unveränderten Code. Das Ergebnis ist per Konstruktion das des letzten Laufs auf `main`. Belegt an einem echten Doku-PR: 2m24s.

Das `main`-Ruleset verlangt keine Status-Checks (nur PR + kein Force-Push), ein übersprungener Job blockiert also nichts.

## Wie

**Zweiter `paths-filter`-Schritt mit Negationen und `predicate-quantifier: every`:**

```yaml
non-docs:
  - '!**/*.md'
  - '!docs/**'
  - '!.claude/**'
```

Die Frage ist nicht „welcher Code hat sich geändert", sondern „gibt es eine geänderte Datei, die **kein** Dokument ist". Die Richtung ist Absicht: Eine Positivliste (`src/**`, `scripts/**`, `.husky/**`, `Dockerfile`, …) müsste bei jeder neuen Datei am Repo-Rand nachgezogen werden und prüfte beim Vergessen still zu wenig. So zählt Unbekanntes als Code — der Filter kann nur zu viel prüfen, nie zu wenig.

**Neuer Job `Commit Lint`:** Die Commit-Konvention gilt auch für Doku-Commits, hing aber an `Validate`. Läuft ungegated, mit `npm ci --ignore-scripts` (gebraucht wird nur die commitlint-CLI, `prepare`/husky hat in CI nichts zu tun).

**Der tote `docs`-Filter fällt weg** — kein Output hat ihn je gelesen.

## Wächter

`scripts/ciJobGating.test.ts` liest `ci.yml` (Filter, `outputs:`, die `needs.changes.outputs.*` aus den `if:`-Blöcken) und rechnet die Gates für Beispiel-Dateimengen nach — keine zweite Kopie der Filterlisten. Hängt über `vitest.config.ts` in `test:quick`.

Nötig, weil der Fehlermodus still ist: Ein zu weit gefasster Filter lässt einen Job aus, der PR wird grün, die Prüfung lief nie. Genau so kamen #636 und #641 durch.

## Für Reviewer

Der Test hat beim Schreiben eine echte Falle gefunden. Der erste Entwurf benutzte `node:path.matchesGlob` — keine Abhängigkeit, für `src/**` und `*.config.ts` deckungsgleich. Er ist still falsch bei Punkt-Verzeichnissen: `**` läuft dort nicht hinein, `.github/PULL_REQUEST_TEMPLATE.md` galt damit **nicht** als `**/*.md`. Der Wächter hätte „Validate läuft" behauptet, während CI überspringt.

paths-filter benutzt `picomatch(pattern, { dot: true })` — nachgesehen in [`src/filter.ts`](https://github.com/dorny/paths-filter/blob/v4/src/filter.ts), dort auch `EVERY` als `patterns.every(...)`. Der Wächter benutzt jetzt dieselbe Bibliothek mit derselben Option; die Abweichung von `matchesGlob` ist als eigener Testfall festgehalten, damit sie niemand „vereinfacht".

`picomatch` kommt bewusst transitiv (v4.0.5, über Vite/Tailwind) und ist **keine** direkte Dependency: Der Lockfile-Diff hätte den `dependencies`-Filter ausgelöst und für eine ohnehin im Baum liegende Bibliothek die volle Suite gezogen. Fällt sie weg, bricht der Test laut.

Zwei Dinge bewusst nicht angefasst: `Commit Lint` braucht weiterhin `npm ci` (ohne Lockfile-Install ginge nur `npx --yes`, das pro Lauf aus dem Netz zieht), und `has-code-changes` gated weiterhin nur die Coverage innerhalb von `Validate`.

## Test

`npm run test:quick` grün: 292 Dateien, 4416 Tests, exit 0. Dieser PR ist selbst ein gemischter (Code + Doku) und muss deshalb die volle Suite ziehen — der Doku-Fall wird durch den Wächter abgedeckt, nicht durch diesen Lauf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
