### PR TITLE
feat(admin): melder-historie von neutral bis grün abstufen

### DIFF
--- a/.claude/rules/admin.md
+++ b/.claude/rules/admin.md
@@ -192,9 +192,21 @@ Eingangskarte und Kontakt-Karte der Detailansicht zeigen dasselbe Badge aus
   unterscheiden: kein Badge, kein Fehlertext. Das ist der Preis des Fail-open
   und bewusst so, nicht nachzurüsten ohne die Fail-open-Eigenschaft selbst
   aufzugeben.
-- **Kein `badge-success` und keine Filter/Sortierung im Eingang.** Grün neben
-  dem Freigeben-Knopf läse sich als Urteil über die Meldung, und der Eingang
-  bleibt eine Task-Liste ohne Filter (dafür gibt es `/admin/sichtungen`).
+- **Keine Filter und keine Sortierung im Eingang.** Er bleibt eine Task-Liste;
+  dafür gibt es `/admin/sichtungen`.
+- **`badge-success` ab 10 Freigaben — mit zwei bekannten Einwänden.**
+  Ursprünglich trugen alle Stufen außer der Warnung `badge-ghost`; damit waren
+  `new`, `known` und `established` ununterscheidbar, und die Schwellen 3 und 10
+  änderten nur das Adjektiv im Tooltip. Ein Zwischenschritt mit Tönungen
+  (`bg-primary/10` und `/20`) war im Betrieb **nachweislich nicht zu erkennen**
+  und wurde wieder entfernt. Seit dem 2026-08-10 trägt `established`
+  `badge-success` (Entscheidung Jan). Die zwei Einwände dagegen sind bewusst
+  überstimmt und gehören trotzdem gekannt: Grün trifft rund die Hälfte der
+  offenen Karten (300 von 659, weil es im Bestand nur 5 Ablehnungen gibt), und
+  dieselbe Farbe ist zugleich der Sichtungsstatus „Freigegeben" — in Tabelle
+  und Detailansicht stehen damit zwei Grüns nebeneinander, die Verschiedenes
+  meinen. Alle sechs Zustände nebeneinander: `/styleguide`, Abschnitt
+  „Melder-Historie (Admin)".
 
 ### Modal und Detailkarte zeigen zwei Befunde, nicht einen
 

--- a/src/app.css
+++ b/src/app.css
@@ -355,6 +355,34 @@ h6 {
 }
 
 /* ===== Component Refinements ===== */
+/* Badge-Soft: dieselbe Korrektur wie bei den Alerts, eine Ebene tiefer.
+   DaisyUI setzt für `.badge-soft` `color: var(--badge-color)` — die Statusfarbe
+   als Text auf einer 8-%-Tönung derselben Farbe. Auf diesem Theme misst
+   `text-success` so 3,81:1 und `text-warning` 2,74:1; WCAG 1.4.3 verlangt
+   4,5:1. Mit `base-content` sind es über 13:1.
+
+   Die Tönung ist zugleich von 8 % auf 18 % angehoben und der Rahmen von 10 %
+   auf 35 %: Bei 8 % war die Abstufung im Betrieb nicht von einem neutralen
+   Badge zu unterscheiden (nachgesehen am 2026-08-10 an der Melder-Historie,
+   davor schon an einer eigenen `bg-primary/10`-Tönung gescheitert). Der Rahmen
+   ist der Teil, der die Fläche überhaupt als eigene Stufe lesbar macht.
+
+   Ungelayert und damit vor DaisyUIs `@layer` — dieselbe Mechanik wie beim
+   Fokus- und Alert-Override (.claude/rules/daisyui.md). */
+.badge-soft {
+	color: var(--color-base-content);
+	background-color: color-mix(
+		in oklab,
+		var(--badge-color, var(--color-base-content)) 18%,
+		var(--color-base-100)
+	);
+	border-color: color-mix(
+		in oklab,
+		var(--badge-color, var(--color-base-content)) 35%,
+		var(--color-base-100)
+	);
+}
+
 /* Alerts: Soft-Style als Default. Begründung und Messwerte in
    .claude/rules/daisyui.md. Textfarbe ist base-content, nicht die
    Statusfarbe — die Bedeutung trägt das Icon. */

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte
@@ -20,7 +20,7 @@
 
 {#if level && presentation && history}
 	<span
-		class="badge badge-sm {presentation.badgeClass} {presentation.accentClass}"
+		class="badge badge-sm {presentation.badgeClass}"
 		data-testid="reporter-badge"
 		title={presentation.description}
 	>

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte
@@ -20,7 +20,7 @@
 
 {#if level && presentation && history}
 	<span
-		class="badge badge-sm {presentation.badgeClass} {presentation.borderClass}"
+		class="badge badge-sm {presentation.badgeClass} {presentation.accentClass}"
 		data-testid="reporter-badge"
 		title={presentation.description}
 	>

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte
@@ -20,7 +20,7 @@
 
 {#if level && presentation && history}
 	<span
-		class="badge badge-sm {presentation.badgeClass}"
+		class="badge badge-sm {presentation.badgeClass} {presentation.borderClass}"
 		data-testid="reporter-badge"
 		title={presentation.description}
 	>

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -90,8 +90,12 @@ describe('ReporterHistoryBadge', () => {
 			return container.querySelector('[data-testid="reporter-badge"]')?.className ?? '';
 		};
 
+		// Vollton bei 30, Soft-Variante bei 5 — beide tragen `badge-success`,
+		// unterschieden werden sie über `badge-soft`.
 		expect(klasse(30)).toContain('badge-success');
-		expect(klasse(5)).toContain('badge-ghost');
-		expect(klasse(5)).not.toContain('badge-success');
+		expect(klasse(30)).not.toContain('badge-soft');
+		expect(klasse(5)).toContain('badge-soft');
+		expect(klasse(1)).toContain('badge-soft');
+		expect(klasse(0)).toContain('badge-neutral');
 	});
 });

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -78,31 +78,20 @@ describe('ReporterHistoryBadge', () => {
 		expect(flaggedIcon?.outerHTML).not.toBe(firstIcon?.outerHTML);
 	});
 
