### PR TITLE
fix(admin): resolve entry channel id and unify export filter labels

### DIFF
--- a/src/lib/components/admin/exportFilterDisplay.test.ts
+++ b/src/lib/components/admin/exportFilterDisplay.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
+import { AUFNAHME_LABEL, MELDEART_LABEL } from '$lib/components/admin/filterLabels';
+import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
+import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 import { getActiveFiltersDisplay } from './exportFilterDisplay';
 
 describe('getActiveFiltersDisplay', () => {
@@ -40,7 +45,68 @@ describe('getActiveFiltersDisplay', () => {
 		});
 
 		expect(anzeige).toContain('Suche: „ostsee"');
-		expect(anzeige).toContain('Nur freigegebene Sichtungen');
+		expect(anzeige).toContain(`Status: ${SIGHTING_STATUS_PRESENTATION.approved.label}`);
 		expect(anzeige).toHaveLength(3);
+	});
+
+	// Der Kanal stand als rohe Datenbank-Zahl im Dialog („Kanal: 0"), während
+	// der Chip derselben Seite „Kanal: Web" sagte — beide gleichzeitig sichtbar.
+	// Aufgelöst wird über dieselbe Quelle wie im Panel und im Chip.
+	it('löst die Kanal-ID über getEntryChannelOptions auf', () => {
+		for (const option of getEntryChannelOptions()) {
+			expect(getActiveFiltersDisplay({ entryChannel: String(option.value) })).toEqual([
+				`Kanal: ${option.label}`
+			]);
+		}
+	});
+
+	// Gleiche Begründung wie beim Chip: Ein Wert, den keine Quelle kennt
+	// (veraltetes Lesezeichen), erscheint unverändert — besser als ein Badge,
+	// das einen wirksamen Filter verschweigt.
+	it('zeigt eine unbekannte Kanal-ID unverändert', () => {
+		expect(getActiveFiltersDisplay({ entryChannel: '99' })).toEqual(['Kanal: 99']);
+	});
+
+	it('lässt den Kanal-Filter bei „all" aus', () => {
+		expect(getActiveFiltersDisplay({ entryChannel: 'all' })).toEqual(['Keine Filter aktiv']);
+	});
+
+	// Die Statuswörter sind dieselben wie an den Statusreitern der Tabelle —
+	// „Offen"/„Freigegeben"/„Abgelehnt", nicht „Nur offene Sichtungen".
+	it('benennt den Status wie die Statusreiter', () => {
+		expect(getActiveFiltersDisplay({ verified: 'open' })).toEqual([
+			`Status: ${SIGHTING_STATUS_PRESENTATION.open.label}`
+		]);
+		expect(getActiveFiltersDisplay({ verified: 'rejected' })).toEqual([
+			`Status: ${SIGHTING_STATUS_PRESENTATION.rejected.label}`
+		]);
+		// Alias aus dem alten Filter-Parameter (`?verified=1`).
+		expect(getActiveFiltersDisplay({ verified: '1' })).toEqual([
+			`Status: ${SIGHTING_STATUS_PRESENTATION.approved.label}`
+		]);
+	});
+
+	// Satzbau bleibt, das Wort kommt aus AUFNAHME_LABEL — sonst heißt derselbe
+	// Filter im Panel „Mit" und im Export „mit Aufnahmen", sobald einer der
+	// beiden angefasst wird.
+	it('baut den Aufnahme-Satz aus AUFNAHME_LABEL', () => {
+		expect(getActiveFiltersDisplay({ mediaUpload: '1' })).toEqual([
+			`Nur ${AUFNAHME_LABEL['1'].toLowerCase()} Aufnahmen`
+		]);
+		expect(getActiveFiltersDisplay({ mediaUpload: '0' })).toEqual([
+			`Nur ${AUFNAHME_LABEL['0'].toLowerCase()} Aufnahmen`
+		]);
+		expect(getActiveFiltersDisplay({ mediaUpload: MEDIA_UPLOAD_ANNOUNCED_MISSING })).toEqual([
+			`Nur ${AUFNAHME_LABEL[MEDIA_UPLOAD_ANNOUNCED_MISSING].toLowerCase()}`
+		]);
+	});
+
+	it('benennt die Meldeart aus MELDEART_LABEL', () => {
+		expect(getActiveFiltersDisplay({ deadFinding: '1' })).toEqual([
+			`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`
+		]);
+		expect(getActiveFiltersDisplay({ deadFinding: '0' })).toEqual([
+			`Meldeart: ${MELDEART_LABEL['0']}`
+		]);
 	});
 });

