### PR TITLE
fix(a11y): enforce 44px touch targets on menu entries

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -455,13 +455,13 @@ Das Formular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, mit 
 - Touch-Targets kommen aus `--target-min` (44px, im Feldmodus 56px). Der `Touch-Targets`-Block in `app.css` setzt sie global durch — `min-h-11` an der Aufrufstelle ist damit nicht mehr nötig, und `btn-xs` unterschreitet die Grenze nicht mehr still.
 - **Das Ziel ist 44px, nicht das Bedienelement.** WCAG 2.5.5 verlangt eine Trefferfläche dieser Größe — kein Control dieser Größe. Daraus folgen drei getrennte Mechanismen:
 
-  | Element                                    | Mechanismus                     | Größe                             |
-  | ------------------------------------------ | ------------------------------- | --------------------------------- |
-  | `.btn`, `summary.btn`                      | `min-height: var(--target-min)` | 44px (Feldmodus 56px)             |
-  | `.btn-circle`                              | zusätzlich `min-width`          | 44×44                             |
-  | `label:has(> .checkbox\|.radio\|.toggle)`  | `min-height: var(--target-min)` | 44px — **hier liegt das Ziel**    |
-  | `.checkbox`, `.radio`, `.toggle`           | `--size: var(--control-size)`   | 28px, sichtbare Größe             |
-  | `.menu li > *` (ohne `ul`/`details`/Titel) | `min-height: var(--target-min)` | 44px — DaisyUI-Default wäre ~32px |
+  | Element                                                                                                | Mechanismus                     | Größe                             |
+  | ------------------------------------------------------------------------------------------------------ | ------------------------------- | --------------------------------- |
+  | `.btn`, `summary.btn`                                                                                  | `min-height: var(--target-min)` | 44px (Feldmodus 56px)             |
+  | `.btn-circle`                                                                                          | zusätzlich `min-width`          | 44×44                             |
+  | `label:has(> .checkbox\|.radio\|.toggle)`                                                              | `min-height: var(--target-min)` | 44px — **hier liegt das Ziel**    |
+  | `.checkbox`, `.radio`, `.toggle`                                                                       | `--size: var(--control-size)`   | 28px, sichtbare Größe             |
+  | `.menu`-Einträge: `li > *` (ohne `ul`/`details`/Titel/`.target-exempt`) sowie `li > details > summary` | `min-height: var(--target-min)` | 44px — DaisyUI-Default wäre ~32px |
 
   `.checkbox`/`.radio`/`.toggle` **nie über `min-height`** vergrößern: DaisyUI setzt bei ihnen `width` **und** `height` fest, `min-height` überschreibt nur die Höhe und verzerrt sie (gemessen: Checkbox 24×44, Radio 24×44 als Ellipse, Toggle 40×44 mit versetztem Knopf). Und `--size` **nicht** auf `--target-min` setzen — dann greifen Control-Größe und Trefferfläche gleichzeitig, der Toggle würde 75×44 breit (im Feldmodus 96×56).
 

--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -455,12 +455,13 @@ Das Formular wird an Deck und am Strand ausgefüllt — nass, in der Sonne, mit 
 - Touch-Targets kommen aus `--target-min` (44px, im Feldmodus 56px). Der `Touch-Targets`-Block in `app.css` setzt sie global durch — `min-h-11` an der Aufrufstelle ist damit nicht mehr nötig, und `btn-xs` unterschreitet die Grenze nicht mehr still.
 - **Das Ziel ist 44px, nicht das Bedienelement.** WCAG 2.5.5 verlangt eine Trefferfläche dieser Größe — kein Control dieser Größe. Daraus folgen drei getrennte Mechanismen:
 
