### PR TITLE
test: Komponenten-Tests ins Commit-Gate aufnehmen

### DIFF
--- a/.claude/agents/testing.md
+++ b/.claude/agents/testing.md
@@ -166,8 +166,11 @@ npm run test:unit:watch  # Watch Mode
 ## Befehle
 
 ```bash
-# Alle Unit Tests
+# Unit Tests des Server-Projekts (*.test.ts)
 npm run test:unit
+
+# Komponenten-Tests des Browser-Projekts (*.svelte.test.ts)
+npm run test:unit:client
 
 # Spezifischer Test
 npm run test:unit -- src/lib/utils/date/defaultYear.test.ts
@@ -181,7 +184,7 @@ npm run test:e2e
 # E2E mit UI
 npm run test:e2e -- --ui
 
-# Quick Check (vor Commit)
+# Gate vor dem Commit — enthält beide Vitest-Projekte, aber keine E2E-Suite
 npm run test:quick
 ```
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -62,9 +62,51 @@ npm run test:unit:all     # Alle Unit Tests (Server + Browser)
 npm run test:unit:watch   # Server Unit Tests im Watch-Modus
 npm run test:e2e          # E2E Tests (Playwright)
 npm run test:e2e:shards   # Shard-Zuordnung prüfen — PFLICHT nach neuem E2E-Spec
-npm run test:quick        # Schnell-Test (Shard-Abgleich + lint + type-check + svelte-check + unit)
+npm run test:quick        # Gate vor dem Commit (siehe unten)
 npm run test:coverage     # Coverage-Report (Server-Tests + v8)
 ```
+
+### Was `test:quick` prüft — und was nicht
+
+| Schritt            | Kommando           | Laufzeit  |
+| ------------------ | ------------------ | --------- |
+| E2E-Shard-Abgleich | `test:e2e:shards`  | ~2 s      |
+| ESLint             | `lint`             |           |
+| TypeScript         | `type-check`       | ~25 s     |
+| svelte-check       | `check`            | zusammen  |
+| Unit-Tests Server  | `test:unit`        | ~26 s     |
+| Komponenten-Tests  | `test:unit:client` | ~18 s     |
+| **Summe**          |                    | **~70 s** |
+
+**Nicht enthalten:** die E2E-Suite (`npm run test:e2e`). Die braucht Dev-Server und
+Datenbank und läuft in CI in drei Shards; `test:quick` prüft davon nur, ob jeder Spec
+einem Shard zugeordnet ist.
+
+Die Komponenten-Tests standen bis zum 2026-08-10 **nicht** in diesem Kommando: Es fuhr
+nur `vitest run --project server`, und alle `*.svelte.test.ts` liegen im Projekt
+`client`. Ein Branch legte sieben davon an, die als „grün" galten, ohne dass das Gate
+sie je angefasst hätte — der Lauf meldete Erfolg für eine Prüfung, die nicht
+stattgefunden hatte. Gemessen kostet das Browser-Projekt weniger als das
+Server-Projekt (18 s gegen 26 s); das Laufzeit-Argument, das die Trennung getragen
+hatte, hielt der Messung nicht stand.
+
+Damit sich die Lücke nicht wiederholt, rechnet `scripts/testGate.test.ts` nach, ob
+`test:quick` jedes in `vitest.config.ts` konfigurierte Vitest-Projekt fährt. Ein neues
+Projekt bricht diesen Test, statt still unbeobachtet zu bleiben.
+
+### Der Browser-Lauf endet mit „close timed out"
+
+```
+close timed out after 2000ms
+Tests closed successfully but something prevents the main process from exiting
+```
+
+Das ist **kein** Fehlschlag. Nach dem letzten Test bleiben Dateihandles offen, die der
+`hanging-process`-Reporter nur als „FILEHANDLE (unknown stack trace)" ausweist; danach
+beendet sich der Prozess von selbst, und es bleibt nachweislich weder ein Port noch ein
+Chromium zurück. Vitests Default von 10 s wurde deshalb in `vitest.config.ts` auf 2 s
+gekürzt — reine Wartezeit, die bei jedem Gate anfiel. Abgeschaltet ist die Meldung
+bewusst nicht: Bliebe eines Tages doch etwas zurück, ist sie der einzige Hinweis darauf.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,9 @@ npm run lint         # ESLint
 npm run type-check   # TypeScript
 npm run check        # Svelte-Check
 
-npm run test:quick   # Schnell-Test (E2E-Shard-Abgleich + lint + types + check + unit)
+npm run test:quick   # Gate vor dem Commit: E2E-Shard-Abgleich + lint + types + check
+                     # + Unit-Tests (Server) + Komponenten-Tests (Browser). ~70 s.
+                     # Nicht enthalten: die E2E-Suite (npm run test:e2e).
 ```
 
 Vollständige Test-Befehle: `.claude/rules/testing.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,16 +156,18 @@ These hooks are automatically installed when you run `npm install`.
 Before submitting a PR, ensure all checks pass:
 
 ```bash
