### PR TITLE
feat(admin): meldekanal-auswertung und abgelehnte in der statistik

### DIFF
--- a/src/routes/admin/statistics/+page.server.ts
+++ b/src/routes/admin/statistics/+page.server.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '$lib/logger.server';
 import { db } from '$lib/server/db';
-import { approvedOnly, openOnly } from '$lib/server/db/approvalFilter';
+import { approvedOnly, openOnly, pendingOnly, rejectedOnly } from '$lib/server/db/approvalFilter';
 import { sightings } from '$lib/server/db/schema';
 import { EARLIEST_PLAUSIBLE_SIGHTING_DATE } from '$lib/server/db/sightingRepository';
 import { berlinCalendarDate, berlinDatePart } from '$lib/server/db/sqlTimeZone';
@@ -66,6 +66,38 @@ async function loadBasicStats(grundmenge: SQL): Promise<AdminBasicStats> {
 		.where(grundmenge);
 
 	return row ?? EMPTY_BASIC_STATS;
+}
+
+/**
+ * Die abgelehnte Grundmenge: **nicht freigegeben und abgelehnt**.
+ *
+ * `rejectedOnly()` allein täte es nicht. Die Kopfzeile stellt drei Zahlen
+ * nebeneinander und behauptet damit eine Zerlegung — freigegeben, offen,
+ * abgelehnt. Trüge eine Zeile beide Stempel, stünde sie in zweien davon. Im
+ * Bestand gibt es das nicht (gemessen am 2026-08-10: 0 Zeilen), die Datenbank
+ * verbietet es aber nicht, und der Freigabeteil kostet nichts. Nebeneffekt, der
+ * ebenso gewollt ist: Die Abfrage trägt damit einen erkennbaren Freigabebezug
+ * (Vorgabe 3 in `approvalFilter.ts`) — als einzige Kennzahl der Seite hätte sie
+ * ihn sonst nicht.
+ */
+const rejectedNotApproved = (): SQL => and(pendingOnly(), rejectedOnly()) as SQL;
+
+/**
+ * Zählt eine Grundmenge — mehr braucht die dritte Kopfzahl nicht.
+ *
+ * Bewusst nicht `loadBasicStats`: Gruppengröße, Totfunde und Medienanteil der
+ * abgelehnten Meldungen sind Kennzahlen ohne Abnehmer, und die Anzeige würde sie
+ * nirgends zeigen. Und bewusst eine **eigene** Abfrage statt CASE-Aggregaten
+ * neben den anderen beiden: Getrennte Läufe können strukturell nicht zu einer
+ * Summe verschmelzen (Vorgabe 2).
+ */
+async function loadRejectedCount(grundmenge: SQL): Promise<number> {
+	const [row] = await db
+		.select({ rejectedSightings: sql<number>`COUNT(*)::integer` })
+		.from(sightings)
+		.where(grundmenge);
+
+	return row?.rejectedSightings ?? 0;
 }
 
 /**
@@ -157,11 +189,12 @@ export const load: PageServerLoad = async ({ url }) => {
 		// falsch, weil er eine dritte Menge neben freigegeben/nicht freigegeben
 		// aufmachte. Deshalb ändert sich hier die Aufrufstelle und nicht das
 		// gemeinsame Prädikat.
-		const [approvedStats, openStats] = await Promise.all([
+		const [approvedStats, openStats, rejectedCount] = await Promise.all([
 			loadBasicStats(mitJahr(approvedOnly())),
-			loadBasicStats(mitJahr(openOnly()))
+			loadBasicStats(mitJahr(openOnly())),
+			loadRejectedCount(mitJahr(rejectedNotApproved()))
 		]);
-		const basicStats = { approved: approvedStats, open: openStats };
+		const basicStats = { approved: approvedStats, open: openStats, rejected: rejectedCount };
 
 		// Species distribution
 		const speciesStats = await db
@@ -176,6 +209,28 @@ export const load: PageServerLoad = async ({ url }) => {
 			.from(sightings)
 			.where(mitJahr(approvedOnly()))
 			.groupBy(sightings.species)
+			.orderBy(sql`COUNT(*) DESC`);
+
+		// Meldekanal (`eingangskanal`) — über welchen Weg die Meldung hereinkam.
+		//
+		// Dieselbe Grundmenge wie die Artenverteilung darüber: freigegeben, mit
+		// Jahresauswahl. Bewusst **ohne** `plausiblesDatum()` — das ist keine
+		// Kalenderauswertung, und die 280 Epoch-Platzhalter sind ohnehin sämtlich
+		// offen (Herleitung am Docblock von `plausiblesDatum`). Ein Datumsfilter
+		// wäre hier eine Bedingung ohne Wirkung.
+		//
+		// Die Zuordnung Zahl → Bezeichnung bleibt in `entryChannel.ts` und wird
+		// erst in der Anzeige aufgelöst: Sie ist dieselbe wie in Formular,
+		// Tabelle und E-Mail-Versand, und eine zweite Liste hier liefe ihr davon.
+		const channelStats = await db
+			.select({
+				channel: sightings.entryChannel,
+				count: sql<number>`COUNT(*)::integer`,
+				percentage: sql<number>`ROUND((COUNT(*) * 100.0 / SUM(COUNT(*)) OVER()), 2)::numeric`
+			})
+			.from(sightings)
+			.where(mitJahr(approvedOnly()))
+			.groupBy(sightings.entryChannel)
 			.orderBy(sql`COUNT(*) DESC`);
 
 		// Jahr und Monat in deutscher Ortszeit gruppieren: `sichtungsdatum` hält
@@ -384,6 +439,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			availableYears,
 			basicStats,
 			speciesStats,
+			channelStats,
 			yearlyStats,
 			monthlyStats,
 			recentActivity,

--- a/src/routes/admin/statistics/+page.svelte
+++ b/src/routes/admin/statistics/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import BarChart from '$lib/components/charts/BarChart.svelte';
+	import { getEntryChannelLabel } from '$lib/report/formOptions/entryChannel';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import Icon from '$lib/components/Icon.svelte';
 	import { WEEKDAY_LABELS, buildActivityHeatmap, type HeatmapStep } from './activityHeatmap';
@@ -40,6 +41,18 @@
 			label,
 			value: Number(data.monthlyStats.find((m) => Number(m.month) === index + 1)?.sightings ?? 0)
 		}))
+	);
+
+	/**
+	 * Bezugsgröße der Kanal-Balken.
+	 *
+	 * Die Summe der Kanäle und nicht die Kopfzahl `approved.totalSightings`:
+	 * Beide zählen zwar dieselbe Grundmenge, aber wenn eine der beiden Abfragen
+	 * einmal abweicht, ergäben die Anteile hier nicht mehr 100 %. Der Balken
+	 * bezieht sich damit auf genau die Zahlen, die daneben stehen.
+	 */
+	const channelTotal = $derived(
+		data.channelStats.reduce((summe, kanal) => summe + Number(kanal.count), 0) || 1
 	);
 
 	/** Jahrestrends über alle Jahre; das gewählte Jahr ist hervorgehoben. */