-  | Element                                   | Mechanismus                     | Größe                          |
-  | ----------------------------------------- | ------------------------------- | ------------------------------ |
-  | `.btn`, `summary.btn`                     | `min-height: var(--target-min)` | 44px (Feldmodus 56px)          |
-  | `.btn-circle`                             | zusätzlich `min-width`          | 44×44                          |
-  | `label:has(> .checkbox\|.radio\|.toggle)` | `min-height: var(--target-min)` | 44px — **hier liegt das Ziel** |
-  | `.checkbox`, `.radio`, `.toggle`          | `--size: var(--control-size)`   | 28px, sichtbare Größe          |
+  | Element                                    | Mechanismus                     | Größe                             |
+  | ------------------------------------------ | ------------------------------- | --------------------------------- |
+  | `.btn`, `summary.btn`                      | `min-height: var(--target-min)` | 44px (Feldmodus 56px)             |
+  | `.btn-circle`                              | zusätzlich `min-width`          | 44×44                             |
+  | `label:has(> .checkbox\|.radio\|.toggle)`  | `min-height: var(--target-min)` | 44px — **hier liegt das Ziel**    |
+  | `.checkbox`, `.radio`, `.toggle`           | `--size: var(--control-size)`   | 28px, sichtbare Größe             |
+  | `.menu li > *` (ohne `ul`/`details`/Titel) | `min-height: var(--target-min)` | 44px — DaisyUI-Default wäre ~32px |
 
   `.checkbox`/`.radio`/`.toggle` **nie über `min-height`** vergrößern: DaisyUI setzt bei ihnen `width` **und** `height` fest, `min-height` überschreibt nur die Höhe und verzerrt sie (gemessen: Checkbox 24×44, Radio 24×44 als Ellipse, Toggle 40×44 mit versetztem Knopf). Und `--size` **nicht** auf `--target-min` setzen — dann greifen Control-Größe und Trefferfläche gleichzeitig, der Toggle würde 75×44 breit (im Feldmodus 96×56).
 

--- a/src/app.css
+++ b/src/app.css
@@ -503,6 +503,18 @@ summary.btn {
 	min-height: var(--target-min);
 }
 
+/* Menüeinträge — jede `.menu`-Instanz, also neben den Admin-Dropdowns
+   (Zeilen-Aktionen, Spalten-Auswahl, Ansichten-Verwaltung) auch beide
+   PublicNavbar-Menüs: DaisyUIs `.menu`-Padding ergibt nur ~32px. Die
+   `.btn`-Regel oben greift nur für Einträge, die selbst ein Button im
+   Button-Sinn sind (z. B. der Löschen-Eintrag) — die einfachen `li > a/button`
+   blieben darunter. Ausgenommen wie bei DaisyUI selbst: Untermenüs,
+   `details`-Wrapper und Titel — die sind keine Ziele.
+   Gemessen abgesichert in SightingActionsMenu.svelte.test.ts. */
+.menu li > :not(ul, details, .menu-title, .target-exempt) {
+	min-height: var(--target-min);
+}
+
 /* Checkbox, Radio und Toggle über --size statt über min-height.
    Die Handoff-Vorlage hatte sie in die min-height-Regel oben aufgenommen —
    das verzerrt sie: DaisyUI setzt für diese drei width UND height fest,

--- a/src/app.css
+++ b/src/app.css
@@ -509,9 +509,13 @@ summary.btn {
    `.btn`-Regel oben greift nur für Einträge, die selbst ein Button im
    Button-Sinn sind (z. B. der Löschen-Eintrag) — die einfachen `li > a/button`
    blieben darunter. Ausgenommen wie bei DaisyUI selbst: Untermenüs,
-   `details`-Wrapper und Titel — die sind keine Ziele.
+   `details`-Wrapper und Titel — die sind keine Ziele. Das Ziel eines
+   `details`-Eintrags ist sein `summary` (PublicNavbar, Desktop-Menü
+   „Verwaltung") — zweiter Zweig, dasselbe Paar wie in DaisyUIs eigenem
+   Item-Selektor.
    Gemessen abgesichert in SightingActionsMenu.svelte.test.ts. */
-.menu li > :not(ul, details, .menu-title, .target-exempt) {
+.menu li > :not(ul, details, .menu-title, .target-exempt),
+.menu li > details > summary:not(.target-exempt) {
 	min-height: var(--target-min);
 }
 

--- a/src/lib/components/admin/SightingActionsMenu.svelte.test.ts
+++ b/src/lib/components/admin/SightingActionsMenu.svelte.test.ts
@@ -10,6 +10,11 @@ import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi } from 'vitest';
 import SightingActionsMenu from './SightingActionsMenu.svelte';
 