-# Run quick checks (lint + type-check + svelte-check + unit tests)
+# Commit gate: e2e shard check + lint + type-check + svelte-check
+# + server unit tests + browser component tests (~70 s, no E2E suite)
 npm run test:quick
 
 # Individual checks
-npm run lint          # ESLint
-npm run type-check    # TypeScript
-npm run check         # Svelte check
-npm run test:unit     # Unit tests
-npm run test:e2e      # E2E tests
-npm run build         # Build check
+npm run lint             # ESLint
+npm run type-check       # TypeScript
+npm run check            # Svelte check
+npm run test:unit        # Unit tests (server project)
+npm run test:unit:client # Component tests (browser project)
+npm run test:e2e         # E2E tests
+npm run build            # Build check
 ```
 
 ## 📦 Release Process

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ npm run test:unit:watch
 # E2E-Tests ausführen (Playwright)
 npm run test:e2e
 
-# Schnelle Tests (Lint + Type-Check + Unit-Tests)
+# Gate vor dem Commit (Shard-Abgleich + Lint + Typen + svelte-check
+# + Unit-Tests Server + Komponenten-Tests Browser, ~70 s — ohne E2E)
 npm run test:quick
 
 # Code-Qualität

--- a/docs/WORKTREES.md
+++ b/docs/WORKTREES.md
@@ -172,6 +172,19 @@ false`, und der Job startet seinen eigenen Server im eigenen Container. Der
 Identitäts-Check läuft dort trotzdem mit, damit ein versehentlich entferntes Plugin
 auffällt, statt die Prüfung still abzuschalten.
 
+### Komponenten-Tests: derselbe Fehler, eigener Port
+
+Vitest bindet im Browser-Modus fest auf **63315** — in jedem Worktree derselbe Port.
+Seit die Komponenten-Tests Teil von `npm run test:quick` sind (2026-08-10), ist der
+gleichzeitige Lauf in zwei Worktrees der Normalfall, und der Zusammenstoß meldete sich
+nicht als Portfehler, sondern als vereinzelter Fehlschlag oder als „no tests": ein
+Befund, der nach einem Defekt am Code aussieht und keiner ist.
+
+`worktreeBrowserApiPort()` zieht deshalb aus demselben Pfad-Hash einen Port aus
+**45000–48999** — eigenes Fenster, damit sich Dev-Server und Komponenten-Tests im
+selben Worktree nicht verdrängen. Welcher Port es ist, steht in den Fehlermeldungen des
+Laufs (`http://localhost:<port>/src/…`).
+
 ## `CI=1` lokal: Adressfamilie, nicht Port (behoben 2026-08-04)
 
 Bis zum 2026-08-04 brach `CI=1 npx playwright test` bei parallel laufendem

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"test:unit:all": "vitest run",
 		"test:unit:watch": "vitest --project server",
 		"test": "npm run test:quick",
-		"test:quick": "npm run test:e2e:shards && npm run lint && npm run type-check && npm run check && npm run test:unit",
+		"test:quick": "npm run test:e2e:shards && npm run lint && npm run type-check && npm run check && npm run test:unit && npm run test:unit:client",
 		"test:coverage": "vitest run --coverage --project server",
 		"test:e2e": "playwright test",
 		"test:e2e:shards": "bash scripts/e2e-shards.sh --check",

