### PR TITLE
fix(admin): linke Tabellenkante aufräumen und mediaUpload beim Bearbeiten ableiten

### DIFF
--- a/src/lib/utils/media/mediaUploadFlag.test.ts
+++ b/src/lib/utils/media/mediaUploadFlag.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Das `mediaUpload`-Flag beim Bearbeiten einer Sichtung.
+ *
+ * Der interessante Fall ist die Asymmetrie: Eine angehängte Datei setzt das
+ * Flag, das Fehlen einer Datei löscht es aber nicht — sonst verlöre jede
+ * Bearbeitung einer Sichtung im Zustand „Foto angekündigt, folgt per E-Mail"
+ * genau die Aussage, auf der die Admin-Arbeitsliste steht.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { resolveMediaUploadFlag } from './mediaUploadFlag';
+
+describe('resolveMediaUploadFlag', () => {
+	it('setzt das Flag, wenn eine Datei angehängt ist', () => {
+		expect(resolveMediaUploadFlag({ current: 0, attachedFileCount: 1 })).toBe(true);
+	});
+
+	it('löscht ein gesetztes Flag nicht, wenn keine Datei angehängt ist', () => {
+		// „Angekündigt, aber noch nicht eingetroffen" — der Zustand, auf dem der
+		// Filter `announced_missing` steht. Eine Bearbeitung darf ihn nicht tilgen.
+		expect(resolveMediaUploadFlag({ current: 1, attachedFileCount: 0 })).toBe(true);
+	});
+
+	it('bleibt aus, solange weder Flag noch Datei vorliegen', () => {
+		expect(resolveMediaUploadFlag({ current: 0, attachedFileCount: 0 })).toBe(false);
+	});
+
+	it('nimmt das Flag als DB-Integer wie als Formular-Boolean entgegen', () => {
+		expect(resolveMediaUploadFlag({ current: true, attachedFileCount: 0 })).toBe(true);
+		expect(resolveMediaUploadFlag({ current: false, attachedFileCount: 0 })).toBe(false);
+		expect(resolveMediaUploadFlag({ current: null, attachedFileCount: 0 })).toBe(false);
+		expect(resolveMediaUploadFlag({ current: undefined, attachedFileCount: 2 })).toBe(true);
+	});
+});

--- a/src/lib/utils/media/mediaUploadFlag.ts
+++ b/src/lib/utils/media/mediaUploadFlag.ts
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Das `mediaUpload`-Flag beim **Bearbeiten** einer Sichtung.
+ *
+ * Beim Anlegen leitet das Meldeformular das Flag aus den hochgeladenen Dateien
+ * ab (`ModernReportForm.svelte`). Die Admin-Maske tat das nicht: Sie reichte
+ * den geladenen Wert nur durch. Lud ein Admin ein nachgereichtes Foto an eine
+ * Sichtung mit `mediaUpload = 0`, wurde die Datei gespeichert und verknüpft —
+ * die Spalte „Aufnahme" in der Admin-Tabelle zeigte trotzdem weiter „Nein".
+ *
+ * **Das ist bewusst keine Checkbox in der Maske geworden.** Ein Bedienelement
+ * neben der Dropzone wäre eine zweite Quelle für dieselbe Aussage und könnte
+ * ihr widersprechen. Abgeleitet kann das Flag gar nicht erst lügen.
+ *
+ * **Die Regel ist asymmetrisch, und das ist der Kern.** Eine Datei setzt das
+ * Flag; das Fehlen einer Datei löscht es **nicht**. `mediaUpload = 1` ohne
+ * angehängte Datei ist kein Widerspruch, sondern der Zustand „Foto
+ * angekündigt, folgt per E-Mail" (`photoAnnouncement.ts`) — die Aussage, auf
+ * der die Admin-Arbeitsliste und der Filter `announced_missing` stehen. Eine
+ * rein aus dem Dateibestand berechnete Ableitung hätte diesen Zustand bei
+ * jeder Bearbeitung getilgt und die Meldung still aus der Arbeitsliste
+ * genommen, bevor das Foto eingetroffen ist.
+ *
+ * Zurücknehmen lässt sich das Flag über diesen Weg damit nicht. Das ist
+ * hinnehmbar: Es gab dafür vorher ebenso wenig ein Bedienelement, und der
+ * Fehlerfall „Foto war doch keins" ist selten genug für einen eigenen Weg.
+ */
+
+/** Zählt als „gesetzt", egal ob DB-Integer (0/1) oder Formular-Boolean. */
+type MediaUploadFlag = number | boolean | null | undefined;
+
+export interface MediaUploadFlagInput {
+	/** Der Wert, wie er aus dem Bearbeitungsformular zurückkommt. */
+	current: MediaUploadFlag;
+	/** Anzahl der Dateien, die nach dieser Bearbeitung an der Sichtung hängen. */
+	attachedFileCount: number;
+}
+
+export function resolveMediaUploadFlag({
+	current,
+	attachedFileCount
+}: MediaUploadFlagInput): boolean {
+	return !!current || attachedFileCount > 0;
+}

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -1,10 +1,7 @@
 import { db } from '$lib/server/db';
 import { sightings } from '$lib/server/db/schema';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
