### PR TITLE
feat(admin): move rare row actions into an overflow menu

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -145,6 +145,7 @@ dieselbe, deshalb steht sie einmal.
 | `SpamFinding.svelte`           | Ein Spam-Befund (Modal + Detailkarte)       |
 | `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)    |
 | `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel     |
+| `SightingActionsMenu.svelte`   | Overflow-Menü der Zeilen-Aktionen (Tabelle + Karten) |
 
 ### Spam-Score: vier Anzeigestellen, eine Schwelle
 

--- a/e2e/admin-spam-check.spec.ts
+++ b/e2e/admin-spam-check.spec.ts
@@ -188,7 +188,14 @@ test.describe('Spam-Check — Erstbefund und Neuberechnung nebeneinander', () =>
 			// Die Spalte zeigt den Erstbefund — unverändert, das war nie der Fehler.
 			await expect(zeile).toContainText(String(ERSTBEFUND_SCORE));
 
-			await zeile.getByRole('button', { name: 'Spam-Check durchführen' }).click();
+			/* Seit 2026-08-10 steht der Spam-Check im Overflow-Menü der Zeile
+			   (`SightingActionsMenu.svelte`) — erst öffnen, dann klicken. Der
+			   Eintrag wird über `page` gesucht, nicht über `zeile`: Es gibt zwar
+			   ein Menü pro Zeile, aber `popover="auto"` lässt nur eines offen,
+			   und geschlossene Popover stehen nicht im Accessibility-Baum —
+			   sichtbar ist also genau der Eintrag der gerade geöffneten Zeile. */
+			await zeile.getByRole('button', { name: /^Weitere Aktionen zu Sichtung/ }).click();
+			await page.getByRole('button', { name: 'Spam-Check durchführen' }).click();
 
 			const modal = page.locator('.modal-box').filter({ hasText: 'Spam-Analyse' });
 			await expect(modal).toBeVisible();

--- a/src/lib/components/admin/SightingActionsMenu.svelte
+++ b/src/lib/components/admin/SightingActionsMenu.svelte
@@ -1,0 +1,116 @@
+<!--
+	Overflow-Menü der seltenen Zeilen-Aktionen: Spam-Check, Test-Mail (nur
+	Superadmin), Löschen. Sichtbar an der Zeile bleiben nur Ansehen und der
+	Statuswechsel — die täglichen Aktionen (Entscheidung Jan, 2026-08-10, nach
+	dem UX-Review). Vorher trug jede der 50 Zeilen einen rot umrandeten
+	Löschen-Button; die kanonische destruktive Variante machte damit die
+	seltenste und gefährlichste Aktion zum auffälligsten Element der Tabelle
+	und lag direkt neben dem täglich benutzten Status-Control.
+
+	Eine Komponente für Tabelle UND Kartenansicht: gleiche Aktion = gleiche
+	Variante = gleiches Icon (Button-Hierarchie), und der Wortlaut der
+	Einträge existiert nur einmal.
+
+	Popover-API statt `details.dropdown` (DaisyUI-5-Methode 2): Das Menü
+	rendert im Top-Layer. In der Tabelle sitzt der Auslöser in der fixierten
+	Aktionsspalte innerhalb des `overflow-x-auto`-Containers — ein
+	`dropdown-content` mit `position: absolute` würde dort vom Scroll-Container
+	geklippt bzw. zöge Scrollbalken in die Tabelle. Der Top-Layer braucht
+	zudem kein `z-*`-Token. Browser ohne CSS-Anchor-Positioning zeigen das
+	Menü zentriert statt am Auslöser — bedienbar bleibt es auch dort.
+
+	`menuId` muss dokumentweit eindeutig sein: Tabelle und Kartenansicht
+	stehen BEIDE im DOM (die Umschaltung in `layoutSwitch.ts` ist reines CSS),
+	die Aufrufstellen prefixen deshalb pro Ansicht.
+-->
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import { TEST_EMAIL_HINT } from '$lib/components/admin/sightingActions';
+
+	interface Props {
+		/** Dokumentweit eindeutige id des Popover-Elements (siehe Kopfkommentar). */
+		menuId: string;
+		/** Zugänglicher Name des Auslösers — benennt die Sichtung, nicht nur „Menü". */
+		label: string;
+		/** Steuert nur das Bedienelement — das Gate steht zusätzlich am Endpunkt. */
+		isSuperAdmin: boolean;
+		size?: 'xs' | 'sm';
+		onspamcheck: () => void;
+		ontestemail: () => void;
+		ondelete: () => void;
+	}
+
+	let {
+		menuId,
+		label,
+		isSuperAdmin,
+		size = 'sm',
+		onspamcheck,
+		ontestemail,
+		ondelete
+	}: Props = $props();
+</script>
+
+<button
+	type="button"
+	class="btn btn-ghost {size === 'xs' ? 'btn-xs' : 'btn-sm'}"
+	popovertarget={menuId}
+	style="anchor-name:--{menuId}"
+	title="Weitere Aktionen"
+	aria-label={label}
+>
+	<Icon icon="lucide:ellipsis-vertical" class="h-4 w-4" aria-hidden="true" />
+</button>
+<!-- `dropdown` an einem `[popover]` ist DaisyUIs Popover-Positionierung, kein
+     Klick-Verhalten; auf/zu übernimmt der Browser über `popovertarget`.
+     `whitespace-normal`: In der Tabelle steht der Auslöser in einer Zelle mit
+     `whitespace-nowrap` — das Menü erbt das und schnitt den Mail-Eintrag ab,
+     statt ihn umzubrechen. -->
+<ul
+	class="dropdown dropdown-end menu bg-base-100 rounded-box border-base-300 shadow-floating w-64 border p-2 whitespace-normal"
+	popover="auto"
+	id={menuId}
+	style="position-anchor:--{menuId}"
+>
+	<!-- `popovertargetaction="hide"` an jedem Eintrag: schließt das Menü
+	     deklarativ nach der Auswahl — ohne eigenes Open-State-Management. -->
+	<li>
+		<button type="button" popovertarget={menuId} popovertargetaction="hide" onclick={onspamcheck}>
+			<Icon icon="lucide:shield-alert" class="h-4 w-4" aria-hidden="true" />
+			Spam-Check durchführen
+		</button>
+	</li>
+	{#if isSuperAdmin}
+		<!-- Nur Superadmins: Der Klick erzeugt im Team-Postfach eine Mail, die von
+		     einer echten Neu-Meldung nicht zu unterscheiden ist. -->
+		<li>
+			<button
+				type="button"
+				popovertarget={menuId}
+				popovertargetaction="hide"
+				onclick={ontestemail}
+				title={TEST_EMAIL_HINT}
+			>
+				<Icon icon="lucide:mail" class="h-4 w-4" aria-hidden="true" />
+				Benachrichtigung ans Team senden
+			</button>
+		</li>
+	{/if}
+	<!-- Kanonische destruktive Variante statt `text-error` am Menüeintrag —
+	     gleiche Konstruktion und Begründung wie im Ansichten-Menü der
+	     Tabellenseite: DaisyUI färbt Menüeinträge beim Hovern dunkler als
+	     `base-300`, dort läge `text-error` unter AA; die Menü-Hover-Regel
+	     greift nicht auf `.btn`. -->
+	<li>
+		<button
+			type="button"
+			class="btn btn-outline btn-error btn-sm w-full justify-start"
+			popovertarget={menuId}
+			popovertargetaction="hide"
+			onclick={ondelete}
+		>
+			<Icon icon="lucide:trash-2" class="h-4 w-4" aria-hidden="true" />
+			Eintrag löschen
+		</button>
+	</li>
+</ul>

--- a/src/lib/components/admin/SightingActionsMenu.svelte.test.ts
+++ b/src/lib/components/admin/SightingActionsMenu.svelte.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Overflow-Menü der Zeilen-Aktionen (Tabelle + Kartenansicht).
+ *
+ * Browser-Test, weil die Zusagen im DOM liegen: Das Menü öffnet per Popover,
+ * die Einträge feuern ihre Callbacks und schließen das Menü wieder, und die
+ * Mail-Aktion existiert nur für Superadmins. Popover-API läuft im echten
+ * Chromium — in jsdom gäbe es `showPopover` nicht.
+ */
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import SightingActionsMenu from './SightingActionsMenu.svelte';
+
+function renderMenu(overrides: Partial<Parameters<typeof render>[1]> = {}) {
+	const onspamcheck = vi.fn();
+	const ontestemail = vi.fn();
+	const ondelete = vi.fn();
+	const screen = render(SightingActionsMenu, {
+		menuId: 'aktionen-test-1',
+		label: 'Weitere Aktionen zu Sichtung REF-1',
+		isSuperAdmin: false,
+		onspamcheck,
+		ontestemail,
+		ondelete,
+		...overrides
+	});
+	return { screen, onspamcheck, ontestemail, ondelete };
+}
+
+describe('SightingActionsMenu', () => {
+	it('öffnet das Menü über den benannten Auslöser', async () => {
+		const { screen } = renderMenu();
+
+		const trigger = screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' });
+		await trigger.click();
+
+		await expect
+			.element(screen.getByRole('button', { name: 'Spam-Check durchführen' }))
+			.toBeVisible();
+		await expect.element(screen.getByRole('button', { name: 'Eintrag löschen' })).toBeVisible();
+	});
+
+	it('feuert die Callbacks und schließt das Menü nach der Auswahl', async () => {
+		const { screen, onspamcheck, ondelete } = renderMenu();
+
+		await screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' }).click();
+		await screen.getByRole('button', { name: 'Spam-Check durchführen' }).click();
+		expect(onspamcheck).toHaveBeenCalledOnce();
+		/* `popovertargetaction="hide"` am Eintrag: nach der Auswahl ist das Menü zu.
+		   Geprüft am Element statt per Locator — ein geschlossenes Popover ist für
+		   `getByRole` nicht „unsichtbar", sondern gar nicht auffindbar. */
+		const popover = screen.container.querySelector('[popover]');
+		expect(popover?.matches(':popover-open')).toBe(false);
+
+		await screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' }).click();
+		await screen.getByRole('button', { name: 'Eintrag löschen' }).click();
+		expect(ondelete).toHaveBeenCalledOnce();
+	});
+
+	it('zeigt die Mail-Aktion nur für Superadmins', async () => {
+		const { screen, ontestemail } = renderMenu({ isSuperAdmin: true });
+
+		await screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' }).click();
+		const mail = screen.getByRole('button', { name: 'Benachrichtigung ans Team senden' });
+		await expect.element(mail).toBeVisible();
+		await mail.click();
+		expect(ontestemail).toHaveBeenCalledOnce();
+	});
+
+	it('hat ohne Superadmin-Rolle keinen Mail-Eintrag', async () => {
+		const { screen } = renderMenu();
+
+		await screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' }).click();
+		expect(
+			screen.container.querySelectorAll('[popover] li button').length,
+			'nur Spam-Check und Löschen'
+		).toBe(2);
+	});
+});

--- a/src/routes/admin/destructiveButtonVariant.test.ts
+++ b/src/routes/admin/destructiveButtonVariant.test.ts
@@ -74,12 +74,14 @@ describe('Admin — destruktive Schaltflächen tragen die kanonische Variante', 
 		expect(verstoesse).toEqual([]);
 	});
 
-	it('löscht in Tabelle, Karte und Detailansicht mit derselben Variante', () => {
+	it('löscht in Zeilen-Menü und Detailansicht mit derselben Variante', () => {
 		// Der Scan oben verbietet die falsche Variante; dieser Test verlangt die
 		// richtige. Ohne ihn wäre auch „gar kein Löschen-Knopf mehr" grün.
+		// Tabelle und Kartenansicht löschen seit 2026-08-10 über das gemeinsame
+		// Overflow-Menü (`SightingActionsMenu.svelte`) — deshalb steht hier die
+		// Menü-Komponente statt der beiden Ansichten.
 		for (const pfad of [
-			'./sichtungen/SichtungenTable.svelte',
-			'./sichtungen/SichtungenCards.svelte',
+			'../../lib/components/admin/SightingActionsMenu.svelte',
 			'./[id]/+page.svelte'
 		]) {
 			const quelle = readFileSync(fileURLToPath(new URL(pfad, import.meta.url)), 'utf-8');

--- a/src/routes/admin/sichtungen/SichtungenCards.svelte
+++ b/src/routes/admin/sichtungen/SichtungenCards.svelte
@@ -13,9 +13,9 @@
 <script lang="ts">
 	import Icon from '$lib/components/Icon.svelte';
 	import { DEAD_FINDING_PRESENTATION, isDeadFinding } from '$lib/components/admin/deadFinding';
+	import SightingActionsMenu from '$lib/components/admin/SightingActionsMenu.svelte';
 	import SightingStatusControl from '$lib/components/admin/SightingStatusControl.svelte';
 	import { getSightingStatus, type SightingStatus } from '$lib/components/admin/sightingStatus';
-	import { TEST_EMAIL_HINT } from '$lib/components/admin/sightingActions';
 	import type { SightingVerdict } from '$lib/components/admin/sightingVerdict';
 	import { getSpeciesLabel } from '$lib/report/formOptions/species';
 	import type { SichtungenListRow } from './listColumns';
@@ -107,38 +107,18 @@
 					>
 						<Icon icon="lucide:eye" class="h-4 w-4" />
 					</button>
-					<!-- Nur Superadmins: Der Klick erzeugt im Team-Postfach eine Mail, die
-					     von einer echten Neu-Meldung nicht zu unterscheiden ist. Das Gate
-					     steht zusätzlich am Endpunkt — hier verschwindet nur das Bedienelement. -->
-					{#if isSuperAdmin}
-						<button
-							class="btn btn-ghost btn-sm"
-							onclick={() => ontestemail(sighting.id)}
-							title={TEST_EMAIL_HINT}
-							aria-label="Benachrichtigung zu dieser Sichtung an das Team senden"
-						>
-							<Icon icon="lucide:mail" class="h-4 w-4" />
-						</button>
-					{/if}
-					<button
-						class="btn btn-ghost btn-sm"
-						onclick={() => onspamcheck(sighting.id)}
-						title="Spam-Check"
-						aria-label="Spam-Check durchführen"
-					>
-						<Icon icon="lucide:shield-alert" class="h-4 w-4" />
-					</button>
-					<!-- Kanonische destruktive Variante, gleiche Begründung wie in der
-					     Tabellenzeile nebenan (`SichtungenTable.svelte`): dieselbe Aktion,
-					     dieselbe Variante, dasselbe Icon — unabhängig von der Ansicht. -->
-					<button
-						class="btn btn-outline btn-error btn-sm"
-						onclick={() => ondelete(sighting)}
-						title="Eintrag löschen"
-						aria-label="Eintrag löschen"
-					>
-						<Icon icon="lucide:trash-2" class="h-4 w-4" />
-					</button>
+					<!-- Dasselbe Overflow-Menü wie in der Tabellenzeile nebenan
+					     (`SichtungenTable.svelte`): dieselben Aktionen, dieselbe Reihenfolge,
+					     derselbe Wortlaut — unabhängig von der Ansicht. Das eigene
+					     id-Präfix ist Pflicht: Beide Ansichten stehen gleichzeitig im DOM. -->
+					<SightingActionsMenu
+						menuId="aktionen-karte-{sighting.id}"
+						label="Weitere Aktionen zu Sichtung {sighting.referenceId ?? sighting.id}"
+						{isSuperAdmin}
+						onspamcheck={() => onspamcheck(sighting.id)}
+						ontestemail={() => ontestemail(sighting.id)}
+						ondelete={() => ondelete(sighting)}
+					/>
 				</div>
 			</div>
 

--- a/src/routes/admin/sichtungen/SichtungenTable.svelte
+++ b/src/routes/admin/sichtungen/SichtungenTable.svelte
@@ -10,8 +10,8 @@
 	import { page } from '$app/state';
 	import Icon from '$lib/components/Icon.svelte';
 	import { DEAD_FINDING_PRESENTATION, isDeadFinding } from '$lib/components/admin/deadFinding';
+	import SightingActionsMenu from '$lib/components/admin/SightingActionsMenu.svelte';
 	import SightingStatusControl from '$lib/components/admin/SightingStatusControl.svelte';
-	import { TEST_EMAIL_HINT } from '$lib/components/admin/sightingActions';
 	import {
 		getSightingStatus,
 		SIGHTING_STATUS_PRESENTATION,
@@ -517,42 +517,22 @@
 									>
 										<Icon icon="lucide:eye" class="h-4 w-4" />
 									</button>
-									<!-- Nur Superadmins — Begründung an der Kartenansicht in `SichtungenCards.svelte`. -->
-									{#if isSuperAdmin}
-										<button
-											class="btn btn-ghost btn-xs"
-											onclick={() => ontestemail(sighting.id)}
-											title={TEST_EMAIL_HINT}
-											aria-label="Benachrichtigung zu dieser Sichtung an das Team senden"
-										>
-											<Icon icon="lucide:mail" class="h-4 w-4" />
-										</button>
-									{/if}
-									<button
-										class="btn btn-ghost btn-xs"
-										onclick={() => onspamcheck(sighting.id)}
-										title="Spam-Check"
-										aria-label="Spam-Check durchführen"
-									>
-										<Icon icon="lucide:shield-alert" class="h-4 w-4" />
-									</button>
-									<!-- Die kanonische destruktive Variante (`btn btn-outline btn-error`,
-									     Button-Hierarchie in `design-system.md`) — vorher stand hier
-									     `btn-ghost text-error`, also genau die zweite Variante, die die
-									     Regel wörtlich als Anti-Pattern nennt. Der Rahmen zwischen drei
-									     rahmenlosen Icons ist dabei nicht Nebenwirkung, sondern Zweck:
-									     Löschen ist die einzige Aktion der Zeile, die man nicht
-									     zurücknehmen kann.
-									     `btn-xs` bleibt: Die Größe trägt die Zeilenhöhe, nicht die
-									     Variante — die 44px Trefferfläche kommen ohnehin aus app.css. -->
-									<button
-										class="btn btn-outline btn-error btn-xs"
-										onclick={() => ondelete(sighting)}
-										title="Eintrag löschen"
-										aria-label="Eintrag löschen"
-									>
-										<Icon icon="lucide:trash-2" class="h-4 w-4" />
-									</button>
+									<!-- Spam-Check, Test-Mail und Löschen stehen seit 2026-08-10 im
+									     Overflow-Menü statt als eigene Buttons (Entscheidung Jan nach dem
+									     UX-Review): 50 rot umrandete Löschen-Buttons pro Seite waren das
+									     auffälligste Element der Tabelle — für die seltenste Aktion,
+									     direkt neben dem täglich benutzten Status-Control. Sichtbar
+									     bleiben Ansehen und der Statuswechsel. Begründung der
+									     Popover-Technik im Kopf der Komponente. -->
+									<SightingActionsMenu
+										menuId="aktionen-tabelle-{sighting.id}"
+										label="Weitere Aktionen zu Sichtung {sighting.referenceId ?? sighting.id}"
+										{isSuperAdmin}
+										size="xs"
+										onspamcheck={() => onspamcheck(sighting.id)}
+										ontestemail={() => ontestemail(sighting.id)}
+										ondelete={() => ondelete(sighting)}
+									/>
 								</div>
 							</td>
 						{/if}


### PR DESCRIPTION
## Was

Spam-Check, Test-Mail und Löschen wandern aus den Tabellenzeilen und Mobil-Karten in ein gemeinsames Overflow-Menü (`SightingActionsMenu.svelte`). Sichtbar pro Zeile bleiben **Ansehen** und das **Status-Control** — die täglichen Aktionen.

## Warum

Befund 5 des UX-Reviews vom 2026-08-09 (Entscheidung Jan): 50 rot umrandete Löschen-Buttons pro Seite machten die seltenste und gefährlichste Aktion zum auffälligsten Element der Tabelle — direkt neben dem täglich benutzten Status-Control. Die kanonische destruktive Variante bleibt erhalten, nur ihr Ort ändert sich: Das Rot arbeitet jetzt im geöffneten Menü als Warnung statt im Ruhezustand als Rauschen.

## Wie

- **Popover-API (DaisyUI-5-Methode 2)** statt `details.dropdown`: Das Menü rendert im Top-Layer und entgeht dem Clipping durch den `overflow-x-auto`-Container der Tabelle (Sticky-Aktionsspalte). Kein z-Index-Token nötig; Einträge schließen deklarativ per `popovertargetaction="hide"`.
- **Eine Komponente für beide Ansichten** — gleiche Aktionen, gleiche Reihenfolge, gleicher Wortlaut; id-Präfix pro Ansicht, weil Tabelle und Karten gleichzeitig im DOM stehen.
- `whitespace-normal` am Menü kontert das aus der Sticky-Zelle geerbte `nowrap` (schnitt den Mail-Eintrag ab).
- Guard `destructiveButtonVariant.test.ts` scannt jetzt die Menü-Komponente statt der beiden Ansichten; der Spam-Check-E2E öffnet erst das Menü.

## Tests

- Neuer Browser-Test `SightingActionsMenu.svelte.test.ts` (4 Fälle: Öffnen, Callbacks + Schließen, Superadmin-Gate positiv/negativ) — TDD, echtes Chromium wegen Popover-API
- `npm run test:quick` grün; `e2e/admin-spam-check.spec.ts` 3/3
- Visuell verifiziert (1440px Tabelle inkl. unterster Zeile als Clipping-Probe, 480px Karten)

## Bekannte Grenzen

- Browser ohne CSS-Anchor-Positioning zeigen das Menü zentriert statt am Auslöser — bedienbar, im Komponenten-Kommentar dokumentiert.
- Menüeinträge (`.menu`, nicht `.btn`) liegen bei ~36px Trefferhöhe — vorbestehendes Muster der zwei anderen Tabellen-Dropdowns; gemeinsamer Fix als Folge-Task notiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)