--- a/scripts/testGate.test.ts
+++ b/scripts/testGate.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import vitestConfig from '../vitest.config';
+import { flattenScript, projectsCoveredBy, readScripts, vitestProjectsIn } from './testGate';
+
+/**
+ * Wächter über das Gate vor dem Commit.
+ *
+ * `test:quick` ist in `CLAUDE.md` und `.claude/rules/testing.md` als das Kommando
+ * benannt, das vor jedem Commit durchlaufen muss. Deckt es nicht jedes Projekt aus
+ * `vitest.config.ts` ab, meldet es Erfolg für Tests, die es nie ausgeführt hat —
+ * genau der stille Ausfall, der am 2026-08-10 sieben Komponenten-Tests als "grün"
+ * durchgehen ließ. Ein neues Vitest-Projekt bricht diesen Test, statt still
+ * unbeobachtet zu bleiben.
+ */
+const GATE_SCRIPT = 'test:quick';
+
+function configuredProjectNames(): string[] {
+	const projects = vitestConfig.test?.projects ?? [];
+	return projects.map((project, index) => {
+		const name = typeof project === 'object' && project?.test?.name;
+		if (typeof name !== 'string') {
+			throw new Error(`Vitest-Projekt #${index} hat keinen Namen — Wächter kann nicht prüfen`);
+		}
+		return name;
+	});
+}
+
+describe('Test-Gate', () => {
+	it('kennt mehr als ein Vitest-Projekt (sonst prüft der Wächter nichts)', () => {
+		expect(configuredProjectNames().length).toBeGreaterThan(1);
+		expect(configuredProjectNames()).toContain('client');
+	});
+
+	it(`${GATE_SCRIPT} fährt jedes konfigurierte Vitest-Projekt`, () => {
+		const covered = projectsCoveredBy(GATE_SCRIPT);
+		if (covered === 'all') return;
+
+		// Fehlermeldung nennt die Lücke beim Namen — "expected [server] to equal
+		// [server, client]" allein sagt nicht, was zu tun ist.
+		const missing = configuredProjectNames().filter((name) => !covered.includes(name));
+		expect(
+			missing,
+			`${GATE_SCRIPT} lässt die Vitest-Projekte ${missing.join(', ')} aus. ` +
+				`Entweder ins Skript aufnehmen oder die Dokumentation auf ein anderes Gate umstellen.`
+		).toEqual([]);
+	});
+
+	it('npm test zeigt auf dasselbe Gate', () => {
+		// `npm test` ist der Reflex; zeigte es auf etwas Engeres, hätte die
+		// Dokumentation wieder zwei Wahrheiten.
+		expect(flattenScript('test')).toEqual(flattenScript(GATE_SCRIPT));
+	});
+
+	describe('Auflösung der npm-Skripte', () => {
+		const scripts = {
+			a: 'npm run b && echo zwei',
+			b: 'echo eins',
+			zyklisch: 'npm run zyklisch'
+		};
+
+		it('löst verschachtelte npm-run-Aufrufe auf', () => {
+			expect(flattenScript('a', scripts)).toEqual(['echo eins', 'echo zwei']);
+		});
+
+		it('bricht bei einem Zyklus ab statt endlos zu laufen', () => {
+			expect(() => flattenScript('zyklisch', scripts)).toThrow(/Zyklus/);
+		});
+
+		it('meldet ein fehlendes Skript', () => {
+			expect(() => flattenScript('gibtsnicht', scripts)).toThrow(/Kein npm-Skript/);
+		});
+
+		it('nimmt jedes echte Skript aus package.json auseinander', () => {
+			// Kein zufälliger Treffer: Sobald ein Skript eine Form bekommt, die
+			// `flattenScript` nicht kennt (Klammern, `;`, `||`), fällt es hier auf.
+			for (const name of Object.keys(readScripts())) {
+				expect(() => flattenScript(name)).not.toThrow();
+			}
+		});
+	});
+
+	describe('Projekt-Erkennung', () => {
+		it.each([
+			['vitest run --project server', ['server']],
+			['vitest run --project=client', ['client']],
+			['vitest run --project server --project client', ['server', 'client']],
+			['vitest run', 'all'],
+			['vitest run --coverage --project server', ['server']],
+			['eslint . --config eslint.config.js', null],
+			// `vitest` ohne `run` ist der Watch-Modus — der ist kein Gate.
+			['vitest --project server', null]
+		])('%s → %j', (command, expected) => {
+			expect(vitestProjectsIn(command)).toEqual(expected);
+		});
+	});
+});