-import {
-	MEDIA_UPLOAD_ANNOUNCED_MISSING,
-	mediaUploadCondition
-} from '$lib/server/db/mediaUploadFilter';
+import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { searchCondition, normalizeSearchTerm } from '$lib/server/db/sightingSearchFilter';
@@ -176,27 +173,19 @@ export const load: PageServerLoad = async ({ url }) => {
 	// WHERE-Klausel zur Count-Abfrage hinzufügen
 	const countQuery = whereCondition ? countBaseQuery.where(whereCondition) : countBaseQuery;
 
-	// Arbeitslisten-Zähler „Foto angekündigt, fehlt noch" — unabhängig vom
-	// aktiven Filter, damit er als Hinweis im Dashboard-Kopf sichtbar ist, auch
-	// wenn gerade eine andere Ansicht gefiltert ist.
-	const pendingPhotoQuery = db
-		.select({ count: sql<number>`count(*)` })
-		.from(sightings)
-		.where(mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING));
-
 	// Abfragen ausführen — voneinander unabhängig, deshalb parallel statt
-	// sequenziell (drei Round-Trips gleichzeitig statt hintereinander).
-	const [data, countResult, pendingPhotoResult] = await Promise.all([
-		paginatedQuery,
-		countQuery,
-		pendingPhotoQuery
-	]);
+	// sequenziell (zwei Round-Trips gleichzeitig statt hintereinander).
+	//
+	// Der dritte Zähler „Foto angekündigt, fehlt noch" ist mit dem zugehörigen
+	// Knopf im Kopf entfallen (Begründung in `+page.svelte`): Er kostete auf
+	// jedem Seitenaufruf dieser Tabelle eine eigene Abfrage über den gesamten
+	// Bestand, für eine Zahl, die der Eingang ohnehin führt.
+	const [data, countResult] = await Promise.all([paginatedQuery, countQuery]);
 	// `count(*)` ist bigint und kommt je nach PG-Treiber als String zurück. Der
 	// Loader-Vertrag sagt `number`, also wird hier normalisiert und nicht in
 	// jeder Aufrufstelle einzeln: `"1" === 1` ist falsch und ergab in der
 	// Kopfzeile „1 Fotos ausstehend".
 	const count = Number(countResult[0]?.count ?? 0);
-	const pendingPhotoAnnouncements = Number(pendingPhotoResult[0]?.count ?? 0);
 
 	// Wer eine ganze Referenz-ID einfügt (aus einer Bestätigungsmail, einer
 	// Rückfrage), will die Sichtung sehen — nicht eine Trefferliste mit einer