-	/* Text und Icon sind bei 3 und bei 30 Freigaben identisch — ohne die Tönung
-	   wäre die Stufe im DOM nicht vorhanden, und die Schwellen 3/10 blieben eine
-	   reine Tooltip-Angelegenheit. Geprüft wird die gerenderte Klasse, nicht das
-	   Präsentationsobjekt: Die Komponente könnte die Tönung sonst still
-	   fallenlassen. */
-	it('reicht die Stufen-Tönung bis ins Markup durch', async () => {
-		const { container: knownContainer } = render(ReporterHistoryBadge, {
-			history: historie({ approved: 5 })
-		});
-		const known = knownContainer.querySelector('[data-testid="reporter-badge"]');
+	/* Text und Icon sind bei 5 und bei 30 Freigaben identisch — ohne die
+	   Flächenfarbe wäre die Stufe im DOM nicht vorhanden, und die Schwelle 10
+	   bliebe eine reine Tooltip-Angelegenheit. Ein Zwischenschritt mit Tönungen
+	   (`bg-primary/10` und `/20`) war im Betrieb nicht zu erkennen; deshalb
+	   jetzt eine Vollton-Fläche. Geprüft wird die gerenderte Klasse, nicht das
+	   Präsentationsobjekt: Die Komponente könnte sie sonst still fallenlassen. */
+	it('hebt die etablierte Stufe farblich von der bekannten ab', async () => {
+		const klasse = (approved: number) => {
+			const { container } = render(ReporterHistoryBadge, { history: historie({ approved }) });
+			return container.querySelector('[data-testid="reporter-badge"]')?.className ?? '';
+		};
 
-		const { container: establishedContainer } = render(ReporterHistoryBadge, {
-			history: historie({ approved: 30 })
-		});
-		const established = establishedContainer.querySelector('[data-testid="reporter-badge"]');
-
-		const { container: newContainer } = render(ReporterHistoryBadge, {
-			history: historie({ approved: 1 })
-		});
-		const neu = newContainer.querySelector('[data-testid="reporter-badge"]');
-
-		expect(known?.className).toContain('bg-primary/');
-		expect(established?.className).toContain('bg-primary/');
-		expect(known?.className).not.toBe(established?.className);
-		// Die unterste Stufe bleibt ungetönt — sonst gäbe es keinen Ruhezustand.
-		expect(neu?.className).not.toContain('bg-primary/');
+		expect(klasse(30)).toContain('badge-success');
+		expect(klasse(5)).toContain('badge-ghost');
+		expect(klasse(5)).not.toContain('badge-success');
 	});
 });

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -77,4 +77,32 @@ describe('ReporterHistoryBadge', () => {
 		expect(firstIcon).not.toBeNull();
 		expect(flaggedIcon?.outerHTML).not.toBe(firstIcon?.outerHTML);
 	});
+
+	/* Text und Icon sind bei 3 und bei 30 Freigaben identisch — ohne den Rahmen
+	   wäre die Stufe im DOM nicht vorhanden, und die Schwellen 3/10 blieben eine
+	   reine Tooltip-Angelegenheit. Geprüft wird die gerenderte Klasse, nicht das
+	   Präsentationsobjekt: Die Komponente könnte den Rahmen sonst still
+	   fallenlassen. */
+	it('reicht den Stufen-Rahmen bis ins Markup durch', async () => {
+		const { container: knownContainer } = render(ReporterHistoryBadge, {
+			history: historie({ approved: 5 })
+		});
+		const known = knownContainer.querySelector('[data-testid="reporter-badge"]');
+
+		const { container: establishedContainer } = render(ReporterHistoryBadge, {
+			history: historie({ approved: 30 })
+		});
+		const established = establishedContainer.querySelector('[data-testid="reporter-badge"]');
+
+		const { container: newContainer } = render(ReporterHistoryBadge, {
+			history: historie({ approved: 1 })
+		});
+		const neu = newContainer.querySelector('[data-testid="reporter-badge"]');
+
+		expect(known?.className).toContain('border');
+		expect(established?.className).toContain('border');
+		expect(known?.className).not.toBe(established?.className);
+		// Die unterste Stufe bleibt rahmenlos — sonst gäbe es keinen Ruhezustand.
+		expect(neu?.className).not.toContain('border');
+	});
 });

--- a/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
+++ b/src/lib/components/admin/ReporterHistoryBadge.svelte.test.ts
@@ -78,12 +78,12 @@ describe('ReporterHistoryBadge', () => {
 		expect(flaggedIcon?.outerHTML).not.toBe(firstIcon?.outerHTML);
 	});
 
-	/* Text und Icon sind bei 3 und bei 30 Freigaben identisch — ohne den Rahmen
+	/* Text und Icon sind bei 3 und bei 30 Freigaben identisch — ohne die Tönung
 	   wäre die Stufe im DOM nicht vorhanden, und die Schwellen 3/10 blieben eine
 	   reine Tooltip-Angelegenheit. Geprüft wird die gerenderte Klasse, nicht das
-	   Präsentationsobjekt: Die Komponente könnte den Rahmen sonst still
+	   Präsentationsobjekt: Die Komponente könnte die Tönung sonst still
 	   fallenlassen. */
-	it('reicht den Stufen-Rahmen bis ins Markup durch', async () => {
+	it('reicht die Stufen-Tönung bis ins Markup durch', async () => {
 		const { container: knownContainer } = render(ReporterHistoryBadge, {
 			history: historie({ approved: 5 })
 		});
@@ -99,10 +99,10 @@ describe('ReporterHistoryBadge', () => {
 		});
 		const neu = newContainer.querySelector('[data-testid="reporter-badge"]');
 
-		expect(known?.className).toContain('border');
-		expect(established?.className).toContain('border');
+		expect(known?.className).toContain('bg-primary/');
+		expect(established?.className).toContain('bg-primary/');
 		expect(known?.className).not.toBe(established?.className);
-		// Die unterste Stufe bleibt rahmenlos — sonst gäbe es keinen Ruhezustand.
-		expect(neu?.className).not.toContain('border');
+		// Die unterste Stufe bleibt ungetönt — sonst gäbe es keinen Ruhezustand.
+		expect(neu?.className).not.toContain('bg-primary/');
 	});
 });

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -5,6 +5,7 @@
  * und stehen deshalb hier als Test und nicht nur als Konstante: Eine Zahl, die
  * niemand nachrechnet, verschiebt sich beim nächsten Umbau unbemerkt.
  */