--- a/scripts/testGate.ts
+++ b/scripts/testGate.ts
@@ -1,0 +1,83 @@
+/**
+ * Rechnet nach, welche Vitest-Projekte ein npm-Skript tatsächlich fährt.
+ *
+ * Hintergrund: `test:quick` ist in `CLAUDE.md` und `.claude/rules/testing.md` als
+ * das Gate vor jedem Commit benannt, fuhr aber nur `vitest run --project server`.
+ * Alle `*.svelte.test.ts` (Projekt `client`) lagen außerhalb — am 2026-08-10 legte
+ * ein Branch sieben davon an, die als "grün" galten, ohne dass das Gate sie je
+ * angefasst hätte. Der Fehlermodus ist der gefährlichere von beiden: Das Kommando
+ * meldet Erfolg für eine Prüfung, die nicht gelaufen ist.
+ *
+ * Deshalb wird die Abdeckung hier ausgerechnet statt zugesichert — `testGate.test.ts`
+ * vergleicht sie mit den Projekten aus `vitest.config.ts`.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+
+export function readScripts(): Record<string, string> {
+	const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+		scripts?: Record<string, string>;
+	};
+	return pkg.scripts ?? {};
+}
+
+/**
+ * Löst ein npm-Skript rekursiv in die Liste der Kommandos auf, die am Ende laufen.
+ *
+ * Bewusst nur `&&` und `npm run <name>`: Genau daraus bestehen die Gate-Skripte.
+ * Ein Parser für die volle Shell-Grammatik wäre hier mehr Fehlerquelle als Nutzen —
+ * kommt etwas Komplexeres dazu, fällt es über die Tests zu diesem Modul auf, nicht
+ * über ein still falsches Ergebnis.
+ */
+export function flattenScript(
+	name: string,
+	scripts: Record<string, string> = readScripts(),
+	stack: readonly string[] = []
+): string[] {
+	if (stack.includes(name)) {
+		throw new Error(`Zyklus in den npm-Skripten: ${[...stack, name].join(' → ')}`);
+	}
+	const body = scripts[name];
+	if (body === undefined) throw new Error(`Kein npm-Skript namens "${name}" in package.json`);
+
+	return body
+		.split('&&')
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.flatMap((command) => {
+			const nested = /^npm run ([\w:.-]+)$/.exec(command);
+			return nested
+				? flattenScript(nested[1], scripts, [...stack, name])
+				: [command.replace(/^npx\s+/, '')];
+		});
+}
+
+/**
+ * Die Vitest-Projekte, die ein einzelnes Kommando fährt — oder `null`, wenn es
+ * gar kein Vitest-Lauf ist.
+ *
+ * `'all'` statt einer Namensliste, wenn kein `--project` gesetzt ist: Vitest fährt
+ * dann jedes Projekt der Config, auch ein später hinzugefügtes. Diese Unterscheidung
+ * ist der Grund, warum das Modul nicht einfach Namen zählt.
+ */
+export function vitestProjectsIn(command: string): string[] | 'all' | null {
+	if (!/(^|\s)vitest\s+run(\s|$)/.test(command)) return null;
+	const named = [...command.matchAll(/--project[= ]([\w-]+)/g)].map((match) => match[1]);
+	return named.length > 0 ? named : 'all';
+}
+
+/** Die Vitest-Projekte, die ein npm-Skript insgesamt abdeckt. */
+export function projectsCoveredBy(
+	name: string,
+	scripts: Record<string, string> = readScripts()
+): string[] | 'all' {
+	const covered = new Set<string>();
+	for (const command of flattenScript(name, scripts)) {
+		const projects = vitestProjectsIn(command);
+		if (projects === 'all') return 'all';
+		projects?.forEach((project) => covered.add(project));
+	}
+	return [...covered];
+}