@@ -239,7 +228,6 @@ export const load: PageServerLoad = async ({ url }) => {
 			totalPages: Math.ceil(count / perPage),
 			total: count,
 			maxPerPage: paginationConfig.maxSightingsPerPage
-		},
-		pendingPhotoAnnouncements
+		}
 	};
 };

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -336,18 +336,6 @@
 	}
 
 	/**
-	 * Springt direkt zur Arbeitsliste „Foto angekündigt, fehlt noch"
-	 * (siehe `$lib/utils/media/photoAnnouncement.ts`). Setzt nur den
-	 * Aufnahme-Filter — andere aktive Filter bleiben erhalten, damit z. B. ein
-	 * bereits gesetzter Datumsbereich nicht verloren geht.
-	 */
-	function showPendingPhotoAnnouncements(): void {
-		mediaUpload = MEDIA_UPLOAD_ANNOUNCED_MISSING;
-		isFilterPanelOpen = true;
-		applyFilters();
-	}
-
-	/**
 	 * Absenden der Suche. Läuft über `applyFilters()`, damit ein aktiver
 	 * Filter erhalten bleibt und die Seitenzahl auf 1 zurückspringt — sonst
 	 * stünde man mit einer frischen Suche auf einer leeren Seite 7.
@@ -667,30 +655,12 @@
 <div class="pt-6">
 	<!-- Page Header -->
 	<div class="container mx-auto mb-6 px-4 md:px-6">
-		<!--
-			Arbeitslisten-Hinweis „Foto angekündigt, fehlt noch"
-			(siehe $lib/utils/media/photoAnnouncement.ts). Echter `btn btn-outline`
-			statt eines mit `onclick` klickbar gemachten `badge`: Nur `.btn` bzw.
-			`summary.btn` bekommen über app.css automatisch die 44px-Touch-Target-
-			Mindestgröße (design-system.md „Feldmodus und Touch-Targets") — ein
-			`badge` bleibt bei ~24px hoch und wäre auf der Mobile-Kartenansicht
-			dieser Seite nicht zuverlässig zu treffen. `btn-outline` statt eines
-			vollton-farbigen `btn-info`, weil Vollton-Sekundärbuttons neben der
-			Primäraktion „Export" optisch mit ihr konkurrieren würden (Button-
-			Hierarchie-Regel); die Statusfarbe trägt stattdessen nur das Icon
-			(`text-info-strong`, AA-geprüft laut tokens.css).
-		-->
-		{#snippet pendingPhotoBadge()}
-			<button
-				type="button"
-				class="btn btn-sm btn-outline"
-				onclick={showPendingPhotoAnnouncements}
-				title="Sichtungen mit angekündigtem, aber noch nicht eingetroffenem Foto anzeigen"
-			>
-				<Icon icon="lucide:camera" class="text-info-strong mr-1 h-4 w-4" aria-hidden="true" />
-				{data.pendingPhotoAnnouncements} Foto{data.pendingPhotoAnnouncements === 1 ? '' : 's'} ausstehend
-			</button>
-		{/snippet}
+		<!-- Der Arbeitslisten-Knopf „n Fotos ausstehend" stand bis 2026-08-09 hier.
+		     Er ist raus, weil dieselbe Arbeitsliste auf dieser Seite bereits über
+		     den Aufnahme-Filter („Angekündigt, fehlt noch") erreichbar ist und der
+		     Eingang (`/admin`) den Hinweis samt Zähler ohnehin führt — dort gehört
+		     er hin, das ist die Task-Liste. Drei Einstiege in dieselbe Abfrage
+		     hießen drei Stellen, die auseinanderlaufen können. -->
 
 		<!-- Kompakter Kopf. Die Grenze kommt aus `layoutSwitch.ts` und ist dieselbe
 		     wie bei Kartenliste und Tabelle — vorher schaltete der Kopf bei `sm`,
@@ -724,14 +694,9 @@
 						Export
 					</button>
 				</div>
-				{#if (data.pagination && data.pagination.total) || data.pendingPhotoAnnouncements}
+				{#if data.pagination && data.pagination.total}
 					<div class="flex flex-wrap items-center justify-center gap-2">
-						{#if data.pagination && data.pagination.total}
-							<span class="badge badge-outline text-sm">{data.pagination.total} Ergebnisse</span>
-						{/if}
-						{#if data.pendingPhotoAnnouncements}
-							{@render pendingPhotoBadge()}
-						{/if}
+						<span class="badge badge-outline text-sm">{data.pagination.total} Ergebnisse</span>
 					</div>
 				{/if}
 			</div>
@@ -808,9 +773,6 @@
 					<Icon icon="lucide:download" class="mr-1 h-4 w-4" />
 					Export
 				</button>
-				{#if data.pendingPhotoAnnouncements}
-					{@render pendingPhotoBadge()}
-				{/if}
 				{#if data.pagination && data.pagination.total}
 					<span class="badge badge-outline whitespace-nowrap"
 						>{data.pagination.total} Ergebnisse</span

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -203,14 +203,30 @@
 		<table class="table-zebra table w-full">
 			<thead class="bg-base-200 text-base-content">
 				<tr>
-					<!-- Auswahlspalte, ganz links und wie die Markerspalte daneben fest:
+					<!-- Die Totfund-Kante sitzt an DIESER Spalte, nicht mehr an der
+					     Markerspalte daneben: Dort lag sie zwischen Checkbox und Icon und
+					     las sich als Trennstrich der Auswahlspalte statt als Auszeichnung
+					     der Zeile — eine „linke Kante", die seit Einführung der Auswahl
+					     gar nicht mehr links war. Sie steht weiter an einer Zelle und
+					     nicht am `<tr>`: unter `border-collapse` entscheidet dort sonst
+					     die Konfliktauflösung der Nachbarkanten, ob sie gezeichnet wird.
+
+					     `border-l-error` und nicht `border-error`: Letzteres färbt ALLE
+					     vier Kanten. DaisyUIs Zeilentrenner steht in `:where()` ohne
+					     Spezifität und verliert dagegen — die untere Zellkante lief damit
+					     rot weiter und sah aus wie ein Rendering-Fehler.
+
+					     Die 4px trägt jede Zeile, im Normalfall transparent. Sonst
+					     wanderte die Spalte bei jeder Totfund-Zeile um 4px nach rechts.
+
+					     Auswahlspalte, ganz links und wie die Markerspalte daneben fest:
 					     Sie steht bewusst nicht in `AVAILABLE_COLUMNS`. Abschaltbar wäre die
 					     Bulk-Funktion je nach gespeicherter Spaltenwahl unerreichbar — und
 					     der gespeicherte Stand überlebt seit U2 den Reload.
 					     Nicht `sticky-col`: Der fixierte Bereich liegt rechts (Status,
 					     Aktionen); eine zweite fixierte Kante links stahl auf schmalen
 					     Fenstern zusätzlich Platz vom scrollenden Mittelteil. -->
-					<th class="select-col w-px p-0">
+					<th class="select-col w-px border-l-4 border-l-transparent px-2 py-0">
 						<label class="target-exempt flex cursor-pointer justify-center">
 							<input
 								type="checkbox"
@@ -227,7 +243,13 @@
 					<!-- Feste Markerspalte, nicht in der Spaltenauswahl: Sie steht vor
 					     allen konfigurierbaren Spalten und überlebt damit sowohl jede
 					     Spaltenwahl als auch das horizontale Scrollen der Tabelle. -->
-					<th class="w-px p-0"><span class="sr-only">Art der Meldung</span></th>
+					<!-- „Tot" statt eines `sr-only`-Titels: Die Spalte war für Sehende
+					     unbeschriftet, das Icon darunter musste sich damit selbst
+					     erklären. Kurz gehalten, weil die Spalte nur ein 16px-Icon breit
+					     ist — „Totfund" (die Beschriftung des Badges, `deadFinding.ts`)
+					     verdoppelte ihre Breite für eine Spalte, die in den meisten Zeilen
+					     leer bleibt. Das Wort im Klartext steht weiter am Icon selbst. -->
+					<th class="w-px px-2 text-center">Tot</th>
 					<!-- Kein `hover:bg-base-300` an den nicht sortierbaren Köpfen: Die
 					     Aufhellung unter dem Zeiger versprach eine Sortierung, die es hier
 					     nicht gibt — sortierbare Köpfe tragen sie am <button> in `sortableTh`. -->
@@ -304,7 +326,11 @@
 						<!-- Auswahl-Checkbox, Gegenstück zur Kopfspalte oben. Das `aria-label`
 						     nennt die Referenz-ID und nicht nur „Zeile 3": Beim Vorlesen ist
 						     die Nummer der Meldung das, woran die Zeile erkennbar ist. -->
-						<td class="select-col w-px p-0">
+						<td
+							class="select-col w-px border-l-4 px-2 py-0 {isDeadFinding(sighting.isDead)
+								? 'border-l-error'
+								: 'border-l-transparent'}"
+						>
 							<label class="target-exempt flex cursor-pointer justify-center">
 								<input
 									type="checkbox"
@@ -316,14 +342,12 @@
 								/>
 							</label>
 						</td>
-						<!-- Kante und Icon zusammen: Die Kante wirkt beim Überfliegen, das
-						     Icon trägt zusätzlich eine Form — Farbe allein wäre kein
-						     Merkmal (WCAG 1.4.1). Der `sr-only`-Text benennt beides, sonst
-						     bliebe die Zelle für Screenreader leer.
-						     Die Kante steht an der Zelle und nicht am `<tr>`: unter
-						     `border-collapse` entscheidet dort sonst die Konfliktauflösung
-						     der Nachbarkanten, ob sie überhaupt gezeichnet wird. -->
-						<td class="w-px p-0 {isDeadFinding(sighting.isDead) ? 'border-error border-l-4' : ''}">
+						<!-- Nur noch das Icon: Die rote Kante sitzt seit dem Umbau eine
+						     Zelle weiter links, an der Auswahlspalte (Begründung dort).
+						     Das Icon bleibt trotzdem — Farbe allein wäre kein Merkmal
+						     (WCAG 1.4.1). Der `sr-only`-Text benennt es, sonst bliebe die
+						     Zelle für Screenreader leer. -->
+						<td class="w-px p-0">
 							{#if isDeadFinding(sighting.isDead)}
 								<span class="flex items-center justify-center px-2">
 									<Icon
@@ -543,9 +567,13 @@
 	   Die `min-height: var(--target-min)` aus derselben Regel bleibt
 	   unangetastet — die 44px Trefferfläche trägt weiterhin das Label.
 
-	   Die Breite kommt jetzt allein aus der Checkbox (28px, `--control-size`)
-	   statt zusätzlich aus einem `px-2` am Label: 44px Spaltenbreite für ein
-	   28px-Control war der breiteste Teil einer Zeile, der nichts anzeigt.
+	   Die Breite kommt aus der Checkbox (28px, `--control-size`) plus `px-2` an
+	   der Zelle statt am Label: 44px Spaltenbreite für ein 28px-Control war der
+	   breiteste Teil einer Zeile, der nichts anzeigt. Ganz ohne Polsterung
+	   klebte die Checkbox dagegen an der Außenkante der Tabelle und rechts am
+	   Totfund-Icon. Die Polsterung sitzt an der Zelle und nicht am Label, damit
+	   sie nicht Teil der Trefferfläche wird — ein Klick daneben soll die Zeile
+	   nicht auswählen.
 
 	   Damit ist das Ziel 44px hoch und 28px breit und unterschreitet das
 	   Projekt-Mindestmaß von 44×44 in der Breite. Das Label trägt deshalb

--- a/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
+++ b/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
@@ -38,8 +38,7 @@ function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
-		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
-		pendingPhotoAnnouncements: 0
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -3,14 +3,15 @@
  *
  * Der neu gebaute iOS-Client setzt `aufnahmeHochladen`, kann aber kein Foto
  * hochladen — es kommt per E-Mail nach (`$lib/utils/media/photoAnnouncement.ts`).
- * `load()` muss zwei Dinge leisten:
+ * `load()` muss dafür eines leisten: Der Filterwert
+ * `mediaUpload=announced_missing` muss dieselbe Bedingung erzeugen wie
+ * `mediaUploadCondition()` — sonst driftet die Admin-Liste vom zentral
+ * getesteten Filter auseinander.
  *
- * 1. Der Filterwert `mediaUpload=announced_missing` muss dieselbe Bedingung
- *    erzeugen wie `mediaUploadCondition()` — sonst driftet die Admin-Liste vom
- *    zentral getesteten Filter auseinander.
- * 2. Unabhängig vom aktiven Filter liefert `load()` einen globalen Zähler
- *    `pendingPhotoAnnouncements`, damit Admins die Arbeitsliste sehen, ohne
- *    den Filter erst öffnen zu müssen.
+ * Den globalen Zähler `pendingPhotoAnnouncements` gab es hier bis 2026-08-09
+ * zusätzlich. Er ist mit dem Knopf im Tabellenkopf entfallen: Der Eingang
+ * (`/admin`) führt dieselbe Zahl, und die Tabelle erreicht die Arbeitsliste
+ * über den Aufnahme-Filter.
  *
  * Testansatz wie `statisticsApprovalScope.test.ts`: ein aufzeichnender
  * `db.select`-Mock, das WHERE-Prädikat wird über den echten `PgDialect` zu SQL
@@ -99,17 +100,6 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		resolvedRows = [[{ id: 1 }], [{ count: 5 }], [{ count: 2 }]];
 	});
 
-	it('liefert pendingPhotoAnnouncements unabhängig vom aktiven Filter', async () => {
-		// `PageServerLoad` erlaubt generisch auch `void` als Rückgabe (Redirects
-		// o.ä.); für diesen Test ist das tatsächlich zurückgegebene Objekt
-		// bekannt, deshalb der Cast statt eines Guards gegen `void`.
-		const result = (await load({
-			url: makeUrl()
-		} as unknown as Parameters<typeof load>[0])) as { pendingPhotoAnnouncements: number };
-
-		expect(result.pendingPhotoAnnouncements).toBe(2);
-	});
-
 	/*
 	 * Befund 20: Die Hauptliste lief als `db.select()` über die ganze Zeile und
 	 * lieferte bis zu 100 vollständige Datensätze ins HTML — Telefonnummer,
@@ -160,19 +150,7 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		expect(recordedSelects[0]?.orderBySql).toMatch(/nulls last/i);
 	});
 
-	it('das dritte select() trägt exakt die Bedingung von mediaUploadCondition(announced_missing)', async () => {
-		await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0]);
-
-		const expected = toSqlText(
-			mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING) as unknown as SQLWrapper
-		);
-		const thirdSelect = recordedSelects[2];
-		expect(thirdSelect?.whereSql).toBe(expected);
-	});
-
 	it('?mediaUpload=announced_missing filtert die Hauptliste mit derselben Bedingung', async () => {
-		// Ohne weitere Filter ruft nur die neue Arbeitslisten-Abfrage where()
-		// auf — mit diesem Query-Parameter tut es zusätzlich die Hauptliste.
 		await load({
 			url: makeUrl({ mediaUpload: MEDIA_UPLOAD_ANNOUNCED_MISSING })
 		} as unknown as Parameters<typeof load>[0]);
@@ -180,8 +158,8 @@ describe('admin/+page.server load() — Foto-Ankündigungs-Arbeitsliste', () => 
 		const expected = toSqlText(
 			mediaUploadCondition(MEDIA_UPLOAD_ANNOUNCED_MISSING) as unknown as SQLWrapper
 		);
-		// Erster Select = Hauptliste, zweiter = Pagination-Count — beide
-		// müssen jetzt dieselbe Bedingung tragen wie die Arbeitslisten-Abfrage.
+		// Erster Select = Hauptliste, zweiter = Pagination-Count — beide müssen
+		// dieselbe Bedingung tragen wie `mediaUploadCondition`.
 		expect(recordedSelects[0]?.whereSql).toBe(expected);
 		expect(recordedSelects[1]?.whereSql).toBe(expected);
 	});
@@ -424,24 +402,16 @@ describe('admin/sichtungen/+page.server load() — Freitext-Suche', () => {
 });
 
 /**
- * `count(*)` kommt je nach PG-Treiber als **String** zurück (bigint). Die Seite
- * verglich `pendingPhotoAnnouncements === 1` und zeigte deshalb „1 Fotos
- * ausstehend". Die Normalisierung gehört in den Loader, nicht in jede
- * Aufrufstelle: Ein Loader-Vertrag mit `number` gilt für alle.
+ * `count(*)` kommt je nach PG-Treiber als **String** zurück (bigint). Aufgefallen
+ * ist das am Zähler „1 Fotos ausstehend" (`'1' === 1` ist falsch); der Knopf ist
+ * seit 2026-08-09 weg, die Falle bleibt für `pagination.total` dieselbe. Die
+ * Normalisierung gehört in den Loader, nicht in jede Aufrufstelle: Ein
+ * Loader-Vertrag mit `number` gilt für alle.
  */
 describe('admin/sichtungen/+page.server load() — Zähler sind Zahlen, keine Strings', () => {
 	beforeEach(() => {
 		recordedSelects = [];
 		resolvedRows = [[{ id: 1 }], [{ count: '42' }], [{ count: '1' }]];
-	});
-
-	it('liefert pendingPhotoAnnouncements als Zahl, auch wenn der Treiber einen String liefert', async () => {
-		const result = (await load({
-			url: makeUrl()
-		} as unknown as Parameters<typeof load>[0])) as { pendingPhotoAnnouncements: number };
-
-		expect(result.pendingPhotoAnnouncements).toBe(1);
-		expect(typeof result.pendingPhotoAnnouncements).toBe('number');
 	});
 
 	it('liefert pagination.total als Zahl und rechnet totalPages daraus', async () => {

--- a/src/routes/admin/sichtungen/paginationNav.svelte.test.ts
+++ b/src/routes/admin/sichtungen/paginationNav.svelte.test.ts
@@ -60,8 +60,7 @@ function sichtung(): SightingSelect {
 function daten(pagination: Partial<PageData['pagination']>): PageData {
 	return {
 		sightings: [sichtung()],
-		pagination: { page: 1, perPage: 20, total: 1, totalPages: 1, maxPerPage: 100, ...pagination },
-		pendingPhotoAnnouncements: 0
+		pagination: { page: 1, perPage: 20, total: 1, totalPages: 1, maxPerPage: 100, ...pagination }
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/sichtungen/searchParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/searchParam.svelte.test.ts
@@ -34,8 +34,7 @@ const SichtungenSeite = (await import('./+page.svelte')).default;
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
-		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
-		pendingPhotoAnnouncements: 0
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/sichtungen/statusColumn.svelte.test.ts
+++ b/src/routes/admin/sichtungen/statusColumn.svelte.test.ts
@@ -48,8 +48,7 @@ function daten(rows: SightingSelect[]): PageData {
 			total: rows.length,
 			totalPages: 1,
 			maxPerPage: 100
-		},
-		pendingPhotoAnnouncements: 0
+		}
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/sichtungen/statusFilterParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/statusFilterParam.svelte.test.ts
@@ -35,8 +35,7 @@ const SichtungenSeite = (await import('./+page.svelte')).default;
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
-		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
-		pendingPhotoAnnouncements: 0
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -39,8 +39,7 @@ function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
-		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 },
-		pendingPhotoAnnouncements: 0
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }
 

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -119,9 +119,15 @@ export const PUT: RequestHandler = async ({ params, request, locals, url, getCli
 		// — Begründung in `$lib/utils/media/mediaUploadFlag.ts`.
 		//
 		// `uploadedFiles` ist der vollständige Bestand nach dieser Bearbeitung und
-		// nicht nur der Zuwachs: `saveSightingFiles` ersetzt die Verknüpfungen
-		// unten komplett. Fehlt der Schlüssel im Body, bleibt es beim gemeldeten
-		// Wert — dann wurden auch unten keine Dateien angefasst.
+		// nicht nur der Zuwachs — aber nur, wenn die Liste etwas enthält:
+		// `saveSightingFiles` ersetzt die Verknüpfungen dann komplett. Bei leerer
+		// Liste UND bei fehlendem Schlüssel läuft der Aufruf unten gar nicht bzw.
+		// steigt sofort aus; die Anhänge bleiben in beiden Fällen unberührt.
+		//
+		// `attachedFileCount: 0` heißt hier also nie „die Dateien wurden
+		// entfernt", sondern „an den Dateien wurde nichts geändert". Genau
+		// deshalb darf die Ableitung das Flag nicht löschen — sie wüsste sonst
+		// gar nicht, worauf sie sich beruft.
 		const updatedSighting = await updateSighting(Number(id), {
 			...formData,
 			mediaUpload: resolveMediaUploadFlag({

--- a/src/routes/api/sightings/[id]/+server.ts
+++ b/src/routes/api/sightings/[id]/+server.ts
@@ -14,6 +14,7 @@ import {
 	updateSighting
 } from '$lib/server/db/sightingRepository';
 import type { ExifData } from '$lib/types';
+import { resolveMediaUploadFlag } from '$lib/utils/media/mediaUploadFlag';
 import { createId } from '@paralleldrive/cuid2';
 import { error, isHttpError, json } from '@sveltejs/kit';
 import { ValidationError } from 'yup';
@@ -112,8 +113,21 @@ export const PUT: RequestHandler = async ({ params, request, locals, url, getCli
 			.where(eq(sightings.id, Number(id)))
 			.limit(1);
 
+		// `mediaUpload` wird abgeleitet, nicht durchgereicht: Das Bearbeitungs-
+		// formular kennt kein Ankreuzfeld dafür, und ein hier hochgeladenes Foto
+		// muss auch in der Spalte „Aufnahme" ankommen. Die Regel ist asymmetrisch
+		// — Begründung in `$lib/utils/media/mediaUploadFlag.ts`.
+		//
+		// `uploadedFiles` ist der vollständige Bestand nach dieser Bearbeitung und
+		// nicht nur der Zuwachs: `saveSightingFiles` ersetzt die Verknüpfungen
+		// unten komplett. Fehlt der Schlüssel im Body, bleibt es beim gemeldeten
+		// Wert — dann wurden auch unten keine Dateien angefasst.
 		const updatedSighting = await updateSighting(Number(id), {
 			...formData,
+			mediaUpload: resolveMediaUploadFlag({
+				current: formData.mediaUpload,
+				attachedFileCount: uploadedFiles?.length ?? 0
+			}),
 			uploadedFiles: uploadedFiles || []
 		});
 


### PR DESCRIPTION
## Worum es geht

Zwei Rückmeldungen aus der Admin-Tabelle, dazu ein Befund, der beim Nachsehen aufgefallen ist.

## Linke Tabellenkante (`SichtungenTable.svelte`)

Vier Dinge an derselben Stelle:

- **Checkbox klebte am Rand.** Seit #832 hatte die Auswahlspalte gar keine Polsterung mehr. Jetzt `px-2` an der Zelle — bewusst nicht am Label, damit die Polsterung nicht Teil der Trefferfläche wird und ein Klick daneben die Zeile nicht auswählt.
- **Die Totfund-Kante saß an der falschen Spalte.** Sie lag auf der Markerspalte und damit *zwischen* Checkbox und Icon. Als „linke Kante der Zeile" gedacht, war sie seit Einführung der Auswahlspalte nicht mehr links und las sich als Trennstrich der Checkbox-Spalte. Sie sitzt jetzt an der Auswahlspalte, am tatsächlichen Zeilenanfang. Die 4px trägt jede Zeile transparent — sonst wanderte die Spalte bei jeder Totfund-Zeile um 4px nach rechts.
- **Der rote Strich knickte ab.** `border-error` färbt alle vier Kanten, und DaisyUIs Zeilentrenner steht in `:where()` ohne Spezifität — die *untere* Zellkante lief damit rot weiter und sah aus wie ein Rendering-Fehler. Jetzt `border-l-error`.
- **Die Markerspalte heißt sichtbar „Tot".** Vorher nur ein `sr-only`-Titel; für Sehende war die Spalte unbeschriftet und das Icon musste sich selbst erklären. Kurz gehalten, weil die Spalte nur ein Icon breit ist — „Totfund" steht weiter als `sr-only` am Icon.

## „n Fotos ausstehend" entfernt

Knopf, Snippet, Handler und der Loader-Zähler samt eigener `count(*)`-Abfrage über den Gesamtbestand bei **jedem** Seitenaufruf der Tabelle. Dieselbe Arbeitsliste ist auf der Seite über den Aufnahme-Filter („Angekündigt, fehlt noch") erreichbar, und der Eingang (`/admin`) führt den Hinweis ohnehin — dort gehört er hin, das ist die Task-Liste. Drei Einstiege in dieselbe Abfrage hießen drei Stellen, die auseinanderlaufen können.

Zwei Tests sind mitgegangen; einer prüfte genau die gelöschte dritte Query.

## `mediaUpload` wird beim Bearbeiten abgeleitet

Der eigentliche Befund. Lud ein Admin ein per E-Mail nachgereichtes Foto über die Bearbeitungsmaske hoch, wurde die Datei gespeichert und verknüpft — `aufnahmeHochladen` blieb aber auf dem geladenen Wert, weil die Maske ihn nur durchreichte. Die Spalte „Aufnahme" zeigte danach weiter **„Nein"**, obwohl eine Datei an der Sichtung hing. Das Meldeformular leitet das Flag seit jeher aus den Uploads ab; nur dieser Pfad tat es nicht.

Bewusst **keine** Checkbox in der Maske: Ein Bedienelement neben der Dropzone wäre eine zweite Quelle für dieselbe Aussage und könnte ihr widersprechen.

**Die Regel ist asymmetrisch, und das ist der Punkt für den Review:** Eine Datei setzt das Flag, das Fehlen einer Datei löscht es **nicht**. `mediaUpload = 1` ohne angehängte Datei ist kein Widerspruch, sondern der Zustand „Foto angekündigt, folgt per E-Mail" (`photoAnnouncement.ts`) — die Aussage, auf der der Filter `announced_missing` steht. Rein aus dem Dateibestand berechnet, hätte jede Bearbeitung diesen Zustand getilgt und die Meldung still aus der Arbeitsliste genommen, bevor das Foto eingetroffen ist. Zurücknehmen lässt sich das Flag über diesen Weg damit nicht — dafür gab es vorher ebenso wenig einen Weg.

Neu: `$lib/utils/media/mediaUploadFlag.ts` + Test (test-first geschrieben, RED gesehen).

## Prüfung

`npm run test:quick` grün — 294 Dateien, 4425 Tests. Die zwei ESLint-Warnungen in `src/tests/contract/helpers/createEvent.ts` sind Bestand und nicht aus diesem PR.

**Nicht visuell verifiziert:** Die Chrome-Verbindung stand während der Sitzung nicht, die Tabellenkante habe ich also nicht selbst im Browser gesehen — nur die Screenshots aus der Rückmeldung. Ein Blick auf `/admin/sichtungen` mit mindestens einer Totfund-Zeile wäre vor dem Merge sinnvoll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)