### PR TITLE
feat(admin): status tabs, filter chips and url-driven filter state for the sightings table

### DIFF
--- a/docs/ADMIN_IMPROVEMENTS_SPEC.md
+++ b/docs/ADMIN_IMPROVEMENTS_SPEC.md
@@ -70,6 +70,33 @@ den Default zurück; SSR rendert ohne Fehler.
 (`columnPreferences.ts`) mit Unit-Tests (kaputtes JSON, unbekannte Schlüssel,
 neue Spalte).
 
+**Umgesetzt (2026-08-10)** in `src/routes/admin/sichtungen/columnPreferences.ts`
+plus Spalten-Dropdown in `+page.svelte`; Regressionstest in
+`tableColumns.svelte.test.ts`.
+
+Das Akzeptanzkriterium „Auswahl übersteht Reload" galt bis dahin **nicht** —
+und zwar nicht, weil die Persistenz fehlte, sondern weil sie nie lief. Der eine
+`$effect`, der schreiben sollte, kehrte in seinem ersten Durchlauf zurück,
+_bevor_ er `columnVisibility` gelesen hatte. Svelte 5 ermittelt die
+Abhängigkeiten eines Effekts aus den Werten, die er tatsächlich gelesen hat —
+der Effekt hatte damit gar keine, lief genau einmal und schrieb nie nach
+`localStorage`. Die Spalten fielen für jeden Bearbeiter bei jedem Reload auf den
+Default zurück, ohne dass irgendetwas brach. Drei Festlegungen aus der
+Umsetzung:
+
+- **Zwei Effekte statt einem.** Einer lädt (einmalig), einer schreibt (bei
+  Änderung). Die Trennung ist nicht Kosmetik: Sie ist die einzige Form, in der
+  der schreibende Effekt seinen Wert unbedingt liest und damit überhaupt
+  abonniert. Wer sie wieder zusammenlegt, stellt den Bug her.
+- **Der Lesezugriff steht vor jedem `return`.** Auch im getrennten Effekt gilt
+  das: Ein Guard oberhalb des `serializeColumnPreferences(columnVisibility)`
+  bringt denselben Fehler zurück, nur unauffälliger.
+- **Ein bloßer Seitenaufruf schreibt nichts.** Der Speicher wird erst berührt,
+  wenn der Bearbeiter etwas ändert (`letzterPersistierterStand`). Sonst würde
+  der Default beim ersten Besuch festgeschrieben, und eine spätere Änderung an
+  `DEFAULT_COLUMN_VISIBILITY` erreichte niemanden mehr, der die Seite je offen
+  hatte — `mergeColumnPreferences` behält gespeicherte Schlüssel.
+
 ### U3 — Suche über Sichtungen (**Follow-Up-Chip**)
 
 **Befund:** Es gibt keinen Weg, eine Sichtung per E-Mail, Name, Referenz-ID
@@ -241,6 +268,38 @@ Dezimalpunkt, direkt neben deutsch formatierten Zahlen (`19.284`).
 **Akzeptanz:** Alle Prozentwerte der Seite mit Komma; kein „Mortalität" mehr.
 **Tests:** `formatPercentage` als reine Funktion extrahieren + Unit-Tests
 (0, 9.2, 100, String-Input).
+
+---
+
+### X5 — Statusreiter, Filter-Chips und URL als einzige Filterquelle
+
+Nachgetragen aus dem UX-Review der Sichtungstabelle vom 2026-08-09; nicht Teil
+des ursprünglichen Reviews vom 2026-08-08.
+
+**Umgesetzt (2026-08-10)** in `activeFilters.ts`, `statusTabs.ts` /
+`StatusTabs.svelte` und `filterChips.ts`, jeweils neben `+page.svelte`; E2E in
+`e2e/admin-status-tabs.spec.ts`.
+
+- **Der Filterzustand steht ausschließlich in `page.url`.** `currentFilters` las
+  vorher nur `q` aus der URL und die übrigen sieben Filter aus dem Feld-State
+  des Panels. Wer ein Datum eintippte, nicht „Anwenden" klickte und dann
+  exportierte, exportierte eine Menge, die die Tabelle nie gezeigt hatte. Die
+  Feld-States sind seither reiner Editier-Puffer und speisen nur `applyFilters()`.
+- **Die Statusreiter zählen über die gefilterte Menge _ohne_ den Statusfilter
+  selbst** — sonst stünde auf jedem inaktiven Reiter eine 0. Die Bedingungen
+  kommen aus `approvalFilter.ts`; „offen" ist nicht ein zweites Mal formuliert.
+- **Die Reiter sind kein zweiter Zustand.** Sie schreiben denselben
+  `?verified=`-Parameter wie das `<select>` im Panel, das bewusst stehen bleibt.
+- **Chips zeigen keinen Status-Chip**, solange die Reiter eingebunden sind
+  (`skipVerified`) — der aktive Reiter sagt dasselbe bereits.
+- **Beschriftungen haben genau eine Quelle.** Chips, Reiter und die
+  `<option>`-Listen des Panels lesen aus denselben Presentation-Modulen;
+  `AUFNAHME_LABEL`/`MELDEART_LABEL` liegen in `filterChips.ts`, und das Panel
+  rendert daraus, statt die Wörter ein zweites Mal zu tippen.
+
+Bewusst **nicht** umgesetzt (Entscheidung aus dem Review): Löschen-Knopf in ein
+Overflow-Menü, Zeilenklick → Detail, „Springe zu Seite N", Schnellbereiche im
+Datumsfilter.
 
 ---
 

--- a/e2e/admin-status-tabs.spec.ts
+++ b/e2e/admin-status-tabs.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { seedAdminSession } from './helpers/adminSession';
+
+/**
+ * admin-status-tabs.spec.ts — Statusleiste über der Sichtungstabelle (WP2).
+ *
+ * Die Komponente selbst ist in `src/routes/admin/sichtungen/statusTabs.svelte.test.ts`
+ * abgedeckt (Beschriftung, `aria-current`, gemeldeter Wert), die Zähler-Query in
+ * `page.server.test.ts`. Hier läuft nur die Strecke, die dort nicht prüfbar ist:
+ * dass ein Klick die URL wirklich setzt und wieder räumt, dass Leiste und
+ * Panel-`<select>` denselben Stand zeigen (beide lesen die URL), und dass die
+ * Zahl auf dem Reiter die Trefferzahl der Ansicht dahinter ist.
+ */
+
+function statusReiter(page: Page, name: RegExp): Locator {
+	return page
+		.getByRole('navigation', { name: 'Status der Sichtungen' })
+		.getByRole('button', { name });
+}
+
+/**
+ * Klickt einen Reiter und wartet auf die erwartete URL.
+ *
+ * In `toPass`, nicht direkt: Die Leiste kommt aus dem SSR-Durchlauf und ist
+ * klickbar, **bevor** die Hydration ihren `onclick` angehängt hat. Ein einzelner
+ * Klick landet dann im Leeren — und der Fehlschlag sähe nach einem kaputten
+ * Feature aus statt nach einem Timing-Problem. Gleiche Begründung wie in
+ * `admin-filter-presets.spec.ts`.
+ */
+async function reiterKlicken(page: Page, name: RegExp, ziel: RegExp | ((url: URL) => boolean)) {
+	await expect(async () => {
+		await statusReiter(page, name).click();
+		await expect(page).toHaveURL(ziel, { timeout: 1000 });
+	}).toPass();
+}
+
+test.describe('Admin-Sichtungstabelle — Statusleiste', () => {
+	test.beforeEach(async ({ context, baseURL }) => {
+		await seedAdminSession(context, baseURL!, ['admin']);
+	});
+
+	test('setzt und räumt den Statusfilter ohne das Filter-Panel', async ({ page }) => {
+		await page.goto('/admin/sichtungen');
+
+		// „Alle" ist der Ausgangszustand — ohne `?verified=` in der URL.
+		await expect(statusReiter(page, /Alle/)).toHaveAttribute('aria-current', 'true');
+
+		await reiterKlicken(page, /Offen/, /verified=open/);
+		await expect(page).toHaveURL(/page=1/);
+		await expect(statusReiter(page, /Offen/)).toHaveAttribute('aria-current', 'true');
+		await expect(statusReiter(page, /Alle/)).not.toHaveAttribute('aria-current', 'true');
+
+		// Zurück auf „Alle" heißt: Der Parameter verschwindet, er wird nicht auf
+		// einen Leerwert gesetzt.
+		await reiterKlicken(page, /Alle/, (url) => !url.searchParams.has('verified'));
+		await expect(statusReiter(page, /Alle/)).toHaveAttribute('aria-current', 'true');
+	});
+
+	test('zeigt im Panel denselben Stand wie die Leiste', async ({ page }) => {
+		await page.goto('/admin/sichtungen?verified=rejected');
+
+		await expect(statusReiter(page, /Abgelehnt/)).toHaveAttribute('aria-current', 'true');
+
+		/* Den Filter-Knopf gibt es zweimal im DOM — kompakter und weiter Kopf sind
+		   nur per CSS getrennt. `filter({ visible: true })` nimmt den des aktuellen
+		   Layouts, statt an der Strict-Mode-Verletzung zu scheitern. Der Klick läuft
+		   in `toPass`, weil das Panel an Client-State hängt: Vor der Hydration
+		   bewirkt er nichts (Begründung wie bei `reiterKlicken`).
+
+		   Das `<select>` über seine `id` und nicht über `getByLabel('Status')`: Das
+		   Wort steht auf dieser Seite auch an der Leiste selbst und an jedem
+		   Segmented Control einer Zeile — die Abfrage träfe ein Dutzend Elemente. */
+		const statusAuswahl = page.locator('select#verified');
+		await expect(async () => {
+			await page
+				.getByRole('button', { name: /^Filter/ })
+				.filter({ visible: true })
+				.click();
+			await expect(statusAuswahl).toBeVisible({ timeout: 1000 });
+		}).toPass();
+		await expect(statusAuswahl).toHaveValue('rejected');
+	});
+
+	test('nennt auf dem Reiter die Trefferzahl der Ansicht dahinter', async ({ page }) => {
+		await page.goto('/admin/sichtungen');
+
+		const reiter = statusReiter(page, /Offen/);
+		const angekuendigt = Number((await reiter.locator('.badge').innerText()).trim());
+
+		await reiterKlicken(page, /Offen/, /verified=open/);
+
+		/* Die Zahl unter der Tabelle ist `pagination.total` — dieselbe Menge, die
+		   der Reiter angekündigt hat. Weichen sie ab, zählt die Reiter-Query eine
+		   andere Grundmenge als die Liste. */
+		await expect(page.getByText(`${angekuendigt} Einträge`)).toBeVisible();
+	});
+});

--- a/e2e/admin-status-tabs.spec.ts
+++ b/e2e/admin-status-tabs.spec.ts
@@ -84,14 +84,18 @@ test.describe('Admin-Sichtungstabelle — Statusleiste', () => {
 	test('nennt auf dem Reiter die Trefferzahl der Ansicht dahinter', async ({ page }) => {
 		await page.goto('/admin/sichtungen');
 
-		const reiter = statusReiter(page, /Offen/);
-		const angekuendigt = Number((await reiter.locator('.badge').innerText()).trim());
-
 		await reiterKlicken(page, /Offen/, /verified=open/);
 
-		/* Die Zahl unter der Tabelle ist `pagination.total` — dieselbe Menge, die
-		   der Reiter angekündigt hat. Weichen sie ab, zählt die Reiter-Query eine
-		   andere Grundmenge als die Liste. */
+		/* Beide Zahlen aus demselben gerenderten Zustand lesen — Datenbank und
+		   `uploads/` sind zwischen Worktrees geteilt (docs/WORKTREES.md), und
+		   parallel laufende Specs seeden/löschen Sichtungen. Ein Vorher-Nachher-
+		   Vergleich (Badge vor dem Klick, Gesamtzahl danach) verglich damit
+		   gelegentlich zwei verschiedene Zeitpunkte und schlug spurios fehl. Die
+		   Zahl unter der Tabelle ist `pagination.total` — dieselbe Menge, die der
+		   Reiter für die Ansicht ankündigt. Weichen sie ab, zählt die Reiter-Query
+		   eine andere Grundmenge als die Liste. */
+		const reiter = statusReiter(page, /Offen/);
+		const angekuendigt = Number((await reiter.getByTestId('status-tab-count').innerText()).trim());
 		await expect(page.getByText(`${angekuendigt} Einträge`)).toBeVisible();
 	});
 });