--- a/scripts/testGate.ts
+++ b/scripts/testGate.ts
@@ -13,8 +13,11 @@
  */
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const repoRoot = path.resolve(import.meta.dirname, '..');
+// `fileURLToPath(import.meta.url)` statt `import.meta.dirname` — dasselbe Muster wie
+// in `vite.config.ts`, und unabhängig davon, wie die Datei transformiert wird.
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 export function readScripts(): Record<string, string> {
 	const pkg = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -17,6 +17,7 @@ import {
 	devServerIdentity,
 	devTrustAnchors,
 	loopbackHostFor,
+	worktreeBrowserApiPort,
 	worktreeDevPort
 } from './dev-server-identity';
 
@@ -76,6 +77,40 @@ describe('worktreeDevPort', () => {
 			expect(port).toBeGreaterThanOrEqual(41_000);
 			expect(port).toBeLessThanOrEqual(44_999);
 		}
+	});
+});
+
+describe('worktreeBrowserApiPort', () => {
+	it('liefert für dasselbe Verzeichnis immer denselben Port', () => {
+		expect(worktreeBrowserApiPort(WORKTREE_A)).toBe(worktreeBrowserApiPort(WORKTREE_A));
+	});
+
+	it('trennt Haupt-Repo und Worktrees', () => {
+		const ports = [MAIN_REPO, WORKTREE_A, WORKTREE_B].map(worktreeBrowserApiPort);
+		expect(new Set(ports).size).toBe(3);
+	});
+
+	it('liegt außerhalb des Dev-Server-Bereichs', () => {
+		// Der eigentliche Zweck der zweiten Funktion: Browser-Test-Server und
+		// Dev-Server dürfen sich im selben Worktree nicht gegenseitig verdrängen.
+		for (let i = 0; i < 500; i++) {
+			const root = `${WORKTREE_A}-${i}`;
+			const port = worktreeBrowserApiPort(root);
+			expect(port).toBeGreaterThanOrEqual(45_000);
+			expect(port).toBeLessThanOrEqual(48_999);
+			expect(port).not.toBe(worktreeDevPort(root));
+		}
+	});
+
+	it('ignoriert einen abschließenden Schrägstrich', () => {
+		expect(worktreeBrowserApiPort(`${WORKTREE_A}/`)).toBe(worktreeBrowserApiPort(WORKTREE_A));
+	});
+
+	it('streut breit genug, dass Kollisionen selten bleiben', () => {
+		const ports = Array.from({ length: 200 }, (_, i) =>
+			worktreeBrowserApiPort(`${WORKTREE_A}-${i}`)
+		);
+		expect(new Set(ports).size).toBeGreaterThanOrEqual(185);
 	});
 });
 

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -45,6 +45,16 @@ const PORT_RANGE_START = 41_000;
 const PORT_RANGE_SIZE = 4_000;
 
 /**
+ * Port-Fenster für den Vitest-Browser-Server: 45000–48999.
+ *
+ * Eigenes Fenster oberhalb des Dev-Bereichs, damit im selben Worktree Dev-Server und
+ * Komponenten-Tests nebeneinander laufen können, und weiterhin unterhalb des
+ * ephemeren Bereichs (ab 49152 auf macOS).
+ */
+const BROWSER_PORT_RANGE_START = 45_000;
+const BROWSER_PORT_RANGE_SIZE = 4_000;
+
+/**
  * Host, auf den der E2E-Dev-Server bindet (`vite.config.ci.ts`).
  *
  * Der Wildcard ist dort gewollt — in CI muss der Server auch von außerhalb des
@@ -127,6 +137,25 @@ function normalizeRoot(root: string): string {
 export function worktreeDevPort(root: string): number {
 	const digest = createHash('sha256').update(normalizeRoot(root)).digest();
 	return PORT_RANGE_START + (digest.readUInt32BE(0) % PORT_RANGE_SIZE);
+}
+
+/**
+ * Leitet aus dem Arbeitsverzeichnis den Port des Vitest-Browser-Servers ab.
+ *
+ * Vitest bindet im Browser-Modus fest auf 63315. Alle Worktrees teilen sich diesen
+ * Port, und `npm run test:unit:client` gleichzeitig in zweien laufen zu lassen ist
+ * beim parallelen Arbeiten der Normalfall, nicht die Ausnahme. Der Zusammenstoß
+ * meldet sich dabei nicht als Portfehler, sondern als vereinzelter Testfehlschlag
+ * oder als "no tests" — also als etwas, das nach einem Defekt am Code aussieht.
+ *
+ * Getrennter Hash-Versatz statt `worktreeDevPort + Offset`: Sonst zöge jede
+ * Kollision im Dev-Bereich die Browser-Ports gleich mit.
+ */
+export function worktreeBrowserApiPort(root: string): number {
+	const digest = createHash('sha256')
+		.update(`vitest-browser:${normalizeRoot(root)}`)
+		.digest();
+	return BROWSER_PORT_RANGE_START + (digest.readUInt32BE(0) % BROWSER_PORT_RANGE_SIZE);
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,22 @@
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
+import { worktreeBrowserApiPort } from './src/tools/dev-server-identity';
 
 export default defineConfig({
 	test: {
+		/**
+		 * Vitests Default sind 10 s — und die werden im Browser-Projekt *jedes Mal*
+		 * voll ausgeschöpft: Nach dem letzten Test bleiben Dateihandles offen, die
+		 * der `hanging-process`-Reporter nur als „FILEHANDLE (unknown stack trace)"
+		 * ausweist, und der Lauf endet mit „close timed out after 10000ms". Danach
+		 * beendet sich der Prozess von selbst; nachgemessen bleibt weder Port noch
+		 * Chromium zurück. Es ist also eine reine Wartezeit — bei einem Lauf von
+		 * ~17 s über ein Drittel der Gesamtdauer, und die fällt bei jedem Gate an.
+		 *
+		 * Bewusst nur gekürzt, nicht abgeschaltet: Bliebe eines Tages doch etwas
+		 * zurück, ist die Meldung der einzige Hinweis darauf.
+		 */
+		teardownTimeout: 2_000,
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'json', 'html'],
@@ -64,7 +78,15 @@ export default defineConfig({
 						enabled: true,
 						headless: true,
 						provider: playwright(),
-						instances: [{ browser: 'chromium' }]
+						instances: [{ browser: 'chromium' }],
+						/*
+						 * Ohne diese Zeile bindet Vitest fest auf 63315 — in *jedem*
+						 * Worktree derselbe Port. Zwei gleichzeitige Läufe stören sich
+						 * dann gegenseitig, und zwar nicht als Portfehler, sondern als
+						 * vereinzelter Fehlschlag oder als „no tests": ein Befund, der
+						 * nach einem Defekt am Code aussieht und keiner ist.
+						 */
+						api: { port: worktreeBrowserApiPort(process.cwd()) }
 					},
 					include: ['src/**/*.svelte.{test,spec}.{js,ts}'],
 					exclude: ['src/lib/server/**'],


### PR DESCRIPTION
## Worum es geht

`npm run test:quick` ist in `CLAUDE.md` und `.claude/rules/testing.md` als **das** Gate vor jedem Commit benannt, fuhr aber nur `vitest run --project server`. Alle `*.svelte.test.ts` liegen im Vitest-Projekt `client` und damit außerhalb.

Aufgefallen am 2026-08-10 im Branch `claude/sichtungstabelle-ux-umsetzung-922945`: Der Branch legte sieben neue Komponenten-Tests an, die alle grün waren — aber nicht, weil das Gate sie geprüft hätte. Sie liefen nur, weil sie einzeln angestoßen wurden. Das Kommando meldete Erfolg für eine Prüfung, die nicht stattgefunden hat.

In CI greift der Job „Component Tests" (`npm run test:unit:client`), das Loch war also rein lokal. Gefährlich ist es trotzdem, weil es Sicherheit suggeriert.

## Messung vor der Entscheidung

Das Argument gegen die Aufnahme war die Laufzeit. Es hat der Messung nicht standgehalten:

| Lauf | Wanduhr |
| --- | --- |
| `test:unit` (Projekt `server`) | ~26 s |
| `test:unit:client` (Projekt `client`) | 27 s → **18 s** nach dem Teardown-Fix unten |
| `test:unit:all` (beide in einem Prozess) | ~60 s — *langsamer* als beide nacheinander (~44 s), CPU-Konkurrenz |
| `test:quick` gesamt | 51 s → **~70 s** |

Das Browser-Projekt ist **billiger** als das Server-Projekt, nicht teurer. Damit entfällt der Grund für eine Aufteilung: kein separates `test:pre-commit`, sondern ein Gate, das hält was es verspricht. Bewusst `test:unit && test:unit:client` statt `test:unit:all` — die Messung oben zeigt, dass ein gemeinsamer Prozess durch CPU-Konkurrenz langsamer ist.

## Was drin ist

**`test(test): run component tests in the commit gate`**

- `test:quick` fährt jetzt beide Vitest-Projekte.
- Neu: `scripts/testGate.test.ts` + `scripts/testGate.ts` — löst die `npm run`-Ketten aus `package.json` auf und vergleicht die abgedeckten Vitest-Projekte mit denen aus `vitest.config.ts`. Ein neues Projekt bricht diesen Test, statt still unbeobachtet zu bleiben. Vorbild und direkter Nachbar ist `scripts/ciJobGating.test.ts`.
- Dokumentation (`CLAUDE.md`, `.claude/rules/testing.md`, `.claude/agents/testing.md`, `README.md`, `CONTRIBUTING.md`) beschreibt jetzt Schritt für Schritt, was das Kommando prüft — inklusive der ausdrücklichen Zeile, dass die **E2E-Suite nicht enthalten** ist und davon nur die Shard-Zuordnung geprüft wird.

**`fix(config): vitest browser port per worktree, shorter teardown wait`**

Die Nebenbeobachtung aus dem Issue, die mit dem Gate zum wiederkehrenden Ärgernis geworden wäre:

- **Port:** Vitest bindet im Browser-Modus fest auf `63315` — in jedem Worktree derselbe Port. Seit die Komponenten-Tests im Gate hängen, ist der gleichzeitige Lauf in zwei Worktrees der Normalfall. Der Zusammenstoß meldet sich nicht als Portfehler, sondern als vereinzelter Fehlschlag oder als „no tests": ein Befund, der nach einem Defekt am Code aussieht. `worktreeBrowserApiPort()` zieht den Port jetzt aus dem Pfad-Hash (45000–48999, eigenes Fenster neben dem Dev-Bereich 41000–44999).
- **Teardown:** `close timed out after 10000ms` schöpfte Vitests Default jedes Mal voll aus. Nachgemessen bleibt danach weder ein belegter Port noch ein Chromium zurück — es ist reine Wartezeit (`hanging-process` zeigt nur „FILEHANDLE (unknown stack trace)"). `teardownTimeout` daher auf 2 s. Die Meldung bleibt bewusst bestehen: Bliebe eines Tages doch etwas zurück, ist sie der einzige Hinweis darauf.

## Für das Review

- **CI ändert sich nicht.** Der Job `Validate` ruft die Einzelkommandos auf (`lint`, `type-check`, `check`, `test:unit`), nicht `test:quick`; `Component Tests` bleibt ein eigener Job. Keine Doppelausführung.
- Zwei Annahmen aus dem Projektgedächtnis haben sich als **falsch** erwiesen und sind korrigiert: `--browser.api.port` wirkt auch beim Projektlauf (nicht nur bei Einzeldateien), und der Teardown-Hänger lässt keine Prozesse zurück.
- `scripts/` liegt außerhalb von `tsc --noEmit` (nur `docker-migrate.ts` ist dort erfasst) — die neuen Dateien werden über ESLint und den Vitest-Lauf selbst abgedeckt.
- Verifiziert: voller `npm run test:quick` grün, 4.425 Server- + 716 Browser-Tests. Der Wächter-Test war vorher rot mit der Meldung *„test:quick lässt die Vitest-Projekte client aus."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