+import { readFile } from 'node:fs/promises';
 import { describe, expect, it } from 'vitest';
 import type { ReporterHistory } from '$lib/types/reporterHistory';
 import {
@@ -99,14 +100,34 @@ describe('reporterBadgeText', () => {
 
 describe('REPORTER_LEVEL_PRESENTATION', () => {
 	/* Die Farbwahl ist eine Produktentscheidung (Jan, 2026-08-10) und steht
-	   deshalb als Test da: Grün ab 10 Freigaben, Gelb bei überwiegend
-	   abgelehnten, alles andere neutral. Die drei unteren Stufen teilen sich
-	   bewusst `badge-ghost` — sie unterscheiden sich über die Zahl im Text. */
-	it('vergibt Farbe nur an die etablierte und die Warnstufe', () => {
+	   deshalb als Test da. Die Leiter läuft von „nichts bekannt" zu „bewährt":
+	   dunkelgrau, hellgrau, zweimal blassgrün, grün — plus Gelb als Warnung.
+
+	   `new` und `known` teilen sich bewusst dieselbe Fläche: Drei
+	   unterscheidbare Grüntöne gibt das Theme nicht her, und die Zahl im Text
+	   trennt sie ohnehin („2 freigegeben" gegen „5 freigegeben"). */
+	it('bildet eine Leiter von neutral über blassgrün nach grün', () => {
+		expect(REPORTER_LEVEL_PRESENTATION.first.badgeClass).toBe('badge-neutral');
+		expect(REPORTER_LEVEL_PRESENTATION.pending.badgeClass).toBe('badge-ghost');
+		expect(REPORTER_LEVEL_PRESENTATION.new.badgeClass).toBe('badge-soft badge-success');
+		expect(REPORTER_LEVEL_PRESENTATION.known.badgeClass).toBe('badge-soft badge-success');
 		expect(REPORTER_LEVEL_PRESENTATION.established.badgeClass).toBe('badge-success');
 		expect(REPORTER_LEVEL_PRESENTATION.flagged.badgeClass).toBe('badge-warning');
-		for (const level of ['first', 'pending', 'new', 'known'] as const) {
-			expect(REPORTER_LEVEL_PRESENTATION[level].badgeClass).toBe('badge-ghost');
+	});
+
+	/* `badge-soft` färbt bei DaisyUI den *Text* in der Statusfarbe — auf diesem
+	   Theme 3,81:1 für Grün und damit unter WCAG 1.4.3. Der Override in
+	   `src/app.css` zieht ihn auf `base-content`. Wer die Klasse hier verwendet,
+	   verlässt sich darauf; der Test hält die Abhängigkeit fest, damit ein
+	   entfernter Override nicht nur optisch auffällt. */
+	it('nutzt badge-soft nur zusammen mit dem Kontrast-Override aus app.css', async () => {
+		const appCss = await readFile('src/app.css', 'utf-8');
+		const nutztSoft = Object.values(REPORTER_LEVEL_PRESENTATION).some((p) =>
+			p.badgeClass.includes('badge-soft')
+		);
+
+		if (nutztSoft) {
+			expect(appCss).toMatch(/\.badge-soft\s*\{[^}]*color:\s*var\(--color-base-content\)/);
 		}
 	});
 

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -108,6 +108,29 @@ describe('REPORTER_LEVEL_PRESENTATION', () => {
 		}
 	});
 
+	/* Ohne den Rahmen waren `new`, `known` und `established` ununterscheidbar:
+	   gleiche Fläche, gleiches Icon, gleicher Text („Melder: N freigegeben").
+	   Die Schwellen 3 und 10 änderten damit nur das Adjektiv im Tooltip — ein
+	   Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30. */
+	it('macht die drei Freigabe-Stufen am Rahmen unterscheidbar', () => {
+		const rahmen = (['new', 'known', 'established'] as const).map(
+			(level) => REPORTER_LEVEL_PRESENTATION[level].borderClass
+		);
+
+		expect(new Set(rahmen).size).toBe(3);
+		expect(REPORTER_LEVEL_PRESENTATION.new.borderClass).toBe('');
+	});
+
+	/* Der Rahmen ist Verstärkung, nicht Träger: `flagged` hat die Warnfläche,
+	   ein zusätzlicher Rahmen wäre doppelt. Und keine Stufe darf ihre Fläche
+	   über den Rahmen doch noch einfärben. */
+	it('lässt die Warnstufe ohne Rahmen und hält ihn aus den Flächenklassen heraus', () => {
+		expect(REPORTER_LEVEL_PRESENTATION.flagged.borderClass).toBe('');
+		for (const presentation of Object.values(REPORTER_LEVEL_PRESENTATION)) {
+			expect(presentation.borderClass).not.toMatch(/\bbg-|\bbadge-/);
+		}
+	});
+
 	it('gibt jeder Stufe ein Icon — Farbe trägt die Bedeutung nicht allein', () => {
 		for (const presentation of Object.values(REPORTER_LEVEL_PRESENTATION)) {
 			expect(presentation.icon).toMatch(/^lucide:/);

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -98,45 +98,15 @@ describe('reporterBadgeText', () => {
 });
 
 describe('REPORTER_LEVEL_PRESENTATION', () => {
-	/* `badge-success` wäre neben dem Freigeben-Knopf eine Aussage über die
-	   Meldung, nicht über den Melder — dieselbe Begründung wie bei der Stufe
-	   `clean` in `spamScorePresentation.ts`. */
-	it('reserviert Farbe für die Warnstufe und lässt den Rest neutral', () => {
+	/* Die Farbwahl ist eine Produktentscheidung (Jan, 2026-08-10) und steht
+	   deshalb als Test da: Grün ab 10 Freigaben, Gelb bei überwiegend
+	   abgelehnten, alles andere neutral. Die drei unteren Stufen teilen sich
+	   bewusst `badge-ghost` — sie unterscheiden sich über die Zahl im Text. */
+	it('vergibt Farbe nur an die etablierte und die Warnstufe', () => {
+		expect(REPORTER_LEVEL_PRESENTATION.established.badgeClass).toBe('badge-success');
 		expect(REPORTER_LEVEL_PRESENTATION.flagged.badgeClass).toBe('badge-warning');
-		for (const level of ['first', 'pending', 'new', 'known', 'established'] as const) {
+		for (const level of ['first', 'pending', 'new', 'known'] as const) {
 			expect(REPORTER_LEVEL_PRESENTATION[level].badgeClass).toBe('badge-ghost');
-		}
-	});
-
-	/* Ohne die Tönung waren `new`, `known` und `established` ununterscheidbar:
-	   gleiche Fläche, gleiches Icon, gleicher Text („Melder: N freigegeben").
-	   Die Schwellen 3 und 10 änderten damit nur das Adjektiv im Tooltip — ein
-	   Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30. */
-	it('macht die drei Freigabe-Stufen an der Fläche unterscheidbar', () => {
-		const flaechen = (['new', 'known', 'established'] as const).map(
-			(level) => REPORTER_LEVEL_PRESENTATION[level].accentClass
-		);
-
-		expect(new Set(flaechen).size).toBe(3);
-		// Die unterste Stufe bleibt ungetönt — sonst gäbe es keinen Ruhezustand.
-		expect(REPORTER_LEVEL_PRESENTATION.new.accentClass).toBe('');
-	});
-
-	/* Die Tönung ist Verstärkung, nicht Träger: `flagged` hat die Warnfläche,
-	   eine zweite Tönung wäre doppelt.
-
-	   Und sie bleibt bei der Markenfarbe. Ein grüner Tint neben dem
-	   Freigeben-Knopf wäre ein Urteil über die *Meldung* („kann durch") statt
-	   eine Auszeichnung der *Adresse* — dieselbe Begründung, aus der
-	   `badgeClass` nirgends `badge-success` trägt. Der Test nennt die
-	   Statusfarben einzeln, damit auch `warning`/`error`/`info` nicht auf diesem
-	   Weg hereinkommen. */
-	it('lässt die Warnstufe ungetönt und hält Statusfarben aus der Tönung heraus', () => {
-		expect(REPORTER_LEVEL_PRESENTATION.flagged.accentClass).toBe('');
-		for (const presentation of Object.values(REPORTER_LEVEL_PRESENTATION)) {
-			expect(presentation.accentClass).not.toMatch(/\b(?:bg|badge)-(?:success|warning|error|info)/);
-			// Eine Vollton-Fläche wäre keine Tönung mehr — Deckkraft ist Pflicht.
-			if (presentation.accentClass) expect(presentation.accentClass).toMatch(/\/\d{1,2}$/);
 		}
 	});
 

--- a/src/lib/components/admin/reporterHistoryPresentation.test.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.test.ts
@@ -108,26 +108,35 @@ describe('REPORTER_LEVEL_PRESENTATION', () => {
 		}
 	});
 
-	/* Ohne den Rahmen waren `new`, `known` und `established` ununterscheidbar:
+	/* Ohne die Tönung waren `new`, `known` und `established` ununterscheidbar:
 	   gleiche Fläche, gleiches Icon, gleicher Text („Melder: N freigegeben").
 	   Die Schwellen 3 und 10 änderten damit nur das Adjektiv im Tooltip — ein
 	   Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30. */
-	it('macht die drei Freigabe-Stufen am Rahmen unterscheidbar', () => {
-		const rahmen = (['new', 'known', 'established'] as const).map(
-			(level) => REPORTER_LEVEL_PRESENTATION[level].borderClass
+	it('macht die drei Freigabe-Stufen an der Fläche unterscheidbar', () => {
+		const flaechen = (['new', 'known', 'established'] as const).map(
+			(level) => REPORTER_LEVEL_PRESENTATION[level].accentClass
 		);
 
-		expect(new Set(rahmen).size).toBe(3);
-		expect(REPORTER_LEVEL_PRESENTATION.new.borderClass).toBe('');
+		expect(new Set(flaechen).size).toBe(3);
+		// Die unterste Stufe bleibt ungetönt — sonst gäbe es keinen Ruhezustand.
+		expect(REPORTER_LEVEL_PRESENTATION.new.accentClass).toBe('');
 	});
 
-	/* Der Rahmen ist Verstärkung, nicht Träger: `flagged` hat die Warnfläche,
-	   ein zusätzlicher Rahmen wäre doppelt. Und keine Stufe darf ihre Fläche
-	   über den Rahmen doch noch einfärben. */
-	it('lässt die Warnstufe ohne Rahmen und hält ihn aus den Flächenklassen heraus', () => {
-		expect(REPORTER_LEVEL_PRESENTATION.flagged.borderClass).toBe('');
+	/* Die Tönung ist Verstärkung, nicht Träger: `flagged` hat die Warnfläche,
+	   eine zweite Tönung wäre doppelt.
+
+	   Und sie bleibt bei der Markenfarbe. Ein grüner Tint neben dem
+	   Freigeben-Knopf wäre ein Urteil über die *Meldung* („kann durch") statt
+	   eine Auszeichnung der *Adresse* — dieselbe Begründung, aus der
+	   `badgeClass` nirgends `badge-success` trägt. Der Test nennt die
+	   Statusfarben einzeln, damit auch `warning`/`error`/`info` nicht auf diesem
+	   Weg hereinkommen. */
+	it('lässt die Warnstufe ungetönt und hält Statusfarben aus der Tönung heraus', () => {
+		expect(REPORTER_LEVEL_PRESENTATION.flagged.accentClass).toBe('');
 		for (const presentation of Object.values(REPORTER_LEVEL_PRESENTATION)) {
-			expect(presentation.borderClass).not.toMatch(/\bbg-|\bbadge-/);
+			expect(presentation.accentClass).not.toMatch(/\b(?:bg|badge)-(?:success|warning|error|info)/);
+			// Eine Vollton-Fläche wäre keine Tönung mehr — Deckkraft ist Pflicht.
+			if (presentation.accentClass) expect(presentation.accentClass).toMatch(/\/\d{1,2}$/);
 		}
 	});
 

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -68,6 +68,27 @@ export function getReporterLevel(
 export interface ReporterLevelPresentation {
 	/** Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
 	badgeClass: string;
+	/**
+	 * Rahmen, der die Stufe sichtbar macht — leer, wo es nichts zu unterscheiden
+	 * gibt.
+	 *
+	 * **Warum es das Feld gibt.** `new`, `known` und `established` trugen
+	 * dieselbe Fläche, dasselbe Icon und denselben Text („Melder: N
+	 * freigegeben"); die Schwellen 3 und 10 änderten damit nur das Adjektiv im
+	 * Tooltip. Ein Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30
+	 * (Entscheidung Jan, 2026-08-10).
+	 *
+	 * **Warum ein Rahmen und keine Fläche.** Eine Vollton- oder Tint-Fläche wäre
+	 * ein Urteil über die Meldung („grün = kann durch"); der Rahmen ist eine
+	 * Auszeichnung der Adresse und drängt sich neben Spam- und Statusbadge nicht
+	 * vor. Er ist zudem **redundant**: Die Zahl im Text trägt die Aussage
+	 * weiterhin allein, der Rahmen verstärkt sie nur (WCAG 1.4.1 — die Bedeutung
+	 * hängt an keiner Stelle allein an ihm).
+	 *
+	 * Deshalb steht hier auch kein Rahmen an `flagged`: Dort trägt die
+	 * Warnfläche, ein zusätzlicher Rahmen wäre doppelt gemoppelt.
+	 */
+	borderClass: string;
 	/** Icon-Name für `$lib/components/Icon.svelte` — die farbunabhängige Unterscheidung. */
 	icon: string;
 	/** Was die Stufe bedeutet — als `title` und für Screenreader. */
@@ -77,26 +98,31 @@ export interface ReporterLevelPresentation {
 export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPresentation> = {
 	first: {
 		badgeClass: 'badge-ghost',
+		borderClass: '',
 		icon: 'lucide:user-plus',
 		description: 'Erste Meldung dieser E-Mail-Adresse — keine Vorgeschichte im Bestand'
 	},
 	pending: {
 		badgeClass: 'badge-ghost',
+		borderClass: '',
 		icon: 'lucide:users',
 		description: 'Weitere Meldungen dieser Adresse sind selbst noch unbearbeitet'
 	},
 	new: {
 		badgeClass: 'badge-ghost',
+		borderClass: '',
 		icon: 'lucide:user-check',
 		description: 'Einzelne frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	known: {
 		badgeClass: 'badge-ghost',
+		borderClass: 'border border-base-content/25',
 		icon: 'lucide:user-check',
 		description: 'Mehrere frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	established: {
 		badgeClass: 'badge-ghost',
+		borderClass: 'border border-primary/45',
 		/* Nicht „langjährig": Die Stufe zählt Freigaben, nicht Dauer — zehn
 		   Meldungen können aus einer Woche stammen. Wie lange die Adresse meldet,
 		   sagt `since` in der Detailansicht, und zwar getrennt davon. */
@@ -105,6 +131,7 @@ export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPre
 	},
 	flagged: {
 		badgeClass: 'badge-warning',
+		borderClass: '',
 		icon: 'lucide:user-x',
 		description: 'Ein erheblicher Teil der bearbeiteten Meldungen dieser Adresse wurde abgelehnt'
 	}

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -97,7 +97,7 @@ export interface ReporterLevelPresentation {
 
 export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPresentation> = {
 	first: {
-		badgeClass: 'badge-ghost',
+		badgeClass: 'badge-neutral',
 		icon: 'lucide:user-plus',
 		description: 'Erste Meldung dieser E-Mail-Adresse — keine Vorgeschichte im Bestand'
 	},
@@ -107,12 +107,12 @@ export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPre
 		description: 'Weitere Meldungen dieser Adresse sind selbst noch unbearbeitet'
 	},
 	new: {
-		badgeClass: 'badge-ghost',
+		badgeClass: 'badge-soft badge-success',
 		icon: 'lucide:user-check',
 		description: 'Einzelne frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	known: {
-		badgeClass: 'badge-ghost',
+		badgeClass: 'badge-soft badge-success',
 		icon: 'lucide:user-check',
 		description: 'Mehrere frühere Meldungen dieser Adresse wurden freigegeben'
 	},

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -69,8 +69,8 @@ export interface ReporterLevelPresentation {
 	/** Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
 	badgeClass: string;
 	/**
-	 * Rahmen, der die Stufe sichtbar macht — leer, wo es nichts zu unterscheiden
-	 * gibt.
+	 * Die Fläche, die die Stufe sichtbar macht — leer, wo es nichts zu
+	 * unterscheiden gibt.
 	 *
 	 * **Warum es das Feld gibt.** `new`, `known` und `established` trugen
 	 * dieselbe Fläche, dasselbe Icon und denselben Text („Melder: N
@@ -78,17 +78,28 @@ export interface ReporterLevelPresentation {
 	 * Tooltip. Ein Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30
 	 * (Entscheidung Jan, 2026-08-10).
 	 *
-	 * **Warum ein Rahmen und keine Fläche.** Eine Vollton- oder Tint-Fläche wäre
-	 * ein Urteil über die Meldung („grün = kann durch"); der Rahmen ist eine
-	 * Auszeichnung der Adresse und drängt sich neben Spam- und Statusbadge nicht
-	 * vor. Er ist zudem **redundant**: Die Zahl im Text trägt die Aussage
-	 * weiterhin allein, der Rahmen verstärkt sie nur (WCAG 1.4.1 — die Bedeutung
-	 * hängt an keiner Stelle allein an ihm).
+	 * **Erst ein Rahmen, dann ein Tint.** Die erste Fassung setzte hier
+	 * `border-base-content/25` bzw. `border-primary/45`. Im Betrieb war davon
+	 * nichts zu erkennen: Ein 1px-Rahmen auf einer `badge-ghost`-Fläche
+	 * verschwindet zwischen den übrigen Badges der Karte. Deshalb jetzt eine
+	 * Tönung — sie belegt dieselbe Fläche wie das Badge selbst und ist damit
+	 * auch beim Überfliegen einer 50-Karten-Liste sichtbar.
 	 *
-	 * Deshalb steht hier auch kein Rahmen an `flagged`: Dort trägt die
-	 * Warnfläche, ein zusätzlicher Rahmen wäre doppelt gemoppelt.
+	 * **Primärfarbe und ausdrücklich nicht `success`.** Ein grüner Tint neben
+	 * dem Freigeben-Knopf wäre ein Urteil über die **Meldung** („kann durch");
+	 * die Markenfarbe zeichnet die **Adresse** aus, ohne etwas zu behaupten.
+	 * Dieselbe Begründung, aus der `badgeClass` nirgends `badge-success` trägt.
+	 *
+	 * **Auf einem Tint gilt `text-base-content`, nie `*-content`**
+	 * (`.claude/rules/design-system.md`). Das Badge erbt seine Textfarbe von
+	 * `badge-ghost` und bekommt hier bewusst keine eigene — ein
+	 * `text-primary-content` (Weiß) auf 10 % Tönung ergäbe rund 1,3:1.
+	 *
+	 * Der Tint bleibt **redundant**: Die Zahl im Text trägt die Aussage
+	 * weiterhin allein (WCAG 1.4.1). Und `flagged` bekommt keinen — dort trägt
+	 * die Warnfläche, eine zweite Tönung wäre doppelt gemoppelt.
 	 */
-	borderClass: string;
+	accentClass: string;
 	/** Icon-Name für `$lib/components/Icon.svelte` — die farbunabhängige Unterscheidung. */
 	icon: string;
 	/** Was die Stufe bedeutet — als `title` und für Screenreader. */
@@ -98,31 +109,31 @@ export interface ReporterLevelPresentation {
 export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPresentation> = {
 	first: {
 		badgeClass: 'badge-ghost',
-		borderClass: '',
+		accentClass: '',
 		icon: 'lucide:user-plus',
 		description: 'Erste Meldung dieser E-Mail-Adresse — keine Vorgeschichte im Bestand'
 	},
 	pending: {
 		badgeClass: 'badge-ghost',
-		borderClass: '',
+		accentClass: '',
 		icon: 'lucide:users',
 		description: 'Weitere Meldungen dieser Adresse sind selbst noch unbearbeitet'
 	},
 	new: {
 		badgeClass: 'badge-ghost',
-		borderClass: '',
+		accentClass: '',
 		icon: 'lucide:user-check',
 		description: 'Einzelne frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	known: {
 		badgeClass: 'badge-ghost',
-		borderClass: 'border border-base-content/25',
+		accentClass: 'bg-primary/10',
 		icon: 'lucide:user-check',
 		description: 'Mehrere frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	established: {
 		badgeClass: 'badge-ghost',
-		borderClass: 'border border-primary/45',
+		accentClass: 'bg-primary/20',
 		/* Nicht „langjährig": Die Stufe zählt Freigaben, nicht Dauer — zehn
 		   Meldungen können aus einer Woche stammen. Wie lange die Adresse meldet,
 		   sagt `since` in der Detailansicht, und zwar getrennt davon. */
@@ -131,7 +142,7 @@ export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPre
 	},
 	flagged: {
 		badgeClass: 'badge-warning',
-		borderClass: '',
+		accentClass: '',
 		icon: 'lucide:user-x',
 		description: 'Ein erheblicher Teil der bearbeiteten Meldungen dieser Adresse wurde abgelehnt'
 	}

--- a/src/lib/components/admin/reporterHistoryPresentation.ts
+++ b/src/lib/components/admin/reporterHistoryPresentation.ts
@@ -66,40 +66,29 @@ export function getReporterLevel(
 }
 
 export interface ReporterLevelPresentation {
-	/** Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`). */
-	badgeClass: string;
 	/**
-	 * Die Fläche, die die Stufe sichtbar macht — leer, wo es nichts zu
-	 * unterscheiden gibt.
+	 * Flächenfarbe — ohne `-strong`-Suffix (`.claude/rules/design-system.md`).
 	 *
-	 * **Warum es das Feld gibt.** `new`, `known` und `established` trugen
-	 * dieselbe Fläche, dasselbe Icon und denselben Text („Melder: N
-	 * freigegeben"); die Schwellen 3 und 10 änderten damit nur das Adjektiv im
-	 * Tooltip. Ein Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30
-	 * (Entscheidung Jan, 2026-08-10).
+	 * **`established` trägt seit dem 2026-08-10 `badge-success`** (Entscheidung
+	 * Jan). Davor waren `new`, `known` und `established` alle `badge-ghost` und
+	 * damit ununterscheidbar; ein Zwischenschritt mit Tönungen
+	 * (`bg-primary/10` und `/20`) war im Betrieb nachweislich nicht zu erkennen
+	 * und wurde wieder entfernt — was unsichtbar ist, gehört nicht in den Code.
 	 *
-	 * **Erst ein Rahmen, dann ein Tint.** Die erste Fassung setzte hier
-	 * `border-base-content/25` bzw. `border-primary/45`. Im Betrieb war davon
-	 * nichts zu erkennen: Ein 1px-Rahmen auf einer `badge-ghost`-Fläche
-	 * verschwindet zwischen den übrigen Badges der Karte. Deshalb jetzt eine
-	 * Tönung — sie belegt dieselbe Fläche wie das Badge selbst und ist damit
-	 * auch beim Überfliegen einer 50-Karten-Liste sichtbar.
+	 * Zwei Einwände standen dagegen und sind bewusst überstimmt worden:
+	 * Grün trifft rund die Hälfte der offenen Karten (300 von 659 am
+	 * 2026-08-10, weil es im Bestand nur 5 Ablehnungen gibt), und
+	 * `badge-success` ist zugleich der Sichtungsstatus „Freigegeben"
+	 * (`sightingStatus.ts`) — in Tabelle und Detailansicht stehen damit zwei
+	 * Grüns nebeneinander, die Verschiedenes meinen. Wer das zurückdreht,
+	 * sollte diese zwei Punkte kennen und nicht neu entdecken.
 	 *
-	 * **Primärfarbe und ausdrücklich nicht `success`.** Ein grüner Tint neben
-	 * dem Freigeben-Knopf wäre ein Urteil über die **Meldung** („kann durch");
-	 * die Markenfarbe zeichnet die **Adresse** aus, ohne etwas zu behaupten.
-	 * Dieselbe Begründung, aus der `badgeClass` nirgends `badge-success` trägt.
-	 *
-	 * **Auf einem Tint gilt `text-base-content`, nie `*-content`**
-	 * (`.claude/rules/design-system.md`). Das Badge erbt seine Textfarbe von
-	 * `badge-ghost` und bekommt hier bewusst keine eigene — ein
-	 * `text-primary-content` (Weiß) auf 10 % Tönung ergäbe rund 1,3:1.
-	 *
-	 * Der Tint bleibt **redundant**: Die Zahl im Text trägt die Aussage
-	 * weiterhin allein (WCAG 1.4.1). Und `flagged` bekommt keinen — dort trägt
-	 * die Warnfläche, eine zweite Tönung wäre doppelt gemoppelt.
+	 * Kontrast ist **kein** Einwand: `--color-success` mit weißem Text misst
+	 * 4,56:1 (`daisyui.md`). Die dortige Warnung gilt weiter — die Lightness
+	 * dieser Fläche darf nicht erhöht werden, sonst fällt jedes
+	 * `badge-success` im Projekt unter AA.
 	 */
-	accentClass: string;
+	badgeClass: string;
 	/** Icon-Name für `$lib/components/Icon.svelte` — die farbunabhängige Unterscheidung. */
 	icon: string;
 	/** Was die Stufe bedeutet — als `title` und für Screenreader. */
@@ -109,31 +98,26 @@ export interface ReporterLevelPresentation {
 export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPresentation> = {
 	first: {
 		badgeClass: 'badge-ghost',
-		accentClass: '',
 		icon: 'lucide:user-plus',
 		description: 'Erste Meldung dieser E-Mail-Adresse — keine Vorgeschichte im Bestand'
 	},
 	pending: {
 		badgeClass: 'badge-ghost',
-		accentClass: '',
 		icon: 'lucide:users',
 		description: 'Weitere Meldungen dieser Adresse sind selbst noch unbearbeitet'
 	},
 	new: {
 		badgeClass: 'badge-ghost',
-		accentClass: '',
 		icon: 'lucide:user-check',
 		description: 'Einzelne frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	known: {
 		badgeClass: 'badge-ghost',
-		accentClass: 'bg-primary/10',
 		icon: 'lucide:user-check',
 		description: 'Mehrere frühere Meldungen dieser Adresse wurden freigegeben'
 	},
 	established: {
-		badgeClass: 'badge-ghost',
-		accentClass: 'bg-primary/20',
+		badgeClass: 'badge-success',
 		/* Nicht „langjährig": Die Stufe zählt Freigaben, nicht Dauer — zehn
 		   Meldungen können aus einer Woche stammen. Wie lange die Adresse meldet,
 		   sagt `since` in der Detailansicht, und zwar getrennt davon. */
@@ -142,7 +126,6 @@ export const REPORTER_LEVEL_PRESENTATION: Record<ReporterLevel, ReporterLevelPre
 	},
 	flagged: {
 		badgeClass: 'badge-warning',
-		accentClass: '',
 		icon: 'lucide:user-x',
 		description: 'Ein erheblicher Teil der bearbeiteten Meldungen dieser Adresse wurde abgelehnt'
 	}

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -26,6 +26,9 @@
 -->
 <script lang="ts">
 	import ConnectionBadge from '$lib/components/ConnectionBadge.svelte';
+	import ReporterHistoryBadge from '$lib/components/admin/ReporterHistoryBadge.svelte';
+	import { SIGHTING_STATUS_PRESENTATION } from '$lib/components/admin/sightingStatus';
+	import { SPAM_RISK_PRESENTATION } from '$lib/components/admin/spamScorePresentation';
 	import Icon from '$lib/components/Icon.svelte';
 	import StatusBlock from '$lib/components/StatusBlock.svelte';
 	import SubmitStatus from '$lib/report/components/form/SubmitStatus.svelte';
@@ -130,6 +133,44 @@
 			delete root.dataset.density;
 		};
 	});
+
+	/**
+	 * Die sechs Zustände der Melder-Historie, mit den Zahlen, die sie auslösen.
+	 * Bewusst echte `ReporterHistory`-Objekte durch die echte Komponente — eine
+	 * nachgebaute Badge-Zeile wäre eine zweite Quelle und würde altern.
+	 */
+	const reporterBeispiele = [
+		{
+			stufe: 'first',
+			bedingung: 'keine weitere Meldung dieser Adresse',
+			history: { approved: 0, rejected: 0, open: 0, since: null }
+		},
+		{
+			stufe: 'pending',
+			bedingung: 'weitere Meldungen vorhanden, alle noch unbearbeitet',
+			history: { approved: 0, rejected: 0, open: 4, since: null }
+		},
+		{
+			stufe: 'new',
+			bedingung: '1–2 Freigaben',
+			history: { approved: 2, rejected: 0, open: 0, since: null }
+		},
+		{
+			stufe: 'known',
+			bedingung: 'ab 3 Freigaben',
+			history: { approved: 5, rejected: 0, open: 0, since: null }
+		},
+		{
+			stufe: 'established',
+			bedingung: 'ab 10 Freigaben',
+			history: { approved: 23, rejected: 0, open: 0, since: null }
+		},
+		{
+			stufe: 'flagged',
+			bedingung: 'ab ⅓ Ablehnungen unter den bearbeiteten Meldungen',
+			history: { approved: 2, rejected: 2, open: 0, since: null }
+		}
+	];
 </script>
 
 <svelte:head>
@@ -597,6 +638,56 @@
 			<span class="badge badge-warning">Außerhalb</span>
 			<span class="badge badge-info">aus Cache</span>
 			<span class="badge badge-secondary">Kamera</span>
+		</div>
+	</section>
+
+	<!-- ══ Melder-Historie ══ -->
+	<section class="mb-10">
+		<h2 class="text-title mb-1 font-bold">Melder-Historie (Admin)</h2>
+		<p class="text-support text-base-content/70 mb-4">
+			Sechs Zustände, abgeleitet aus den Meldungen derselben E-Mail-Adresse (<code
+				>reporterHistoryPresentation.ts</code
+			>). Die Zahl im Text trägt die Aussage, Tönung und Icon verstärken sie nur — die Bedeutung
+			hängt an keiner Stelle allein an der Farbe.
+		</p>
+		<div class="overflow-x-auto">
+			<table class="table-zebra table-sm table w-full">
+				<thead>
+					<tr>
+						<th>Badge</th>
+						<th>Stufe</th>
+						<th>Bedingung</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each reporterBeispiele as fall (fall.stufe)}
+						<tr>
+							<td><ReporterHistoryBadge history={fall.history} /></td>
+							<td><code>{fall.stufe}</code></td>
+							<td class="text-support text-base-content/70">{fall.bedingung}</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<h3 class="text-section mt-6 mb-1 font-semibold">Was auf derselben Karte noch grün ist</h3>
+		<p class="text-support text-base-content/70 mb-3">
+			Der Grund, warum die Melder-Historie kein <code>badge-success</code> trägt: Grün ist auf
+			derselben Fläche bereits der <em>Sichtungs</em>status. Zwei Grüns nebeneinander meinten
+			Verschiedenes.
+		</p>
+		<div class="flex flex-wrap items-center gap-2">
+			<span class="badge badge-sm {SIGHTING_STATUS_PRESENTATION.approved.badgeClass}">
+				{SIGHTING_STATUS_PRESENTATION.approved.label}
+			</span>
+			<span class="badge badge-sm {SIGHTING_STATUS_PRESENTATION.rejected.badgeClass}">
+				{SIGHTING_STATUS_PRESENTATION.rejected.label}
+			</span>
+			<span class="badge badge-sm {SPAM_RISK_PRESENTATION.suspicious.badgeClass}">Spam: 3</span>
+			<span class="badge badge-sm {SPAM_RISK_PRESENTATION.high.badgeClass}">Spam: 7</span>
+			<span class="badge badge-sm badge-info">Ostsee</span>
+			<ReporterHistoryBadge history={{ approved: 23, rejected: 0, open: 1, since: null }} />
 		</div>
 	</section>
 

--- a/src/routes/styleguide/+page.svelte
+++ b/src/routes/styleguide/+page.svelte
@@ -671,11 +671,12 @@
 			</table>
 		</div>
 
-		<h3 class="text-section mt-6 mb-1 font-semibold">Was auf derselben Karte noch grün ist</h3>
+		<h3 class="text-section mt-6 mb-1 font-semibold">Was auf derselben Karte noch farbig ist</h3>
 		<p class="text-support text-base-content/70 mb-3">
-			Der Grund, warum die Melder-Historie kein <code>badge-success</code> trägt: Grün ist auf
-			derselben Fläche bereits der <em>Sichtungs</em>status. Zwei Grüns nebeneinander meinten
-			Verschiedenes.
+			Die Reihe zeigt den bekannten Einwand gegen das Grün: Dieselbe Farbe trägt auch der
+			<em>Sichtungs</em>status „Freigegeben". In Tabelle und Detailansicht stehen damit zwei Grüns
+			nebeneinander, die Verschiedenes meinen — bewusst in Kauf genommen, weil ohne Vollton-Fläche
+			keine der Freigabe-Stufen erkennbar war.
 		</p>
 		<div class="flex flex-wrap items-center gap-2">
 			<span class="badge badge-sm {SIGHTING_STATUS_PRESENTATION.approved.badgeClass}">


### PR DESCRIPTION
Nachtrag zu #852.

## Das Problem

Die Stufen `new` (1–2 Freigaben), `known` (ab 3) und `established` (ab 10) waren im DOM **nicht unterscheidbar**: dieselbe Fläche (`badge-ghost`), dasselbe Icon, derselbe Text („Melder: N freigegeben"). Die Schwellen änderten nur das Adjektiv im Tooltip — ein Bearbeiter sah bei 3 Freigaben dasselbe Badge wie bei 30.

## Die Leiter

| Stufe | Fläche |
| --- | --- |
| `first` — Erstmeldung | `badge-neutral` (dunkelgrau, Vollton) |
| `pending` — nur unbearbeitete Vorgeschichte | `badge-ghost` (hellgrau) |
| `new` (1–2) und `known` (ab 3) | `badge-soft badge-success` (blassgrün) |
| `established` (ab 10) | `badge-success` (grün) |
| `flagged` (ab ⅓ Ablehnungen) | `badge-warning` |

`new` und `known` teilen sich bewusst eine Fläche: Drei unterscheidbare Grüntöne gibt das Theme nicht her, und die Zahl im Text trennt sie ohnehin.

## Zwei verworfene Zwischenschritte

**Ein Rahmen** (`border-base-content/25`, `border-primary/45`) war im Betrieb nicht zu erkennen. **Eine Tönung** (`bg-primary/10` und `/20`) ebenfalls nicht — am Screenshot nachgesehen, die Stufen lagen optisch aufeinander. Beides wieder entfernt: Was unsichtbar ist, gehört nicht in den Code.

## Der Fund, der das fast still kaputtgemacht hätte

DaisyUIs `.badge-soft` setzt `color: var(--badge-color)` — **die Statusfarbe als Text** auf einer 8-%-Tönung derselben Farbe. Auf diesem Theme misst `text-success` so **3,81:1**; WCAG 1.4.3 verlangt 4,5:1. Es ist derselbe Fehler, den das Projekt für `alert-soft` bereits gemessen und in `app.css` behoben hat.

Der Override ist deshalb eine Ebene tiefer nachgezogen: Text auf `base-content` (über 13:1). Im selben Zug die Tönung von 8 % auf **18 %** und der Rahmen von 10 % auf **35 %** — bei 8 % wäre das Blassgrün vom neutralen Badge nicht zu unterscheiden gewesen, und der Rahmen ist der Teil, der die Fläche als eigene Stufe lesbar macht.

Ein Test hält die Abhängigkeit fest: Wer `badge-soft` verwendet, verlässt sich auf den Override. Verschwindet er aus `app.css`, wird der Test rot — statt dass nur der Kontrast schlecht wird.

## Zwei Einwände gegen Grün, bewusst überstimmt

Sie stehen im Code und in `.claude/rules/admin.md`, damit der nächste Leser sie kennt statt sie neu zu entdecken:

1. **Grün trifft rund die Hälfte der offenen Karten.** 300 von 659 stammen von Meldern, deren bearbeitete Meldungen alle freigegeben wurden — im ganzen Bestand gibt es nur 5 Ablehnungen.
2. **`badge-success` ist zugleich der Sichtungsstatus „Freigegeben"** (`sightingStatus.ts`).

In Kauf genommen, weil ohne Vollton-Fläche keine der Freigabe-Stufen erkennbar war. Eine unsichtbare Unterscheidung ist schlechter als eine doppeldeutige Farbe.

**Kein Blau für die Erstmeldung**, obwohl naheliegend: Auf der Eingangskarte steht direkt daneben das Ostsee-Badge in `badge-info`. `badge-neutral` setzt sie ab, ohne einen Farbton zu belegen.

## Alle Zustände auf einen Blick

Neuer Abschnitt **„Melder-Historie (Admin)"** auf `/styleguide`: alle sechs Zustände, gerendert durch die echte Komponente mit echten `ReporterHistory`-Objekten. Darunter eine Reihe mit Status-, Spam- und Ostsee-Badge, die den Farbkonflikt sichtbar macht.

`npm run test:quick` grün: 4.544 Server-Tests, 760 Komponenten-Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
