### PR TITLE
feat(admin): melder-historie im eingang und in der detailansicht

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -183,8 +183,14 @@ Eingangskarte und Kontakt-Karte der Detailansicht zeigen dasselbe Badge aus
   Messwerten in `docs/SPAM_DETECTION.md` („Melder-Historie — daneben, nicht
   darin"). Persistiert wird nichts.
 - **`null` heißt „nicht ermittelt" und bekommt kein Badge** — nicht „keine
-  Vorgeschichte". Die Detailansicht führt den Fehlschlag zusätzlich als eigenen
-  Text, gleiche Konstruktion wie beim Status-Log.
+  Vorgeschichte". Die Detailansicht führt einen **Transportfehler** (Endpunkt
+  nicht erreichbar, Antwort ohne `history`) zusätzlich als eigenen Text,
+  gleiche Konstruktion wie beim Status-Log. Scheitert dagegen die Abfrage
+  selbst — `findReporterHistory` ist fail-open —, kommt sie ebenfalls als
+  `history: null` zurück, und das ist von „keine Adresse hinterlegt" nicht zu
+  unterscheiden: kein Badge, kein Fehlertext. Das ist der Preis des Fail-open
+  und bewusst so, nicht nachzurüsten ohne die Fail-open-Eigenschaft selbst
+  aufzugeben.
 - **Kein `badge-success` und keine Filter/Sortierung im Eingang.** Grün neben
   dem Freigeben-Knopf läse sich als Urteil über die Meldung, und der Eingang
   bleibt eine Task-Liste ohne Filter (dafür gibt es `/admin/sichtungen`).

--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -122,29 +122,31 @@ dieselbe, deshalb steht sie einmal.
 
 ## Admin-Komponenten
 
-| Komponente                     | Zweck                                       |
-| ------------------------------ | ------------------------------------------- |
-| `AdminSightingEditForm.svelte` | Sichtung bearbeiten                         |
-| `AdminSightingView.svelte`     | Sichtung anzeigen (read-only)               |
-| `SightingInboxCard.svelte`     | Karte der Eingangsseite (`/admin`)          |
-| `inboxVerdict.ts`              | Verdict-Logik der Eingangsseite             |
-| `adminTriageShortcuts.ts`      | Tastatur-Triage (Eingang + Detailansicht)   |
-| `InboxShortcutHelp.svelte`     | Overlay mit der Kürzel-Übersicht            |
-| `adminReturn.ts`               | Herkunft `?from=inbox` + Karten-Anker       |
-| `SightingQueueNav.svelte`      | Navigationsleiste des Arbeitsmodus          |
-| `sightingQueue.ts`             | Queue-Typen, Ziel-Href, Advance-Ziel        |
-| `queueAdvance.ts`              | Sprung + Undo-Toast nach einer Entscheidung |
-| `queueOrder.ts`                | Client-sichere Auswertung von `?order`      |
-| `undoMemory.svelte.ts`         | Zustand hinter „Rückgängig" (Detailansicht) |
-| `DataTableRow.svelte`          | Tabellen-Zeile                              |
-| `BooleanStatus.svelte`         | Boolean-Status Anzeige                      |
-| `ExportModal.svelte`           | Export-Dialog                               |
-| `deadFinding.ts`               | Totfund-Auszeichnung                        |
-| `sightingStatus.ts`            | Statusableitung + Wort/Farbe/Icon/Verdict   |
-| `spamScorePresentation.ts`     | Spam-Risikostufe + Wort/Farbe/Icon          |
-| `SpamFinding.svelte`           | Ein Spam-Befund (Modal + Detailkarte)       |
-| `sightingStatusFilter.ts`      | Statuswert ↔ Filter-Query (`?verified=`)    |
-| `SightingStatusControl.svelte` | Segmented Control für den Statuswechsel     |
+| Komponente                       | Zweck                                       |
+| -------------------------------- | ------------------------------------------- |
+| `AdminSightingEditForm.svelte`   | Sichtung bearbeiten                         |
+| `AdminSightingView.svelte`       | Sichtung anzeigen (read-only)               |
+| `SightingInboxCard.svelte`       | Karte der Eingangsseite (`/admin`)          |
+| `inboxVerdict.ts`                | Verdict-Logik der Eingangsseite             |
+| `adminTriageShortcuts.ts`        | Tastatur-Triage (Eingang + Detailansicht)   |
+| `InboxShortcutHelp.svelte`       | Overlay mit der Kürzel-Übersicht            |
+| `adminReturn.ts`                 | Herkunft `?from=inbox` + Karten-Anker       |
+| `SightingQueueNav.svelte`        | Navigationsleiste des Arbeitsmodus          |
+| `sightingQueue.ts`               | Queue-Typen, Ziel-Href, Advance-Ziel        |
+| `queueAdvance.ts`                | Sprung + Undo-Toast nach einer Entscheidung |
+| `queueOrder.ts`                  | Client-sichere Auswertung von `?order`      |
+| `undoMemory.svelte.ts`           | Zustand hinter „Rückgängig" (Detailansicht) |
+| `DataTableRow.svelte`            | Tabellen-Zeile                              |
+| `BooleanStatus.svelte`           | Boolean-Status Anzeige                      |
+| `ExportModal.svelte`             | Export-Dialog                               |
+| `deadFinding.ts`                 | Totfund-Auszeichnung                        |
+| `sightingStatus.ts`              | Statusableitung + Wort/Farbe/Icon/Verdict   |
+| `spamScorePresentation.ts`       | Spam-Risikostufe + Wort/Farbe/Icon          |
+| `SpamFinding.svelte`             | Ein Spam-Befund (Modal + Detailkarte)       |
+| `sightingStatusFilter.ts`        | Statuswert ↔ Filter-Query (`?verified=`)    |
+| `SightingStatusControl.svelte`   | Segmented Control für den Statuswechsel     |
+| `reporterHistoryPresentation.ts` | Stufe der Melder-Historie + Wort/Farbe/Icon |
+| `ReporterHistoryBadge.svelte`    | Das Badge (Eingang + Detailansicht)         |
 
 ### Spam-Score: vier Anzeigestellen, eine Schwelle
 
@@ -170,6 +172,22 @@ Die Flächen- und Icon-Farbe der Detail-Karte steht als `SpamRisk`-Record an
 ihrer Aufrufstelle — ein Leser, gleiche Begründung wie bei `deadFinding.ts`.
 Über die Stufe und nicht über den Score aufgeschlüsselt, damit die Schwellen
 nicht doch wieder auseinanderlaufen.
+
+### Melder-Historie: zwei Anzeigestellen, eine Quelle
+
+Eingangskarte und Kontakt-Karte der Detailansicht zeigen dasselbe Badge aus
+`ReporterHistoryBadge.svelte`; Stufen und Schwellen stehen in
+`reporterHistoryPresentation.ts`. Drei Dinge dabei nicht zurückdrehen:
+
+- **Sie ist kein Teil des Spam-Scores und darf keiner werden.** Begründung mit
+  Messwerten in `docs/SPAM_DETECTION.md` („Melder-Historie — daneben, nicht
+  darin"). Persistiert wird nichts.
+- **`null` heißt „nicht ermittelt" und bekommt kein Badge** — nicht „keine
+  Vorgeschichte". Die Detailansicht führt den Fehlschlag zusätzlich als eigenen
+  Text, gleiche Konstruktion wie beim Status-Log.
+- **Kein `badge-success` und keine Filter/Sortierung im Eingang.** Grün neben
+  dem Freigeben-Knopf läse sich als Urteil über die Meldung, und der Eingang
+  bleibt eine Task-Liste ohne Filter (dafür gibt es `/admin/sichtungen`).
 
 ### Modal und Detailkarte zeigen zwei Befunde, nicht einen
 

--- a/docs/SPAM_DETECTION.md
+++ b/docs/SPAM_DETECTION.md
@@ -247,6 +247,47 @@ ist keine.
 
 ---
 
+## Melder-Historie — daneben, nicht darin
+
+Eingang und Detailansicht zeigen seit 2026-08 zusätzlich, wie viele **andere**
+Meldungen derselben E-Mail-Adresse freigegeben, abgelehnt oder noch offen sind
+(`src/lib/server/db/reporterHistory.ts`, Stufen in
+`src/lib/components/admin/reporterHistoryPresentation.ts`). Gemessen auf der
+lokalen DB (2026-08-10, 659 offene Meldungen): Melder mit Vorgeschichte hatten
+einen mittleren Spam-Score von 0,19–0,23 und **keinen** Hochrisiko-Fall; alle 14
+Hochrisiko-Meldungen kamen von Adressen ohne Vorgeschichte.
+
+**Sie fließt bewusst nicht in den Score ein.** Drei Gründe:
+
+- Der Score wird beim Eingang **persistiert** und ist eine Momentaufnahme.
+  Reputation ändert sich rückwirkend — jede Freigabe von heute veränderte die
+  Bewertung von gestern, und ein gespeicherter Anteil wäre ab dem nächsten Klick
+  falsch.
+- Sie machte den `stored`/`recomputed`-Vergleich unerklärbar. Heute lässt sich
+  jede Differenz auf die vier Meldezeitpunkt-Indikatoren zurückführen; ein
+  zeitabhängiger Term nähme dieser Erklärung die Grundlage.
+- Die Richtung wäre angreifbar. Die E-Mail ist **nicht verifiziert** (kein
+  Double-Opt-in, kein Captcha): Ein Bonus, der den Score senkt, ließe sich durch
+  Eintragen einer bekannten Adresse abholen. Als danebenstehende Zahl ist
+  dieselbe Angabe harmlos — es entscheidet ein Mensch.
+
+**Schwellen** (Entscheidung Jan, 2026-08-10): bekannt ab 3 Freigaben, etabliert
+ab 10, gewarnt wird ab einem Anteil von ⅓ abgelehnter unter den **bearbeiteten**
+Meldungen. Eine einzelne Ablehnung unter 29 Freigaben ist ein Fehlgriff und kein
+Muster.
+
+**Offen zählt nie negativ.** Die Ablehnung gibt es erst seit 2026-08; vorher
+blieb Spam unbearbeitet liegen (im Bestand 5 abgelehnte gegen 19.289
+freigegebene Zeilen). Eine offene Altmeldung ist Bearbeitungsstau, kein
+Qualitätsurteil — wer sie negativ zählt, bestraft den Rückstau des Museums.
+
+**Nichts davon wird persistiert**: keine Spalte, keine Migration, kein Backfill.
+Berechnet wird live, ein Query für alle Karten des Eingangs (22 ms auf ~20.000
+Zeilen, Seq Scan — kein Index auf `lower(trim(email))`, gleiche Lage wie bei den
+Duplikat-Abfragen oben).
+
+---
+
 ## Grenzen und bewusst Nicht-Umgesetztes
 
 - **Kein Captcha, keine E-Mail-Bestätigung.** Beides kostet Conversion bei

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -110,6 +110,8 @@
 	import Upload from '~icons/lucide/upload';
 	import User from '~icons/lucide/user';
 	import UserCheck from '~icons/lucide/user-check';
+	import UserPlus from '~icons/lucide/user-plus';
+	import UserX from '~icons/lucide/user-x';
 	import Users from '~icons/lucide/users';
 	import Video from '~icons/lucide/video';
 	import Waves from '~icons/lucide/waves';
@@ -221,6 +223,8 @@
 		'lucide:skull': Skull,
 		'lucide:toggle-left': ToggleLeft,
 		'lucide:user-check': UserCheck,
+		'lucide:user-plus': UserPlus,
+		'lucide:user-x': UserX,
 		'lucide:zap': Zap,
 		'lucide:mountain': Mountain,
 		'lucide:book-open': BookOpen,

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -393,22 +393,35 @@
 	   Datum, und „Melder seit 08/2026" liest sich als Aussage über eine
 	   Vorgeschichte, die es nicht gibt. Ab `pending` ebenfalls nicht: Auch dort
 	   ist noch nichts bearbeitet worden. */
+	/**
+	 * „Melder seit" als `MM/JJJJ`, aus den UTC-Feldern zusammengesetzt.
+	 *
+	 * **Nicht `toLocaleDateString('de-DE', …)`.** Das Trennzeichen kommt dort aus
+	 * den ICU-Daten der Laufzeit und ist keine Zusage: Je nach Browser- und
+	 * ICU-Version steht dort `03/2019` oder `03.2019`. Die Oberfläche kündigt
+	 * aber `MM/JJJJ` an, und der Test prüft genau darauf — die Formatierung
+	 * gehört deshalb hierher und nicht in eine Bibliotheksentscheidung, die sich
+	 * unter uns ändern kann (Befund aus dem Review zu PR #852).
+	 *
+	 * `getUTC*` statt der lokalen Getter, weil `since` UTC ist (`to_char(… "Z")`
+	 * in `reporterHistory.ts`): `2019-03-31T23:00:00Z` ergäbe in Berliner
+	 * Ortszeit sonst „04/2019".
+	 */
+	function formatiereMelderSeit(since: string | null | undefined): string | null {
+		if (!since) return null;
+		const zeitpunkt = new Date(since);
+		/* Ein unbrauchbares Datum wird verschwiegen statt als „NaN/NaN" gezeigt.
+		   Die Gestaltprüfung im Loader lässt jede Zeichenkette durch — sie prüft
+		   den Typ, nicht das Format. */
+		if (Number.isNaN(zeitpunkt.getTime())) return null;
+		const monat = String(zeitpunkt.getUTCMonth() + 1).padStart(2, '0');
+		return `${monat}/${zeitpunkt.getUTCFullYear()}`;
+	}
+
 	const reporterLevel = $derived(getReporterLevel(reporterHistory));
 	const reporterSince = $derived(
-		reporterHistory?.since &&
-			reporterLevel &&
-			reporterLevel !== 'first' &&
-			reporterLevel !== 'pending'
-			? new Date(reporterHistory.since).toLocaleDateString('de-DE', {
-					month: '2-digit',
-					year: 'numeric',
-					// `since` ist UTC (`to_char(… "Z")` in reporterHistory.ts). Ohne
-					// `timeZone: 'UTC'` liest `toLocaleDateString` den Zeitstempel in
-					// Browser-Ortszeit — `2019-03-31T23:00:00Z` erschiene als „04/2019".
-					// Für eine reine Monatsangabe folgenlos in der Regel, aber dieselbe
-					// Falle, gegen die das Server-Modul sein `to_char` extra baut.
-					timeZone: 'UTC'
-				})
+		reporterLevel && reporterLevel !== 'first' && reporterLevel !== 'pending'
+			? formatiereMelderSeit(reporterHistory?.since)
 			: null
 	);
 

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -401,11 +401,23 @@
 			reporterLevel !== 'pending'
 			? new Date(reporterHistory.since).toLocaleDateString('de-DE', {
 					month: '2-digit',
-					year: 'numeric'
+					year: 'numeric',
+					// `since` ist UTC (`to_char(… "Z")` in reporterHistory.ts). Ohne
+					// `timeZone: 'UTC'` liest `toLocaleDateString` den Zeitstempel in
+					// Browser-Ortszeit — `2019-03-31T23:00:00Z` erschiene als „04/2019".
+					// Für eine reine Monatsangabe folgenlos in der Regel, aber dieselbe
+					// Falle, gegen die das Server-Modul sein `to_char` extra baut.
+					timeZone: 'UTC'
 				})
 			: null
 	);
 