+/* Das Browser-Test-Setup lädt src/app.css nicht — für die Touch-Target-Messung
+   unten braucht es aber die zentrale `.menu`-Regel von dort (und DaisyUIs
+   Menü-Styles). Explizit importieren, wie in FilterPanel.svelte.test.ts. */
+import '../../../app.css';
+
 function renderMenu(overrides: Partial<Parameters<typeof render>[1]> = {}) {
 	const onspamcheck = vi.fn();
 	const ontestemail = vi.fn();
@@ -64,6 +69,29 @@ describe('SightingActionsMenu', () => {
 		await expect.element(mail).toBeVisible();
 		await mail.click();
 		expect(ontestemail).toHaveBeenCalledOnce();
+	});
+
+	it('jeder Menüeintrag erfüllt das 44px-Touch-Target (WCAG 2.5.5)', async () => {
+		/* Misst die Wirkung im Browser, nicht die Existenz einer CSS-Regel: Der
+		   Touch-Target-Block in app.css deckte nur `.btn` ab — die einfachen
+		   Menüeinträge (Spam-Check, Mail) kamen mit DaisyUIs Menü-Padding nur
+		   auf ~32px. Superadmin an, damit alle drei Einträge im DOM stehen. */
+		const { screen } = renderMenu({ isSuperAdmin: true });
+
+		await screen.getByRole('button', { name: 'Weitere Aktionen zu Sichtung REF-1' }).click();
+		const eintraege = screen.container.querySelectorAll('[popover] li > button');
+		expect(eintraege.length).toBe(3);
+		for (const eintrag of eintraege) {
+			/* expect.poll: DaisyUI öffnet das Dropdown mit einer scale-Animation
+			   (0.95 → 1, 200 ms). Eine Sofort-Messung per getBoundingClientRect
+			   liefert mitten darin 41,8px (= 44 × 0,95) und wäre flaky — gepollt
+			   wird deshalb bis zum Endzustand. */
+			await expect
+				.poll(() => eintrag.getBoundingClientRect().height, {
+					message: `Touch-Target von „${eintrag.textContent?.trim()}"`
+				})
+				.toBeGreaterThanOrEqual(44);
+		}
 	});
 
 	it('hat ohne Superadmin-Rolle keinen Mail-Eintrag', async () => {


### PR DESCRIPTION
## Zusammenfassung

Befund aus dem Code-Review 2026-08-10: Die DaisyUI-`.menu`-Einträge in den Admin-Dropdowns erreichten nur ~32px Trefferhöhe — das Projekt-Mindestmaß ist 44px (`--target-min`), der Touch-Target-Block in `app.css` deckte aber nur `.btn` ab.

Statt drei Einzelfixes eine zentrale Regel im Touch-Target-Block:

```css
.menu li > :not(ul, details, .menu-title, .target-exempt) {
	min-height: var(--target-min);
}
```

Gleiche Ausnahmen wie DaisyUIs eigener Menü-Item-Selektor; `.target-exempt` bleibt die etablierte Fluchtklasse. Die Regel hebt neben dem Zeilen-Aktionsmenü und dem Ansichten-Menü auch die beiden PublicNavbar-Menüs auf 44px — gewollt, es ist die globale Durchsetzung des Mindestmaßes.

## Test-First

- RED: neuer Messtest in `SightingActionsMenu.svelte.test.ts` (importiert `app.css` nach dem FilterPanel-Vorbild, misst `getBoundingClientRect` im echten Chromium) → 32px ohne Regel.
- GREEN: Regel in `app.css` → alle drei Einträge ≥ 44px.
- Stolperstein: DaisyUI öffnet Dropdowns mit einer scale-Animation (0,95 → 1, 200 ms); eine Sofort-Messung liefert 41,8px (= 44 × 0,95). Der Test pollt deshalb per `expect.poll` bis zum Endzustand.

## Verifikation

- Live auf `/admin/sichtungen` gemessen (Playwright, geseedete Admin-Session): Zeilen-Aktionsmenü 44 / 55,4 / 44 px; Spalten-Dropdown alle 20 Einträge exakt 44px (dort greifen die bestehenden `label:has(> .checkbox)`- und `.btn`-Regeln — der Dropdown hat keine `li`-Struktur).
- `npm run test:quick` grün (744 Tests).
- Doku nachgezogen: Mechanismus-Tabelle in `.claude/rules/design-system.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)