--- a/scripts/e2e-shards.sh
+++ b/scripts/e2e-shards.sh
@@ -137,6 +137,12 @@ form=(
 	# ~12 s; die Presets liegen in `localStorage`, der Spec räumt sie
 	# in `beforeEach` selbst ab und braucht keine Testzeilen in der DB.
 	e2e/admin-filter-presets.spec.ts
+	# Direkt beim Preset-Spec darüber: dieselbe Route (/admin/sichtungen),
+	# dieselbe Leiste über der Tabelle, kein eigener Seed — der Spec liest
+	# nur, was der Bestand hergibt. Der Kaltkompilier-Aufschlag der Route
+	# ist damit längst bezahlt. Lokal 3 Tests, ~10 s. Nicht nach `smoke`:
+	# der ist laut der Messung oben mit 249–271 s der längste Shard.
+	e2e/admin-status-tabs.spec.ts
 	# Hover-Übergänge von .card/.btn. Thematisch stünde der Spec bei
 	# design-tokens.spec.ts in `smoke` — er prüft das Design System,
 	# nicht das Formular. Er kommt trotzdem hierher, weil der Hinweis

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -21,6 +21,7 @@
 	import ChevronLeft from '~icons/lucide/chevron-left';
 	import ChevronRight from '~icons/lucide/chevron-right';
 	import ChevronUp from '~icons/lucide/chevron-up';
+	import ChevronsUpDown from '~icons/lucide/chevrons-up-down';
 	import CircleAlert from '~icons/lucide/circle-alert';
 	import CircleCheck from '~icons/lucide/circle-check';
 	import CircleHelp from '~icons/lucide/circle-help';
@@ -139,6 +140,7 @@
 		'lucide:chevron-left': ChevronLeft,
 		'lucide:chevron-right': ChevronRight,
 		'lucide:chevron-up': ChevronUp,
+		'lucide:chevrons-up-down': ChevronsUpDown,
 		'lucide:filter': Filter,
 		'lucide:download': Download,
 		'lucide:code': Code,

--- a/src/lib/components/admin/exportFilterDisplay.test.ts
+++ b/src/lib/components/admin/exportFilterDisplay.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from 'vitest';
+import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
 import { getActiveFiltersDisplay } from './exportFilterDisplay';
 
 describe('getActiveFiltersDisplay', () => {
 	it('meldet ohne Filter „Keine Filter aktiv"', () => {
 		expect(getActiveFiltersDisplay({})).toEqual(['Keine Filter aktiv']);
+	});
+
+	// WP4: „Von"/„Bis" nannten kein Bezugsfeld. Der Export-Dialog beschreibt
+	// dieselben Filter wie das Panel und Filter-Chips (+page.svelte,
+	// filterChips.ts) und muss deshalb dasselbe Wort benutzen —
+	// „Sichtung von"/„Sichtung bis", da der Bereich serverseitig das
+	// Sichtungsdatum filtert (`sightingCalendarDate`).
+	it('benennt den Datumsfilter nach dem Sichtungsdatum', () => {
+		expect(getActiveFiltersDisplay({ fromDate: '2026-06-01' })).toEqual([
+			`Sichtung von: ${formatWallClockDateTime('2026-06-01')}`
+		]);
+		expect(getActiveFiltersDisplay({ toDate: '2026-06-30' })).toEqual([
+			`Sichtung bis: ${formatWallClockDateTime('2026-06-30')}`
+		]);
 	});
 
 	it('zeigt den Suchbegriff an', () => {

--- a/src/lib/components/admin/exportFilterDisplay.ts
+++ b/src/lib/components/admin/exportFilterDisplay.ts
@@ -35,10 +35,14 @@ export function getActiveFiltersDisplay(
 	// ohne Date-Objekt (sonst bestimmt die Browser-Zone den Tag mit, bis zu
 	// ±1 Tag).
 	if (currentFilters.fromDate) {
-		filterDisplays.push(`Von: ${formatWallClockDateTime(currentFilters.fromDate as string)}`);
+		filterDisplays.push(
+			`Sichtung von: ${formatWallClockDateTime(currentFilters.fromDate as string)}`
+		);
 	}
 	if (currentFilters.toDate) {
-		filterDisplays.push(`Bis: ${formatWallClockDateTime(currentFilters.toDate as string)}`);
+		filterDisplays.push(
+			`Sichtung bis: ${formatWallClockDateTime(currentFilters.toDate as string)}`
+		);
 	}
 	const statusFilter = normalizeStatusParam(currentFilters.verified as string | null);
 	if (statusFilter) {

--- a/src/routes/admin/sichtungen/+page.server.ts
+++ b/src/routes/admin/sichtungen/+page.server.ts
@@ -5,6 +5,7 @@ import { mediaUploadCondition } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
 import { searchCondition, normalizeSearchTerm } from '$lib/server/db/sightingSearchFilter';
+import { approvedOnly, openOnly, rejectedOnly } from '$lib/server/db/approvalFilter';
 import { and, eq, sql, type SQL } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 import { redirect } from '@sveltejs/kit';
@@ -15,6 +16,7 @@ import { isValidDateParam } from './dateParam';
 import { SIGHTING_LIST_COLUMNS } from './listColumns';
 import { resolveSort, type SortColumn } from './sortParams';
 import { statusCondition } from './statusFilter';
+import type { StatusCounts } from './statusTabs';
 
 export const load: PageServerLoad = async ({ url }) => {
 	const page = Math.max(1, Number(url.searchParams.get('page')) || 1);
@@ -101,12 +103,20 @@ export const load: PageServerLoad = async ({ url }) => {
 	}
 
 	// Kombinierte WHERE-Bedingung erstellen
-	const whereCondition =
-		conditions.length > 0
-			? conditions.length === 1
-				? conditions[0]
-				: and(...conditions)
-			: undefined;
+	const kombiniere = (liste: SQL[]): SQL | undefined =>
+		liste.length === 0 ? undefined : liste.length === 1 ? liste[0] : and(...liste);
+
+	const whereCondition = kombiniere(conditions);
+
+	// Grundmenge der Statusreiter: dieselben Filter **ohne** den Statusfilter
+	// selbst. Zählte er mit, stünde auf jedem inaktiven Reiter eine 0 — die
+	// Leiste soll aber gerade sagen, wie viel hinter den anderen Reitern liegt.
+	// Herausgefiltert wird die Bedingung, statt sie in einer zweiten Liste
+	// nachzubauen: So bleibt die Reihenfolge der übrigen Bedingungen dieselbe
+	// wie in der Hauptabfrage.
+	const statusCountsWhere = kombiniere(
+		conditions.filter((condition) => condition !== statusFilter)
+	);
 
 	// Sortierungs-Mapping. Als `Record<SortColumn, …>` typisiert: Die Liste der
 	// sortierbaren Spalten steht in `sortParams.ts` und speist auch die
@@ -173,6 +183,23 @@ export const load: PageServerLoad = async ({ url }) => {
 	// WHERE-Klausel zur Count-Abfrage hinzufügen
 	const countQuery = whereCondition ? countBaseQuery.where(whereCondition) : countBaseQuery;
 
+	// Zähler der Statusreiter — eine Abfrage mit bedingten Aggregaten statt drei
+	// Rundreisen. Die Prädikate kommen aus `approvalFilter.ts`, also aus
+	// derselben Quelle wie `statusCondition()` oben: Reiterzahl und
+	// Trefferliste können damit nicht auseinanderlaufen.
+	const statusCountsBaseQuery = db
+		.select({
+			all: sql<number>`count(*)`,
+			open: sql<number>`count(*) filter (where ${openOnly()})`,
+			approved: sql<number>`count(*) filter (where ${approvedOnly()})`,
+			rejected: sql<number>`count(*) filter (where ${rejectedOnly()})`
+		})
+		.from(sightings);
+
+	const statusCountsQuery = statusCountsWhere
+		? statusCountsBaseQuery.where(statusCountsWhere)
+		: statusCountsBaseQuery;
+
 	// Abfragen ausführen — voneinander unabhängig, deshalb parallel statt
 	// sequenziell (zwei Round-Trips gleichzeitig statt hintereinander).
 	//
@@ -180,12 +207,27 @@ export const load: PageServerLoad = async ({ url }) => {
 	// Knopf im Kopf entfallen (Begründung in `+page.svelte`): Er kostete auf
 	// jedem Seitenaufruf dieser Tabelle eine eigene Abfrage über den gesamten
 	// Bestand, für eine Zahl, die der Eingang ohnehin führt.
-	const [data, countResult] = await Promise.all([paginatedQuery, countQuery]);
+	const [data, countResult, statusCountsResult] = await Promise.all([
+		paginatedQuery,
+		countQuery,
+		statusCountsQuery
+	]);
 	// `count(*)` ist bigint und kommt je nach PG-Treiber als String zurück. Der
 	// Loader-Vertrag sagt `number`, also wird hier normalisiert und nicht in
 	// jeder Aufrufstelle einzeln: `"1" === 1` ist falsch und ergab in der
 	// Kopfzeile „1 Fotos ausstehend".
 	const count = Number(countResult[0]?.count ?? 0);
+
+	// Dieselbe bigint-Falle wie beim Pagination-Zähler: `count(*) filter (…)`
+	// kommt je nach Treiber als String, und `'7' === 7` ist falsch. Der
+	// Loader-Vertrag sagt `number`, also wird hier normalisiert.
+	const statusCountsRow = statusCountsResult[0];
+	const statusCounts: StatusCounts = {
+		all: Number(statusCountsRow?.all ?? 0),
+		open: Number(statusCountsRow?.open ?? 0),
+		approved: Number(statusCountsRow?.approved ?? 0),
+		rejected: Number(statusCountsRow?.rejected ?? 0)
+	};
 
 	// Wer eine ganze Referenz-ID einfügt (aus einer Bestätigungsmail, einer
 	// Rückfrage), will die Sichtung sehen — nicht eine Trefferliste mit einer
@@ -222,6 +264,7 @@ export const load: PageServerLoad = async ({ url }) => {
 
 	return {
 		sightings: data,
+		statusCounts,
 		pagination: {
 			page,
 			perPage,

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -913,8 +913,16 @@
 						<Icon icon="lucide:x" class="h-4 w-4" />
 					</button>
 				</div>
-				<!-- Kein `sm:grid-cols-2`: `sm` ist keine Layout-Grenze (Breakpoint-Vertrag). -->
-				<div class="grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6">
+				<!-- Kein `sm:grid-cols-2`: `sm` ist keine Layout-Grenze (Breakpoint-Vertrag).
+
+				     Vier statt sechs Spalten auf `lg`, zwei statt drei auf `md`: Es sind
+				     sieben Felder. Im Sechser-Raster stand „Ostsee" allein in der zweiten
+				     Zeile und ließ fünf Zellen leer; bei drei Spalten blieb es dieselbe
+				     Waise. Teilerfremd zu 7 ist jede Spaltenzahl — aber bei vier bzw. zwei
+				     bleibt genau EINE Lücke statt fünf, und sie liegt am Zeilenende direkt
+				     über den Knöpfen, wo sie als Abstand liest statt als Loch. Nebenbei
+				     werden die Felder breiter, was den Datumsfeldern zugutekommt. -->
+				<div class="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-4">
 					<div class="fieldset w-full">
 						<label for="fromDate" class="label py-0">
 							<span class="text-support">Sichtung von</span>
@@ -946,7 +954,7 @@
 						<select
 							id="verified"
 							name="verified"
-							class="select select-sm w-full text-sm"
+							class="select select-sm w-full"
 							bind:value={verified}
 						>
 							<option value="">Alle</option>
@@ -962,7 +970,7 @@
 						<select
 							id="deadFinding"
 							name="deadFinding"
-							class="select select-sm w-full text-sm"
+							class="select select-sm w-full"
 							bind:value={deadFinding}
 						>
 							<option value="">Alle</option>
@@ -977,7 +985,7 @@
 						<select
 							id="entryChannel"
 							name="entryChannel"
-							class="select select-sm w-full text-sm"
+							class="select select-sm w-full"
 							bind:value={selectedChannel}
 						>
 							<option value="all">Alle</option>
@@ -993,7 +1001,7 @@
 						<select
 							id="mediaUpload"
 							name="mediaUpload"
-							class="select select-sm w-full text-sm"
+							class="select select-sm w-full"
 							bind:value={mediaUpload}
 						>
 							<option value="">Alle</option>
@@ -1011,7 +1019,7 @@
 						<select
 							id="balticSea"
 							name="balticSea"
-							class="select select-sm w-full text-sm"
+							class="select select-sm w-full"
 							bind:value={balticSea}
 						>
 							<option value="">Alle</option>
@@ -1093,7 +1101,13 @@
 					placeholder="Referenz-ID, E-Mail, Name oder Fahrwasser"
 				/>
 			</label>
-			<button type="submit" class="btn btn-sm btn-outline">Suchen</button>
+			<!-- Kein `btn-sm`: Das Feld daneben trägt seit dem Höhenabgleich 16px Schrift
+			     (`app.css` setzt `.input/.select/.textarea` ungelayert auf `--text-body`
+			     und schlägt damit jeden DaisyUI-Größenmodifier). `btn-sm` brächte 12px —
+			     der Knopf sähe neben dem Feld kleiner aus, als er ist. Die Höhe ändert
+			     sich dadurch nicht: beide standen schon auf den 44px aus dem
+			     Touch-Target-Block. -->
+			<button type="submit" class="btn btn-outline">Suchen</button>
 		</form>
 
 		<!--

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -29,7 +29,8 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
-	import { hasActiveFilters as hatAktiveFilter, readFilterParams } from './activeFilters';
+	import { readFilterParams, type FilterParams } from './activeFilters';
+	import { buildFilterChips, removeFilterParam } from './filterChips';
 	import SichtungenCards from './SichtungenCards.svelte';
 	import StatusTabs from './StatusTabs.svelte';
 	import type { StatusTabValue } from './statusTabs';
@@ -72,7 +73,10 @@
 	   Steht bewusst vor den Feld-States: Sie initialisieren sich daraus, statt die
 	   URL ein zweites Mal selbst zu lesen. */
 	let currentFilters = $derived(readFilterParams(page.url.searchParams));
-	let hasActiveFilters = $derived(hatAktiveFilter(currentFilters));
+	/* `skipVerified`, solange die Statusreiter über der Tabelle stehen: Der
+	   aktive Reiter zeigt den Status bereits — ein Status-Chip daneben wäre ein
+	   zweites Bedienelement für dieselbe Aussage. */
+	let filterChips = $derived(buildFilterChips(currentFilters, { skipVerified: true }));
 
 	/* Startwerte des Editier-Puffers. Der `$effect` weiter unten, der ihn nach
 	   einer Navigation nachzieht, läuft im SSR-Durchlauf nicht; ohne diese
@@ -335,9 +339,8 @@
 		// ohnehin (normalizeSearchTerm). Der getrimmte Wert geht zurück in den
 		// State, nicht nur in die URL: Sonst zeigte das Feld nach dem Suchen
 		// weiter die ungetrimmte Eingabe, und ein Feld aus lauter Leerzeichen
-		// zählte in `hasActiveFilters` als aktiver Filter — die
-		// Filter-Schaltfläche stünde markiert da, während die URL gar keine
-		// Suche trägt.
+		// zählte als aktiver Filter — es stünde ein Chip „Suche: ‚   '" über der
+		// Tabelle, während die URL gar keine Suche trägt.
 		searchTerm = searchTerm.trim();
 		if (searchTerm) url.searchParams.set('q', searchTerm);
 		else url.searchParams.delete('q');
@@ -391,6 +394,16 @@
 		else url.searchParams.delete('verified');
 		url.searchParams.set('page', '1');
 		goto(url);
+	}
+
+	/**
+	 * Einen einzelnen Filter über seinen Chip zurücknehmen. Dieselbe Bauform wie
+	 * `selectStatus()` und `applyFilters()` — URL abwandeln, `page=1`, `goto` —,
+	 * damit nicht ein zweiter Navigationsweg neben ihnen entsteht; die Rechnung
+	 * selbst steht in `filterChips.ts` und ist dort geprüft.
+	 */
+	function filterEntfernen(param: keyof FilterParams): void {
+		goto(removeFilterParam(page.url, param));
 	}
 
 	function changePage(newPage: number): void {
@@ -694,20 +707,22 @@
 			<h1 class="text-display font-bold">Sichtungen</h1>
 			<div class="flex flex-col gap-2">
 				<div class="flex items-center gap-2">
+					<!-- Zwei Zustände statt drei: offen (`btn-accent`) oder zu (`btn-outline`).
+					     Der frühere `btn-primary`-Zustand „es ist gefiltert" und der
+					     Punkt-Badge daneben sind entfallen — die Chip-Zeile darunter sagt
+					     jetzt, WAS gefiltert ist, und sie steht in jeder Breite da. Das
+					     Punkt-Badge auf Mobil zu behalten hieße, dieselbe Aussage zweimal
+					     zu machen, und zwar in der schwächeren Fassung: Es benennt keinen
+					     Filter und lässt sich nicht anklicken. Die Chip-Zeile bricht um
+					     statt zu scrollen; sie braucht auf schmalen Geräten mehr Höhe,
+					     kostet aber keine Bedienbarkeit. -->
 					<button
-						class="btn btn-sm flex-1 {isFilterPanelOpen
-							? 'btn-accent'
-							: hasActiveFilters
-								? 'btn-primary'
-								: 'btn-outline'}"
+						class="btn btn-sm flex-1 {isFilterPanelOpen ? 'btn-accent' : 'btn-outline'}"
 						onclick={() => (isFilterPanelOpen = !isFilterPanelOpen)}
 						title="Filter ein-/ausblenden"
 					>
 						<Icon icon="lucide:filter" class="mr-1 h-4 w-4" />
 						Filter
-						{#if hasActiveFilters}
-							<span class="badge badge-accent badge-sm ml-1">•</span>
-						{/if}
 					</button>
 					<button
 						class="btn btn-sm btn-primary flex-1"
@@ -774,20 +789,14 @@
 						</div>
 					</div>
 				</details>
+				<!-- Zwei Zustände, Begründung am Mobil-Zwilling weiter oben. -->
 				<button
-					class="btn btn-sm {isFilterPanelOpen
-						? 'btn-accent'
-						: hasActiveFilters
-							? 'btn-primary'
-							: 'btn-outline'}"
+					class="btn btn-sm {isFilterPanelOpen ? 'btn-accent' : 'btn-outline'}"
 					onclick={() => (isFilterPanelOpen = !isFilterPanelOpen)}
 					title="Filter ein-/ausblenden"
 				>
 					<Icon icon="lucide:filter" class="mr-1 h-4 w-4" />
 					Filter
-					{#if hasActiveFilters}
-						<span class="badge badge-accent badge-sm ml-1">•</span>
-					{/if}
 				</button>
 				<button
 					class="btn btn-sm btn-primary"
@@ -969,6 +978,53 @@
 				</button>
 			{/if}
 		</div>
+
+		<!--
+			Aktive Filter (WP3). Unter den Ansichten und über den Statusreitern: Was
+			gefiltert ist, gehört neben die Menge, die es beschreibt — nicht in ein
+			Panel, das man dafür aufklappen muss.
+
+			Echte `btn` statt `badge`, gleiche Begründung wie bei den Ansichten-Chips
+			darüber: Nur `.btn` bekommt über app.css die 44px-Touch-Target-
+			Mindestgröße (design-system.md, „Feldmodus und Touch-Targets").
+
+			`btn-outline` und keine Vollton-Fläche: Die einzige Vollton-Fläche dieses
+			Bereichs ist die aktive Ansicht bzw. der aktive Statusreiter
+			(Button-Hierarchie). Ein Chip ist eine Nebenaktion.
+
+			Die Beschriftung steht im Knopf, das Entfernen sagt das `aria-label` —
+			sonst läse ein Screenreader nur „Von 01.06.2026" und nichts darüber, was
+			ein Klick bewirkt. Das `x`-Icon ist deshalb `aria-hidden`.
+
+			Kein Status-Chip: `filterChips` wird mit `skipVerified` gebaut, der aktive
+			Statusreiter direkt darunter zeigt ihn bereits.
+		-->
+		{#if filterChips.length > 0}
+			<div class="mt-3 flex flex-wrap items-center gap-2">
+				<span class="text-support text-base-content/70">Aktive Filter:</span>
+
+				{#each filterChips as chip (chip.param)}
+					<button
+						type="button"
+						class="btn btn-sm btn-outline"
+						aria-label="Filter {chip.label} entfernen"
+						onclick={() => filterEntfernen(chip.param)}
+					>
+						{chip.label}
+						<Icon icon="lucide:x" class="h-4 w-4" aria-hidden="true" />
+					</button>
+				{/each}
+
+				<!-- Erst ab zwei Chips: Bei einem einzigen Filter ist der Chip selbst
+				     schon der Weg zurück, und ein zweiter Knopf daneben verdoppelte
+				     dieselbe Handlung. -->
+				{#if filterChips.length >= 2}
+					<button type="button" class="btn btn-sm btn-ghost" onclick={resetFilters}>
+						Alle Filter zurücksetzen
+					</button>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	<!-- Filter Panel.

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -1368,10 +1368,17 @@
 			     worüber entschieden wird (WCAG 4.1.2). Es war die einzige Stelle im
 			     Admin ohne zugänglichen Namen. -->
 			<label class="text-sm font-medium" for="perPage">Einträge pro Seite:</label>
+			<!-- Weder `text-sm` noch `min-h-8`: Beide waren wirkungslos und damit tote
+			     Utility-Klassen (design-system.md). `app.css` setzt `.input/.select/.textarea`
+			     ungelayert auf `--text-body` und schlägt jeden Schriftgrößen-Modifier — das
+			     Feld misst mit und ohne `text-sm` 16px. Und `.select` bezieht seine Höhe aus
+			     `--size`, das `select-sm` auf 2rem stellt; die `min-height` von `min-h-8` traf
+			     denselben Wert und konnte nie greifen. `select-sm` bleibt: Es wirkt als
+			     einziges der drei (ohne es misst das Feld 40 statt 32px). -->
 			<select
 				id="perPage"
 				name="perPage"
-				class="select select-sm min-h-8 text-sm"
+				class="select select-sm"
 				onchange={(e) => changeItemsPerPage(Number(e.currentTarget.value))}
 			>
 				{#each [10, 20, 50, 100].filter((size) => size <= (data.pagination?.maxPerPage || 50)) as size (size)}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -30,7 +30,12 @@
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 	import { readFilterParams, type FilterParams } from './activeFilters';
-	import { buildFilterChips, removeFilterParam } from './filterChips';
+	import {
+		AUFNAHME_LABEL,
+		buildFilterChips,
+		MELDEART_LABEL,
+		removeFilterParam
+	} from './filterChips';
 	import SichtungenCards from './SichtungenCards.svelte';
 	import StatusTabs from './StatusTabs.svelte';
 	import type { StatusTabValue } from './statusTabs';
@@ -1105,7 +1110,7 @@
 					>
 						<option value="">Alle</option>
 						<option value="1">{DEAD_FINDING_PRESENTATION.label}</option>
-						<option value="0">Lebendsichtung</option>
+						<option value="0">{MELDEART_LABEL['0']}</option>
 					</select>
 				</div>
 				<div class="fieldset w-full">
@@ -1135,9 +1140,11 @@
 						bind:value={mediaUpload}
 					>
 						<option value="">Alle</option>
-						<option value="1">Mit</option>
-						<option value="0">Ohne</option>
-						<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}>Angekündigt, fehlt noch</option>
+						<option value="1">{AUFNAHME_LABEL['1']}</option>
+						<option value="0">{AUFNAHME_LABEL['0']}</option>
+						<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}
+							>{AUFNAHME_LABEL[MEDIA_UPLOAD_ANNOUNCED_MISSING]}</option
+						>
 					</select>
 				</div>
 				<div class="fieldset w-full">

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -129,6 +129,11 @@
 	   `columnPreferences.ts`. */
 	let columnVisibility = $state({ ...DEFAULT_COLUMN_VISIBILITY });
 	let hatGespeicherteSpaltenGeladen = false;
+	/* Serialisierter Stand, den der Lade-Effekt zuletzt gesehen hat (geladener
+	   Wert oder unveränderter Default). Der Speicher-Effekt vergleicht dagegen
+	   und überspringt den Schreibvorgang, solange sich nichts geändert hat —
+	   siehe Begründung dort. */
+	let letzterPersistierterStand: string | null = null;
 	let istSpaltenauswahlDefault = $derived(
 		isDefaultVisibility(columnVisibility, DEFAULT_COLUMN_VISIBILITY)
 	);
@@ -157,6 +162,12 @@
 		} catch (err) {
 			logger.warn({ err }, 'Gespeicherte Spaltenauswahl kann nicht gelesen werden');
 		} finally {
+			// Merkt sich den geladenen (oder mangels Storage unveränderten
+			// Default-)Stand, damit der Speicher-Effekt seinen ersten Durchlauf
+			// nicht sofort wieder zurückschreibt (Fix-Runde 2: genau das
+			// passierte vorher bei jedem Seitenaufruf, siehe dortiger
+			// Kommentar).
+			letzterPersistierterStand = serializeColumnPreferences(columnVisibility);
 			hatGespeicherteSpaltenGeladen = true;
 		}
 	});
@@ -175,15 +186,27 @@
 		   bliebe für immer stumm, egal in welcher Reihenfolge die Effekte
 		   künftig stehen. Genau das war der Bug, der die Aufspaltung oben nötig
 		   gemacht hat; ihn hier wieder einzuführen wäre derselbe Fehler eine
-		   Ebene tiefer. */
+		   Ebene tiefer.
+
+		   Zweiter Guard unten (`serialisiert === letzterPersistierterStand`):
+		   Weil `hatGespeicherteSpaltenGeladen` beim Laden bereits synchron auf
+		   `true` steht, passiert dieser Effekt den ersten Guard schon bei
+		   seinem allerersten Durchlauf — ohne den Vergleich schriebe er den
+		   gerade erst geladenen (oder unveränderten Default-)Stand sofort
+		   zurück nach `localStorage`, bei jedem Seitenaufruf, nicht nur bei
+		   einer tatsächlichen Änderung. Da `mergeColumnPreferences` jeden
+		   gespeicherten Schlüssel für immer beibehält, hätte das eine spätere
+		   Änderung von `DEFAULT_COLUMN_VISIBILITY` nie wieder erreicht. */
 		const serialisiert = serializeColumnPreferences(columnVisibility);
 		if (typeof window === 'undefined' || !hatGespeicherteSpaltenGeladen) return;
+		if (serialisiert === letzterPersistierterStand) return;
 		// Jede Änderung (Checkbox im „Spalten"-Dropdown, „Standard
 		// wiederherstellen") wird persistiert. `try/catch`, weil `setItem`
 		// werfen kann (volle Quota, Safari im privaten Modus) — die
 		// Spaltenauswahl ist eine Bequemlichkeit, kein Grund zum Absturz.
 		try {
 			window.localStorage.setItem(COLUMN_PREFERENCES_STORAGE_KEY, serialisiert);
+			letzterPersistierterStand = serialisiert;
 		} catch (err) {
 			logger.warn(
 				{ err },

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -44,6 +44,7 @@
 	import { NUR_KOMPAKT, NUR_WEIT_FLEX } from './layoutSwitch';
 	import {
 		COLUMN_PREFERENCES_STORAGE_KEY,
+		isDefaultVisibility,
 		loadColumnPreferences,
 		serializeColumnPreferences
 	} from './columnPreferences';
@@ -128,26 +129,45 @@
 	   `columnPreferences.ts`. */
 	let columnVisibility = $state({ ...DEFAULT_COLUMN_VISIBILITY });
 	let hatGespeicherteSpaltenGeladen = false;
+	let istSpaltenauswahlDefault = $derived(
+		isDefaultVisibility(columnVisibility, DEFAULT_COLUMN_VISIBILITY)
+	);
+
+	/* Zwei getrennte Effekte statt einem: Ein einzelner `$effect`, der beim
+	   ersten Durchlauf per `return` aussteigt, OHNE `columnVisibility` zu
+	   *lesen* (nur zu schreiben), trackt diese Abhängigkeit nie — Svelte
+	   ermittelt die Abhängigkeiten eines Effekts aus den in seinem letzten
+	   Durchlauf gelesenen reaktiven Werten. Der Effekt liefe dadurch nach dem
+	   Laden genau einmal und nie wieder, egal wie oft `columnVisibility`
+	   danach per Checkbox oder „Standard wiederherstellen" geändert wird —
+	   beobachtet beim manuellen Nachstellen des WP7-Buttons (Browser-Check,
+	   `localStorage` blieb nach mehreren Änderungen durchgehend leer). Mit
+	   getrennten Effekten liest der Speicher-Effekt `columnVisibility` in
+	   jedem Durchlauf und bleibt damit dauerhaft abonniert. */
+	$effect(() => {
+		if (typeof window === 'undefined' || hatGespeicherteSpaltenGeladen) return;
+		try {
+			// Einmaliges Laden beim Mount. Kaputtes/altes JSON und unbekannte
+			// Schlüssel fallen in `loadColumnPreferences` still auf den Default
+			// zurück; neue Spalten erscheinen mit ihrem eigenen Default-Wert.
+			columnVisibility = loadColumnPreferences(
+				window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY),
+				DEFAULT_COLUMN_VISIBILITY
+			);
+		} catch (err) {
+			logger.warn({ err }, 'Gespeicherte Spaltenauswahl kann nicht gelesen werden');
+		} finally {
+			hatGespeicherteSpaltenGeladen = true;
+		}
+	});
 
 	$effect(() => {
-		if (typeof window === 'undefined') return;
-		/* try/catch um beide Zugriffe: `localStorage` selbst kann werfen
-		   (Storage per Policy deaktiviert → SecurityError) und `setItem`
-		   ebenso (volle Quota, Safari im privaten Modus). Die Spaltenauswahl
-		   ist eine Bequemlichkeit — ohne Storage läuft die Seite einfach ohne
-		   Persistenz weiter, statt beim Hydratisieren zu crashen. */
+		if (typeof window === 'undefined' || !hatGespeicherteSpaltenGeladen) return;
+		// Jede Änderung (Checkbox im „Spalten"-Dropdown, „Standard
+		// wiederherstellen") wird persistiert. `try/catch`, weil `setItem`
+		// werfen kann (volle Quota, Safari im privaten Modus) — die
+		// Spaltenauswahl ist eine Bequemlichkeit, kein Grund zum Absturz.
 		try {
-			if (!hatGespeicherteSpaltenGeladen) {
-				// Einmaliges Laden beim Mount. Kaputtes/altes JSON und unbekannte
-				// Schlüssel fallen in `loadColumnPreferences` still auf den Default
-				// zurück; neue Spalten erscheinen mit ihrem eigenen Default-Wert.
-				columnVisibility = loadColumnPreferences(
-					window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY),
-					DEFAULT_COLUMN_VISIBILITY
-				);
-				return; // Diesen Durchlauf nicht sofort wieder zurückschreiben.
-			}
-			// Jede weitere Änderung (Checkbox im „Spalten"-Dropdown) wird persistiert.
 			window.localStorage.setItem(
 				COLUMN_PREFERENCES_STORAGE_KEY,
 				serializeColumnPreferences(columnVisibility)
@@ -157,11 +177,6 @@
 				{ err },
 				'Spaltenauswahl kann nicht gespeichert werden — Storage nicht verfügbar'
 			);
-		} finally {
-			/* Im finally, damit auch ein geworfenes `getItem` den Lade-Versuch
-			   abschließt — sonst überschriebe der nächste Durchlauf jede
-			   Nutzerauswahl erneut mit dem (dann fehlgeschlagenen) Laden. */
-			hatGespeicherteSpaltenGeladen = true;
 		}
 	});
 
@@ -792,6 +807,13 @@
 								</label>
 							{/each}
 						</div>
+						<button
+							class="btn btn-ghost btn-xs mt-2 w-full"
+							disabled={istSpaltenauswahlDefault}
+							onclick={() => (columnVisibility = { ...DEFAULT_COLUMN_VISIBILITY })}
+						>
+							Standard wiederherstellen
+						</button>
 					</div>
 				</details>
 				<!-- Zwei Zustände, Begründung am Mobil-Zwilling weiter oben. -->

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -863,7 +863,14 @@
 			nicht sehen.
 		-->
 		<div class="mt-3 flex flex-wrap items-center gap-2">
-			<span class="text-support text-base-content/70">Ansichten:</span>
+			{#if filterPresets.length > 0 || zeigeAnsichtFormular}
+				<!-- Ohne gespeicherte Presets und mit geschlossenem Formular stünde das
+				     Label vor einem einzelnen „Ansicht speichern“-Knopf — ein Label ohne
+				     etwas, das es benennt (UX-Review WP6). Der Knopf selbst bleibt in
+				     jedem Fall sichtbar: Er ist der Einstieg ins Feature, nicht Teil der
+				     Aufzählung, die er benennt. -->
+				<span class="text-support text-base-content/70">Ansichten:</span>
+			{/if}
 
 			{#each filterPresets as preset (preset.id)}
 				{#if umbenennenId === preset.id}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -31,6 +31,8 @@
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 	import { hasActiveFilters as hatAktiveFilter, readFilterParams } from './activeFilters';
 	import SichtungenCards from './SichtungenCards.svelte';
+	import StatusTabs from './StatusTabs.svelte';
+	import type { StatusTabValue } from './statusTabs';
 	import SichtungenTable from './SichtungenTable.svelte';
 	import { AVAILABLE_COLUMNS, DEFAULT_COLUMN_VISIBILITY } from './columns';
 	import { NUR_KOMPAKT, NUR_WEIT_FLEX } from './layoutSwitch';
@@ -373,6 +375,20 @@
 		url.searchParams.delete('balticSea');
 		url.searchParams.delete('deadFinding');
 		url.searchParams.delete('q');
+		url.searchParams.set('page', '1');
+		goto(url);
+	}
+
+	/**
+	 * Statusleiste über der Tabelle. Schreibt denselben Parameter wie das
+	 * `<select>` im Panel — es gibt keinen zweiten gemerkten Zustand, beide
+	 * lesen ihren Stand aus der URL. `page=1`, weil die Trefferzahl mit dem
+	 * Status springt und man sonst auf einer leeren Seite 7 landete.
+	 */
+	function selectStatus(value: StatusTabValue): void {
+		const url = new URL(page.url);
+		if (value) url.searchParams.set('verified', value);
+		else url.searchParams.delete('verified');
 		url.searchParams.set('page', '1');
 		goto(url);
 	}
@@ -1092,6 +1108,18 @@
 			</div>
 		</div>
 	{/if}
+
+	<!-- Statusleiste über beiden Layouts, nicht nur über der Tabelle: Auf Mobil
+	     rendert `SichtungenCards`, und gerade dort soll der wichtigste Filter
+	     ohne Aufklappen des Panels erreichbar sein. `active` kommt aus der URL
+	     (`currentFilters`) — dieselbe Quelle wie das `<select>` im Panel. -->
+	<div class="container mx-auto mb-3 px-4 md:px-6">
+		<StatusTabs
+			counts={data.statusCounts}
+			active={currentFilters.verified as StatusTabValue}
+			onselect={selectStatus}
+		/>
+	</div>
 
 	<SichtungenCards
 		{sightings}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -162,16 +162,28 @@
 	});
 
 	$effect(() => {
+		/* `columnVisibility` MUSS gelesen werden, bevor irgendein `return`
+		   greifen kann — Svelte trackt die Abhängigkeiten eines Effekts nur aus
+		   den in seinem letzten Durchlauf tatsächlich gelesenen reaktiven
+		   Werten. `hatGespeicherteSpaltenGeladen` ist ein einfaches `let`, kein
+		   `$state` — der Effekt läuft heute nur deshalb ein zweites Mal, weil
+		   der Lade-Effekt oben zuerst deklariert ist und das Flag VOR dem
+		   ersten Durchlauf dieses Effekts auf `true` setzt. Stünde die
+		   Serialisierung hinter dem Guard, würde der allererste Durchlauf beim
+		   noch nicht geladenen Stand früh aussteigen, OHNE `columnVisibility`
+		   je zu lesen — der Effekt abonnierte sich dann nie auf Änderungen und
+		   bliebe für immer stumm, egal in welcher Reihenfolge die Effekte
+		   künftig stehen. Genau das war der Bug, der die Aufspaltung oben nötig
+		   gemacht hat; ihn hier wieder einzuführen wäre derselbe Fehler eine
+		   Ebene tiefer. */
+		const serialisiert = serializeColumnPreferences(columnVisibility);
 		if (typeof window === 'undefined' || !hatGespeicherteSpaltenGeladen) return;
 		// Jede Änderung (Checkbox im „Spalten"-Dropdown, „Standard
 		// wiederherstellen") wird persistiert. `try/catch`, weil `setItem`
 		// werfen kann (volle Quota, Safari im privaten Modus) — die
 		// Spaltenauswahl ist eine Bequemlichkeit, kein Grund zum Absturz.
 		try {
-			window.localStorage.setItem(
-				COLUMN_PREFERENCES_STORAGE_KEY,
-				serializeColumnPreferences(columnVisibility)
-			);
+			window.localStorage.setItem(COLUMN_PREFERENCES_STORAGE_KEY, serialisiert);
 		} catch (err) {
 			logger.warn(
 				{ err },

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -998,8 +998,8 @@
 			(Button-Hierarchie). Ein Chip ist eine Nebenaktion.
 
 			Die Beschriftung steht im Knopf, das Entfernen sagt das `aria-label` —
-			sonst läse ein Screenreader nur „Von 01.06.2026" und nichts darüber, was
-			ein Klick bewirkt. Das `x`-Icon ist deshalb `aria-hidden`.
+			sonst läse ein Screenreader nur „Sichtung von 01.06.2026" und nichts
+			darüber, was ein Klick bewirkt. Das `x`-Icon ist deshalb `aria-hidden`.
 
 			Kein Status-Chip: `filterChips` wird mit `skipVerified` gebaut, der aktive
 			Statusreiter direkt darunter zeigt ihn bereits.
@@ -1060,7 +1060,7 @@
 			<div class="grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6">
 				<div class="fieldset w-full">
 					<label for="fromDate" class="label py-0">
-						<span class="text-support">Von</span>
+						<span class="text-support">Sichtung von</span>
 					</label>
 					<input
 						type="date"
@@ -1072,7 +1072,7 @@
 				</div>
 				<div class="fieldset w-full">
 					<label for="toDate" class="label py-0">
-						<span class="text-support">Bis</span>
+						<span class="text-support">Sichtung bis</span>
 					</label>
 					<input
 						type="date"

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -1029,11 +1029,18 @@
 						</select>
 					</div>
 				</div>
+				<!-- Kein `md:btn-xs` mehr: Die Höhe hat es ohnehin nie geändert (beide
+				     Knöpfe messen die 44px aus dem Touch-Target-Block), es verkleinerte
+				     nur Schrift und Innenabstand — und zwar auf dem GRÖSSEREN Schirm, wo
+				     Platz kein Argument ist. „Anwenden" ist die Aktion, ohne die das
+				     Panel nichts bewirkt; sie auf dem Desktop zu verkleinern lief der
+				     Bedeutung entgegen. `btn-sm` bleibt und stimmt mit den übrigen
+				     Aktionsknöpfen der Seite überein (Spalten, Filter, Export); die
+				     Rangfolge im Panel trägt weiterhin `btn-primary` gegen
+				     `btn-outline`, nicht die Größe. -->
 				<div class="mt-3 flex flex-col gap-2 md:flex-row md:justify-end">
-					<button class="btn btn-outline btn-sm md:btn-xs" onclick={resetFilters}
-						>Zurücksetzen</button
-					>
-					<button class="btn btn-primary btn-sm md:btn-xs" onclick={applyFilters}>Anwenden</button>
+					<button class="btn btn-outline btn-sm" onclick={resetFilters}>Zurücksetzen</button>
+					<button class="btn btn-primary btn-sm" onclick={applyFilters}>Anwenden</button>
 				</div>
 			</div>
 		{/if}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -906,11 +906,15 @@
 			Echte `btn` statt klickbar gemachter `badge`: Nur `.btn` bekommt über
 			app.css die 44px-Touch-Target-Mindestgröße (design-system.md
 			„Feldmodus und Touch-Targets"); ein `badge` bliebe bei ~24px.
-			Die aktive Ansicht trägt `btn-primary` — sie ist die einzige
-			Vollton-Fläche der Leiste, alle übrigen sind `btn-outline`, damit
-			„aktiv" nicht mit „auswählbar" verschwimmt (Button-Hierarchie).
-			`aria-current="true"` sagt dasselbe für Screenreader, die die Farbe
-			nicht sehen.
+			Die aktive Ansicht trägt `btn-active` — dieselbe „aktueller
+			Zustand"-Optik wie der aktive Statusreiter direkt darunter und die
+			Seitenzahl in der Paginierung. `btn-primary` bleibt Export und
+			„Anwenden" vorbehalten: Auf breiten Bildschirmen standen bislang bis
+			zu vier Vollton-Flächen binnen 150px Höhe nebeneinander, weil
+			`btn-primary` gleichzeitig „das ist die Aktion hier" und „das ist
+			ausgewählt" bedeutete (Button-Hierarchie). `aria-current="true"`
+			sagt „ausgewählt" weiterhin für Screenreader, die die Farbe nicht
+			sehen.
 		-->
 		<div class="mt-3 flex flex-wrap items-center gap-2">
 			{#if filterPresets.length > 0 || zeigeAnsichtFormular}
@@ -948,7 +952,7 @@
 						<button
 							type="button"
 							class="btn btn-sm join-item {aktiveAnsichtId === preset.id
-								? 'btn-primary'
+								? 'btn-active'
 								: 'btn-outline'}"
 							aria-current={aktiveAnsichtId === preset.id ? 'true' : undefined}
 							onclick={() => ansichtAnwenden(preset)}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -29,7 +29,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
-	import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+	import { hasActiveFilters as hatAktiveFilter, readFilterParams } from './activeFilters';
 	import SichtungenCards from './SichtungenCards.svelte';
 	import SichtungenTable from './SichtungenTable.svelte';
 	import { AVAILABLE_COLUMNS, DEFAULT_COLUMN_VISIBILITY } from './columns';
@@ -61,19 +61,42 @@
 
 	// Reaktive States mit Runes
 	let sightings = $derived(data.sightings);
-	let fromDate = $state(page.url.searchParams.get('fromDate') || '');
-	let toDate = $state(page.url.searchParams.get('toDate') || '');
-	/* `normalizeStatusParam`, nicht der Rohwert: Der Server versteht die alten
-	   Aliase `verified=1`/`verified=0` weiterhin (Lesezeichen, verlinkte
-	   Filteransichten), aber das `<select>` unten kennt nur `open`/`approved`/
-	   `rejected` — ohne die Normalisierung kam die gefilterte Liste zurück,
-	   während das Feld selbst leer stand. */
-	let verified = $state(normalizeStatusParam(page.url.searchParams.get('verified')) ?? '');
-	let selectedChannel = $state(page.url.searchParams.get('entryChannel') || 'all');
-	let mediaUpload = $state(page.url.searchParams.get('mediaUpload') || '');
-	let balticSea = $state(page.url.searchParams.get('balticSea') || '');
-	let deadFinding = $state(page.url.searchParams.get('deadFinding') || '');
-	let searchTerm = $state(page.url.searchParams.get('q') || '');
+	/* Der Filterzustand kommt vollständig aus der URL, nicht aus den Feld-States:
+	   Die Tabelle zeigt, was in der URL steht. Ein im Panel getippter, aber nicht
+	   angewendeter Wert exportierte sonst eine Menge, die die Tabelle nie gezeigt
+	   hat, und markierte die Filter-Schaltfläche schon beim Tippen. Für `q` galt
+	   das schon länger — jetzt für alle acht.
+
+	   Steht bewusst vor den Feld-States: Sie initialisieren sich daraus, statt die
+	   URL ein zweites Mal selbst zu lesen. */
+	let currentFilters = $derived(readFilterParams(page.url.searchParams));
+	let hasActiveFilters = $derived(hatAktiveFilter(currentFilters));
+
+	/* Startwerte des Editier-Puffers. Der `$effect` weiter unten, der ihn nach
+	   einer Navigation nachzieht, läuft im SSR-Durchlauf nicht; ohne diese
+	   Initialisierung stünde das Suchfeld im servergerenderten Frame leer,
+	   obwohl die URL ein `?q=` trägt.
+
+	   Eine eigene, nicht-reaktive Momentaufnahme statt `currentFilters`: Ein
+	   `$derived` in einem `$state`-Initialisierer meldet Svelte als
+	   `state_referenced_locally` — zu Recht, denn genommen wird hier bewusst nur
+	   der Startwert. */
+	const startFilter = readFilterParams(page.url.searchParams);
+	let fromDate = $state(startFilter.fromDate);
+	let toDate = $state(startFilter.toDate);
+	/* Ausnahmsweise über `currentFilters`, obwohl `startFilter` danebensteht:
+	   `verifiedReadScan.test.ts` lässt den Property-Zugriff `.verified` nur an
+	   diesem einen Empfänger zu — er ist dort als Query-Parameter der Tabelle
+	   ausgenommen und nicht als Datenbankspalte. Der Wert ist derselbe. */
+	// svelte-ignore state_referenced_locally
+	let verified = $state(currentFilters.verified);
+	// `all` ist das Sentinel des `<select>` für „egal"; in der URL steht dafür
+	// gar kein Parameter.
+	let selectedChannel = $state(startFilter.entryChannel || 'all');
+	let mediaUpload = $state(startFilter.mediaUpload);
+	let balticSea = $state(startFilter.balticSea);
+	let deadFinding = $state(startFilter.deadFinding);
+	let searchTerm = $state(startFilter.q);
 	let showDeleteDialog = $state(false);
 	let sightingToDelete = $state<SichtungenListRow | null>(null);
 	let isFilterPanelOpen = $state(false);
@@ -255,36 +278,22 @@
 	   Rechnung selbst in `paginationControls.ts` (Leerfall `totalPages === 0`). */
 	let seiten = $derived(paginationControls(data.pagination.page, data.pagination.totalPages));
 
-	// Prüft ob irgendwelche Filter aktiv sind
-	let hasActiveFilters = $derived(
-		!!(
-			fromDate ||
-			toDate ||
-			verified ||
-			(selectedChannel && selectedChannel !== 'all') ||
-			mediaUpload ||
-			balticSea ||
-			deadFinding ||
-			searchTerm
-		)
-	);
-
-	// Aktuelle Filter für Export-Modal
-	let currentFilters = $derived.by(() => ({
-		fromDate: fromDate || '',
-		toDate: toDate || '',
-		verified: verified || '',
-		entryChannel: selectedChannel !== 'all' ? selectedChannel : '',
-		mediaUpload: mediaUpload || '',
-		balticSea: balticSea || '',
-		deadFinding: deadFinding || '',
-		/* Aus der URL, nicht aus dem Feld-State: Das Suchfeld steht dauerhaft im
-		   Kopf, ein getippter, aber nicht abgeschickter Begriff ist damit leicht
-		   stehengelassen. Aus dem Feld gelesen, exportierte der Dialog dann eine
-		   Menge, die die sichtbare Tabelle gar nicht anwendet — und die Badges
-		   versprächen sie obendrein. */
-		q: page.url.searchParams.get('q') ?? ''
-	}));
+	/* Die Feld-States sind der Editier-Puffer des Panels und speisen nur noch
+	   `applyFilters()`. Nach jeder Navigation — Preset-Klick, Zurück-Button,
+	   entfernter Filter — übernehmen sie den URL-Stand, sonst zeigte das Panel
+	   veraltete Werte. Wer mitten im Editieren navigiert, hat den Puffer damit
+	   bewusst verworfen; ein „wird gerade editiert"-Wächter daneben wäre ein
+	   zweiter gemerkter Zustand neben der URL. */
+	$effect(() => {
+		fromDate = currentFilters.fromDate;
+		toDate = currentFilters.toDate;
+		verified = currentFilters.verified;
+		selectedChannel = currentFilters.entryChannel || 'all';
+		mediaUpload = currentFilters.mediaUpload;
+		balticSea = currentFilters.balticSea;
+		deadFinding = currentFilters.deadFinding;
+		searchTerm = currentFilters.q;
+	});
 
 	function applyFilters(): void {
 		const url = new URL(page.url);

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -1044,12 +1044,51 @@
 			Mobilgeräten die passende Tastatur mit „Suchen"-Taste.
 		-->
 		<form class="mt-3 flex items-center gap-2" onsubmit={submitSearch} role="search">
-			<label class="input input-sm flex flex-1 items-center gap-2">
+			<!-- `.input` bringt bereits `display:inline-flex`, `align-items:center`
+			     und `gap:.5rem` mit (daisyui/components/input.css, 5.7.4 nachgelesen) —
+			     `flex items-center gap-2` am Label doppelte das nur bzw. überschrieb
+			     dabei `inline-flex` mit `flex`. `flex-1` bleibt: `.input` trägt
+			     `width: clamp(3rem, 20rem, 100%)`, ohne `flex-1` bliebe das Feld bei
+			     320px stehen statt die Zeile zu füllen. Das `grow` am inneren
+			     `<input>` war ebenfalls wirkungslos — `.input & input` setzt
+			     `width/height: 100%` bereits über die Elternklasse.
+
+			     Kein `input-sm`: An diesem Element ist der Modifier tote Utility.
+			     `src/app.css` trägt ungelayert `.input, .select, .textarea { font-size:
+			     var(--text-body) }` (Formularfelder ≥ 16px, WCAG AA + iOS-Auto-Zoom,
+			     `daisyui.md` „Vorhandene Overrides respektieren") — das schlägt
+			     DaisyUIs gelayerte `--font-size-min` aus `input-sm` unbedingt, exakt
+			     dieselbe Kaskaden-Mechanik wie beim Fokus- und Alert-Override dort.
+			     Im Browser gemessen: `getComputedStyle(label).fontSize` ist mit UND
+			     ohne `input-sm` `16px`. `--in-size-mul` (die zweite Wirkung des
+			     Modifiers) ist hier ebenfalls tot, weil `--size` direkt überschrieben
+			     wird (siehe unten) — `--in-size-mul` fließt nur in die
+			     `--size`-Berechnung ein, die dieser Override ersetzt. `--spin-my`
+			     bleibt drittens wirkungslos, weil `type="search"` keinen
+			     Number-Spinner hat. `input-sm` täte an diesem Feld also nichts mehr
+			     (design-system.md, „Keine toten Utility-Klassen").
+
+			     `--size` überschreibt `.input`s Standardhöhe (2.5rem/40px bei
+			     `--size-field: 0.25rem` × `--in-size-mul: 10`) direkt auf die
+			     44px-Touch-Target-Höhe (`--target-min`), statt sie über `min-height`
+			     zu erzwingen: `.input` setzt `height: var(--size)`, ein `min-height`
+			     würde also nichts bewirken. Gleiches Muster wie
+			     `.checkbox/.radio/.toggle { --size: … }` in app.css. Der Knopf daneben
+			     bekommt seine 44px unbedingt über die projektweite `.btn`-Regel
+			     (design-system.md, „Feldmodus und Touch-Targets") — das Feld muss also
+			     wachsen, nicht der Knopf schrumpfen.
+
+			     Schriftgröße dadurch nicht mehr symmetrisch zum Knopf: Das Feld zeigt
+			     16px (`--text-body`, unveränderlich seit dem App.css-Override), der
+			     `btn-sm` daneben 12px (`--fontsize` aus DaisyUIs `.btn-sm`, von diesem
+			     Override nicht betroffen). Ob der Knopf auf `btn-md`/Standardgröße
+			     wechselt, ist hier bewusst offengelassen — Entscheidung Jan,
+			     2026-08-10. -->
+			<label class="input flex-1" style="--size: var(--target-min)">
 				<Icon icon="lucide:search" class="h-4 w-4 opacity-70" aria-hidden="true" />
 				<span class="sr-only">Suche nach Referenz-ID, E-Mail, Name oder Fahrwasser</span>
 				<input
 					type="search"
-					class="grow"
 					bind:value={searchTerm}
 					placeholder="Referenz-ID, E-Mail, Name oder Fahrwasser"
 				/>

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -138,17 +138,10 @@
 		isDefaultVisibility(columnVisibility, DEFAULT_COLUMN_VISIBILITY)
 	);
 
-	/* Zwei getrennte Effekte statt einem: Ein einzelner `$effect`, der beim
-	   ersten Durchlauf per `return` aussteigt, OHNE `columnVisibility` zu
-	   *lesen* (nur zu schreiben), trackt diese Abhängigkeit nie — Svelte
-	   ermittelt die Abhängigkeiten eines Effekts aus den in seinem letzten
-	   Durchlauf gelesenen reaktiven Werten. Der Effekt liefe dadurch nach dem
-	   Laden genau einmal und nie wieder, egal wie oft `columnVisibility`
-	   danach per Checkbox oder „Standard wiederherstellen" geändert wird —
-	   beobachtet beim manuellen Nachstellen des WP7-Buttons (Browser-Check,
-	   `localStorage` blieb nach mehreren Änderungen durchgehend leer). Mit
-	   getrennten Effekten liest der Speicher-Effekt `columnVisibility` in
-	   jedem Durchlauf und bleibt damit dauerhaft abonniert. */
+	// Zwei getrennte Effekte statt einem — die Begründung (Svelte trackt
+	// Abhängigkeiten nur aus gelesenen, nicht aus geschriebenen reaktiven
+	// Werten; der WP7-Bug entstand genau daraus) steht beim Speicher-Effekt
+	// unten, wo sie an derselben Stelle vor einer Regression schützt.
 	$effect(() => {
 		if (typeof window === 'undefined' || hatGespeicherteSpaltenGeladen) return;
 		try {

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -66,6 +66,12 @@
 
 	const logger = createLogger('SichtungenPage');
 
+	/* Feste id statt eines generierten Werts: Das Panel existiert genau einmal,
+	   die zwei Auslöser (Mobil-Kopf und Weit-Kopf) verweisen beide per
+	   `aria-controls` darauf — ein `crypto.randomUUID()` o. Ä. wäre hier ohne
+	   Nutzen, weil nichts dynamisch mehrfach gerendert wird. */
+	const FILTER_PANEL_ID = 'sichtungen-filter-panel';
+
 	let { data }: { data: PageData } = $props();
 
 	// Reaktive States mit Runes
@@ -768,6 +774,8 @@
 						class="btn btn-sm flex-1 {isFilterPanelOpen ? 'btn-accent' : 'btn-outline'}"
 						onclick={() => (isFilterPanelOpen = !isFilterPanelOpen)}
 						title="Filter ein-/ausblenden"
+						aria-expanded={isFilterPanelOpen}
+						aria-controls={FILTER_PANEL_ID}
 					>
 						<Icon icon="lucide:filter" class="mr-1 h-4 w-4" />
 						Filter
@@ -849,6 +857,8 @@
 					class="btn btn-sm {isFilterPanelOpen ? 'btn-accent' : 'btn-outline'}"
 					onclick={() => (isFilterPanelOpen = !isFilterPanelOpen)}
 					title="Filter ein-/ausblenden"
+					aria-expanded={isFilterPanelOpen}
+					aria-controls={FILTER_PANEL_ID}
 				>
 					<Icon icon="lucide:filter" class="mr-1 h-4 w-4" />
 					Filter
@@ -869,6 +879,156 @@
 				{/if}
 			</div>
 		</div>
+
+		<!-- Filter Panel.
+
+		     Direkt hinter dem Kopfbereich und vor der Suche: Beide Filter-Auslöser
+		     sitzen im Kopf, ein per Tastatur geöffnetes Panel soll deshalb nicht
+		     erst hinter Suche, Ansichten und Chip-Zeile liegen. Kein eigener
+		     `container mx-auto px-4 md:px-6` mehr — das übernimmt jetzt der
+		     umschließende Kopfbereich-Container, eine zweite Verschachtelung hätte
+		     den Innenabstand verdoppelt. `mt-3` statt des früheren `mb-4`, damit der
+		     Abstand zum Kopf darüber demselben Rhythmus folgt wie Suche, Ansichten
+		     und Chip-Zeile weiter unten (jeweils `mt-3` zum Vorgänger).
+
+		     Hier stand `transition-all duration-300`. Das ist als einzige der 19
+		     Dauer-Fundstellen NICHT auf ein Motion-Token gewandert, sondern
+		     ersatzlos entfallen: Das Panel hängt an einem `{#if}` und wird ein- und
+		     ausgehängt statt ein- und ausgeblendet — es gibt keinen Zustand, von
+		     dem aus ein Übergang laufen könnte, und die Klasse hat nie gewirkt.
+		     Ein `duration-panel` an ihrer Stelle sähe token-konform aus und täte
+		     weiterhin nichts. Wer hier wirklich animieren will, braucht
+		     `transition:slide` aus `svelte/transition` (design-system.md, „Keine
+		     toten Utility-Klassen"). -->
+		{#if isFilterPanelOpen}
+			<div id={FILTER_PANEL_ID} class="bg-base-200 shadow-raised mt-3 rounded-lg p-3">
+				<div class="mb-2 flex items-center justify-between">
+					<h2 class="text-base font-semibold">Filter</h2>
+					<button
+						class="btn btn-ghost btn-xs"
+						onclick={() => (isFilterPanelOpen = false)}
+						title="Filter ausblenden"
+						aria-label="Filter ausblenden"
+					>
+						<Icon icon="lucide:x" class="h-4 w-4" />
+					</button>
+				</div>
+				<!-- Kein `sm:grid-cols-2`: `sm` ist keine Layout-Grenze (Breakpoint-Vertrag). -->
+				<div class="grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6">
+					<div class="fieldset w-full">
+						<label for="fromDate" class="label py-0">
+							<span class="text-support">Sichtung von</span>
+						</label>
+						<input
+							type="date"
+							id="fromDate"
+							name="fromDate"
+							class="input input-sm w-full"
+							bind:value={fromDate}
+						/>
+					</div>
+					<div class="fieldset w-full">
+						<label for="toDate" class="label py-0">
+							<span class="text-support">Sichtung bis</span>
+						</label>
+						<input
+							type="date"
+							id="toDate"
+							name="toDate"
+							class="input input-sm w-full"
+							bind:value={toDate}
+						/>
+					</div>
+					<div class="fieldset w-full">
+						<label for="verified" class="label py-0">
+							<span class="text-support">Status</span>
+						</label>
+						<select
+							id="verified"
+							name="verified"
+							class="select select-sm w-full text-sm"
+							bind:value={verified}
+						>
+							<option value="">Alle</option>
+							<option value="open">Offen</option>
+							<option value="approved">Freigegeben</option>
+							<option value="rejected">Abgelehnt</option>
+						</select>
+					</div>
+					<div class="fieldset w-full">
+						<label for="deadFinding" class="label py-0">
+							<span class="text-support">Meldeart</span>
+						</label>
+						<select
+							id="deadFinding"
+							name="deadFinding"
+							class="select select-sm w-full text-sm"
+							bind:value={deadFinding}
+						>
+							<option value="">Alle</option>
+							<option value="1">{DEAD_FINDING_PRESENTATION.label}</option>
+							<option value="0">{MELDEART_LABEL['0']}</option>
+						</select>
+					</div>
+					<div class="fieldset w-full">
+						<label for="entryChannel" class="label py-0">
+							<span class="text-support">Kanal</span>
+						</label>
+						<select
+							id="entryChannel"
+							name="entryChannel"
+							class="select select-sm w-full text-sm"
+							bind:value={selectedChannel}
+						>
+							<option value="all">Alle</option>
+							{#each getEntryChannelOptions() as { value, label } (value)}
+								<option value={String(value)}>{label}</option>
+							{/each}
+						</select>
+					</div>
+					<div class="fieldset w-full">
+						<label for="mediaUpload" class="label py-0">
+							<span class="text-support">Aufnahme</span>
+						</label>
+						<select
+							id="mediaUpload"
+							name="mediaUpload"
+							class="select select-sm w-full text-sm"
+							bind:value={mediaUpload}
+						>
+							<option value="">Alle</option>
+							<option value="1">{AUFNAHME_LABEL['1']}</option>
+							<option value="0">{AUFNAHME_LABEL['0']}</option>
+							<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}
+								>{AUFNAHME_LABEL[MEDIA_UPLOAD_ANNOUNCED_MISSING]}</option
+							>
+						</select>
+					</div>
+					<div class="fieldset w-full">
+						<label for="balticSea" class="label py-0">
+							<span class="text-support">Ostsee</span>
+						</label>
+						<select
+							id="balticSea"
+							name="balticSea"
+							class="select select-sm w-full text-sm"
+							bind:value={balticSea}
+						>
+							<option value="">Alle</option>
+							{#each Object.entries(BALTIC_SEA_STATUS_PRESENTATION) as [value, presentation] (value)}
+								<option {value}>{presentation.label}</option>
+							{/each}
+						</select>
+					</div>
+				</div>
+				<div class="mt-3 flex flex-col gap-2 md:flex-row md:justify-end">
+					<button class="btn btn-outline btn-sm md:btn-xs" onclick={resetFilters}
+						>Zurücksetzen</button
+					>
+					<button class="btn btn-primary btn-sm md:btn-xs" onclick={applyFilters}>Anwenden</button>
+				</div>
+			</div>
+		{/if}
 
 		<!--
 			Die Freitext-Suche steht bewusst außerhalb des Filter-Panels — sie ist
@@ -1092,146 +1252,6 @@
 			</div>
 		{/if}
 	</div>
-
-	<!-- Filter Panel.
-
-	     Hier stand `transition-all duration-300`. Das ist als einzige der 19
-	     Dauer-Fundstellen NICHT auf ein Motion-Token gewandert, sondern
-	     ersatzlos entfallen: Das Panel hängt an einem `{#if}` und wird ein- und
-	     ausgehängt statt ein- und ausgeblendet — es gibt keinen Zustand, von
-	     dem aus ein Übergang laufen könnte, und die Klasse hat nie gewirkt.
-	     Ein `duration-panel` an ihrer Stelle sähe token-konform aus und täte
-	     weiterhin nichts. Wer hier wirklich animieren will, braucht
-	     `transition:slide` aus `svelte/transition` (design-system.md, „Keine
-	     toten Utility-Klassen"). -->
-	{#if isFilterPanelOpen}
-		<div class="bg-base-200 shadow-raised container mx-auto mb-4 rounded-lg p-3 px-4 md:px-6">
-			<div class="mb-2 flex items-center justify-between">
-				<h2 class="text-base font-semibold">Filter</h2>
-				<button
-					class="btn btn-ghost btn-xs"
-					onclick={() => (isFilterPanelOpen = false)}
-					title="Filter ausblenden"
-					aria-label="Filter ausblenden"
-				>
-					<Icon icon="lucide:x" class="h-4 w-4" />
-				</button>
-			</div>
-			<!-- Kein `sm:grid-cols-2`: `sm` ist keine Layout-Grenze (Breakpoint-Vertrag). -->
-			<div class="grid grid-cols-1 gap-2 md:grid-cols-3 lg:grid-cols-6">
-				<div class="fieldset w-full">
-					<label for="fromDate" class="label py-0">
-						<span class="text-support">Sichtung von</span>
-					</label>
-					<input
-						type="date"
-						id="fromDate"
-						name="fromDate"
-						class="input input-sm w-full"
-						bind:value={fromDate}
-					/>
-				</div>
-				<div class="fieldset w-full">
-					<label for="toDate" class="label py-0">
-						<span class="text-support">Sichtung bis</span>
-					</label>
-					<input
-						type="date"
-						id="toDate"
-						name="toDate"
-						class="input input-sm w-full"
-						bind:value={toDate}
-					/>
-				</div>
-				<div class="fieldset w-full">
-					<label for="verified" class="label py-0">
-						<span class="text-support">Status</span>
-					</label>
-					<select
-						id="verified"
-						name="verified"
-						class="select select-sm w-full text-sm"
-						bind:value={verified}
-					>
-						<option value="">Alle</option>
-						<option value="open">Offen</option>
-						<option value="approved">Freigegeben</option>
-						<option value="rejected">Abgelehnt</option>
-					</select>
-				</div>
-				<div class="fieldset w-full">
-					<label for="deadFinding" class="label py-0">
-						<span class="text-support">Meldeart</span>
-					</label>
-					<select
-						id="deadFinding"
-						name="deadFinding"
-						class="select select-sm w-full text-sm"
-						bind:value={deadFinding}
-					>
-						<option value="">Alle</option>
-						<option value="1">{DEAD_FINDING_PRESENTATION.label}</option>
-						<option value="0">{MELDEART_LABEL['0']}</option>
-					</select>
-				</div>
-				<div class="fieldset w-full">
-					<label for="entryChannel" class="label py-0">
-						<span class="text-support">Kanal</span>
-					</label>
-					<select
-						id="entryChannel"
-						name="entryChannel"
-						class="select select-sm w-full text-sm"
-						bind:value={selectedChannel}
-					>
-						<option value="all">Alle</option>
-						{#each getEntryChannelOptions() as { value, label } (value)}
-							<option value={String(value)}>{label}</option>
-						{/each}
-					</select>
-				</div>
-				<div class="fieldset w-full">
-					<label for="mediaUpload" class="label py-0">
-						<span class="text-support">Aufnahme</span>
-					</label>
-					<select
-						id="mediaUpload"
-						name="mediaUpload"
-						class="select select-sm w-full text-sm"
-						bind:value={mediaUpload}
-					>
-						<option value="">Alle</option>
-						<option value="1">{AUFNAHME_LABEL['1']}</option>
-						<option value="0">{AUFNAHME_LABEL['0']}</option>
-						<option value={MEDIA_UPLOAD_ANNOUNCED_MISSING}
-							>{AUFNAHME_LABEL[MEDIA_UPLOAD_ANNOUNCED_MISSING]}</option
-						>
-					</select>
-				</div>
-				<div class="fieldset w-full">
-					<label for="balticSea" class="label py-0">
-						<span class="text-support">Ostsee</span>
-					</label>
-					<select
-						id="balticSea"
-						name="balticSea"
-						class="select select-sm w-full text-sm"
-						bind:value={balticSea}
-					>
-						<option value="">Alle</option>
-						{#each Object.entries(BALTIC_SEA_STATUS_PRESENTATION) as [value, presentation] (value)}
-							<option {value}>{presentation.label}</option>
-						{/each}
-					</select>
-				</div>
-			</div>
-			<div class="mt-3 flex flex-col gap-2 md:flex-row md:justify-end">
-				<button class="btn btn-outline btn-sm md:btn-xs" onclick={resetFilters}>Zurücksetzen</button
-				>
-				<button class="btn btn-primary btn-sm md:btn-xs" onclick={applyFilters}>Anwenden</button>
-			</div>
-		</div>
-	{/if}
 
 	<!-- Statusleiste über beiden Layouts, nicht nur über der Tabelle: Auf Mobil
 	     rendert `SichtungenCards`, und gerade dort soll der wichtigste Filter

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -135,6 +135,15 @@
 			{label}
 			{#if isActive}
 				<span aria-hidden="true">{isDesc ? '↓' : '↑'}</span>
+			{:else}
+				<!-- Affordance im Ruhezustand: ohne sie war ein sortierbarer Kopf von
+				     einem reinen Textkopf nicht zu unterscheiden — der Richtungspfeil
+				     stand nur an der aktiven Spalte. -->
+				<Icon
+					icon="lucide:chevrons-up-down"
+					class="text-base-content/70 h-3 w-3"
+					aria-hidden="true"
+				/>
 			{/if}
 		</button>
 	</th>

--- a/src/routes/admin/sichtungen/StatusTabs.svelte
+++ b/src/routes/admin/sichtungen/StatusTabs.svelte
@@ -53,7 +53,7 @@
 				     Statusfarbe als Textfarbe verfehlt den Kontrast
 				     (design-system.md, „Statusfarben haben zwei Rollen"). Die
 				     Bedeutung trägt das Icon davor. -->
-				<span class="badge badge-sm">{counts[tab.countKey]}</span>
+				<span class="badge badge-sm" data-testid="status-tab-count">{counts[tab.countKey]}</span>
 			</button>
 		{/each}
 	</div>

--- a/src/routes/admin/sichtungen/StatusTabs.svelte
+++ b/src/routes/admin/sichtungen/StatusTabs.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { STATUS_TABS, type StatusCounts, type StatusTabValue } from './statusTabs';
+
+	interface Props {
+		/** Trefferzahlen der aktuellen Filtermenge **ohne** den Statusfilter. */
+		counts: StatusCounts;
+		/** Der Stand aus der URL (`?verified=`); leer heißt „Alle". */
+		active: StatusTabValue;
+		/** Meldet den gewählten Wert; das Navigieren macht die Seite. */
+		onselect: (value: StatusTabValue) => void;
+	}
+
+	let { counts, active, onselect }: Props = $props();
+</script>
+
+<!--
+	Statusleiste über der Tabelle (WP2). Der Status ist die Haupt-Triage-
+	Dimension und steckte bis hierher im aufklappbaren Filter-Panel; das
+	`<select>` dort bleibt, beide schreiben denselben URL-Parameter.
+
+	**`join` aus `.btn` statt `tabs tabs-border`** — die offengelassene
+	Entscheidung des Auftrags, mit drei Gründen:
+	1. Das hier sind keine Reiter im ARIA-Sinn. `role="tab"` verspricht ein
+	   Widget mit `tabpanel`, Roving-Tabindex und Pfeiltasten-Navigation; die
+	   Leiste navigiert stattdessen die Seite. `aria-current` an einer
+	   Schaltfläche sagt genau das, was hier passiert.
+	2. Nur `.btn` bekommt über `app.css` die 44px-Touch-Target-Mindestgröße
+	   (design-system.md, „Feldmodus und Touch-Targets"). `.tab` bliebe darunter
+	   — und diese Leiste ist gerade auf Mobil das wichtigste Bedienelement.
+	3. Dieselbe Bauform wie die Ansichten-Leiste direkt darüber: aktiv =
+	   `btn-primary` (die einzige Vollton-Fläche), alle übrigen `btn-outline`,
+	   damit „aktiv" nicht mit „auswählbar" verschwimmt.
+
+	Waagerecht scrollbar statt umbrechend: Ein Umbruch verschöbe bei jedem
+	Filterwechsel die Tabelle darunter.
+-->
+<nav class="overflow-x-auto" aria-label="Status der Sichtungen">
+	<div class="join">
+		{#each STATUS_TABS as tab (tab.value)}
+			{@const aktiv = tab.value === active}
+			<button
+				type="button"
+				class="btn btn-sm join-item {aktiv ? 'btn-primary' : 'btn-outline'}"
+				aria-current={aktiv ? 'true' : undefined}
+				onclick={() => onselect(tab.value)}
+			>
+				{#if tab.icon}
+					<Icon icon={tab.icon} width="16" height="16" aria-hidden="true" />
+				{/if}
+				{tab.label}
+				<!-- Neutrales Badge ohne Statusfarbe: Die Zahl ist Text, und eine
+				     Statusfarbe als Textfarbe verfehlt den Kontrast
+				     (design-system.md, „Statusfarben haben zwei Rollen"). Die
+				     Bedeutung trägt das Icon davor. -->
+				<span class="badge badge-sm">{counts[tab.countKey]}</span>
+			</button>
+		{/each}
+	</div>
+</nav>

--- a/src/routes/admin/sichtungen/StatusTabs.svelte
+++ b/src/routes/admin/sichtungen/StatusTabs.svelte
@@ -29,8 +29,12 @@
 	   (design-system.md, „Feldmodus und Touch-Targets"). `.tab` bliebe darunter
 	   — und diese Leiste ist gerade auf Mobil das wichtigste Bedienelement.
 	3. Dieselbe Bauform wie die Ansichten-Leiste direkt darüber: aktiv =
-	   `btn-primary` (die einzige Vollton-Fläche), alle übrigen `btn-outline`,
-	   damit „aktiv" nicht mit „auswählbar" verschwimmt.
+	   `btn-active` (dieselbe „aktueller Zustand"-Optik wie die Seitenzahl in
+	   der Paginierung weiter unten), alle übrigen `btn-outline`. `btn-primary`
+	   bleibt Export und „Anwenden" vorbehalten (Button-Hierarchie) — sonst
+	   sagt dieselbe Vollton-Fläche gleichzeitig „das ist die Aktion hier" und
+	   „das ist ausgewählt", und auf breiten Bildschirmen standen bis zu vier
+	   solcher Flächen binnen 150px Höhe nebeneinander.
 
 	Waagerecht scrollbar statt umbrechend: Ein Umbruch verschöbe bei jedem
 	Filterwechsel die Tabelle darunter.
@@ -41,7 +45,7 @@
 			{@const aktiv = tab.value === active}
 			<button
 				type="button"
-				class="btn btn-sm join-item {aktiv ? 'btn-primary' : 'btn-outline'}"
+				class="btn btn-sm join-item {aktiv ? 'btn-active' : 'btn-outline'}"
 				aria-current={aktiv ? 'true' : undefined}
 				onclick={() => onselect(tab.value)}
 			>

--- a/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
@@ -33,6 +33,9 @@ const SichtungenSeite = (await import('./+page.svelte')).default;
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
@@ -1,0 +1,53 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+/**
+ * activeFilters.svelte.test.ts — der Puffer im Panel ist noch kein Filter.
+ *
+ * Gegenstück zu `activeFilters.test.ts`, das die reine Ableitung aus der URL
+ * prüft: Hier hängt die Verdrahtung dran. Ein ins Panel getipptes Datum, das
+ * nicht angewendet wurde, darf die Filter-Schaltfläche nicht markieren — die
+ * Tabelle darunter zeigt weiterhin die ungefilterte Menge, und derselbe Wert
+ * ging vorher auch in den Export.
+ *
+ * Eigene Datei mit eigenem `$app/state`-Mock (URL ohne Filterparameter), aus
+ * demselben Grund wie bei `statusFilterParam.svelte.test.ts`: `vi.mock` gilt
+ * für das ganze Modul.
+ */
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function daten(rows: SightingSelect[]): PageData {
+	return {
+		sightings: rows,
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
+	} as unknown as PageData;
+}
+
+describe('Sichtungstabelle — aktive Filter kommen aus der URL', () => {
+	it('markiert die Filter-Schaltfläche nicht, solange ein Datum nur getippt ist', async () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		// Filter-Panel ist standardmäßig zu — Mobile- UND Desktop-Button stehen im
+		// Test-DOM (nur per CSS getrennt), `.first()` genügt für beide.
+		await screen.getByRole('button', { name: 'Filter' }).first().click();
+
+		await screen.getByLabelText('Von').fill('2026-01-01');
+		await expect.element(screen.getByLabelText('Von')).toHaveValue('2026-01-01');
+
+		expect(screen.container.querySelectorAll('.badge-accent')).toHaveLength(0);
+	});
+});

--- a/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
@@ -8,9 +8,14 @@ import type { PageData } from './$types';
  *
  * Gegenstück zu `activeFilters.test.ts`, das die reine Ableitung aus der URL
  * prüft: Hier hängt die Verdrahtung dran. Ein ins Panel getipptes Datum, das
- * nicht angewendet wurde, darf die Filter-Schaltfläche nicht markieren — die
- * Tabelle darunter zeigt weiterhin die ungefilterte Menge, und derselbe Wert
- * ging vorher auch in den Export.
+ * nicht angewendet wurde, ist kein aktiver Filter — die Tabelle darunter zeigt
+ * weiterhin die ungefilterte Menge, und derselbe Wert ging vorher auch in den
+ * Export.
+ *
+ * Geprüft wird das seit WP3 an der Chip-Zeile: Sie ist die Anzeige, die „es
+ * ist gefiltert" trägt. Vorher stand hier das Punkt-Badge an der
+ * Filter-Schaltfläche — es ist mit den Chips entfallen, und die Zusicherung
+ * darüber wäre seitdem grün, ohne noch etwas zu belegen.
  *
  * Eigene Datei mit eigenem `$app/state`-Mock (URL ohne Filterparameter), aus
  * demselben Grund wie bei `statusFilterParam.svelte.test.ts`: `vi.mock` gilt
@@ -41,7 +46,7 @@ function daten(rows: SightingSelect[]): PageData {
 }
 
 describe('Sichtungstabelle — aktive Filter kommen aus der URL', () => {
-	it('markiert die Filter-Schaltfläche nicht, solange ein Datum nur getippt ist', async () => {
+	it('zeigt keinen Filter-Chip, solange ein Datum nur getippt ist', async () => {
 		const screen = render(SichtungenSeite, { data: daten([]) });
 
 		// Filter-Panel ist standardmäßig zu — Mobile- UND Desktop-Button stehen im
@@ -51,6 +56,8 @@ describe('Sichtungstabelle — aktive Filter kommen aus der URL', () => {
 		await screen.getByLabelText('Von').fill('2026-01-01');
 		await expect.element(screen.getByLabelText('Von')).toHaveValue('2026-01-01');
 
-		expect(screen.container.querySelectorAll('.badge-accent')).toHaveLength(0);
+		/* Über das Suffix und nicht über „Filter …": Das Panel steht in diesem
+		   Test offen, und sein Schließen-Knopf heißt „Filter ausblenden". */
+		expect(screen.container.querySelectorAll('[aria-label$=" entfernen"]')).toHaveLength(0);
 	});
 });

--- a/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.svelte.test.ts
@@ -53,8 +53,8 @@ describe('Sichtungstabelle — aktive Filter kommen aus der URL', () => {
 		// Test-DOM (nur per CSS getrennt), `.first()` genügt für beide.
 		await screen.getByRole('button', { name: 'Filter' }).first().click();
 
-		await screen.getByLabelText('Von').fill('2026-01-01');
-		await expect.element(screen.getByLabelText('Von')).toHaveValue('2026-01-01');
+		await screen.getByLabelText('Sichtung von').fill('2026-01-01');
+		await expect.element(screen.getByLabelText('Sichtung von')).toHaveValue('2026-01-01');
 
 		/* Über das Suffix und nicht über „Filter …": Das Panel steht in diesem
 		   Test offen, und sein Schließen-Knopf heißt „Filter ausblenden". */

--- a/src/routes/admin/sichtungen/activeFilters.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hasActiveFilters, readFilterParams, type FilterParams } from './activeFilters';
+import { readFilterParams, type FilterParams } from './activeFilters';
 
 /**
  * activeFilters.test.ts — Filterzustand kommt aus der URL, nicht aus dem Panel.
@@ -79,17 +79,4 @@ describe('readFilterParams', () => {
 			verified: erwartet
 		});
 	});
-});
-
-describe('hasActiveFilters', () => {
-	it('ist falsch, wenn kein Filter gesetzt ist', () => {
-		expect(hasActiveFilters(LEER)).toBe(false);
-	});
-
-	it.each(Object.keys(LEER) as (keyof FilterParams)[])(
-		'ist wahr, sobald nur `%s` gesetzt ist',
-		(feld) => {
-			expect(hasActiveFilters({ ...LEER, [feld]: 'x' })).toBe(true);
-		}
-	);
 });

--- a/src/routes/admin/sichtungen/activeFilters.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.test.ts
@@ -1,3 +1,4 @@
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 import { describe, expect, it } from 'vitest';
 import { readFilterParams, type FilterParams } from './activeFilters';
 
@@ -27,15 +28,21 @@ describe('readFilterParams', () => {
 		expect(readFilterParams(new URLSearchParams())).toEqual(LEER);
 	});
 
+	/* Die Werte sind bewusst die, die tatsächlich vorkommen können:
+	   `mediaUpload` kennt `1`/`0`/`announced_missing`, `balticSea` die drei
+	   Schlüssel aus `BALTIC_SEA_STATUS_PRESENTATION`, `deadFinding` nur `1`/`0`
+	   (`deadFindingFilter.ts`). Eine Fixture mit erfundenen Werten liest sich
+	   wie eine Zusicherung, dass die Tabelle danach filtert — sie tut es nicht,
+	   der Server verwirft sie stillschweigend. */
 	it('liest alle acht Parameter aus der URL', () => {
 		const params = new URLSearchParams({
 			fromDate: '2026-01-01',
 			toDate: '2026-01-31',
 			verified: 'rejected',
 			entryChannel: '1',
-			mediaUpload: 'pending',
-			balticSea: 'inside',
-			deadFinding: 'true',
+			mediaUpload: MEDIA_UPLOAD_ANNOUNCED_MISSING,
+			balticSea: 'outside',
+			deadFinding: '1',
 			q: 'müller'
 		});
 
@@ -44,11 +51,21 @@ describe('readFilterParams', () => {
 			toDate: '2026-01-31',
 			verified: 'rejected',
 			entryChannel: '1',
-			mediaUpload: 'pending',
-			balticSea: 'inside',
-			deadFinding: 'true',
+			mediaUpload: MEDIA_UPLOAD_ANNOUNCED_MISSING,
+			balticSea: 'outside',
+			deadFinding: '1',
 			q: 'müller'
 		});
+	});
+
+	/* `all` ist das Sentinel des Panel-`<select>` für „egal" und steht in der URL
+	   normalerweise nie — ein altes Lesezeichen oder ein vor dem Umbau
+	   gespeichertes Preset kann es aber tragen. Der Loader behandelt es korrekt
+	   als „kein Filter" (`entryChannel !== 'all'`); ohne diese Normalisierung
+	   hielten Chip-Zeile und Export-Dialog es für einen aktiven Filter und
+	   zeigten „Kanal: all" über einer ungefilterten Tabelle. */
+	it('normalisiert das UI-Sentinel `entryChannel=all` zu „nicht gesetzt"', () => {
+		expect(readFilterParams(new URLSearchParams({ entryChannel: 'all' }))).toEqual(LEER);
 	});
 
 	it('ignoriert Parameter, die nicht zum Filterzustand gehören', () => {

--- a/src/routes/admin/sichtungen/activeFilters.test.ts
+++ b/src/routes/admin/sichtungen/activeFilters.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { hasActiveFilters, readFilterParams, type FilterParams } from './activeFilters';
+
+/**
+ * activeFilters.test.ts — Filterzustand kommt aus der URL, nicht aus dem Panel.
+ *
+ * Vorher las `currentFilters` in `+page.svelte` nur `q` aus der URL und die
+ * übrigen sieben Filter aus den Feld-States des Panels. Wer ein Datum wählte,
+ * nicht „Anwenden" klickte und dann exportierte, exportierte eine Menge, die
+ * die Tabelle nie gezeigt hat; die Filter-Schaltfläche leuchtete schon beim
+ * Tippen. Beide Ableitungen hängen deshalb an diesen zwei Funktionen.
+ */
+
+const LEER: FilterParams = {
+	fromDate: '',
+	toDate: '',
+	verified: '',
+	entryChannel: '',
+	mediaUpload: '',
+	balticSea: '',
+	deadFinding: '',
+	q: ''
+};
+
+describe('readFilterParams', () => {
+	it('liefert für jeden fehlenden Parameter einen leeren String', () => {
+		expect(readFilterParams(new URLSearchParams())).toEqual(LEER);
+	});
+
+	it('liest alle acht Parameter aus der URL', () => {
+		const params = new URLSearchParams({
+			fromDate: '2026-01-01',
+			toDate: '2026-01-31',
+			verified: 'rejected',
+			entryChannel: '1',
+			mediaUpload: 'pending',
+			balticSea: 'inside',
+			deadFinding: 'true',
+			q: 'müller'
+		});
+
+		expect(readFilterParams(params)).toEqual({
+			fromDate: '2026-01-01',
+			toDate: '2026-01-31',
+			verified: 'rejected',
+			entryChannel: '1',
+			mediaUpload: 'pending',
+			balticSea: 'inside',
+			deadFinding: 'true',
+			q: 'müller'
+		});
+	});
+
+	it('ignoriert Parameter, die nicht zum Filterzustand gehören', () => {
+		const params = new URLSearchParams({ page: '7', sort: 'created', perPage: '50' });
+
+		expect(readFilterParams(params)).toEqual(LEER);
+	});
+
+	/* Statuswerte über `toEqual` gegen ein Objektliteral geprüft, nicht über den
+	   Property-Zugriff: `verifiedReadScan.test.ts` verbietet `.verified` außerhalb
+	   der zwei dort namentlich ausgenommenen Empfänger. */
+	it.each([
+		// Exakt die Zuordnung aus `sightingStatusFilter.ts`: `1` meinte „geprüft"
+		// und heißt heute `approved`, `0` meinte „nicht geprüft" und heißt `open`.
+		['1', 'approved'],
+		['0', 'open'],
+		// Die drei kanonischen Werte bleiben unverändert.
+		['open', 'open'],
+		['approved', 'approved'],
+		['rejected', 'rejected'],
+		/* Ein unbekannter Wert wird verworfen statt durchgereicht:
+		   `normalizeStatusParam` liefert dafür `undefined`, und als Filterwert wäre
+		   das ein Zustand, den weder Server noch `<select>` kennen. */
+		['vielleicht', '']
+	])('normalisiert den Statusparameter %s zu %s', (roh, erwartet) => {
+		expect(readFilterParams(new URLSearchParams({ verified: roh }))).toEqual({
+			...LEER,
+			verified: erwartet
+		});
+	});
+});
+
+describe('hasActiveFilters', () => {
+	it('ist falsch, wenn kein Filter gesetzt ist', () => {
+		expect(hasActiveFilters(LEER)).toBe(false);
+	});
+
+	it.each(Object.keys(LEER) as (keyof FilterParams)[])(
+		'ist wahr, sobald nur `%s` gesetzt ist',
+		(feld) => {
+			expect(hasActiveFilters({ ...LEER, [feld]: 'x' })).toBe(true);
+		}
+	);
+});

--- a/src/routes/admin/sichtungen/activeFilters.ts
+++ b/src/routes/admin/sichtungen/activeFilters.ts
@@ -41,8 +41,15 @@ export function readFilterParams(searchParams: URLSearchParams): FilterParams {
 		   liefert `undefined` und gilt hier als „nicht gesetzt". */
 		verified: normalizeStatusParam(searchParams.get('verified')) ?? '',
 		/* Ohne das UI-Sentinel `all`: Das Panel-`<select>` braucht einen Wert für
-		   „egal", die URL trägt dafür gar keinen Parameter. */
-		entryChannel: lies('entryChannel'),
+		   „egal", die URL trägt dafür gar keinen Parameter — normalerweise. Ein
+		   Lesezeichen oder eine vor dem Umbau gespeicherte Ansicht kann `all`
+		   trotzdem tragen, und der Loader liest es korrekt als „kein Filter"
+		   (`entryChannel !== 'all'` in `+page.server.ts`). Ohne die Umrechnung
+		   hier hielten Chip-Zeile und Export-Dialog es für einen aktiven Filter
+		   und behaupteten „Kanal: all" über einer ungefilterten Tabelle. Die
+		   Normalisierung gehört an diese Stelle und nicht in `buildFilterChips`,
+		   damit alle Leser des Filterzustands dieselbe Sicht haben. */
+		entryChannel: lies('entryChannel') === 'all' ? '' : lies('entryChannel'),
 		mediaUpload: lies('mediaUpload'),
 		balticSea: lies('balticSea'),
 		deadFinding: lies('deadFinding'),

--- a/src/routes/admin/sichtungen/activeFilters.ts
+++ b/src/routes/admin/sichtungen/activeFilters.ts
@@ -49,7 +49,3 @@ export function readFilterParams(searchParams: URLSearchParams): FilterParams {
 		q: lies('q')
 	};
 }
-
-export function hasActiveFilters(params: FilterParams): boolean {
-	return Object.values(params).some((wert) => wert !== '');
-}

--- a/src/routes/admin/sichtungen/activeFilters.ts
+++ b/src/routes/admin/sichtungen/activeFilters.ts
@@ -1,0 +1,55 @@
+import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+
+/**
+ * Der Filterzustand der Sichtungstabelle, gelesen aus der URL.
+ *
+ * **Warum aus der URL und nicht aus den Feld-States des Panels:** Die Tabelle
+ * zeigt, was in der URL steht — nichts anderes. Wer im Panel ein Datum wählt
+ * und nicht „Anwenden" klickt, hat keinen Filter gesetzt; die Feld-States sind
+ * bis dahin ein Editier-Puffer. Aus ihnen abgeleitet, exportierte der
+ * Export-Dialog eine Menge, die die Tabelle nie gezeigt hat, und die
+ * Filter-Schaltfläche stand schon beim Tippen markiert da.
+ *
+ * Client-sicher: `+page.svelte` und (über WP2/WP3) die Statusreiter und
+ * Filter-Chips lesen dieselben zwei Funktionen.
+ *
+ * Leerer String heißt „nicht gesetzt" — die Form, die `ExportModal.svelte`
+ * ohnehin erwartet.
+ */
+export type FilterParams = {
+	fromDate: string;
+	toDate: string;
+	verified: string;
+	entryChannel: string;
+	mediaUpload: string;
+	balticSea: string;
+	deadFinding: string;
+	q: string;
+};
+
+export function readFilterParams(searchParams: URLSearchParams): FilterParams {
+	const lies = (name: string): string => searchParams.get(name) ?? '';
+
+	return {
+		fromDate: lies('fromDate'),
+		toDate: lies('toDate'),
+		/* Normalisiert, nicht roh: Der Server versteht die alten Aliase
+		   `verified=1`/`verified=0` weiterhin (Lesezeichen, verlinkte
+		   Filteransichten). Ohne die Umrechnung stünde in der Beschriftung des
+		   Export-Dialogs eine `1`, und das `<select>` im Panel — das nur
+		   `open`/`approved`/`rejected` kennt — bliebe leer. Ein unbekannter Wert
+		   liefert `undefined` und gilt hier als „nicht gesetzt". */
+		verified: normalizeStatusParam(searchParams.get('verified')) ?? '',
+		/* Ohne das UI-Sentinel `all`: Das Panel-`<select>` braucht einen Wert für
+		   „egal", die URL trägt dafür gar keinen Parameter. */
+		entryChannel: lies('entryChannel'),
+		mediaUpload: lies('mediaUpload'),
+		balticSea: lies('balticSea'),
+		deadFinding: lies('deadFinding'),
+		q: lies('q')
+	};
+}
+
+export function hasActiveFilters(params: FilterParams): boolean {
+	return Object.values(params).some((wert) => wert !== '');
+}

--- a/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
+++ b/src/routes/admin/sichtungen/bulkActions.svelte.test.ts
@@ -38,6 +38,9 @@ function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/columnPreferences.test.ts
+++ b/src/routes/admin/sichtungen/columnPreferences.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
 	COLUMN_PREFERENCES_STORAGE_KEY,
+	isDefaultVisibility,
 	loadColumnPreferences,
 	mergeColumnPreferences,
 	serializeColumnPreferences
@@ -100,5 +101,27 @@ describe('serializeColumnPreferences', () => {
 			v: 1,
 			columns: { a: true }
 		});
+	});
+});
+
+describe('isDefaultVisibility', () => {
+	it('liefert true, wenn die aktuelle Auswahl dem Default entspricht', () => {
+		expect(isDefaultVisibility(DEFAULTS, DEFAULTS)).toBe(true);
+		expect(isDefaultVisibility({ a: true, b: false, c: true }, DEFAULTS)).toBe(true);
+	});
+
+	it('liefert false, wenn eine Spalte vom Default abweicht', () => {
+		expect(isDefaultVisibility({ a: false, b: false, c: true }, DEFAULTS)).toBe(false);
+	});
+
+	it('liefert false, wenn die aktuelle Auswahl einen Schlüssel weniger als der Default hat', () => {
+		const { a: _a, ...rest } = DEFAULTS;
+		expect(isDefaultVisibility(rest as unknown as typeof DEFAULTS, DEFAULTS)).toBe(false);
+	});
+
+	it('liefert false, wenn die aktuelle Auswahl einen Schlüssel mehr als der Default hat', () => {
+		expect(
+			isDefaultVisibility({ ...DEFAULTS, extra: true } as unknown as typeof DEFAULTS, DEFAULTS)
+		).toBe(false);
 	});
 });

--- a/src/routes/admin/sichtungen/columnPreferences.ts
+++ b/src/routes/admin/sichtungen/columnPreferences.ts
@@ -83,11 +83,14 @@ export function serializeColumnPreferences(columns: Record<string, boolean>): st
  * steuert den „Standard wiederherstellen"-Knopf im Spalten-Dropdown (nur aktiv
  * bei Abweichung).
  *
- * Schlüsselzahl **und** Werte müssen übereinstimmen: Eine fehlende (neue Spalte
- * seit dem letzten Speichern) oder überzählige (entfernte Spalte im
- * localStorage-Rest) Spalte zählt als Abweichung, auch wenn alle gemeinsamen
- * Werte gleich sind — sonst bliebe der Knopf inaktiv, obwohl ein Reset die
- * fehlende Spalte erst auf ihren Default brächte.
+ * Schlüsselzahl **und** Werte müssen übereinstimmen. Der Schlüsselzahl-Vergleich
+ * ist reine Verteidigung: `mergeColumnPreferences` (oben) baut sein Ergebnis
+ * immer als `{ ...defaults }` und überschreibt darin nur Schlüssel, die in
+ * `defaults` existieren — der zurückgegebene Schlüsselsatz ist damit immer
+ * exakt der Default-Schlüsselsatz, nie mehr, nie weniger. Ein `current`, das
+ * hier abweicht, kann also nur über einen anderen Aufrufpfad entstehen. Diese
+ * Funktion prüft trotzdem beide Seiten, statt sich auf den einen bekannten
+ * Aufrufer zu verlassen.
  */
 export function isDefaultVisibility(
 	current: Record<string, boolean>,

--- a/src/routes/admin/sichtungen/columnPreferences.ts
+++ b/src/routes/admin/sichtungen/columnPreferences.ts
@@ -77,3 +77,24 @@ export function serializeColumnPreferences(columns: Record<string, boolean>): st
 	const preferences: ColumnPreferences = { v: CURRENT_VERSION, columns };
 	return JSON.stringify(preferences);
 }
+
+/**
+ * Prüft, ob die aktuelle Auswahl exakt dem kuratierten Default entspricht —
+ * steuert den „Standard wiederherstellen"-Knopf im Spalten-Dropdown (nur aktiv
+ * bei Abweichung).
+ *
+ * Schlüsselzahl **und** Werte müssen übereinstimmen: Eine fehlende (neue Spalte
+ * seit dem letzten Speichern) oder überzählige (entfernte Spalte im
+ * localStorage-Rest) Spalte zählt als Abweichung, auch wenn alle gemeinsamen
+ * Werte gleich sind — sonst bliebe der Knopf inaktiv, obwohl ein Reset die
+ * fehlende Spalte erst auf ihren Default brächte.
+ */
+export function isDefaultVisibility(
+	current: Record<string, boolean>,
+	defaults: Record<string, boolean>
+): boolean {
+	const currentKeys = Object.keys(current);
+	const defaultKeys = Object.keys(defaults);
+	if (currentKeys.length !== defaultKeys.length) return false;
+	return defaultKeys.every((key) => current[key] === defaults[key]);
+}

--- a/src/routes/admin/sichtungen/filterChips.svelte.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.svelte.test.ts
@@ -1,0 +1,98 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { goto } from '$app/navigation';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+/**
+ * filterChips.svelte.test.ts — die Verdrahtung der Chip-Zeile.
+ *
+ * Gegenstück zu `filterChips.test.ts`, das nur die Rechnung prüft: Hier hängt
+ * die Seite dran. Der Chip muss die Tabelle tatsächlich neu laden — ein Chip,
+ * der nur anzeigt, wäre die Hälfte des Befunds („nichts ist einzeln
+ * entfernbar").
+ *
+ * Eigene Datei mit eigenem `$app/state`-Mock (URL mit zwei Filtern und
+ * `page=7`), aus demselben Grund wie bei `statusFilterParam.svelte.test.ts`:
+ * `vi.mock` gilt für das ganze Modul.
+ */
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: {
+		url: new URL(
+			'https://localhost:4000/admin/sichtungen?fromDate=2026-06-01&q=delfin&verified=approved&page=7'
+		)
+	}
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function daten(rows: SightingSelect[]): PageData {
+	return {
+		sightings: rows,
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
+		pagination: { page: 7, perPage: 20, total: rows.length, totalPages: 9, maxPerPage: 100 }
+	} as unknown as PageData;
+}
+
+describe('Sichtungstabelle — Chip-Zeile der aktiven Filter', () => {
+	it('zeigt je gesetztem Filter einen entfernbaren Chip', async () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		await expect.element(screen.getByLabelText('Filter Von 01.06.2026 entfernen')).toBeVisible();
+		await expect.element(screen.getByLabelText('Filter Suche: „delfin“ entfernen')).toBeVisible();
+	});
+
+	/* Den Status zeigt der Reiter direkt darunter — ein Chip dafür wäre ein
+	   zweites Bedienelement für dieselbe Aussage. */
+	it('zeigt keinen Chip für den Status', () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		expect(screen.container.querySelectorAll('[aria-label^="Filter Status:"]')).toHaveLength(0);
+	});
+
+	it('entfernt beim Klick genau diesen Filter und springt auf Seite 1', async () => {
+		vi.mocked(goto).mockClear();
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		await screen.getByLabelText('Filter Suche: „delfin“ entfernen').click();
+
+		const ziel = new URL(String(vi.mocked(goto).mock.calls.at(-1)?.[0]));
+		expect(ziel.searchParams.get('q')).toBeNull();
+		expect(ziel.searchParams.get('fromDate')).toBe('2026-06-01');
+		expect(ziel.searchParams.get('page')).toBe('1');
+	});
+
+	it('bietet ab zwei Chips das Zurücksetzen aller Filter an', async () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		await expect
+			.element(screen.getByRole('button', { name: 'Alle Filter zurücksetzen' }))
+			.toBeVisible();
+	});
+
+	/* Die Chips tragen das Signal „es ist gefiltert" jetzt allein. Ein Punkt-
+	   Badge an der Filter-Schaltfläche sagte dasselbe noch einmal, ohne einen
+	   Filter zu benennen und ohne anklickbar zu sein. */
+	it('markiert die Filter-Schaltfläche nicht zusätzlich', () => {
+		const screen = render(SichtungenSeite, { data: daten([]) });
+
+		const filterKnoepfe = [...screen.container.querySelectorAll('button')].filter(
+			(knopf) => knopf.textContent?.trim() === 'Filter'
+		);
+
+		// Mobil- und Desktop-Kopf stehen beide im Test-DOM (nur per CSS getrennt).
+		expect(filterKnoepfe).toHaveLength(2);
+		for (const knopf of filterKnoepfe) {
+			expect(knopf.classList.contains('btn-primary')).toBe(false);
+			expect(knopf.querySelector('.badge')).toBeNull();
+		}
+	});
+});

--- a/src/routes/admin/sichtungen/filterChips.svelte.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.svelte.test.ts
@@ -46,7 +46,9 @@ describe('Sichtungstabelle — Chip-Zeile der aktiven Filter', () => {
 	it('zeigt je gesetztem Filter einen entfernbaren Chip', async () => {
 		const screen = render(SichtungenSeite, { data: daten([]) });
 
-		await expect.element(screen.getByLabelText('Filter Von 01.06.2026 entfernen')).toBeVisible();
+		await expect
+			.element(screen.getByLabelText('Filter Sichtung von 01.06.2026 entfernen'))
+			.toBeVisible();
 		await expect.element(screen.getByLabelText('Filter Suche: „delfin“ entfernen')).toBeVisible();
 	});
 

--- a/src/routes/admin/sichtungen/filterChips.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
+import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
+import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+import type { FilterParams } from './activeFilters';
+import { buildFilterChips, removeFilterParam } from './filterChips';
+
+/**
+ * filterChips.test.ts — was gefiltert ist, muss sichtbar und einzeln
+ * entfernbar sein.
+ *
+ * Bei geschlossenem Panel zeigte nur ein Punkt-Badge, *dass* gefiltert wird.
+ * Welcher Filter greift, stand nirgends, und zurücknehmen ließ sich nur alles
+ * auf einmal.
+ *
+ * Die Beschriftungen kommen ausnahmslos aus den Quellen, die auch das Panel
+ * benutzt — deshalb prüfen die Fälle unten gegen diese Quellen und nicht gegen
+ * abgetippte Wörter: Ein Test mit eigenem Wortlaut wäre selbst die zweite
+ * Beschriftungsquelle, die es hier zu vermeiden gilt.
+ */
+
+const LEER: FilterParams = {
+	fromDate: '',
+	toDate: '',
+	verified: '',
+	entryChannel: '',
+	mediaUpload: '',
+	balticSea: '',
+	deadFinding: '',
+	q: ''
+};
+
+/** Ein Filter gesetzt, alle anderen leer. */
+function nur(param: keyof FilterParams, wert: string): FilterParams {
+	return { ...LEER, [param]: wert };
+}
+
+describe('buildFilterChips', () => {
+	it('liefert für einen leeren Filterzustand keine Chips', () => {
+		expect(buildFilterChips(LEER)).toEqual([]);
+	});
+
+	it.each(Object.keys(LEER) as (keyof FilterParams)[])(
+		'erzeugt für `%s` genau einen Chip',
+		(param) => {
+			const chips = buildFilterChips(nur(param, '1'));
+
+			expect(chips).toHaveLength(1);
+			expect(chips[0]?.param).toBe(param);
+		}
+	);
+
+	it('erzeugt je gesetztem Filter einen Chip', () => {
+		const chips = buildFilterChips({ ...LEER, fromDate: '2026-06-01', q: 'delfin' });
+
+		expect(chips.map((chip) => chip.param)).toEqual(['fromDate', 'q']);
+	});
+
+	it('beschriftet die Datumsgrenzen im Format der Tabelle', () => {
+		expect(buildFilterChips(nur('fromDate', '2026-06-01'))[0]?.label).toBe('Von 01.06.2026');
+		expect(buildFilterChips(nur('toDate', '2026-06-30'))[0]?.label).toBe('Bis 30.06.2026');
+	});
+
+	it('löst den Kanal über die Options-Liste des Panels auf', () => {
+		const [option] = getEntryChannelOptions();
+
+		expect(buildFilterChips(nur('entryChannel', String(option?.value)))[0]?.label).toBe(
+			`Kanal: ${option?.label}`
+		);
+	});
+
+	it.each([
+		['1', 'Mit'],
+		['0', 'Ohne'],
+		[MEDIA_UPLOAD_ANNOUNCED_MISSING, 'Angekündigt, fehlt noch']
+	])('beschriftet den Aufnahme-Filter %s als „%s"', (wert, erwartet) => {
+		expect(buildFilterChips(nur('mediaUpload', wert))[0]?.label).toBe(`Aufnahme: ${erwartet}`);
+	});
+
+	it('nimmt das Totfund-Wort aus der gemeinsamen Auszeichnung', () => {
+		expect(buildFilterChips(nur('deadFinding', '1'))[0]?.label).toBe(
+			`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`
+		);
+		expect(buildFilterChips(nur('deadFinding', '0'))[0]?.label).toBe('Meldeart: Lebendsichtung');
+	});
+
+	it('nimmt das Ostsee-Wort aus der gemeinsamen Statusdarstellung', () => {
+		expect(buildFilterChips(nur('balticSea', 'edge'))[0]?.label).toBe(
+			`Ostsee: ${BALTIC_SEA_STATUS_PRESENTATION.edge.label}`
+		);
+	});
+
+	it('zeigt den Suchbegriff in Anführungszeichen', () => {
+		expect(buildFilterChips(nur('q', 'delfin'))[0]?.label).toBe('Suche: „delfin“');
+	});
+
+	/* Ein Wert, den keine Quelle kennt (veraltetes Lesezeichen, von Hand
+	   getippte URL), darf den Chip nicht verschlucken — sonst filterte die
+	   Tabelle sichtbar anders, ohne dass es etwas zum Wegklicken gäbe. */
+	it('zeigt einen unbekannten Wert unverändert, statt den Chip wegzulassen', () => {
+		expect(buildFilterChips(nur('entryChannel', '99'))[0]?.label).toBe('Kanal: 99');
+		expect(buildFilterChips(nur('balticSea', 'atlantik'))[0]?.label).toBe('Ostsee: atlantik');
+	});
+
+	describe('Statusreiter', () => {
+		it('beschriftet den Status aus der gemeinsamen Statusdarstellung', () => {
+			expect(buildFilterChips(nur('verified', 'approved'))[0]?.label).toBe(
+				`Status: ${SIGHTING_STATUS_PRESENTATION.approved.label}`
+			);
+		});
+
+		/* Solange die Statusreiter über der Tabelle stehen, zeigt der aktive
+		   Reiter den Status bereits — ein zweites Bedienelement für dieselbe
+		   Aussage wäre die Sorte Doppelung, gegen die WP2 angetreten ist. */
+		it('unterdrückt den Status-Chip, wenn die Reiter ihn schon zeigen', () => {
+			expect(buildFilterChips(nur('verified', 'approved'), { skipVerified: true })).toEqual([]);
+		});
+
+		it('lässt die übrigen Chips dabei unangetastet', () => {
+			const chips = buildFilterChips(
+				{ ...LEER, verified: 'open', q: 'delfin' },
+				{ skipVerified: true }
+			);
+
+			expect(chips.map((chip) => chip.param)).toEqual(['q']);
+		});
+	});
+});
+
+describe('removeFilterParam', () => {
+	const url = () =>
+		new URL('https://example.test/admin/sichtungen?fromDate=2026-06-01&q=delfin&page=7');
+
+	it('löscht genau den übergebenen Parameter', () => {
+		const neu = removeFilterParam(url(), 'q');
+
+		expect(neu.searchParams.get('q')).toBeNull();
+		expect(neu.searchParams.get('fromDate')).toBe('2026-06-01');
+	});
+
+	/* Wie bei jedem anderen Filterwechsel: Die Trefferzahl springt, und ohne
+	   Rücksprung stünde man auf einer leeren Seite 7. */
+	it('springt auf die erste Seite zurück', () => {
+		expect(removeFilterParam(url(), 'q').searchParams.get('page')).toBe('1');
+	});
+
+	it('lässt die Ausgangs-URL unverändert', () => {
+		const original = url();
+		removeFilterParam(original, 'q');
+
+		expect(original.searchParams.get('q')).toBe('delfin');
+		expect(original.searchParams.get('page')).toBe('7');
+	});
+
+	it('behält Parameter, die nicht zum Filterzustand gehören', () => {
+		const mitSortierung = new URL('https://example.test/admin/sichtungen?q=delfin&sort=created');
+
+		expect(removeFilterParam(mitSortierung, 'q').searchParams.get('sort')).toBe('created');
+	});
+});

--- a/src/routes/admin/sichtungen/filterChips.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.test.ts
@@ -3,9 +3,8 @@ import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
 import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
 import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
 import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
-import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 import type { FilterParams } from './activeFilters';
-import { buildFilterChips, removeFilterParam } from './filterChips';
+import { AUFNAHME_LABEL, buildFilterChips, MELDEART_LABEL, removeFilterParam } from './filterChips';
 
 /**
  * filterChips.test.ts — was gefiltert ist, muss sichtbar und einzeln
@@ -71,19 +70,22 @@ describe('buildFilterChips', () => {
 		);
 	});
 
-	it.each([
-		['1', 'Mit'],
-		['0', 'Ohne'],
-		[MEDIA_UPLOAD_ANNOUNCED_MISSING, 'Angekündigt, fehlt noch']
-	])('beschriftet den Aufnahme-Filter %s als „%s"', (wert, erwartet) => {
-		expect(buildFilterChips(nur('mediaUpload', wert))[0]?.label).toBe(`Aufnahme: ${erwartet}`);
-	});
+	it.each(Object.keys(AUFNAHME_LABEL))(
+		'beschriftet den Aufnahme-Filter %s wie die exportierte Beschriftung',
+		(wert) => {
+			expect(buildFilterChips(nur('mediaUpload', wert))[0]?.label).toBe(
+				`Aufnahme: ${AUFNAHME_LABEL[wert]}`
+			);
+		}
+	);
 
 	it('nimmt das Totfund-Wort aus der gemeinsamen Auszeichnung', () => {
 		expect(buildFilterChips(nur('deadFinding', '1'))[0]?.label).toBe(
 			`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`
 		);
-		expect(buildFilterChips(nur('deadFinding', '0'))[0]?.label).toBe('Meldeart: Lebendsichtung');
+		expect(buildFilterChips(nur('deadFinding', '0'))[0]?.label).toBe(
+			`Meldeart: ${MELDEART_LABEL['0']}`
+		);
 	});
 
 	it('nimmt das Ostsee-Wort aus der gemeinsamen Statusdarstellung', () => {

--- a/src/routes/admin/sichtungen/filterChips.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.test.ts
@@ -57,9 +57,17 @@ describe('buildFilterChips', () => {
 		expect(chips.map((chip) => chip.param)).toEqual(['fromDate', 'q']);
 	});
 
+	// WP4: „Von"/„Bis" nannten kein Bezugsfeld — die Tabelle zeigt zwei
+	// Datumsspalten (Sichtungsdatum, Meldeeingang). Server-seitig filtert der
+	// Bereich das Sichtungsdatum (`+page.server.ts` → `sightingCalendarDate`),
+	// deshalb heißt der Chip jetzt „Sichtung von"/„Sichtung bis" — Wort für
+	// Wort wie das Filter-Panel (+page.svelte), keine zweite
+	// Beschriftungsvokabular für denselben Filter.
 	it('beschriftet die Datumsgrenzen im Format der Tabelle', () => {
-		expect(buildFilterChips(nur('fromDate', '2026-06-01'))[0]?.label).toBe('Von 01.06.2026');
-		expect(buildFilterChips(nur('toDate', '2026-06-30'))[0]?.label).toBe('Bis 30.06.2026');
+		expect(buildFilterChips(nur('fromDate', '2026-06-01'))[0]?.label).toBe(
+			'Sichtung von 01.06.2026'
+		);
+		expect(buildFilterChips(nur('toDate', '2026-06-30'))[0]?.label).toBe('Sichtung bis 30.06.2026');
 	});
 
 	it('löst den Kanal über die Options-Liste des Panels auf', () => {

--- a/src/routes/admin/sichtungen/filterChips.ts
+++ b/src/routes/admin/sichtungen/filterChips.ts
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview Die aktiven Filter der Sichtungstabelle als einzeln
+ * entfernbare Chips.
+ *
+ * Bei geschlossenem Panel zeigte nur ein Punkt-Badge, *dass* gefiltert wird.
+ * Welcher Filter greift, stand nirgends, und zurücknehmen ließ sich nur alles
+ * auf einmal — wer eine zu enge Menge vor sich hatte, musste das Panel
+ * aufklappen und die sieben Felder durchsehen.
+ *
+ * **Keine zweite Beschriftungsquelle.** Wort für Wort kommen die Chips aus
+ * denselben Quellen wie die `<select>`-Felder des Panels:
+ * `getEntryChannelOptions()`, `DEAD_FINDING_PRESENTATION`,
+ * `BALTIC_SEA_STATUS_PRESENTATION`, `SIGHTING_STATUS_PRESENTATION` und
+ * `MEDIA_UPLOAD_ANNOUNCED_MISSING`. Ein eigener Wortschatz hier hieße, dass
+ * Chip und Panel denselben Filter verschieden benennen, sobald eine der beiden
+ * Stellen angefasst wird — derselbe Fehler, gegen den `deadFinding.ts` und
+ * `balticSeaStatus.ts` angelegt wurden.
+ *
+ * Client-sicher: **kein** Import aus `$lib/server/**`. Die Seite ist eine
+ * Client-Komponente, und der Bruch fiele erst in `npm run build` auf.
+ *
+ * Der Filterzustand kommt aus `activeFilters.ts` und damit aus der URL — hier
+ * entsteht kein zweiter gemerkter Zustand.
+ */
+import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import {
+	SIGHTING_STATUS_PRESENTATION,
+	type SightingStatus
+} from '$lib/components/admin/sightingStatus';
+import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
+import { formatLocalDateTime } from '$lib/utils/format/dateTime';
+import { BALTIC_SEA_STATUS_PRESENTATION, isBalticSeaStatus } from '$lib/utils/geo/balticSeaStatus';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+import type { FilterParams } from './activeFilters';
+
+export type FilterChip = {
+	param: keyof FilterParams;
+	/** Menschenlesbar und für sich verständlich — „Von 01.06.2026", „Kanal: Web". */
+	label: string;
+};
+
+export type BuildFilterChipsOptions = {
+	/**
+	 * Den Status-Chip auslassen. Die Aufrufstelle setzt das, solange die
+	 * Statusreiter über der Tabelle stehen: Der aktive Reiter zeigt den Status
+	 * bereits, ein zweites Bedienelement für dieselbe Aussage wäre die
+	 * Doppelung, gegen die die Reiter angetreten sind.
+	 */
+	skipVerified?: boolean;
+};
+
+/**
+ * Reihenfolge der Chips — dieselbe wie im Panel, damit „zweiter Chip" und
+ * „zweites Feld" dasselbe meinen. Die Freitext-Suche steht zuletzt; ihr Feld
+ * liegt außerhalb des Panels.
+ */
+const CHIP_ORDER = [
+	'fromDate',
+	'toDate',
+	'verified',
+	'deadFinding',
+	'entryChannel',
+	'mediaUpload',
+	'balticSea',
+	'q'
+] as const satisfies readonly (keyof FilterParams)[];
+
+/**
+ * Das Datum im Format der Tabelle. `fromDate`/`toDate` sind reine
+ * Kalenderdaten (`YYYY-MM-DD`) und werden als UTC-Mitternacht gelesen — in
+ * Europe/Berlin liegt der Offset ganzjährig vorwärts, der Datumsteil kippt
+ * also nicht auf den Vortag.
+ */
+function datum(value: string): string {
+	return formatLocalDateTime(value, 'date');
+}
+
+function kanalLabel(value: string): string {
+	return getEntryChannelOptions().find((option) => String(option.value) === value)?.label ?? value;
+}
+
+function statusLabel(value: string): string {
+	return isSightingStatus(value) ? SIGHTING_STATUS_PRESENTATION[value].label : value;
+}
+
+function isSightingStatus(value: string): value is SightingStatus {
+	return Object.hasOwn(SIGHTING_STATUS_PRESENTATION, value);
+}
+
+/**
+ * „Mit"/„Ohne" stehen hier und nicht in einer geteilten Konstante: Sie sind
+ * keine Auszeichnung eines Datensatzes, sondern nur die zwei Seiten eines
+ * Ja/Nein-Filters, und ihre einzige weitere Fundstelle ist das `<select>` des
+ * Panels daneben. Der Sonderwert dagegen kommt aus seinem Modul — er trägt
+ * eine fachliche Aussage (`photoAnnouncement.ts`).
+ */
+const AUFNAHME_LABEL: Record<string, string> = {
+	'1': 'Mit',
+	'0': 'Ohne',
+	[MEDIA_UPLOAD_ANNOUNCED_MISSING]: 'Angekündigt, fehlt noch'
+};
+
+/** Gegenstück zum Totfund; `deadFinding.ts` führt für den Normalfall bewusst kein Wort. */
+const MELDEART_LABEL: Record<string, string> = {
+	'1': DEAD_FINDING_PRESENTATION.label,
+	'0': 'Lebendsichtung'
+};
+
+/**
+ * Ein Wert, den keine Quelle kennt (veraltetes Lesezeichen, von Hand getippte
+ * URL), erscheint unverändert. Den Chip wegzulassen wäre der schlechtere
+ * Ausgang: Die Tabelle filterte dann sichtbar, ohne dass es etwas zum
+ * Wegklicken gäbe.
+ */
+const CHIP_LABEL: Record<keyof FilterParams, (value: string) => string> = {
+	fromDate: (value) => `Von ${datum(value)}`,
+	toDate: (value) => `Bis ${datum(value)}`,
+	verified: (value) => `Status: ${statusLabel(value)}`,
+	deadFinding: (value) => `Meldeart: ${MELDEART_LABEL[value] ?? value}`,
+	entryChannel: (value) => `Kanal: ${kanalLabel(value)}`,
+	mediaUpload: (value) => `Aufnahme: ${AUFNAHME_LABEL[value] ?? value}`,
+	balticSea: (value) =>
+		`Ostsee: ${isBalticSeaStatus(value) ? BALTIC_SEA_STATUS_PRESENTATION[value].label : value}`,
+	q: (value) => `Suche: „${value}“`
+};
+
+/** Ein Chip je gesetztem Filter, in der Reihenfolge des Panels. */
+export function buildFilterChips(
+	params: FilterParams,
+	options: BuildFilterChipsOptions = {}
+): FilterChip[] {
+	return CHIP_ORDER.filter((param) => {
+		if (options.skipVerified && param === 'verified') return false;
+		return params[param] !== '';
+	}).map((param) => ({ param, label: CHIP_LABEL[param](params[param]) }));
+}
+
+/**
+ * Die URL ohne diesen einen Filter.
+ *
+ * `page=1` aus demselben Grund wie bei jedem anderen Filterwechsel: Die
+ * Trefferzahl springt, und ohne Rücksprung stünde man auf einer leeren Seite 7.
+ * Die übergebene URL bleibt unverändert — der Aufrufer navigiert mit dem
+ * Rückgabewert.
+ */
+export function removeFilterParam(url: URL, param: keyof FilterParams): URL {
+	const ziel = new URL(url);
+	ziel.searchParams.delete(param);
+	ziel.searchParams.set('page', '1');
+	return ziel;
+}

--- a/src/routes/admin/sichtungen/filterChips.ts
+++ b/src/routes/admin/sichtungen/filterChips.ts
@@ -11,10 +11,14 @@
  * denselben Quellen wie die `<select>`-Felder des Panels:
  * `getEntryChannelOptions()`, `DEAD_FINDING_PRESENTATION`,
  * `BALTIC_SEA_STATUS_PRESENTATION`, `SIGHTING_STATUS_PRESENTATION` und
- * `MEDIA_UPLOAD_ANNOUNCED_MISSING`. Ein eigener Wortschatz hier hieße, dass
- * Chip und Panel denselben Filter verschieden benennen, sobald eine der beiden
- * Stellen angefasst wird — derselbe Fehler, gegen den `deadFinding.ts` und
- * `balticSeaStatus.ts` angelegt wurden.
+ * `MEDIA_UPLOAD_ANNOUNCED_MISSING`. Für die beiden Ja/Nein-Wortpaare ohne
+ * eigenes Präsentationsmodul — „Mit"/„Ohne" und „Lebendsichtung" — ist diese
+ * Datei selbst die Quelle: `AUFNAHME_LABEL` und `MELDEART_LABEL` sind exportiert,
+ * und das Panel (`+page.svelte`) rendert seine `<option>`-Beschriftungen daraus,
+ * statt sie ein zweites Mal zu tippen. Ein eigener Wortschatz an einer der
+ * beiden Stellen hieße, dass Chip und Panel denselben Filter verschieden
+ * benennen, sobald eine der beiden angefasst wird — derselbe Fehler, gegen den
+ * `deadFinding.ts` und `balticSeaStatus.ts` angelegt wurden.
  *
  * Client-sicher: **kein** Import aus `$lib/server/**`. Die Seite ist eine
  * Client-Komponente, und der Bruch fiele erst in `npm run build` auf.
@@ -88,20 +92,25 @@ function isSightingStatus(value: string): value is SightingStatus {
 }
 
 /**
- * „Mit"/„Ohne" stehen hier und nicht in einer geteilten Konstante: Sie sind
- * keine Auszeichnung eines Datensatzes, sondern nur die zwei Seiten eines
- * Ja/Nein-Filters, und ihre einzige weitere Fundstelle ist das `<select>` des
- * Panels daneben. Der Sonderwert dagegen kommt aus seinem Modul — er trägt
- * eine fachliche Aussage (`photoAnnouncement.ts`).
+ * „Mit"/„Ohne" sind keine Auszeichnung eines Datensatzes, sondern nur die zwei
+ * Seiten eines Ja/Nein-Filters — kein `deadFinding.ts`/`balticSeaStatus.ts`-Modul
+ * nimmt sie auf. Diese Datei ist deshalb selbst die Quelle, exportiert für das
+ * `<select>` des Panels (`+page.svelte`), das seine `<option>`-Beschriftungen von
+ * hier bezieht statt sie ein zweites Mal zu tippen. Der Sonderwert kommt aus
+ * seinem eigenen Modul — er trägt eine fachliche Aussage (`photoAnnouncement.ts`).
  */
-const AUFNAHME_LABEL: Record<string, string> = {
+export const AUFNAHME_LABEL: Record<string, string> = {
 	'1': 'Mit',
 	'0': 'Ohne',
 	[MEDIA_UPLOAD_ANNOUNCED_MISSING]: 'Angekündigt, fehlt noch'
 };
 
-/** Gegenstück zum Totfund; `deadFinding.ts` führt für den Normalfall bewusst kein Wort. */
-const MELDEART_LABEL: Record<string, string> = {
+/**
+ * Gegenstück zum Totfund; `deadFinding.ts` führt für den Normalfall bewusst kein
+ * Wort, deshalb steht „Lebendsichtung" hier. Exportiert aus demselben Grund wie
+ * `AUFNAHME_LABEL`: Das Panel rendert seine Option daraus.
+ */
+export const MELDEART_LABEL: Record<string, string> = {
 	'1': DEAD_FINDING_PRESENTATION.label,
 	'0': 'Lebendsichtung'
 };

--- a/src/routes/admin/sichtungen/filterChips.ts
+++ b/src/routes/admin/sichtungen/filterChips.ts
@@ -39,7 +39,7 @@ import type { FilterParams } from './activeFilters';
 
 export type FilterChip = {
 	param: keyof FilterParams;
-	/** Menschenlesbar und für sich verständlich — „Von 01.06.2026", „Kanal: Web". */
+	/** Menschenlesbar und für sich verständlich — „Sichtung von 01.06.2026", „Kanal: Web". */
 	label: string;
 };
 
@@ -122,8 +122,8 @@ export const MELDEART_LABEL: Record<string, string> = {
  * Wegklicken gäbe.
  */
 const CHIP_LABEL: Record<keyof FilterParams, (value: string) => string> = {
-	fromDate: (value) => `Von ${datum(value)}`,
-	toDate: (value) => `Bis ${datum(value)}`,
+	fromDate: (value) => `Sichtung von ${datum(value)}`,
+	toDate: (value) => `Sichtung bis ${datum(value)}`,
 	verified: (value) => `Status: ${statusLabel(value)}`,
 	deadFinding: (value) => `Meldeart: ${MELDEART_LABEL[value] ?? value}`,
 	entryChannel: (value) => `Kanal: ${kanalLabel(value)}`,

--- a/src/routes/admin/sichtungen/filterPanelPlacement.svelte.test.ts
+++ b/src/routes/admin/sichtungen/filterPanelPlacement.svelte.test.ts
@@ -1,0 +1,118 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+
+/**
+ * filterPanelPlacement.svelte.test.ts — Filter-Panel an seinen Auslöser
+ * gerückt (UX-Anforderung 2026-08).
+ *
+ * Vorher stand das Panel hinter Suche, Ansichten und Chip-Zeile — wer „Filter"
+ * per Tastatur öffnete, tabbte durch drei fremde Bereiche, bevor er im Panel
+ * landete, und beide Auslöser hatten keinen ARIA-Zustand (nur Farbe). Geprüft
+ * wird hier:
+ *  - beide Auslöser tragen `aria-expanded` synchron zum Panel-Zustand,
+ *  - beide tragen `aria-controls` auf dieselbe, existierende Panel-`id`,
+ *  - das Panel steht im DOM VOR der Freitextsuche,
+ *  - die Chip-Zeile bleibt unmittelbar vor den Statusreitern, auch bei
+ *    offenem Panel (kein Panel dazwischengeschoben).
+ *
+ * Eigene Datei statt Erweiterung von `searchParam.svelte.test.ts`: Diese
+ * Datei rendert die volle Seite und prüft reine DOM-Reihenfolge/ARIA, kein
+ * Such-Verhalten — dieselbe Trennung wie zwischen `filterChips.test.ts`
+ * (reine Rechnung) und `filterChips.svelte.test.ts` (DOM).
+ */
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen?q=m%C3%BCller') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function daten(rows: SightingSelect[] = []): PageData {
+	return {
+		sightings: rows,
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
+	} as unknown as PageData;
+}
+
+/** Vergleicht die DOM-Reihenfolge zweier Elemente. */
+function stehtVor(a: Element, b: Element): boolean {
+	// Bit 4 (DOCUMENT_POSITION_FOLLOWING) ist gesetzt, wenn `b` NACH `a` kommt.
+	return !!(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+}
+
+describe('Sichtungstabelle — Filter-Panel-Platzierung', () => {
+	it('beide Auslöser tragen aria-expanded=false und ein aria-controls, solange das Panel zu ist', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		const ausloeser = screen.getByRole('button', { name: 'Filter', exact: true });
+		await expect.element(ausloeser.first()).toHaveAttribute('aria-expanded', 'false');
+		await expect.element(ausloeser.last()).toHaveAttribute('aria-expanded', 'false');
+
+		const ersterController = ausloeser.first().element().getAttribute('aria-controls');
+		const zweiterController = ausloeser.last().element().getAttribute('aria-controls');
+		expect(ersterController).toBeTruthy();
+		expect(ersterController).toBe(zweiterController);
+	});
+
+	it('öffnet über einen Auslöser: beide schalten auf aria-expanded=true, das Panel bekommt die referenzierte id', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		const ausloeser = screen.getByRole('button', { name: 'Filter', exact: true });
+		const controllerId = ausloeser.first().element().getAttribute('aria-controls');
+		expect(controllerId).toBeTruthy();
+
+		await ausloeser.first().click();
+
+		await expect.element(ausloeser.first()).toHaveAttribute('aria-expanded', 'true');
+		await expect.element(ausloeser.last()).toHaveAttribute('aria-expanded', 'true');
+
+		const panel = screen.container.querySelector(`#${controllerId}`);
+		expect(panel).not.toBeNull();
+	});
+
+	it('rendert das Panel im DOM vor der Freitextsuche, sobald es offen ist', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		const ausloeser = screen.getByRole('button', { name: 'Filter', exact: true });
+		const controllerId = ausloeser.first().element().getAttribute('aria-controls');
+		await ausloeser.first().click();
+
+		const panel = screen.container.querySelector(`#${controllerId}`);
+		const suchfeld = screen.getByRole('searchbox', { name: /suche/i }).element();
+		expect(panel).not.toBeNull();
+		expect(stehtVor(panel as Element, suchfeld)).toBe(true);
+	});
+
+	it('lässt die Chip-Zeile unmittelbar vor den Statusreitern stehen, auch bei offenem Panel', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		// `?q=müller` aus dem URL-Mock erzeugt bereits einen Chip.
+		const entfernenChip = screen.getByRole('button', { name: /Filter Suche.*entfernen/i });
+		await expect.element(entfernenChip).toBeVisible();
+
+		const ausloeser = screen.getByRole('button', { name: 'Filter', exact: true });
+		await ausloeser.first().click();
+
+		const chipZeile = entfernenChip.element().closest('div');
+		const statusReiter = screen.container.querySelector('nav[aria-label="Status der Sichtungen"]');
+		expect(chipZeile).not.toBeNull();
+		expect(statusReiter).not.toBeNull();
+		expect(stehtVor(chipZeile as Element, statusReiter as Element)).toBe(true);
+
+		// Kein Filter-Panel zwischen Chip-Zeile und Statusreitern.
+		const controllerId = ausloeser.first().element().getAttribute('aria-controls');
+		const panel = screen.container.querySelector(`#${controllerId}`) as Element;
+		const panelKommtVorChips = stehtVor(panel, chipZeile as Element);
+		expect(panelKommtVorChips).toBe(true);
+	});
+});

--- a/src/routes/admin/sichtungen/filterPresetsRow.svelte.test.ts
+++ b/src/routes/admin/sichtungen/filterPresetsRow.svelte.test.ts
@@ -1,0 +1,82 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import type { SightingSelect } from '$lib/server/db/schema';
+import type { PageData } from './$types';
+import {
+	FILTER_PRESETS_STORAGE_KEY,
+	serializeFilterPresets,
+	type FilterPreset
+} from './filterPresets';
+
+/**
+ * filterPresetsRow.svelte.test.ts — WP6: das Label „Ansichten:“ ist nur dann
+ * sinnvoll, wenn es tatsächlich etwas benennt.
+ *
+ * Eigene Datei statt einer Erweiterung von `filterPresets.test.ts`: Jene Datei
+ * prüft nur die reine Rechnung (Serialisierung, Vergleich, URL-Bau) ohne
+ * `window`/DOM — keiner der dortigen Tests rendert die Zeile. Gleiches Muster
+ * wie `filterChips.svelte.test.ts` neben `filterChips.test.ts`.
+ */
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(() => Promise.resolve()),
+	invalidateAll: vi.fn(() => Promise.resolve())
+}));
+vi.mock('$app/state', () => ({
+	page: { url: new URL('https://localhost:4000/admin/sichtungen') }
+}));
+vi.mock('$lib/components/admin/sightingVerdict', () => ({
+	submitVerdict: vi.fn(() => Promise.resolve(true))
+}));
+
+const SichtungenSeite = (await import('./+page.svelte')).default;
+
+function daten(rows: SightingSelect[] = []): PageData {
+	return {
+		sightings: rows,
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
+		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
+	} as unknown as PageData;
+}
+
+function seedPresets(presets: FilterPreset[]): void {
+	window.localStorage.setItem(FILTER_PRESETS_STORAGE_KEY, serializeFilterPresets(presets));
+}
+
+function findeAnsichtenLabel(container: HTMLElement): HTMLElement | undefined {
+	return [...container.querySelectorAll('span')].find(
+		(span) => span.textContent?.trim() === 'Ansichten:'
+	);
+}
+
+describe('Sichtungstabelle — Ansichten-Zeile', () => {
+	afterEach(() => {
+		window.localStorage.removeItem(FILTER_PRESETS_STORAGE_KEY);
+	});
+
+	it('zeigt das Label „Ansichten:“ nicht, solange es weder Presets noch ein offenes Formular gibt', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		// „Ansicht speichern" ist der Einstieg ins Feature und bleibt sichtbar —
+		// nur das Label davor wäre ohne Inhalt ein Torso.
+		await expect.element(screen.getByRole('button', { name: 'Ansicht speichern' })).toBeVisible();
+		expect(findeAnsichtenLabel(screen.container)).toBeUndefined();
+	});
+
+	it('zeigt das Label, sobald mindestens ein Preset existiert', async () => {
+		seedPresets([{ id: 'id-1', name: 'Offene Totfunde', params: { deadFinding: 'true' } }]);
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		await expect.element(screen.getByRole('button', { name: 'Offene Totfunde' })).toBeVisible();
+		expect(findeAnsichtenLabel(screen.container)).toBeDefined();
+	});
+
+	it('zeigt das Label, während das Speichern-Formular offen ist', async () => {
+		const screen = render(SichtungenSeite, { data: daten() });
+
+		await screen.getByRole('button', { name: 'Ansicht speichern' }).click();
+
+		await expect.element(screen.getByLabelText('Name der Ansicht')).toBeVisible();
+		expect(findeAnsichtenLabel(screen.container)).toBeDefined();
+	});
+});

--- a/src/routes/admin/sichtungen/filterPresetsRow.svelte.test.ts
+++ b/src/routes/admin/sichtungen/filterPresetsRow.svelte.test.ts
@@ -64,7 +64,11 @@ describe('Sichtungstabelle — Ansichten-Zeile', () => {
 	});
 
 	it('zeigt das Label, sobald mindestens ein Preset existiert', async () => {
-		seedPresets([{ id: 'id-1', name: 'Offene Totfunde', params: { deadFinding: 'true' } }]);
+		/* `1` und nicht `true`: Nur `1`/`0` lösen serverseitig ein Prädikat aus
+		   (`deadFindingFilter.ts`). Ein Preset namens „Offene Totfunde" mit einem
+		   Wert, der gar nicht filtert, wäre eine Fixture, die etwas zusichert,
+		   was der Code nicht tut. */
+		seedPresets([{ id: 'id-1', name: 'Offene Totfunde', params: { deadFinding: '1' } }]);
 		const screen = render(SichtungenSeite, { data: daten() });
 
 		await expect.element(screen.getByRole('button', { name: 'Offene Totfunde' })).toBeVisible();

--- a/src/routes/admin/sichtungen/page.server.test.ts
+++ b/src/routes/admin/sichtungen/page.server.test.ts
@@ -28,7 +28,7 @@ import {
 } from '$lib/server/db/mediaUploadFilter';
 import { balticSeaCondition } from '$lib/server/db/balticSeaFilter';
 import { deadFindingCondition } from '$lib/server/db/deadFindingFilter';
-import { rejectedOnly } from '$lib/server/db/approvalFilter';
+import { approvedOnly, openOnly, rejectedOnly } from '$lib/server/db/approvalFilter';
 import { berlinCalendarDate } from '$lib/server/db/sqlTimeZone';
 import { sightings } from '$lib/server/db/schema';
 import { SIGHTING_LIST_FIELDS } from './listColumns';
@@ -398,6 +398,83 @@ describe('admin/sichtungen/+page.server load() — Freitext-Suche', () => {
 		} as unknown as Parameters<typeof load>[0]);
 
 		expect(result).toBeDefined();
+	});
+});
+
+/**
+ * Statusreiter über der Tabelle (WP2): `statusCounts` trägt die Trefferzahlen
+ * für „Alle | Offen | Freigegeben | Abgelehnt".
+ *
+ * Der Punkt, an dem eine naive Umsetzung scheitert: Gezählt wird über die
+ * aktuell gefilterte Menge **ohne den Statusfilter selbst**. Zählte sie mit,
+ * stünde auf jedem inaktiven Reiter eine 0 — und die Leiste wäre als
+ * Übersicht wertlos, gerade wenn ein Filter aktiv ist.
+ */
+describe('admin/sichtungen/+page.server load() — Statusreiter-Zähler', () => {
+	/** Dritter `db.select()`-Aufruf: Liste (0), Pagination-Count (1), Statuszähler (2). */
+	const ZAEHLER = 2;
+
+	beforeEach(() => {
+		recordedSelects = [];
+		resolvedRows = [[{ id: 1 }], [{ count: 5 }], [{ all: 12, open: 7, approved: 4, rejected: 1 }]];
+	});
+
+	it('zählt die drei Zustände über dieselben Prädikate wie der Filter', async () => {
+		await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0]);
+
+		const spalten = (recordedSelects[ZAEHLER]?.columns ?? {}) as Record<string, SQLWrapper>;
+		const spaltenSql = (name: string): string => toSqlText(spalten[name] as SQLWrapper);
+
+		expect(spaltenSql('open')).toContain(toSqlText(openOnly()));
+		expect(spaltenSql('approved')).toContain(toSqlText(approvedOnly()));
+		expect(spaltenSql('rejected')).toContain(toSqlText(rejectedOnly()));
+	});
+
+	it('lässt den Statusfilter aus der Zähler-Grundmenge heraus', async () => {
+		await load({
+			url: makeUrl({ verified: 'approved' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		// Die Liste filtert, die Zähler nicht — sonst stünde auf „Offen" und
+		// „Abgelehnt" jeweils 0, sobald „Freigegeben" gewählt ist.
+		expect(recordedSelects[0]?.whereSql).toBe(toSqlText(approvedOnly()));
+		/* Erst die Existenz, dann die Abwesenheit der WHERE-Klausel: Ohne die
+		   erste Zusicherung wäre der Test auch dann grün, wenn es die
+		   Zähler-Abfrage gar nicht gibt. */
+		expect(recordedSelects).toHaveLength(3);
+		expect(recordedSelects[ZAEHLER]?.whereSql).toBeUndefined();
+	});
+
+	it('nimmt die übrigen Filter dagegen mit', async () => {
+		await load({
+			url: makeUrl({ verified: 'approved', deadFinding: '1' })
+		} as unknown as Parameters<typeof load>[0]);
+
+		const totfund = toSqlText(deadFindingCondition('1') as unknown as SQLWrapper);
+		expect(recordedSelects[0]?.whereSql).toBe(
+			toSqlText(and(approvedOnly(), deadFindingCondition('1')) as unknown as SQLWrapper)
+		);
+		expect(recordedSelects[ZAEHLER]?.whereSql).toBe(totfund);
+	});
+
+	it('liefert die Zahlen als Zahlen, auch wenn der Treiber Strings liefert', async () => {
+		resolvedRows[ZAEHLER] = [{ all: '12', open: '7', approved: '4', rejected: '1' }];
+
+		const result = (await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0])) as {
+			statusCounts: { all: number; open: number; approved: number; rejected: number };
+		};
+
+		expect(result.statusCounts).toEqual({ all: 12, open: 7, approved: 4, rejected: 1 });
+	});
+
+	it('liefert bei fehlender Zeile überall 0 statt NaN', async () => {
+		resolvedRows[ZAEHLER] = [];
+
+		const result = (await load({ url: makeUrl() } as unknown as Parameters<typeof load>[0])) as {
+			statusCounts: { all: number; open: number; approved: number; rejected: number };
+		};
+
+		expect(result.statusCounts).toEqual({ all: 0, open: 0, approved: 0, rejected: 0 });
 	});
 });
 

--- a/src/routes/admin/sichtungen/paginationNav.svelte.test.ts
+++ b/src/routes/admin/sichtungen/paginationNav.svelte.test.ts
@@ -60,6 +60,9 @@ function sichtung(): SightingSelect {
 function daten(pagination: Partial<PageData['pagination']>): PageData {
 	return {
 		sightings: [sichtung()],
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: 1, open: 1, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: 1, totalPages: 1, maxPerPage: 100, ...pagination }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/searchParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/searchParam.svelte.test.ts
@@ -65,8 +65,8 @@ describe('Sichtungstabelle — Freitext-Suche', () => {
 	it('übernimmt den getrimmten Begriff auch ins Feld zurück', async () => {
 		// Nur die URL zu trimmen genügt nicht: Das Feld zeigte danach weiter die
 		// ungetrimmte Eingabe, und ein Feld aus lauter Leerzeichen zählte in
-		// `hasActiveFilters` als aktiver Filter — die Filter-Schaltfläche stünde
-		// also markiert da, während die URL gar keine Suche trägt.
+		// `hasActiveFilters` als aktiver Filter — die URL trüge dadurch fälschlich
+		// einen aktiven Chip in der Filterzeile, obwohl gar keine Suche gesetzt ist.
 		goto.mockClear();
 		const screen = render(SichtungenSeite, { data: daten([]) });
 

--- a/src/routes/admin/sichtungen/searchParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/searchParam.svelte.test.ts
@@ -34,6 +34,9 @@ const SichtungenSeite = (await import('./+page.svelte')).default;
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/statusColumn.svelte.test.ts
+++ b/src/routes/admin/sichtungen/statusColumn.svelte.test.ts
@@ -42,6 +42,9 @@ function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: {
 			page: 1,
 			perPage: 20,

--- a/src/routes/admin/sichtungen/statusFilterParam.svelte.test.ts
+++ b/src/routes/admin/sichtungen/statusFilterParam.svelte.test.ts
@@ -35,6 +35,9 @@ const SichtungenSeite = (await import('./+page.svelte')).default;
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/statusTabs.svelte.test.ts
+++ b/src/routes/admin/sichtungen/statusTabs.svelte.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Statusleiste über der Sichtungstabelle (WP2).
+ *
+ * Der Status ist die Haupt-Triage-Dimension und steckte bis hierher im
+ * aufklappbaren Filter-Panel. Die Leiste macht ihn ohne Aufklappen bedienbar.
+ *
+ * Geprüft wird das, was die Komponente selbst verantwortet: die vier Reiter mit
+ * ihren Zahlen, die Markierung des aktiven Reiters und der gemeldete Wert. Die
+ * URL kennt sie nicht — das Navigieren macht `+page.svelte`, abgesichert im
+ * E2E-Spec `admin-status-tabs.spec.ts`.
+ */
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
+import StatusTabs from './StatusTabs.svelte';
+import type { StatusCounts } from './statusTabs';
+
+const ZAEHLER: StatusCounts = { all: 12, open: 7, approved: 4, rejected: 1 };
+
+describe('StatusTabs', () => {
+	it('zeigt die vier Reiter mit ihren Trefferzahlen', async () => {
+		const screen = render(StatusTabs, { counts: ZAEHLER, active: '', onselect: vi.fn() });
+
+		/* Die Beschriftungen gegen `SIGHTING_STATUS_PRESENTATION` geprüft und
+		   nicht gegen Literale: Sonst wäre die Leiste eine zweite Quelle für
+		   Wort und Reihenfolge neben der Statusableitung. */
+		await expect.element(screen.getByRole('button', { name: /Alle/ })).toBeVisible();
+		for (const [status, zahl] of [
+			['open', ZAEHLER.open],
+			['approved', ZAEHLER.approved],
+			['rejected', ZAEHLER.rejected]
+		] as const) {
+			const label = SIGHTING_STATUS_PRESENTATION[status].label;
+			await expect
+				.element(screen.getByRole('button', { name: new RegExp(`${label}.*${zahl}`) }))
+				.toBeVisible();
+		}
+		await expect
+			.element(screen.getByRole('button', { name: new RegExp(`Alle.*${ZAEHLER.all}`) }))
+			.toBeVisible();
+	});
+
+	it('markiert den aktiven Reiter mit aria-current', async () => {
+		const screen = render(StatusTabs, { counts: ZAEHLER, active: 'open', onselect: vi.fn() });
+
+		await expect
+			.element(screen.getByRole('button', { name: /Offen/ }))
+			.toHaveAttribute('aria-current', 'true');
+		await expect
+			.element(screen.getByRole('button', { name: /Alle/ }))
+			.not.toHaveAttribute('aria-current');
+	});
+
+	it('markiert ohne Statusfilter den Reiter „Alle"', async () => {
+		const screen = render(StatusTabs, { counts: ZAEHLER, active: '', onselect: vi.fn() });
+
+		await expect
+			.element(screen.getByRole('button', { name: /Alle/ }))
+			.toHaveAttribute('aria-current', 'true');
+		await expect
+			.element(screen.getByRole('button', { name: /Offen/ }))
+			.not.toHaveAttribute('aria-current');
+	});
+
+	it.each([
+		['Offen', 'open'],
+		['Freigegeben', 'approved'],
+		['Abgelehnt', 'rejected']
+	])('meldet beim Klick auf „%s" den Wert %s', async (label, wert) => {
+		const onselect = vi.fn();
+		const screen = render(StatusTabs, { counts: ZAEHLER, active: '', onselect });
+
+		await screen.getByRole('button', { name: new RegExp(label) }).click();
+
+		expect(onselect).toHaveBeenCalledWith(wert);
+	});
+
+	it('meldet beim Klick auf „Alle" den leeren Wert', async () => {
+		const onselect = vi.fn();
+		const screen = render(StatusTabs, { counts: ZAEHLER, active: 'approved', onselect });
+
+		await screen.getByRole('button', { name: /Alle/ }).click();
+
+		expect(onselect).toHaveBeenCalledWith('');
+	});
+});

--- a/src/routes/admin/sichtungen/statusTabs.ts
+++ b/src/routes/admin/sichtungen/statusTabs.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Vokabular der Statusreiter über der Sichtungstabelle.
+ *
+ * Zwei Seiten lesen hier: `+page.server.ts` liefert die Zahlen in der Form von
+ * `StatusCounts`, `StatusTabs.svelte` baut daraus die Leiste. Der Typ steht
+ * deshalb in einem eigenen, **client-sicheren** Modul und nicht im Loader —
+ * ein Import aus `+page.server.ts` zöge server-only Code in den Client-Bundle.
+ *
+ * Wort und Icon je Zustand kommen aus `SIGHTING_STATUS_PRESENTATION`; hier
+ * steht nur, welche Reiter es gibt und welcher Zähler zu welchem gehört. Der
+ * Reiter „Alle" trägt den leeren Filterwert — genau den, den die URL zeigt,
+ * wenn kein `?verified=` gesetzt ist.
+ */
+import {
+	SIGHTING_STATUS_ORDER,
+	SIGHTING_STATUS_PRESENTATION,
+	type SightingStatus
+} from '$lib/components/admin/sightingStatus';
+
+/** Trefferzahlen der aktuell gefilterten Menge, ohne den Statusfilter selbst. */
+export type StatusCounts = {
+	all: number;
+	open: number;
+	approved: number;
+	rejected: number;
+};
+
+/** Der Wert des Filters `?verified=` — leer heißt „Alle". */
+export type StatusTabValue = '' | SightingStatus;
+
+export type StatusTab = {
+	value: StatusTabValue;
+	label: string;
+	/** Schlüssel in `StatusCounts` — für „Alle" die Gesamtzahl. */
+	countKey: keyof StatusCounts;
+	/** Icon-Name für `$lib/components/Icon.svelte`; „Alle" trägt keines. */
+	icon?: string;
+};
+
+export const STATUS_TABS: readonly StatusTab[] = [
+	{ value: '', label: 'Alle', countKey: 'all' },
+	...SIGHTING_STATUS_ORDER.map((status) => ({
+		value: status,
+		label: SIGHTING_STATUS_PRESENTATION[status].label,
+		countKey: status,
+		icon: SIGHTING_STATUS_PRESENTATION[status].icon
+	}))
+];

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -2,6 +2,7 @@ import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type { SightingSelect } from '$lib/server/db/schema';
 import type { PageData } from './$types';
+import { COLUMN_PREFERENCES_STORAGE_KEY } from './columnPreferences';
 
 vi.mock('$app/navigation', () => ({
 	goto: vi.fn(() => Promise.resolve()),
@@ -224,5 +225,50 @@ describe('Sichtungstabelle — Spalten', () => {
 		for (const th of nichtSortierbar) {
 			expect([...th.classList]).not.toContain('hover:bg-base-300');
 		}
+	});
+
+	/* WP7-Bugfix-Regression: Der bestehende Persistenz-`$effect` schrieb vor
+	   der Aufspaltung nie in `localStorage` — er verließ sich beim allerersten
+	   Durchlauf per `return` aus dem Lade-Zweig, OHNE `columnVisibility` zu
+	   *lesen*, und trackte dadurch nie eine Abhängigkeit darauf (Svelte
+	   ermittelt Effekt-Abhängigkeiten aus den im letzten Durchlauf gelesenen
+	   reaktiven Werten). Der mittlere Schritt unten — `localStorage` nach
+	   einer Checkbox-Änderung — ist der, der genau diesen Bug reproduziert;
+	   gegen die unaufgespaltene Fassung schlägt er fehl (siehe Fix-Report). */
+	it('speichert die Spaltenauswahl bei jeder Änderung und setzt sie per Reset-Button zurück', async () => {
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const resetButton = [...screen.container.querySelectorAll('button')].find(
+			(button) => button.textContent?.trim() === 'Standard wiederherstellen'
+		) as HTMLButtonElement;
+		expect(resetButton, 'Reset-Button existiert').toBeTruthy();
+		expect(resetButton.disabled, 'Ruhezustand entspricht dem Default').toBe(true);
+
+		const sichtungsdatumCheckbox = [...screen.container.querySelectorAll('label')]
+			.find((label) => label.textContent?.includes('Sichtungsdatum'))
+			?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+		expect(sichtungsdatumCheckbox, 'Checkbox „Sichtungsdatum" existiert').toBeTruthy();
+		expect(sichtungsdatumCheckbox.checked, 'Spalte ist per Default sichtbar').toBe(true);
+
+		sichtungsdatumCheckbox.click();
+
+		// Reproduziert den Bug: Vor der Effekt-Aufspaltung blieb `localStorage`
+		// hier dauerhaft leer, weil der Speicher-Effekt nie eine Abhängigkeit
+		// auf `columnVisibility` trackte.
+		await vi.waitFor(() => expect(resetButton.disabled).toBe(false));
+		await vi.waitFor(() => {
+			const gespeichert = window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY);
+			expect(gespeichert).toBeTruthy();
+			expect(JSON.parse(gespeichert as string).columns.sightingDate).toBe(false);
+		});
+
+		resetButton.click();
+
+		await vi.waitFor(() => expect(resetButton.disabled).toBe(true));
+		await vi.waitFor(() => {
+			const gespeichert = window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY);
+			expect(JSON.parse(gespeichert as string).columns.sightingDate).toBe(true);
+		});
+		expect(sichtungsdatumCheckbox.checked, 'Checkbox folgt dem Reset').toBe(true);
 	});
 });

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -232,11 +232,6 @@ describe('Sichtungstabelle — Spalten', () => {
 		}
 	});
 
-	/* WP7-Bugfix-Regression: Begründung der Effekt-Aufspaltung steht in
-	   `+page.svelte` beim Speicher-Effekt. Der mittlere Schritt unten —
-	   `localStorage` nach einer Checkbox-Änderung — reproduziert genau den
-	   Bug, den die Aufspaltung behoben hat; gegen die unaufgespaltene Fassung
-	   schlägt er fehl (siehe Fix-Report). */
 	it('lässt localStorage unangetastet, solange niemand die Spaltenauswahl ändert', () => {
 		// Fix-Runde-2-Regression: Die Effekt-Aufspaltung setzte
 		// `hatGespeicherteSpaltenGeladen` synchron im Lade-Effekt, bevor der
@@ -249,6 +244,11 @@ describe('Sichtungstabelle — Spalten', () => {
 		expect(window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY)).toBeNull();
 	});
 
+	/* WP7-Bugfix-Regression: Begründung der Effekt-Aufspaltung steht in
+	   `+page.svelte` beim Speicher-Effekt. Der mittlere Schritt unten —
+	   `localStorage` nach einer Checkbox-Änderung — reproduziert genau den
+	   Bug, den die Aufspaltung behoben hat; gegen die unaufgespaltene Fassung
+	   schlägt er fehl (siehe Fix-Report). */
 	it('speichert die Spaltenauswahl bei jeder Änderung und setzt sie per Reset-Button zurück', async () => {
 		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
 

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -63,6 +63,11 @@ describe('Sichtungstabelle — Spalten', () => {
 	beforeEach(() => {
 		document.documentElement.style.setProperty('--color-base-100', BASE_100);
 		document.documentElement.style.setProperty('--color-base-200', BASE_200);
+		// Ohne das hier: Der Round-Trip-Test unten schreibt eine geänderte
+		// Spaltenauswahl in denselben `localStorage` (jsdom teilt ihn über alle
+		// Tests der Datei), und ein davor oder danach laufender Test bekäme sie
+		// ungefragt untergeschoben.
+		window.localStorage.clear();
 	});
 
 	afterEach(async () => {
@@ -227,14 +232,23 @@ describe('Sichtungstabelle — Spalten', () => {
 		}
 	});
 
-	/* WP7-Bugfix-Regression: Der bestehende Persistenz-`$effect` schrieb vor
-	   der Aufspaltung nie in `localStorage` — er verließ sich beim allerersten
-	   Durchlauf per `return` aus dem Lade-Zweig, OHNE `columnVisibility` zu
-	   *lesen*, und trackte dadurch nie eine Abhängigkeit darauf (Svelte
-	   ermittelt Effekt-Abhängigkeiten aus den im letzten Durchlauf gelesenen
-	   reaktiven Werten). Der mittlere Schritt unten — `localStorage` nach
-	   einer Checkbox-Änderung — ist der, der genau diesen Bug reproduziert;
-	   gegen die unaufgespaltene Fassung schlägt er fehl (siehe Fix-Report). */
+	/* WP7-Bugfix-Regression: Begründung der Effekt-Aufspaltung steht in
+	   `+page.svelte` beim Speicher-Effekt. Der mittlere Schritt unten —
+	   `localStorage` nach einer Checkbox-Änderung — reproduziert genau den
+	   Bug, den die Aufspaltung behoben hat; gegen die unaufgespaltene Fassung
+	   schlägt er fehl (siehe Fix-Report). */
+	it('lässt localStorage unangetastet, solange niemand die Spaltenauswahl ändert', () => {
+		// Fix-Runde-2-Regression: Die Effekt-Aufspaltung setzte
+		// `hatGespeicherteSpaltenGeladen` synchron im Lade-Effekt, bevor der
+		// Speicher-Effekt zum ersten Mal lief — dessen erster Durchlauf schrieb
+		// dadurch den (unveränderten) Default sofort zurück. Jeder Seitenaufruf
+		// seedete damit `localStorage`, nicht nur der einer Person, die die
+		// Spaltenauswahl tatsächlich ändert.
+		render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		expect(window.localStorage.getItem(COLUMN_PREFERENCES_STORAGE_KEY)).toBeNull();
+	});
+
 	it('speichert die Spaltenauswahl bei jeder Änderung und setzt sie per Reset-Button zurück', async () => {
 		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
 

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -39,6 +39,9 @@ function sichtung(overrides: Partial<SightingSelect>): SightingSelect {
 function daten(rows: SightingSelect[]): PageData {
 	return {
 		sightings: rows,
+		/* Die Statusreiter über der Tabelle lesen diese Zahlen; ohne sie liefe
+		   die Seite hier gar nicht erst durch. */
+		statusCounts: { all: rows.length, open: rows.length, approved: 0, rejected: 0 },
 		pagination: { page: 1, perPage: 20, total: rows.length, totalPages: 1, maxPerPage: 100 }
 	} as unknown as PageData;
 }

--- a/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
+++ b/src/routes/admin/sichtungen/tableColumns.svelte.test.ts
@@ -157,6 +157,28 @@ describe('Sichtungstabelle — Spalten', () => {
 		expect(kopf.querySelector('button')?.getAttribute('aria-label')).toContain('absteigend');
 	});
 
+	it('zeigt an inaktiven sortierbaren Köpfen ein dezentes Sortier-Icon, an nicht sortierbaren keins', () => {
+		// Default-Sortierung ist Sichtungsdatum absteigend — Meldedatum ist damit
+		// ein sortierbarer, aber inaktiver Kopf; Aufnahme ist gar nicht sortierbar.
+		const screen = render(SichtungenSeite, { data: daten([sichtung({})]) });
+
+		const köpfe = [...screen.container.querySelectorAll('thead th')];
+		const meldedatum = köpfe.find((th) => th.textContent?.includes('Meldedatum')) as HTMLElement;
+		const aufnahme = köpfe.find((th) => th.textContent?.trim() === 'Aufnahme') as HTMLElement;
+
+		expect(meldedatum.getAttribute('aria-sort')).toBe('none');
+		expect(
+			meldedatum.querySelector('svg[aria-hidden="true"]'),
+			'inaktiver sortierbarer Kopf zeigt das Affordance-Icon'
+		).toBeTruthy();
+
+		expect(aufnahme.querySelector('button'), 'Aufnahme ist nicht sortierbar').toBeFalsy();
+		expect(
+			aufnahme.querySelector('svg'),
+			'nicht sortierbarer Kopf bekommt kein Sortier-Icon'
+		).toBeFalsy();
+	});
+
 	it('zentriert die Auswahl-Checkbox in ihrer Zelle', () => {
 		// `app.css` setzt für jedes `label:has(> .checkbox)` ungelayert
 		// `align-items: flex-start` — richtig für mehrzeilige Feld-Labels, in


### PR DESCRIPTION
Setzt die Spec `2026-08-09-sichtungstabelle-ux-umsetzung.md` um — die Befunde des
UX-Reviews der Admin-Sichtungstabelle vom 2026-08-09. Ein Subagent pro Work
Package, Review zwischen den Paketen; drei Pakete brauchten eine Fix-Runde.

## Was sich ändert

| WP | Ergebnis |
| --- | --- |
| WP1 | `activeFilters.ts` — der Filterzustand kommt aus `page.url`, nicht mehr aus den Feld-Puffern des Panels |
| WP2 | `StatusTabs.svelte` + Zähler-Query: **Alle \| Offen \| Freigegeben \| Abgelehnt** immer sichtbar über der Tabelle |
| WP3 | `filterChips.ts` — aktive Filter als einzeln entfernbare Chips; Filter-Knopf auf zwei Zustände reduziert |
| WP4 | „Sichtung von/bis" statt „Von/Bis" — in Panel, Export-Dialog und Chips |
| WP5 | Affordance-Icon an inaktiven sortierbaren Spaltenköpfen |
| WP6 | „Ansichten:"-Label nur, wenn es etwas zu beschriften gibt |
| WP7 | „Standard wiederherstellen" im Spalten-Dropdown |

## Zwei Bugs, die dabei aufgefallen sind

**Der Export exportierte, was die Tabelle nie gezeigt hat.** `currentFilters` las
nur `q` aus der URL und die übrigen sieben Filter aus dem Feld-State des Panels.
Wer ein Datum eintippte, nicht „Anwenden" klickte und dann exportierte, bekam
eine andere Menge als die auf dem Schirm. Behoben mit WP1; die Feld-States sind
seither reiner Editier-Puffer.

**Die Spaltenauswahl wurde nie gespeichert.** Der `$effect`, der nach
`localStorage` schreiben sollte, kehrte in seinem ersten Durchlauf zurück,
_bevor_ er `columnVisibility` gelesen hatte — Svelte 5 leitet die Abhängigkeiten
eines Effekts aus den tatsächlich gelesenen Werten ab, also hatte er keine, lief
genau einmal und schrieb nie. Für jeden Bearbeiter fielen die Spalten bei jedem
Reload auf den Default zurück, ohne dass etwas brach. Aufgefallen beim Prüfen
der Spec-Annahme „die Persistenz übernimmt der bestehende `$effect` automatisch"
— sie stimmte nicht. Behoben durch Aufspaltung in einen Lade- und einen
Schreib-Effekt, mit Regressionstest.

## Entscheidungen, die dabei getroffen wurden

- **`btn-primary` trennt jetzt Aktion von Auswahl.** Auf der Seite standen bis zu
  vier Vollton-Primärflächen gleichzeitig (Export, aktive Ansicht, aktiver
  Statusreiter, „Anwenden"). Auswahl-Zustände tragen jetzt `btn-active`,
  `aria-current` bleibt unverändert.
- **`hasActiveFilters` ist gelöscht.** Nach der Chip-Zeile hatte der Export
  keinen Leser mehr; ein getesteter Export ohne Aufrufer liest sich für den
  Nächsten als tragend.
- **Das Filter-Panel sitzt jetzt hinter seinem Auslöser.** Es stand hinter Suche,
  Ansichten und Chip-Zeile — wer „Filter" per Tastatur drückte, tabbte durch drei
  fremde Bereiche. Dazu `aria-expanded`/`aria-controls` an beiden Auslösern; der
  Zustand war vorher rein farblich codiert (WCAG 1.4.1).

## Tote Utility-Klassen, gemessen und entfernt

`app.css` setzt `.input/.select/.textarea` ungelayert auf `--text-body` und
schlägt damit **jeden** DaisyUI-Schriftgrößen-Modifier. Betroffen waren
`input-sm` am Suchfeld, `text-sm` an fünf Panel-Selects und `text-sm` +
`min-h-8` am „Einträge pro Seite"-Select — alle syntaktisch einwandfrei, alle
wirkungslos. Jeweils mit und ohne die Klasse am laufenden Dev-Server gemessen,
dann entfernt. Das Suchfeld stand außerdem 32 px neben einem 44-px-Knopf.

## Prüfung

- `npm run test:quick` — 296 Dateien / 4470 Tests
- `npm run test:unit:client` — 77 Dateien / 735 Tests
- `npm run test:e2e:shards` — 54 Specs, alle zugeordnet
- `e2e/design-tokens.spec.ts` — 112 passed
- `e2e/admin-status-tabs.spec.ts` — live gegen den Worktree-Server
- Optik an 1280 px und 390 px gemessen und per Screenshot geprüft

**Hinweis:** `npm run test:quick` fährt nur das Server-Vitest-Projekt — die neuen
`*.svelte.test.ts` liegen außerhalb des lokalen Gates und laufen in CI über den
Job „Component Tests". Das ist eine bestehende Lücke im lokalen Gate, kein Thema
dieses Branches; sie wird separat verfolgt.

## Bewusst nicht enthalten

Löschen-Knopf in ein Overflow-Menü (Befund 5), Zeilenklick → Detail (6),
„Springe zu Seite N" (7c), Schnellbereiche im Datumsfilter — alle vier sind im
Review begründet ausgeschlossen worden.

Offen als Follow-up: `exportFilterDisplay.ts` beschriftet die Filter weiter
eigenständig und zeigt beim Kanal die rohe Datenbank-ID statt des Namens
(Altbestand, den dieser Branch nur sichtbarer macht).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