--- a/src/lib/components/admin/exportFilterDisplay.ts
+++ b/src/lib/components/admin/exportFilterDisplay.ts
@@ -9,16 +9,64 @@
  * der Dialog eine andere Menge, als die Datei enthält; als reine Funktion ist
  * das ohne Browser testbar (`exportFilterDisplay.test.ts`).
  *
- * Die Beschriftungen kommen, wo vorhanden, aus den Präsentations-Konstanten
- * (`BALTIC_SEA_STATUS_PRESENTATION`, `DEAD_FINDING_PRESENTATION`) statt neu
- * formuliert zu werden — sonst laufen Filter-Panel und Export-Zusammenfassung
- * auseinander.
+ * **Kein eigener Wortschatz.** Jedes Wort kommt aus derselben Quelle wie im
+ * Filter-Panel und in der Chip-Zeile der Tabelle: `getEntryChannelOptions()`,
+ * `SIGHTING_STATUS_PRESENTATION`, `DEAD_FINDING_PRESENTATION`,
+ * `BALTIC_SEA_STATUS_PRESENTATION` und `filterLabels.ts`. Bis 2026-08-10 stand
+ * hier ein zweiter Satz Formulierungen; der sichtbarste Schaden war der Kanal,
+ * der als rohe Datenbank-Zahl erschien („Kanal: 0"), während der Chip
+ * derselben Seite „Kanal: Web" sagte — beide gleichzeitig am Bildschirm.
+ *
+ * **Warum nicht einfach `buildFilterChips` aufrufen**, wo die Chips dieselbe
+ * Rechnung schon anstellen? Drei Gründe, jeder für sich ausreichend:
+ *
+ * 1. `buildFilterChips` liegt in `src/routes/admin/sichtungen/` — ein Import
+ *    von hier aus wäre eine Abhängigkeit von `$lib` auf eine Route.
+ * 2. Die Eingaben sind verschiedene Typen. Die Chips lesen `FilterParams`, wo
+ *    jeder Schlüssel als String existiert und „nicht gesetzt" `''` heißt; hier
+ *    kommt ein loses `Record<string, string | boolean | undefined>` an, wie es
+ *    an die Export-API geht.
+ * 3. Das Datum wird bewusst anders formatiert. `formatWallClockDateTime`
+ *    sortiert den Kalendertag nur um, ohne `Date`-Objekt — sonst bestimmte die
+ *    Browser-Zone den Tag mit (bis zu ±1 Tag).
+ *
+ * Übernommen werden deshalb die **Wörter**, nicht die Sätze: „Nur mit
+ * Aufnahmen" bleibt satzartig, weil dieser Dialog eine Menge beschreibt und
+ * kein wegklickbares Bedienelement ist. Beim **Status** geht das nicht — aus
+ * „Freigegeben" lässt sich „freigegebene" nicht mechanisch bilden, und ein
+ * zweites, gebeugtes Wort je Status wäre genau die Zweitbeschriftung, um die
+ * es hier geht. Dort steht deshalb `Status: Freigegeben`, wortgleich zum
+ * Statusreiter über der Tabelle — und in derselben `Feld: Wert`-Form wie die
+ * sechs übrigen Einträge dieser Liste.
  */
 import { formatWallClockDateTime } from '$lib/utils/format/formatWallClockDateTime';
 import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 import { BALTIC_SEA_STATUS_PRESENTATION, isBalticSeaStatus } from '$lib/utils/geo/balticSeaStatus';
-import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import {
+	AUFNAHME_LABEL,
+	isAufnahmeFilterWert,
+	isMeldeartFilterWert,
+	kanalLabel,
+	MELDEART_LABEL,
+	type AufnahmeFilterWert
+} from '$lib/components/admin/filterLabels';
+import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
 import { normalizeStatusParam } from '$lib/components/admin/sightingStatusFilter';
+
+/**
+ * Der Aufnahme-Filter als Satz. „Mit"/„Ohne" stehen in `AUFNAHME_LABEL` als
+ * Satzanfang groß — hier stehen sie mitten im Satz.
+ *
+ * Der Sonderwert bekommt keinen `Aufnahmen`-Zusatz: „Nur angekündigt, fehlt
+ * noch Aufnahmen" wäre kein Satz.
+ */
+const AUFNAHME_SATZ: Record<AufnahmeFilterWert, string> = {
+	'1': `Nur ${AUFNAHME_LABEL['1'].toLowerCase()} Aufnahmen`,
+	'0': `Nur ${AUFNAHME_LABEL['0'].toLowerCase()} Aufnahmen`,
+	[MEDIA_UPLOAD_ANNOUNCED_MISSING]: `Nur ${AUFNAHME_LABEL[
+		MEDIA_UPLOAD_ANNOUNCED_MISSING
+	].toLowerCase()}`
+};
 
 /**
  * @param currentFilters Die Filterwerte der Tabelle, so wie sie auch an die
@@ -46,31 +94,22 @@ export function getActiveFiltersDisplay(
 	}
 	const statusFilter = normalizeStatusParam(currentFilters.verified as string | null);
 	if (statusFilter) {
-		const statusLabel = {
-			open: 'Nur offene Sichtungen',
-			approved: 'Nur freigegebene Sichtungen',
-			rejected: 'Nur abgelehnte Sichtungen'
-		}[statusFilter];
-		filterDisplays.push(statusLabel);
+		filterDisplays.push(`Status: ${SIGHTING_STATUS_PRESENTATION[statusFilter].label}`);
 	}
 	if (currentFilters.entryChannel && currentFilters.entryChannel !== 'all') {
-		filterDisplays.push(`Kanal: ${currentFilters.entryChannel}`);
+		filterDisplays.push(`Kanal: ${kanalLabel(String(currentFilters.entryChannel))}`);
 	}
-	if (currentFilters.mediaUpload === '1') {
-		filterDisplays.push('Nur mit Aufnahmen');
-	} else if (currentFilters.mediaUpload === '0') {
-		filterDisplays.push('Nur ohne Aufnahmen');
-	} else if (currentFilters.mediaUpload === MEDIA_UPLOAD_ANNOUNCED_MISSING) {
-		filterDisplays.push('Nur angekündigt, Foto fehlt noch');
+	const mediaUpload = currentFilters.mediaUpload;
+	if (typeof mediaUpload === 'string' && isAufnahmeFilterWert(mediaUpload)) {
+		filterDisplays.push(AUFNAHME_SATZ[mediaUpload]);
 	}
 	if (isBalticSeaStatus(currentFilters.balticSea)) {
 		const presentation = BALTIC_SEA_STATUS_PRESENTATION[currentFilters.balticSea];
 		filterDisplays.push(`Ostsee-Status: ${presentation.label}`);
 	}
-	if (currentFilters.deadFinding === '1') {
-		filterDisplays.push(`Meldeart: ${DEAD_FINDING_PRESENTATION.label}`);
-	} else if (currentFilters.deadFinding === '0') {
-		filterDisplays.push('Meldeart: Lebendsichtung');
+	const deadFinding = currentFilters.deadFinding;
+	if (typeof deadFinding === 'string' && isMeldeartFilterWert(deadFinding)) {
+		filterDisplays.push(`Meldeart: ${MELDEART_LABEL[deadFinding]}`);
 	}
 	// Getrimmt geprüft und getrimmt angezeigt — dieselbe Grenze wie serverseitig
 	// in `normalizeSearchTerm`, sonst stünde hier ein Badge für eine Suche, die

--- a/src/lib/components/admin/filterLabels.ts
+++ b/src/lib/components/admin/filterLabels.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Beschriftung der Filterwerte der Sichtungstabelle: die zwei
+ * Ja/Nein-Wortpaare — „Mit"/„Ohne" und „Lebendsichtung" — und die Auflösung
+ * der Kanal-ID.
+ *
+ * Sie standen bis 2026-08-10 in `src/routes/admin/sichtungen/filterChips.ts`,
+ * mit der dort notierten Begründung: Kein Präsentationsmodul führt diese Wörter,
+ * weil sie keine Auszeichnung eines Datensatzes sind, sondern nur die zwei
+ * Seiten eines Filters. Die Begründung gilt unverändert — geändert hat sich nur,
+ * **wer** sie braucht: neben Chip-Zeile und Filter-Panel jetzt auch der
+ * Export-Dialog (`exportFilterDisplay.ts`), und der liegt in `$lib`. Ein Import
+ * aus `src/routes/**` hinein wäre eine umgekehrte Abhängigkeit; dieselben Wörter
+ * ein zweites Mal zu tippen wäre die Zweitbeschriftung, gegen die die Chips
+ * angetreten sind. Also stehen sie hier, wo beide Seiten sie erreichen.
+ *
+ * Der Sonderwert der Aufnahme-Auswahl kommt weiterhin aus seinem eigenen Modul
+ * — er trägt eine fachliche Aussage (`photoAnnouncement.ts`).
+ *
+ * Client-sicher: **kein** Import aus `$lib/server/**`.
+ */
+import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
+import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+
+/**
+ * Die Kanal-ID aus der URL als Wort. Ein Wert, den keine Quelle kennt
+ * (veraltetes Lesezeichen, von Hand getippte URL), erscheint unverändert — ihn
+ * wegzulassen wäre der schlechtere Ausgang: Gefiltert würde weiterhin, nur
+ * stünde es nirgends.
+ */
+export function kanalLabel(value: string): string {
+	return getEntryChannelOptions().find((option) => String(option.value) === value)?.label ?? value;
+}
+
+/**
+ * Die drei Zustände des Aufnahme-Filters. Quelle für die `<option>`-Texte des
+ * Panels (`admin/sichtungen/+page.svelte`), für den Chip und für den Satz im
+ * Export-Dialog.
+ *
+ * Endliche Schlüsselmenge statt `Record<string, string>`: So liefert ein
+ * Zugriff mit bekanntem Schlüssel unter `noUncheckedIndexedAccess` ein `string`
+ * statt `string | undefined`, und ein Wert aus der URL muss vorher durch den
+ * Wächter — dieselbe Konstruktion wie bei `isBalticSeaStatus`.
+ */
+export type AufnahmeFilterWert = '1' | '0' | typeof MEDIA_UPLOAD_ANNOUNCED_MISSING;
+
+export const AUFNAHME_LABEL: Record<AufnahmeFilterWert, string> = {
+	'1': 'Mit',
+	'0': 'Ohne',
+	[MEDIA_UPLOAD_ANNOUNCED_MISSING]: 'Angekündigt, fehlt noch'
+};
+
+export function isAufnahmeFilterWert(value: string): value is AufnahmeFilterWert {
+	return Object.hasOwn(AUFNAHME_LABEL, value);
+}
+
+/**
+ * Gegenstück zum Totfund; `deadFinding.ts` führt für den Normalfall bewusst kein
+ * Wort, deshalb steht „Lebendsichtung" hier.
+ */
+export type MeldeartFilterWert = '1' | '0';
+
+export const MELDEART_LABEL: Record<MeldeartFilterWert, string> = {
+	'1': DEAD_FINDING_PRESENTATION.label,
+	'0': 'Lebendsichtung'
+};
+
+export function isMeldeartFilterWert(value: string): value is MeldeartFilterWert {
+	return Object.hasOwn(MELDEART_LABEL, value);
+}

--- a/src/routes/admin/sichtungen/+page.svelte
+++ b/src/routes/admin/sichtungen/+page.svelte
@@ -29,13 +29,9 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 	import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
+	import { AUFNAHME_LABEL, MELDEART_LABEL } from '$lib/components/admin/filterLabels';
 	import { readFilterParams, type FilterParams } from './activeFilters';
-	import {
-		AUFNAHME_LABEL,
-		buildFilterChips,
-		MELDEART_LABEL,
-		removeFilterParam
-	} from './filterChips';
+	import { buildFilterChips, removeFilterParam } from './filterChips';
 	import SichtungenCards from './SichtungenCards.svelte';
 	import StatusTabs from './StatusTabs.svelte';
 	import type { StatusTabValue } from './statusTabs';

--- a/src/routes/admin/sichtungen/filterChips.test.ts
+++ b/src/routes/admin/sichtungen/filterChips.test.ts
@@ -4,7 +4,8 @@ import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStat
 import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
 import { BALTIC_SEA_STATUS_PRESENTATION } from '$lib/utils/geo/balticSeaStatus';
 import type { FilterParams } from './activeFilters';
-import { AUFNAHME_LABEL, buildFilterChips, MELDEART_LABEL, removeFilterParam } from './filterChips';
+import { AUFNAHME_LABEL, MELDEART_LABEL } from '$lib/components/admin/filterLabels';
+import { buildFilterChips, removeFilterParam } from './filterChips';
 
 /**
  * filterChips.test.ts — was gefiltert ist, muss sichtbar und einzeln
@@ -78,11 +79,11 @@ describe('buildFilterChips', () => {
 		);
 	});
 
-	it.each(Object.keys(AUFNAHME_LABEL))(
+	it.each(Object.entries(AUFNAHME_LABEL))(
 		'beschriftet den Aufnahme-Filter %s wie die exportierte Beschriftung',
-		(wert) => {
+		(wert, beschriftung) => {
 			expect(buildFilterChips(nur('mediaUpload', wert))[0]?.label).toBe(
-				`Aufnahme: ${AUFNAHME_LABEL[wert]}`
+				`Aufnahme: ${beschriftung}`
 			);
 		}
 	);

--- a/src/routes/admin/sichtungen/filterChips.ts
+++ b/src/routes/admin/sichtungen/filterChips.ts
@@ -11,13 +11,15 @@
  * denselben Quellen wie die `<select>`-Felder des Panels:
  * `getEntryChannelOptions()`, `DEAD_FINDING_PRESENTATION`,
  * `BALTIC_SEA_STATUS_PRESENTATION`, `SIGHTING_STATUS_PRESENTATION` und
- * `MEDIA_UPLOAD_ANNOUNCED_MISSING`. Für die beiden Ja/Nein-Wortpaare ohne
- * eigenes Präsentationsmodul — „Mit"/„Ohne" und „Lebendsichtung" — ist diese
- * Datei selbst die Quelle: `AUFNAHME_LABEL` und `MELDEART_LABEL` sind exportiert,
- * und das Panel (`+page.svelte`) rendert seine `<option>`-Beschriftungen daraus,
+ * `MEDIA_UPLOAD_ANNOUNCED_MISSING`. Die beiden Ja/Nein-Wortpaare ohne eigenes
+ * Präsentationsmodul — „Mit"/„Ohne" und „Lebendsichtung" — standen dafür bis
+ * 2026-08-10 in dieser Datei; sie liegen jetzt in
+ * `$lib/components/admin/filterLabels.ts`, weil mit dem Export-Dialog eine
+ * Aufrufstelle in `$lib` dazugekommen ist (Begründung dort). Das Panel
+ * (`+page.svelte`) rendert seine `<option>`-Beschriftungen weiterhin daraus,
  * statt sie ein zweites Mal zu tippen. Ein eigener Wortschatz an einer der
- * beiden Stellen hieße, dass Chip und Panel denselben Filter verschieden
- * benennen, sobald eine der beiden angefasst wird — derselbe Fehler, gegen den
+ * Stellen hieße, dass Chip, Panel und Export denselben Filter verschieden
+ * benennen, sobald eine davon angefasst wird — derselbe Fehler, gegen den
  * `deadFinding.ts` und `balticSeaStatus.ts` angelegt wurden.
  *
  * Client-sicher: **kein** Import aus `$lib/server/**`. Die Seite ist eine
@@ -26,15 +28,19 @@
  * Der Filterzustand kommt aus `activeFilters.ts` und damit aus der URL — hier
  * entsteht kein zweiter gemerkter Zustand.
  */
-import { DEAD_FINDING_PRESENTATION } from '$lib/components/admin/deadFinding';
+import {
+	AUFNAHME_LABEL,
+	isAufnahmeFilterWert,
+	isMeldeartFilterWert,
+	kanalLabel,
+	MELDEART_LABEL
+} from '$lib/components/admin/filterLabels';
 import {
 	SIGHTING_STATUS_PRESENTATION,
 	type SightingStatus
 } from '$lib/components/admin/sightingStatus';
-import { getEntryChannelOptions } from '$lib/report/formOptions/entryChannel';
 import { formatLocalDateTime } from '$lib/utils/format/dateTime';
 import { BALTIC_SEA_STATUS_PRESENTATION, isBalticSeaStatus } from '$lib/utils/geo/balticSeaStatus';
-import { MEDIA_UPLOAD_ANNOUNCED_MISSING } from '$lib/utils/media/photoAnnouncement';
 import type { FilterParams } from './activeFilters';
 
 export type FilterChip = {
@@ -79,10 +85,6 @@ function datum(value: string): string {
 	return formatLocalDateTime(value, 'date');
 }
 
-function kanalLabel(value: string): string {
-	return getEntryChannelOptions().find((option) => String(option.value) === value)?.label ?? value;
-}
-
 function statusLabel(value: string): string {
 	return isSightingStatus(value) ? SIGHTING_STATUS_PRESENTATION[value].label : value;
 }
@@ -90,30 +92,6 @@ function statusLabel(value: string): string {
 function isSightingStatus(value: string): value is SightingStatus {
 	return Object.hasOwn(SIGHTING_STATUS_PRESENTATION, value);
 }
-
-/**
- * „Mit"/„Ohne" sind keine Auszeichnung eines Datensatzes, sondern nur die zwei
- * Seiten eines Ja/Nein-Filters — kein `deadFinding.ts`/`balticSeaStatus.ts`-Modul
- * nimmt sie auf. Diese Datei ist deshalb selbst die Quelle, exportiert für das
- * `<select>` des Panels (`+page.svelte`), das seine `<option>`-Beschriftungen von
- * hier bezieht statt sie ein zweites Mal zu tippen. Der Sonderwert kommt aus
- * seinem eigenen Modul — er trägt eine fachliche Aussage (`photoAnnouncement.ts`).
- */
-export const AUFNAHME_LABEL: Record<string, string> = {
-	'1': 'Mit',
-	'0': 'Ohne',
-	[MEDIA_UPLOAD_ANNOUNCED_MISSING]: 'Angekündigt, fehlt noch'
-};
-
-/**
- * Gegenstück zum Totfund; `deadFinding.ts` führt für den Normalfall bewusst kein
- * Wort, deshalb steht „Lebendsichtung" hier. Exportiert aus demselben Grund wie
- * `AUFNAHME_LABEL`: Das Panel rendert seine Option daraus.
- */
-export const MELDEART_LABEL: Record<string, string> = {
-	'1': DEAD_FINDING_PRESENTATION.label,
-	'0': 'Lebendsichtung'
-};
 
 /**
  * Ein Wert, den keine Quelle kennt (veraltetes Lesezeichen, von Hand getippte
@@ -125,9 +103,11 @@ const CHIP_LABEL: Record<keyof FilterParams, (value: string) => string> = {
 	fromDate: (value) => `Sichtung von ${datum(value)}`,
 	toDate: (value) => `Sichtung bis ${datum(value)}`,
 	verified: (value) => `Status: ${statusLabel(value)}`,
-	deadFinding: (value) => `Meldeart: ${MELDEART_LABEL[value] ?? value}`,
+	deadFinding: (value) =>
+		`Meldeart: ${isMeldeartFilterWert(value) ? MELDEART_LABEL[value] : value}`,
 	entryChannel: (value) => `Kanal: ${kanalLabel(value)}`,
-	mediaUpload: (value) => `Aufnahme: ${AUFNAHME_LABEL[value] ?? value}`,
+	mediaUpload: (value) =>
+		`Aufnahme: ${isAufnahmeFilterWert(value) ? AUFNAHME_LABEL[value] : value}`,
 	balticSea: (value) =>
 		`Ostsee: ${isBalticSeaStatus(value) ? BALTIC_SEA_STATUS_PRESENTATION[value].label : value}`,
 	q: (value) => `Suche: „${value}“`


### PR DESCRIPTION
## Worum es geht

`getActiveFiltersDisplay()` (Export-Dialog) beschriftete die aktiven Filter mit
einem eigenen, hartkodierten Wortschatz — die letzte verbliebene
Zweitbeschriftung im Admin-Bereich, nachdem #845 mit `filterChips.ts` **eine**
Beschriftungsquelle etabliert hatte.

**Der sichtbare Fehler:** Der Kanal erschien als rohe Datenbank-Zahl
(„Kanal: 0"), während der Filter-Chip zwei Zeilen darüber auf derselben Seite
korrekt „Kanal: Web" sagte. Beide konnten gleichzeitig am Bildschirm stehen.

## Die Entscheidung: Wörter übernehmen, nicht Sätze

`getActiveFiltersDisplay` setzt **nicht** auf `buildFilterChips` auf. Drei
Gründe, jeder für sich ausreichend (Begründung steht im Modul-Docblock):

1. `buildFilterChips` liegt in `src/routes/admin/sichtungen/` — ein Import von
   `$lib` dorthin wäre eine umgekehrte Abhängigkeit.
2. Verschiedene Eingabetypen: Chips lesen `FilterParams` (jeder Schlüssel
   existiert, „nicht gesetzt" heißt `''`), der Export ein loses
   `Record<string, string | boolean | undefined>`.
3. Das Datum wird bewusst anders formatiert — `formatWallClockDateTime` ohne
   `Date`-Objekt, sonst bestimmte die Browser-Zone den Kalendertag mit (±1 Tag).

Übernommen werden deshalb die **Wörter**, der satzartige Ton des Dialogs bleibt:
„Nur mit Aufnahmen" wird aus `AUFNAHME_LABEL['1']` gebildet.

### Die eine begründete Abweichung: der Status

Beim Status geht das nicht. Aus „Freigegeben" lässt sich „freigegebene" nicht
mechanisch bilden, und ein zweites, gebeugtes Wort je Status in
`SIGHTING_STATUS_PRESENTATION` wäre genau die Zweitbeschriftung, um die es hier
geht. Dort steht jetzt `Status: Freigegeben` — wortgleich zum Statusreiter über
der Tabelle und in derselben `Feld: Wert`-Form wie die sechs übrigen Einträge
dieser Liste, die ohnehin schon so gebaut sind.

## Sichtbare Textänderungen

| vorher                            | nachher                    |
| --------------------------------- | -------------------------- |
| `Kanal: 0`                        | `Kanal: Web`               |
| `Nur offene Sichtungen`           | `Status: Offen`            |
| `Nur freigegebene Sichtungen`     | `Status: Freigegeben`      |
| `Nur abgelehnte Sichtungen`       | `Status: Abgelehnt`        |
| `Nur angekündigt, Foto fehlt noch` | `Nur angekündigt, fehlt noch` |

`Nur mit Aufnahmen`, `Nur ohne Aufnahmen` und `Meldeart: …` bleiben wortgleich —
sie kommen jetzt nur aus der gemeinsamen Quelle statt aus einem Literal.

## Neues Modul `$lib/components/admin/filterLabels.ts`

`AUFNAHME_LABEL`, `MELDEART_LABEL` und `kanalLabel` ziehen aus `filterChips.ts`
hierher, weil mit dem Export-Dialog eine Aufrufstelle in `$lib` dazugekommen ist.
`kanalLabel` stand sonst zweimal identisch da — dieselbe Doppelung, um die es in
diesem PR geht.

Die beiden Records tragen dabei jetzt endliche Schlüsselmengen plus Wächter
(`isAufnahmeFilterWert` / `isMeldeartFilterWert`) statt `Record<string, string>`.
Nötig wegen `noUncheckedIndexedAccess`, und dieselbe Konstruktion wie
`isBalticSeaStatus`.

## Tests

TDD: erst der fehlschlagende Test in `exportFilterDisplay.test.ts`, dann die
Umsetzung. Neu abgedeckt: Kanal-Auflösung über **alle** Optionen aus
`getEntryChannelOptions()`, unbekannte Kanal-ID, `entryChannel=all`, alle drei
Statuswerte inkl. Alias `?verified=1`, alle drei Aufnahme-Werte, beide
Meldearten.

`npm run test:quick` ist grün (297 Server-Testdateien, 77 Komponenten-Testdateien).
Die E2E-Suite ist nicht gelaufen; die Änderung ist reine Textableitung ohne
DOM-Struktur- oder Routing-Anteil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
