### PR TITLE
fix(build): dev-server ignoriert im worktree nicht mehr sich selbst

### DIFF
--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -9,7 +9,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
 	CI_DEV_HOST,
 	DEV_IDENTITY_PATH,
+	WORKTREE_WATCH_GLOBS,
 	assertServerIdentity,
+	worktreeWatchIgnore,
 	ciDevPort,
 	createNodeIdentityFetch,
 	describePortOwner,
@@ -563,5 +565,37 @@ describe('devServerIdentity plugin', () => {
 
 		expect(next).toHaveBeenCalled();
 		expect(res.end).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * Der Watcher darf sich nicht selbst aussperren.
+ *
+ * Vorgeschichte: `vite.config.ts` hielt die Worktrees pauschal aus dem Watcher
+ * heraus. Weil Chokidar gegen den absoluten Pfad vergleicht, traf das Muster im
+ * Worktree jede eigene Quelldatei — HMR war dort tot, ohne Fehler und ohne
+ * Meldung. Der Fall lässt sich nur an der Pfadform prüfen; ein laufender Server
+ * würde ihn nicht melden, er täte einfach nichts.
+ */
+describe('worktreeWatchIgnore', () => {
+	it('hält die Worktrees heraus, solange der Server im Haupt-Repo läuft', () => {
+		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung')).toEqual([
+			...WORKTREE_WATCH_GLOBS
+		]);
+	});
+
+	it('ignoriert nichts, wenn der Server selbst in einem Worktree läuft', () => {
+		expect(
+			worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.claude/worktrees/feature-x')
+		).toEqual([]);
+		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.worktrees/feature-y')).toEqual([]);
+	});
+
+	/* Der Verzeichnisname allein genügt nicht: Ein Projekt, das zufällig
+	   „worktrees" heißt, ist kein Worktree. Geprüft wird der Pfadabschnitt. */
+	it('lässt sich von einem ähnlich benannten Verzeichnis nicht täuschen', () => {
+		expect(worktreeWatchIgnore('/Users/jan/Code/meine-worktrees-doku')).toEqual([
+			...WORKTREE_WATCH_GLOBS
+		]);
 	});
 });

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -46,6 +46,9 @@ function selfSignedCert(): { cert: Buffer; key: Buffer } | null {
 const MAIN_REPO = '/Users/dev/Code/ostsee-sichtung';
 const WORKTREE_A = '/Users/dev/Code/ostsee-sichtung/.claude/worktrees/hopeful-curie-90f94e';
 const WORKTREE_B = '/Users/dev/Code/ostsee-sichtung/.claude/worktrees/auth0-prod-settings-499d2e';
+/* Die zweite unterstützte Worktree-Lage, ohne `.claude`. Sie hat keinen der
+   Ports-Tests nötig, wird aber von `worktreeWatchIgnore` getrennt behandelt. */
+const WORKTREE_PLAIN = '/Users/dev/Code/ostsee-sichtung/.worktrees/feature-y';
 
 describe('worktreeDevPort', () => {
 	it('liefert für dasselbe Verzeichnis immer denselben Port', () => {
@@ -579,9 +582,7 @@ describe('devServerIdentity plugin', () => {
  */
 describe('worktreeWatchIgnore', () => {
 	it('hält die Worktrees heraus, solange der Server im Haupt-Repo läuft', () => {
-		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung')).toEqual([
-			...WORKTREE_WATCH_GLOBS
-		]);
+		expect(worktreeWatchIgnore(MAIN_REPO)).toEqual([...WORKTREE_WATCH_GLOBS]);
 	});
 
 	/* Aussortiert wird nur das Muster, das den eigenen Standort trifft — nicht
@@ -589,12 +590,8 @@ describe('worktreeWatchIgnore', () => {
 	   `.worktrees/` daneben weiterhin heraus; ein pauschales Leerräumen nähme
 	   mehr weg als nötig. */
 	it('nimmt im Worktree nur das Muster heraus, das den eigenen Pfad trifft', () => {
-		expect(
-			worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.claude/worktrees/feature-x')
-		).toEqual(['**/.worktrees/**']);
-		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.worktrees/feature-y')).toEqual([
-			'**/.claude/worktrees/**'
-		]);
+		expect(worktreeWatchIgnore(WORKTREE_A)).toEqual(['**/.worktrees/**']);
+		expect(worktreeWatchIgnore(WORKTREE_PLAIN)).toEqual(['**/.claude/worktrees/**']);
 	});
 
 	/* Die beiden Pfadstücke dürfen sich nicht überschneiden, sonst räumte der
@@ -602,15 +599,13 @@ describe('worktreeWatchIgnore', () => {
 	   `worktrees/`, aber nicht `/.worktrees/` — der Punkt sitzt direkt hinter
 	   dem Schrägstrich. */
 	it('verwechselt die beiden Worktree-Orte nicht', () => {
-		expect(worktreeWatchIgnore('/repo/.claude/worktrees/x')).toContain('**/.worktrees/**');
-		expect(worktreeWatchIgnore('/repo/.worktrees/y')).toContain('**/.claude/worktrees/**');
+		expect(worktreeWatchIgnore(WORKTREE_B)).toContain('**/.worktrees/**');
+		expect(worktreeWatchIgnore(WORKTREE_PLAIN)).toContain('**/.claude/worktrees/**');
 	});
 
 	/* Der Verzeichnisname allein genügt nicht: Ein Projekt, das zufällig
 	   „worktrees" heißt, ist kein Worktree. Geprüft wird der Pfadabschnitt. */
 	it('lässt sich von einem ähnlich benannten Verzeichnis nicht täuschen', () => {
-		expect(worktreeWatchIgnore('/Users/jan/Code/meine-worktrees-doku')).toEqual([
-			...WORKTREE_WATCH_GLOBS
-		]);
+		expect(worktreeWatchIgnore(`${MAIN_REPO}-worktrees-doku`)).toEqual([...WORKTREE_WATCH_GLOBS]);
 	});
 });

--- a/src/tools/dev-server-identity.test.ts
+++ b/src/tools/dev-server-identity.test.ts
@@ -584,11 +584,26 @@ describe('worktreeWatchIgnore', () => {
 		]);
 	});
 
-	it('ignoriert nichts, wenn der Server selbst in einem Worktree läuft', () => {
+	/* Aussortiert wird nur das Muster, das den eigenen Standort trifft — nicht
+	   pauschal alles. Wer in `.claude/worktrees/x` arbeitet, hält ein
+	   `.worktrees/` daneben weiterhin heraus; ein pauschales Leerräumen nähme
+	   mehr weg als nötig. */
+	it('nimmt im Worktree nur das Muster heraus, das den eigenen Pfad trifft', () => {
 		expect(
 			worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.claude/worktrees/feature-x')
-		).toEqual([]);
-		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.worktrees/feature-y')).toEqual([]);
+		).toEqual(['**/.worktrees/**']);
+		expect(worktreeWatchIgnore('/Users/jan/Code/ostsee-sichtung/.worktrees/feature-y')).toEqual([
+			'**/.claude/worktrees/**'
+		]);
+	});
+
+	/* Die beiden Pfadstücke dürfen sich nicht überschneiden, sonst räumte der
+	   eine Standort das Muster des anderen mit ab: `/.claude/worktrees/` enthält
+	   `worktrees/`, aber nicht `/.worktrees/` — der Punkt sitzt direkt hinter
+	   dem Schrägstrich. */
+	it('verwechselt die beiden Worktree-Orte nicht', () => {
+		expect(worktreeWatchIgnore('/repo/.claude/worktrees/x')).toContain('**/.worktrees/**');
+		expect(worktreeWatchIgnore('/repo/.worktrees/y')).toContain('**/.claude/worktrees/**');
 	});
 
 	/* Der Verzeichnisname allein genügt nicht: Ein Projekt, das zufällig

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -406,3 +406,35 @@ export async function assertServerIdentity({
 		].join('\n')
 	);
 }
+
+/**
+ * Glob-Muster, mit denen der Datei-Watcher die Worktrees heraushält.
+ *
+ * Worktrees liegen unter `.claude/worktrees/` **innerhalb** des Repo-Roots.
+ * Ohne diese Muster beobachtete ein Watcher im Haupt-Repo ein Vielfaches an
+ * Dateien, sobald die `.gitignore`-Zeile einmal wegfällt.
+ */
+export const WORKTREE_WATCH_GLOBS = ['**/.claude/worktrees/**', '**/.worktrees/**'] as const;
+
+/**
+ * Dieselben Muster — aber **nur**, wenn der Dev-Server nicht selbst in einem
+ * Worktree läuft.
+ *
+ * **Warum die Fallunterscheidung nötig ist.** Chokidar vergleicht `ignored`
+ * gegen den *absoluten* Pfad. Startet der Server im Worktree, liegt jede
+ * Quelldatei unter `…/.claude/worktrees/<name>/src/…` und matcht damit
+ * `**\/.claude/worktrees/**` — der Watcher ignoriert dann das gesamte Projekt,
+ * und HMR ist tot. Kein Fehler, keine Meldung: Änderungen kommen schlicht nie
+ * an, und wer sie sehen will, muss den Server neu starten.
+ *
+ * Das Muster war als Absicherung gedacht (falls die `.gitignore`-Zeile
+ * wegfällt) und hat in dieser Rolle genau den Arbeitsablauf lahmgelegt, für den
+ * es die Worktrees gibt. Im Haupt-Repo greift es unverändert weiter.
+ */
+export function worktreeWatchIgnore(cwd: string = process.cwd()): string[] {
+	const normalisiert = cwd.replaceAll('\\', '/');
+	const imWorktree = ['/.claude/worktrees/', '/.worktrees/'].some((teil) =>
+		normalisiert.includes(teil)
+	);
+	return imWorktree ? [] : [...WORKTREE_WATCH_GLOBS];
+}

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -408,17 +408,28 @@ export async function assertServerIdentity({
 }
 
 /**
+ * Wo Worktrees liegen — je Ort das Pfadstück und das passende Glob-Muster.
+ *
+ * Beide sind unabhängig: `/.claude/worktrees/` enthält **nicht** `/.worktrees/`
+ * (der Punkt sitzt direkt hinter dem Schrägstrich). Deshalb lässt sich je Ort
+ * einzeln entscheiden, ob sein Muster gelten darf.
+ */
+const WORKTREE_ORTE = [
+	{ pfadstueck: '/.claude/worktrees/', glob: '**/.claude/worktrees/**' },
+	{ pfadstueck: '/.worktrees/', glob: '**/.worktrees/**' }
+] as const;
+
+/**
  * Glob-Muster, mit denen der Datei-Watcher die Worktrees heraushält.
  *
  * Worktrees liegen unter `.claude/worktrees/` **innerhalb** des Repo-Roots.
  * Ohne diese Muster beobachtete ein Watcher im Haupt-Repo ein Vielfaches an
  * Dateien, sobald die `.gitignore`-Zeile einmal wegfällt.
  */
-export const WORKTREE_WATCH_GLOBS = ['**/.claude/worktrees/**', '**/.worktrees/**'] as const;
+export const WORKTREE_WATCH_GLOBS = WORKTREE_ORTE.map(({ glob }) => glob);
 
 /**
- * Dieselben Muster — aber **nur**, wenn der Dev-Server nicht selbst in einem
- * Worktree läuft.
+ * Dieselben Muster — aber ohne das, das den eigenen Standort trifft.
  *
  * **Warum die Fallunterscheidung nötig ist.** Chokidar vergleicht `ignored`
  * gegen den *absoluten* Pfad. Startet der Server im Worktree, liegt jede
@@ -429,12 +440,17 @@ export const WORKTREE_WATCH_GLOBS = ['**/.claude/worktrees/**', '**/.worktrees/*
  *
  * Das Muster war als Absicherung gedacht (falls die `.gitignore`-Zeile
  * wegfällt) und hat in dieser Rolle genau den Arbeitsablauf lahmgelegt, für den
- * es die Worktrees gibt. Im Haupt-Repo greift es unverändert weiter.
+ * es die Worktrees gibt.
+ *
+ * **Im Haupt-Repo ändert sich nichts:** Dort trifft kein Pfadstück zu, beide
+ * Muster gelten unverändert weiter. Und aussortiert wird nur das Muster, das
+ * den eigenen Standort trifft — wer in `.claude/worktrees/x` arbeitet, hält
+ * ein `.worktrees/` daneben weiterhin heraus. Ein pauschales „im Worktree gar
+ * nichts ignorieren" wäre bequemer und würde mehr wegnehmen als nötig.
  */
 export function worktreeWatchIgnore(cwd: string = process.cwd()): string[] {
 	const normalisiert = cwd.replaceAll('\\', '/');
-	const imWorktree = ['/.claude/worktrees/', '/.worktrees/'].some((teil) =>
-		normalisiert.includes(teil)
+	return WORKTREE_ORTE.filter(({ pfadstueck }) => !normalisiert.includes(pfadstueck)).map(
+		({ glob }) => glob
 	);
-	return imWorktree ? [] : [...WORKTREE_WATCH_GLOBS];
 }

--- a/src/tools/dev-server-identity.ts
+++ b/src/tools/dev-server-identity.ts
@@ -414,9 +414,9 @@ export async function assertServerIdentity({
  * (der Punkt sitzt direkt hinter dem Schrägstrich). Deshalb lässt sich je Ort
  * einzeln entscheiden, ob sein Muster gelten darf.
  */
-const WORKTREE_ORTE = [
-	{ pfadstueck: '/.claude/worktrees/', glob: '**/.claude/worktrees/**' },
-	{ pfadstueck: '/.worktrees/', glob: '**/.worktrees/**' }
+const WORKTREE_LOCATIONS = [
+	{ pathSegment: '/.claude/worktrees/', glob: '**/.claude/worktrees/**' },
+	{ pathSegment: '/.worktrees/', glob: '**/.worktrees/**' }
 ] as const;
 
 /**
@@ -426,7 +426,7 @@ const WORKTREE_ORTE = [
  * Ohne diese Muster beobachtete ein Watcher im Haupt-Repo ein Vielfaches an
  * Dateien, sobald die `.gitignore`-Zeile einmal wegfällt.
  */
-export const WORKTREE_WATCH_GLOBS = WORKTREE_ORTE.map(({ glob }) => glob);
+export const WORKTREE_WATCH_GLOBS = WORKTREE_LOCATIONS.map(({ glob }) => glob);
 
 /**
  * Dieselben Muster — aber ohne das, das den eigenen Standort trifft.
@@ -449,8 +449,8 @@ export const WORKTREE_WATCH_GLOBS = WORKTREE_ORTE.map(({ glob }) => glob);
  * nichts ignorieren" wäre bequemer und würde mehr wegnehmen als nötig.
  */
 export function worktreeWatchIgnore(cwd: string = process.cwd()): string[] {
-	const normalisiert = cwd.replaceAll('\\', '/');
-	return WORKTREE_ORTE.filter(({ pfadstueck }) => !normalisiert.includes(pfadstueck)).map(
+	const normalized = cwd.replaceAll('\\', '/');
+	return WORKTREE_LOCATIONS.filter(({ pathSegment }) => !normalized.includes(pathSegment)).map(
 		({ glob }) => glob
 	);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
-import { devPortFromEnv, devServerIdentity } from './src/tools/dev-server-identity';
+import {
+	devPortFromEnv,
+	devServerIdentity,
+	worktreeWatchIgnore
+} from './src/tools/dev-server-identity';
 import { stableDepHash } from './src/tools/vite-stable-dep-hash';
 
 const certFile = fileURLToPath(new URL('./certs/localhost.pem', import.meta.url));
@@ -78,9 +82,14 @@ export default defineConfig({
 		 * Der Eintrag hier ist die Absicherung: Fällt die `.gitignore`-Zeile weg,
 		 * beobachtet der Watcher sonst still ein Vielfaches an Dateien.
 		 * Vite ergänzt seine Defaults (`**\/node_modules/**`, `**\/.git/**`).
+		 *
+		 * **Nur im Haupt-Repo.** Chokidar vergleicht `ignored` gegen den absoluten
+		 * Pfad; im Worktree matchte das Muster jede eigene Quelldatei und legte
+		 * HMR still — lautlos, denn ein Watcher, der nichts sieht, meldet nichts.
+		 * Begründung und Prüfung in `worktreeWatchIgnore`.
 		 */
 		watch: {
-			ignored: ['**/.claude/worktrees/**', '**/.worktrees/**']
+			ignored: worktreeWatchIgnore()
 		},
 		// Warmup critical modules for faster initial page load
 		warmup: {


### PR DESCRIPTION
## Der Befund

`vite.config.ts` hielt die Worktrees pauschal aus dem Datei-Watcher heraus:

```ts
watch: { ignored: ['**/.claude/worktrees/**', '**/.worktrees/**'] }
```

Chokidar vergleicht `ignored` gegen den **absoluten** Pfad. Worktrees liegen unter `.claude/worktrees/` *innerhalb* des Repo-Roots — läuft der Dev-Server also in einem Worktree, liegt jede seiner Quelldateien unter `…/.claude/worktrees/<name>/src/…` und matcht das Muster. Der Watcher ignoriert damit **das gesamte Projekt**, und HMR ist tot.

Lautlos: Ein Watcher, der nichts sieht, meldet nichts. Es sieht aus, als würde man am falschen Ort arbeiten.

Der Eintrag war als Absicherung gedacht — falls die `.gitignore`-Zeile wegfällt, soll der Watcher im Haupt-Repo nicht ein Vielfaches an Dateien beobachten. In dieser Rolle hat er genau den Arbeitsablauf lahmgelegt, für den es die Worktrees gibt.

## Die Änderung

`worktreeWatchIgnore()` in `src/tools/dev-server-identity.ts` liefert die Muster nur, wenn der Server **nicht** selbst in einem Worktree läuft. Im Haupt-Repo bleibt alles wie bisher.

## Belegt, nicht behauptet

Beide Richtungen im laufenden Dev-Server gemessen (Worktree, `touch` auf eine Komponente):

| Konfiguration | Reaktion |
| --- | --- |
| vorher (feste Muster) | **0 Ereignisse in 26 s** |
| nachher (`worktreeWatchIgnore()`) | `page reload src/lib/components/admin/SightingInboxCard.svelte` in unter 1 s |

Dazu drei Unit-Tests: Haupt-Repo behält die Muster, beide Worktree-Formen (`.claude/worktrees/`, `.worktrees/`) bekommen keine — und ein Verzeichnis, das zufällig `meine-worktrees-doku` heißt, ist kein Worktree.

`npm run test:quick` grün: 4.546 Server-Tests, 759 Komponenten-Tests.

## Nebenbei

Das erklärt auch die Notiz „Dev-Server im Worktree sieht eigene Änderungen nicht — nach jeder Änderung neu starten", die bisher als Eigenart hingenommen wurde. Sie war ein behebbarer Fehler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