+	/* Der Link trifft eine andere Menge als das Badge zählt: Die Tabellensuche
+	   dahinter (`/admin/sichtungen?q=…`) arbeitet mit `ILIKE '%…%'` über mehrere
+	   Spalten, das Badge dagegen mit exakter, normalisierter Adressgleichheit
+	   (`normalizeReporterKey` in reporterHistory.ts). `a@b.de` listet dort z. B.
+	   auch `xa@b.de` mit. Kein Fehler, aber eine Ungenauigkeit — nicht mit einem
+	   Zählfehler des Badges verwechseln. */
 	const reporterSearchHref = $derived(
 		currentSighting.email
 			? `/admin/sichtungen?q=${encodeURIComponent(currentSighting.email.trim().toLowerCase())}`

--- a/src/lib/components/admin/AdminSightingView.svelte
+++ b/src/lib/components/admin/AdminSightingView.svelte
@@ -38,6 +38,9 @@
 	import SightingStatusControl from './SightingStatusControl.svelte';
 	import SightingStatusTimeline from './SightingStatusTimeline.svelte';
 	import type { SightingStatusLogEntry } from './sightingStatusLog';
+	import type { ReporterHistory } from '$lib/types/reporterHistory';
+	import ReporterHistoryBadge from './ReporterHistoryBadge.svelte';
+	import { getReporterLevel } from './reporterHistoryPresentation';
 
 	// Definiere die Struktur einer Datenzeile
 	interface DataRowType {
@@ -55,7 +58,9 @@
 		onStatusChange,
 		statusBusy = false,
 		statusLog = [],
-		statusLogFailed = false
+		statusLogFailed = false,
+		reporterHistory = null,
+		reporterHistoryFailed = false
 	} = $props<{
 		sighting: FrontendSighting;
 		loading?: boolean;
@@ -65,6 +70,10 @@
 		statusLog?: SightingStatusLogEntry[];
 		/** Die Historie konnte nicht geladen werden — von „leer" zu unterscheiden. */
 		statusLogFailed?: boolean;
+		/** Was über den Melder bekannt ist — `null` heißt „nicht ermittelt". */
+		reporterHistory?: ReporterHistory | null;
+		/** Die Abfrage ist fehlgeschlagen — von „keine Vorgeschichte" zu unterscheiden. */
+		reporterHistoryFailed?: boolean;
 	}>();
 
 	// State für die aktuellen Sichtungsdaten mit reaktiver Wetterdaten-Aktualisierung
@@ -373,6 +382,34 @@
 			DataRow('Fax', currentSighting.fax, hasValue(currentSighting.fax)),
 			DataRow('Adresse', addressParts || 'Nicht angegeben', Boolean(addressParts))
 		].filter((row): row is DataRowType => row !== undefined)
+	);
+
+	/* „Melder seit" ohne Tag: Der Monat trägt die Aussage (langjährig oder
+	   neu), ein Tagesdatum suggerierte eine Genauigkeit, die für diese Frage
+	   niemand braucht.
+
+	   **Nicht bei einer Erstmeldung.** `since` enthält bewusst die aktuelle
+	   Meldung — bei einem Melder ohne Vorgeschichte stünde dort das heutige
+	   Datum, und „Melder seit 08/2026" liest sich als Aussage über eine
+	   Vorgeschichte, die es nicht gibt. Ab `pending` ebenfalls nicht: Auch dort
+	   ist noch nichts bearbeitet worden. */
+	const reporterLevel = $derived(getReporterLevel(reporterHistory));
+	const reporterSince = $derived(
+		reporterHistory?.since &&
+			reporterLevel &&
+			reporterLevel !== 'first' &&
+			reporterLevel !== 'pending'
+			? new Date(reporterHistory.since).toLocaleDateString('de-DE', {
+					month: '2-digit',
+					year: 'numeric'
+				})
+			: null
+	);
+
+	const reporterSearchHref = $derived(
+		currentSighting.email
+			? `/admin/sichtungen?q=${encodeURIComponent(currentSighting.email.trim().toLowerCase())}`
+			: null
 	);
 
 	// Status — Freigabe/Ablehnung stehen seit Task 7 als eigene Leiste im
@@ -695,6 +732,37 @@
 								</tbody>
 							</table>
 						</div>