@@ -144,8 +157,21 @@
 					     dieselbe Menge wie der Eingang auf `/admin`. Wer hier „nicht
 					     freigegeben" schreibt, verspricht die Gegenmenge der Freigabe und
 					     weicht damit wieder um die Abgelehnten vom Eingang ab. -->
+					<!-- Der Trennpunkt trägt keine Bedeutung und gehört deshalb nicht in die
+					     Vorlesereihenfolge (`design-system.md`, Abschnitt „Beim Beheben nicht
+					     mechanisch ersetzen"). Ohne `aria-hidden` liest der Screenreader
+					     zwischen den Zahlen „Mittelpunkt". Gilt für beide Zahlen. -->
 					<span class="text-base-content/70">
-						· {formatNumber(data.basicStats?.open.totalSightings || 0)} noch offen
+						<span aria-hidden="true">·</span>
+						{formatNumber(data.basicStats?.open.totalSightings || 0)} noch offen
+					</span>
+					<!-- Die dritte Zahl steht auch bei 0 da. Wegzulassen, was gerade leer ist,
+					     macht das Fehlen zweideutig: Wer „5 abgelehnt" kennt und es beim
+					     nächsten Jahr nicht sieht, kann nicht unterscheiden, ob keine
+					     abgelehnt wurden oder ob die Anzeige die Zahl nicht mehr führt. -->
+					<span class="text-base-content/70">
+						<span aria-hidden="true">·</span>
+						{formatNumber(data.basicStats?.rejected || 0)} abgelehnt
 					</span>
 				</p>
 			</div>
@@ -399,6 +425,71 @@
 				</div>
 			</div>
 
+			<!-- Meldekanal -->
+			<div class="card bg-base-100 shadow-raised">
+				<div class="card-body">
+					<h2 class="card-title">
+						<Icon icon="lucide:inbox" class="h-6 w-6" />
+						Meldekanal (freigegebene Sichtungen{yearSuffix})
+					</h2>
+					<!-- Anteil statt bloßer Anzahl als führende Aussage: Web und App tragen
+					     zusammen über 90 %, die absoluten Zahlen der kleinen Kanäle sagen
+					     ohne diesen Bezug wenig. Balken statt Diagramm, weil sechs
+					     benannte Kategorien in eine Tabelle passen und die Bezeichnung
+					     („Fax") neben der Zahl stehen soll — anders als bei zwölf Monaten
+					     auf einer Achse.
+
+					     Dass hier wieder `progress` steht, ist kein Rückfall hinter die
+					     Umstellung der Saisonalität (Begründung weiter oben an ihrem
+					     Diagramm): Dort waren es zwölf gleichrangige Werte ohne
+					     Bezugsgröße, ein Fortschrittsbalken behauptete ein Ziel, das es
+					     nicht gab. Ein Anteil am Ganzen hat dieses Ziel — 100 % —, und
+					     genau dafür stehen die Balken der Datenqualität darunter seit
+					     jeher. -->
+					{#if data.channelStats.length === 0}
+						<p class="text-base-content/70">
+							Für diesen Zeitraum liegen keine freigegebenen Sichtungen vor.
+						</p>
+					{:else}
+						<div class="overflow-x-auto">
+							<table class="table-zebra table">
+								<thead>
+									<tr>
+										<th>Kanal</th>
+										<th>Sichtungen</th>
+										<th>Anteil</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each data.channelStats as kanal (kanal.channel)}
+										<tr>
+											<td class="font-medium">{getEntryChannelLabel(kanal.channel)}</td>
+											<td>{formatNumber(kanal.count)}</td>
+											<td>
+												<div class="flex items-center gap-3">
+													<!-- Der Balken wiederholt nur die Prozentzahl daneben und hat
+													     keinen eigenen Namen — als `progressbar` ohne Beschriftung
+													     läse ihn ein Screenreader als zweite, unbenannte Angabe
+													     derselben Zahl. Gleiche Auszeichnung wie an den beiden
+													     Balken der Datenqualität weiter unten. -->
+													<progress
+														class="progress progress-primary w-24"
+														value={kanal.count}
+														max={channelTotal}
+														aria-hidden="true"
+													></progress>
+													<span class="min-w-16">{formatPercentage(kanal.percentage)}</span>
+												</div>
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					{/if}
+				</div>
+			</div>
+
 			<!-- Data Quality & User Engagement -->
 			<div class="card bg-base-100 shadow-raised">
 				<div class="card-body">
@@ -447,6 +538,7 @@
 										class="progress progress-primary w-full"
 										value={data.qualityStats?.withCoordinates || 0}
 										max={total}
+										aria-hidden="true"
 									></progress>
 								</div>
 								<span class="min-w-16 text-sm font-medium">
@@ -460,6 +552,7 @@
 										class="progress progress-accent w-full"
 										value={data.qualityStats?.withBehavior || 0}
 										max={total}
+										aria-hidden="true"
 									></progress>
 								</div>
 								<span class="min-w-16 text-sm font-medium">

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -212,7 +212,15 @@ describe('admin/statistics load() — „noch offen" schließt Abgelehnte aus', 
 		await ladeSeite();
 
 		const texte = recordedWhereClauses.map(toSqlText);
-		const offeneAbfragen = texte.filter((t) => /freigegeben_am"? is null/i.test(t));
+		// „Nicht freigegeben" **und nicht** die Abgelehnten-Kopfzahl: Die zählt
+		// abgelehnte Meldungen absichtlich und nennt sie auch so. Ausgeschlossen
+		// wird sie über das positive `abgelehnt_am IS NOT NULL` — eine Abfrage mit
+		// dieser Bedingung kann keine Zahl über „noch offen" sein. Ein
+		// versehentliches `pendingOnly()` trägt sie gerade nicht und fällt der
+		// Prüfung unten weiterhin zum Opfer.
+		const offeneAbfragen = texte.filter(
+			(t) => /freigegeben_am"? is null/i.test(t) && !/abgelehnt_am"? is not null/i.test(t)
+		);
 
 		expect(
 			offeneAbfragen.length,
@@ -282,7 +290,15 @@ describe('admin/statistics load() — Jahresauswahl', () => {
 
 		await ladeSeite('?jahr=2020');
 
-		for (const spalte of ['species', 'month', 'uniqueUsers', 'uniqueShips', 'email']) {
+		for (const spalte of [
+			'species',
+			'month',
+			'channel',
+			'rejectedSightings',
+			'uniqueUsers',
+			'uniqueShips',
+			'email'
+		]) {
 			const abfrage = abfrageMit(spalte);
 			expect(abfrage, `Abfrage mit Spalte „${spalte}" nicht gefunden`).toBeDefined();
 			expect(hatJahresfilter(abfrage!), `Abfrage „${spalte}" ignoriert die Jahresauswahl`).toBe(
@@ -342,6 +358,89 @@ describe('admin/statistics load() — Jahresauswahl', () => {
 			expect(abfrage.where, 'Jahresliste ohne Freigabebezug').toBeDefined();
 			expect(toSqlText(abfrage.where!)).toContain('freigegeben_am');
 		}
+	});
+});
+
+/**
+ * Die dritte Kopfzahl: abgelehnt.
+ *
+ * Sie steht neben „freigegeben" und „noch offen" und wird mit keiner der beiden
+ * summiert (Vorgabe 2 aus `approvalFilter.ts`). Zusammen bilden die drei eine
+ * **Zerlegung** des Bestands — und genau deshalb läuft sie nicht über
+ * `rejectedOnly()` allein, sondern über „nicht freigegeben UND abgelehnt":
+ *
+ * - Ohne den Freigabeteil wäre eine Zeile mit beiden Stempeln in zwei Kopfzahlen
+ *   gleichzeitig gezählt. Im Bestand gibt es sie nicht (gemessen 2026-08-10: 0),
+ *   aber die Datenbank verbietet sie nicht — und die Kopfzeile behauptet mit drei
+ *   Zahlen nebeneinander implizit, dass sie sich nicht überlappen.
+ * - `rejectedOnly()` allein trägt zudem kein `freigegeben_am` im SQL und wäre
+ *   damit die erste Zahl dieser Seite ohne erkennbaren Freigabebezug (Vorgabe 3).
+ */
+describe('admin/statistics load() — Kopfzahl „abgelehnt"', () => {
+	it('zählt die Abgelehnten getrennt und überschneidungsfrei', async () => {
+		recordedQueries = [];
+
+		const daten = await ladeSeite();
+
+		const abgelehnt = recordedQueries.find((eintrag) => 'rejectedSightings' in eintrag.columns);
+		expect(abgelehnt, 'Abfrage der abgelehnten Kopfzahl nicht gefunden').toBeDefined();
+
+		const text = toSqlText(abgelehnt!.where!);
+		expect(text, 'Kopfzahl ohne Freigabebezug').toMatch(/freigegeben_am"? is null/i);
+		expect(text, 'Kopfzahl ohne Ablehnungsbezug').toMatch(/abgelehnt_am"? is not null/i);
+
+		expect(daten.basicStats.rejected).toBeDefined();
+	});
+
+	it('führt sie nicht mit den beiden anderen Kopfzahlen zusammen', async () => {
+		recordedQueries = [];
+
+		await ladeSeite();
+
+		// `loadBasicStats` bleibt bei zwei Läufen; die dritte Zahl ist eine eigene,
+		// schmale Abfrage. Eine gemeinsame mit CASE-Aggregaten könnte summiert
+		// werden — getrennte Läufe können es strukturell nicht.
+		const kopfzahlen = recordedQueries.filter((eintrag) => 'totalSightings' in eintrag.columns);
+		expect(kopfzahlen.length).toBe(2);
+		for (const abfrage of kopfzahlen) {
+			expect(toSqlText(abfrage.where!)).not.toMatch(/abgelehnt_am"? is not null/i);
+		}
+	});
+});
+
+/**
+ * Meldekanal-Auswertung (`eingangskanal`).
+ *
+ * Sie zählt dieselbe Grundmenge wie Artenverteilung und Saisonalität —
+ * freigegeben, mit Jahresauswahl. Das ist keine Formalie: Die Kanäle verteilen
+ * sich sehr ungleich (Web und App tragen zusammen über 90 %), eine still
+ * beigemischte offene Meldung verschiebt den Anteil eines kleinen Kanals wie Fax
+ * (14 Zeilen im Gesamtbestand) sofort sichtbar.
+ *
+ * **Kein Epoch-Ausschluss**, denn dies ist keine Kalenderauswertung: Die 280
+ * Platzhalter-Zeilen sind allesamt offen (siehe unten) und damit ohnehin nicht
+ * in der Grundmenge — ein Datumsfilter hier wäre eine Bedingung ohne Wirkung
+ * und ohne Begründung.
+ */
+describe('admin/statistics load() — Meldekanal', () => {
+	it('zählt die Kanäle über die freigegebene Menge', async () => {
+		recordedQueries = [];
+
+		await ladeSeite();
+
+		const kanaele = recordedQueries.find((eintrag) => 'channel' in eintrag.columns);
+		expect(kanaele, 'Meldekanal-Abfrage nicht gefunden').toBeDefined();
+		expect(kanaele!.where, 'Meldekanal-Abfrage ohne Grundmenge').toBeDefined();
+		expect(toSqlText(kanaele!.where!)).toMatch(/freigegeben_am"? is not null/i);
+	});
+
+	it('liefert je Kanal Anzahl und Anteil', async () => {
+		recordedQueries = [];
+
+		await ladeSeite();
+
+		const kanaele = recordedQueries.find((eintrag) => 'channel' in eintrag.columns)!;
+		expect(Object.keys(kanaele.columns).sort()).toEqual(['channel', 'count', 'percentage']);
 	});
 });
 

--- a/src/routes/admin/statistics/page.server.test.ts
+++ b/src/routes/admin/statistics/page.server.test.ts
@@ -385,6 +385,8 @@ describe('admin/statistics load() — Kopfzahl „abgelehnt"', () => {
 		const abgelehnt = recordedQueries.find((eintrag) => 'rejectedSightings' in eintrag.columns);
 		expect(abgelehnt, 'Abfrage der abgelehnten Kopfzahl nicht gefunden').toBeDefined();
 
+		expect(abgelehnt!.where, 'Kopfzahl ohne Grundmenge').toBeDefined();
+
 		const text = toSqlText(abgelehnt!.where!);
 		expect(text, 'Kopfzahl ohne Freigabebezug').toMatch(/freigegeben_am"? is null/i);
 		expect(text, 'Kopfzahl ohne Ablehnungsbezug').toMatch(/abgelehnt_am"? is not null/i);
@@ -439,8 +441,9 @@ describe('admin/statistics load() — Meldekanal', () => {
 
 		await ladeSeite();
 
-		const kanaele = recordedQueries.find((eintrag) => 'channel' in eintrag.columns)!;
-		expect(Object.keys(kanaele.columns).sort()).toEqual(['channel', 'count', 'percentage']);
+		const kanaele = recordedQueries.find((eintrag) => 'channel' in eintrag.columns);
+		expect(kanaele, 'Meldekanal-Abfrage nicht gefunden').toBeDefined();
+		expect(Object.keys(kanaele!.columns).sort()).toEqual(['channel', 'count', 'percentage']);
 	});
 });
 


### PR DESCRIPTION
## Was

Zwei Lücken in der Admin-Statistik (`/admin/statistics`):

**1. Der Meldekanal wurde nirgends ausgewertet.** `eingangskanal` wird seit jeher gefüllt, und die Kanäle verteilen sich sehr ungleich — auf dem lokalen Stand: Web 11.003 (57 %), App 6.436 (33,4 %), E-Mail 1.278 (6,6 %), Telefon 462, Post 96, Fax 14. Neue Karte mit Anzahl und Anteil je Kanal.

**2. Abgelehnte Sichtungen kamen in keiner Zahl der Seite vor.** „Freigegeben" läuft über `approvedOnly()`, „noch offen" seit #800 über `openOnly()` — beide schließen sie aus. Auf dem lokalen Stand ergeben die zwei Kopfzahlen 19.948, die Tabelle hat 19.953; die Differenz waren die 5 Abgelehnten, und die Seite erklärte sie nicht. Sie stehen jetzt als dritte Angabe in der Kopfzeile, getrennt ausgewiesen und mit nichts summiert.

## Zwei Entscheidungen, die Erklärung brauchen

**Die Abgelehnten-Zahl läuft über `and(pendingOnly(), rejectedOnly())`, nicht über `rejectedOnly()` allein.** Drei Zahlen nebeneinander behaupten implizit eine Zerlegung des Bestands; eine Zeile mit beiden Stempeln stünde sonst in zweien davon. Im Bestand gibt es sie nicht (gemessen: 0), die Datenbank verbietet sie aber nicht. Nebeneffekt, der die Wahl zusätzlich trägt: Nur so hat die Abfrage einen erkennbaren Freigabebezug im SQL — mit `rejectedOnly()` allein wäre sie die erste Kennzahl der Seite ohne einen (Vorgabe 3 in `approvalFilter.ts`).

**Der Meldekanal trägt keinen Epoch-Ausschluss.** Das ist keine Kalenderauswertung, und die 280 Platzhalter-Zeilen sind sämtlich offen — ein Datumsfilter wäre eine Bedingung ohne Wirkung. Der Guard „Epoch-Ausschluss nur in den Kalenderauswertungen" hält beide Richtungen fest.

## Eine geänderte Testzeile

Der Wächter „noch offen schließt Abgelehnte aus" sammelte alle Abfragen mit `freigegeben_am IS NULL` und verlangte von jeder den `openOnly()`-Kern — die neue Abgelehnten-Abfrage fiel als Fehlalarm hinein. Sie ist jetzt über das positive `abgelehnt_am IS NOT NULL` ausgenommen. Der Wächter verliert dadurch nichts: `openOnly()` trägt `abgelehnt_am IS NULL`, ein versehentliches `pendingOnly()` trägt die Bedingung gar nicht — beide fallen weiterhin unter die Prüfung.

## Aus dem Review mitgenommen

`aria-hidden` an den drei Fortschrittsbalken der Seite (sie wiederholen die Prozentzahl daneben und wären sonst als unbenannte `progressbar` eine zweite Angabe derselben Zahl) und an den Trennpunkten der Kopfzeile — `design-system.md` verlangt das für bedeutungslose Zeichen. Die zwei vorbestehenden Balken der Datenqualität sind mitgezogen, weil eine halbe Umsetzung schlechter wäre als keine.

## Test-First

Drei Testblöcke vor der Implementierung geschrieben, jeweils rot gesehen:
- Meldekanal: Grundmenge und Spaltensatz
- Abgelehnte: Überschneidungsfreiheit, keine Verschmelzung mit den anderen Kopfzahlen
- beide neu in der Liste der Abfragen, die die Jahresauswahl tragen müssen

## Verifiziert

`npm run test:quick` grün (4429 Tests), `lint`/`type-check`/`svelte-check` sauber. Visuell gegen die lokale DB geprüft (Playwright, Admin-Session ohne Auth0): Karte rendert korrekt, Anteile summieren auf 100 %, Kopfzeile trägt die Jahresauswahl mit (2026: 11 / 26 / 4 · 2024: 1.068 / 14 / 0). Vorlesereihenfolge der Kopfzeile gegengeprüft — kein `progressbar`, keine Trennpunkte.

Die Abgelehnten-Zahl steht **auch bei 0** da: Wegzulassen, was gerade leer ist, macht das Fehlen zweideutig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)