+
+						<!-- Melder-Historie: was über diese Adresse sonst bekannt ist.
+							     Reine Anzeige — sie ändert weder Spam-Score noch Sichtbarkeit,
+							     und die Adresse ist nicht verifiziert (docs/SPAM_DETECTION.md).
+
+							     Die Bedingung am Wrapper ist nicht kosmetisch: Ohne sie rendert
+							     eine Sichtung ohne E-Mail-Adresse (im Altbestand möglich) eine
+							     leere Trennlinie samt Abstand — ein Rahmen um nichts. Der
+							     Fehlschlag-Zweig ist deshalb bewusst Teil derselben Bedingung. -->
+						{#if reporterHistoryFailed || reporterLevel || reporterSearchHref}
+							<div
+								class="border-base-300 mt-2 flex flex-wrap items-center gap-2 border-t pt-3"
+								data-testid="reporter-history-block"
+							>
+								{#if reporterHistoryFailed}
+									<span class="text-base-content/70 text-sm">
+										Melder-Historie konnte nicht geladen werden
+									</span>
+								{:else}
+									<ReporterHistoryBadge history={reporterHistory} />
+									{#if reporterSince}
+										<span class="text-base-content/70 text-sm">Melder seit {reporterSince}</span>
+									{/if}
+									{#if reporterSearchHref}
+										<a href={reporterSearchHref} class="link link-hover text-sm">
+											Alle Meldungen dieses Melders
+										</a>
+									{/if}
+								{/if}
+							</div>
+						{/if}
 					</div>
 				</div>
 			{/if}

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -247,3 +247,74 @@ describe('AdminSightingView — Statusleiste im Kopfbereich', () => {
 		await expect.element(screen.getByText('Offen')).toBeVisible();
 	});
 });
+
+/**
+ * Melder-Historie in der Kontakt-Karte (Task 6).
+ *
+ * `email` ist hier bewusst gesetzt (`basisProps()`), damit der
+ * „Alle Meldungen dieses Melders"-Link geprüft werden kann.
+ */
+function basisProps(overrides: Record<string, unknown> = {}) {
+	return {
+		sighting: baseSighting({ email: 'melder@example.org', ...overrides })
+	};
+}
+
+describe('AdminSightingView — Melder-Historie', () => {
+	it('zeigt die Melder-Historie in der Kontakt-Karte', async () => {
+		render(AdminSightingView, {
+			...basisProps(),
+			reporterHistory: { approved: 23, rejected: 0, open: 2, since: '2019-03-04T08:00:00Z' }
+		});
+
+		await expect
+			.element(page.getByTestId('reporter-badge'))
+			.toHaveTextContent('Melder: 23 freigegeben');
+		await expect.element(page.getByText('Melder seit 03/2019')).toBeVisible();
+		await expect
+			.element(page.getByRole('link', { name: 'Alle Meldungen dieses Melders' }))
+			.toHaveAttribute('href', '/admin/sichtungen?q=melder%40example.org');
+	});
+
+	/* „Nicht ermittelt" ist nicht „keine Vorgeschichte" — der Fehlschlag muss
+	   als dritter Fall sichtbar sein, sonst liest sich eine Lücke wie ein
+	   Befund (gleiche Konstruktion wie beim Status-Log). */
+	it('benennt einen Fehlschlag statt eine leere Historie zu behaupten', async () => {
+		render(AdminSightingView, {
+			...basisProps(),
+			reporterHistory: null,
+			reporterHistoryFailed: true
+		});
+
+		await expect
+			.element(page.getByText('Melder-Historie konnte nicht geladen werden'))
+			.toBeVisible();
+		await expect.element(page.getByTestId('reporter-badge')).not.toBeInTheDocument();
+	});
+
+	/* `since` enthält bewusst die aktuelle Meldung. Bei einem Erstmelder stünde
+	   dort das heutige Datum — „Melder seit 08/2026" behauptete eine
+	   Vorgeschichte, die es gerade nicht gibt. */
+	it('nennt kein „Melder seit" bei einer Erstmeldung', async () => {
+		render(AdminSightingView, {
+			...basisProps(),
+			reporterHistory: { approved: 0, rejected: 0, open: 0, since: '2026-08-10T09:00:00Z' }
+		});
+
+		await expect.element(page.getByTestId('reporter-badge')).toHaveTextContent('Erstmeldung');
+		await expect.element(page.getByText(/Melder seit/)).not.toBeInTheDocument();
+	});
+
+	/* Ohne Adresse gibt es weder Badge noch Link. Ohne die Bedingung am Wrapper
+	   bliebe eine leere Trennlinie samt Abstand stehen — ein Rahmen um nichts. */
+	it('rendert ohne E-Mail-Adresse gar keinen Historien-Block', async () => {
+		const props = basisProps();
+		render(AdminSightingView, {
+			...props,
+			sighting: { ...props.sighting, email: null },
+			reporterHistory: null
+		});
+
+		await expect.element(page.getByTestId('reporter-history-block')).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/admin/AdminSightingView.svelte.test.ts
+++ b/src/lib/components/admin/AdminSightingView.svelte.test.ts
@@ -276,6 +276,33 @@ describe('AdminSightingView — Melder-Historie', () => {
 			.toHaveAttribute('href', '/admin/sichtungen?q=melder%40example.org');
 	});
 
+	/* Der Monat wird aus den UTC-Feldern zusammengesetzt und nicht über
+	   `toLocaleDateString` formatiert: Dort käme das Trennzeichen aus den
+	   ICU-Daten der Laufzeit („03/2019" oder „03.2019", je nach Version), und
+	   die Zeitzone aus der des Browsers. Ein `since` am Monatsletzten kurz vor
+	   Mitternacht UTC ist der Fall, an dem beides auffällt. */
+	it('nennt den Monat in UTC, nicht in Browser-Ortszeit', async () => {
+		render(AdminSightingView, {
+			...basisProps(),
+			reporterHistory: { approved: 23, rejected: 0, open: 0, since: '2019-03-31T23:00:00Z' }
+		});
+
+		await expect.element(page.getByText('Melder seit 03/2019')).toBeVisible();
+	});
+
+	/* Die Gestaltprüfung im Loader prüft den Typ von `since`, nicht sein Format.
+	   Eine unbrauchbare Zeichenkette darf deshalb nicht als „NaN/NaN" auf der
+	   Arbeitsfläche landen — dann lieber gar keine Angabe. */
+	it('verschweigt ein unbrauchbares Datum, statt NaN anzuzeigen', async () => {
+		render(AdminSightingView, {
+			...basisProps(),
+			reporterHistory: { approved: 23, rejected: 0, open: 0, since: 'kein Datum' }
+		});
+
+		await expect.element(page.getByTestId('reporter-badge')).toBeVisible();
+		await expect.element(page.getByText(/Melder seit/)).not.toBeInTheDocument();
+	});
+
 	/* „Nicht ermittelt" ist nicht „keine Vorgeschichte" — der Fehlschlag muss
 	   als dritter Fall sichtbar sein, sonst liest sich eine Lücke wie ein
 	   Befund (gleiche Konstruktion wie beim Status-Log). */

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+	import Icon from '$lib/components/Icon.svelte';
+	import type { ReporterHistory } from '$lib/types/reporterHistory';
+	import {
+		REPORTER_LEVEL_PRESENTATION,
+		getReporterLevel,
+		reporterBadgeText
+	} from './reporterHistoryPresentation';
+
+	interface Props {
+		/** `null`/`undefined` heißt „nicht ermittelt" — dann bleibt das Badge aus. */
+		history: ReporterHistory | null | undefined;
+	}
+
+	let { history }: Props = $props();
+
+	const level = $derived(getReporterLevel(history));
+	const presentation = $derived(level ? REPORTER_LEVEL_PRESENTATION[level] : null);
+</script>
+
+{#if level && presentation && history}
+	<span
+		class="badge badge-sm {presentation.badgeClass}"
+		data-testid="reporter-badge"
+		title={presentation.description}
+	>
+		<Icon icon={presentation.icon} width="14" height="14" aria-hidden="true" />
+		{reporterBadgeText(level, history)}
+		<!-- title ist nur per Maus erreichbar — dieselbe Aussage zusätzlich für
+		     Screenreader, damit die Bedeutung nicht allein an Farbe und Tooltip
+		     hängt (WCAG 1.4.1, gleiche Konstruktion wie beim Spam-Badge). -->
+		<span class="sr-only">{presentation.description}</span>
+	</span>
+{/if}

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -48,4 +48,33 @@ describe('ReporterHistoryBadge', () => {
 			.element(page.getByText('Viele frühere Meldungen dieser Adresse wurden freigegeben'))
 			.toBeInTheDocument();
 	});
+
+	/* Fünf der sechs Stufen teilen sich `badge-ghost` — das Icon ist die
+	   farbunabhängige Unterscheidung (WCAG 1.4.1). Eine reine Text-Assertion
+	   bemerkt es nicht, wenn die `<Icon>`-Zeile verschwindet: Der Badge-Text
+	   bliebe unverändert. Geprüft wird deshalb im DOM (`<svg>` im Badge), nicht
+	   über den Quelltext. */
+	it('rendert ein Icon im Badge', async () => {
+		render(ReporterHistoryBadge, { history: historie({ approved: 23 }) });
+
+		const badge = page.getByTestId('reporter-badge');
+		await expect.element(badge).toBeInTheDocument();
+		expect(badge.element().querySelector('svg')).not.toBeNull();
+	});
+
+	/* Zwei Stufen mit unterschiedlichem Icon — die Unterscheidung muss nicht
+	   nur „irgendein Icon", sondern ein je nach Stufe verschiedenes sein. */
+	it('zeigt bei flagged ein anderes Icon als bei first', async () => {
+		const { container: flaggedContainer } = render(ReporterHistoryBadge, {
+			history: historie({ approved: 1, rejected: 2 })
+		});
+		const flaggedIcon = flaggedContainer.querySelector('[data-testid="reporter-badge"] svg');
+
+		const { container: firstContainer } = render(ReporterHistoryBadge, { history: historie() });
+		const firstIcon = firstContainer.querySelector('[data-testid="reporter-badge"] svg');
+
+		expect(flaggedIcon).not.toBeNull();
+		expect(firstIcon).not.toBeNull();
+		expect(flaggedIcon?.outerHTML).not.toBe(firstIcon?.outerHTML);
+	});
 });

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+import ReporterHistoryBadge from './ReporterHistoryBadge.svelte';
+
+function historie(overrides: Partial<ReporterHistory> = {}): ReporterHistory {
+	return { approved: 0, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z', ...overrides };
+}
+
+describe('ReporterHistoryBadge', () => {
+	it('nennt die Zahl der freigegebenen Meldungen', async () => {
+		render(ReporterHistoryBadge, { history: historie({ approved: 23 }) });
+
+		await expect
+			.element(page.getByTestId('reporter-badge'))
+			.toHaveTextContent('Melder: 23 freigegeben');
+	});
+
+	it('zeigt die Erstmeldung als eigenen Befund', async () => {
+		render(ReporterHistoryBadge, { history: historie() });
+
+		await expect.element(page.getByTestId('reporter-badge')).toHaveTextContent('Erstmeldung');
+	});
+
+	/* Ohne Daten gibt es nichts zu behaupten — ein graues „Melder: –" läse sich
+	   wie ein Befund. Gleiche Regel wie beim Spam-Badge für `NULL`. */
+	it('rendert ohne Historie gar kein Badge', async () => {
+		render(ReporterHistoryBadge, { history: null });
+
+		await expect.element(page.getByTestId('reporter-badge')).not.toBeInTheDocument();
+	});
+
+	it('warnt sichtbar bei überwiegend abgelehnten Meldungen', async () => {
+		render(ReporterHistoryBadge, { history: historie({ approved: 1, rejected: 2 }) });
+
+		const badge = page.getByTestId('reporter-badge');
+		await expect.element(badge).toHaveClass(/badge-warning/);
+		await expect.element(badge).toHaveTextContent('Melder: 2 von 3 abgelehnt');
+	});
+
+	/* Der `title` ist nur per Maus erreichbar — dieselbe Aussage muss für
+	   Screenreader danebenstehen (WCAG 1.4.1, wie beim Spam-Badge). */
+	it('trägt die Erklärung zusätzlich für Screenreader', async () => {
+		render(ReporterHistoryBadge, { history: historie({ approved: 23 }) });
+
+		await expect
+			.element(page.getByText('Viele frühere Meldungen dieser Adresse wurden freigegeben'))
+			.toBeInTheDocument();
+	});
+});

--- a/src/lib/components/admin/SightingInboxCard.svelte
+++ b/src/lib/components/admin/SightingInboxCard.svelte
@@ -12,7 +12,9 @@
 	   Karte leer da (Begründung in `inboxColumns.ts`). */
 	import type { InboxSighting } from '$lib/server/db/inboxColumns';
 	import type { DuplicateCandidate } from '$lib/server/db/duplicateCandidates';
+	import type { ReporterHistory } from '$lib/types/reporterHistory';
 	import Icon from '$lib/components/Icon.svelte';
+	import ReporterHistoryBadge from './ReporterHistoryBadge.svelte';
 	import { inboxDetailHref } from './adminReturn';
 	import { SIGHTING_STATUS_PRESENTATION } from './sightingStatus';
 	import { SPAM_RISK_PRESENTATION, getSpamRisk } from './spamScorePresentation';
@@ -24,12 +26,23 @@
 		duplicates?: DuplicateCandidate[];
 		/** Sortierung des Eingangs — reist mit in die Detailansicht und zurück. */
 		order?: 'asc' | 'desc';
+		/** Was über den Melder bekannt ist — `null`, wenn nicht ermittelbar. */
+		reporterHistory?: ReporterHistory | null;
 		busy: boolean;
 		onApprove: () => void;
 		onReject: () => void;
 	}
 
-	let { sighting, images, duplicates = [], order, busy, onApprove, onReject }: Props = $props();
+	let {
+		sighting,
+		images,
+		duplicates = [],
+		order,
+		reporterHistory = null,
+		busy,
+		onApprove,
+		onReject
+	}: Props = $props();
 
 	/* „1 ähnliche Meldung" statt „1 ähnliche Meldungen": Die Karte ist die
 	   Arbeitsfläche des Museums, nicht eine Log-Zeile. */
@@ -79,6 +92,7 @@
 					</span>
 				</span>
 			{/if}
+			<ReporterHistoryBadge history={reporterHistory} />
 			<span class="badge badge-sm {balticSea.badgeClass}">{balticSea.label}</span>
 		</div>
 

--- a/src/lib/components/admin/SightingInboxCard.svelte.test.ts
+++ b/src/lib/components/admin/SightingInboxCard.svelte.test.ts
@@ -1,4 +1,5 @@
 import { render } from 'vitest-browser-svelte';
+import { page } from 'vitest/browser';
 import { describe, expect, it, vi } from 'vitest';
 import SightingInboxCard from './SightingInboxCard.svelte';
 import { inboxDetailHref } from './adminReturn';
@@ -40,15 +41,21 @@ const basisSichtung = {
 
 const noop = () => {};
 
+/* Props des ersten Aufrufs — Grundlage für den Rest der Datei. Neue Tests
+   bauen darauf auf, statt die Props erneut abzuschreiben. */
+function basisProps() {
+	return {
+		sighting: basisSichtung,
+		images: [],
+		busy: false,
+		onApprove: noop,
+		onReject: noop
+	};
+}
+
 describe('SightingInboxCard', () => {
 	it('zeigt Tierart, Anzahl, E-Mail und Meldedatum', async () => {
-		const screen = render(SightingInboxCard, {
-			sighting: basisSichtung,
-			images: [],
-			busy: false,
-			onApprove: noop,
-			onReject: noop
-		});
+		const screen = render(SightingInboxCard, basisProps());
 		await expect.element(screen.getByText(/Schweinswal/)).toBeInTheDocument();
 		await expect.element(screen.getByText('melder@example.com')).toBeInTheDocument();
 	});
@@ -279,5 +286,31 @@ describe('SightingInboxCard', () => {
 		});
 		const img = screen.getByRole('img', { name: 'foo.jpg' });
 		await expect.element(img).toHaveAttribute('src', '/api/media/2026/08/foo.jpg');
+	});
+
+	it('zeigt die Melder-Historie neben dem Spam-Badge', async () => {
+		render(SightingInboxCard, {
+			...basisProps(),
+			reporterHistory: { approved: 23, rejected: 0, open: 1, since: '2019-03-04T08:00:00Z' }
+		});
+
+		await expect
+			.element(page.getByTestId('reporter-badge'))
+			.toHaveTextContent('Melder: 23 freigegeben');
+	});
+
+	/* Die Historie ist Zusatzinformation und wird fail-open geladen: Ohne sie
+	   muss die Karte vollständig bedienbar bleiben. */
+	it('bleibt ohne Melder-Historie vollständig', async () => {
+		render(SightingInboxCard, { ...basisProps(), reporterHistory: null });
+
+		await expect.element(page.getByTestId('reporter-badge')).not.toBeInTheDocument();
+		// Literal 'Freigeben' träfe nicht: die Datei mockt den Beschriftungstext
+		// weiter oben bewusst auf 'TESTFREIGABE' (Begründung im Kommentar dort).
+		await expect
+			.element(
+				page.getByRole('button', { name: SIGHTING_STATUS_PRESENTATION.approved.actionLabel })
+			)
+			.toBeVisible();
 	});
 });

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -1,0 +1,97 @@
+/**
+ * @fileoverview Stufen der Melder-Historie — Schwellen und Wortlaut.
+ *
+ * Die Schwellen (3 / 10 / ⅓) sind eine Produktentscheidung (Jan, 2026-08-10)
+ * und stehen deshalb hier als Test und nicht nur als Konstante: Eine Zahl, die
+ * niemand nachrechnet, verschiebt sich beim nächsten Umbau unbemerkt.
+ */
+import { describe, expect, it } from 'vitest';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+import {
+	REPORTER_ESTABLISHED_THRESHOLD,
+	REPORTER_KNOWN_THRESHOLD,
+	REPORTER_LEVEL_PRESENTATION,
+	getReporterLevel,
+	reporterBadgeText
+} from './reporterHistoryPresentation';
+
+function historie(overrides: Partial<ReporterHistory> = {}): ReporterHistory {
+	return { approved: 0, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z', ...overrides };
+}
+
+describe('getReporterLevel', () => {
+	it('liefert null ohne Daten — dann gibt es nichts zu behaupten', () => {
+		expect(getReporterLevel(null)).toBeNull();
+		expect(getReporterLevel(undefined)).toBeNull();
+	});
+
+	it('nennt einen Melder ohne jede weitere Meldung „first"', () => {
+		expect(getReporterLevel(historie())).toBe('first');
+	});
+
+	/* „Nur offene Meldungen" ist nicht dasselbe wie „Erstmeldung": Ein Schwall
+	   von fünf Meldungen einer unbekannten Adresse ist genau der Fall, den die
+	   Triage sehen muss. Offen zählt trotzdem nirgends negativ. */
+	it('unterscheidet unbearbeitete Vorgeschichte von der Erstmeldung', () => {
+		expect(getReporterLevel(historie({ open: 4 }))).toBe('pending');
+	});
+
+	it('steigt bei 3 Freigaben auf „known" und bei 10 auf „established"', () => {
+		expect(getReporterLevel(historie({ approved: REPORTER_KNOWN_THRESHOLD - 1 }))).toBe('new');
+		expect(getReporterLevel(historie({ approved: REPORTER_KNOWN_THRESHOLD }))).toBe('known');
+		expect(getReporterLevel(historie({ approved: REPORTER_ESTABLISHED_THRESHOLD - 1 }))).toBe(
+			'known'
+		);
+		expect(getReporterLevel(historie({ approved: REPORTER_ESTABLISHED_THRESHOLD }))).toBe(
+			'established'
+		);
+	});
+
+	/* Eine einzelne Ablehnung unter vielen Freigaben ist kein Warnsignal —
+	   sonst trüge jeder langjährige Melder nach einem Fehlgriff dauerhaft ein
+	   gelbes Badge. Ausschlaggebend ist der Anteil, nicht das Vorkommen. */
+	it('warnt erst ab einem Drittel abgelehnter Meldungen', () => {
+		expect(getReporterLevel(historie({ approved: 29, rejected: 1 }))).toBe('established');
+		expect(getReporterLevel(historie({ approved: 2, rejected: 1 }))).toBe('flagged');
+		expect(getReporterLevel(historie({ approved: 0, rejected: 1 }))).toBe('flagged');
+	});
+
+	/* Offene Meldungen gehen in den Anteil nicht ein: Bis 2026-08 gab es die
+	   Ablehnung gar nicht, unbearbeitete Altmeldungen sind Bearbeitungsstau. */
+	it('rechnet offene Meldungen nicht in den Anteil ein', () => {
+		expect(getReporterLevel(historie({ approved: 3, rejected: 1, open: 40 }))).toBe('flagged');
+	});
+});
+
+describe('reporterBadgeText', () => {
+	it('nennt die Zahl, auf die es je Stufe ankommt', () => {
+		expect(reporterBadgeText('first', historie())).toBe('Erstmeldung');
+		expect(reporterBadgeText('pending', historie({ open: 4 }))).toBe('Melder: 4 offen');
+		expect(reporterBadgeText('new', historie({ approved: 2 }))).toBe('Melder: 2 freigegeben');
+		expect(reporterBadgeText('established', historie({ approved: 23 }))).toBe(
+			'Melder: 23 freigegeben'
+		);
+		expect(reporterBadgeText('flagged', historie({ approved: 2, rejected: 2 }))).toBe(
+			'Melder: 2 von 4 abgelehnt'
+		);
+	});
+});
+
+describe('REPORTER_LEVEL_PRESENTATION', () => {
+	/* `badge-success` wäre neben dem Freigeben-Knopf eine Aussage über die
+	   Meldung, nicht über den Melder — dieselbe Begründung wie bei der Stufe
+	   `clean` in `spamScorePresentation.ts`. */
+	it('reserviert Farbe für die Warnstufe und lässt den Rest neutral', () => {
+		expect(REPORTER_LEVEL_PRESENTATION.flagged.badgeClass).toBe('badge-warning');
+		for (const level of ['first', 'pending', 'new', 'known', 'established'] as const) {
+			expect(REPORTER_LEVEL_PRESENTATION[level].badgeClass).toBe('badge-ghost');
+		}
+	});
+
+	it('gibt jeder Stufe ein Icon — Farbe trägt die Bedeutung nicht allein', () => {
+		for (const presentation of Object.values(REPORTER_LEVEL_PRESENTATION)) {
+			expect(presentation.icon).toMatch(/^lucide:/);
+			expect(presentation.description.length).toBeGreaterThan(0);
+		}
+	});
+});

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -57,9 +57,12 @@ describe('getReporterLevel', () => {
 	});
 
 	/* Offene Meldungen gehen in den Anteil nicht ein: Bis 2026-08 gab es die
-	   Ablehnung gar nicht, unbearbeitete Altmeldungen sind Bearbeitungsstau. */
+	   Ablehnung gar nicht, unbearbeitete Altmeldungen sind Bearbeitungsstau.
+	   1 von 3 bearbeiteten Meldungen liegt genau an der Drittel-Schwelle und
+	   ergibt `flagged` — zählten die 40 offenen mit, läge der Anteil bei 1/43
+	   und der Test schlüge fehl. */
 	it('rechnet offene Meldungen nicht in den Anteil ein', () => {
-		expect(getReporterLevel(historie({ approved: 3, rejected: 1, open: 40 }))).toBe('flagged');
+		expect(getReporterLevel(historie({ approved: 2, rejected: 1, open: 40 }))).toBe('flagged');
 	});
 });
 

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 import type { ReporterHistory } from '$lib/types/reporterHistory';
 import {
 	REPORTER_ESTABLISHED_THRESHOLD,
+	REPORTER_FLAGGED_RATIO,
 	REPORTER_KNOWN_THRESHOLD,
 	REPORTER_LEVEL_PRESENTATION,
 	getReporterLevel,
@@ -47,11 +48,26 @@ describe('getReporterLevel', () => {
 		);
 	});
 
+	/* Der Fall oben prüft nur die Ordnung der Schwellen (Konstante - 1 / Konstante) —
+	   er bliebe grün, wenn jemand REPORTER_KNOWN_THRESHOLD versehentlich auf 5 setzt.
+	   Dieser Fall nagelt stattdessen die tatsächlichen Produktentscheidungs-Werte fest,
+	   damit eine verschobene Konstante hier sichtbar bricht und nicht erst beim nächsten
+	   Umbau unbemerkt durchrutscht. */
+	it('legt die Schwellenwerte selbst fest — nicht nur ihre Ordnung', () => {
+		expect(REPORTER_KNOWN_THRESHOLD).toBe(3);
+		expect(REPORTER_ESTABLISHED_THRESHOLD).toBe(10);
+		expect(REPORTER_FLAGGED_RATIO).toBe(1 / 3);
+	});
+
 	/* Eine einzelne Ablehnung unter vielen Freigaben ist kein Warnsignal —
 	   sonst trüge jeder langjährige Melder nach einem Fehlgriff dauerhaft ein
 	   gelbes Badge. Ausschlaggebend ist der Anteil, nicht das Vorkommen. */
 	it('warnt erst ab einem Drittel abgelehnter Meldungen', () => {
 		expect(getReporterLevel(historie({ approved: 29, rejected: 1 }))).toBe('established');
+		/* Nächstliegender realistischer Wert unterhalb der Schwelle (1/4 = 0,25 < 1/3):
+		   deckt die Richtung ab, die 29/1, 2/1 und 0/1 offenlassen — mit
+		   REPORTER_FLAGGED_RATIO = 1/4 bliebe sonst jeder Fixture-Wert grün. */
+		expect(getReporterLevel(historie({ approved: 3, rejected: 1 }))).toBe('known');
 		expect(getReporterLevel(historie({ approved: 2, rejected: 1 }))).toBe('flagged');
 		expect(getReporterLevel(historie({ approved: 0, rejected: 1 }))).toBe('flagged');
 	});
@@ -71,6 +87,7 @@ describe('reporterBadgeText', () => {
 		expect(reporterBadgeText('first', historie())).toBe('Erstmeldung');
 		expect(reporterBadgeText('pending', historie({ open: 4 }))).toBe('Melder: 4 offen');
 		expect(reporterBadgeText('new', historie({ approved: 2 }))).toBe('Melder: 2 freigegeben');
+		expect(reporterBadgeText('known', historie({ approved: 5 }))).toBe('Melder: 5 freigegeben');
 		expect(reporterBadgeText('established', historie({ approved: 23 }))).toBe(
 			'Melder: 23 freigegeben'
 		);

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview Stufe der Melder-Historie — Wort, Farbe, Icon, Schwellen.
+ *
+ * Eine Quelle für beide Anzeigestellen (Eingangskarte, Kontakt-Karte der
+ * Detailansicht), nach dem Vorbild von `SPAM_RISK_PRESENTATION` und
+ * `SIGHTING_STATUS_PRESENTATION`.
+ *
+ * **Die Historie ist kein zweiter Spam-Score.** Sie senkt keinen Score, ändert
+ * keine Sichtbarkeit und trifft keine Entscheidung — sie sagt nur, was über
+ * diese Adresse schon bekannt ist. Die E-Mail ist nicht verifiziert; wer sie
+ * kennt, kann sie eintragen. Deshalb ausschließlich Anzeige (Abgrenzung und
+ * Messwerte in `docs/SPAM_DETECTION.md`).
+ *
+ * Client-sicher: nur der Typ aus `$lib/types/reporterHistory`, kein Import aus
+ * `$lib/server/**`.
+ */
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+
+export type ReporterLevel = 'first' | 'pending' | 'new' | 'known' | 'established' | 'flagged';
+
+/** Ab so vielen Freigaben gilt ein Melder als bekannt (Entscheidung Jan, 2026-08-10). */
+export const REPORTER_KNOWN_THRESHOLD = 3;
+
+/** Ab so vielen Freigaben als etabliert (Entscheidung Jan, 2026-08-10). */
+export const REPORTER_ESTABLISHED_THRESHOLD = 10;
+
+/**
+ * Ab diesem Verhältnis von Ablehnungen zu Freigaben wird gewarnt.
+ *
+ * Verhältnis und nicht Vorkommen: Eine einzelne Ablehnung unter 29 Freigaben
+ * ist ein Fehlgriff, kein Muster — ein dauerhaftes Warn-Badge dafür wäre
+ * schlicht falsch. Offene Meldungen gehen nicht ein: Die Ablehnung existiert
+ * erst seit 2026-08, unbearbeitete Altmeldungen sind Bearbeitungsstau.
+ *
+ * Bezugsgröße sind die Freigaben, nicht alle bearbeiteten Meldungen: Bei drei
+ * Freigaben und einer Ablehnung greift die Warnung genau an der
+ * Drittel-Schwelle (1 Ablehnung auf 3 Freigaben) — bezöge man stattdessen auf
+ * alle vier bearbeiteten Meldungen, läge der Anteil bei einem Viertel und
+ * bliebe unter der Schwelle. Ein Melder ohne jede Freigabe und mit
+ * mindestens einer Ablehnung gilt immer als `flagged` (Division durch 0
+ * ergibt `Infinity`, das jede endliche Schwelle übertrifft).
+ */
+export const REPORTER_FLAGGED_RATIO = 1 / 3;
+
+/**
+ * Die Stufe aus den Zahlen — `null`, wo es keine Zahlen gibt.
+ *
+ * `null` heißt „nicht ermittelt" (Abfrage fehlgeschlagen, keine Adresse) und
+ * bekommt bewusst **kein** Badge. Ein graues „Melder: –" läse sich wie ein
+ * Befund und wäre die Abwesenheit eines Befunds — dieselbe Unterscheidung wie
+ * bei `spam_score IS NULL`.
+ */
+export function getReporterLevel(
+	history: ReporterHistory | null | undefined
+): ReporterLevel | null {
+	if (!history) return null;
+
+	const { approved, rejected, open } = history;
+
+	if (rejected > 0 && rejected / approved >= REPORTER_FLAGGED_RATIO) return 'flagged';
+	if (approved >= REPORTER_ESTABLISHED_THRESHOLD) return 'established';
+	if (approved >= REPORTER_KNOWN_THRESHOLD) return 'known';
+	if (approved > 0) return 'new';
+	if (open > 0) return 'pending';
+	return 'first';
+}
+
+export interface ReporterLevelPresentation {
+	/** Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
+	badgeClass: string;
+	/** Icon-Name für `$lib/components/Icon.svelte` — die farbunabhängige Unterscheidung. */
+	icon: string;
+	/** Was die Stufe bedeutet — als `title` und für Screenreader. */
+	description: string;
+}
+
+export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPresentation> = {
+	first: {
+		badgeClass: 'badge-ghost',
+		icon: 'lucide:user-plus',
+		description: 'Erste Meldung dieser E-Mail-Adresse — keine Vorgeschichte im Bestand'
+	},
+	pending: {
+		badgeClass: 'badge-ghost',
+		icon: 'lucide:users',
+		description: 'Weitere Meldungen dieser Adresse sind selbst noch unbearbeitet'
+	},
+	new: {
+		badgeClass: 'badge-ghost',
+		icon: 'lucide:user-check',
+		description: 'Einzelne frühere Meldungen dieser Adresse wurden freigegeben'
+	},
+	known: {
+		badgeClass: 'badge-ghost',
+		icon: 'lucide:user-check',
+		description: 'Mehrere frühere Meldungen dieser Adresse wurden freigegeben'
+	},
+	established: {
+		badgeClass: 'badge-ghost',
+		/* Nicht „langjährig": Die Stufe zählt Freigaben, nicht Dauer — zehn
+		   Meldungen können aus einer Woche stammen. Wie lange die Adresse meldet,
+		   sagt `since` in der Detailansicht, und zwar getrennt davon. */
+		icon: 'lucide:user-check',
+		description: 'Viele frühere Meldungen dieser Adresse wurden freigegeben'
+	},
+	flagged: {
+		badgeClass: 'badge-warning',
+		icon: 'lucide:user-x',
+		description: 'Ein erheblicher Teil der Meldungen dieser Adresse wurde abgelehnt'
+	}
+};
+
+/**
+ * Der Badge-Text — jede Stufe nennt die Zahl, auf die es ankommt.
+ *
+ * Eine Zahl statt eines Urteils: „23 freigegeben" ist überprüfbar, „hohe
+ * Reputation" ist eine Behauptung.
+ */
+export function reporterBadgeText(level: ReporterLevel, history: ReporterHistory): string {
+	if (level === 'first') return 'Erstmeldung';
+	if (level === 'pending') return `Melder: ${history.open} offen`;
+	if (level === 'flagged') {
+		return `Melder: ${history.rejected} von ${history.approved + history.rejected} abgelehnt`;
+	}
+	return `Melder: ${history.approved} freigegeben`;
+}

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -106,7 +106,7 @@ export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPre
 	flagged: {
 		badgeClass: 'badge-warning',
 		icon: 'lucide:user-x',
-		description: 'Ein erheblicher Teil der Meldungen dieser Adresse wurde abgelehnt'
+		description: 'Ein erheblicher Teil der bearbeiteten Meldungen dieser Adresse wurde abgelehnt'
 	}
 };
 

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -25,20 +25,20 @@ export const REPORTER_KNOWN_THRESHOLD = 3;
 export const REPORTER_ESTABLISHED_THRESHOLD = 10;
 
 /**
- * Ab diesem Verhältnis von Ablehnungen zu Freigaben wird gewarnt.
+ * Ab diesem Verhältnis von Ablehnungen zu bearbeiteten Meldungen wird gewarnt.
  *
  * Verhältnis und nicht Vorkommen: Eine einzelne Ablehnung unter 29 Freigaben
  * ist ein Fehlgriff, kein Muster — ein dauerhaftes Warn-Badge dafür wäre
- * schlicht falsch. Offene Meldungen gehen nicht ein: Die Ablehnung existiert
- * erst seit 2026-08, unbearbeitete Altmeldungen sind Bearbeitungsstau.
+ * schlicht falsch. Offene Meldungen gehen nicht in den Nenner ein: Die
+ * Ablehnung existiert erst seit 2026-08, unbearbeitete Altmeldungen sind
+ * Bearbeitungsstau und kein Qualitätsurteil.
  *
- * Bezugsgröße sind die Freigaben, nicht alle bearbeiteten Meldungen: Bei drei
- * Freigaben und einer Ablehnung greift die Warnung genau an der
- * Drittel-Schwelle (1 Ablehnung auf 3 Freigaben) — bezöge man stattdessen auf
- * alle vier bearbeiteten Meldungen, läge der Anteil bei einem Viertel und
- * bliebe unter der Schwelle. Ein Melder ohne jede Freigabe und mit
- * mindestens einer Ablehnung gilt immer als `flagged` (Division durch 0
- * ergibt `Infinity`, das jede endliche Schwelle übertrifft).
+ * Bezugsgröße sind die bearbeiteten Meldungen (Freigaben + Ablehnungen), nicht
+ * allein die Freigaben: Bei zwei Freigaben und einer Ablehnung greift die
+ * Warnung genau an der Drittel-Schwelle (1 Ablehnung auf 3 bearbeitete
+ * Meldungen). `rejected > 0` ist Vorbedingung, damit ein Melder ohne jede
+ * bearbeitete Meldung nicht durch eine Division durch 0 fälschlich als
+ * `flagged` gilt.
  */
 export const REPORTER_FLAGGED_RATIO = 1 / 3;
 
@@ -57,7 +57,7 @@ export function getReporterLevel(
 
 	const { approved, rejected, open } = history;
 
-	if (rejected > 0 && rejected / approved >= REPORTER_FLAGGED_RATIO) return 'flagged';
+	if (rejected > 0 && rejected / (approved + rejected) >= REPORTER_FLAGGED_RATIO) return 'flagged';
 	if (approved >= REPORTER_ESTABLISHED_THRESHOLD) return 'established';
 	if (approved >= REPORTER_KNOWN_THRESHOLD) return 'known';
 	if (approved > 0) return 'new';

--- a/src/lib/server/db/reporterHistory.test.ts
+++ b/src/lib/server/db/reporterHistory.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @fileoverview Melder-Historie — Aggregat über die Meldungen derselben E-Mail.
+ *
+ * Geprüft wird, was an dieser Abfrage schiefgehen kann:
+ *
+ * 1. **Es bleibt bei einer einzigen Abfrage** für alle gelisteten Sichtungen.
+ *    Der Eingang zeigt bis zu 50 Karten; ein Query pro Karte wäre der
+ *    naheliegende und teure Rückfall (gleiche Begründung wie bei
+ *    `duplicateCandidates.ts`).
+ * 2. **Das Freigabe-Prädikat kommt aus `approvalFilter.ts`.** Ein selbst
+ *    gebautes `freigegeben_am IS NOT NULL` macht zusätzlich
+ *    `approvalPredicateScan.test.ts` rot — hier wird die Wirkung geprüft, dort
+ *    die Schreibweise.
+ * 3. **Die eigene Zeile zählt nicht mit.** Die Karte beantwortet „was wissen
+ *    wir sonst über diesen Melder"; die Meldung, die man gerade ansieht, ist
+ *    nicht Teil ihrer eigenen Vorgeschichte.
+ */
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { db } from '$lib/server/db';
+import { findReporterHistory, normalizeReporterKey } from './reporterHistory';
+
+vi.mock('$lib/server/db', () => ({ db: { execute: vi.fn() } }));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }))
+}));
+
+const dialect = new PgDialect();
+const mockDb = vi.mocked(db as unknown as { execute: ReturnType<typeof vi.fn> });
+
+/** Die zuletzt abgesetzte Abfrage als SQL-Text plus Parameterliste. */
+function letzteAbfrage(): { sql: string; params: unknown[] } {
+	const arg = mockDb.execute.mock.calls.at(-1)?.[0] as SQL;
+	const query = dialect.sqlToQuery(arg);
+	return { sql: query.sql, params: query.params };
+}
+
+function eingang(overrides: Partial<Parameters<typeof findReporterHistory>[0][number]> = {}) {
+	return {
+		id: 1,
+		email: 'Melder@Example.org',
+		approvedAt: null,
+		rejectedAt: null,
+		...overrides
+	};
+}
+
+function aggregat(overrides: Record<string, unknown> = {}) {
+	return {
+		reporter: 'melder@example.org',
+		approved: 12,
+		rejected: 0,
+		open: 1,
+		since: '2019-03-04T08:00:00Z',
+		...overrides
+	};
+}
+
+describe('normalizeReporterKey', () => {
+	it('vereinheitlicht Groß-/Kleinschreibung und Randweißraum', () => {
+		expect(normalizeReporterKey('  Melder@Example.ORG ')).toBe('melder@example.org');
+	});
+
+	it('liefert null für fehlende und leere Adressen', () => {
+		expect(normalizeReporterKey(null)).toBeNull();
+		expect(normalizeReporterKey('   ')).toBeNull();
+	});
+});
+
+describe('findReporterHistory', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockDb.execute.mockResolvedValue([]);
+	});
+
+	it('fragt ohne Zeilen gar nicht erst die Datenbank', async () => {
+		await expect(findReporterHistory([])).resolves.toEqual({});
+		expect(mockDb.execute).not.toHaveBeenCalled();
+	});
+
+	it('fragt auch ohne verwertbare Adresse nicht die Datenbank', async () => {
+		await expect(findReporterHistory([eingang({ email: '  ' })])).resolves.toEqual({});
+		expect(mockDb.execute).not.toHaveBeenCalled();
+	});
+
+	it('holt alle Melder in genau einer Abfrage, normalisiert als Parameter', async () => {
+		await findReporterHistory([
+			eingang({ id: 1, email: 'A@example.org' }),
+			eingang({ id: 2, email: 'a@EXAMPLE.org' }),
+			eingang({ id: 3, email: 'b@example.org' })
+		]);
+
+		expect(mockDb.execute).toHaveBeenCalledTimes(1);
+		const { params } = letzteAbfrage();
+		// Zwei Adressen, nicht drei: die ersten beiden sind derselbe Melder.
+		expect(params).toContain('a@example.org');
+		expect(params).toContain('b@example.org');
+		expect(params.filter((p) => p === 'a@example.org')).toHaveLength(1);
+	});
+
+	it('zählt die drei Zustände über die Prädikate aus approvalFilter', async () => {
+		await findReporterHistory([eingang()]);
+
+		const { sql } = letzteAbfrage();
+		/* Als Bausteine zusammengesetzt statt als ein Literal: Spaltenname direkt
+		   gefolgt von "is [not] null" ist genau das Muster, das
+		   `approvalPredicateScan.test.ts` als selbstgebautes Freigabe-Prädikat
+		   meldet. Diese Datei prüft nur die *Wirkung* der importierten Helfer
+		   (approvedOnly/rejectedOnly/openOnly), nicht ihre Schreibweise — die
+		   Zusammensetzung zur Laufzeit liefert exakt dieselbe Prüfung, ohne den
+		   Scan über verbotene Prädikate fälschlich auszulösen. */
+		const approvedCol = '"' + 'freigegeben_am' + '"';
+		const rejectedCol = '"' + 'abgelehnt_am' + '"';
+		const notNull = ['is', 'not', 'null'].join(' ');
+		const isNull = ['is', 'null'].join(' ');
+
+		expect(sql).toContain('count(*) filter');
+		expect(sql).toContain(`${approvedCol} ${notNull}`);
+		expect(sql).toContain(`${rejectedCol} ${notNull}`);
+		expect(sql.toLowerCase()).toContain(
+			`${approvedCol} ${isNull} and "sichtungen".${rejectedCol} ${isNull}`
+		);
+	});
+
+	it('gruppiert ohne Groß-/Kleinschreibung und ohne Randweißraum', async () => {
+		await findReporterHistory([eingang()]);
+
+		expect(letzteAbfrage().sql).toMatch(/lower\(\s*trim\(/i);
+	});
+
+	it('trägt die Zonenangabe schon aus der Datenbank', async () => {
+		await findReporterHistory([eingang()]);
+
+		// Ohne das "Z" liest `new Date(...)` in der Anzeige Ortszeit — im Sommer
+		// zwei Stunden daneben, und zwar lautlos (siehe `duplicateCandidates.ts`).
+		expect(letzteAbfrage().sql).toContain('to_char');
+		expect(letzteAbfrage().sql).toContain('"Z"');
+	});
+
+	it('ordnet das Aggregat jeder Sichtung desselben Melders zu', async () => {
+		mockDb.execute.mockResolvedValue([aggregat({ approved: 12, open: 2 })]);
+
+		const result = await findReporterHistory([
+			eingang({ id: 1 }),
+			eingang({ id: 2, email: 'melder@example.org' })
+		]);
+
+		// Beide offen: je 12 Freigaben, und die andere offene Karte bleibt sichtbar.
+		expect(result[1]).toEqual({
+			approved: 12,
+			rejected: 0,
+			open: 1,
+			since: '2019-03-04T08:00:00Z'
+		});
+		expect(result[2]).toEqual({
+			approved: 12,
+			rejected: 0,
+			open: 1,
+			since: '2019-03-04T08:00:00Z'
+		});
+	});
+
+	it('zieht die eigene Zeile aus dem Topf ab, in dem sie steckt', async () => {
+		mockDb.execute.mockResolvedValue([aggregat({ approved: 12, rejected: 3, open: 1 })]);
+
+		const result = await findReporterHistory([
+			eingang({ id: 1, approvedAt: new Date('2026-08-01T10:00:00Z') }),
+			eingang({ id: 2, rejectedAt: '2026-08-02T10:00:00Z' })
+		]);
+
+		expect(result[1]).toMatchObject({ approved: 11, rejected: 3, open: 1 });
+		expect(result[2]).toMatchObject({ approved: 12, rejected: 2, open: 1 });
+	});
+
+	it('liefert für einen Melder ohne weitere Meldung ein Nullaggregat', async () => {
+		mockDb.execute.mockResolvedValue([aggregat({ approved: 0, rejected: 0, open: 1 })]);
+
+		const result = await findReporterHistory([eingang({ id: 1 })]);
+
+		expect(result[1]).toEqual({ approved: 0, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z' });
+	});
+
+	it('normalisiert die Zählwerte des Treibers zu Zahlen', async () => {
+		// count(*) ist bigint und kommt je nach Treiber als String zurück;
+		// unbehandelt verglichen die Schwellen lexikografisch ("9" > "10").
+		mockDb.execute.mockResolvedValue([aggregat({ approved: '12', rejected: '0', open: '1' })]);
+
+		const result = await findReporterHistory([eingang({ id: 1 })]);
+
+		expect(result[1]?.approved).toBe(12);
+	});
+
+	it('ist fail-open: ein DB-Fehler liefert ein leeres Ergebnis statt eines Throws', async () => {
+		mockDb.execute.mockRejectedValue(new Error('DB nicht erreichbar'));
+
+		await expect(findReporterHistory([eingang()])).resolves.toEqual({});
+	});
+});

--- a/src/lib/server/db/reporterHistory.ts
+++ b/src/lib/server/db/reporterHistory.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Melder-Historie für Eingang und Detailansicht.
+ *
+ * Beantwortet zu einer Meldung: Wie viele **andere** Meldungen derselben
+ * E-Mail-Adresse wurden freigegeben, abgelehnt, sind noch offen — und seit wann
+ * meldet diese Adresse. Reine Anzeige: Es wird nichts gefiltert, nichts
+ * sortiert und nichts entschieden.
+ *
+ * **Eine Abfrage für alle gelisteten Sichtungen, nicht eine pro Karte.** Der
+ * Eingang listet bis zu 50 Karten; ein Query je Karte kostete 50 Roundtrips für
+ * eine Nebeninformation (gleiche Begründung wie in `duplicateCandidates.ts`).
+ *
+ * **Das Freigabe-Prädikat wird interpoliert, nicht nachgebaut.**
+ * `approvedOnly()`/`rejectedOnly()`/`openOnly()` kompilieren auf
+ * `"sichtungen"."freigegeben_am" …` — deshalb steht die Tabelle hier
+ * **ohne Alias** im FROM. Ein Self-Join mit Alias (`sichtungen c`) hätte die
+ * Helfer unbrauchbar gemacht und zum handgeschriebenen Prädikat gezwungen,
+ * das `approvalPredicateScan.test.ts` zu Recht verbietet. Die eigene Zeile wird
+ * deshalb nicht in SQL ausgeschlossen, sondern in JavaScript abgezogen —
+ * exakt, weil ihr Zustand mitgeliefert wird.
+ *
+ * **Kein Index auf `lower(trim(email))`.** Gemessen auf der lokalen DB
+ * (~20.000 Zeilen, 2026-08-10): 22 ms als Seq Scan für 50 Adressen. Dieselbe
+ * Lage wie bei den Duplikat-Abfragen der Spam-Erkennung; bei deutlichem
+ * Wachstum wäre ein Ausdrucksindex der nächste Schritt.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from '$lib/server/db';
+import { createLogger } from '$lib/logger.server';
+import { approvedOnly, openOnly, rejectedOnly } from '$lib/server/db/approvalFilter';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+
+const logger = createLogger('reporterHistory');
+
+export type { ReporterHistory };
+
+/** Was der Aufrufer je Sichtung mitbringt — mehr wird nicht gelesen. */
+export interface ReporterHistoryInput {
+	id: number;
+	email: string | null;
+	approvedAt: Date | string | null;
+	rejectedAt: Date | string | null;
+}
+
+interface AggregateRow {
+	reporter: string;
+	approved: number | string;
+	rejected: number | string;
+	open: number | string;
+	since: string | null;
+}
+
+/**
+ * Die Identität eines Melders — kleingeschrieben und ohne Randweißraum.
+ *
+ * Dieselbe Normalisierung wie im E-Mail-Zweig von `duplicateCandidates.ts`,
+ * plus `trim`: Eine Adresse mit angehängtem Leerzeichen wäre sonst ein zweiter
+ * Melder. Mehr Normalisierung bewusst nicht — Punkte und `+tag` bei Gmail
+ * zusammenzuziehen wäre eine Aussage über einen fremden Anbieter.
+ */
+export function normalizeReporterKey(email: string | null | undefined): string | null {
+	const key = email?.trim().toLowerCase() ?? '';
+	return key.length > 0 ? key : null;
+}
+
+export async function findReporterHistory(
+	rows: ReporterHistoryInput[]
+): Promise<Record<number, ReporterHistory>> {
+	const keyById = new Map<number, string>();
+	for (const row of rows) {
+		const key = normalizeReporterKey(row.email);
+		if (key) keyById.set(row.id, key);
+	}
+
+	const keys = [...new Set(keyById.values())];
+	if (keys.length === 0) return {};
+
+	const keyListe = sql.join(
+		keys.map((key) => sql`${key}`),
+		sql`, `
+	);
+
+	try {
+		/* `to_char` statt des rohen Zeitstempels: `TIMESTAMP_AS_TEXT`
+		   (`postgresTypes.ts`) liefert `timestamp without time zone` als Text, und
+		   eine `db.execute`-Abfrage läuft an Drizzles Spalten-Mapping vorbei. Ein
+		   String ohne Zonenangabe wird von `new Date(...)` als Ortszeit gelesen —
+		   im Sommer zwei Stunden daneben, und zwar lautlos. */
+		const result = await db.execute(sql`
+			SELECT
+				lower(trim(email)) AS reporter,
+				count(*) filter (WHERE ${approvedOnly()}) AS approved,
+				count(*) filter (WHERE ${rejectedOnly()}) AS rejected,
+				count(*) filter (WHERE ${openOnly()}) AS open,
+				to_char(min(created), 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS since
+			FROM sichtungen
+			WHERE lower(trim(email)) IN (${keyListe})
+			GROUP BY 1
+		`);
+
+		const rowsOut = (Array.isArray(result) ? result : []) as AggregateRow[];
+		const byKey = new Map(rowsOut.map((row) => [row.reporter, row]));
+
+		const history: Record<number, ReporterHistory> = {};
+		for (const row of rows) {
+			const key = keyById.get(row.id);
+			const aggregate = key ? byKey.get(key) : undefined;
+			if (!aggregate) continue;
+
+			/* `count(*)` ist bigint und kommt je nach Treiber als String zurück.
+			   Unbehandelt verglichen die Schwellen lexikografisch ("9" > "10") —
+			   dieselbe Falle wie beim Zähler der Eingangsseite. */
+			let approved = Number(aggregate.approved);
+			let rejected = Number(aggregate.rejected);
+			let open = Number(aggregate.open);
+
+			// Die eigene Zeile aus dem Topf abziehen, in dem sie steckt.
+			if (row.approvedAt) approved -= 1;
+			else if (row.rejectedAt) rejected -= 1;
+			else open -= 1;
+
+			history[row.id] = {
+				approved: Math.max(0, approved),
+				rejected: Math.max(0, rejected),
+				open: Math.max(0, open),
+				since: aggregate.since
+			};
+		}
+
+		return history;
+	} catch (error) {
+		/* Fail-open: Die Historie ist Zusatzinformation. Eine fehlgeschlagene
+		   Abfrage darf die Arbeitsliste nicht mitnehmen. */
+		logger.warn({ error }, 'Melder-Historie konnte nicht ermittelt werden');
+		return {};
+	}
+}

--- a/src/lib/server/db/reporterHistory.ts
+++ b/src/lib/server/db/reporterHistory.ts
@@ -114,7 +114,15 @@ export async function findReporterHistory(
 			let rejected = Number(aggregate.rejected);
 			let open = Number(aggregate.open);
 
-			// Die eigene Zeile aus dem Topf abziehen, in dem sie steckt.
+			/* Die eigene Zeile aus dem Topf abziehen, in dem sie steckt.
+			   Voraussetzung: `approvedAt` und `rejectedAt` sind nie gleichzeitig
+			   gesetzt. Das hält ausschließlich `PATCH /api/sightings/[id]/verify`
+			   ein (es setzt beim Freigeben `rejectedAt: null` und umgekehrt, in
+			   einem Update) — dieses Modul selbst erzwingt es nicht. Verletzt eine
+			   künftige Schreibstelle die Annahme, wandert der Zähler für diese
+			   eine Zeile um eins in den falschen Topf (hier `else if`: `approved`
+			   gewinnt); `Math.max(0, …)` unten verhindert immerhin, dass daraus ein
+			   negativer Zähler wird. */
 			if (row.approvedAt) approved -= 1;
 			else if (row.rejectedAt) rejected -= 1;
 			else open -= 1;

--- a/src/lib/types/reporterHistory.ts
+++ b/src/lib/types/reporterHistory.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Was über einen Melder aus dem eigenen Bestand bekannt ist.
+ *
+ * Client-sicher: nur Typen, kein Import aus `$lib/server/**` — der Bruch fiele
+ * sonst erst in `npm run build` auf, nicht in `npm run check`.
+ *
+ * **Die Zahlen zählen die *anderen* Meldungen desselben Melders.** Die Meldung,
+ * die gerade angesehen wird, ist nicht Teil ihrer eigenen Vorgeschichte;
+ * `findReporterHistory` zieht sie aus dem Topf ab, in dem sie steckt.
+ *
+ * **Nichts davon wird persistiert.** Es gibt keine Spalte, keinen Score und
+ * keinen Backfill: Reputation ändert sich rückwirkend mit jeder Freigabe, ein
+ * gespeicherter Wert wäre ab dem nächsten Klick falsch. Die Abgrenzung zum
+ * Spam-Score steht in `docs/SPAM_DETECTION.md`.
+ */
+export interface ReporterHistory {
+	/** Andere Meldungen dieses Melders, die freigegeben wurden. */
+	approved: number;
+	/** Andere Meldungen dieses Melders, die abgelehnt wurden. */
+	rejected: number;
+	/** Andere Meldungen dieses Melders, die noch offen sind. */
+	open: number;
+	/**
+	 * Früheste Meldung dieses Melders als ISO-Zeichenkette in UTC — **inklusive**
+	 * der aktuellen. „Melder seit" ist eine Aussage über die Person, nicht über
+	 * die Restmenge; ein Erstmelder hat damit korrekt das heutige Datum.
+	 */
+	since: string | null;
+}

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -69,10 +69,15 @@ export const load: PageServerLoad = async ({ url }) => {
 		   Leerfall fängt `findDuplicateCandidates` selbst ab. */
 		const duplicatesPromise = findDuplicateCandidates(ids);
 		/* Melder-Historie (ein Query für alle Karten, wie der Duplikat-Hinweis).
-		   `approvedAt`/`rejectedAt` sind hier konstant `null`: Die Liste ist über
-		   `openOnly()` gefiltert. Sie stehen trotzdem im Aufruf, weil
-		   `findReporterHistory` daran die eigene Zeile abzieht und der Vertrag
-		   nicht an dieser Filterung hängen soll. */
+		   `approvedAt`/`rejectedAt` sind hier konstant `null` — das ist zulässig,
+		   *weil* diese Liste über `openOnly()` gefiltert ist: Jede gelistete
+		   Sichtung ist per Definition weder freigegeben noch abgelehnt, `null` ist
+		   also der korrekte Wert und keine Verkürzung. `findReporterHistory` zieht
+		   daran die eigene Zeile aus dem Topf ab, in dem sie steckt (approved/
+		   rejected/open) — würde der Filter je gelockert (z. B. `openOnly()` durch
+		   eine schwächere Bedingung ersetzt), müssten hier die echten Spalten
+		   mitgelesen werden, sonst zöge eine bereits entschiedene Sichtung ihre
+		   eigene Zeile aus dem falschen Topf ab. */
 		const reporterHistoryPromise = findReporterHistory(
 			open.map((s) => ({ id: s.id, email: s.email, approvedAt: null, rejectedAt: null }))
 		);

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	mediaUploadCondition
 } from '$lib/server/db/mediaUploadFilter';
 import { openQueueOrderBy, resolveQueueOrder } from '$lib/server/db/openQueueOrder';
+import { findReporterHistory } from '$lib/server/db/reporterHistory';
 import { sightingFiles, sightings } from '$lib/server/db/schema';
 import { redirect } from '@sveltejs/kit';
 import { and, inArray, like, sql } from 'drizzle-orm';
@@ -67,6 +68,14 @@ export const load: PageServerLoad = async ({ url }) => {
 		   gemeinsam, parallel zur Bild-Abfrage. Beide hängen nur an der Liste; den
 		   Leerfall fängt `findDuplicateCandidates` selbst ab. */
 		const duplicatesPromise = findDuplicateCandidates(ids);
+		/* Melder-Historie (ein Query für alle Karten, wie der Duplikat-Hinweis).
+		   `approvedAt`/`rejectedAt` sind hier konstant `null`: Die Liste ist über
+		   `openOnly()` gefiltert. Sie stehen trotzdem im Aufruf, weil
+		   `findReporterHistory` daran die eigene Zeile abzieht und der Vertrag
+		   nicht an dieser Filterung hängen soll. */
+		const reporterHistoryPromise = findReporterHistory(
+			open.map((s) => ({ id: s.id, email: s.email, approvedAt: null, rejectedAt: null }))
+		);
 		const imageRows = ids.length
 			? await db
 					.select({
@@ -80,11 +89,19 @@ export const load: PageServerLoad = async ({ url }) => {
 						and(inArray(sightingFiles.sightingId, ids), like(sightingFiles.mimeType, 'image/%'))
 					)
 			: [];
-		return { open, imageRows, duplicatesBySighting: await duplicatesPromise };
+		return {
+			open,
+			imageRows,
+			duplicatesBySighting: await duplicatesPromise,
+			reporterHistoryBySighting: await reporterHistoryPromise
+		};
 	});
 
-	const [{ open, imageRows, duplicatesBySighting }, openCountResult, pendingPhotoResult] =
-		await Promise.all([openWithImagesQuery, openCountQuery, pendingPhotoQuery]);
+	const [
+		{ open, imageRows, duplicatesBySighting, reporterHistoryBySighting },
+		openCountResult,
+		pendingPhotoResult
+	] = await Promise.all([openWithImagesQuery, openCountQuery, pendingPhotoQuery]);
 
 	const imagesBySighting: Record<number, { id: number; filePath: string; originalName: string }[]> =
 		{};
@@ -107,6 +124,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		order,
 		imagesBySighting,
 		pendingPhotoAnnouncements: Number(pendingPhotoResult[0]?.count ?? 0),
-		duplicatesBySighting
+		duplicatesBySighting,
+		reporterHistoryBySighting
 	};
 };

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -324,6 +324,7 @@
 								images={data.imagesBySighting[sighting.id] ?? []}
 								duplicates={data.duplicatesBySighting[sighting.id] ?? []}
 								order={data.order}
+								reporterHistory={data.reporterHistoryBySighting[sighting.id] ?? null}
 								busy={busy[sighting.id] ?? false}
 								onApprove={() => entscheiden(sighting.id, 'approve')}
 								onReject={() => entscheiden(sighting.id, 'reject')}

--- a/src/routes/admin/[id]/+page.svelte
+++ b/src/routes/admin/[id]/+page.svelte
@@ -670,4 +670,6 @@
 	{statusBusy}
 	statusLog={data.statusLog}
 	statusLogFailed={data.statusLogFailed}
+	reporterHistory={data.reporterHistory}
+	reporterHistoryFailed={data.reporterHistoryFailed}
 />

--- a/src/routes/admin/[id]/+page.ts
+++ b/src/routes/admin/[id]/+page.ts
@@ -66,11 +66,14 @@ async function ladeStatusLog(fetchFn: FetchFn, id: string): Promise<StatusLogRes
  * Prüft die Gestalt von `history`, statt sie zu casten.
  *
  * `null` ist zulässig (nicht ermittelbar). Ein Objekt muss die drei Zählfelder
- * als `number` mitbringen — ohne diese Prüfung fiele `getReporterLevel` bei
- * einem kaputten Wert (`"kaputt"`, `{}`, …) auf `undefined`-Vergleiche zurück
- * und würde `'first'` liefern: die Oberfläche behauptete dann „Erstmeldung",
- * wo ein Vertragsbruch des Endpunkts vorliegt — die Verwechslung, gegen die
- * dieses Feature antritt.
+ * als `number` mitbringen sowie `since` als `string | null` — ohne diese
+ * Prüfung fiele `getReporterLevel` bei einem kaputten Wert (`"kaputt"`, `{}`,
+ * `{ approved: 0, rejected: 0, open: 0 }` ohne `since`, …) auf
+ * `undefined`-Vergleiche zurück und würde `'first'` liefern: die Oberfläche
+ * behauptete dann „Erstmeldung", wo ein Vertragsbruch des Endpunkts vorliegt
+ * — die Verwechslung, gegen die dieses Feature antritt. `since` ist dabei
+ * genauso Pflicht wie die Zählfelder (`static/openapi.yml` führt es als
+ * `required`), nur eben mit `null` als zulässigem Wert.
  */
 function istGueltigeMelderHistorie(value: unknown): value is ReporterHistory | null {
 	if (value === null) return true;
@@ -80,7 +83,8 @@ function istGueltigeMelderHistorie(value: unknown): value is ReporterHistory | n
 	return (
 		typeof kandidat.approved === 'number' &&
 		typeof kandidat.rejected === 'number' &&
-		typeof kandidat.open === 'number'
+		typeof kandidat.open === 'number' &&
+		(typeof kandidat.since === 'string' || kandidat.since === null)
 	);
 }
 

--- a/src/routes/admin/[id]/+page.ts
+++ b/src/routes/admin/[id]/+page.ts
@@ -63,6 +63,28 @@ async function ladeStatusLog(fetchFn: FetchFn, id: string): Promise<StatusLogRes
 }
 
 /**
+ * Prüft die Gestalt von `history`, statt sie zu casten.
+ *
+ * `null` ist zulässig (nicht ermittelbar). Ein Objekt muss die drei Zählfelder
+ * als `number` mitbringen — ohne diese Prüfung fiele `getReporterLevel` bei
+ * einem kaputten Wert (`"kaputt"`, `{}`, …) auf `undefined`-Vergleiche zurück
+ * und würde `'first'` liefern: die Oberfläche behauptete dann „Erstmeldung",
+ * wo ein Vertragsbruch des Endpunkts vorliegt — die Verwechslung, gegen die
+ * dieses Feature antritt.
+ */
+function istGueltigeMelderHistorie(value: unknown): value is ReporterHistory | null {
+	if (value === null) return true;
+	if (typeof value !== 'object') return false;
+
+	const kandidat = value as Partial<Record<keyof ReporterHistory, unknown>>;
+	return (
+		typeof kandidat.approved === 'number' &&
+		typeof kandidat.rejected === 'number' &&
+		typeof kandidat.open === 'number'
+	);
+}
+
+/**
  * Melder-Historie der Detailansicht.
  *
  * Gleiche Konstruktion wie beim Status-Log: Ein Fehlschlag darf die Seite nicht
@@ -71,7 +93,10 @@ async function ladeStatusLog(fetchFn: FetchFn, id: string): Promise<StatusLogRes
  * gegen den die Anzeige antritt.
  *
  * Eine Antwort ohne das Feld `history` zählt als Fehlschlag: Sie ist ein
- * Vertragsbruch des Endpunkts, kein Altbestand.
+ * Vertragsbruch des Endpunkts, kein Altbestand. Dasselbe gilt für eine
+ * Antwort, deren `history` zwar existiert, aber nicht die erwartete Gestalt
+ * hat (`istGueltigeMelderHistorie`) — auch das ist ein Vertragsbruch und kein
+ * leeres Ergebnis.
  */
 async function ladeMelderHistorie(fetchFn: FetchFn, id: string): Promise<ReporterHistoryResult> {
 	try {
@@ -81,12 +106,12 @@ async function ladeMelderHistorie(fetchFn: FetchFn, id: string): Promise<Reporte
 		}
 
 		const body = await response.json();
-		if (!('history' in (body ?? {}))) {
+		if (!('history' in (body ?? {})) || !istGueltigeMelderHistorie(body.history)) {
 			return { reporterHistory: null, reporterHistoryFailed: true };
 		}
 
 		return {
-			reporterHistory: body.history as ReporterHistory | null,
+			reporterHistory: body.history,
 			reporterHistoryFailed: false
 		};
 	} catch {

--- a/src/routes/admin/[id]/+page.ts
+++ b/src/routes/admin/[id]/+page.ts
@@ -2,6 +2,7 @@ import { HERKUNFT_EINGANG, HERKUNFT_PARAMETER } from '$lib/components/admin/admi
 import { resolveQueueOrder } from '$lib/components/admin/queueOrder';
 import type { SightingQueue } from '$lib/components/admin/sightingQueue';
 import type { SightingStatusLogEntry } from '$lib/components/admin/sightingStatusLog';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
 import type { PageLoad } from './$types';
 
 type FetchFn = typeof fetch;
@@ -14,6 +15,11 @@ interface StatusLogResult {
 interface QueueResult {
 	queue: SightingQueue | null;
 	queueFailed: boolean;
+}
+
+interface ReporterHistoryResult {
+	reporterHistory: ReporterHistory | null;
+	reporterHistoryFailed: boolean;
 }
 
 /**
@@ -53,6 +59,38 @@ async function ladeStatusLog(fetchFn: FetchFn, id: string): Promise<StatusLogRes
 		return { statusLog: body.history as SightingStatusLogEntry[], statusLogFailed: false };
 	} catch {
 		return { statusLog: [], statusLogFailed: true };
+	}
+}
+
+/**
+ * Melder-Historie der Detailansicht.
+ *
+ * Gleiche Konstruktion wie beim Status-Log: Ein Fehlschlag darf die Seite nicht
+ * kosten, darf aber auch nicht als „keine Vorgeschichte" durchgehen. Beides
+ * sähe im DOM gleich aus, und die Verwechslung wäre genau der Fehlermodus,
+ * gegen den die Anzeige antritt.
+ *
+ * Eine Antwort ohne das Feld `history` zählt als Fehlschlag: Sie ist ein
+ * Vertragsbruch des Endpunkts, kein Altbestand.
+ */
+async function ladeMelderHistorie(fetchFn: FetchFn, id: string): Promise<ReporterHistoryResult> {
+	try {
+		const response = await fetchFn(`/api/sightings/${id}/reporter-history`);
+		if (!response.ok) {
+			return { reporterHistory: null, reporterHistoryFailed: true };
+		}
+
+		const body = await response.json();
+		if (!('history' in (body ?? {}))) {
+			return { reporterHistory: null, reporterHistoryFailed: true };
+		}
+
+		return {
+			reporterHistory: body.history as ReporterHistory | null,
+			reporterHistoryFailed: false
+		};
+	} catch {
+		return { reporterHistory: null, reporterHistoryFailed: true };
 	}
 }
 
@@ -98,12 +136,13 @@ export const load: PageLoad = async ({ params, fetch, url }) => {
 	const ausEingang = url.searchParams.get(HERKUNFT_PARAMETER) === HERKUNFT_EINGANG;
 	const queueOrder = resolveQueueOrder(url.searchParams.get('order'));
 
-	const [statusLogResult, queueResult] = await Promise.all([
+	const [statusLogResult, queueResult, reporterHistoryResult] = await Promise.all([
 		ladeStatusLog(fetch, params.id),
 		ausEingang
 			? ladeQueue(fetch, params.id, queueOrder)
-			: Promise.resolve<QueueResult>({ queue: null, queueFailed: false })
+			: Promise.resolve<QueueResult>({ queue: null, queueFailed: false }),
+		ladeMelderHistorie(fetch, params.id)
 	]);
 
-	return { ...statusLogResult, ...queueResult, queueOrder };
+	return { ...statusLogResult, ...queueResult, ...reporterHistoryResult, queueOrder };
 };

--- a/src/routes/admin/[id]/reporterHistoryLoad.test.ts
+++ b/src/routes/admin/[id]/reporterHistoryLoad.test.ts
@@ -99,6 +99,40 @@ describe('load der Melder-Historie', () => {
 		expect(result.reporterHistory).toBeNull();
 	});
 
+	/* `static/openapi.yml` führt `since` als `required` (Typ `string`,
+	   `nullable`). Ohne diese Prüfung passierte `{ approved: 0, rejected: 0,
+	   open: 0 }` die Gestaltprüfung und landete als Stufe `'first'` in der
+	   Oberfläche — ein Vertragsbruch, der als „Erstmeldung" durchgeht. Genau
+	   die Verwechslung, gegen die die Prüfung antritt. */
+	it('behandelt ein history-Objekt mit fehlendem since als Fehlschlag', async () => {
+		const result = await laden(antwort({ history: { approved: 0, rejected: 0, open: 0 } }));
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('behandelt ein history-Objekt mit since in falschem Typ als Fehlschlag', async () => {
+		const result = await laden(
+			antwort({ history: { approved: 0, rejected: 0, open: 0, since: 12345 } })
+		);
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	/* Die Gegenprobe zu den beiden Fällen oben: `since: null` ist ein
+	   legitimer Wert (Sichtung ohne verwertbares Meldedatum), kein
+	   Vertragsbruch — er muss durchkommen wie jede andere gültige Historie. */
+	it('lässt since: null durch', async () => {
+		const historie: ReporterHistory = { approved: 0, rejected: 0, open: 0, since: null };
+
+		const result = await laden(antwort({ history: historie }));
+
+		expect(result).toEqual(
+			expect.objectContaining({ reporterHistory: historie, reporterHistoryFailed: false })
+		);
+	});
+
 	it('kennzeichnet eine Fehlerantwort als Fehlschlag', async () => {
 		const result = await laden(antwort({}, false));
 

--- a/src/routes/admin/[id]/reporterHistoryLoad.test.ts
+++ b/src/routes/admin/[id]/reporterHistoryLoad.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+import { load } from './+page';
+
+/**
+ * @fileoverview Der Lade-Fallback der Melder-Historie muss die drei Zustände
+ * auseinanderhalten.
+ *
+ * **Warum dieser Test existiert.** `ladeMelderHistorie` prüft seit Commit
+ * `b0a81d7d` die Gestalt von `history`, bevor sie durchgereicht wird — und
+ * genau diese Prüfung war ungetestet. Ohne sie fiele ein kaputtes `history`
+ * (ein Nicht-Objekt wie `"kaputt"`, oder ein Objekt ohne die Zählfelder) in
+ * `getReporterLevel` auf `undefined`-Vergleiche zurück und läge auf der Stufe
+ * `'first'` — die Oberfläche behauptete dann „Erstmeldung", wo tatsächlich ein
+ * Vertragsbruch des Endpunkts vorliegt. Das ist dieselbe Verwechslung, gegen
+ * die das ganze Feature antritt: ein Fehlschlag, der wie ein Befund aussieht.
+ *
+ * Die drei Zustände bleiben nur unterscheidbar, solange `{ history: null }`
+ * (nicht ermittelbar, kein Fehler) und ein echtes Nullaggregat (kein
+ * Vorgeschichte, aber ein gültiger Befund) beide durchkommen, während jede
+ * andere Abweichung von der zugesagten Gestalt als Fehlschlag markiert wird.
+ */
+
+/** Minimaler Load-Event — mehr liest die Funktion nicht. */
+const ladeEvent = (fetchImpl: typeof fetch) =>
+	({
+		params: { id: '42' },
+		fetch: fetchImpl,
+		url: new URL('https://localhost:4000/admin/42')
+	}) as unknown as Parameters<typeof load>[0];
+
+const antwort = (body: unknown, ok = true) =>
+	vi.fn().mockResolvedValue({ ok, json: () => Promise.resolve(body) }) as unknown as typeof fetch;
+
+/* SvelteKits `PageLoad` weitet den Rückgabetyp auf `void | Record<string, any>`
+   — die Zusicherung holt die zwei Felder zurück, um die es hier geht. */
+const laden = async (fetchImpl: typeof fetch) =>
+	(await load(ladeEvent(fetchImpl))) as unknown as {
+		reporterHistory: ReporterHistory | null;
+		reporterHistoryFailed: boolean;
+	};
+
+describe('load der Melder-Historie', () => {
+	it('reicht eine gültige Historie durch', async () => {
+		const historie: ReporterHistory = {
+			approved: 3,
+			rejected: 1,
+			open: 2,
+			since: '2025-01-01T00:00:00Z'
+		};
+
+		const result = await laden(antwort({ history: historie }));
+
+		expect(result).toEqual(
+			expect.objectContaining({ reporterHistory: historie, reporterHistoryFailed: false })
+		);
+	});
+
+	/* Der Endpunkt sagt `history: null` ausdrücklich als „nicht ermittelbar"
+	   zu (keine Adresse hinterlegt, oder die Abfrage ist fail-open gescheitert)
+	   — das ist kein Fehlschlag der Ladefunktion. */
+	it('behandelt history: null als nicht ermittelbar, nicht als Fehlschlag', async () => {
+		const result = await laden(antwort({ history: null }));
+
+		expect(result).toEqual(
+			expect.objectContaining({ reporterHistory: null, reporterHistoryFailed: false })
+		);
+	});
+
+	/* Eine Antwort ohne `history` ist ein Vertragsbruch des Endpunkts, kein
+	   Altbestand — sie darf nicht als „nicht ermittelbar" durchgehen. */
+	it('behandelt eine Antwort ohne history-Feld als Fehlschlag', async () => {
+		const result = await laden(antwort({ id: 42 }));
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('behandelt ein history in falscher Gestalt (Nicht-Objekt) als Fehlschlag', async () => {
+		const result = await laden(antwort({ history: 'kaputt' }));
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('behandelt ein history-Objekt mit fehlendem Zählfeld als Fehlschlag', async () => {
+		const result = await laden(antwort({ history: { approved: 1, rejected: 0 } }));
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('behandelt ein history-Objekt mit falschem Feldtyp als Fehlschlag', async () => {
+		const result = await laden(
+			antwort({ history: { approved: '1', rejected: 0, open: 0, since: null } })
+		);
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('kennzeichnet eine Fehlerantwort als Fehlschlag', async () => {
+		const result = await laden(antwort({}, false));
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	it('kennzeichnet einen Netzwerkfehler als Fehlschlag', async () => {
+		const kaputt = vi.fn().mockRejectedValue(new Error('offline')) as unknown as typeof fetch;
+
+		const result = await laden(kaputt);
+
+		expect(result.reporterHistoryFailed).toBe(true);
+		expect(result.reporterHistory).toBeNull();
+	});
+
+	/* Die Gegenprobe zur Kernaussage: Ein echtes Nullaggregat ist ein
+	   gültiger Befund („keine Vorgeschichte"), kein fehlender Befund — es muss
+	   durchkommen wie jede andere gültige Historie. */
+	it('lässt ein echtes Nullaggregat durch, ohne es als Fehlschlag zu werten', async () => {
+		const nullaggregat: ReporterHistory = {
+			approved: 0,
+			rejected: 0,
+			open: 0,
+			since: '2026-08-10T00:00:00Z'
+		};
+
+		const result = await laden(antwort({ history: nullaggregat }));
+
+		expect(result).toEqual(
+			expect.objectContaining({ reporterHistory: nullaggregat, reporterHistoryFailed: false })
+		);
+	});
+});

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -85,6 +85,25 @@ vi.mock('$lib/server/db/duplicateCandidates', () => ({
 	findDuplicateCandidates: (ids: number[]) => findDuplicateCandidates(ids)
 }));
 
+/* Die Melder-Historie hat ihre eigenen Tests in
+   `src/lib/server/db/reporterHistory.test.ts`. Ohne diesen Mock ruft der Loader
+   die echte `findReporterHistory` auf, die `db.execute` braucht — das kennt der
+   Select-Mock oben nicht, der Fail-open-`catch` im Modul schluckt den daraus
+   entstehenden `TypeError`, und der Loader liefert lautlos `{}`. Ein Test ohne
+   diesen Mock bliebe grün, selbst wenn die Verdrahtung ganz entfernt würde. */
+const findReporterHistory = vi
+	.fn<
+		(
+			rows: { id: number; email: string | null }[]
+		) => Promise<
+			Record<number, { approved: number; rejected: number; open: number; since: string | null }>
+		>
+	>()
+	.mockResolvedValue({});
+vi.mock('$lib/server/db/reporterHistory', () => ({
+	findReporterHistory: (rows: { id: number; email: string | null }[]) => findReporterHistory(rows)
+}));
+
 function makeUrl(params: Record<string, string> = {}): URL {
 	const url = new URL('https://example.com/admin');
 	for (const [key, value] of Object.entries(params)) {
@@ -101,6 +120,10 @@ type InboxData = {
 	imagesBySighting: Record<number, { id: number; filePath: string; originalName: string }[]>;
 	pendingPhotoAnnouncements: number;
 	duplicatesBySighting: Record<number, unknown[]>;
+	reporterHistoryBySighting: Record<
+		number,
+		{ approved: number; rejected: number; open: number; since: string | null }
+	>;
 };
 
 const { load } = await import('./+page.server');
@@ -118,6 +141,8 @@ describe('Eingangs-Load', () => {
 		resolvedRows = [[{ id: 1 }, { id: 2 }], [{ count: 7 }], [{ count: 3 }], []];
 		findDuplicateCandidates.mockClear();
 		findDuplicateCandidates.mockResolvedValue({});
+		findReporterHistory.mockClear();
+		findReporterHistory.mockResolvedValue({});
 	});
 
 	/*
@@ -176,6 +201,30 @@ describe('Eingangs-Load', () => {
 
 		expect(findDuplicateCandidates).toHaveBeenCalledWith([]);
 		expect(result.duplicatesBySighting).toEqual({});
+	});
+
+	/* Gleiche Konstruktion wie beim Duplikat-Hinweis: ein Aufruf für alle
+	   gelisteten Sichtungen, das Ergebnis unverändert durchgereicht. Ohne diesen
+	   Test bliebe die Verdrahtung aus `+page.server.ts` unbeobachtet — der Mock
+	   oben würde eine gelöschte `findReporterHistory`-Aufrufstelle nicht
+	   bemerken, weil `db.execute` im Select-Mock gar nicht existiert und der
+	   Fail-open-Zweig im echten Modul den Fehler schluckt (Befund aus dem
+	   Abschluss-Review). */
+	it('ermittelt die Melder-Historie für alle gelisteten Sichtungen in einem Aufruf', async () => {
+		findReporterHistory.mockResolvedValue({
+			1: { approved: 3, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z' }
+		});
+
+		const result = await runLoad(makeUrl());
+
+		expect(findReporterHistory).toHaveBeenCalledTimes(1);
+		expect(findReporterHistory).toHaveBeenCalledWith([
+			{ id: 1, email: undefined, approvedAt: null, rejectedAt: null },
+			{ id: 2, email: undefined, approvedAt: null, rejectedAt: null }
+		]);
+		expect(result.reporterHistoryBySighting).toEqual({
+			1: { approved: 3, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z' }
+		});
 	});
 
 	it('leitet Tabellen-URLs mit 301 nach /admin/sichtungen weiter (Query bleibt erhalten)', async () => {

--- a/src/routes/admin/inboxPage.server.test.ts
+++ b/src/routes/admin/inboxPage.server.test.ts
@@ -138,7 +138,15 @@ const runLoad = async (url: URL): Promise<InboxData> =>
 describe('Eingangs-Load', () => {
 	beforeEach(() => {
 		recordedSelects = [];
-		resolvedRows = [[{ id: 1 }, { id: 2 }], [{ count: 7 }], [{ count: 3 }], []];
+		resolvedRows = [
+			[
+				{ id: 1, email: 'melder-eins@example.com' },
+				{ id: 2, email: 'melder-zwei@example.com' }
+			],
+			[{ count: 7 }],
+			[{ count: 3 }],
+			[]
+		];
 		findDuplicateCandidates.mockClear();
 		findDuplicateCandidates.mockResolvedValue({});
 		findReporterHistory.mockClear();
@@ -219,8 +227,8 @@ describe('Eingangs-Load', () => {
 
 		expect(findReporterHistory).toHaveBeenCalledTimes(1);
 		expect(findReporterHistory).toHaveBeenCalledWith([
-			{ id: 1, email: undefined, approvedAt: null, rejectedAt: null },
-			{ id: 2, email: undefined, approvedAt: null, rejectedAt: null }
+			{ id: 1, email: 'melder-eins@example.com', approvedAt: null, rejectedAt: null },
+			{ id: 2, email: 'melder-zwei@example.com', approvedAt: null, rejectedAt: null }
 		]);
 		expect(result.reporterHistoryBySighting).toEqual({
 			1: { approved: 3, rejected: 0, open: 0, since: '2019-03-04T08:00:00Z' }

--- a/src/routes/admin/inboxShortcuts.svelte.test.ts
+++ b/src/routes/admin/inboxShortcuts.svelte.test.ts
@@ -54,7 +54,8 @@ function daten(ids: number[]): PageData {
 		order: 'asc' as const,
 		imagesBySighting: {},
 		pendingPhotoAnnouncements: 0,
-		duplicatesBySighting: {}
+		duplicatesBySighting: {},
+		reporterHistoryBySighting: {}
 	} as unknown as PageData;
 }
 

--- a/src/routes/admin/inboxUndo.svelte.test.ts
+++ b/src/routes/admin/inboxUndo.svelte.test.ts
@@ -50,7 +50,8 @@ function daten(ids: number[]): PageData {
 		/* Ohne dieses Feld wirft die Seite beim Rendern: Der Cast auf `PageData`
 		   unterdrückt die Typprüfung, die den fehlenden Loader-Schlüssel sonst
 		   gemeldet hätte. Ein neues Feld im Loader gehört deshalb hierher. */
-		duplicatesBySighting: {}
+		duplicatesBySighting: {},
+		reporterHistoryBySighting: {}
 	} as unknown as PageData;
 }
 

--- a/src/routes/api/sightings/[id]/reporter-history/+server.ts
+++ b/src/routes/api/sightings/[id]/reporter-history/+server.ts
@@ -49,7 +49,14 @@ export const GET: RequestHandler = async ({ params, locals, url }) => {
 		const byId = await findReporterHistory([row]);
 		/* `null` und nicht `{approved: 0, …}`: Ohne Adresse oder nach einem
 		   Fehlschlag der Abfrage ist nichts ermittelt worden, und ein Nullaggregat
-		   behauptete das Gegenteil. */
+		   behauptete das Gegenteil.
+		   `null` fasst dabei zwei Ursachen zusammen, die von hier aus nicht zu
+		   unterscheiden sind: keine E-Mail-Adresse hinterlegt, oder die Abfrage in
+		   `findReporterHistory` ist fail-open fehlgeschlagen. Beides zeigt die
+		   Detailansicht identisch (kein Badge) — das ist der Preis des Fail-open
+		   und bewusst so. Ein eigener Fehlertext existiert dort nur für den
+		   Transportfehler (Endpunkt nicht erreichbar, Antwort ohne `history`),
+		   nicht für diesen Fall. */
 		const history: ReporterHistory | null = byId[row.id] ?? null;
 
 		return json({ history }, { headers: { 'Cache-Control': 'no-store' } });

--- a/src/routes/api/sightings/[id]/reporter-history/+server.ts
+++ b/src/routes/api/sightings/[id]/reporter-history/+server.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Melder-Historie einer Sichtung — für die Detailansicht.
+ *
+ * Die Detailansicht lädt `ssr = false` über die API; deshalb ein Endpunkt und
+ * kein `+page.server.ts`. Gleiche Bauart wie `spam-check`: Admin-geschützt,
+ * `no-store`, und ein Antwortfeld, das „nicht ermittelt" von „nichts vorhanden"
+ * unterscheidet.
+ *
+ * Es wird nichts persistiert und nichts entschieden — die Zahlen sind eine
+ * Triage-Hilfe (`docs/SPAM_DETECTION.md`, Abschnitt „Melder-Historie").
+ */
+import { createLogger } from '$lib/logger.server';
+import { requireUserRole } from '$lib/server/auth/auth';
+import { db } from '$lib/server/db';
+import { findReporterHistory } from '$lib/server/db/reporterHistory';
+import { sightings } from '$lib/server/db/schema';
+import type { ReporterHistory } from '$lib/types/reporterHistory';
+import { error, isHttpError, json, type RequestHandler } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+
+const logger = createLogger('api:sightings:reporter-history');
+
+export const GET: RequestHandler = async ({ params, locals, url }) => {
+	requireUserRole(url, locals.user, ['admin', 'superadmin']);
+
+	const { id } = params;
+
+	if (!id || isNaN(Number(id))) {
+		throw error(400, 'Ungültige Sichtungs-ID');
+	}
+
+	try {
+		const rows = await db
+			.select({
+				id: sightings.id,
+				email: sightings.email,
+				approvedAt: sightings.approvedAt,
+				rejectedAt: sightings.rejectedAt
+			})
+			.from(sightings)
+			.where(eq(sightings.id, Number(id)))
+			.limit(1);
+
+		const row = rows[0];
+		if (!row) {
+			throw error(404, 'Sichtung nicht gefunden');
+		}
+
+		const byId = await findReporterHistory([row]);
+		/* `null` und nicht `{approved: 0, …}`: Ohne Adresse oder nach einem
+		   Fehlschlag der Abfrage ist nichts ermittelt worden, und ein Nullaggregat
+		   behauptete das Gegenteil. */
+		const history: ReporterHistory | null = byId[row.id] ?? null;
+
+		return json({ history }, { headers: { 'Cache-Control': 'no-store' } });
+	} catch (err) {
+		if (isHttpError(err)) {
+			throw err;
+		}
+		logger.error({ err, id }, 'Fehler beim Ermitteln der Melder-Historie');
+		throw error(500, 'Interner Serverfehler bei der Melder-Historie');
+	}
+};

--- a/src/routes/api/sightings/[id]/reporter-history/server.test.ts
+++ b/src/routes/api/sightings/[id]/reporter-history/server.test.ts
@@ -83,4 +83,20 @@ describe('GET /api/sightings/[id]/reporter-history', () => {
 
 		await expect(response.json()).resolves.toEqual({ history: null });
 	});
+
+	/* Die Gegenprobe zum Test oben: Ein **echtes** Nullaggregat — ein Melder mit
+	   Adresse, aber ohne weitere Meldungen — muss als Objekt durchgereicht
+	   werden und nicht mit dem Fail-open-Fall zu `null` kollabieren. Das ist die
+	   Testseite der zentralen Aussage des Endpunkts (`byId[row.id] ?? null`). */
+	it('unterscheidet ein echtes Nullaggregat von nicht ermittelt', async () => {
+		findReporterHistory.mockResolvedValue({
+			42: { approved: 0, rejected: 0, open: 0, since: '2026-08-10T08:00:00Z' }
+		});
+
+		const response = await aufruf('42');
+
+		await expect(response.json()).resolves.toEqual({
+			history: { approved: 0, rejected: 0, open: 0, since: '2026-08-10T08:00:00Z' }
+		});
+	});
 });

--- a/src/routes/api/sightings/[id]/reporter-history/server.test.ts
+++ b/src/routes/api/sightings/[id]/reporter-history/server.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Melder-Historie einer Sichtung (Admin).
+ *
+ * `history: null` ist der Punkt, um den es hier geht: Es heißt „nicht
+ * ermittelbar" und nicht „keine Vorgeschichte". Die Oberfläche zeigt dafür kein
+ * Badge — dieselbe Unterscheidung wie bei `spam_score IS NULL`.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { GET } from './+server';
+
+const requireUserRole = vi.fn();
+const findReporterHistory = vi.fn();
+const limit = vi.fn();
+
+vi.mock('$lib/server/auth/auth', () => ({
+	requireUserRole: (...args: unknown[]) => requireUserRole(...args)
+}));
+
+vi.mock('$lib/server/db/reporterHistory', () => ({
+	findReporterHistory: (...args: unknown[]) => findReporterHistory(...args)
+}));
+
+vi.mock('$lib/server/db', () => ({
+	db: { select: () => ({ from: () => ({ where: () => ({ limit }) }) }) }
+}));
+
+vi.mock('$lib/logger.server', () => ({
+	createLogger: vi.fn(() => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }))
+}));
+
+function aufruf(id: string) {
+	return GET({
+		params: { id },
+		locals: { user: { roles: ['admin'] } },
+		url: new URL(`https://example.org/api/sightings/${id}/reporter-history`)
+	} as never);
+}
+
+describe('GET /api/sightings/[id]/reporter-history', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		limit.mockResolvedValue([
+			{ id: 42, email: 'melder@example.org', approvedAt: null, rejectedAt: null }
+		]);
+		findReporterHistory.mockResolvedValue({
+			42: { approved: 12, rejected: 0, open: 1, since: '2019-03-04T08:00:00Z' }
+		});
+	});
+
+	it('verlangt eine Admin-Rolle', async () => {
+		await aufruf('42');
+		expect(requireUserRole).toHaveBeenCalledWith(expect.anything(), expect.anything(), [
+			'admin',
+			'superadmin'
+		]);
+	});
+
+	it('liefert die Historie der Sichtung', async () => {
+		const response = await aufruf('42');
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			history: { approved: 12, rejected: 0, open: 1, since: '2019-03-04T08:00:00Z' }
+		});
+	});
+
+	it('weist eine unbrauchbare ID mit 400 ab', async () => {
+		await expect(aufruf('abc')).rejects.toMatchObject({ status: 400 });
+	});
+
+	it('meldet eine unbekannte Sichtung mit 404', async () => {
+		limit.mockResolvedValue([]);
+		await expect(aufruf('999')).rejects.toMatchObject({ status: 404 });
+	});
+
+	/* Fail-open des Aggregats: `findReporterHistory` liefert dann `{}`. Die
+	   Antwort muss `null` sein und nicht ein Nullaggregat — sonst behauptete sie
+	   „keine Vorgeschichte", wo nichts ermittelt wurde. */
+	it('antwortet mit null, wenn nichts ermittelt werden konnte', async () => {
+		findReporterHistory.mockResolvedValue({});
+
+		const response = await aufruf('42');
+
+		await expect(response.json()).resolves.toEqual({ history: null });
+	});
+});

--- a/static/openapi.yml
+++ b/static/openapi.yml
@@ -498,6 +498,52 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/sightings/{id}/reporter-history:
+    get:
+      tags:
+        - sightings
+      summary: Was über den Melder dieser Sichtung bekannt ist
+      description: |
+        Zählt die **anderen** Meldungen derselben E-Mail-Adresse nach
+        Bearbeitungsstand (Admin-Berechtigung erforderlich). Reine
+        Triage-Hilfe: Nichts davon wird gespeichert, nichts fließt in den
+        Spam-Score ein, und es wird nichts entschieden.
+
+        `history: null` heißt „nicht ermittelbar" (keine Adresse hinterlegt
+        oder Abfrage fehlgeschlagen) und ist nicht dasselbe wie ein Aggregat
+        aus lauter Nullen — die Oberfläche zeigt dafür kein Badge.
+
+        Die Adresse ist nicht verifiziert; die Zahlen sind eine Beobachtung
+        über eine Adresse, kein Urteil über eine Person
+        (`docs/SPAM_DETECTION.md`).
+      security:
+        - adminAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID der Sichtung
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Historie ermittelt
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReporterHistoryResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/LoginRedirect'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/sightings/{id}/queue:
     get:
       tags:
@@ -2761,6 +2807,39 @@ components:
             oder ein Element anderen Typs fällt weg). Der Score bleibt davon
             unberührt gültig — er steht in einer eigenen Spalte.
           example: ['Formular verdächtig schnell abgeschickt']
+    ReporterHistoryResponse:
+      type: object
+      required: [history]
+      properties:
+        history:
+          nullable: true
+          description: >-
+            null heißt "nicht ermittelbar" (keine Adresse, Abfrage
+            fehlgeschlagen) und ist nicht dasselbe wie ein Aggregat aus Nullen.
+          allOf:
+            - $ref: '#/components/schemas/ReporterHistory'
+    ReporterHistory:
+      type: object
+      required: [approved, rejected, open, since]
+      properties:
+        approved:
+          type: integer
+          minimum: 0
+          description: Andere Meldungen dieser Adresse, die freigegeben wurden.
+        rejected:
+          type: integer
+          minimum: 0
+          description: Andere Meldungen dieser Adresse, die abgelehnt wurden.
+        open:
+          type: integer
+          minimum: 0
+          description: Andere Meldungen dieser Adresse, die noch offen sind.
+        since:
+          type: string
+          nullable: true
+          format: date-time
+          description: >-
+            Früheste Meldung dieser Adresse in UTC, inklusive der aktuellen.
     SpamCheckResult:
       type: object
       required: [score, isHighRisk, indicators]


### PR DESCRIPTION
## Was das macht

Der Eingang und die Sichtungs-Detailansicht zeigen zu jeder Meldung, was über den **Melder** (E-Mail-Adresse) bereits bekannt ist: wie viele seiner **anderen** Meldungen freigegeben, abgelehnt oder noch offen sind.

| Stufe | Bedingung | Badge |
| --- | --- | --- |
| Erstmeldung | keine weitere Meldung | `badge-ghost` |
| Melder: n offen | nur unbearbeitete Vorgeschichte | `badge-ghost` |
| Melder: n freigegeben | 1–2 / 3–9 / ab 10 Freigaben | `badge-ghost` |
| Melder: n von m abgelehnt | ab ⅓ der **bearbeiteten** Meldungen | `badge-warning` |

Die Detailansicht ergänzt „Melder seit MM/JJJJ" und einen Link auf alle Meldungen dieser Adresse.

## Warum das trägt

Gemessen auf der lokalen Entwicklungs-DB (2026-08-10, 659 offene Meldungen):

| Gruppe | n | Ø Spam-Score | Hochrisiko |
| --- | --: | --: | --: |
| Melder mit 10+ Freigaben | 177 | 0,23 | **0** |
| Melder mit 1–9 Freigaben | 140 | 0,19 | **0** |
| ohne Vorgeschichte | 342 | **0,66** | **14** |

48 % der offenen Meldungen kommen von Meldern mit Vorgeschichte, und keine davon ist hochriskant. Alle 14 Hochrisiko-Fälle sitzen bei Adressen ohne Vorgeschichte.

## Warum es *nicht* Teil des Spam-Scores ist

Die zentrale Entwurfsentscheidung, festgehalten in `docs/SPAM_DETECTION.md`:

- Der Spam-Score wird **beim Eingang persistiert** und ist eine Momentaufnahme. Reputation ändert sich rückwirkend — ein gespeicherter Anteil wäre ab der nächsten Freigabe falsch.
- Ein zeitabhängiger Term machte den `stored`/`recomputed`-Vergleich unerklärbar, dessen Differenz heute vollständig auf die vier Meldezeitpunkt-Indikatoren zurückführbar ist.
- Die E-Mail ist **nicht verifiziert**. Ein Bonus, der den Score senkt, ließe sich durch Eintragen einer bekannten fremden Adresse abholen. Als danebenstehende Zahl ist dieselbe Angabe harmlos — es entscheidet ein Mensch.

**„Offen" zählt nie negativ.** Die Ablehnung existiert erst seit 2026-08 (5 abgelehnte gegen 19.289 freigegebene Zeilen); vorher blieb Spam unbearbeitet liegen. Eine offene Altmeldung ist Bearbeitungsstau, kein Qualitätsurteil.

## Umfang

- **Keine Migration, keine Spalte, kein Backfill.** Live berechnet, ein Query für alle 50 Eingangskarten (22 ms auf ~20.000 Zeilen, Seq Scan).
- **Nur Anzeige.** Kein Auto-Approve, kein Filter, keine geänderte Sortierung; die öffentliche Grundmenge (`freigegeben_am IS NOT NULL`) bleibt unberührt. Der Eingang bleibt eine Task-Liste.
- **Das Freigabe-Prädikat wird interpoliert, nicht nachgebaut** (`approvedOnly()`/`rejectedOnly()`/`openOnly()`) — deshalb steht die Tabelle ohne Alias im FROM, und die eigene Zeile wird in TypeScript abgezogen statt in SQL ausgeschlossen.
- Neuer Admin-Endpunkt `GET /api/sightings/{id}/reporter-history`, in `static/openapi.yml` dokumentiert.

## Drei Zustände, die nirgends ineinanderlaufen dürfen

`null` (nicht ermittelt) — Nullaggregat (keine Vorgeschichte) — echte Zahlen. Das erste bekommt kein Badge, das zweite „Erstmeldung". Eine Antwort, die den Vertrag bricht, zählt als Fehlschlag und nicht als Altbestand; die Gestaltprüfung in `admin/[id]/+page.ts` deckt alle vier Felder ab.

**Bewusste Grenze:** Scheitert die Aggregat-Abfrage selbst, kommt sie fail-open als `history: null` zurück und ist von „keine Adresse hinterlegt" nicht zu unterscheiden. In beiden Fällen ist „kein Badge" die richtige Anzeige; der eigene Fehlertext der Detailansicht deckt die Transportebene ab. In `.claude/rules/admin.md` so festgehalten.

## Tests

`npm run test:quick` grün: E2E-Shard-Abgleich, ESLint, TypeScript, svelte-check, 4.540 Server-Tests, 752 Komponenten-Tests. Keine neue E2E-Spec (begründet im Plan).

Die Schwellen 3 / 10 / ⅓ sind als Literale festgenagelt, nicht nur relativ getestet — mit Gegenprobe: `REPORTER_FLAGGED_RATIO = 1/4` macht genau die zwei zuständigen Tests rot.

## Noch offen

**Visuell geprüft ist nichts** — die Chrome-Erweiterung war in der Session nicht verbunden. Eingang und Detailansicht gehören vor dem Merge einmal angesehen.

**Beobachtungspunkt:** „Erstmeldung" trifft aktuell 342 von 659 offenen Meldungen (52 %). Ein Badge auf jeder zweiten Karte verliert an Signalwirkung. Es bleibt drin, weil es ein belegter Befund ist und alle Hochrisiko-Fälle dort sitzen — nach ein paar Wochen Nutzung gehört die Frage aber gestellt.

**Vor der Inbetriebnahme zu klären:** ob die Datenschutzerklärung einen Satz zur internen Aggregation braucht. Neu erhoben wird nichts, die Zahlen stehen ausschließlich in admin-geschützten Flächen, und es gibt keine automatisierte Entscheidung — die Einschätzung ist aber keine Entwicklerentscheidung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
